### PR TITLE
Rename init images to drop `-ubi` suffix

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
             - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-database-ubi
             - name: INIT_DATABASE_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-database-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
               value: 0.1.0
             - name: DATABASE_VERSION
@@ -73,12 +73,12 @@ spec:
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
               value: 0.1.0
             # AppDB
             - name: INIT_APPDB_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-appdb
             - name: INIT_APPDB_VERSION
               value: 0.1.0
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
@@ -122,11 +122,11 @@ spec:
             - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_0_1_0
               value: "quay.io/mongodb/mongodb-kubernetes-database-ubi:0.1.0"
             - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_0_1_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database-ubi:0.1.0"
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:0.1.0"
             - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_0_1_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi:0.1.0"
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:0.1.0"
             - name: RELATED_IMAGE_INIT_APPDB_IMAGE_REPOSITORY_0_1_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi:0.1.0"
+              value: "quay.io/mongodb/mongodb-kubernetes-init-appdb:0.1.0"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1
               value: "quay.io/mongodb/mongodb-agent-ubi:107.0.13.8702-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1_1_31_0

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -117,7 +117,7 @@ database:
   version: 0.1.0
 
 initDatabase:
-  name: mongodb-kubernetes-init-database-ubi
+  name: mongodb-kubernetes-init-database
   version: 0.1.0
 
 ## Ops Manager
@@ -125,12 +125,12 @@ opsManager:
   name: mongodb-enterprise-ops-manager-ubi
 
 initOpsManager:
-  name: mongodb-kubernetes-init-ops-manager-ubi
+  name: mongodb-kubernetes-init-ops-manager
   version: 0.1.0
 
 ## Application Database
 initAppDb:
-  name: mongodb-kubernetes-init-appdb-ubi
+  name: mongodb-kubernetes-init-appdb
   version: 0.1.0
 
 agent:

--- a/inventories/init_appdb.yaml
+++ b/inventories/init_appdb.yaml
@@ -36,17 +36,17 @@ images:
       imagebase: $(inputs.params.registry)/mongodb-kubernetes-init-appdb-context:$(inputs.params.version_id)
     dockerfile: $(stages['init-appdb-template-ubi'].outputs[0].dockerfile)
     output:
-    - registry: $(inputs.params.registry)/mongodb-kubernetes-init-appdb-ubi
+    - registry: $(inputs.params.registry)/mongodb-kubernetes-init-appdb
       tag: $(inputs.params.version_id)
 
   - name: master-latest
     task_type: tag_image
     tags: [ "master" ]
     source:
-      registry: $(inputs.params.registry)/mongodb-kubernetes-init-appdb-ubi
+      registry: $(inputs.params.registry)/mongodb-kubernetes-init-appdb
       tag: $(inputs.params.version_id)
     destination:
-      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-appdb-ubi
+      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-appdb
         tag: latest
 
   - name: init-appdb-release-context

--- a/inventories/init_database.yaml
+++ b/inventories/init_database.yaml
@@ -40,19 +40,19 @@ images:
     inputs:
       - is_appdb
     output:
-      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-database-ubi
+      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-database
         tag: $(inputs.params.version_id)
-      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-database-ubi
+      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-database
         tag: $(inputs.params.version)
 
   - name: master-latest
     task_type: tag_image
     tags: ["master"]
     source:
-      registry: $(inputs.params.registry)/mongodb-kubernetes-init-database-ubi
+      registry: $(inputs.params.registry)/mongodb-kubernetes-init-database
       tag: $(inputs.params.version_id)
     destination:
-      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-database-ubi
+      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-database
         tag: latest
 
   - name: init-database-release-context

--- a/inventories/init_om.yaml
+++ b/inventories/init_om.yaml
@@ -32,17 +32,17 @@ images:
     buildargs:
       imagebase: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager-context:$(inputs.params.version_id)
     output:
-    - registry: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager-ubi
+    - registry: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager
       tag: $(inputs.params.version_id)
 
   - name: master-latest
     task_type: tag_image
     tags: ["master"]
     source:
-      registry: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager-ubi
+      registry: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager
       tag: $(inputs.params.version_id)
     destination:
-      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager-ubi
+      - registry: $(inputs.params.registry)/mongodb-kubernetes-init-ops-manager
         tag: latest
 
   - name: init-ops-manager-release-context

--- a/pipeline.py
+++ b/pipeline.py
@@ -643,10 +643,10 @@ def args_for_daily_image(image_name: str) -> Dict[str, str]:
     """
     image_configs = [
         image_config("database"),
-        image_config("init-appdb"),
+        image_config("init-appdb", ubi_suffix=""),
         image_config("agent", name_prefix="mongodb-enterprise-"),
-        image_config("init-database"),
-        image_config("init-ops-manager"),
+        image_config("init-database", ubi_suffix=""),
+        image_config("init-ops-manager", ubi_suffix=""),
         image_config("operator"),
         image_config("ops-manager", name_prefix="mongodb-enterprise-"),
         image_config("mongodb-agent", name_prefix="", ubi_suffix="-ubi", base_suffix="-ubi"),
@@ -1314,7 +1314,7 @@ def _build_agent_operator(
     # We could rely on input params (quay_registry or registry), but it makes templating more complex in the inventory
     non_quay_registry = os.environ.get("REGISTRY", "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev")
     base_init_database_repo = QUAY_REGISTRY_URL if use_quay else non_quay_registry
-    init_database_image = f"{base_init_database_repo}/mongodb-kubernetes-init-database-ubi:{operator_version}"
+    init_database_image = f"{base_init_database_repo}/mongodb-kubernetes-init-database:{operator_version}"
 
     tasks_queue.put(
         executor.submit(

--- a/public/architectures/setup-multi-cluster/setup-operator/output/0210_helm_install_operator.out
+++ b/public/architectures/setup-multi-cluster/setup-operator/output/0210_helm_install_operator.out
@@ -266,7 +266,7 @@ spec:
             - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-database-ubi
             - name: INIT_DATABASE_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-database-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
               value: 1.33.0
             - name: DATABASE_VERSION
@@ -275,12 +275,12 @@ spec:
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
               value: 1.33.0
             # AppDB
             - name: INIT_APPDB_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-appdb
             - name: INIT_APPDB_VERSION
               value: 1.33.0
             - name: OPS_MANAGER_IMAGE_PULL_POLICY

--- a/public/mongodb-enterprise-multi-cluster.yaml
+++ b/public/mongodb-enterprise-multi-cluster.yaml
@@ -323,7 +323,7 @@ spec:
             - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-database-ubi
             - name: INIT_DATABASE_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-database-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
               value: 0.1.0
             - name: DATABASE_VERSION
@@ -332,12 +332,12 @@ spec:
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
               value: 0.1.0
             # AppDB
             - name: INIT_APPDB_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-appdb
             - name: INIT_APPDB_VERSION
               value: 0.1.0
             - name: OPS_MANAGER_IMAGE_PULL_POLICY

--- a/public/mongodb-enterprise-openshift.yaml
+++ b/public/mongodb-enterprise-openshift.yaml
@@ -318,7 +318,7 @@ spec:
             - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-database-ubi
             - name: INIT_DATABASE_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-database-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
               value: 0.1.0
             - name: DATABASE_VERSION
@@ -327,12 +327,12 @@ spec:
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
               value: 0.1.0
             # AppDB
             - name: INIT_APPDB_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-appdb
             - name: INIT_APPDB_VERSION
               value: 0.1.0
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
@@ -374,11 +374,11 @@ spec:
             - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_0_1_0
               value: "quay.io/mongodb/mongodb-kubernetes-database-ubi:0.1.0"
             - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_0_1_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database-ubi:0.1.0"
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:0.1.0"
             - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_0_1_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi:0.1.0"
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:0.1.0"
             - name: RELATED_IMAGE_INIT_APPDB_IMAGE_REPOSITORY_0_1_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi:0.1.0"
+              value: "quay.io/mongodb/mongodb-kubernetes-init-appdb:0.1.0"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1
               value: "quay.io/mongodb/mongodb-agent-ubi:107.0.13.8702-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1_1_31_0

--- a/public/mongodb-enterprise.yaml
+++ b/public/mongodb-enterprise.yaml
@@ -319,7 +319,7 @@ spec:
             - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-database-ubi
             - name: INIT_DATABASE_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-database-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
               value: 0.1.0
             - name: DATABASE_VERSION
@@ -328,12 +328,12 @@ spec:
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
               value: 0.1.0
             # AppDB
             - name: INIT_APPDB_IMAGE_REPOSITORY
-              value: quay.io/mongodb/mongodb-kubernetes-init-appdb-ubi
+              value: quay.io/mongodb/mongodb-kubernetes-init-appdb
             - name: INIT_APPDB_VERSION
               value: 0.1.0
             - name: OPS_MANAGER_IMAGE_PULL_POLICY

--- a/scripts/evergreen/periodic-cleanup-aws.py
+++ b/scripts/evergreen/periodic-cleanup-aws.py
@@ -7,10 +7,10 @@ import boto3
 
 REPOSITORIES_NAMES = [
     "dev/mongodb-agent-ubi",
-    "dev/mongodb-kubernetes-init-appdb-ubi",
+    "dev/mongodb-kubernetes-init-appdb",
     "dev/mongodb-enterprise-database-ubi",
-    "dev/mongodb-kubernetes-init-database-ubi",
-    "dev/mongodb-kubernetes-init-ops-manager-ubi",
+    "dev/mongodb-kubernetes-init-database",
+    "dev/mongodb-kubernetes-init-ops-manager",
     "dev/mongodb-enterprise-ops-manager-ubi",
     "dev/mongodb-enterprise-operator-ubi",
 ]


### PR DESCRIPTION
# Summary

We want to move away from `-ubi` suffix for the images eventually. This PR only renames initi images for now.

## Proof of Work

CI must be green (except for OLM upgrade jobs which will be fixed in #22)