### PR TITLE
CLOUDP-307082: Update preflight scripts

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -16,7 +16,7 @@ tasks:
       - func: setup_preflight
       - func: preflight_image
         vars:
-          image_name: operator
+          image_name: mongodb-kubernetes
       - func: preflight_image
         vars:
           image_name: init-appdb

--- a/scripts/preflight_images.py
+++ b/scripts/preflight_images.py
@@ -26,8 +26,8 @@ logging.basicConfig(level=LOGLEVEL)
 def image_config(
     image: str,
     rh_cert_project_id: str,
-    name_prefix: str = "mongodb-enterprise-",
-    name_suffix: str = "-ubi",
+    name_prefix: str = "mongodb-kubernetes-",
+    name_suffix: str = "",
 ) -> Tuple[str, Dict[str, str]]:
     args = {
         "registry": f"quay.io/mongodb/{name_prefix}{image}{name_suffix}",
@@ -52,37 +52,43 @@ def official_server_image(
 def args_for_image(image: str) -> Dict[str, str]:
     image_configs = [
         image_config(
-            "database",
-            "633fc9e582f7934b1ad3be45",
+            image="database",
+            name_suffix="",
+            rh_cert_project_id="6809ece067e8953c22ff54fc",
         ),
         official_server_image(
-            "mongodb-enterprise-server",  # official server images
-            "643daaa56da4ecc48795693a",
+            image="mongodb-enterprise-server",  # official server images
+            rh_cert_project_id="643daaa56da4ecc48795693a",
         ),
         image_config(
-            "init-appdb",
-            "633fcb576f43719c9df9349f",
+            image="init-appdb",
+            rh_cert_project_id="6809ec113193c2e55779b8dc",
+            name_suffix="",
         ),
         image_config(
-            "init-database",
-            "633fcc2982f7934b1ad3be46",
+            image="init-database",
+            rh_cert_project_id="680a22928e2dc72376f34990",
+            name_suffix="",
         ),
         image_config(
-            "init-ops-manager",
-            "633fccb16f43719c9df934a0",
+            image="init-ops-manager",
+            rh_cert_project_id="680a247d67e8953c22000544",
+            name_suffix="",
         ),
         image_config(
-            "operator",
-            "633fcdfaade0e891294196ac",
-        ),
-        image_config(
-            "ops-manager",
-            "633fcd36c4ee7ff29edff589",
-        ),
-        image_config(
-            "mongodb-agent",
-            "633fcfd482f7934b1ad3be47",
+            image="mongodb-kubernetes",
+            rh_cert_project_id="6809ea243193c2e55779b4a5",
             name_prefix="",
+            name_suffix="",
+        ),
+        image_config(
+            image="ops-manager",
+            rh_cert_project_id="633fcd36c4ee7ff29edff589",
+            name_prefix="mongodb-enterprise-",
+            name_suffix="-ubi",
+        ),
+        image_config(
+            image="mongodb-agent", rh_cert_project_id="633fcfd482f7934b1ad3be47", name_prefix="", name_suffix="-ubi"
         ),
     ]
     images = {k: v for k, v in image_configs}


### PR DESCRIPTION
# Summary

* Fixes pre-flight scripts to work with MCK images
* Updates Red Hat project IDs for new images
* ~~Moves to `init-appdb`, `database` and `init-database` from UBI8 to UBI9. Note: `init-ops-manager` and `mongodb-kubernetes` already use UBI9.~~

## Proof of Work

* CI must be green
* Preflight tasks must be green (see [this patch](https://spruce.mongodb.com/version/680b5115f3357a0007f78717/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC))
    ```yaml
    evergreen patch -v preflight_release_images -t all  -p mongodb-kubernetes --path .evergreen.yml -v all -f -d $(git branch --show-current):$(git rev-parse HEAD)  --param pin_tag_at=$(date +'%H:%M')  -y -u --browse
    ```
