### PR TITLE
Skip building arm64 community images in patches

### DIFF
--- a/pipeline_test.py
+++ b/pipeline_test.py
@@ -225,3 +225,102 @@ class TestRunCommandWithRetries(unittest.TestCase):
 
         self.assertEqual(mock_run.call_count, 3)
         self.assertEqual(mock_sleep.call_count, 2)
+
+
+@patch("subprocess.run")
+def test_create_and_push_manifest_success(mock_run):
+    """Test successful creation and pushing of manifest with multiple architectures."""
+    # Setup mock to return success for both calls
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+
+    image = "test/image"
+    tag = "1.0.0"
+    architectures = ["amd64", "arm64"]
+
+    from pipeline import create_and_push_manifest
+
+    create_and_push_manifest(image, tag, architectures)
+
+    assert mock_run.call_count == 2
+
+    # Verify first call - create manifest
+    create_call_args = mock_run.call_args_list[0][0][0]
+    assert create_call_args == [
+        "docker",
+        "manifest",
+        "create",
+        "test/image:1.0.0",
+        "--amend",
+        "test/image:1.0.0-amd64",
+        "--amend",
+        "test/image:1.0.0-arm64",
+    ]
+
+    # Verify second call - push manifest
+    push_call_args = mock_run.call_args_list[1][0][0]
+    assert push_call_args == ["docker", "manifest", "push", f"{image}:{tag}"]
+
+
+@patch("subprocess.run")
+def test_create_and_push_manifest_single_arch(mock_run):
+    """Test manifest creation with a single architecture."""
+    # Setup mock to return success for both calls
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+
+    image = "test/image"
+    tag = "1.0.0"
+    architectures = ["amd64"]
+
+    from pipeline import create_and_push_manifest
+
+    create_and_push_manifest(image, tag, architectures)
+
+    # Verify first call - create manifest (should only include one architecture)
+    create_call_args = mock_run.call_args_list[0][0][0]
+    assert " ".join(create_call_args) == f"docker manifest create {image}:{tag} --amend {image}:{tag}-amd64"
+
+
+@patch("subprocess.run")
+def test_create_and_push_manifest_create_error(mock_run):
+    """Test error handling when manifest creation fails."""
+    # Setup mock to return error for create call
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout=b"", stderr=b"Error creating manifest"
+    )
+
+    image = "test/image"
+    tag = "1.0.0"
+    architectures = ["amd64", "arm64"]
+
+    from pipeline import create_and_push_manifest
+
+    # Verify exception is raised with the stderr content
+    with pytest.raises(Exception) as exc_info:
+        create_and_push_manifest(image, tag, architectures)
+
+    assert "Error creating manifest" in str(exc_info.value)
+    assert mock_run.call_count == 1  # Only the create call, not the push call
+
+
+@patch("subprocess.run")
+def test_create_and_push_manifest_push_error(mock_run):
+    """Test error handling when manifest push fails."""
+    # Setup mock to return success for create but error for push
+    mock_run.side_effect = [
+        subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b""),  # create success
+        subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"Error pushing manifest"),  # push error
+    ]
+
+    # Call function with test parameters
+    image = "test/image"
+    tag = "1.0.0"
+    architectures = ["amd64", "arm64"]
+
+    from pipeline import create_and_push_manifest
+
+    # Verify exception is raised with the stderr content
+    with pytest.raises(Exception) as exc_info:
+        create_and_push_manifest(image, tag, architectures)
+
+    assert "Error pushing manifest" in str(exc_info.value)
+    assert mock_run.call_count == 2  # Both create and push calls


### PR DESCRIPTION
# Summary

It skips building arm64 docker images when building images in patches and in evergreen. 
arm64 images takes long time to build probably due to emulation (>10min arm64 vs 10s amd64). 

The change should not impact any daily build processes. 

## Proof of Work

Only manual run: 
[with skipped arm64](https://spruce.mongodb.com/task/mongodb_kubernetes_init_test_run_build_readiness_probe_image_patch_f0050b8942545701e8cb9e42d54d14f0cb58ee6a_680bc0fd99bf4d0007ff73f4_25_04_25_17_06_06/logs?execution=0), total time: 2min ([link to relevant log message](https://parsley.mongodb.com/evergreen/mongodb_kubernetes_init_test_run_build_readiness_probe_image_patch_f0050b8942545701e8cb9e42d54d14f0cb58ee6a_680bc0fd99bf4d0007ff73f4_25_04_25_17_06_06/0/task?bookmarks=0%2C542&selectedLineRange=L505&shareLine=505))
[build from master](https://spruce.mongodb.com/task/mongodb_kubernetes_init_test_run_build_readiness_probe_image_f0050b8942545701e8cb9e42d54d14f0cb58ee6a_25_04_25_12_41_27/logs?execution=1): total time: 12min


## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
