### PR TITLE
Tag latest readiness and versionhook when building on master

### DIFF
--- a/inventories/readiness_probe.yaml
+++ b/inventories/readiness_probe.yaml
@@ -60,3 +60,13 @@ images:
         tags: ["release"]
         output:
           - dockerfile: $(inputs.params.s3_bucket)/$(inputs.params.version)/ubi/Dockerfile
+
+      - name: master-latest
+        task_type: tag_image
+        tags: [ "master" ]
+        source:
+          registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe
+          tag: $(inputs.params.version_id)
+        destination:
+          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe
+            tag: latest

--- a/inventories/upgrade_hook.yaml
+++ b/inventories/upgrade_hook.yaml
@@ -60,3 +60,13 @@ images:
         tags: ["release"]
         output:
           - dockerfile: $(inputs.params.s3_bucket)/$(inputs.params.version)/ubi/Dockerfile
+
+      - name: master-latest
+        task_type: tag_image
+        tags: [ "master" ]
+        source:
+          registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook
+          tag: $(inputs.params.version_id)
+        destination:
+          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook
+            tag: latest


### PR DESCRIPTION
# Summary

Readiness probe and version hook images are not tagged with "latest" when built on master. It fills the gap after merging repositories. All other images are built with latest allowing to use "latest" tag for most auxiliary images when testing locally. 

## Proof of Work

If green, then the change is safe. Then we will verify it on master as it's difficult to recreate master merge conditions in patch build.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?