### PR TITLE
Revert "Tag latest readiness and versionhook when building on master"

### DIFF
--- a/inventories/readiness_probe.yaml
+++ b/inventories/readiness_probe.yaml
@@ -60,13 +60,3 @@ images:
         tags: ["release"]
         output:
           - dockerfile: $(inputs.params.s3_bucket)/$(inputs.params.version)/ubi/Dockerfile
-
-      - name: master-latest
-        task_type: tag_image
-        tags: [ "master" ]
-        source:
-          registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe
-          tag: $(inputs.params.version_id)
-        destination:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe
-            tag: latest

--- a/inventories/upgrade_hook.yaml
+++ b/inventories/upgrade_hook.yaml
@@ -60,13 +60,3 @@ images:
         tags: ["release"]
         output:
           - dockerfile: $(inputs.params.s3_bucket)/$(inputs.params.version)/ubi/Dockerfile
-
-      - name: master-latest
-        task_type: tag_image
-        tags: [ "master" ]
-        source:
-          registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook
-          tag: $(inputs.params.version_id)
-        destination:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook
-            tag: latest


### PR DESCRIPTION
Reverts mongodb/mongodb-kubernetes#57

The inventory task cannot work as pushing the multi-arch manifest required for this tagging job is only happening after the sonar instructions:
https://github.com/mongodb/mongodb-kubernetes/blob/master/pipeline.py#L840-L853