### PR TITLE
Fixed swallowing python client exceptions in e2e tests

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/__init__.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/__init__.py
@@ -42,10 +42,12 @@ def create_or_update_secret(
     api_client: Optional[client.ApiClient] = None,
 ) -> str:
     try:
-        create_secret(namespace, name, data, type, api_client)
+        create_secret(namespace, name, data, type, api_client, )
     except kubernetes.client.ApiException as e:
         if e.status == 409:
             update_secret(namespace, name, data, api_client)
+        else:
+            raise e
 
     return name
 
@@ -161,6 +163,8 @@ def create_or_update_service(
             update_service(
                 namespace, service_name, cluster_ip=cluster_ip, ports=ports, selector=selector, service=service
             )
+        else:
+            raise e
     return service_name
 
 
@@ -269,6 +273,8 @@ def create_or_update_namespace(
     except kubernetes.client.ApiException as e:
         if e.status == 409:
             client.CoreV1Api(api_client=api_client).patch_namespace(namespace, namespace_resource)
+        else:
+            raise e
 
 
 def delete_namespace(name: str):

--- a/docker/mongodb-kubernetes-tests/kubetester/certs.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/certs.py
@@ -804,8 +804,8 @@ def create_x509_agent_tls_certs(issuer: str, namespace: str, name: str, secret_b
 
 def approve_certificate(name: str) -> None:
     """Approves the CertificateSigningRequest with the provided name"""
-    body = client.CertificatesV1beta1Api().read_certificate_signing_request_status(name)
-    conditions = client.V1beta1CertificateSigningRequestCondition(
+    body = client.CertificatesV1Api().read_certificate_signing_request_status(name)
+    conditions = client.V1CertificateSigningRequestCondition(
         last_update_time=datetime.now(timezone.utc).astimezone(),
         message="This certificate was approved by E2E testing framework",
         reason="E2ETestingFramework",
@@ -813,7 +813,7 @@ def approve_certificate(name: str) -> None:
     )
 
     body.status.conditions = [conditions]
-    client.CertificatesV1beta1Api().replace_certificate_signing_request_approval(name, body)
+    client.CertificatesV1Api().replace_certificate_signing_request_approval(name, body)
 
 
 def create_x509_user_cert(issuer: str, namespace: str, path: str):
@@ -876,7 +876,7 @@ def yield_existing_csrs(csr_names: List[str], timeout: int = 300) -> Generator[s
     while len(csr_names) > 0 and time.time() < stop_time:
         csr = random.choice(csr_names)
         try:
-            client.CertificatesV1beta1Api().read_certificate_signing_request_status(csr)
+            client.CertificatesV1Api().read_certificate_signing_request_status(csr)
         except ApiException:
             time.sleep(3)
             continue

--- a/docker/mongodb-kubernetes-tests/kubetester/crypto.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/crypto.py
@@ -50,7 +50,7 @@ def generate_csr(namespace: str, host: str, servicename: str):
 
 
 def get_pem_certificate(name: str) -> Optional[str]:
-    body = client.CertificatesV1beta1Api().read_certificate_signing_request_status(name)
+    body = client.CertificatesV1Api().read_certificate_signing_request_status(name)
     if body.status.certificate is None:
         return None
     return base64.b64decode(body.status.certificate)

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -327,7 +327,7 @@ class KubernetesTester(object):
             "appsv1": client.AppsV1Api(api_client=api_client),
             "storagev1": client.StorageV1Api(api_client=api_client),
             "customv1": client.CustomObjectsApi(api_client=api_client),
-            "certificates": client.CertificatesApi(api_client=api_client),
+            "certificates": client.CertificatesV1Api(api_client=api_client),
             "namespace": KubernetesTester.get_namespace(),
         }[name]
 
@@ -809,7 +809,7 @@ class KubernetesTester(object):
         self.client = client
         self.corev1 = client.CoreV1Api()
         self.appsv1 = client.AppsV1Api()
-        self.certificates = client.CertificatesV1beta1Api()
+        self.certificates = client.CertificatesV1Api()
         self.customv1 = client.CustomObjectsApi()
         self.namespace = KubernetesTester.get_namespace()
         self.name = None
@@ -1226,19 +1226,19 @@ class KubernetesTester(object):
         if namespace is None:
             namespace = self.namespace
 
-        csr_body = client.V1beta1CertificateSigningRequest(
+        csr_body = client.V1CertificateSigningRequest(
             metadata=client.V1ObjectMeta(name=csr_name, namespace=namespace),
-            spec=client.V1beta1CertificateSigningRequestSpec(
+            spec=client.V1CertificateSigningRequestSpec(
                 groups=["system:authenticated"],
                 usages=["digital signature", "key encipherment", "client auth"],
                 request=encoded_request,
             ),
         )
 
-        client.CertificatesV1beta1Api().create_certificate_signing_request(csr_body)
+        client.CertificatesV1Api().create_certificate_signing_request(csr_body)
         self.approve_certificate(csr_name)
         wait_for_certs_to_be_issued([csr_name])
-        csr = client.CertificatesV1beta1Api().read_certificate_signing_request(csr_name)
+        csr = client.CertificatesV1Api().read_certificate_signing_request(csr_name)
         certificate = b64decode(csr.status.certificate)
 
         tmp = tempfile.NamedTemporaryFile()
@@ -1385,7 +1385,7 @@ class KubernetesTester(object):
         Return all of the subject alternative names for a given Kubernetes
         certificate signing request.
         """
-        csr = client.CertificatesV1beta1Api().read_certificate_signing_request_status(csr_name)
+        csr = client.CertificatesV1Api().read_certificate_signing_request_status(csr_name)
         base64_csr_request = csr.spec.request
         csr_pem_string = b64decode(base64_csr_request)
         csr = x509.load_pem_x509_csr(csr_pem_string, default_backend())

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -327,7 +327,7 @@ class KubernetesTester(object):
             "appsv1": client.AppsV1Api(api_client=api_client),
             "storagev1": client.StorageV1Api(api_client=api_client),
             "customv1": client.CustomObjectsApi(api_client=api_client),
-            "certificates": client.CertificatesV1beta1Api(api_client=api_client),
+            "certificates": client.CertificatesApi(api_client=api_client),
             "namespace": KubernetesTester.get_namespace(),
         }[name]
 

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -303,6 +303,8 @@ class KubernetesTester(object):
                 cls.clients("corev1", api_client=api_client).patch_namespaced_persistent_volume_claim(
                     body=body, name=body["metadata"]["name"], namespace=namespace
                 )
+            else:
+                raise e
 
     @classmethod
     def delete_pvc(cls, namespace: str, name: str):

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
@@ -379,8 +379,8 @@ def test_meko_operator_upgrade_to_mck(
         except kubernetes.client.ApiException as e:
             if e.status == 409:
                 return False
-        else:
-            raise e
+            else:
+                raise e
 
     run_periodically(update_subscription, timeout=100, msg="Subscription to be updated")
 

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
@@ -363,8 +363,8 @@ def test_operator_upgrade_to_fast(
         except kubernetes.client.ApiException as e:
             if e.status == 409:
                 return False
-        else:
-            raise e
+            else:
+                raise e
 
     run_periodically(update_subscription, timeout=100, msg="Subscription to be updated")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
@@ -152,6 +152,8 @@ class TestOpsManagerCreation:
                 "initial_delay_seconds": 5,
                 "_exec": None,
                 "tcp_socket": None,
+                "grpc": None,
+                "termination_grace_period_seconds": None,
             },
             "startup_probe": {
                 "http_get": {
@@ -168,6 +170,8 @@ class TestOpsManagerCreation:
                 "initial_delay_seconds": 1,
                 "_exec": None,
                 "tcp_socket": None,
+                "grpc": None,
+                "termination_grace_period_seconds": None,
             },
             "volume_mounts": [
                 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ MarkupSafe==2.0.1
 semver==2.13.0
 chardet==3.0.4
 jsonpatch==1.33
-kubernetes==17.17.0
+kubernetes==30.1.0
 pymongo==4.6.3
 pytest==7.4.3
 pytest-asyncio==0.14.0


### PR DESCRIPTION
# Summary

Fix for swallowing some k8s exceptions in python e2e tests. 

## Proof of Work

Green suite should suffice - it's an obvious fix that cannot get us any worse that it was before.