### PR TITLE
CLOUDP-317911 Add pprof integration in operator

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,11 +278,11 @@ func main() {
 		log.Info("Not running telemetry component!")
 	}
 
-	pprofEnabledString := env.ReadOrDefault(util.PprofEnabledEnv, "")
+	pprofEnabledString := env.ReadOrDefault(util.OperatorPprofEnabledEnv, "")
 	if pprofEnabled, err := pprof.IsPprofEnabled(pprofEnabledString, getOperatorEnv()); err != nil {
 		log.Errorf("Unable to check if pprof is enabled: %s", err)
 	} else if pprofEnabled {
-		port := env.ReadIntOrDefault(util.PprofPortEnv, util.PprofDefaultPort)
+		port := env.ReadIntOrDefault(util.OperatorPprofPortEnv, util.OperatorPprofDefaultPort)
 		if err := mgr.Add(pprof.NewRunnable(port, log)); err != nil {
 			log.Errorf("Unable to start pprof server: %s", err)
 		}

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -63,16 +63,16 @@ func (p *Runnable) Start(ctx context.Context) error {
 	return nil
 }
 
-// IsPprofEnabled checks if pprof is enabled based on the PPROF_ENABLED
+// IsPprofEnabled checks if pprof is enabled based on the MDB_OPERATOR_PPROF_ENABLED
 // and OPERATOR_ENV environment variables. It returns true if:
-// - PPROF_ENABLED is set to true
-// - OPERATOR_ENV is set to dev or local and PPROF_ENABLED is not set
+// - MDB_OPERATOR_PPROF_ENABLED is set to true
+// - OPERATOR_ENV is set to dev or local and MDB_OPERATOR_PPROF_ENABLED is not set
 // Otherwise, it returns false.
 func IsPprofEnabled(pprofEnabledString string, operatorEnv util.OperatorEnvironment) (bool, error) {
 	if pprofEnabledString != "" {
 		pprofEnabled, err := strconv.ParseBool(pprofEnabledString)
 		if err != nil {
-			return false, fmt.Errorf("unable to parse %s environment variable: %w", util.PprofEnabledEnv, err)
+			return false, fmt.Errorf("unable to parse %s environment variable: %w", util.OperatorPprofEnabledEnv, err)
 		}
 
 		return pprofEnabled, nil

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,82 @@
+package pprof
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+type Runnable struct {
+	port int
+	log  *zap.SugaredLogger
+}
+
+func NewRunnable(port int, log *zap.SugaredLogger) *Runnable {
+	return &Runnable{
+		port: port,
+		log:  log,
+	}
+}
+
+func (p *Runnable) Start(ctx context.Context) error {
+	pprofAddress := fmt.Sprintf("localhost:%d", p.port)
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("GET /debug/pprof/", pprof.Index)
+	handler.HandleFunc("GET /debug/pprof/cmdline/", pprof.Cmdline)
+	handler.HandleFunc("GET /debug/pprof/profile/", pprof.Profile)
+	handler.HandleFunc("GET /debug/pprof/symbol/", pprof.Symbol)
+	handler.HandleFunc("GET /debug/pprof/trace/", pprof.Trace)
+
+	server := &http.Server{
+		Addr:              pprofAddress,
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler:           handler,
+	}
+
+	go func() {
+		p.log.Infof("Starting pprof server at %s", pprofAddress)
+		if err := server.ListenAndServe(); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				p.log.Errorf("unable to start pprof server: %s", err.Error())
+			}
+		}
+		p.log.Info("pprof server stopped")
+	}()
+
+	go func() {
+		<-ctx.Done()
+		p.log.Info("Stopping pprof server")
+		if err := server.Shutdown(context.Background()); err != nil {
+			p.log.Errorf("unable to shutdown pprof server: %s", err.Error())
+		}
+	}()
+
+	return nil
+}
+
+// IsPprofEnabled checks if pprof is enabled based on the PPROF_ENABLED
+// and OPERATOR_ENV environment variables. It returns true if:
+// - PPROF_ENABLED is set to true
+// - OPERATOR_ENV is set to dev or local and PPROF_ENABLED is not set
+// Otherwise, it returns false.
+func IsPprofEnabled(pprofEnabledString string, operatorEnv util.OperatorEnvironment) (bool, error) {
+	if pprofEnabledString != "" {
+		pprofEnabled, err := strconv.ParseBool(pprofEnabledString)
+		if err != nil {
+			return false, fmt.Errorf("unable to parse %s environment variable: %w", util.PprofEnabledEnv, err)
+		}
+
+		return pprofEnabled, nil
+	}
+
+	return operatorEnv == util.OperatorEnvironmentDev || operatorEnv == util.OperatorEnvironmentLocal, nil
+}

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -62,7 +62,7 @@ func TestIsPprofEnabled(t *testing.T) {
 			pprofEnabledString: "false11",
 			operatorEnv:        util.OperatorEnvironmentProd,
 			expected:           false,
-			expectedErrMsg:     "unable to parse PPROF_ENABLED environment variable: strconv.ParseBool: parsing \"false11\": invalid syntax",
+			expectedErrMsg:     "unable to parse MDB_OPERATOR_PPROF_ENABLED environment variable: strconv.ParseBool: parsing \"false11\": invalid syntax",
 		},
 	}
 

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -1,0 +1,80 @@
+package pprof
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+func TestIsPprofEnabled(t *testing.T) {
+	tests := map[string]struct {
+		pprofEnabledString string
+		operatorEnv        util.OperatorEnvironment
+		expected           bool
+		expectedErrMsg     string
+	}{
+		"pprof enabled by default in dev": {
+			operatorEnv: util.OperatorEnvironmentDev,
+			expected:    true,
+		},
+		"pprof enabled by default in local": {
+			operatorEnv: util.OperatorEnvironmentLocal,
+			expected:    true,
+		},
+		"pprof disabled by default in prod": {
+			operatorEnv: util.OperatorEnvironmentProd,
+			expected:    false,
+		},
+		"pprof enabled in prod": {
+			pprofEnabledString: "true",
+			operatorEnv:        util.OperatorEnvironmentProd,
+			expected:           true,
+		},
+		"pprof explicitly enabled in dev": {
+			pprofEnabledString: "true",
+			operatorEnv:        util.OperatorEnvironmentDev,
+			expected:           true,
+		},
+		"pprof explicitly enabled in local": {
+			pprofEnabledString: "true",
+			operatorEnv:        util.OperatorEnvironmentLocal,
+			expected:           true,
+		},
+		"pprof disabled in dev": {
+			pprofEnabledString: "false",
+			operatorEnv:        util.OperatorEnvironmentDev,
+			expected:           false,
+		},
+		"pprof disabled in local": {
+			pprofEnabledString: "false",
+			operatorEnv:        util.OperatorEnvironmentLocal,
+			expected:           false,
+		},
+		"pprof disabled explicitly in prod": {
+			pprofEnabledString: "false",
+			operatorEnv:        util.OperatorEnvironmentProd,
+			expected:           false,
+		},
+		"pprof misconfigured": {
+			pprofEnabledString: "false11",
+			operatorEnv:        util.OperatorEnvironmentProd,
+			expected:           false,
+			expectedErrMsg:     "unable to parse PPROF_ENABLED environment variable: strconv.ParseBool: parsing \"false11\": invalid syntax",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := IsPprofEnabled(test.pprofEnabledString, test.operatorEnv)
+			if test.expectedErrMsg != "" {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedErrMsg, err.Error())
+			}
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -155,9 +155,9 @@ const (
 	MinimumScramSha256MdbVersion      = "4.0.0"
 
 	// pprof variables
-	PprofEnabledEnv  = "PPROF_ENABLED"
-	PprofPortEnv     = "PPROF_PORT"
-	PprofDefaultPort = 10081
+	OperatorPprofEnabledEnv  = "MDB_OPERATOR_PPROF_ENABLED"
+	OperatorPprofPortEnv     = "MDB_OPERATOR_PPROF_PORT"
+	OperatorPprofDefaultPort = 10081
 
 	// these were historically used and constituted a security issue—if set they should be changed
 	InvalidKeyFileContents         = "DUMMYFILE"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -154,6 +154,11 @@ const (
 	LDAP                              = "LDAP"
 	MinimumScramSha256MdbVersion      = "4.0.0"
 
+	// pprof variables
+	PprofEnabledEnv  = "PPROF_ENABLED"
+	PprofPortEnv     = "PPROF_PORT"
+	PprofDefaultPort = 10081
+
 	// these were historically used and constituted a security issue—if set they should be changed
 	InvalidKeyFileContents         = "DUMMYFILE"
 	InvalidAutomationAgentPassword = "D9XK2SfdR2obIevI9aKsYlVH" //nolint //Part of the algorithm


### PR DESCRIPTION
# Summary

pprof can be configured by two new environment variables:
 - `MDB_OPERATOR_PPROF_ENABLED` - together with `OPERATOR_ENV` controls enabling of pprof server. Basically the rule for enabling pprof is defined in `IsPprofEnabled` function: https://github.com/mongodb/mongodb-kubernetes/blob/94fc9eac3f36cc7df096e86b5eef8ce9fed02f58/pkg/pprof/pprof.go#L66-L70
 - `MDB_OPERATOR_PPROF_PORT` - by default it is set to 10081

It's more than `_ "net/http/pprof"` one liner for a couple of reasons:
- having the possibility to enable pprof for the production environment is necessary for debugging memory issues and it does not add much overhead either https://stackoverflow.com/a/64057856. Previously it was only enabled for dev and local
- exposing by default pprof server in production is a no-go in many organisations due to sensitive information exposed or just exposing some port is enough to alert security staff https://cwe.mitre.org/data/definitions/200.html
standard way of starting pprof by is discouraged for lack of configurability and security issues
   - G114: Use of net/http serve function that has no support for setting timeouts (gosec)
   - G108: Profiling endpoint is automatically exposed on /debug/pprof (gosec)
```go
import _ "net/http/pprof"

[...]
  go func() {
    log.Println(http.ListenAndServe("localhost:10081", nil))
  }()
```

## Proof of Work

pprof debug page is available at default `localhost:10081` port
![Screenshot 2025-05-09 at 16 33 59](https://github.com/user-attachments/assets/44c0c900-2dc5-45ff-b1de-917302a052b7)


Added unit tests that verify `IsPprofEnabled` function. Shutdown is also working:
```go
2025-05-09T16:32:56.750+0200	INFO	pprof/pprof.go:57	Stopping pprof server
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:235	Shutdown signal received, waiting for all workers to finish	{"controller": "mongodbuser-controller"}
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:237	All workers finished	{"controller": "mongodbmulticluster-controller"}
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:237	All workers finished	{"controller": "mongodbreplicaset-controller"}
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:237	All workers finished	{"controller": "mongodbstandalone-controller"}
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:237	All workers finished	{"controller": "mongodbuser-controller"}
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:237	All workers finished	{"controller": "opsmanager-controller"}
2025-05-09T16:32:56.750+0200	INFO	controller/controller.go:237	All workers finished	{"controller": "mongodbshardedcluster-controller"}
2025-05-09T16:32:56.750+0200	INFO	manager/internal.go:537	Stopping and waiting for caches
2025-05-09T16:32:56.750+0200	INFO	pprof/pprof.go:52	pprof server stopped
```

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
