### PR TITLE
Ignore X.509 users in scram secret collision validation

### DIFF
--- a/mongodb-community-operator/controllers/validation/validation.go
+++ b/mongodb-community-operator/controllers/validation/validation.go
@@ -83,16 +83,18 @@ func validateUsers(mdb mdbv1.MongoDBCommunity) error {
 			connectionStringSecretNameMap[connectionStringSecretName] = user
 		}
 
-		// Ensure no collisions in the secret holding scram credentials
-		scramSecretName := user.ScramCredentialsSecretName
-		if previousUser, exists := scramSecretNameMap[scramSecretName]; exists {
-			scramSecretNameCollisions = append(scramSecretNameCollisions,
-				fmt.Sprintf(`[scram secret name: "%s" for user: "%s" and user: "%s"]`,
-					scramSecretName,
-					previousUser.Username,
-					user.Username))
-		} else {
-			scramSecretNameMap[scramSecretName] = user
+		if user.Database != constants.ExternalDB {
+			// Ensure no collisions in the secret holding scram credentials
+			scramSecretName := user.ScramCredentialsSecretName
+			if previousUser, exists := scramSecretNameMap[scramSecretName]; exists {
+				scramSecretNameCollisions = append(scramSecretNameCollisions,
+					fmt.Sprintf(`[scram secret name: "%s" for user: "%s" and user: "%s"]`,
+						scramSecretName,
+						previousUser.Username,
+						user.Username))
+			} else {
+				scramSecretNameMap[scramSecretName] = user
+			}
 		}
 
 		if user.Database == constants.ExternalDB {

--- a/mongodb-community-operator/controllers/validation/validation.go
+++ b/mongodb-community-operator/controllers/validation/validation.go
@@ -83,9 +83,9 @@ func validateUsers(mdb mdbv1.MongoDBCommunity) error {
 			connectionStringSecretNameMap[connectionStringSecretName] = user
 		}
 
-		if user.Database != constants.ExternalDB {
-			// Ensure no collisions in the secret holding scram credentials
-			scramSecretName := user.ScramCredentialsSecretName
+		// Ensure no collisions in the secret holding scram credentials
+		scramSecretName := user.ScramCredentialsSecretName
+		if scramSecretName != "" {
 			if previousUser, exists := scramSecretNameMap[scramSecretName]; exists {
 				scramSecretNameCollisions = append(scramSecretNameCollisions,
 					fmt.Sprintf(`[scram secret name: "%s" for user: "%s" and user: "%s"]`,


### PR DESCRIPTION
# Summary
During validation, users without the scramCredentialsSecretName parameter are [added](https://github.com/mongodb/mongodb-kubernetes/blob/7fa6687dd12bc523f6d5df834672c849b1b737ed/mongodb-community-operator/controllers/validation/validation.go#L95) to a dictionary with an empty key, which leads to the error mentioned in issue #122.

Closes #122

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
