### PR TITLE
CLOUDP-318984: Print image digest SHA256 in build logs

### DIFF
--- a/lib/sonar/builders/docker.py
+++ b/lib/sonar/builders/docker.py
@@ -48,7 +48,10 @@ def docker_build(
 
         client = docker_client()
         image = client.images.get(image_name)
-        logger.info("Successfully build docker-image, SHA256: {}".format(image.id))
+        logger.info("successfully build docker-image, SHA256: {}".format(image.id))
+
+        span = trace.get_current_span()
+        span.set_attribute("mck.image.sha256", image.id)
 
         return image
     except docker.errors.APIError as e:

--- a/lib/sonar/builders/docker.py
+++ b/lib/sonar/builders/docker.py
@@ -47,7 +47,10 @@ def docker_build(
         )
 
         client = docker_client()
-        return client.images.get(image_name)
+        image = client.images.get(image_name)
+        logger.info("Successfully build docker-image, SHA256: {}".format(image.id))
+
+        return image
     except docker.errors.APIError as e:
         raise SonarAPIError from e
 

--- a/lib/sonar/builders/docker.py
+++ b/lib/sonar/builders/docker.py
@@ -48,7 +48,7 @@ def docker_build(
 
         client = docker_client()
         image = client.images.get(image_name)
-        logger.info("successfully build docker-image, SHA256: {}".format(image.id))
+        logger.info("successfully built docker-image, SHA256: {}".format(image.id))
 
         span = trace.get_current_span()
         span.set_attribute("mck.image.sha256", image.id)


### PR DESCRIPTION
# Summary

CLOUDP-318984: Print image digest SHA256 in build logs

## Proof of Work

```
[2025/05/15 10:18:10.029] INFO     2025-05-15 08:18:10,028 [docker]  path: .
[2025/05/15 10:18:10.029] INFO     2025-05-15 08:18:10,029 [docker]  dockerfile: /data/mci/29b9d13cde870de4a9f51dadb28d48e9/tmp/tmpczprlyge
[2025/05/15 10:18:10.029] INFO     2025-05-15 08:18:10,029 [docker]  tag: sonar-docker-build-9574
[2025/05/15 10:18:10.029] INFO     2025-05-15 08:18:10,029 [docker]  buildargs: {'imagebase': '268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/ops-manager-context:6825a2b7cba4af0007d7845c'}
[2025/05/15 10:18:10.029] INFO     2025-05-15 08:18:10,029 [docker]  labels: {}
[2025/05/15 10:18:10.029] INFO     2025-05-15 08:18:10,029 [docker]  executing cli docker build: docker buildx build --load --progress plain . -f /data/mci/29b9d13cde870de4a9f51dadb28d48e9/tmp/tmpczprlyge -t sonar-docker-build-9574 --build-arg imagebase=<...>.amazonaws.com/dev/ops-manager-context:6825a2b7cba4af0007d7845c --platform linux/amd64
[2025/05/15 10:20:17.794] INFO     2025-05-15 08:20:17,794 [docker]  Successfully build docker-image, SHA256: sha256:2a686352db2cb409f23d17da71ece6f9308ad89ead6daa118dbb24e0a915dc5c
[2025/05/15 10:20:17.794] [ops-manager-build/docker_build] docker-image-push: <...>.amazonaws.com/dev/mongodb-enterprise-ops-manager-ubi:8.0.7
```

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
