### PR TITLE
Cherry-pick: Rename init container (#64)

### DIFF
--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	appDBServiceAccount    = "mongodb-kubernetes-appdb"
-	InitAppDbContainerName = "mongodb-enterprise-init-appdb"
+	InitAppDbContainerName = "mongodb-kubernetes-init-appdb"
 	// AppDB environment variable names
 	InitAppdbVersionEnv          = "INIT_APPDB_VERSION"
 	podNamespaceEnv              = "POD_NAMESPACE"

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -48,7 +48,7 @@ const (
 	databaseLivenessProbeCommand  = "/opt/scripts/probe.sh"
 	databaseReadinessProbeCommand = "/opt/scripts/readinessprobe"
 
-	InitDatabaseContainerName = "mongodb-enterprise-init-database"
+	InitDatabaseContainerName = "mongodb-kubernetes-init-database"
 
 	// Database environment variable names
 	InitDatabaseVersionEnv = "INIT_DATABASE_VERSION"


### PR DESCRIPTION
# Summary

All our init images have been renamed from mongodb-enterprise- to mongodb-kubernetes-
There was a mistake in
`controllers/operator/construct/appdb_construction.go`

---------

# Summary

<!-- Enter your issue summary here.-->

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
