### PR TITLE
Cherry-pick: Fix configure_docker_auth Evergreen credentials caching (#137)

### DIFF
--- a/scripts/dev/configure_docker_auth.sh
+++ b/scripts/dev/configure_docker_auth.sh
@@ -44,7 +44,7 @@ remove_element() {
 check_docker_daemon_is_running
 
 if [[ -f ~/.docker/config.json ]]; then
-  if [[ "${RUNNING_IN_EVG:-""}" == "true" ]]; then
+  if [[ "${RUNNING_IN_EVG:-"false"}" != "true" ]]; then
     # when running locally we don't need to docker login all the time - we can do it once in 11 hours (ECR tokens expire each 12 hours)
     if [[ -n "$(find ~/.docker/config.json -mmin -360 -type f)" ]] &&
       grep "quay.io" -q ~/.docker/config.json && # TODO to be removed at public preview stage of community-search


### PR DESCRIPTION
# Summary
`configure_docker_auth.sh` should only try to skip logging in when not running on Evergreen, according to its comments, but the shell script condition was inverted to only enable the early exit on Evergreen, not locally.

This now causes issues on Evergreen where preceding runs might have left stale quay.io registry credentials. Always configuring docker auth on CI ensures that our credentials override any stale ones.

## Proof of Work
No CI tasks output `Docker credentials are up to date - not performing the new login!`.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

# Summary

<!-- Enter your issue summary here.-->

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
