### PR TITLE
Skip quay login when building OpenShift bundles

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -587,7 +587,6 @@ tasks:
       - func: clone
       - func: setup_aws
       - func: configure_docker_auth
-      - func: quay_login
       - func: setup_prepare_openshift_bundles
       - func: prepare_openshift_bundles
       - func: update_evergreen_expansions


### PR DESCRIPTION
# Summary

The EVG `quay_login` step is overriding the credentials required for building the bundle with all the images.

## Proof of Work

Successful patch: https://spruce.mongodb.com/version/682ebab0a50ac10007169b43

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
