### PR TITLE
Aggregating code snippets output branches

### DIFF
--- a/scripts/code_snippets/cherry_pick_snippet_updates.sh
+++ b/scripts/code_snippets/cherry_pick_snippet_updates.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+release_branch="$1"
+if [[ -z "${release_branch}" ]]; then
+  echo "Usage: $0 <release-branch>"
+  exit 1
+fi
+current_date=$(date "+%Y%m%d")
+branch_pattern="origin/meko-snippets-update-${current_date}*"
+new_branch_name="mck-snippets-update-cherry-picked-${current_date}-$(date "+%H%M%S")"
+
+echo "Fetching from origin..."
+git fetch origin
+
+echo "Looking for branches matching '${branch_pattern}'..."
+branches_to_pick=()
+while IFS= read -r line; do
+    branches_to_pick+=("$line")
+done < <(git branch -r --list "${branch_pattern}" | sed 's/^[[:space:]]*//')
+
+if [[ ${#branches_to_pick[@]} -eq 0 ]]; then
+  echo "No branches found matching '${branch_pattern}'. Exiting."
+  exit 0
+fi
+
+echo "Found branches to cherry-pick:"
+printf "  %s\n" "${branches_to_pick[@]}"
+
+echo "Creating new branch '${new_branch_name}' from 'origin/${release_branch}'..."
+git checkout -b "${new_branch_name}" "origin/${release_branch}"
+
+echo "Cherry-picking commits..."
+for branch in "${branches_to_pick[@]}"; do
+  echo "  Picking from ${branch}..."
+  git cherry-pick "${branch}" || true
+
+  # automatically resolve cherry-pick conflicts by taking whatever it is in the cherry-picked commit
+  # in case there are no conflicts, this will do nothing
+  git status --porcelain | grep "^UU" | awk '{print $2}' | xargs -I {} git checkout --theirs {} || true
+  git status --porcelain | grep "^UU" | awk '{print $2}' | xargs -I {} git add {} || true
+  # || true for ignoring errors if there are no conflicts
+  git cherry-pick --continue || true
+done
+
+echo "New branch '${new_branch_name}' created with cherry-picked commits."
+echo "Push with: git push origin ${new_branch_name}"

--- a/scripts/code_snippets/cherry_pick_snippet_updates.sh
+++ b/scripts/code_snippets/cherry_pick_snippet_updates.sh
@@ -7,8 +7,8 @@ if [[ -z "${release_branch}" ]]; then
   echo "Usage: $0 <release-branch>"
   exit 1
 fi
-current_date=$(date "+%Y%m%d")
-branch_pattern="origin/meko-snippets-update-${current_date}*"
+current_date=$(date "+%Y%m%d")s
+branch_pattern="origin/mck-snippets-update-${current_date}*"
 new_branch_name="mck-snippets-update-cherry-picked-${current_date}-$(date "+%H%M%S")"
 
 echo "Fetching from origin..."

--- a/scripts/code_snippets/sample_commit_output.sh
+++ b/scripts/code_snippets/sample_commit_output.sh
@@ -5,7 +5,7 @@ source scripts/dev/set_env_context.sh
 
 if [ "${COMMIT_OUTPUT:-false}" = true ]; then
   echo "Pushing output files"
-  branch="meko-snippets-update-$(date "+%Y%m%d%H%M%S")"
+  branch="mck-snippets-update-$(date "+%Y%m%d%H%M%S")"
   git checkout -b "${branch}"
   git reset
   git add public/architectures/**/*.out


### PR DESCRIPTION
# Summary

Each code snippets task creates a separate branch with updated snippets outputs. It's tedious to manually cherry-pick them after the test finishes. 

This scripts semi-automates cherry-picking all code snippets update branches pushed by the update scripts. 

It's not a final nor bulletproof solution (we should not push the outputs as separate branches in the first place), but it's an improvement nevertheless that avoids cherry-picking the branches manually. 

## Proof of Work

```
scripts/code_snippets/cherry_pick_snippet_updates.sh release-1.1
Fetching from origin...
Looking for branches matching 'origin/mck-snippets-update-20250522*'...
Found branches to cherry-pick:
  origin/mck-snippets-update-20250522141139
  origin/mck-snippets-update-20250522150715
  origin/mck-snippets-update-20250522151200
Creating new branch 'mck-snippets-update-cherry-picked-20250522-180736' from 'origin/release-1.1'...
branch 'mck-snippets-update-cherry-picked-20250522-180736' set up to track 'origin/release-1.1'.
Switched to a new branch 'mck-snippets-update-cherry-picked-20250522-180736'
Cherry-picking commits...
  Picking from origin/mck-snippets-update-20250522141139...
[mck-snippets-update-cherry-picked-20250522-180736 945fc0c5f] Update code snippets outputs
 Author: Evergreen <kubernetes-hosted-team@mongodb.com>
 Date: Thu May 22 14:11:40 2025 +0000
 5 files changed, 54 insertions(+), 103 deletions(-)
error: no cherry-pick or revert in progress
fatal: cherry-pick failed
  Picking from origin/mck-snippets-update-20250522150715...
[mck-snippets-update-cherry-picked-20250522-180736 93c6ebcfb] Update code snippets outputs
 Author: Evergreen <kubernetes-hosted-team@mongodb.com>
 Date: Thu May 22 15:07:15 2025 +0000
 10 files changed, 87 insertions(+), 74 deletions(-)
error: no cherry-pick or revert in progress
fatal: cherry-pick failed
  Picking from origin/mck-snippets-update-20250522151200...
Auto-merging public/architectures/setup-multi-cluster/setup-cert-manager/output/0216_helm_install_cert_manager.out
CONFLICT (content): Merge conflict in public/architectures/setup-multi-cluster/setup-cert-manager/output/0216_helm_install_cert_manager.out
Auto-merging public/architectures/setup-multi-cluster/setup-gke/output/0030_verify_access_to_clusters.out
CONFLICT (content): Merge conflict in public/architectures/setup-multi-cluster/setup-gke/output/0030_verify_access_to_clusters.out
Auto-merging public/architectures/setup-multi-cluster/setup-operator/output/0200_kubectl_mongodb_configure_multi_cluster.out
CONFLICT (content): Merge conflict in public/architectures/setup-multi-cluster/setup-operator/output/0200_kubectl_mongodb_configure_multi_cluster.out
Auto-merging public/architectures/setup-multi-cluster/setup-operator/output/0210_helm_install_operator.out
CONFLICT (content): Merge conflict in public/architectures/setup-multi-cluster/setup-operator/output/0210_helm_install_operator.out
Auto-merging public/architectures/setup-multi-cluster/setup-operator/output/0211_check_operator_deployment.out
CONFLICT (content): Merge conflict in public/architectures/setup-multi-cluster/setup-operator/output/0211_check_operator_deployment.out
error: could not apply e5968139c... Update code snippets outputs
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
hint: Disable this message with "git config advice.mergeConflict false"
Updated 1 path from the index
Updated 1 path from the index
Updated 1 path from the index
Updated 1 path from the index
Updated 1 path from the index
[mck-snippets-update-cherry-picked-20250522-180736 ae75b3ca5] Update code snippets outputs
 Author: Evergreen <kubernetes-hosted-team@mongodb.com>
 Date: Thu May 22 15:12:00 2025 +0000
 14 files changed, 70 insertions(+), 70 deletions(-)
New branch 'mck-snippets-update-cherry-picked-20250522-180736' created with cherry-picked commits.
Push with: git push origin mck-snippets-update-cherry-picked-20250522-180736
```
