### PR TITLE
[CODEOWNERS] Remove @dan-mckean @vinilage from helm_chart/crds/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @mongodb/kubernetes-hosted
-
-helm_chart/crds/ @dan-mckean @vinilage


### PR DESCRIPTION
# Summary

Based on discussion in slack thread we are removing @dan-mckean and @vinilage form /helm-chart/crds/ codeowners. This means engineers will need to explicitly ask them to review API changes in PRs - if that is necessary and @dan-mckean or @vinilage aren't already aware of the changes through other means.

## Proof of Work

No need for PoW. CODEOWNERS file just needs to be valid.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
