### PR TITLE
CLOUDP-321398: Bump Cloud Manager version for MongoDB Agent container images for MMS release branch v20250604

### DIFF
--- a/release.json
+++ b/release.json
@@ -98,8 +98,8 @@
       ],
       "opsManagerMapping": {
         "Description": "These are the agents from which we start supporting static containers.",
-        "cloud_manager": "13.34.0.9465-1",
-        "cloud_manager_tools": "100.12.0",
+        "cloud_manager": "13.35.0.9498-1",
+        "cloud_manager_tools": "100.12.1",
         "ops_manager": {
           "6.0.25": {
             "agent_version": "12.0.33.7866-1",


### PR DESCRIPTION

_Opened by Private Cloud Tools (PCT)_.

# Ticket
[CLOUDP-321398](https://jira.mongodb.org/browse/CLOUDP-321398)

# Description
Bump Cloud Manager version for MongoDB Agent container images for mms version v20250604.

# Reviewer Checklist

Before merging this PR, verify the following:
- [ ] the following tasks are passing in Evergreen:
  - `release_agent` task (variant: `release_agent`)
- [ ] the `cloud_manager` was updated correctly
- [ ] the `cloud_manager_tools` was updated correctly

