### PR TITLE
CLOUDP-324668 - Optimized mongodb-agent docker layers

### DIFF
--- a/docker/mongodb-agent-non-matrix/Dockerfile
+++ b/docker/mongodb-agent-non-matrix/Dockerfile
@@ -1,6 +1,17 @@
 ARG imagebase
 FROM ${imagebase} as base
 
+FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
+
+RUN microdnf install -y tar gzip && microdnf clean all
+
+COPY --from=base /data/mongodb-agent.tar.gz /data/mongodb-tools.tgz /tmp/
+RUN tar xfz /tmp/mongodb-agent.tar.gz -C /opt && \
+    tar xfz /tmp/mongodb-tools.tgz -C /opt && \
+    rm /tmp/*.tgz /tmp/*.tar.gz
+
+RUN chmod +x /opt/mongodb-mms-automation-agent-*/mongodb-mms-automation-agent
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 ARG version
@@ -15,46 +26,32 @@ LABEL name="MongoDB Agent" \
 
 # Replace libcurl-minimal and curl-minimal with the full versions
 # https://bugzilla.redhat.com/show_bug.cgi?id=1994521
-RUN  microdnf install -y libssh libpsl libbrotli \
+RUN    microdnf install -y libssh libpsl libbrotli \
     && microdnf download curl libcurl \
     && rpm -Uvh --nodeps --replacefiles "*curl*$( uname -i ).rpm" \
-    && microdnf remove -y libcurl-minimal curl-minimal
-
-RUN microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper
-# Copy-pasted from https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-red-hat-tarball/
-RUN microdnf install -y --disableplugin=subscription-manager \
- cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs openldap openssl xz-libs
-# Dependencies for the Agent
-RUN microdnf install -y --disableplugin=subscription-manager  --setopt=install_weak_deps=0 \
-        net-snmp \
-        net-snmp-agent-libs
-RUN microdnf install -y --disableplugin=subscription-manager \
-    hostname tar gzip procps jq \
+    && microdnf remove -y libcurl-minimal curl-minimal \
+    && microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper \
+    && microdnf install -y --disableplugin=subscription-manager \
+    cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs openldap openssl xz-libs \
+    && microdnf install -y --disableplugin=subscription-manager  --setopt=install_weak_deps=0 \
+           net-snmp \
+           net-snmp-agent-libs \
+    && microdnf install -y --disableplugin=subscription-manager \
+       hostname tar gzip procps jq \
     && microdnf upgrade -y  \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all \
+    && mkdir -p /agent \
+             /var/lib/mongodb-mms-automation \
+             /var/log/mongodb-mms-automation \
+             /var/lib/automation/config \
+    && chmod -R +wr /var/log/mongodb-mms-automation/ \
+    && touch /var/log/mongodb-mms-automation/readiness.log \
+    && chmod ugo+rw /var/log/mongodb-mms-automation/readiness.log \
+    && chmod -R +r /var/lib/automation/config
 
-RUN mkdir -p /agent \
-    && mkdir -p /var/lib/mongodb-mms-automation \
-      && mkdir -p /var/log/mongodb-mms-automation/ \
-      && chmod -R +wr /var/log/mongodb-mms-automation/ \
-      # ensure that the agent user can write the logs in OpenShift
-      && touch /var/log/mongodb-mms-automation/readiness.log \
-      && chmod ugo+rw /var/log/mongodb-mms-automation/readiness.log
-
-
-COPY --from=base /data/mongodb-agent.tar.gz /agent
-COPY --from=base /data/mongodb-tools.tgz /agent
 COPY --from=base /data/LICENSE /licenses/LICENSE
-
-RUN tar xfz /agent/mongodb-agent.tar.gz \
-    && mv mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent \
-    && chmod +x /agent/mongodb-agent \
-    && mkdir -p /var/lib/automation/config \
-    && chmod -R +r /var/lib/automation/config \
-    && rm /agent/mongodb-agent.tar.gz \
-    && rm -r mongodb-mms-automation-agent-*
-
-RUN tar xfz /agent/mongodb-tools.tgz --directory /var/lib/mongodb-mms-automation/ && rm /agent/mongodb-tools.tgz
+COPY --from=builder /opt/mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent
+COPY --from=builder /opt/mongodb-database-tools-*/bin/ /usr/local/bin/
 
 USER 2000
 CMD ["/agent/mongodb-agent", "-cluster=/var/lib/automation/config/automation-config.json"]

--- a/docker/mongodb-agent/Dockerfile
+++ b/docker/mongodb-agent/Dockerfile
@@ -1,5 +1,27 @@
 ARG imagebase
-FROM ${imagebase} as base
+FROM ${imagebase} AS base
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
+
+RUN microdnf install -y tar gzip && microdnf clean all
+
+COPY --from=base /data/mongodb_tools_ubi.tgz /data/mongodb_agent_ubi.tgz /tmp/
+
+RUN tar xfz /tmp/mongodb_tools_ubi.tgz -C /opt && \
+    tar xfz /tmp/mongodb_agent_ubi.tgz -C /opt && \
+    rm /tmp/*.tgz
+
+RUN chmod +x /opt/mongodb-mms-automation-agent-*/mongodb-mms-automation-agent
+RUN chmod +x /opt/mongodb-database-tools-*/bin/*
+
+COPY --from=base /data/probe.sh \
+                 /data/readinessprobe \
+                 /data/version-upgrade-hook \
+                 /data/agent-launcher-lib.sh \
+                 /data/agent-launcher.sh \
+                 /opt/scripts/
+
+RUN chmod +x  /opt/scripts/*
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
@@ -13,51 +35,37 @@ LABEL name="MongoDB Agent" \
       release="1" \
       maintainer="support@mongodb.com"
 
-COPY --from=base /data/probe.sh /opt/scripts/probe.sh
-COPY --from=base /data/readinessprobe /opt/scripts/readinessprobe
-COPY --from=base /data/version-upgrade-hook /opt/scripts/version-upgrade-hook
-COPY --from=base /data/agent-launcher-lib.sh /opt/scripts/agent-launcher-lib.sh
-COPY --from=base /data/agent-launcher.sh /opt/scripts/agent-launcher.sh
-COPY --from=base /data/LICENSE /licenses/LICENSE
-
-# Replace libcurl-minimal and curl-minimal with the full versions
-# https://bugzilla.redhat.com/show_bug.cgi?id=1994521
-RUN  microdnf install -y libssh libpsl libbrotli \
+RUN    microdnf install -y libssh libpsl libbrotli \
     && microdnf download curl libcurl \
     && rpm -Uvh --nodeps --replacefiles "*curl*$( uname -i ).rpm" \
-    && microdnf remove -y libcurl-minimal curl-minimal
-
-RUN microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper
-# Copy-pasted from https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-red-hat-tarball/
-RUN microdnf install -y --disableplugin=subscription-manager \
- cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs openldap openssl xz-libs
-# Dependencies for the Agent
-RUN microdnf install -y --disableplugin=subscription-manager  --setopt=install_weak_deps=0 \
-        net-snmp \
-        net-snmp-agent-libs
-RUN microdnf install -y --disableplugin=subscription-manager \
-    hostname tar gzip procps jq \
+    && microdnf remove -y libcurl-minimal curl-minimal \
+    && microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper \
+    && microdnf install -y --disableplugin=subscription-manager \
+    cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs openldap openssl xz-libs \
+    && microdnf install -y --disableplugin=subscription-manager  --setopt=install_weak_deps=0 \
+           net-snmp \
+           net-snmp-agent-libs \
+    && microdnf install -y --disableplugin=subscription-manager \
+       hostname tar gzip procps jq \
     && microdnf upgrade -y  \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all \
+    && mkdir -p /agent \
+             /var/lib/mongodb-mms-automation \
+             /var/log/mongodb-mms-automation \
+             /var/lib/automation/config \
+    && chmod -R +wr /var/log/mongodb-mms-automation/ \
+    && touch /var/log/mongodb-mms-automation/readiness.log \
+    && chmod ugo+rw /var/log/mongodb-mms-automation/readiness.log \
+    && chmod -R +r /var/lib/automation/config
 
+COPY --from=base /data/LICENSE /licenses/LICENSE
 
-COPY --from=base /data/mongodb_tools_ubi.tgz /tools/mongodb_tools.tgz
-COPY --from=base /data/mongodb_agent_ubi.tgz /agent/mongodb_agent.tgz
+COPY --from=builder /opt/scripts/* /opt/scripts/
+COPY --from=builder /opt/mongodb-database-tools-*/bin /tools
+COPY --from=builder /opt/mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent
 
-RUN tar xfz /tools/mongodb_tools.tgz
-RUN mv mongodb-database-tools-*/bin/* /tools
-RUN chmod +x /tools/*
-RUN rm /tools/mongodb_tools.tgz
-RUN rm -rf /mongodb-database-tools-*
-
-RUN tar xfz /agent/mongodb_agent.tgz
-RUN mv mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent
-RUN chmod +x /agent/mongodb-agent
-RUN rm /agent/mongodb_agent.tgz
-RUN rm -rf mongodb-mms-automation-agent-*
-
-RUN mkdir -p /var/lib/automation/config
-RUN chmod -R +r /var/lib/automation/config
+RUN mkdir -p /var/lib/automation/config \
+    && chmod -R +r /var/lib/automation/config
 
 USER 2000
 


### PR DESCRIPTION
# Summary

This is a PoC of building agent's docker images with a better layer packing to avoid unnecessarily duplicating binaries/archives there.

It works simply by batching all filesystem manipulations into one RUN and moving some .tgz unpacking into the previous build stages.

What's left: 
- [x] Checking agent images built for static architecture
- [ ] Checking agent images built for AppDB and MongoDBCommunity (we don't build them as part of normal patches, only on bumps)

## Proof of Work


**Before (dive)**:
```
$ dive quay.io/mongodb/mongodb-agent-ubi:13.35.0.9498-1_1.1.0
[...]
Image name: quay.io/mongodb/mongodb-agent-ubi:13.35.0.9498-1_1.1.0
Total Image size: 1.1 GB
Potential wasted space: 568 MB
Image efficiency score: 51 %
```

**After (dive)**:
```
$ dive 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-agent-ubi:13.35.0.9498-1_684be130a0378600072c885c
Image name: 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-agent-ubi:13.35.0.9498-1_684be130a0378600072c885c  
Total Image size: 581 MB                                                                                                
Potential wasted space: 33 MB                                                                                           
Image efficiency score: 96 %       
```

**Before**: 
For the agents used in static arch we have the following image before the change: 
```
$ docker inspect quay.io/mongodb/mongodb-agent-ubi:13.35.0.9498-1_1.1.0 | jq '.[0].Size' | numfmt --to=si
1.2G

$ docker history quay.io/mongodb/mongodb-agent-ubi:13.35.0.9498-1_1.1.0
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
de7b13198c63   8 days ago    HEALTHCHECK &{["CMD-SHELL" "ls /opt/scripts/…   0B        buildkit.dockerfile.v0
<missing>      8 days ago    USER 2000                                       0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   135MB     buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   139MB     buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   0B        buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   69.7MB    buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   139MB     buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   139MB     buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/mongodb_agent_ubi.tgz /agent/mong…   56.6MB    buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/mongodb_tools_ubi.tgz /tools/mong…   69.7MB    buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   20.7MB    buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   24.6MB    buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   52.5MB    buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   46.8MB    buildkit.dockerfile.v0
<missing>      8 days ago    RUN |1 version=13.35.0.9498-1_1.1.0 /bin/sh …   25.2MB    buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/LICENSE /licenses/LICENSE # build…   160B      buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/agent-launcher.sh /opt/scripts/ag…   10kB      buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/agent-launcher-lib.sh /opt/script…   5.31kB    buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/version-upgrade-hook /opt/scripts…   49.3MB    buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/readinessprobe /opt/scripts/readi…   54.9MB    buildkit.dockerfile.v0
<missing>      8 days ago    COPY /data/probe.sh /opt/scripts/probe.sh # …   1.02kB    buildkit.dockerfile.v0
<missing>      8 days ago    LABEL name=MongoDB Agent version=13.35.0.949…   0B        buildkit.dockerfile.v0
<missing>      8 days ago    ARG version=13.35.0.9498-1_1.1.0                0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL "build-date"="2025-0…   104MB
<missing>      4 weeks ago   /bin/sh -c #(nop) COPY file:58cc94f5b3b2d60d…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) CMD ["/bin/bash"]             0B
<missing>      4 weeks ago   /bin/sh -c #(nop) COPY file:b37d593713ee21ad…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) COPY dir:9782e2e1b0ca599e0…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) ENV container oci             0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL io.openshift.tags="m…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL io.openshift.expose-…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL io.k8s.display-name=…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL io.k8s.description="…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL description="The Uni…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL summary="Provides th…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL com.redhat.license_t…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL com.redhat.component…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL url="https://www.red…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL vendor="Red Hat, Inc…   0B
<missing>      4 weeks ago   /bin/sh -c #(nop) LABEL maintainer="Red Hat,…   0B
```

**After**:
Getting the image build in this [PR's patch](https://spruce.mongodb.com/version/684be130a0378600072c885c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC):
```
$ docker inspect 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-agent-ubi:13.35.0.9498-1_684be130a0378600072c885c | jq '.[0].Size' | numfmt --to=si
581M

$ docker history 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-agent-ubi:13.35.0.9498-1_684be130a0378600072c885c
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
1431b4573bf2   3 hours ago   HEALTHCHECK &{["CMD-SHELL" "ls /opt/scripts/…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago   USER 2000                                       0B        buildkit.dockerfile.v0
<missing>      3 hours ago   RUN |1 version=13.35.0.9498-1_684be130a03786…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago   COPY /opt/mongodb-mms-automation-agent-*/mon…   135MB     buildkit.dockerfile.v0
<missing>      3 hours ago   COPY /opt/mongodb-database-tools-*/bin /tool…   139MB     buildkit.dockerfile.v0
<missing>      3 hours ago   COPY /opt/scripts/* /opt/scripts/ # buildkit    104MB     buildkit.dockerfile.v0
<missing>      3 hours ago   COPY /data/LICENSE /licenses/LICENSE # build…   160B      buildkit.dockerfile.v0
<missing>      3 hours ago   RUN |1 version=13.35.0.9498-1_684be130a03786…   98.1MB    buildkit.dockerfile.v0
<missing>      3 hours ago   LABEL name=MongoDB Agent version=13.35.0.949…   0B        buildkit.dockerfile.v0
<missing>      3 hours ago   ARG version=13.35.0.9498-1_684be130a03786000…   0B        buildkit.dockerfile.v0
<missing>      3 days ago    /bin/sh -c #(nop) LABEL "build-date"="2025-0…   104MB
<missing>      3 days ago    /bin/sh -c #(nop) COPY file:58cc94f5b3b2d60d…   0B
<missing>      3 days ago    /bin/sh -c #(nop) CMD ["/bin/bash"]             0B
<missing>      3 days ago    /bin/sh -c #(nop) COPY file:b37d593713ee21ad…   0B
<missing>      3 days ago    /bin/sh -c #(nop) COPY dir:bac616b15ea24c824…   0B
<missing>      3 days ago    /bin/sh -c #(nop) ENV container oci             0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL io.openshift.tags="m…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL io.openshift.expose-…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL io.k8s.display-name=…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL io.k8s.description="…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL description="The Uni…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL summary="Provides th…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL com.redhat.license_t…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL com.redhat.component…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL url="https://www.red…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL vendor="Red Hat, Inc…   0B
<missing>      3 days ago    /bin/sh -c #(nop) LABEL maintainer="Red Hat,…   0B
```

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
