### PR TITLE
remove trailing commas and set consistent yaml width

### DIFF
--- a/scripts/evergreen/release/helm_files_handler.py
+++ b/scripts/evergreen/release/helm_files_handler.py
@@ -78,6 +78,7 @@ def update_standalone_installer(yaml_file_path: str, version: str):
     yaml.explicit_start = True  # Ensure explicit `---` in the output
     yaml.indent(mapping=2, sequence=4, offset=2)  # Align with tab width produced by Helm
     yaml.preserve_quotes = True  # Preserve original quotes in the YAML file
+    yaml.width = 4096  # Set a very large line width to prevent inconsistent line wrapping
 
     with open(yaml_file_path, "r") as fd:
         data = list(yaml.load_all(fd))  # Convert the generator to a list

--- a/scripts/evergreen/release/update_helm_values_files.py
+++ b/scripts/evergreen/release/update_helm_values_files.py
@@ -57,9 +57,9 @@ def main() -> int:
 
 
 def update_standalone(operator_version):
-    update_standalone_installer("public/mongodb-kubernetes.yaml", operator_version),
-    update_standalone_installer("public/mongodb-kubernetes-openshift.yaml", operator_version),
-    update_standalone_installer("public/mongodb-kubernetes-multi-cluster.yaml", operator_version),
+    update_standalone_installer("public/mongodb-kubernetes.yaml", operator_version)
+    update_standalone_installer("public/mongodb-kubernetes-openshift.yaml", operator_version)
+    update_standalone_installer("public/mongodb-kubernetes-multi-cluster.yaml", operator_version)
 
 
 def update_helm_charts(operator_version, release):

--- a/scripts/evergreen/release/update_helm_values_files.py
+++ b/scripts/evergreen/release/update_helm_values_files.py
@@ -57,9 +57,13 @@ def main() -> int:
 
 
 def update_standalone(operator_version):
-    update_standalone_installer("public/mongodb-kubernetes.yaml", operator_version)
-    update_standalone_installer("public/mongodb-kubernetes-openshift.yaml", operator_version)
-    update_standalone_installer("public/mongodb-kubernetes-multi-cluster.yaml", operator_version)
+    file_paths = [
+        "public/mongodb-kubernetes.yaml",
+        "public/mongodb-kubernetes-openshift.yaml",
+        "public/mongodb-kubernetes-multi-cluster.yaml",
+    ]
+    for file_path in file_paths:
+        update_standalone_installer(file_path, operator_version)
 
 
 def update_helm_charts(operator_version, release):


### PR DESCRIPTION
# Summary
This pull request includes updates to improve YAML file handling and fixes a minor issue in the `update_standalone` function. The most important changes are grouped below:

### YAML Handling Improvements:
* [`scripts/evergreen/release/helm_files_handler.py`](diffhunk://#diff-3e4bf7eb043336f19b2029c2f2b0c2d3497902c0b116255fc99fe6467ae1e453R81): Added a new configuration to set the YAML line width to 4096 in the `update_standalone_installer` function to prevent inconsistent line wrapping in the CI and locally

### Bug Fix in Function Logic:
* [`scripts/evergreen/release/update_helm_values_files.py`](diffhunk://#diff-362db66ba4c033cb3e6d12456bb89ac5782882ffc6f393e8f7d8d36b69aee0ffL60-R62): Fixed the `update_standalone` function by removing trailing commas, which were causing unintended behavior when calling the `update_standalone_installer` function multiple times.

## Proof of Work

- consistent yaml formatting for linter (passing unit test variant)

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
