### PR TITLE
Remove set -x in install_csi_driver.sh

### DIFF
--- a/scripts/dev/install_csi_driver.sh
+++ b/scripts/dev/install_csi_driver.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -Eeou pipefail
 
 source scripts/funcs/kubernetes
 


### PR DESCRIPTION
# Summary

This removes unnecessary bash debug switch in install_csi_driver.sh and aligns it to the standard `set -Eeou pipefail` preamble we use in all shell scripts. 
