### PR TITLE
Use operator name from env var for webhook setup

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -83,7 +83,6 @@ const (
 	// Pod/StatefulSet specific constants
 	OperatorName                   = "mongodb-kubernetes-operator"
 	LegacyOperatorName             = "mongodb-enterprise-operator" // Still used for some selectors and labels
-	MultiClusterOperatorName       = "mongodb-kubernetes-operator-multi-cluster"
 	OperatorLabelName              = "controller"
 	OperatorLabelValue             = LegacyOperatorName
 	OpsManagerContainerName        = "mongodb-ops-manager"
@@ -196,6 +195,7 @@ const (
 	BackupDisableWaitRetriesEnv      = "BACKUP_WAIT_RETRIES"
 	ManagedSecurityContextEnv        = "MANAGED_SECURITY_CONTEXT"
 	CurrentNamespace                 = "NAMESPACE"
+	OperatorNameEnv                  = "OPERATOR_NAME"
 	WatchNamespace                   = "WATCH_NAMESPACE"
 	OpsManagerMonitorAppDB           = "OPS_MANAGER_MONITOR_APPDB"
 	MongodbCommunityAgentImageEnv    = "MDB_COMMUNITY_AGENT_IMAGE"

--- a/pkg/webhook/setup.go
+++ b/pkg/webhook/setup.go
@@ -24,12 +24,7 @@ import (
 const controllerLabelName = "app.kubernetes.io/name"
 
 // createWebhookService creates a Kubernetes service for the webhook.
-func createWebhookService(ctx context.Context, client client.Client, location types.NamespacedName, webhookPort int, multiClusterMode bool) error {
-	svcSelector := util.OperatorName
-	if multiClusterMode {
-		svcSelector = util.MultiClusterOperatorName
-	}
-
+func createWebhookService(ctx context.Context, client client.Client, location types.NamespacedName, webhookPort int, svcSelector string) error {
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      location.Name,
@@ -186,7 +181,7 @@ func shouldRegisterWebhookConfiguration() bool {
 	return env.ReadBoolOrDefault(util.MdbWebhookRegisterConfigurationEnv, true) // nolint:forbidigo
 }
 
-func Setup(ctx context.Context, client client.Client, serviceLocation types.NamespacedName, certDirectory string, webhookPort int, multiClusterMode bool, log *zap.SugaredLogger) error {
+func Setup(ctx context.Context, client client.Client, serviceLocation types.NamespacedName, certDirectory string, webhookPort int, svcSelector string, log *zap.SugaredLogger) error {
 	if !shouldRegisterWebhookConfiguration() {
 		log.Debugf("Skipping configuration of ValidatingWebhookConfiguration")
 		// After upgrading OLM version after migrating to proper OLM webhooks we don't need that `operator-service` anymore.
@@ -217,7 +212,7 @@ func Setup(ctx context.Context, client client.Client, serviceLocation types.Name
 		return err
 	}
 
-	if err := createWebhookService(ctx, client, serviceLocation, webhookPort, multiClusterMode); err != nil {
+	if err := createWebhookService(ctx, client, serviceLocation, webhookPort, svcSelector); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Summary

No need to hardcode operator name as we can determine it from the env var we already pass to the operator.

## Proof of Work

CI must be green.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
