### PR TITLE
don't rely on version_id magic

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -27,7 +27,7 @@ images:
       TARGETARCH: $(inputs.params.architecture)
     output:
     - registry: $(inputs.params.registry)/mongodb-kubernetes
-      tag: $(inputs.params.version_id)-context-$(inputs.params.architecture)
+      tag: $(inputs.params.version)-context-$(inputs.params.architecture)
 
   - name: operator-race-context
     task_type: docker_build
@@ -40,7 +40,7 @@ images:
       TARGETARCH: $(inputs.params.architecture)
     output:
     - registry: $(inputs.params.registry)/mongodb-kubernetes
-      tag: $(inputs.params.version_id)-context-race-$(inputs.params.architecture)
+      tag: $(inputs.params.version)-context-race-$(inputs.params.architecture)
 
   - name: operator-template-ubi
     task_type: dockerfile_template
@@ -55,27 +55,27 @@ images:
     task_type: docker_build
     dockerfile: $(stages['operator-template-ubi'].outputs[0].dockerfile)
     buildargs:
-      imagebase: $(inputs.params.registry)/mongodb-kubernetes:$(inputs.params.version_id)-context-$(inputs.params.architecture)
+      imagebase: $(inputs.params.registry)/mongodb-kubernetes:$(inputs.params.version)-context-$(inputs.params.architecture)
     output:
     - registry: $(inputs.params.registry)/mongodb-kubernetes
-      tag: $(inputs.params.version_id)-$(inputs.params.architecture)
+      tag: $(inputs.params.version)-$(inputs.params.architecture)
 
   # we don't do multi-arch for race images; so we can just directly release it
   - name: operator-ubi-race-build
     task_type: docker_build
     dockerfile: $(stages['operator-template-ubi'].outputs[0].dockerfile)
     buildargs:
-      imagebase: $(inputs.params.registry)/mongodb-kubernetes:$(inputs.params.version_id)-context-race-$(inputs.params.architecture)
+      imagebase: $(inputs.params.registry)/mongodb-kubernetes:$(inputs.params.version)-context-race-$(inputs.params.architecture)
     output:
     - registry: $(inputs.params.registry)/mongodb-kubernetes
-      tag: $(inputs.params.version_id)-race
+      tag: $(inputs.params.version)-race
 
   - name: master-latest
     task_type: tag_image
     tags: [ "master" ]
     source:
       registry: $(inputs.params.registry)/mongodb-kubernetes
-      tag: $(inputs.params.version_id)-$(inputs.params.architecture)
+      tag: $(inputs.params.version)-$(inputs.params.architecture)
     destination:
       - registry: $(inputs.params.registry)/mongodb-kubernetes
         tag: latest-$(inputs.params.architecture)
@@ -85,7 +85,7 @@ images:
     tags: ["release"]
     source:
       registry: $(inputs.params.registry)/mongodb-kubernetes
-      tag: $(inputs.params.version_id)-context-$(inputs.params.architecture)
+      tag: $(inputs.params.version)-context-$(inputs.params.architecture)
     destination:
     - registry: $(inputs.params.quay_registry)
       tag: $(inputs.params.version)-context-$(inputs.params.architecture)


### PR DESCRIPTION
# Summary

This pull request updates the tagging scheme in the `inventory.yaml` file to replace the `version_id` parameter with the `version` parameter for consistency and clarity across all image tags. The changes affect multiple sections of the file, ensuring uniformity in how image tags are generated.

`version_id` is a evergreen magic env which sonar magically picks up and puts into inventory. Therefore we had those weird tags. This magic is not required anymore - since we pass `version` on every image creation ourselves: https://github.com/mongodb/mongodb-kubernetes/blob/7566a394d41642b1de800ff653f9eb1dfcb92f84/pipeline.py#L265-L278. Additionally, operator was the only leftover where we still used that version_id


## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
