### PR TITLE
[Don't Review] Use custom build of OM to test if failing tests pass

### DIFF
--- a/docker/mongodb-enterprise-ops-manager/Dockerfile.template
+++ b/docker/mongodb-enterprise-ops-manager/Dockerfile.template
@@ -32,7 +32,7 @@ COPY --from=base /data/scripts /opt/scripts
 
 
 {% block static %}
-RUN curl --fail -L -o ops_manager.tar.gz {{ om_download_url }} \
+RUN curl --fail -L -o ops_manager.tar.gz https://mciuploads.s3.amazonaws.com/mms-ops-manager-8.0/mms_ops_manager_8.0_package_rpm_patch_aef37d29bf8fff2b6a354271f649a936ef14d43e_686d413064e4b600075e0ad1_25_07_08_16_03_01/PACKAGE_OPS_MANAGER/mongodb-mms-8.0.11.500.20250708T1655Z.tar.gz \
   && tar -xzf ops_manager.tar.gz \
   && rm ops_manager.tar.gz \
   && mv mongodb-mms* "${MMS_HOME}"

--- a/pipeline.py
+++ b/pipeline.py
@@ -987,7 +987,8 @@ def build_om_image(build_configuration: BuildConfiguration):
     if om_version is None:
         raise ValueError("`om_version` should be defined.")
 
-    om_download_url = os.environ.get("om_download_url", "")
+    # om_download_url = os.environ.get("om_download_url", "")
+    om_download_url = "https://mciuploads.s3.amazonaws.com/mms-ops-manager-8.0/mms_ops_manager_8.0_package_rpm_patch_aef37d29bf8fff2b6a354271f649a936ef14d43e_686d413064e4b600075e0ad1_25_07_08_16_03_01/PACKAGE_OPS_MANAGER/mongodb-mms-8.0.11.500.20250708T1655Z.tar.gz"
     if om_download_url == "":
         om_download_url = find_om_url(om_version)
 


### PR DESCRIPTION


# Summary

`e2e_om_remotemode` has been failing consistently when we try and consume the newer version of OM.
This commit uses the custom build of the OM to potentially fix the problem.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
