### PR TITLE
Add a default value for `OPERATOR_NAME` env var

### DIFF
--- a/scripts/dev/contexts/e2e_multi_cluster_2_clusters
+++ b/scripts/dev/contexts/e2e_multi_cluster_2_clusters
@@ -15,3 +15,10 @@ export test_pod_cluster=kind-e2e-cluster-1
 export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
 
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/e2e_multi_cluster_kind
+++ b/scripts/dev/contexts/e2e_multi_cluster_kind
@@ -15,3 +15,11 @@ export CENTRAL_CLUSTER=kind-e2e-operator
 export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/e2e_multi_cluster_om_appdb
+++ b/scripts/dev/contexts/e2e_multi_cluster_om_appdb
@@ -20,3 +20,11 @@ export CENTRAL_CLUSTER=kind-e2e-cluster-1
 export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="${CUSTOM_OM_VERSION}"
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/e2e_multi_cluster_om_operator_not_in_mesh
+++ b/scripts/dev/contexts/e2e_multi_cluster_om_operator_not_in_mesh
@@ -15,3 +15,11 @@ export CENTRAL_CLUSTER=kind-e2e-operator
 export test_pod_cluster=kind-e2e-cluster-1
 export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export ops_manager_version="${CUSTOM_OM_VERSION}"
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_2_clusters
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_2_clusters
@@ -16,3 +16,11 @@ export ops_manager_version="cloud_qa"
 
 export MDB_DEFAULT_ARCHITECTURE=static
 export CUSTOM_MDB_VERSION=6.0.5
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_kind
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_kind
@@ -20,3 +20,11 @@ export MDB_DEFAULT_ARCHITECTURE=static
 # For upgrade/downgrade tests we need to override this for static containers since we don't have 5.0.x versions
 # of MDB binaries for ubi9
 export CUSTOM_MDB_PREV_VERSION=6.0.5
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_om_appdb
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_om_appdb
@@ -24,3 +24,11 @@ export MDB_DEFAULT_ARCHITECTURE=static
 
 # clear cloud-qa settings
 export OM_ORGID=""
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/manual_telemetry_multi_cluster_dev
+++ b/scripts/dev/contexts/manual_telemetry_multi_cluster_dev
@@ -19,3 +19,11 @@ export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 export MDB_OPERATOR_TELEMETRY_SEND_BASEURL="https://cloud-dev.mongodb.com/"
 export MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY="10m" # let's send frequently
 export MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY="1m" # let's collect as often as we can
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/manual_telemetry_multi_cluster_prod
+++ b/scripts/dev/contexts/manual_telemetry_multi_cluster_prod
@@ -18,3 +18,11 @@ export ops_manager_version="cloud_qa"
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 export MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY="10m" # let's send frequently
 export MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY="1m" # let's collect as often as we can
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -121,3 +121,11 @@ export MDB_SEARCH_COMMUNITY_REPO_URL="quay.io/mongodb"
 if [[ ${MDB_BASH_DEBUG:-0} == 1 ]]; then
   export PS4='+(${BASH_SOURCE}:${LINENO})[^$?]: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator"


### PR DESCRIPTION
# Summary

In https://github.com/mongodb/mongodb-kubernetes/pull/222 we made `OPERATOR_NAME` env var required and it breaks local development workflows.

This change adds a default value for `OPERATOR_NAME` env var into appropriate context files.

## Proof of Work

CI must be green

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
