### PR TITLE
make sure backup csv doesn't run automatically

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1246,18 +1246,6 @@ task_groups:
     <<: *teardown_group
 
 buildvariants:
-
-  ## Backup CSV Images Variant
-  - name: backup_csv_images
-    display_name: "Backup CSV Images"
-    tags: [ "release_csv_backup" ]
-    run_on:
-      - ubuntu2204-small
-    tasks:
-      - name: backup_csv_images_dry_run
-      - name: backup_csv_images_limit_3
-      - name: backup_csv_images_all
-
   ## Unit tests + lint build variant
 
   - name: unit_tests
@@ -1931,6 +1919,16 @@ buildvariants:
       - name: kind_code_snippets_task_group
 
   ### Build variants for manual patch only
+
+  - name: backup_csv_images
+    display_name: "Backup CSV Images"
+    allowed_requesters: [ "patch" ]
+    run_on:
+      - ubuntu2204-small
+    tasks:
+      - name: backup_csv_images_dry_run
+      - name: backup_csv_images_limit_3
+      - name: backup_csv_images_all
 
   - name: publish_om60_images
     display_name: publish_om60_images


### PR DESCRIPTION
# Summary

### Build variant adjustments:

* Removed the `backup_csv_images` build variant from the general `buildvariants` section, including its tasks and tags.
* Re-added the `backup_csv_images` build variant under the `manual patch only` section, specifying `allowed_requesters` as `"patch"` and retaining the same tasks and `run_on` configuration.
-> this makes sure it only runs if manually triggered 
## Proof of Work

- after master merge this shouldn't show in waterfall 

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
