### PR TITLE
wip - fix sharded scram test

### DIFF
--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -27,14 +27,14 @@ func (s *automationConfigScramSha) EnableAgentAuthentication(conn om.Connection,
 			return err
 		}
 
+		// This function is now only responsible for ensuring the user and keyfile exist.
+		// The agent's authentication mechanism is set in a separate step by the calling controller
+		// to prevent a race condition between user creation and agent configuration.
 		auth := ac.Auth
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
 		auth.KeyFile = util.AutomationAgentKeyFilePathInContainer
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
-
-		// We can only have a single agent authentication mechanism specified at a given time
-		auth.AutoAuthMechanisms = []string{string(s.MechanismName)}
 		return nil
 	}, log)
 }

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
@@ -114,7 +114,6 @@ class TestCanEnableScramSha256:
             "SCRAM",
         ]
         sharded_cluster["spec"]["security"]["authentication"]["agents"]["mode"] = "SCRAM"
-        kubetester.wait_processes_ready()
 
         sharded_cluster.update()
         sharded_cluster.assert_reaches_phase(Phase.Running, timeout=800)

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
@@ -114,6 +114,8 @@ class TestCanEnableScramSha256:
             "SCRAM",
         ]
         sharded_cluster["spec"]["security"]["authentication"]["agents"]["mode"] = "SCRAM"
+        kubetester.wait_processes_ready()
+
         sharded_cluster.update()
         sharded_cluster.assert_reaches_phase(Phase.Running, timeout=800)
 


### PR DESCRIPTION
# Summary

- as in other places, we cannot configure scram before all processes are ready. If the deployment is ready it is read and write ready but not necessary ready for changing auth - yet
- its flaky: https://ui.honeycomb.io/mongodb-4b/environments/production/board-query/m7YuTP612BD/result/kXrAsoHTqUS?vs=hideCompare

## Proof of Work
- multiple retries should all succeed 
- [Link](https://spruce.mongodb.com/version/68710c13c1a5ae00073b5432/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
