### PR TITLE
Fix telemetry RBAC template

### DIFF
--- a/helm_chart/templates/operator-roles.yaml
+++ b/helm_chart/templates/operator-roles.yaml
@@ -255,7 +255,6 @@ rules:
       - nodes
     verbs:
       - list
-{{- end}}
 ---
 # ClusterRoleBinding for clusterVersionDetection
 kind: ClusterRoleBinding
@@ -270,4 +269,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.operator.name }}
     namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
-{{- end }}
+  {{- end}}{{/* if ne $telemetry.installClusterRole false */}}
+{{- end }}{{/* if ne $telemetry.enabled false */}}


### PR DESCRIPTION
# Summary

Currently `ClusterRoleBinding` is still being rendered when `telemetry.enabled` is `true`, but `telemetry.installClusterRole` is `false`.

## Proof of Work

Comparing results fo the following template renderings.

1. Telemetry enabled, telemetry RBAC enabled.
    ```bash
    helm template --show-only \
      templates/operator-roles.yaml \
      ./helm_chart \
      --namespace mongodb \
      --set operator.telemetry.enabled=true \
      --set operator.telemetry.installClusterRole=true \
      | yq 'select((.kind == "ClusterRoleBinding" or .kind == "ClusterRole") and (.metadata.name | contains("telemetry")))'
    ```

2. Telemetry enabled, telemetry RBAC disabled
    ```bash
    helm template --show-only \
      templates/operator-roles.yaml \
      ./helm_chart \
      --namespace mongodb \
      --set operator.telemetry.enabled=true \
      --set operator.telemetry.installClusterRole=false \
      | yq 'select((.kind == "ClusterRoleBinding" or .kind == "ClusterRole") and (.metadata.name | contains("telemetry")))'
    ```

### Before

1. Telemetry enabled, telemetry RBAC enabled.
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # Additional ClusterRole for clusterVersionDetection
    kind: ClusterRole
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-cluster-telemetry
    rules:
      # Non-resource URL permissions
      - nonResourceURLs:
          - "/version"
        verbs:
          - get
      # Cluster-scoped resource permissions
      - apiGroups:
          - ''
        resources:
          - namespaces
        resourceNames:
          - kube-system
        verbs:
          - get
      - apiGroups:
          - ''
        resources:
          - nodes
        verbs:
          - list
    ---
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

2. Telemetry enabled, telemetry RBAC disabled
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

### After

1. Telemetry enabled, telemetry RBAC enabled.
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # Additional ClusterRole for clusterVersionDetection
    kind: ClusterRole
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-cluster-telemetry
    rules:
      # Non-resource URL permissions
      - nonResourceURLs:
          - "/version"
        verbs:
          - get
      # Cluster-scoped resource permissions
      - apiGroups:
          - ''
        resources:
          - namespaces
        resourceNames:
          - kube-system
        verbs:
          - get
      - apiGroups:
          - ''
        resources:
          - nodes
        verbs:
          - list
    ---
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

2. Telemetry enabled, telemetry RBAC disabled
    ```yaml
    # (Nothing)
    ```

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
