### PR TITLE
CLOUDP-330671: Bump Cloud Manager version for MongoDB Agent container images for MMS release branch v20250716

### DIFF
--- a/release.json
+++ b/release.json
@@ -105,7 +105,7 @@
       ],
       "opsManagerMapping": {
         "Description": "These are the agents from which we start supporting static containers.",
-        "cloud_manager": "13.36.0.9555-1",
+        "cloud_manager": "13.37.0.9590-1",
         "cloud_manager_tools": "100.12.2",
         "ops_manager": {
           "6.0.25": {


### PR DESCRIPTION

_Opened by Private Cloud Tools (PCT)_.

# Ticket
[CLOUDP-330671](https://jira.mongodb.org/browse/CLOUDP-330671)

# Description
Bump Cloud Manager version for MongoDB Agent container images for mms version v20250716.

# Reviewer Checklist

Before merging this PR, verify the following:
- [ ] the following tasks are passing in Evergreen:
  - `release_agent` task (variant: `release_agent`)
- [ ] the `cloud_manager` was updated correctly
- [ ] the `cloud_manager_tools` was updated correctly

