### PR TITLE
Fix YAML document separator in operator RBAC

### DIFF
--- a/config/rbac/operator-roles.yaml
+++ b/config/rbac/operator-roles.yaml
@@ -13,7 +13,6 @@ rules:
       - clustermongodbroles
 ---
 # Source: mongodb-kubernetes/templates/operator-roles.yaml
----
 # Additional ClusterRole for clusterVersionDetection
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm_chart/templates/operator-roles.yaml
+++ b/helm_chart/templates/operator-roles.yaml
@@ -173,11 +173,11 @@ subjects:
 {{- end }}
 
 {{- end }}
----
 
 {{/* This cluster role and binding is necessary to allow the operator to automatically register ValidatingWebhookConfiguration. */}}
 {{- if and .Values.operator.webhook.registerConfiguration .Values.operator.webhook.installClusterRole }}
 {{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "mongodb-kubernetes-operator-mongodb-webhook") }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
# Summary

Helm doesn't render telemetry `ClusterRole` if webhook RBAC is not rendered due to one of the conditions.


## Proof of Work

Testing with the following commands:

1. Webhook RBAC disabled
    ```bash
    helm template --show-only \
      templates/operator-roles.yaml \
      ./helm_chart \
      --namespace mongodb \
      --set operator.webhook.registerConfiguration=false \
      --set operator.telemetry.enabled=true \
      --set operator.telemetry.installClusterRole=true \
      | yq 'select((.kind == "ClusterRoleBinding" or .kind == "ClusterRole") and (.metadata.name | contains("telemetry")))'
    ```

2. Webhook RBAC enabled
    ```bash
    helm template --show-only \
      templates/operator-roles.yaml \
      ./helm_chart \
      --namespace mongodb \
      --set operator.webhook.registerConfiguration=true \
      --set operator.telemetry.enabled=true \
      --set operator.telemetry.installClusterRole=true \
      | yq 'select((.kind == "ClusterRoleBinding" or .kind == "ClusterRole") and (.metadata.name | contains("telemetry")))'
    ```

### Before

1. Webhook RBAC disabled
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

2. Webhook RBAC enabled
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # Additional ClusterRole for clusterVersionDetection
    kind: ClusterRole
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-cluster-telemetry
    rules:
      # Non-resource URL permissions
      - nonResourceURLs:
          - "/version"
        verbs:
          - get
      # Cluster-scoped resource permissions
      - apiGroups:
          - ''
        resources:
          - namespaces
        resourceNames:
          - kube-system
        verbs:
          - get
      - apiGroups:
          - ''
        resources:
          - nodes
        verbs:
          - list
    ---
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

### After

1. Webhook RBAC disabled
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # Additional ClusterRole for clusterVersionDetection
    kind: ClusterRole
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-cluster-telemetry
    rules:
      # Non-resource URL permissions
      - nonResourceURLs:
          - "/version"
        verbs:
          - get
      # Cluster-scoped resource permissions
      - apiGroups:
          - ''
        resources:
          - namespaces
        resourceNames:
          - kube-system
        verbs:
          - get
      - apiGroups:
          - ''
        resources:
          - nodes
        verbs:
          - list
    ---
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

2. Webhook RBAC enabled
    ```yaml
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # Additional ClusterRole for clusterVersionDetection
    kind: ClusterRole
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-cluster-telemetry
    rules:
      # Non-resource URL permissions
      - nonResourceURLs:
          - "/version"
        verbs:
          - get
      # Cluster-scoped resource permissions
      - apiGroups:
          - ''
        resources:
          - namespaces
        resourceNames:
          - kube-system
        verbs:
          - get
      - apiGroups:
          - ''
        resources:
          - nodes
        verbs:
          - list
    ---
    # Source: mongodb-kubernetes/templates/operator-roles.yaml
    # ClusterRoleBinding for clusterVersionDetection
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
      name: mongodb-kubernetes-operator-mongodb-cluster-telemetry-binding
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: mongodb-kubernetes-operator-cluster-telemetry
    subjects:
      - kind: ServiceAccount
        name: mongodb-kubernetes-operator
        namespace: mongodb
    ```

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
