### PR TITLE
Fix YAML document separator in operator RBAC

### DIFF
--- a/helm_chart/templates/operator-roles.yaml
+++ b/helm_chart/templates/operator-roles.yaml
@@ -142,9 +142,9 @@ subjects:
     namespace: {{ include "mongodb-kubernetes-operator.namespace" $ }}
 {{- end }}
 
----
 
 {{- if .Values.operator.enableClusterMongoDBRoles }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
# Summary

Helm doesn't render webhook `ClusterRole` if `clustermongodbroles` RBAC is not rendered due to `operator.enableClusterMongoDBRoles` being set to `false`.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
