### PR TITLE
CLOUDP-331107 Create jira tickets from PRs automatically

### DIFF
--- a/scripts/dev/create_jira_ticket.sh
+++ b/scripts/dev/create_jira_ticket.sh
@@ -1,3 +1,26 @@
 #!/usr/bin/env bash
 
 set -Eeou pipefail
+
+title=$(gh pr view --json title | jq -r '.title')
+
+if [[ "$title" == "[ticket]"* ]]; then
+  echo "Title starts with '[ticket]', creating a Jira ticket..."
+
+  title=${title#"[ticket]"}
+  title=$(echo "$title" | xargs)
+  echo "Title: $title"
+
+  labels=$(gh pr view --json labels | jq -r '.labels | map(.name) | join(",")')
+  echo "Labels: $labels"
+
+  jira_output=$(jira issue create -tStory -s "$title" -C "Kubernetes Enterprise" --custom assigned-teams="Kubernetes Hosted" -b "This ticket was created from the attached PR" --priority "Minor - P4" --label "$labels" --no-input --raw)
+  echo "Jira ticket created successfully."
+
+  jira_id=$(echo "$jira_output" | jq -r '.key')
+
+  gh pr edit --title "$jira_id $title"
+  echo "PR title updated to include Jira ticket ID: $jira_id $title"
+else
+  echo "Title does not start with '[ticket]', skipping Jira ticket creation."
+fi


### PR DESCRIPTION
# Summary

This ticket adds a script, and (eventually) an evergreen task that creates a jira ticket automatically from this PR and links them.

## Proof of Work

The title started with "[ticket]", the automation created the ticket and automatically changed the title to match the jira ticket id.

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
