### PR TITLE
CLOUDP-331496: Fix `rm` glob expansion

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -45,12 +45,12 @@ function generate_standalone_yaml() {
   cat "helm_chart/crds/"* >public/crds.yaml
 
   # generate openshift public example
-  rm -rf "${charttmpdir:?}/*"
+  rm -rf "${charttmpdir:?}"/*
   helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-openshift.yaml ${HELM_OPTS[@]}
   cat "${FILES[@]}" >public/mongodb-kubernetes-openshift.yaml
 
   # generate openshift files for kustomize used for generating OLM bundle
-  rm -rf "${charttmpdir:?}/*"
+  rm -rf "${charttmpdir:?}"/*
   helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-openshift.yaml \
     --set operator.webhook.registerConfiguration=false --set operator.webhook.installClusterRole=false ${HELM_OPTS[@]}
 
@@ -60,7 +60,7 @@ function generate_standalone_yaml() {
   cp "${charttmpdir}/mongodb-kubernetes/templates/operator-roles.yaml" config/rbac/operator-roles.yaml
 
   # generate multi-cluster public example
-  rm -rf "${charttmpdir:?}/*"
+  rm -rf "${charttmpdir:?}"/*
   helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-multi-cluster.yaml ${HELM_OPTS[@]}
   cat "${FILES[@]}" >public/mongodb-kubernetes-multi-cluster.yaml
 


### PR DESCRIPTION
# Summary

Currently `rm` does not work as expected because `*` glob is not being expanded.

## Proof of Work

`ls` the temporary dir before and after `rm` and you can see that the directory is being left untouched without this change.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
