### PR TITLE
CLOUDP-331496: Split operator roles into smaller templates: split base role

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -35,6 +35,7 @@ function generate_standalone_yaml() {
   FILES=(
     "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-base.yaml"
     "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-clustermongodbroles.yaml"
+    "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml"
     "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-telemetry.yaml"
     "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-webhook.yaml"
     "${charttmpdir}/mongodb-kubernetes/templates/database-roles.yaml"
@@ -62,6 +63,7 @@ function generate_standalone_yaml() {
   cp "${charttmpdir}/mongodb-kubernetes/templates/database-roles.yaml" config/rbac/database-roles.yaml
   cp "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-base.yaml" config/rbac/operator-roles-base.yaml
   cp "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-clustermongodbroles.yaml" config/rbac/operator-roles-clustermongodbroles.yaml
+  cp "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml" config/rbac/operator-roles-pvc-resize.yaml
   cp "${charttmpdir}/mongodb-kubernetes/templates/operator-roles-telemetry.yaml" config/rbac/operator-roles-telemetry.yaml
 
   # generate multi-cluster public example

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - database-roles.yaml
   - operator-roles-base.yaml
   - operator-roles-clustermongodbroles.yaml
+  - operator-roles-pvc-resize.yaml
   - operator-roles-telemetry.yaml
 
 # we have to remove service account namespace from RoleBinding as OLM is not overriding it

--- a/config/rbac/operator-roles-base.yaml
+++ b/config/rbac/operator-roles-base.yaml
@@ -79,18 +79,6 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
-
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - get
-      - delete
-      - list
-      - watch
-      - patch
-      - update
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/config/rbac/operator-roles-pvc-resize.yaml
+++ b/config/rbac/operator-roles-pvc-resize.yaml
@@ -1,0 +1,34 @@
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-pvc-resize
+  namespace: mongodb
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - patch
+      - update
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-pvc-resize-binding
+  namespace: mongodb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mongodb-kubernetes-operator-pvc-resize
+subjects:
+  - kind: ServiceAccount
+    name: mongodb-kubernetes-operator
+    namespace: mongodb

--- a/helm_chart/templates/operator-roles-base.yaml
+++ b/helm_chart/templates/operator-roles-base.yaml
@@ -102,19 +102,6 @@ rules:
       - list
       - watch
 {{- end}}
-{{ if .Values.operator.enablePVCResize }}
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - get
-      - delete
-      - list
-      - watch
-      - patch
-      - update
-{{- end}}
 {{- range $idx, $namespace := $watchNamespace }}
 
 {{- $namespaceBlock := "" }}

--- a/helm_chart/templates/operator-roles-pvc-resize.yaml
+++ b/helm_chart/templates/operator-roles-pvc-resize.yaml
@@ -1,0 +1,63 @@
+{{ if .Values.operator.createOperatorServiceAccount }}
+{{ if .Values.operator.enablePVCResize }}
+
+{{- $watchNamespace := include "mongodb-kubernetes-operator.namespace" . | list }}
+{{- if .Values.operator.watchNamespace }}
+{{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
+{{- $watchNamespace = concat $watchNamespace (include "mongodb-kubernetes-operator.namespace" . | list) | uniq }}
+{{- end }}
+
+
+{{- $roleScope := "Role" -}}
+{{- if or (gt (len $watchNamespace) 1) (eq (first $watchNamespace) "*") }}
+{{- $roleScope = "ClusterRole" }}
+{{- end }}
+---
+kind: {{ $roleScope }}
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.operator.name }}-pvc-resize
+{{- if eq $roleScope "Role" }}
+  namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
+{{- end }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - patch
+      - update
+{{- range $idx, $namespace := $watchNamespace }}
+
+{{- $namespaceBlock := "" }}
+{{- if not (eq $namespace "*") }}
+{{- $namespaceBlock = printf "namespace: %s" $namespace }}
+{{- end }}
+
+---
+{{- if eq $namespace "*" }}
+kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $.Values.operator.name }}-pvc-resize-binding
+  {{ $namespaceBlock }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ $roleScope }}
+  name: {{ $.Values.operator.name }}-pvc-resize
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.operator.name }}
+    namespace: {{ include "mongodb-kubernetes-operator.namespace" $ }}
+{{- end }}
+
+{{- end}}{{/* if .Values.operator.enablePVCResize */}}
+{{- end}}{{/* if .Values.operator.createOperatorServiceAccount */}}

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -79,18 +79,6 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
-
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - get
-      - delete
-      - list
-      - watch
-      - patch
-      - update
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding
@@ -129,6 +117,40 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: mongodb-kubernetes-operator-multi-cluster-mongodb-cluster-mongodb-role
+subjects:
+  - kind: ServiceAccount
+    name: mongodb-kubernetes-operator-multi-cluster
+    namespace: mongodb
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-multi-cluster-pvc-resize
+  namespace: mongodb
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - patch
+      - update
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-multi-cluster-pvc-resize-binding
+  namespace: mongodb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mongodb-kubernetes-operator-multi-cluster-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator-multi-cluster

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -79,18 +79,6 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
-
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - get
-      - delete
-      - list
-      - watch
-      - patch
-      - update
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding
@@ -129,6 +117,40 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: mongodb-kubernetes-operator-mongodb-cluster-mongodb-role
+subjects:
+  - kind: ServiceAccount
+    name: mongodb-kubernetes-operator
+    namespace: mongodb
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-pvc-resize
+  namespace: mongodb
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - patch
+      - update
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-pvc-resize-binding
+  namespace: mongodb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mongodb-kubernetes-operator-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -79,18 +79,6 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
-
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - get
-      - delete
-      - list
-      - watch
-      - patch
-      - update
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding
@@ -129,6 +117,40 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: mongodb-kubernetes-operator-mongodb-cluster-mongodb-role
+subjects:
+  - kind: ServiceAccount
+    name: mongodb-kubernetes-operator
+    namespace: mongodb
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-pvc-resize
+  namespace: mongodb
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - patch
+      - update
+---
+# Source: mongodb-kubernetes/templates/operator-roles-pvc-resize.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator-pvc-resize-binding
+  namespace: mongodb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mongodb-kubernetes-operator-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator


### PR DESCRIPTION
# Summary

In https://github.com/mongodb/mongodb-kubernetes/pull/258 I split existing roles into separate files: base RBAC, telemetry, webhook and `clustermongodbroles` related RBAC.

In this iteration we split basic role further. We separate PVC resize permissions into a separate role.

## Proof of Work

CI must be green.

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
