### PR TITLE
Reverted replicaSetName in favor of putting more hosts in connection string

### DIFF
--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -74,15 +74,18 @@ func newSearchReconciler(
 }
 
 func buildExpectedMongotConfig(search *searchv1.MongoDBSearch, mdbc *mdbcv1.MongoDBCommunity) mongot.Config {
+	var hostAndPorts []string
+	for i := range mdbc.Spec.Members {
+		hostAndPorts = append(hostAndPorts, fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", mdbc.Name, i, mdbc.Name+"-svc", search.Namespace, 27017))
+	}
 	return mongot.Config{
 		SyncSource: mongot.ConfigSyncSource{
 			ReplicaSet: mongot.ConfigReplicaSet{
-				HostAndPort:    fmt.Sprintf("%s.%s.svc.cluster.local:%d", mdbc.Name+"-svc", search.Namespace, 27017),
+				HostAndPort:    hostAndPorts,
 				Username:       "mongot-user",
 				PasswordFile:   "/tmp/sourceUserPassword",
 				TLS:            ptr.To(false),
 				ReadPreference: ptr.To("secondaryPreferred"),
-				ReplicaSetName: "mdb",
 			},
 		},
 		Storage: mongot.ConfigStorage{

--- a/controllers/search_controller/search_construction.go
+++ b/controllers/search_controller/search_construction.go
@@ -38,6 +38,7 @@ type SearchSourceDBResource interface {
 	DatabasePort() int
 	GetMongoDBVersion() string
 	IsSecurityTLSConfigEnabled() bool
+	Members() int
 }
 
 func NewSearchSourceDBResourceFromMongoDBCommunity(mdbc *mdbcv1.MongoDBCommunity) SearchSourceDBResource {
@@ -46,6 +47,10 @@ func NewSearchSourceDBResourceFromMongoDBCommunity(mdbc *mdbcv1.MongoDBCommunity
 
 type mdbcSearchResource struct {
 	db *mdbcv1.MongoDBCommunity
+}
+
+func (r *mdbcSearchResource) Members() int {
+	return r.db.Spec.Members
 }
 
 func (r *mdbcSearchResource) Name() string {

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -229,4 +229,4 @@ search:
     repo: 268558157000.dkr.ecr.eu-west-1.amazonaws.com
     name: mongot/community
     # default MongoDB Search version used; can be overridden by setting MongoDBSearch.spec.version field.
-    version: b9b80915f5571bfa5fc2aa70acb20d784e68d79b
+    version: d6884ae132aab30497af55dbaff05e8274e9775f

--- a/mongodb-community-operator/pkg/mongot/mongot_config.go
+++ b/mongodb-community-operator/pkg/mongot/mongot_config.go
@@ -14,12 +14,11 @@ type ConfigSyncSource struct {
 }
 
 type ConfigReplicaSet struct {
-	HostAndPort    string  `json:"hostAndPort"`
-	Username       string  `json:"username"`
-	PasswordFile   string  `json:"passwordFile"`
-	ReplicaSetName string  `json:"replicaSetName"`
-	TLS            *bool   `json:"tls,omitempty"`
-	ReadPreference *string `json:"readPreference,omitempty"`
+	HostAndPort    []string `json:"hostAndPort"`
+	Username       string   `json:"username"`
+	PasswordFile   string   `json:"passwordFile"`
+	TLS            *bool    `json:"tls,omitempty"`
+	ReadPreference *string  `json:"readPreference,omitempty"`
 }
 
 type ConfigStorage struct {

--- a/scripts/dev/contexts/e2e_mdb_community
+++ b/scripts/dev/contexts/e2e_mdb_community
@@ -13,8 +13,8 @@ export OM_EXTERNALLY_CONFIGURED="true"
 
 # Temporary development images built from mongot master
 #export MDB_SEARCH_COMMUNITY_VERSION="776d43523d185b6b234289e17c191712a3e6569b" # master
-#export MDB_SEARCH_COMMUNITY_VERSION="d6884ae132aab30497af55dbaff05e8274e9775f" # Local->Admin
+export MDB_SEARCH_COMMUNITY_VERSION="d6884ae132aab30497af55dbaff05e8274e9775f" # Local->Admin
 #export MDB_SEARCH_COMMUNITY_VERSION="ad8acf5c3a045d6e0306ad67d61fcb5be40f57ae" # hardcoded mdbc-rs replicaset name
-export MDB_SEARCH_COMMUNITY_VERSION="b9b80915f5571bfa5fc2aa70acb20d784e68d79b" # hardcoded Local->Admin, handled replicaSetName in config
+#export MDB_SEARCH_COMMUNITY_VERSION="b9b80915f5571bfa5fc2aa70acb20d784e68d79b" # hardcoded Local->Admin, handled replicaSetName in config
 export MDB_SEARCH_COMMUNITY_NAME="mongot/community"
 export MDB_SEARCH_COMMUNITY_REPO_URL="268558157000.dkr.ecr.eu-west-1.amazonaws.com"


### PR DESCRIPTION
# Summary

This reverts handling replicaSetName from mongot config and adds passing all mongod hosts in the connection string.

It is not necessary now to set it, as mongot is connecting in a replicaset mode when there is more than one host passed on connection string.


<!-- Enter your issue summary here.-->

## Proof of Work

<!-- Enter your proof that it works here.-->

<!-- start git-machete generated -->

## Based on PR #229

## Chain of upstream PRs as of 2025-07-17

* PR #229:
  `master` ← `search/public-preview`

  * **PR #273 (THIS ONE)**:
    `search/public-preview` ← `lsierant/search-multiple-hosts`

<!-- end git-machete generated -->
