### PR TITLE
POC: Remove db pods and ops manager `ServiceAccounts`

### DIFF
--- a/config/rbac/database-roles.yaml
+++ b/config/rbac/database-roles.yaml
@@ -7,20 +7,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-database-pods
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-ops-manager
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -730,7 +730,6 @@ func buildMongoDBPodTemplateSpec(opts DatabaseStatefulSetOptions, mdb databaseSt
 
 	mods := []podtemplatespec.Modification{
 		sharedDatabaseConfiguration(opts, mdb),
-		podtemplatespec.WithServiceAccount(util.MongoDBServiceAccount),
 		podtemplatespec.WithServiceAccount(serviceAccountName),
 		podtemplatespec.WithVolumes(volumes),
 		podtemplatespec.WithContainerByIndex(0, databaseContainerModifications...),
@@ -756,7 +755,7 @@ func getServiceAccountName(opts DatabaseStatefulSetOptions) string {
 		}
 	}
 
-	return util.MongoDBServiceAccount
+	return ""
 }
 
 // sharedDatabaseConfiguration is a function which applies all the shared configuration

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -466,7 +466,6 @@ func backupAndOpsManagerSharedConfiguration(opts OpsManagerStatefulSetOptions) s
 				configurePodSpecSecurityContext,
 				podtemplatespec.WithPodLabels(labels),
 				pullSecretsConfigurationFunc,
-				podtemplatespec.WithServiceAccount(util.OpsManagerServiceAccount),
 				podtemplatespec.WithAffinity(opts.Name, podAntiAffinityLabelKey, 100),
 				podtemplatespec.WithTopologyKey(util.DefaultAntiAffinityTopologyKey, 0),
 				initContainerMod,

--- a/controllers/search_controller/search_construction.go
+++ b/controllers/search_controller/search_construction.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/probes"
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 const (
@@ -147,7 +146,6 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sourceDBReso
 				}),
 				podtemplatespec.WithVolumes(volumes),
 				podtemplatespec.WithServiceAccount(sourceDBResource.DatabaseServiceName()),
-				podtemplatespec.WithServiceAccount(util.MongoDBServiceAccount),
 				podtemplatespec.WithContainer(MongotContainerName, mongodbSearchContainer(mdbSearch, volumeMounts, searchImage)),
 			),
 		),

--- a/helm_chart/templates/database-roles.yaml
+++ b/helm_chart/templates/database-roles.yaml
@@ -24,28 +24,6 @@ imagePullSecrets:
 {{- end }}
 
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $.Values.operator.baseName }}-database-pods
-  {{ $namespaceBlock }}
-{{- if $.Values.registry.imagePullSecrets}}
-imagePullSecrets:
-  - name: {{ $.Values.registry.imagePullSecrets }}
-{{- end }}
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $.Values.operator.baseName }}-ops-manager
-  {{ $namespaceBlock }}
-{{- if $.Values.registry.imagePullSecrets}}
-imagePullSecrets:
-  - name: {{ $.Values.registry.imagePullSecrets }}
-{{- end }}
-
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -132,10 +132,6 @@ const (
 	RunAsUser = 2000
 	FsGroup   = 2000
 
-	// Service accounts
-	OpsManagerServiceAccount = "mongodb-kubernetes-ops-manager"
-	MongoDBServiceAccount    = "mongodb-kubernetes-database-pods"
-
 	// Authentication
 	AgentSecretName                   = "agent-certs"
 	AutomationConfigX509Option        = "MONGODB-X509"

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -248,20 +248,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-database-pods
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-ops-manager
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -248,20 +248,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-database-pods
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-ops-manager
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -248,20 +248,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-database-pods
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-kubernetes-ops-manager
-  namespace: mongodb
----
-# Source: mongodb-kubernetes/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_member_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_member_cluster.yaml
@@ -155,23 +155,3 @@ metadata:
   namespace: member-namespace
 
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    multi-cluster: "true"
-  name: mongodb-kubernetes-database-pods
-  namespace: member-namespace
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    multi-cluster: "true"
-  name: mongodb-kubernetes-ops-manager
-  namespace: member-namespace
-
----

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_member_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_member_cluster.yaml
@@ -129,23 +129,3 @@ metadata:
   namespace: member-namespace
 
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    multi-cluster: "true"
-  name: mongodb-kubernetes-database-pods
-  namespace: member-namespace
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    multi-cluster: "true"
-  name: mongodb-kubernetes-ops-manager
-  namespace: member-namespace
-
----

--- a/public/tools/multicluster/pkg/common/common_test.go
+++ b/public/tools/multicluster/pkg/common/common_test.go
@@ -660,18 +660,6 @@ func assertDatabaseRolesExist(t *testing.T, ctx context.Context, clientMap map[s
 		require.NotNil(t, sa)
 		assert.Equal(t, sa.Labels, multiClusterLabels())
 
-		// database pods service account
-		sa, err = client.CoreV1().ServiceAccounts(flags.MemberClusterNamespace).Get(ctx, DatabasePodsServiceAccount, metav1.GetOptions{})
-		require.NoError(t, err)
-		require.NotNil(t, sa)
-		assert.Equal(t, sa.Labels, multiClusterLabels())
-
-		// ops manager service account
-		sa, err = client.CoreV1().ServiceAccounts(flags.MemberClusterNamespace).Get(ctx, OpsManagerServiceAccount, metav1.GetOptions{})
-		require.NoError(t, err)
-		require.NotNil(t, sa)
-		assert.Equal(t, sa.Labels, multiClusterLabels())
-
 		// appdb role
 		r, err := client.RbacV1().Roles(flags.MemberClusterNamespace).Get(ctx, AppdbRole, metav1.GetOptions{})
 		require.NoError(t, err)


### PR DESCRIPTION
# Summary

It seems like the only purpose of these `ServiceAccounts` is providing pull secrets. However we also provide pull secrets into `StatefulSets` directly in the spec.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
