### PR TITLE
CLOUDP-333182: Fix OLM install modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,7 @@ bundle: manifests kustomize
 	operator-sdk generate kustomize manifests -q
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)\
 		--channels=stable --default-channel=stable\
+		--extra-service-accounts mongodb-kubernetes-appdb \
 		--output-dir ./bundle/$(VERSION)/
 	operator-sdk bundle validate ./bundle/$(VERSION)
 


### PR DESCRIPTION
# Summary

Currently with OLM we claim to support `OwnNamespace`, `SingleNamespace`, and `AllNamespaces` install modes.

However, only `OwnNamespace` works properly when deploying OpsManager. With other install modes, the operator is able to reconcile resources and create `StatefulSets` for the workloads in OpsManager, but pods never become healthy because only the operator's own namespace has the required `ServiceAccount`.

With this change, we make the relevant `ServiceAccount` managed by OLM. This means the `ServiceAccount` and relevant roles will be created in all required namespaces.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Our Short Guide for PRs: [Link](https://docs.google.com/document/d/1T93KUtdvONq43vfTfUt8l92uo4e4SEEvFbIEKOxGr44/edit?tab=t.0)
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question
