### PR TITLE
make aws_login checks for valid credentials

### DIFF
--- a/scripts/dev/configure_docker_auth.sh
+++ b/scripts/dev/configure_docker_auth.sh
@@ -51,7 +51,7 @@ if [[ -f ~/.docker/config.json ]]; then
     ecr_auth=$(jq -r '.auths."268558157000.dkr.ecr.us-east-1.amazonaws.com".auth // empty' ~/.docker/config.json)
 
     if [[ -n "${ecr_auth}" ]]; then
-      http_status=$(curl -s -o /dev/null -w "%{http_code}" -I --max-time 3 "https://268558157000.dkr.ecr.us-east-1.amazonaws.com/v2/dev/mongodb-kubernetes/manifests/latest" \
+      http_status=$(curl --head -s -o /dev/null -w "%{http_code}" --max-time 3 "https://268558157000.dkr.ecr.us-east-1.amazonaws.com/v2/dev/mongodb-kubernetes/manifests/latest" \
         -H "Authorization: Basic ${ecr_auth}" 2>/dev/null || echo "error/timeout")
 
       if [[ "${http_status}" != "401" && "${http_status}" != "403" && "${http_status}" != "error/timeout" ]]; then


### PR DESCRIPTION
# Summary

This PR adds docker credentials verification in `make aws_login` to reliably refresh docker credentials only if needed.

Previous method of skipping was checking if the ~/.docker/config.json was modified in the last six hours, but it wasn't reliable enough. If you performed docker login  to any other registry or just modified the file, you won't get ECR credentials refreshed.

## Proof of Work

breaking docker credentials (simulating expired): 
```bash
$ cat > ~/.docker/config.json <<EOF
{
  "auths": {
    "268558157000.dkr.ecr.eu-west-1.amazonaws.com": {
      "auth": "INVALID"
    },
    "268558157000.dkr.ecr.us-east-1.amazonaws.com": {
      "auth": "INVALID"
    }
  },
  "currentContext": "desktop-linux"
}
EOF

$ docker pull 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-kubernetes/latest
WARNING: Error parsing config file (/Users/lukasz.sierant/.docker/config.json): illegal base64 data at input byte 4
Using default tag: latest
Error response from daemon: failed to resolve reference "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-kubernetes/latest:latest": pull access denied, repository does not exist or may require authorization: authorization failed: no basic auth credentials

```

**from master** - auth is skipped due to file modification time check only 
```bash
$ make aws_login
Skipping docker daemon check when not running in Linux
Docker credentials are up to date - not performing the new login!
```

**from this PR:** 
```bash
$ make aws_login
Skipping docker daemon check when not running in Linux
Checking if Docker credentials are valid...
Docker login required (HTTP status: 401)
=> Performing docker login to ECR registries
aws-cli/2.27.46 Python/3.13.5 Darwin/24.5.0 source/arm64}
[...]
Login Succeeded
[...]

$ docker pull 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-kubernetes:latest
docker pull 268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-kubernetes:latest
latest: Pulling from dev/mongodb-kubernetes
671b7b89b752: Pulling fs layer
[....]
```

running again skips properly: 
```bash
$ make aws_login
Skipping docker daemon check when not running in Linux
Checking if Docker credentials are valid...
Docker credentials are up to date - not performing the new login!
```

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
