### PR TITLE
running normal go test without verbose, only log if failing

### DIFF
--- a/scripts/evergreen/unit-tests.sh
+++ b/scripts/evergreen/unit-tests.sh
@@ -11,10 +11,10 @@ echo "testing $0"
 rm -f result.suite
 if [ "$USE_RACE" = "true" ]; then
   echo "running test with race enabled"
-  GO_TEST_CMD="go test -v -coverprofile cover.out \$(go list ./... | grep -v \"mongodb-community-operator/test/e2e\")"
+  GO_TEST_CMD="go test -coverprofile cover.out \$(go list ./... | grep -v \"mongodb-community-operator/test/e2e\")"
 else
   echo "running test without race enabled"
-  GO_TEST_CMD="go test -v -coverprofile cover.out \$(go list ./... | grep -v \"mongodb-community-operator/test/e2e\")"
+  GO_TEST_CMD="go test -coverprofile cover.out \$(go list ./... | grep -v \"mongodb-community-operator/test/e2e\")"
 fi
 echo "running $GO_TEST_CMD"
 eval "$GO_TEST_CMD" | tee -a result.suite


### PR DESCRIPTION
# Summary

This pull request includes a minor update to the `scripts/evergreen/unit-tests.sh` file. The change removes the verbose (`-v`) flag from the `go test` command, simplifying the test output.

* [`scripts/evergreen/unit-tests.sh`](diffhunk://#diff-2a75349bb340f98985096d14d89d5543d43abe5a7662454278e74a59d68a71d9L14-R17): Removed the `-v` flag from the `go test` command in both race-enabled and non-race-enabled test configurations.
* this should elevate output in logs and only log on failure cases

## Proof of Work

- passing ci 

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
