### PR TITLE
CLOUDP-331886 - add new agent binaries as base

### DIFF
--- a/docker/mongodb-agent-non-matrix/Dockerfile
+++ b/docker/mongodb-agent-non-matrix/Dockerfile
@@ -46,6 +46,12 @@ COPY --from=base /data/mongodb-agent.tar.gz /agent
 COPY --from=base /data/mongodb-tools.tgz /agent
 COPY --from=base /data/LICENSE /licenses/LICENSE
 
+# Copy scripts to a safe location that won't be overwritten by volume mount
+COPY --from=base /opt/scripts/agent-launcher-shim.sh /usr/local/bin/agent-launcher-shim.sh
+COPY --from=base /opt/scripts/setup-agent-files.sh /usr/local/bin/setup-agent-files.sh
+COPY --from=base /opt/scripts/dummy-probe.sh /usr/local/bin/dummy-probe.sh
+COPY --from=base /opt/scripts/dummy-readinessprobe.sh /usr/local/bin/dummy-readinessprobe
+
 RUN tar xfz /agent/mongodb-agent.tar.gz \
     && mv mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent \
     && chmod +x /agent/mongodb-agent \

--- a/docker/mongodb-agent-non-matrix/Dockerfile.builder
+++ b/docker/mongodb-agent-non-matrix/Dockerfile.builder
@@ -9,3 +9,7 @@ ADD https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/b
 ADD https://downloads.mongodb.org/tools/db/mongodb-database-tools-${tools_distro}-${tools_version}.tgz /data/mongodb-tools.tgz
 
 COPY ./docker/mongodb-kubernetes-init-database/content/LICENSE /data/LICENSE
+COPY ./docker/mongodb-agent/agent-launcher-shim.sh /opt/scripts/agent-launcher-shim.sh
+COPY ./docker/mongodb-agent/setup-agent-files.sh /opt/scripts/setup-agent-files.sh
+COPY ./docker/mongodb-agent/dummy-probe.sh /opt/scripts/dummy-probe.sh
+COPY ./docker/mongodb-agent/dummy-readinessprobe.sh /opt/scripts/dummy-readinessprobe.sh

--- a/docker/mongodb-agent-non-matrix/agent-launcher-shim.sh
+++ b/docker/mongodb-agent-non-matrix/agent-launcher-shim.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+SCRIPTS_DIR="/opt/scripts"
+
+# Function to start the agent launcher
+start_agent_launcher() {
+  echo "Starting agent launcher..."
+  echo "Final contents of $SCRIPTS_DIR:"
+  ls -la "$SCRIPTS_DIR"
+
+  if [[ -f "$SCRIPTS_DIR/agent-launcher.sh" ]]; then
+    echo "Found agent-launcher.sh, executing..."
+    exec "$SCRIPTS_DIR/agent-launcher.sh"
+  else
+    echo "ERROR: agent-launcher.sh not found"
+    exit 1
+  fi
+}
+
+main() {
+  echo "Running setup-agent-files.sh..."
+  if ! /usr/local/bin/setup-agent-files.sh; then
+    echo "ERROR: Failed to set up agent files"
+    exit 1
+  fi
+
+  start_agent_launcher
+}
+
+main "$@"

--- a/docker/mongodb-agent-non-matrix/dummy-probe.sh
+++ b/docker/mongodb-agent-non-matrix/dummy-probe.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Dummy liveness probe that returns success to keep container alive during script copying
+# This prevents container from being killed while waiting for real probe scripts
+echo "Using dummy liveness probe - keeping container alive until real probe script is copied"
+exit 0

--- a/docker/mongodb-agent-non-matrix/dummy-readinessprobe.sh
+++ b/docker/mongodb-agent-non-matrix/dummy-readinessprobe.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Dummy readiness probe that returns NOT READY until real probe is copied
+# Container should not be marked ready until real probe scripts are available
+echo "Using dummy readiness probe - container not ready until real probe script is copied"
+exit 1

--- a/docker/mongodb-agent-non-matrix/setup-agent-files.sh
+++ b/docker/mongodb-agent-non-matrix/setup-agent-files.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -e
+
+SCRIPTS_DIR="/opt/scripts"
+
+# Set up dummy probe scripts
+# liveness always returns success
+# readiness always returns failure
+setup_dummy_probes() {
+  echo "Setting up dummy probe scripts..."
+  cp /usr/local/bin/dummy-probe.sh "$SCRIPTS_DIR/probe.sh"
+  cp /usr/local/bin/dummy-readinessprobe "$SCRIPTS_DIR/readinessprobe"
+  echo "Dummy probe scripts ready"
+}
+
+# wait max 5m for init container to be ready
+find_init_container() {
+  for i in {1..150}; do
+    local pid
+    pid=$(pgrep -f "agent-utilities-holder_marker" | head -n1)
+    if [[ -n "$pid" && -d "/proc/$pid/root/scripts" ]]; then
+      echo "$pid"
+      return 0
+    fi
+    echo "Waiting for init container... (attempt $i)" >&2
+    sleep 2
+  done
+  return 1
+}
+
+link_agent_scripts() {
+  local init_scripts_dir="$1"
+
+  echo "Linking agent launcher scripts..."
+  for script in agent-launcher.sh agent-launcher-lib.sh; do
+    ln -sf "$init_scripts_dir/$script" "$SCRIPTS_DIR/$script"
+    echo "Linked $script"
+  done
+}
+
+# Link probe scripts from init container, replacing dummy ones
+link_probe_scripts() {
+  local init_probes_dir="$1"
+
+  echo "Linking probe scripts..."
+  for probe in probe.sh readinessprobe; do
+    if [[ -f "$init_probes_dir/$probe" ]]; then
+      ln -sf "$init_probes_dir/$probe" "$SCRIPTS_DIR/$probe"
+      echo "Replaced dummy $probe with real one"
+    else
+      echo "WARNING: $probe not found in init container"
+      exit 1
+    fi
+  done
+}
+
+# Main function to set up all files
+main() {
+  setup_dummy_probes
+
+  if init_pid=$(find_init_container); then
+    echo "Found init container with PID: $init_pid"
+
+    init_root="/proc/$init_pid/root"
+    init_scripts="$init_root/scripts"
+    init_probes="$init_root/probes"
+
+    # Verify scripts directory exists
+    if [[ ! -d "$init_scripts" ]]; then
+      echo "ERROR: Scripts directory $init_scripts not found"
+      exit 1
+    fi
+
+    # Verify probes directory exists
+    if [[ ! -d "$init_probes" ]]; then
+      echo "ERROR: Probes directory $init_probes not found"
+      exit 1
+    fi
+
+    # Link scripts from init container
+    link_agent_scripts "$init_scripts"
+    link_probe_scripts "$init_probes"
+
+    echo "File setup completed successfully"
+    exit 0
+  else
+    echo "No init container found"
+    exit 1
+  fi
+}
+
+# Only run main if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
# Summary

- those scripts are required for agent matrix removal. They are placed here - since we overwrite the tag and this would race with the images created in other e2e tests

### Dockerfile updates:
* Updated `docker/mongodb-agent-non-matrix/Dockerfile` to copy new scripts (`agent-launcher-shim.sh`, `setup-agent-files.sh`, `dummy-probe.sh`, `dummy-readinessprobe.sh`) into the container at build time. These scripts are placed in `/usr/local/bin` for execution.
* Updated `docker/mongodb-agent-non-matrix/Dockerfile.builder` to include the same script files in the build process, ensuring they are available in the image.

### New scripts added:
* [`agent-launcher-shim.sh`](diffhunk://#diff-7050c43142cef16fa7268fd7d1356e96bdf5de2c8bc0d050f277babee01a397cR1-R31): A script to initialize the agent launcher by setting up agent files and starting the launcher if the required script is found.
* [`setup-agent-files.sh`](diffhunk://#diff-fbe2cd71b8fc58242e04e18562c58b1085f6b059dce42d94a2f4e5cbdf7a3469R1-R95): A script to set up dummy probe scripts initially, wait for an init container to provide real probe and launcher scripts, and replace the dummy scripts with the real ones.
* [`dummy-probe.sh`](diffhunk://#diff-ff81b0610fd08dd2d32bcbe72c0d78fb402d5f6dbe8a388bad94c7cdf9b95e3bR1-R5): A dummy liveness probe script that always returns success to keep the container alive during the setup process.
* [`dummy-readinessprobe.sh`](diffhunk://#diff-4378f36df04937eb7473771a47dc6ac5a424ec8ffdb171e201b9fc8052a54c26R1-R5): A dummy readiness probe script that always returns a "not ready" status until the real probe script is available.

## Proof of Work

- not used anywhere, ci needs to pass
- used by this pr (that contains more information on how its used): https://github.com/mongodb/mongodb-kubernetes/pull/267

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
