### PR TITLE
Apply Search overrides in e2e operator config map

### DIFF
--- a/scripts/funcs/operator_deployment
+++ b/scripts/funcs/operator_deployment
@@ -34,6 +34,9 @@ get_operator_helm_values() {
     "operator.telemetry.send.enabled=${MDB_OPERATOR_TELEMETRY_SEND_ENABLED:-false}"
     # lets collect and save in the configmap as frequently as we can
     "operator.telemetry.collection.frequency=${MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY:-1m}"
+    "search.community.version=${MDB_SEARCH_COMMUNITY_VERSION}"
+    "search.community.name=${MDB_SEARCH_COMMUNITY_NAME}"
+    "search.community.repo=${MDB_SEARCH_COMMUNITY_REPO_URL}"
   )
 
   if [[ "${MDB_OPERATOR_TELEMETRY_INSTALL_CLUSTER_ROLE_INSTALLATION:-}" != "" ]]; then


### PR DESCRIPTION
# Summary

This makes sure that e2e tests respect the `MDB_SEARCH_COMMUNITY_*` variable overrides in a context.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
