### PR TITLE
Fix shellcheck issues in the kubectl-mongodb plugin scripts

### DIFF
--- a/scripts/release/kubectl-mongodb/install_istio_separate_network.sh
+++ b/scripts/release/kubectl-mongodb/install_istio_separate_network.sh
@@ -15,9 +15,9 @@ curl -L https://istio.io/downloadIstio | sh -
 function_check_external_ip_assigned() {
  while : ; do
    ip=$(kubectl --context="$1" get svc istio-eastwestgateway -n istio-system --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
-   if [ -n "$ip" ]
+   if [ -n "${ip}" ]
    then
-     echo "external ip assigned $ip"
+     echo "external ip assigned ${ip}"
      break
    else
      echo "waiting for external ip to be assigned"
@@ -25,36 +25,36 @@ function_check_external_ip_assigned() {
 done
 }
 
-cd istio-${ISTIO_VERSION}
+cd "istio-${ISTIO_VERSION}"
 mkdir -p certs
 pushd certs
 
 # create root trust for the clusters
 make -f ../tools/certs/Makefile.selfsigned.mk root-ca
-make -f ../tools/certs/Makefile.selfsigned.mk ${CTX_CLUSTER1}-cacerts
-make -f ../tools/certs/Makefile.selfsigned.mk ${CTX_CLUSTER2}-cacerts
-make -f ../tools/certs/Makefile.selfsigned.mk ${CTX_CLUSTER3}-cacerts
+make -f ../tools/certs/Makefile.selfsigned.mk "${CTX_CLUSTER1}-cacerts"
+make -f ../tools/certs/Makefile.selfsigned.mk "${CTX_CLUSTER2}-cacerts"
+make -f ../tools/certs/Makefile.selfsigned.mk "${CTX_CLUSTER3}-cacerts"
 
 kubectl --context="${CTX_CLUSTER1}" create ns istio-system
 kubectl --context="${CTX_CLUSTER1}" create secret generic cacerts -n istio-system \
-      --from-file=${CTX_CLUSTER1}/ca-cert.pem \
-      --from-file=${CTX_CLUSTER1}/ca-key.pem \
-      --from-file=${CTX_CLUSTER1}/root-cert.pem \
-      --from-file=${CTX_CLUSTER1}/cert-chain.pem
+      --from-file="${CTX_CLUSTER1}/ca-cert.pem" \
+      --from-file="${CTX_CLUSTER1}/ca-key.pem" \
+      --from-file="${CTX_CLUSTER1}/root-cert.pem" \
+      --from-file="${CTX_CLUSTER1}/cert-chain.pem"
 
 kubectl --context="${CTX_CLUSTER2}" create ns istio-system
 kubectl --context="${CTX_CLUSTER2}" create secret generic cacerts -n istio-system \
-      --from-file=${CTX_CLUSTER2}/ca-cert.pem \
-      --from-file=${CTX_CLUSTER2}/ca-key.pem \
-      --from-file=${CTX_CLUSTER2}/root-cert.pem \
-      --from-file=${CTX_CLUSTER2}/cert-chain.pem
+      --from-file="${CTX_CLUSTER2}/ca-cert.pem" \
+      --from-file="${CTX_CLUSTER2}/ca-key.pem" \
+      --from-file="${CTX_CLUSTER2}/root-cert.pem" \
+      --from-file="${CTX_CLUSTER2}/cert-chain.pem"
 
 kubectl --context="${CTX_CLUSTER3}" create ns istio-system
 kubectl --context="${CTX_CLUSTER3}" create secret generic cacerts -n istio-system \
-      --from-file=${CTX_CLUSTER3}/ca-cert.pem \
-      --from-file=${CTX_CLUSTER3}/ca-key.pem \
-      --from-file=${CTX_CLUSTER3}/root-cert.pem \
-      --from-file=${CTX_CLUSTER3}/cert-chain.pem
+      --from-file="${CTX_CLUSTER3}/ca-cert.pem" \
+      --from-file="${CTX_CLUSTER3}/ca-key.pem" \
+      --from-file="${CTX_CLUSTER3}/root-cert.pem" \
+      --from-file="${CTX_CLUSTER3}/cert-chain.pem"
 popd
 
 # label namespace in cluster1
@@ -184,5 +184,5 @@ bin/istioctl x create-remote-secret \
 
   # cleanup: delete the istio repo at the end
 cd ..
-rm -r istio-${ISTIO_VERSION}
+rm -r "istio-${ISTIO_VERSION}"
 rm -f cluster1.yaml cluster2.yaml cluster3.yaml

--- a/scripts/release/kubectl-mongodb/sign.sh
+++ b/scripts/release/kubectl-mongodb/sign.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Disables shellcheck on lines 15-21, because vars seem to be assigned to themselves.
+# and we are not sure if removing this would be an issue.
+# shellcheck disable=SC2269
 
 set -euo pipefail
 
@@ -28,14 +31,14 @@ echo "Signing artifact ${ARTIFACT} and saving signature to ${SIGNATURE}"
 } > "${SIGNING_ENVFILE}"
 
 echo "Logging in artifactory.corp"
-echo ${ARTIFACTORY_PASSWORD} | docker login --password-stdin --username ${ARTIFACTORY_USERNAME} ${ARTIFACTORY_URL}
+echo "${ARTIFACTORY_PASSWORD}" | docker login --password-stdin --username "${ARTIFACTORY_USERNAME}" "${ARTIFACTORY_URL}"
 
 echo "Signing artifact"
 echo "Envfile is ${SIGNING_ENVFILE}"
 docker run \
   --env-file="${SIGNING_ENVFILE}" \
   --rm \
-  -v $(pwd):$(pwd) \
-  -w $(pwd) \
-  ${SIGNING_IMAGE_URI} \
-  cosign sign-blob --key "${PKCS11_URI}" --output-signature ${SIGNATURE} ${ARTIFACT} --yes
+  -v "$(pwd)":"$(pwd)" \
+  -w "$(pwd)" \
+  "${SIGNING_IMAGE_URI}" \
+  cosign sign-blob --key "${PKCS11_URI}" --output-signature "${SIGNATURE}" "${ARTIFACT}" --yes

--- a/scripts/release/kubectl-mongodb/verify.sh
+++ b/scripts/release/kubectl-mongodb/verify.sh
@@ -11,9 +11,10 @@ SIGNATURE="${ARTIFACT}.sig"
 HOSTED_SIGN_PUBKEY="https://cosign.mongodb.com/mongodb-enterprise-kubernetes-operator.pem" # to complete
 TMPDIR=${TMPDIR:-/tmp}
 KEY_FILE="${TMPDIR}/host-public.key"
-SIGNING_IMAGE_URI=${SIGNING_IMAGE_URI}
+# shellcheck disable=SC2269
+SIGNING_IMAGE_URI="${SIGNING_IMAGE_URI}"
 
-curl -o ${KEY_FILE} "${HOSTED_SIGN_PUBKEY}"
+curl -o "${KEY_FILE}" "${HOSTED_SIGN_PUBKEY}"
 echo "Verifying signature ${SIGNATURE} of artifact ${ARTIFACT}"
 echo "Keyfile is ${KEY_FILE}"
 
@@ -22,11 +23,11 @@ echo "Keyfile is ${KEY_FILE}"
 
 docker run \
   --rm \
-  -v $(pwd):$(pwd) \
-  -v ${KEY_FILE}:${KEY_FILE} \
-  -w $(pwd) \
-  ${SIGNING_IMAGE_URI} \
-  cosign verify-blob --key ${KEY_FILE} --signature ${SIGNATURE} ${ARTIFACT}
+  -v "$(pwd)":"$(pwd)" \
+  -v "${KEY_FILE}":"${KEY_FILE}" \
+  -w "$(pwd)" \
+  "${SIGNING_IMAGE_URI}" \
+  cosign verify-blob --key "${KEY_FILE}" --signature "${SIGNATURE}" "${ARTIFACT}"
 
 # Without below line, Evergreen fails at archiving with "open dist/kubectl-[...]/kubectl-mongodb.sig: permission denied
-sudo chmod 666 ${SIGNATURE}
+sudo chmod 666 "${SIGNATURE}"


### PR DESCRIPTION
# Summary

This RP fixes the shellcheck (info) issues that we saw in the `kubectl-mongodb` plugin related scripts when we ran `make precommit`.
Most of the issues are fixed when I didn't actually have to make any change but I had to disable check for some lines where it was expected to make some change and I was not sure if that would impact things functionally. 

## Proof of Work

NA

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
