### PR TITLE
Correct `kubectl-mongodb` path for command `prepare_local_e2e`

### DIFF
--- a/scripts/funcs/multicluster
+++ b/scripts/funcs/multicluster
@@ -210,13 +210,13 @@ prepare_multi_cluster_e2e_run() {
     fi
 
     (
-      cd public/tools/multicluster/
+      cd cmd/kubectl-mongodb
       GOOS=darwin GOARCH="${goarch}" go build -o "${MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH}" main.go
     )
     PATH=${PATH}:docker/mongodb-kubernetes-tests
   else
     (
-      cd public/tools/multicluster/
+      cd cmd/kubectl-mongodb
       # shellcheck disable=SC2030
       export PATH=${GOROOT}:${PATH}
       GOOS=linux GOARCH=amd64 go build -o "${MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH}" main.go


### PR DESCRIPTION
# Summary

When we change the directory of `kubectl-mongodb` from `public/tools/multicluster` to `cmd/kubectl-mongodb` we change the source file `build_multi_cluster_kubeconfig_creator.sh` to use the new path but I missed updating the new path in the file `funcs/multicluster`. This PR fixes that problem and updates the path to point to the correct location.

## Proof of Work

Run `make prepare_local_e2e`, that will build the `kubectl-mongodb` binary and use the `kubectl mongodb multicluster` command to setup the multicluster environment. 

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
