### PR TITLE
Update new `kubectl-mongodb` path in the precommit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -117,9 +117,9 @@ function update_release_json() {
 }
 
 function regenerate_public_rbac_multi_cluster() {
-    if echo "$git_last_changed" | grep -q 'public/tools/multicluster'; then
+    if echo "$git_last_changed" | grep -q 'cmd/kubectl-mongodb'; then
       echo 'regenerating multicluster RBAC public example'
-      pushd public/tools/multicluster
+      pushd pkg/kubectl-mongodb/common/
       EXPORT_RBAC_SAMPLES="true" go test ./... -run TestPrintingOutRolesServiceAccountsAndRoleBindings
       popd
       git add public/samples/multi-cluster-cli-gitops

--- a/pkg/kubectl-mongodb/common/common_test.go
+++ b/pkg/kubectl-mongodb/common/common_test.go
@@ -486,7 +486,7 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sb = marshalToYaml(t, sb, "Central Cluster, cluster-scoped resources", "rbac.authorization.k8s.io/v1", "ClusterRoleBinding", crb.Items)
 		sb = marshalToYaml(t, sb, "Central Cluster, cluster-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../../samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml", []byte(sb.String()), os.ModePerm)
 		assert.NoError(t, err)
 	}
 
@@ -505,7 +505,7 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sb = marshalToYaml(t, sb, "Member Cluster, cluster-scoped resources", "rbac.authorization.k8s.io/v1", "ClusterRoleBinding", crb.Items)
 		sb = marshalToYaml(t, sb, "Member Cluster, cluster-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../../samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_member_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_member_cluster.yaml", []byte(sb.String()), os.ModePerm)
 		assert.NoError(t, err)
 	}
 
@@ -526,7 +526,7 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sb = marshalToYaml(t, sb, "Central Cluster, namespace-scoped resources", "rbac.authorization.k8s.io/v1", "RoleBinding", rb.Items)
 		sb = marshalToYaml(t, sb, "Central Cluster, namespace-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../../samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml", []byte(sb.String()), os.ModePerm)
 		assert.NoError(t, err)
 	}
 
@@ -547,7 +547,7 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sb = marshalToYaml(t, sb, "Member Cluster, namespace-scoped resources", "rbac.authorization.k8s.io/v1", "RoleBinding", rb.Items)
 		sb = marshalToYaml(t, sb, "Member Cluster, namespace-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../../samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_member_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_member_cluster.yaml", []byte(sb.String()), os.ModePerm)
 		assert.NoError(t, err)
 	}
 }


### PR DESCRIPTION
# Summary

The precommit hook tries to see if there are any files changed in the multicluster directory and if there are changed files, it runs a `go test` that creates the updated RBAC files for multicluster.
After we changed the location of the `kubectl-mongodb` plugin, I missed updating the new path of the plugin in this file. This PR fixes that.

## Proof of Work

Run `make precommit` to make sure it works fine, that would mean that the path of the binaries and the other locations are configured correctly.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
