### PR TITLE
Fix master builds

### DIFF
--- a/scripts/release/build_context.py
+++ b/scripts/release/build_context.py
@@ -71,7 +71,7 @@ class BuildContext:
             return self.git_tag
         if self.scenario == BuildScenario.STAGING:
             # On master merges, always use "latest" (preserving legacy behavior)
-            return "latest"
+            return self.patch_id
         if self.patch_id:
             return self.patch_id
         # Alternatively, we can fail here if no ID is explicitly defined


### PR DESCRIPTION
# Summary

Master patches are broken because they build with `latest` tag only, while the patch still need the `patch_id` tagged images.
This PR fixes this issue to get master green again, but remove builds to `latest`. They will be added again in https://github.com/mongodb/mongodb-kubernetes/pull/317, using build_info.

## Proof of Work
Unfortunately, we cannot master patches before merging.
