### PR TITLE
CLOUDP-325334: Remove hardcoding of OM 7.0.12

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1458,10 +1458,6 @@ def gather_latest_agent_versions(release: Dict, agent_to_build: str = "") -> Lis
             )
         )
 
-    # TODO: Remove this once we don't need to use OM 7.0.12 in the OM Multicluster DR tests
-    # https://jira.mongodb.org/browse/CLOUDP-297377
-    agent_versions_to_build.append(("107.0.12.8669-1", "100.10.0"))
-
     if agent_to_build != "":
         for agent_tuple in agent_versions_to_build:
             if agent_tuple[0] == agent_to_build:

--- a/pipeline_test.py
+++ b/pipeline_test.py
@@ -163,9 +163,6 @@ def test_build_latest_agent_versions():
     latest_agents = gather_latest_agent_versions(release_json)
     expected_agents = [
         ("107.0.11.8645-1", "100.10.0"),
-        # TODO: Remove this once we don't need to use OM 7.0.12 in the OM Multicluster DR tests
-        # https://jira.mongodb.org/browse/CLOUDP-297377
-        ("107.0.12.8669-1", "100.10.0"),
         ("12.0.31.7825-1", "100.9.4"),
         ("13.19.0.8937-1", "100.9.4"),
     ]

--- a/scripts/dev/contexts/e2e_multi_cluster_om_appdb
+++ b/scripts/dev/contexts/e2e_multi_cluster_om_appdb
@@ -8,11 +8,6 @@ script_dir=$(dirname "${script_name}")
 source "${script_dir}/root-context"
 source "${script_dir}/variables/om70"
 
-# TODO Remove this once the startup script for OM can handle skipping preflight checks.
-# As it stands now, OM 7.0.13 will fail the preflight checks in a disaster recovery scenario.
-# https://jira.mongodb.org/browse/CLOUDP-297377
-export CUSTOM_OM_VERSION=7.0.12
-
 export KUBE_ENVIRONMENT_NAME=multi
 export CLUSTER_NAME="kind-e2e-cluster-1"
 export MEMBER_CLUSTERS="kind-e2e-cluster-1 kind-e2e-cluster-2 kind-e2e-cluster-3"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_om_appdb
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_om_appdb
@@ -8,11 +8,6 @@ script_dir=$(dirname "${script_name}")
 source "${script_dir}/root-context"
 source "${script_dir}/variables/om70"
 
-# TODO Remove this once the startup script for OM can handle skipping preflight checks.
-# As it stands now, OM 7.0.13 will fail the preflight checks in a disaster recovery scenario.
-# https://jira.mongodb.org/browse/CLOUDP-297377
-export CUSTOM_OM_VERSION=7.0.12
-
 export KUBE_ENVIRONMENT_NAME=multi
 export CLUSTER_NAME="kind-e2e-cluster-1"
 export MEMBER_CLUSTERS="kind-e2e-cluster-1 kind-e2e-cluster-2 kind-e2e-cluster-3"

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -495,8 +495,4 @@ def gather_latest_agent_versions(release: Dict) -> List[Tuple[str, str]]:
             )
         )
 
-    # TODO: Remove this once we don't need to use OM 7.0.12 in the OM Multicluster DR tests
-    # https://jira.mongodb.org/browse/CLOUDP-297377
-    agent_versions_to_build.append(("107.0.12.8669-1", "100.10.0"))
-
     return sorted(list(set(agent_versions_to_build)))


### PR DESCRIPTION
# Summary

Removing hardcoding of OM 7.0.12 in DR recovery tests as OM 7.0.17 should have fixed the startup issue by skipping migration checks when OM version has not changed.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
