### PR TITLE
removing pipeline and atomic matrix

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -33,8 +33,7 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
 
   - &base_no_om_image_dependency
     depends_on:
@@ -52,8 +51,7 @@ variables:
         variant: init_test_run
       - name: build_init_appdb_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
 
   - &community_dependency
     depends_on:
@@ -61,8 +59,7 @@ variables:
         variant: init_test_run
       - name: build_test_image
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
       - name: build_readiness_probe_image
         variant: init_test_run
       - name: build_upgrade_hook_image
@@ -153,8 +150,7 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
 
   - &base_om7_dependency_with_race
     depends_on:
@@ -172,8 +168,7 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
 
   - &base_om8_dependency
     depends_on:
@@ -191,8 +186,7 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
 
 parameters:
   - key: evergreen_retry
@@ -347,19 +341,6 @@ tasks:
           image_name: init-ops-manager
           include_tags: release
 
-  - name: release_agent_operator_release
-    tags: [ "image_release" ]
-    allowed_requesters: [ "patch", "github_tag" ]
-    commands:
-      - func: clone
-      - func: setup_building_host
-      - func: quay_login
-      - func: setup_docker_sbom
-      - func: legacy_pipeline
-        vars:
-          image_name: agent
-          include_tags: release
-
   # pct only triggers this variant once a new agent image is out
   - name: release_agent
     # this enables us to run this variant either manually (patch) which pct does or during an OM bump (github_pr)
@@ -391,21 +372,6 @@ tasks:
             - GH_TOKEN
           working_dir: src/github.com/mongodb/mongodb-kubernetes
           binary: scripts/evergreen/precommit_bump.sh
-
-  # Pct only triggers this variant once a new agent image is out
-  # these releases the agent with the operator suffix (not patch id) on ecr to allow for digest pinning to pass.
-  # For this to work, we rely on skip_tags which is used to determine whether
-  # we want to release on quay or not, in this case - ecr instead.
-  # We rely on the init_database from ecr for the agent x operator images.
-  # This runs on agent releases that are not concurrent with operator releases.
-  - name: release_agents_on_ecr_conditional
-    commands:
-      - func: clone
-      - func: run_task_conditionally
-        vars:
-          condition_script: scripts/evergreen/should_release_agents_on_ecr.sh
-          variant: init_release_agents_on_ecr
-          task: release_agents_on_ecr
 
   - name: release_agents_on_ecr
     # this enables us to run this variant either manually (patch) which pct does or during an OM bump (github_pr)
@@ -1334,8 +1300,7 @@ buildvariants:
         variant: init_test_run
       - name: build_init_database_image_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
     tasks:
       - name: e2e_custom_domain_task_group
 
@@ -1369,8 +1334,7 @@ buildvariants:
         variant: init_test_run
       - name: build_init_database_image_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
     run_on:
       - ubuntu2204-small
     tasks:
@@ -1617,8 +1581,7 @@ buildvariants:
         variant: init_tests_with_olm
       - name: build_init_database_image_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
     tasks:
       - name: e2e_kind_olm_group
 
@@ -1683,18 +1646,6 @@ buildvariants:
       - name: build_upgrade_hook_image
       - name: prepare_aws
 
-  - name: init_release_agents_on_ecr
-    display_name: init_release_agents_on_ecr
-    # this enables us to run this variant either manually (patch) which pct does or during an OM bump (github_pr)
-    allowed_requesters: [ "patch", "github_pr" ]
-    tags: [ "release_agents_on_ecr" ]
-    # We want that to run first and finish asap. Digest pinning depends on this to succeed.
-    priority: 70
-    run_on:
-      - ubuntu2204-large
-    tasks:
-      - name: release_agents_on_ecr_conditional
-
   - name: run_pre_commit
     priority: 70
     display_name: run_pre_commit
@@ -1722,8 +1673,7 @@ buildvariants:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
+
     run_on:
       - ubuntu2204-small
     tasks:
@@ -1809,13 +1759,6 @@ buildvariants:
       - name: release_init_database
       - name: release_init_ops_manager
       - name: release_database
-      # Once we release the operator, we will also release the init databases, we require them to be out first
-      # such that we can reference them and retrieve those binaries.
-      # Since we immediately run daily rebuild after creating the image, we can ensure that the init_database is out
-      # such that the agent image build can use it.
-      - name: release_agent_operator_release
-        depends_on:
-          - name: release_init_database
 
   - name: preflight_release_images
     display_name: preflight_release_images
@@ -1847,13 +1790,13 @@ buildvariants:
 
     # It will be called by pct while bumping the agent cloud manager image
   - name: release_agent
-    display_name: (Static Containers) Release Agent matrix
+    display_name: release_agent
     tags: [ "release_agent" ]
     run_on:
       - release-ubuntu2204-large # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     depends_on:
-      - variant: init_release_agents_on_ecr
-        name: '*'
+      - variant: init_test_run
+        name: build_agent_images_ubi # this ensures the agent gets released to ECR as well
       - variant: e2e_multi_cluster_kind
         name: '*'
       - variant: e2e_static_multi_cluster_2_clusters

--- a/pipeline.py
+++ b/pipeline.py
@@ -42,6 +42,7 @@ from packaging.version import Version
 import docker
 from lib.base_logger import logger
 from lib.sonar.sonar import process_image
+from scripts.detect_ops_manager_changes import detect_ops_manager_changes
 from scripts.evergreen.release.agent_matrix import (
     get_supported_version_for_image,
 )
@@ -1245,18 +1246,11 @@ def build_agent_default_case(build_configuration: BuildConfiguration):
     """
     Build the agent only for the latest operator for patches and operator releases.
 
-    See more information in the function: build_agent_on_agent_bump
     """
-    release_json = get_release()
-
-    is_release = build_configuration.is_release_step_executed()
-
-    # We need to release [all agents x latest operator] on operator releases
-    if is_release:
-        agent_versions_to_build = gather_all_supported_agent_versions(release_json)
-    # We only need [latest agents (for each OM major version and for CM) x patch ID] for patches
-    else:
-        agent_versions_to_build = gather_latest_agent_versions(release_json, build_configuration.agent_to_build)
+    agent_versions_to_build = detect_ops_manager_changes()
+    if not agent_versions_to_build:
+        logger.info("No changes detected, skipping agent build")
+        return
 
     logger.info(f"Building Agent versions: {agent_versions_to_build}")
 
@@ -1267,83 +1261,17 @@ def build_agent_default_case(build_configuration: BuildConfiguration):
         if build_configuration.parallel_factor > 0:
             max_workers = build_configuration.parallel_factor
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        logger.info(f"running with factor of {max_workers}")
-        for agent_version in agent_versions_to_build:
+        logger.info(f"Running with factor of {max_workers}")
+        for idx, agent_tools_version in enumerate(agent_versions_to_build):
             # We don't need to keep create and push the same image on every build.
             # It is enough to create and push the non-operator suffixed images only during releases to ecr and quay.
-            if build_configuration.is_release_step_executed() or build_configuration.all_agents:
-                tasks_queue.put(
-                    executor.submit(
-                        build_multi_arch_agent_in_sonar,
-                        build_configuration,
-                        agent_version[0],
-                        agent_version[1],
-                    )
-                )
-            _add_to_agent_queue(agent_version, build_configuration, executor, tasks_queue)
-
-    queue_exception_handling(tasks_queue)
-
-
-def build_agent_on_agent_bump(build_configuration: BuildConfiguration):
-    """
-    Build the agent matrix (operator version x agent version), triggered by PCT.
-
-    We have three cases where we need to build the agent:
-    - e2e test runs
-    - operator releases
-    - OM/CM bumps via PCT
-
-    In OM/CM bumps, we release a new agent.
-    """
-    release_json = get_release()
-    is_release = build_configuration.is_release_step_executed()
-
-    if build_configuration.all_agents:
-        agent_versions_to_build = gather_all_supported_agent_versions(release_json)
-    else:
-        # we only need to release the latest images, we don't need to re-push old images, as we don't clean them up anymore.
-        agent_versions_to_build = gather_latest_agent_versions(release_json, build_configuration.agent_to_build)
-
-    legacy_agent_versions_to_build = release_json["supportedImages"]["mongodb-agent"]["versions"]
-
-    tasks_queue = Queue()
-    max_workers = 1
-    if build_configuration.parallel:
-        max_workers = None
-        if build_configuration.parallel_factor > 0:
-            max_workers = build_configuration.parallel_factor
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        logger.info(f"running with factor of {max_workers}")
-
-        # We need to regularly push legacy agents, otherwise ecr lifecycle policy will expire them.
-        # We only need to push them once in a while to ecr, so no quay required
-        if not is_release:
-            for legacy_agent in legacy_agent_versions_to_build:
-                tasks_queue.put(
-                    executor.submit(
-                        build_multi_arch_agent_in_sonar,
-                        build_configuration,
-                        legacy_agent,
-                        # we assume that all legacy agents are build using that tools version
-                        "100.9.4",
-                    )
-                )
-
-        for agent_version in agent_versions_to_build:
-            # We don't need to keep create and push the same image on every build.
-            # It is enough to create and push the non-operator suffixed images only during releases to ecr and quay.
-            if build_configuration.is_release_step_executed() or build_configuration.all_agents:
-                tasks_queue.put(
-                    executor.submit(
-                        build_multi_arch_agent_in_sonar,
-                        build_configuration,
-                        agent_version[0],
-                        agent_version[1],
-                    )
-                )
-            logger.info(f"Building Agent versions: {agent_version}")
-            _add_to_agent_queue(agent_version, build_configuration, executor, tasks_queue)
+            logger.info(f"======= Building Agent {agent_tools_version} ({idx}/{len(agent_versions_to_build)})")
+            _build_agents(
+                agent_tools_version,
+                build_configuration,
+                executor,
+                tasks_queue,
+            )
 
     queue_exception_handling(tasks_queue)
 
@@ -1384,85 +1312,27 @@ def queue_exception_handling(tasks_queue):
         )
 
 
-def _add_to_agent_queue(
-    agent_version: Tuple[str, str],
-    build_configuration: BuildConfiguration,
+def _build_agents(
+    agent_tools_version: Tuple[str, str],
+    build_configuration: ImageBuildConfiguration,
     executor: ProcessPoolExecutor,
     tasks_queue: Queue,
 ):
-    tools_version = agent_version[1]
-    image_version = f"{agent_version[0]}"
+    agent_version = agent_tools_version[0]
+    agent_distro = "rhel9_x86_64"
+    tools_version = agent_tools_version[1]
+    tools_distro = get_tools_distro(tools_version)["amd"]
 
     tasks_queue.put(
         executor.submit(
             build_multi_arch_agent_in_sonar,
             build_configuration,
-            image_version,
+            agent_version,
+            agent_distro,
             tools_version,
+            tools_distro,
         )
     )
-
-
-def gather_all_supported_agent_versions(release: Dict) -> List[Tuple[str, str]]:
-    # This is a list of a tuples - agent version and corresponding tools version
-    agent_versions_to_build = list()
-    agent_versions_to_build.append(
-        (
-            release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager"],
-            release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager_tools"],
-        )
-    )
-    for _, om in release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"].items():
-        agent_versions_to_build.append((om["agent_version"], om["tools_version"]))
-
-    # lets not build the same image multiple times
-    return sorted(list(set(agent_versions_to_build)))
-
-
-def gather_latest_agent_versions(release: Dict, agent_to_build: str = "") -> List[Tuple[str, str]]:
-    """
-    This function is used when we release a new agent via OM bump.
-    That means we will need to release that agent with all supported operators.
-    Since we don't want to release all agents again, we only release the latest, which will contain the newly added one
-    :return: the latest agent for each major version
-    """
-    agent_versions_to_build = list()
-    agent_versions_to_build.append(
-        (
-            release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager"],
-            release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager_tools"],
-        )
-    )
-
-    latest_versions = {}
-
-    for version in release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"].keys():
-        parsed_version = semver.VersionInfo.parse(version)
-        major_version = parsed_version.major
-        if major_version in latest_versions:
-            latest_parsed_version = semver.VersionInfo.parse(str(latest_versions[major_version]))
-            latest_versions[major_version] = max(parsed_version, latest_parsed_version)
-        else:
-            latest_versions[major_version] = version
-
-    for major_version, latest_version in latest_versions.items():
-        agent_versions_to_build.append(
-            (
-                release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"][str(latest_version)][
-                    "agent_version"
-                ],
-                release["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"][str(latest_version)][
-                    "tools_version"
-                ],
-            )
-        )
-
-    if agent_to_build != "":
-        for agent_tuple in agent_versions_to_build:
-            if agent_tuple[0] == agent_to_build:
-                return [agent_tuple]
-
-    return sorted(list(set(agent_versions_to_build)))
 
 
 def get_builder_function_for_image_name() -> Dict[str, Callable]:
@@ -1478,7 +1348,7 @@ def get_builder_function_for_image_name() -> Dict[str, Callable]:
         "upgrade-hook": build_upgrade_hook_image,
         "operator-quick": build_operator_image_patch,
         "database": build_database_image,
-        "agent-pct": build_agent_on_agent_bump,
+        "agent-pct": build_agent_default_case,
         "agent": build_agent_default_case,
         #
         # Init images

--- a/scripts/detect_ops_manager_changes.py
+++ b/scripts/detect_ops_manager_changes.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Detects changes to opsManagerMapping in release.json for triggering agent releases.
+Relies on git origin/master vs local release.json
+"""
+import json
+import os
+import subprocess
+import sys
+from typing import Dict, List, Optional, Tuple
+
+
+def get_content_from_git(commit: str, file_path: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{commit}:{file_path}"], capture_output=True, text=True, check=True, timeout=30
+        )
+        return result.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def load_base_release_json() -> Optional[Dict]:
+    base_revision = "origin/master"
+
+    content = get_content_from_git(base_revision, "release.json")
+    if not content:
+        print(f"Could not retrieve release.json from {base_revision}")
+        return None
+
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON in base release.json: {e}")
+        return None
+
+
+def load_current_release_json() -> Optional[Dict]:
+    try:
+        with open("release.json", "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"Could not load current release.json: {e}")
+        return None
+
+
+def extract_ops_manager_mapping(release_data: Dict) -> Dict:
+    if not release_data:
+        return {}
+    return release_data.get("supportedImages", {}).get("mongodb-agent", {}).get("opsManagerMapping", {})
+
+
+def get_changed_agents(current_mapping: Dict, base_mapping: Dict) -> List[Tuple[str, str]]:
+    """Returns list of (agent_version, tools_version) tuples for added/changed agents"""
+    added_agents = []
+
+    current_om_mapping = current_mapping.get("ops_manager", {})
+    master_om_mapping = base_mapping.get("ops_manager", {})
+
+    for om_version, agent_tools_version in current_om_mapping.items():
+        if om_version not in master_om_mapping or master_om_mapping[om_version] != agent_tools_version:
+            added_agents.append((agent_tools_version["agent_version"], agent_tools_version["tools_version"]))
+
+    current_cm = current_mapping.get("cloud_manager")
+    master_cm = base_mapping.get("cloud_manager")
+    current_cm_tools = current_mapping.get("cloud_manager_tools")
+    master_cm_tools = base_mapping.get("cloud_manager_tools")
+
+    if current_cm != master_cm or current_cm_tools != master_cm_tools:
+        added_agents.append((current_cm, current_cm_tools))
+
+    return list(set(added_agents))
+
+
+def detect_ops_manager_changes() -> List[Tuple[str, str]]:
+    """Returns (has_changes, changed_agents_list)"""
+    print("=== Detecting OM Mapping Changes (Local vs Base) ===")
+
+    current_release = load_current_release_json()
+    if not current_release:
+        print("ERROR: Could not load current local release.json")
+        return []
+
+    base_release = load_base_release_json()
+    if not base_release:
+        print("WARNING: Could not load base release.json, assuming changes exist")
+        return []
+
+    current_mapping = extract_ops_manager_mapping(current_release)
+    base_mapping = extract_ops_manager_mapping(base_release)
+
+    if current_mapping != base_mapping:
+        return get_changed_agents(current_mapping, base_mapping)
+    else:
+        return []
+
+
+if __name__ == "__main__":
+    if not os.path.exists("release.json"):
+        print("ERROR: release.json not found. Are you in the project root?")
+        sys.exit(2)
+
+    agents = detect_ops_manager_changes()
+    if agents:
+        print(f"Changed agents: {agents}")
+        sys.exit(0)
+    else:
+        print("Skipping agent release")
+        sys.exit(1)

--- a/scripts/test_detect_ops_manager_changes.py
+++ b/scripts/test_detect_ops_manager_changes.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Tests for detect_ops_manager_changes.py
+"""
+import json
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+# Add the scripts directory to the path so we can import the module
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from detect_ops_manager_changes import (
+    detect_ops_manager_changes,
+    extract_ops_manager_mapping,
+    get_content_from_git,
+    load_current_release_json,
+)
+
+
+class TestDetectOpsManagerChanges(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.master_release_data = {
+            "supportedImages": {
+                "mongodb-agent": {
+                    "opsManagerMapping": {
+                        "cloud_manager": "13.37.0.9590-1",
+                        "cloud_manager_tools": "100.12.2",
+                        "ops_manager": {
+                            "6.0.26": {"agent_version": "12.0.34.7888-1", "tools_version": "100.10.0"},
+                            "7.0.11": {"agent_version": "107.0.11.8645-1", "tools_version": "100.10.0"},
+                        },
+                    }
+                }
+            }
+        }
+
+        self.current_release_data = {
+            "supportedImages": {
+                "mongodb-agent": {
+                    "opsManagerMapping": {
+                        "cloud_manager": "13.37.0.9590-1",
+                        "cloud_manager_tools": "100.12.2",
+                        "ops_manager": {
+                            "6.0.26": {"agent_version": "12.0.34.7888-1", "tools_version": "100.10.0"},
+                            "7.0.11": {"agent_version": "107.0.11.8645-1", "tools_version": "100.10.0"},
+                        },
+                    }
+                }
+            }
+        }
+
+    def test_extract_ops_manager_mapping_valid(self):
+        """Test extracting opsManagerMapping from valid release data"""
+        mapping = extract_ops_manager_mapping(self.master_release_data)
+        expected = {
+            "cloud_manager": "13.37.0.9590-1",
+            "cloud_manager_tools": "100.12.2",
+            "ops_manager": {
+                "6.0.26": {"agent_version": "12.0.34.7888-1", "tools_version": "100.10.0"},
+                "7.0.11": {"agent_version": "107.0.11.8645-1", "tools_version": "100.10.0"},
+            },
+        }
+        self.assertEqual(mapping, expected)
+
+    def test_extract_ops_manager_mapping_empty(self):
+        """Test extracting from empty/invalid data"""
+        self.assertEqual(extract_ops_manager_mapping({}), {})
+        self.assertEqual(extract_ops_manager_mapping(None), {})
+
+    def test_extract_ops_manager_mapping_missing_keys(self):
+        """Test extracting when keys are missing"""
+        incomplete_data = {"supportedImages": {}}
+        self.assertEqual(extract_ops_manager_mapping(incomplete_data), {})
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.path.exists", return_value=True)
+    def test_load_current_release_json_success(self, mock_exists, mock_file):
+        """Test successfully loading current release.json"""
+        mock_file.return_value.read.return_value = json.dumps(self.current_release_data)
+
+        result = load_current_release_json()
+        self.assertEqual(result, self.current_release_data)
+
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_load_current_release_json_not_found(self, mock_file):
+        """Test handling missing release.json"""
+        result = load_current_release_json()
+        self.assertIsNone(result)
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.path.exists", return_value=True)
+    def test_load_current_release_json_invalid_json(self, mock_exists, mock_file):
+        """Test handling invalid JSON in release.json"""
+        mock_file.return_value.read.return_value = "invalid json"
+
+        result = load_current_release_json()
+        self.assertIsNone(result)
+
+    @patch("subprocess.run")
+    def test_safe_git_show_success(self, mock_run):
+        """Test successful git show operation"""
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(self.master_release_data)
+        mock_run.return_value = mock_result
+
+        result = get_content_from_git("abc123", "release.json")
+        self.assertEqual(result, json.dumps(self.master_release_data))
+
+        mock_run.assert_called_once_with(
+            ["git", "show", "abc123:release.json"], capture_output=True, text=True, check=True, timeout=30
+        )
+
+    @patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "git"))
+    def test_safe_git_show_failure(self, mock_run):
+        """Test git show failure handling"""
+        result = get_content_from_git("abc123", "release.json")
+        self.assertIsNone(result)
+
+    def test_no_changes_detected(self):
+        """Test when no changes are detected"""
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=self.current_release_data),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertFalse(has_changes)
+            self.assertEqual(changed_agents, [])
+
+    def test_new_ops_manager_version_added(self):
+        """Test detection when new OM version is added"""
+        modified_current = json.loads(json.dumps(self.current_release_data))
+        modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"]["8.0.0"] = {
+            "agent_version": "108.0.0.8694-1",
+            "tools_version": "100.10.0",
+        }
+
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=modified_current),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+            self.assertIn(("108.0.0.8694-1", "100.10.0"), changed_agents)
+
+    def test_ops_manager_version_modified(self):
+        """Test detection when OM version is modified"""
+        modified_current = json.loads(json.dumps(self.current_release_data))
+        modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"]["6.0.26"][
+            "agent_version"
+        ] = "12.0.35.7911-1"
+
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=modified_current),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+            self.assertIn(("12.0.35.7911-1", "100.10.0"), changed_agents)
+
+    def test_cloud_manager_changed(self):
+        """Test detection when cloud_manager is changed"""
+        modified_current = json.loads(json.dumps(self.current_release_data))
+        modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager"] = "13.38.0.9600-1"
+
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=modified_current),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+            self.assertIn(("13.38.0.9600-1", "100.12.2"), changed_agents)
+
+    def test_cloud_manager_tools_changed(self):
+        """Test detection when cloud_manager_tools is changed"""
+        modified_current = json.loads(json.dumps(self.current_release_data))
+        modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager_tools"] = "100.13.0"
+
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=modified_current),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+            self.assertIn(("13.37.0.9590-1", "100.13.0"), changed_agents)
+
+    def test_ops_manager_version_removed(self):
+        """Test detection when OM version is removed"""
+        modified_current = json.loads(json.dumps(self.current_release_data))
+        del modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"]["7.0.11"]
+
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=modified_current),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+
+    def test_both_om_and_cm_changed(self):
+        """Test detection when both OM version and cloud manager are changed"""
+        modified_current = json.loads(json.dumps(self.current_release_data))
+        modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"]["8.0.0"] = {
+            "agent_version": "108.0.0.8694-1",
+            "tools_version": "100.10.0",
+        }
+        modified_current["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["cloud_manager"] = "13.38.0.9600-1"
+
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=modified_current),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+            self.assertIn(("108.0.0.8694-1", "100.10.0"), changed_agents)
+            self.assertIn(("13.38.0.9600-1", "100.12.2"), changed_agents)
+            self.assertEqual(len(changed_agents), 2)
+
+    def test_current_release_load_failure(self):
+        """Test handling when current release.json cannot be loaded"""
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=None),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=self.master_release_data),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertFalse(has_changes)
+            self.assertEqual(changed_agents, [])
+
+    def test_base_release_load_failure_fail_safe(self):
+        """Test fail-safe behavior when base release.json cannot be loaded"""
+        with (
+            patch("detect_ops_manager_changes.load_current_release_json", return_value=self.current_release_data),
+            patch("detect_ops_manager_changes.load_release_json_from_master", return_value=None),
+        ):
+
+            has_changes, changed_agents = detect_ops_manager_changes()
+            self.assertTrue(has_changes)
+            self.assertEqual(changed_agents, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

- adding a detection script that detects agent changes between `local` vs `origin/master` for `release.json` and uses that as a base to do the release
- streamline evergreen.yml and remove matrix builds/releases
- streamline agent builds on pipeline.py

**Evergreen configuration cleanup and simplification:**

* Removed all references to the `build_agent_images_ubi` task and its dependencies across multiple variables and buildvariants, reducing unnecessary build steps and dependencies.
* Removed obsolete tasks and buildvariants related to agent image releases, such as `release_agent_operator_release`, `release_agents_on_ecr_conditional`, and `init_release_agents_on_ecr`, to streamline the release process. 

**Pipeline logic refactoring:**

* Refactored the `build_agent_default_case` function in `pipeline.py` to use the new `detect_ops_manager_changes` function for determining which agent versions to build, and eliminated the separate `build_agent_on_agent_bump` logic. 
* Simplified agent in `pipeline.py` to match `atomic_pipeline.py`
* Updated the image builder function mapping so that both `"agent"` and `"agent-pct"` use the unified `build_agent_default_case` function.

## Proof of Work

- no agent released patch: [Link](https://spruce.mongodb.com/task/mongodb_kubernetes_init_test_run_build_agent_images_ubi_patch_0786a90d4034657a11c9289e917c62691bc2500f_689da41126d25300077a269a_25_08_14_08_53_40/logs?execution=0)
- manual changing release.json, agent to be released: [Link](https://spruce.mongodb.com/task/mongodb_kubernetes_init_test_run_build_agent_images_ubi_patch_0786a90d4034657a11c9289e917c62691bc2500f_689da3cfe533570008004e93_25_08_14_08_52_35/logs?execution=0)
```
[2025/08/14 10:55:01.860] INFO     2025-08-14 08:55:01,860 [atomic_pipeline]  ======= Agent versions to build [('12.0.35.7911-1', '100.10.0'), ('108.0.12.8846-1', '100.12.2')] =======
```

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
