### PR TITLE
fix periodic teardowns

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -336,6 +336,7 @@ functions:
     - command: shell.exec
       type: setup
       params:
+        continue_on_err: true
         shell: bash
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         script: |
@@ -420,6 +421,7 @@ functions:
   upload_e2e_logs:
     - command: s3.put
       params:
+        continue_on_err: true
         aws_key: ${enterprise_aws_access_key_id}
         aws_secret: ${enterprise_aws_secret_access_key}
         local_files_include_filter:

--- a/.evergreen-periodic-builds.yaml
+++ b/.evergreen-periodic-builds.yaml
@@ -19,6 +19,14 @@ variables:
       - func: switch_context
 
 tasks:
+  - name: periodic_teardown_aws
+    commands:
+      - func: cleanup_aws
+
+  - name: periodic_teardown_cloudqa
+    commands:
+      - func: teardown_cloud_qa_all
+
   - name: periodic_teardown_task_group
     <<: *setup_group
     tasks:

--- a/.evergreen-periodic-builds.yaml
+++ b/.evergreen-periodic-builds.yaml
@@ -27,6 +27,7 @@ tasks:
     commands:
       - func: teardown_cloud_qa_all
 
+task_groups:
   - name: periodic_teardown_task_group
     <<: *setup_group
     tasks:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -117,9 +117,9 @@ variables:
       - func: setup_cloud_qa
     teardown_task_can_fail_task: true
     teardown_task:
+      - func: teardown_cloud_qa
       - func: upload_e2e_logs
       - func: teardown_kubernetes_environment
-      - func: teardown_cloud_qa
 
   - &setup_and_teardown_task
     setup_task_can_fail_task: true


### PR DESCRIPTION
# Summary

- when refactoring and removing daily builds we also removed parts of teardown by accident 

## Proof of Work
- periodic getting triggered: https://spruce.mongodb.com/version/689dc0de0e8148000791e683/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
