### PR TITLE
remove agent rebuilds unless we release the agent

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -33,8 +33,6 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
 
   - &base_no_om_image_dependency
     depends_on:
@@ -52,8 +50,6 @@ variables:
         variant: init_test_run
       - name: build_init_appdb_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
 
   - &community_dependency
     depends_on:
@@ -66,8 +62,6 @@ variables:
       - name: build_upgrade_hook_image
         variant: init_test_run
       - name: build_mco_test_image
-        variant: init_test_run
-      - name: build_agent_images_ubi
         variant: init_test_run
 
   - &setup_group
@@ -153,8 +147,6 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
 
   - &base_om7_dependency_with_race
     depends_on:
@@ -172,8 +164,6 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
 
   - &base_om8_dependency
     depends_on:
@@ -190,8 +180,6 @@ variables:
       - name: build_init_appdb_images_ubi
         variant: init_test_run
       - name: build_init_om_images_ubi
-        variant: init_test_run
-      - name: build_agent_images_ubi
         variant: init_test_run
 
 parameters:
@@ -1547,8 +1535,6 @@ buildvariants:
         variant: init_test_run
       - name: prepare_and_upload_openshift_bundles_for_e2e
         variant: init_tests_with_olm
-      - name: build_agent_images_ubi
-        variant: init_test_run
     tasks:
       - name: e2e_kind_olm_group
 
@@ -1572,9 +1558,6 @@ buildvariants:
         variant: init_tests_with_olm
       - name: build_init_database_image_ubi
         variant: init_test_run
-      - name: build_agent_images_ubi
-        variant: init_test_run
-
     tasks:
       - name: e2e_kind_olm_group
 


### PR DESCRIPTION
# Summary

- we shouldn't rebuild and potentially release the agent to ecr unless we run an agent-release
- otherwise, we might change the release.json and release some changes unwanted
- instead, if we want to release a set of agents we should run the `manual_ecr_release_agent` variant
- note; i kept the `release_agent` depends_on build_agent task

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
