### PR TITLE
Agent and OM releases with new pipeline

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -524,7 +524,7 @@ functions:
         shell: bash
         <<: *e2e_include_expansions_in_env
         working_dir: src/github.com/mongodb/mongodb-kubernetes
-        binary: scripts/dev/run_python.sh scripts/release/pipeline_main.py --parallel ${image_name} ${all_agents}
+        binary: scripts/dev/run_python.sh scripts/release/pipeline_main.py --parallel ${image_name} ${all_agents} ${build_scenario}
 
   # TODO: CLOUDP-335471 ; once all image builds are made with the new atomic pipeline, remove the following function
   legacy_pipeline:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -356,9 +356,10 @@ tasks:
       - func: setup_building_host
       - func: quay_login
       - func: setup_docker_sbom
-      - func: legacy_pipeline
+      - func: pipeline
         vars:
           image_name: agent
+          build_scenario: --build-scenario manual_release
 
   - name: run_precommit_and_push
     tags: ["patch-run"]
@@ -543,10 +544,10 @@ tasks:
       - func: setup_building_host
       - func: quay_login
       - func: setup_docker_sbom
-      - func: legacy_pipeline
+      - func: pipeline
         vars:
           image_name: ops-manager
-          include_tags: release
+          build_scenario: --build-scenario manual_release
 
   - name: prepare_and_upload_openshift_bundles_for_e2e
     commands:

--- a/build_info.json
+++ b/build_info.json
@@ -240,7 +240,7 @@
           "linux/amd64"
         ]
       },
-      "release": {
+      "manual_release": {
         "sign": true,
         "repository": "quay.io/mongodb/mongodb-agent-ubi",
         "platforms": [
@@ -266,8 +266,7 @@
           "linux/amd64"
         ]
       },
-      "release": {
-        "version": "om-version-from-release.json",
+      "manual_release": {
         "sign": true,
         "repository": "quay.io/mongodb/mongodb-enterprise-ops-manager",
         "platforms": [

--- a/scripts/release/build/build_info.py
+++ b/scripts/release/build/build_info.py
@@ -80,6 +80,7 @@ def load_build_info(
         initial_version = get_initial_version()
 
     version = scenario.get_version(repository_path, changelog_sub_path, initial_commit_sha, initial_version)
+    # For manual_release, version can be None and will be set by image-specific logic
 
     with open("build_info.json", "r") as f:
         build_info = json.load(f)
@@ -98,7 +99,7 @@ def load_build_info(
 
         # Only update the image_version if it is not already set in the build_info.json file
         image_version = scenario_data.get("version")
-        if not image_version:
+        if not image_version and version is not None:
             image_version = version
 
         images[name] = ImageInfo(

--- a/scripts/release/build/build_scenario.py
+++ b/scripts/release/build/build_scenario.py
@@ -11,6 +11,7 @@ COMMIT_SHA_LENGTH = 8
 
 class BuildScenario(StrEnum):
     RELEASE = "release"  # Official release triggered by a git tag
+    MANUAL_RELEASE = "manual_release"  # Manual release, not part of operator release cycle
     PATCH = "patch"  # CI build for a patch/pull request
     STAGING = "staging"  # CI build from a merge to the master
     DEVELOPMENT = "development"  # Local build on a developer machine
@@ -58,5 +59,9 @@ class BuildScenario(StrEnum):
                 return repo.head.object.hexsha[:COMMIT_SHA_LENGTH]
             case BuildScenario.RELEASE:
                 return calculate_next_version(repo, changelog_sub_path, initial_commit_sha, initial_version)
+            case BuildScenario.MANUAL_RELEASE:
+                # For manual releases, version must be provided externally (e.g., for ops-manager via om_version env var,
+                # for agent via release.json). Return None to indicate version will be set by image-specific logic.
+                return None
 
         raise ValueError(f"Unknown build scenario: {self}")

--- a/scripts/release/pipeline_main.py
+++ b/scripts/release/pipeline_main.py
@@ -114,8 +114,8 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
     sign = args.sign or image_build_info.sign
     dockerfile_path = image_build_info.dockerfile_path
 
-    # Validate version - only ops-manager and agent can have None version
-    # as they manage versions externally (om_version env var and release.json respectively)
+    # Validate version - only ops-manager and agent can have None version as the versions are managed by the agent
+    # and om methods themselves, which are externally retrieved - om_version env var and release.json respectively
     if version is None and image not in ["ops-manager", "agent"]:
         raise ValueError(f"Version cannot be empty for {image}.")
 

--- a/scripts/release/pipeline_main.py
+++ b/scripts/release/pipeline_main.py
@@ -114,6 +114,11 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
     sign = args.sign or image_build_info.sign
     dockerfile_path = image_build_info.dockerfile_path
 
+    # Validate version - only ops-manager and agent can have None version
+    # as they manage versions externally (om_version env var and release.json respectively)
+    if version is None and image not in ["ops-manager", "agent"]:
+        raise ValueError(f"Version cannot be empty for {image}.")
+
     return ImageBuildConfiguration(
         scenario=build_scenario,
         version=version,

--- a/scripts/release/tests/build_info_test.py
+++ b/scripts/release/tests/build_info_test.py
@@ -408,20 +408,6 @@ def test_load_build_info_release(
                 dockerfile_path="docker/mongodb-kubernetes-upgrade-hook/Dockerfile.atomic",
                 sign=True,
             ),
-            "agent": ImageInfo(
-                repository="quay.io/mongodb/mongodb-agent-ubi",
-                platforms=["linux/arm64", "linux/amd64"],
-                version=version,
-                dockerfile_path="docker/mongodb-agent/Dockerfile.atomic",
-                sign=True,
-            ),
-            "ops-manager": ImageInfo(
-                repository="quay.io/mongodb/mongodb-enterprise-ops-manager",
-                platforms=["linux/amd64"],
-                version="om-version-from-release.json",
-                dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",
-                sign=True,
-            ),
         },
         binaries={
             "kubectl-mongodb": BinaryInfo(
@@ -441,5 +427,35 @@ def test_load_build_info_release(
     )
 
     build_info = load_build_info(BuildScenario.RELEASE, git_repo.working_dir)
+
+    assert build_info == expected_build_info
+
+
+def test_load_build_info_manual_release(git_repo: Repo):
+    version = "1.2.0"
+    git_repo.git.checkout(version)
+
+    expected_build_info = BuildInfo(
+        images={
+            "agent": ImageInfo(
+                repository="quay.io/mongodb/mongodb-agent-ubi",
+                platforms=["linux/arm64", "linux/amd64"],
+                version=None,  # Version is None for manual_release scenario
+                dockerfile_path="docker/mongodb-agent/Dockerfile.atomic",
+                sign=True,
+            ),
+            "ops-manager": ImageInfo(
+                repository="quay.io/mongodb/mongodb-enterprise-ops-manager",
+                platforms=["linux/amd64"],
+                version=None,  # Version is None for manual_release scenario
+                dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",
+                sign=True,
+            ),
+        },
+        binaries={},
+        helm_charts={},
+    )
+
+    build_info = load_build_info(BuildScenario.MANUAL_RELEASE, git_repo.working_dir)
 
     assert build_info == expected_build_info


### PR DESCRIPTION
# Summary

Add a new `manual_release` scenario to properly handle image releases that are decoupled from operator releases.

## Proof of Work

Tested `release_agent` task on Evergreen, manually edited json file to point to my repo, and added `--all-agents` ton actually trigger a release.
Task:
https://spruce.mongodb.com/task/mongodb_kubernetes_release_agent_release_agent_patch_cda9f730105c7b461ebb9a5fcf6adfea66006d35_68a5c140eba83800072c1894_25_08_20_12_36_23/logs?execution=0

Agents were pushed to my private repository.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ X ] Have you checked whether your jira ticket required DOCSP changes?
- [ X ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
