### PR TITLE
Enable `staging` build scenario that was commented out by default

### DIFF
--- a/scripts/release/build/build_scenario.py
+++ b/scripts/release/build/build_scenario.py
@@ -31,10 +31,9 @@ class BuildScenario(StrEnum):
         elif is_patch or is_evg:
             scenario = BuildScenario.PATCH
             logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
-        # TODO: Uncomment the following lines when starting to work on staging builds
-        # elif is_evg:
-        #     scenario = BuildScenario.STAGING
-        #     logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
+        elif is_evg:
+            scenario = BuildScenario.STAGING
+            logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
         else:
             scenario = BuildScenario.DEVELOPMENT
             logger.info(f"Build scenario: {scenario}")

--- a/scripts/release/build/build_scenario.py
+++ b/scripts/release/build/build_scenario.py
@@ -3,7 +3,8 @@ from enum import StrEnum
 from git import Repo
 
 from lib.base_logger import logger
-from scripts.release.constants import triggered_by_git_tag, is_evg_patch, is_running_in_evg, get_version_id
+from scripts.release.constants import triggered_by_git_tag, is_evg_patch, is_running_in_evg, get_version_id, \
+    DEFAULT_REPOSITORY_PATH
 from scripts.release.version import calculate_next_version
 
 COMMIT_SHA_LENGTH = 8
@@ -17,7 +18,7 @@ class BuildScenario(StrEnum):
     DEVELOPMENT = "development"  # Local build on a developer machine
 
     @classmethod
-    def infer_scenario_from_environment(cls) -> "BuildScenario":
+    def infer_scenario_from_environment(cls, repository_path: str = DEFAULT_REPOSITORY_PATH) -> "BuildScenario":
         """Infer the build scenario from environment variables."""
         git_tag = triggered_by_git_tag()
         is_patch = is_evg_patch()
@@ -31,9 +32,9 @@ class BuildScenario(StrEnum):
         elif is_patch or is_evg:
             scenario = BuildScenario.PATCH
             logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
-        elif is_evg:
+        elif is_evg and not is_patch:
             scenario = BuildScenario.STAGING
-            logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
+            logger.info(f"Build scenario: {scenario} (version_id: {get_staging_version_id(repository_path)}")
         else:
             scenario = BuildScenario.DEVELOPMENT
             logger.info(f"Build scenario: {scenario}")
@@ -55,7 +56,7 @@ class BuildScenario(StrEnum):
                     raise ValueError(f"version_id environment variable is not set for `{self}` build scenario")
                 return patch_id
             case BuildScenario.STAGING:
-                return repo.head.object.hexsha[:COMMIT_SHA_LENGTH]
+                return get_staging_version_id(repository_path)
             case BuildScenario.RELEASE:
                 return calculate_next_version(repo, changelog_sub_path, initial_commit_sha, initial_version)
             case BuildScenario.MANUAL_RELEASE:
@@ -64,3 +65,8 @@ class BuildScenario(StrEnum):
                 return None
 
         raise ValueError(f"Unknown build scenario: {self}")
+
+
+def get_staging_version_id(repository_path: str):
+    repo = Repo(repository_path)
+    return repo.head.object.hexsha[:COMMIT_SHA_LENGTH]

--- a/scripts/release/build/build_scenario.py
+++ b/scripts/release/build/build_scenario.py
@@ -29,12 +29,12 @@ class BuildScenario(StrEnum):
             # Release scenario and the git tag will be used for promotion process only
             scenario = BuildScenario.RELEASE
             logger.info(f"Build scenario: {scenario} (git_tag: {git_tag})")
-        elif is_patch or is_evg:
-            scenario = BuildScenario.PATCH
-            logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
         elif is_evg and not is_patch:
             scenario = BuildScenario.STAGING
             logger.info(f"Build scenario: {scenario} (version_id: {get_staging_version_id(repository_path)}")
+        elif is_patch or is_evg:
+            scenario = BuildScenario.PATCH
+            logger.info(f"Build scenario: {scenario} (patch_id: {patch_id})")
         else:
             scenario = BuildScenario.DEVELOPMENT
             logger.info(f"Build scenario: {scenario}")


### PR DESCRIPTION
# Summary

The `staging` build scenario was commented out by default because we have not been using it in our workflows. But after [this PR](https://github.com/mongodb/mongodb-kubernetes/pull/320) gets merged we will start using the the staging build scenario for kubectl plugin to build and push it to the staging bucket. That's why this PR enables that build scenario.


## Proof of Work

Once the PR https://github.com/mongodb/mongodb-kubernetes/pull/320 related to kubectl plugin gets merged the goreleaser artifacts should be pushed to the `mongodb-kubernetes-staging/kubectl-mongodb/<commit-sha>` path.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
