### PR TITLE
CLOUDP-339183: Update default agent version (used for AppDB)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,7 +87,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.2.8729-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -144,7 +144,7 @@ initAppDb:
 
 agent:
   name: mongodb-agent
-  version: 108.0.2.8729-1
+  version: 108.0.12.8846-1
 
 # This is only used by the MongoDBCommunity resource reconciler - START
 versionUpgradeHook:
@@ -176,7 +176,7 @@ registry:
   appDb: quay.io/mongodb
   agent: quay.io/mongodb
 
-# This is only used by the MongoDBCommunity resource reconciler - START
+  # This is only used by the MongoDBCommunity resource reconciler - START
   versionUpgradeHook: quay.io/mongodb
   readinessProbe: quay.io/mongodb
 # This is only used by the MongoDBCommunity resource reconciler - END
@@ -215,8 +215,8 @@ community:
       certificateKeySecretRef: tls-certificate
       caCertificateSecretRef: tls-ca-key-pair
       certManager:
-        certDuration: 8760h   # 365 days
-        renewCertBefore: 720h   # 30 days
+        certDuration: 8760h # 365 days
+        renewCertBefore: 720h # 30 days
 
 # MongoDBSearch settings
 search:

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -398,7 +398,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.2.8729-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -393,7 +393,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.2.8729-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -394,7 +394,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.2.8729-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/release.json
+++ b/release.json
@@ -7,7 +7,7 @@
   "initOpsManagerVersion": "1.2.0",
   "initAppDbVersion": "1.2.0",
   "databaseImageVersion": "1.2.0",
-  "agentVersion": "108.0.2.8729-1",
+  "agentVersion": "108.0.12.8846-1",
   "openshift": {
     "minimumSupportedVersion": "4.6"
   },


### PR DESCRIPTION
# Summary

Bump the default agent version used for AppDB to match the latest OM release.

## Proof of Work

CI Passing should be sufficient.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
