### PR TITLE
CLOUDP-340314: Bump Cloud Manager version for MongoDB Agent container images for MMS release branch v20250827

### DIFF
--- a/release.json
+++ b/release.json
@@ -106,7 +106,7 @@
       ],
       "opsManagerMapping": {
         "Description": "These are the agents from which we start supporting static containers.",
-        "cloud_manager": "13.38.0.9654-1",
+        "cloud_manager": "13.39.0.9717-1",
         "cloud_manager_tools": "100.12.2",
         "ops_manager": {
           "6.0.26": {


### PR DESCRIPTION

_Opened by Private Cloud Tools (PCT)_.

# Ticket
[CLOUDP-340314](https://jira.mongodb.org/browse/CLOUDP-340314)

# Description
Bump Cloud Manager version for MongoDB Agent container images for mms version v20250827.

# Reviewer Checklist

Before merging this PR, verify the following:
- [ ] the following tasks are passing in Evergreen:
  - `release_agent` task (variant: `release_agent`)
- [ ] the `cloud_manager` was updated correctly
- [ ] the `cloud_manager_tools` was updated correctly

