### PR TITLE
Update `kind` and `kindest/node` image to latest available versions (`1.33.2`)

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
@@ -76,8 +76,8 @@ def test_migrate_architecture(mongodb_multi: MongoDBMulti, member_cluster_client
     mongodb_multi.load()
     assert mongodb_multi["metadata"]["annotations"]["mongodb.com/v1.architecture"] == target_architecture
 
-    mongodb_multi.assert_abandons_phase(Phase.Running, timeout=2000)
-    mongodb_multi.assert_reaches_phase(Phase.Running, timeout=2000)
+    mongodb_multi.assert_abandons_phase(Phase.Running, timeout=1800)
+    mongodb_multi.assert_reaches_phase(Phase.Running, timeout=1800)
 
     statefulsets = mongodb_multi.read_statefulsets(member_cluster_clients)
     for statefulset in statefulsets.values():

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
@@ -76,8 +76,8 @@ def test_migrate_architecture(mongodb_multi: MongoDBMulti, member_cluster_client
     mongodb_multi.load()
     assert mongodb_multi["metadata"]["annotations"]["mongodb.com/v1.architecture"] == target_architecture
 
-    mongodb_multi.assert_abandons_phase(Phase.Running, timeout=1000)
-    mongodb_multi.assert_reaches_phase(Phase.Running, timeout=1000)
+    mongodb_multi.assert_abandons_phase(Phase.Running, timeout=2000)
+    mongodb_multi.assert_reaches_phase(Phase.Running, timeout=2000)
 
     statefulsets = mongodb_multi.read_statefulsets(member_cluster_clients)
     for statefulset in statefulsets.values():

--- a/scripts/dev/setup_kind_cluster.sh
+++ b/scripts/dev/setup_kind_cluster.sh
@@ -45,7 +45,7 @@ metrics_server_version="v0.7.2"
 
 reg_name='kind-registry'
 reg_port='5000'
-kind_image="${registry}/kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
+kind_image="${registry}/kindest/node:v1.33.2@sha256:c55080dc5be4f2cc242e6966fdf97bb62282e1cd818a28223cf536db8b0fddf4"
 
 usage() {
   echo "Deploy local registry and create kind cluster configured to use this registry. Local Docker registry is deployed at localhost:5000.

--- a/scripts/evergreen/setup_kind.sh
+++ b/scripts/evergreen/setup_kind.sh
@@ -9,7 +9,7 @@ os=$(uname | tr '[:upper:]' '[:lower:]')
 # Detect architecture
 arch_suffix=$(detect_architecture)
 # This should be changed when needed
-latest_version="v0.27.0"
+latest_version="v0.29.0"
 
 # Only proceed with installation if architecture is supported (amd64 or arm64)
 if [[ "${arch_suffix}" == "amd64" || "${arch_suffix}" == "arm64" ]]; then


### PR DESCRIPTION
# Summary

As part of the release process, we update the kind and `kindest/node` to latest available versions. This PR does that.

On EVG environments the script `setup_kind_cluster.sh` tries to pull the image from the ecr mirror instead of pulling it from docker hub to avoid rate limiting issues. That's why to make sure that CI passes on this PR, we will have to copy the image manually to the ecr from docker hub.
Below command can be used to do that

```
# use index digest
docker pull kindest/node:v1.33.2@sha256:c55080dc5be4f2cc242e6966fdf97bb62282e1cd818a28223cf536db8b0fddf4
skopeo copy --preserve-digests --all docker://docker.io/kindest/node:v1.33.2 docker://268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node:v1.33.2
```
The index digest on ecr will be same and that's the same digest that can be used in the script.

After this change somehow the test `e2e_static_multi_cluster_kind/e2e_multi_cluster_replica_set_migration` started failing mainly because of timeout waiting for sts to be ready. And we figured that increasing the timeout is the best path forward. That's why we are also increasing timeout for that test as part of this PR.

## Proof of Work

Successful CI run on this PR would prove that the change is good.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
