### PR TITLE
add multicluster to cloudqa bump tests

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1424,7 +1424,7 @@ buildvariants:
 
   - name: e2e_multi_cluster_kind
     display_name: e2e_multi_cluster_kind
-    tags: [ "e2e_test_suite" ]
+    tags: [ "e2e_test_suite", "cloudqa"]
     run_on:
       - ubuntu2204-large
     <<: *base_om6_dependency
@@ -1433,7 +1433,7 @@ buildvariants:
 
   - name: e2e_static_multi_cluster_kind
     display_name: e2e_static_multi_cluster_kind
-    tags: [ "e2e_test_suite" ]
+    tags: [ "e2e_test_suite", "cloudqa"]
     run_on:
       - ubuntu2204-large
     <<: *base_om6_dependency
@@ -1442,7 +1442,7 @@ buildvariants:
 
   - name: e2e_multi_cluster_2_clusters
     display_name: e2e_multi_cluster_2_clusters
-    tags: [ "e2e_test_suite" ]
+    tags: [ "e2e_test_suite", "cloudqa"]
     run_on:
       - ubuntu2204-large
     <<: *base_om6_dependency
@@ -1451,7 +1451,7 @@ buildvariants:
 
   - name: e2e_static_multi_cluster_2_clusters
     display_name: e2e_static_multi_cluster_2_clusters
-    tags: [ "e2e_test_suite" ]
+    tags: [ "e2e_test_suite", "cloudqa"]
     run_on:
       - ubuntu2204-large
     <<: *base_om6_dependency


### PR DESCRIPTION
# Summary

This pull request updates the build configuration to include the "cloudqa" tag for several multi-cluster end-to-end (E2E) test variants in `.evergreen.yml`. This allows these test suites to be more easily identified and filtered as part of cloud QA processes.

Build configuration updates:

* Added the "cloudqa" tag to the `tags` list for the following build variants in `.evergreen.yml`:
  - `e2e_multi_cluster_kind`
  - `e2e_static_multi_cluster_kind`
  - `e2e_multi_cluster_2_clusters`
  - `e2e_static_multi_cluster_2_clusters`

## Proof of Work

- ci is starting
- evergreen is parsed

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
