### PR TITLE
CLOUDP-290847: Refactor common controller's `updateOmAuthentication`

### DIFF
--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -758,9 +758,8 @@ func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Conte
 
 	caFilePath := fmt.Sprintf("%s/ca-pem", util.TLSCaMountPath)
 
-	// We do not provide an agentCertSecretName on purpose because then we will default to the non pem secret on the central cluster.
-	// Below method has special code handling reading certificates from the central cluster in that case.
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, rs.GetProcessNames(), &mrs, "", caFilePath, internalClusterPath, isRecovering, log)
+	agentCertSecretName := mrs.GetSecurity().AgentClientCertificateSecretName(mrs.GetName())
+	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, rs.GetProcessNames(), &mrs, agentCertSecretName, caFilePath, internalClusterPath, isRecovering, log)
 	if !status.IsOK() && !isRecovering {
 		return xerrors.Errorf("failed to enable Authentication for MongoDB Multi Replicaset")
 	}

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -1084,14 +1084,14 @@ func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(ctx context.C
 		return workflowStatus
 	}
 
-	agentCertSecretName := sc.GetSecurity().AgentClientCertificateSecretName(sc.Name).Name
+	agentCertSecretSelector := sc.GetSecurity().AgentClientCertificateSecretName(sc.Name)
 
 	opts = deploymentOptions{
-		podEnvVars:           podEnvVars,
-		currentAgentAuthMode: currentAgentAuthMode,
-		caFilePath:           caFilePath,
-		agentCertSecretName:  agentCertSecretName,
-		prometheusCertHash:   prometheusCertHash,
+		podEnvVars:              podEnvVars,
+		currentAgentAuthMode:    currentAgentAuthMode,
+		caFilePath:              caFilePath,
+		agentCertSecretSelector: agentCertSecretSelector,
+		prometheusCertHash:      prometheusCertHash,
 	}
 	allConfigs := r.getAllConfigs(ctx, *sc, opts, log)
 
@@ -1789,14 +1789,14 @@ func (r *ShardedClusterReconcileHelper) prepareScaleDownShardedCluster(omClient 
 
 // deploymentOptions contains fields required for creating the OM deployment for the Sharded Cluster.
 type deploymentOptions struct {
-	podEnvVars           *env.PodEnvVars
-	currentAgentAuthMode string
-	caFilePath           string
-	agentCertSecretName  string
-	certTLSType          map[string]bool
-	finalizing           bool
-	processNames         []string
-	prometheusCertHash   string
+	podEnvVars              *env.PodEnvVars
+	currentAgentAuthMode    string
+	caFilePath              string
+	agentCertSecretSelector corev1.SecretKeySelector
+	certTLSType             map[string]bool
+	finalizing              bool
+	processNames            []string
+	prometheusCertHash      string
 }
 
 // updateOmDeploymentShardedCluster performs OM registration operation for the sharded cluster. So the changes will be finally propagated
@@ -1950,7 +1950,7 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 
 	logDiffOfProcessNames(opts.processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "updateOmAuthentication"))
 
-	workflowStatus, additionalReconciliationRequired := r.commonController.updateOmAuthentication(ctx, conn, healthyProcessesToWaitForReadyState, sc, opts.agentCertSecretName, opts.caFilePath, "", isRecovering, log)
+	workflowStatus, additionalReconciliationRequired := r.commonController.updateOmAuthentication(ctx, conn, healthyProcessesToWaitForReadyState, sc, opts.agentCertSecretSelector, opts.caFilePath, "", isRecovering, log)
 	if !workflowStatus.IsOK() {
 		if !isRecovering {
 			return nil, false, workflowStatus

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -319,8 +319,10 @@ func (r *ReconcileMongoDbStandalone) updateOmDeployment(ctx context.Context, con
 		return workflow.Failed(err)
 	}
 
+	agentCertSecretSelector := s.GetSecurity().AgentClientCertificateSecretName(s.Name)
+
 	// TODO standalone PR
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, "", "", "", isRecovering, log)
+	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, agentCertSecretSelector, "", "", isRecovering, log)
 	if !status.IsOK() {
 		return status
 	}


### PR DESCRIPTION
# Summary

* The method now accepts a value of type `corev1.SecretKeySelector` instead of an optional secret name string.
* Controllers using this method now explicitly provide a `corev1.SecretKeySelector`, replacing the previous implicit `""`.

> [!NOTE]  
> This is a refactoring, but it is required for [CLOUDP-290847](https://jira.mongodb.org/browse/CLOUDP-290847) to solve the issue with agent certificate rotation. I'm moving it into a separate PR to make the actual fix PR easier to review.


## Proof of Work

CI must be green

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
