### PR TITLE
Revert "remove agent rebuilds unless we release the agent"

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -33,6 +33,8 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
 
   - &base_no_om_image_dependency
     depends_on:
@@ -50,6 +52,8 @@ variables:
         variant: init_test_run
       - name: build_init_appdb_images_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
 
   - &community_dependency
     depends_on:
@@ -62,6 +66,8 @@ variables:
       - name: build_upgrade_hook_image
         variant: init_test_run
       - name: build_mco_test_image
+        variant: init_test_run
+      - name: build_agent_images_ubi
         variant: init_test_run
 
   - &setup_group
@@ -154,6 +160,8 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
 
   - &base_om7_dependency_with_race
     depends_on:
@@ -171,6 +179,8 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
 
   - &base_om8_dependency
     depends_on:
@@ -187,6 +197,8 @@ variables:
       - name: build_init_appdb_images_ubi
         variant: init_test_run
       - name: build_init_om_images_ubi
+        variant: init_test_run
+      - name: build_agent_images_ubi
         variant: init_test_run
 
 parameters:
@@ -1707,6 +1719,8 @@ buildvariants:
         variant: init_test_run
       - name: prepare_and_upload_openshift_bundles_for_e2e
         variant: init_tests_with_olm
+      - name: build_agent_images_ubi
+        variant: init_test_run
     tasks:
       - name: e2e_kind_olm_group
 
@@ -1730,6 +1744,9 @@ buildvariants:
         variant: init_tests_with_olm
       - name: build_init_database_image_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
+
     tasks:
       - name: e2e_kind_olm_group
 


### PR DESCRIPTION
Reverts mongodb/mongodb-kubernetes#350

veryfing whether this is the rootcause of failing: `e2e_om_ops_manager_queryable_backup` 