### PR TITLE
Fix tools in agent images

### DIFF
--- a/docker/mongodb-agent/Dockerfile.atomic
+++ b/docker/mongodb-agent/Dockerfile.atomic
@@ -20,8 +20,11 @@ RUN case ${TARGETPLATFORM} in \
     && mkdir -p /tools \
     && curl -o /tools/mongodb_tools.tgz "${mongodb_tools_url}/${MONGODB_TOOLS_VERSION}"
 
-RUN tar xfz /tools/mongodb_tools.tgz --directory /tools \
-    && rm /tools/mongodb_tools.tgz
+RUN tar xfz /tools/mongodb_tools.tgz \
+    && mv mongodb-database-tools-*/bin/* /tools \
+    && chmod +x /tools/* \
+    && rm /tools/mongodb_tools.tgz \
+    && rm -r mongodb-database-tools-*
 
 FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal AS agent_downloader
 

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -206,10 +206,10 @@ else
     ln -sf "${MONGOD_ROOT}/bin/mongod" ${mdb_downloads_dir}/mongod/bin/mongod
     ln -sf "${MONGOD_ROOT}/bin/mongos" ${mdb_downloads_dir}/mongod/bin/mongos
 
-    ln -sf "/tools/mongodump" ${mdb_downloads_dir}/mongod/bin/mongodump
-    ln -sf "/tools/mongorestore" ${mdb_downloads_dir}/mongod/bin/mongorestore
-    ln -sf "/tools/mongoexport" ${mdb_downloads_dir}/mongod/bin/mongoexport
-    ln -sf "/tools/mongoimport" ${mdb_downloads_dir}/mongod/bin/mongoimport
+    for tool in mongoimport mongodump mongorestore mongoexport; do
+      [ -e "/tools/${tool}" ] || { echo "/tools/${tool} not found"; exit 1; }
+      ln -sf "/tools/${tool}" ${mdb_downloads_dir}/mongod/bin/${tool}
+    done
   else
     echo "Mongod PID not found within the specified time."
     exit 1


### PR DESCRIPTION
# Summary

This PR fixes an issue with the new agent dockerfiles where the db tools where not placed correctly. The binaries should be present in `/tools`. However, our tests were still passing. For that reason, the agent-script will now fail if the binaries are missing.

## Proof of Work

The tests should fail if the binaries are missing. Example: https://spruce.mongodb.com/version/68af05cace35b000077fae05/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
The pipeline should pass.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
