### PR TITLE
Change OM 8.0.4 from release.json

### DIFF
--- a/release.json
+++ b/release.json
@@ -153,10 +153,6 @@
             "agent_version": "108.0.3.8758-1",
             "tools_version": "100.10.0"
           },
-          "8.0.4": {
-            "agent_version": "108.0.4.8770-1",
-            "tools_version": "100.10.0"
-          },
           "8.0.5": {
             "agent_version": "108.0.4.8770-1",
             "tools_version": "100.11.0"

--- a/release.json
+++ b/release.json
@@ -153,6 +153,10 @@
             "agent_version": "108.0.3.8758-1",
             "tools_version": "100.10.0"
           },
+          "8.0.4": {
+            "agent_version": "108.0.4.8770-1",
+            "tools_version": "100.11.0"
+          },
           "8.0.5": {
             "agent_version": "108.0.4.8770-1",
             "tools_version": "100.11.0"


### PR DESCRIPTION
# Summary

Change the tools_version for OM 8.0.4 in release.json. Both 8.0.4 and 8.0.5 used the same agent version but with different tools versions. This meant that the pipeline for building the agents was rebuilding the same tag twice with different tools versions. This way we don't rebuild the same tag twice, while keeping 8.0.4 in release.json for clarity.

## Proof of Work

CI is green

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
