### PR TITLE
CLOUDP-290847: Remove outdated code

### DIFF
--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -466,7 +466,7 @@ func buildDatabaseStatefulSetConfigurationFunction(mdb databaseStatefulSetSource
 		appLabelKey: opts.ServiceName,
 	}
 
-	annotationFunc := statefulset.WithAnnotations(defaultPodAnnotations(opts.CertificateHash))
+	annotationFunc := statefulset.WithAnnotations(defaultStatefulSetAnnotations(opts.CertificateHash))
 	podTemplateAnnotationFunc := podtemplatespec.NOOP()
 
 	annotationFunc = statefulset.Apply(
@@ -1057,11 +1057,8 @@ func DatabaseStartupProbe() probes.Modification {
 	)
 }
 
-func defaultPodAnnotations(certHash string) map[string]string {
+func defaultStatefulSetAnnotations(certHash string) map[string]string {
 	return map[string]string{
-		// This annotation is necessary to trigger a pod restart
-		// if the certificate secret is out of date. This happens if
-		// existing certificates have been replaced/rotated/renewed.
 		certs.CertHashAnnotationKey: certHash,
 	}
 }

--- a/pkg/statefulset/statefulset_util.go
+++ b/pkg/statefulset/statefulset_util.go
@@ -19,7 +19,6 @@ import (
 	apiEquality "k8s.io/apimachinery/pkg/api/equality"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/mongodb/mongodb-kubernetes/controllers/operator/certs"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/inspect"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
@@ -120,14 +119,6 @@ func CreateOrUpdateStatefulset(ctx context.Context, getUpdateCreator kubernetesC
 		}
 		log.Debug("Created StatefulSet")
 		return statefulSetToCreate, nil
-	}
-	// preserve existing certificate hash if new one is not statefulSetToCreate
-	existingCertHash, okExisting := existingStatefulSet.Spec.Template.Annotations[certs.CertHashAnnotationKey]
-	if newCertHash, okNew := statefulSetToCreate.Spec.Template.Annotations[certs.CertHashAnnotationKey]; existingCertHash != "" && newCertHash == "" && okExisting && okNew {
-		if statefulSetToCreate.Spec.Template.Annotations == nil {
-			statefulSetToCreate.Spec.Template.Annotations = map[string]string{}
-		}
-		statefulSetToCreate.Spec.Template.Annotations[certs.CertHashAnnotationKey] = existingCertHash
 	}
 
 	// there already exists a pvc size annotation, that means we did resize at least once


### PR DESCRIPTION
# Summary

This piece of code is meant to preserve cert hash annotation in the pod template. We currently do not use cert hash annotation on the pod: we only use sts level annotations.

## Proof of Work

Tests must pass

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
