### PR TITLE
Fix Preview Release Notes GH Action for forks

### DIFF
--- a/.github/workflows/preview_release_notes.yml
+++ b/.github/workflows/preview_release_notes.yml
@@ -29,8 +29,10 @@ jobs:
         id: generate_release_notes
         run: python -m scripts.release.release_notes -s $INITIAL_COMMIT_SHA -v $INITIAL_VERSION -o release_notes_tmp.md
         env:
-          INITIAL_COMMIT_SHA: ${{ vars.RELEASE_INITIAL_COMMIT_SHA }}
-          INITIAL_VERSION: ${{ vars.RELEASE_INITIAL_VERSION }}
+          # We can not use environments set via GitHub UI because they will
+          # not be available in the pull requests running from forks.
+          INITIAL_COMMIT_SHA: 9ed5f98fc70c5b3442f633d2393265fb8a2aba0c
+          INITIAL_VERSION: 1.3.0
       - name: Add disclaimer to release notes preview
         run: |
           echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current master branch)_\n" > release_notes_preview.md


### PR DESCRIPTION
# Summary

Use hardcoded values instead of repo variables because variables are not available in the PRs created from forks.

## Proof of Work

Preview Release Notes job must be green on PRs from forks.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
