### PR TITLE
Improve the message in `check_precommit.sh` for go mod licenses case

### DIFF
--- a/scripts/evergreen/check_precommit.sh
+++ b/scripts/evergreen/check_precommit.sh
@@ -23,7 +23,7 @@ if [ "${initial_index_state}" != "${final_index_state}" ]; then
   echo "Final index state:"
   echo "${final_index_state}"
 
-  echo "We have files that differ after running pre-commit, please run the pre-commit locally"
+  echo "We have files that differ after running pre-commit, please run the pre-commit and precommit-with-licenses locally"
   echo "Full diff: "
   git diff --cached --diff-filter=AM
   echo "The following files differ: "

--- a/scripts/evergreen/check_precommit.sh
+++ b/scripts/evergreen/check_precommit.sh
@@ -23,7 +23,7 @@ if [ "${initial_index_state}" != "${final_index_state}" ]; then
   echo "Final index state:"
   echo "${final_index_state}"
 
-  echo "We have files that differ after running pre-commit, please run the make target precommit-with-licenses locally"
+  echo "We have files that differ after running pre-commit, please run make precommit-with-licenses locally"
   echo "Full diff: "
   git diff --cached --diff-filter=AM
   echo "The following files differ: "

--- a/scripts/evergreen/check_precommit.sh
+++ b/scripts/evergreen/check_precommit.sh
@@ -23,7 +23,7 @@ if [ "${initial_index_state}" != "${final_index_state}" ]; then
   echo "Final index state:"
   echo "${final_index_state}"
 
-  echo "We have files that differ after running pre-commit, please run the pre-commit and precommit-with-licenses locally"
+  echo "We have files that differ after running pre-commit, please run the make target precommit-with-licenses locally"
   echo "Full diff: "
   git diff --cached --diff-filter=AM
   echo "The following files differ: "


### PR DESCRIPTION
# Summary

If we (MCK) started consuming a new go mod deps and because of that we would need to regenerate (`update_licenses.sh`) the `LICENSE-THIRD-PARTY` file for the main project as well as `kubectl-mongodb` plugin. If we forget doing that, the CI would fail with below error

```
We have files that differ after running pre-commit, please run the pre-commit locally
```

and running `pre-commit` doesn't really update the licenses file, to do that, we will have to run `make precommit-with-licenses`. And that's why this PR updates above message.

## Proof of Work

NA
