### PR TITLE
CLOUDP-316922 - Fix racy and slow auth tests like in openshift clusters

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -456,6 +456,7 @@ functions:
         content_type: text/plain
     - command: attach.xunit_results
       params:
+        continue_on_err: true
         file: "src/github.com/mongodb/mongodb-kubernetes/logs/myreport.xml"
 
   upload_e2e_logs_gotest:

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_utils_state.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_utils_state.py
@@ -5,11 +5,11 @@ from typing import Optional, Tuple
 
 from kubetester.phase import Phase
 from opentelemetry import trace
-
 from tests import test_logger
 
 TRACER = trace.get_tracer("evergreen-agent")
 logger = test_logger.get_test_logger(__name__)
+
 
 @TRACER.start_as_current_span("in_desired_state")
 def in_desired_state(
@@ -36,7 +36,9 @@ def in_desired_state(
         for event in intermediate_events:
             if event in current_message:
                 found = True
-                logger.debug(f"Found intermediate event in failure: {event} in {current_message}. Skipping the failure state")
+                logger.debug(
+                    f"Found intermediate event in failure: {event} in {current_message}. Skipping the failure state"
+                )
 
         if not found:
             raise AssertionError(f'Got into Failed phase while waiting for Running! ("{current_message}")')

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_utils_state.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_utils_state.py
@@ -6,8 +6,10 @@ from typing import Optional, Tuple
 from kubetester.phase import Phase
 from opentelemetry import trace
 
-TRACER = trace.get_tracer("evergreen-agent")
+from tests import test_logger
 
+TRACER = trace.get_tracer("evergreen-agent")
+logger = test_logger.get_test_logger(__name__)
 
 @TRACER.start_as_current_span("in_desired_state")
 def in_desired_state(
@@ -34,6 +36,7 @@ def in_desired_state(
         for event in intermediate_events:
             if event in current_message:
                 found = True
+                logger.debug(f"Found intermediate event in failure: {event} in {current_message}. Skipping the failure state")
 
         if not found:
             raise AssertionError(f'Got into Failed phase while waiting for Running! ("{current_message}")')

--- a/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
@@ -8,11 +8,8 @@ from typing import Callable, Dict, List, Optional
 
 import kubernetes.client
 import requests
-from kubernetes.client.rest import ApiException
-from opentelemetry import trace
-from requests.auth import HTTPDigestAuth
-
 from kubeobject import CustomObject
+from kubernetes.client.rest import ApiException
 from kubetester import (
     create_configmap,
     create_or_update_secret,
@@ -30,6 +27,8 @@ from kubetester.mongodb_utils_state import in_desired_state
 from kubetester.mongotester import MongoTester, MultiReplicaSetTester, ReplicaSetTester
 from kubetester.omtester import OMContext, OMTester
 from kubetester.phase import Phase
+from opentelemetry import trace
+from requests.auth import HTTPDigestAuth
 from tests import test_logger
 from tests.common.multicluster.multicluster_utils import (
     multi_cluster_pod_names,

--- a/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
@@ -1029,6 +1029,8 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
                 # This can be an intermediate error, right before we check for this secret we create it.
                 # The cluster might just be slow
                 "failed to locate the api key secret",
+                # etcd might be slow
+                "etcdserver: request timed out",
             )
 
             start_time = time.time()

--- a/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
@@ -4,16 +4,18 @@ import json
 import re
 import time
 from base64 import b64decode
-from typing import Any, Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import kubernetes.client
 import requests
-from kubeobject import CustomObject
 from kubernetes.client.rest import ApiException
+from opentelemetry import trace
+from requests.auth import HTTPDigestAuth
+
+from kubeobject import CustomObject
 from kubetester import (
     create_configmap,
     create_or_update_secret,
-    read_configmap,
     read_secret,
 )
 from kubetester.automation_config_tester import AutomationConfigTester
@@ -28,8 +30,6 @@ from kubetester.mongodb_utils_state import in_desired_state
 from kubetester.mongotester import MongoTester, MultiReplicaSetTester, ReplicaSetTester
 from kubetester.omtester import OMContext, OMTester
 from kubetester.phase import Phase
-from opentelemetry import trace
-from requests.auth import HTTPDigestAuth
 from tests import test_logger
 from tests.common.multicluster.multicluster_utils import (
     multi_cluster_pod_names,

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
@@ -106,7 +106,7 @@ class TestCanEnableScramSha256:
     @TRACER.start_as_current_span("test_can_enable_scram_sha_256")
     def test_can_enable_scram_sha_256(self, sharded_cluster: MongoDB, ca_path: str):
         kubetester.wait_processes_ready()
-        sharded_cluster.assert_reaches_phase(Phase.Running, timeout=800)
+        sharded_cluster.assert_reaches_phase(Phase.Running, timeout=1400)
 
         sharded_cluster.load()
         sharded_cluster["spec"]["security"]["authentication"]["enabled"] = True
@@ -115,7 +115,7 @@ class TestCanEnableScramSha256:
         ]
         sharded_cluster["spec"]["security"]["authentication"]["agents"]["mode"] = "SCRAM"
         sharded_cluster.update()
-        sharded_cluster.assert_reaches_phase(Phase.Running, timeout=800)
+        sharded_cluster.assert_reaches_phase(Phase.Running, timeout=1400)
 
     def test_assert_connectivity(self, ca_path: str):
         ShardedClusterTester(MDB_RESOURCE, 1, ssl=True, ca_path=ca_path).assert_connectivity(attempts=25)

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -1684,6 +1684,26 @@ def pytest_sessionfinish(session, exitstatus):
                     ev = tester.get_project_events().json()["results"]
                     with open(f"/tmp/diagnostics/{project_id}-events.json", "w", encoding="utf-8") as f:
                         json.dump(ev, f, ensure_ascii=False, indent=4)
+
+                    if exitstatus != 0:
+                        try:
+                            automation_config_tester = tester.get_automation_config_tester()
+                            automation_config = automation_config_tester.automation_config
+                            if not automation_config:
+                                continue
+
+                            # Remove mongoDbVersions field as it's too large
+                            if "mongoDbVersions" in automation_config:
+                                del automation_config["mongoDbVersions"]
+
+                            with open(
+                                f"/tmp/diagnostics/{project_id}-automation-config.json", "w", encoding="utf-8"
+                            ) as f:
+                                json.dump(automation_config, f, ensure_ascii=False, indent=4)
+
+                            logging.info(f"Saved automation config for project {project_id}")
+                        except Exception as e:
+                            logging.warning(f"Failed to collect automation config for project {project_id}: {e}")
                 else:
                     logging.info("om is not healthy - not collecting events information")
 


### PR DESCRIPTION
# Summary

fixes:
* e2e_sharded_cluster_scram_sha_256_user_connectivity 
* e2e_replica_set_scram_sha_256_user_connectivity 

both were mostly failing on master merges on openshift.
PoW shows 3x passing in a row each one


**Reliability improvements for authentication tests:**

* Added a `_wait_for_mongodbuser_reconciliation` function to ensure all `MongoDBUser` resources reach the "Updated" phase before authentication attempts, preventing race conditions after user/password changes. This function is now called at the start of all authentication assertion methods

* Increased the default number of authentication attempts 50 across all relevant methods
   * Some of the tests and their logs showed that we are updating the secret and sometimes the reconcile is slow to pick them up. In the meantime we already start the verification test which its default of around 100s. That is too short and racy. In this [log](https://operator-e2e-artifacts.s3.us-east-1.amazonaws.com/logs/mongodb_kubernetes_e2e_openshift_static_mdb_ubi_cloudqa_e2e_sharded_cluster_scram_sha_256_user_connectivity_3f4cd2b7bb80a72c09cb9871516d0ca6e0392efe_25_08_28_08_19_54/0/mongodb-kubernetes-operator-8844fcfbf-pfm4t-mongodb-kubernetes-operator.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Checksum-Mode=ENABLED&X-Amz-Credential=AKIAT5B2QITEKCB6K6KZ%2F20250828%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250828T145851Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=6ff83a8aeb9846626203f3bac03fc3ba08077bc1887f56bd8cd7a7a8535cbb8d) one can see that the reconciliation of the user took around 1m but the auth verification already started before that, thus having a total run time larger than the 100s timeout


**Error handling and diagnostics:**

* fixed logging error, we were passing `msg` but that doesn't exist and thus we caused a panic when the test was failing - masking the error

* Enhanced diagnostics collection in `tests/conftest.py` to also save the automation config JSON for each project when tests fail, aiding post-mortem analysis.

## Proof of Work
- green ci 
- green [openshift](https://spruce.mongodb.com/version/68b086ba8764840007614ae0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) tests (passed multiple times in a row) 


## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
