### PR TITLE
Example Patch using custom MongoDB Agent

### DIFF
--- a/controllers/operator/agents/upgrade.go
+++ b/controllers/operator/agents/upgrade.go
@@ -48,29 +48,31 @@ type ClientSecret struct {
 // happens and all existing MongoDBs are required to get agents upgraded (otherwise the "You need to upgrade the
 // automation agent before publishing other changes" error happens for automation config pushes from the Operator)
 func UpgradeAllIfNeeded(ctx context.Context, cs ClientSecret, omConnectionFactory om.ConnectionFactory, watchNamespace []string, isMulti bool) {
-	mux.Lock()
-	defer mux.Unlock()
+	/*
+		mux.Lock()
+		defer mux.Unlock()
 
-	if !time.Now().After(nextScheduledTime) {
-		return
-	}
-	log := zap.S()
-	log.Info("Performing a regular upgrade of Agents for all the MongoDB resources in the cluster...")
+		if !time.Now().After(nextScheduledTime) {
+			return
+		}
+		log := zap.S()
+		log.Info("Performing a regular upgrade of Agents for all the MongoDB resources in the cluster...")
 
-	allMDBs, err := readAllMongoDBs(ctx, cs.Client, watchNamespace, isMulti)
-	if err != nil {
-		log.Errorf("Failed to read MongoDB resources to ensure Agents have the latest version: %s", err)
-		return
-	}
+		allMDBs, err := readAllMongoDBs(ctx, cs.Client, watchNamespace, isMulti)
+		if err != nil {
+			log.Errorf("Failed to read MongoDB resources to ensure Agents have the latest version: %s", err)
+			return
+		}
 
-	err = doUpgrade(ctx, cs.Client, cs.SecretClient, omConnectionFactory, allMDBs)
-	if err != nil {
-		log.Errorf("Failed to perform upgrade of Agents: %s", err)
-	}
+		err = doUpgrade(ctx, cs.Client, cs.SecretClient, omConnectionFactory, allMDBs)
+		if err != nil {
+			log.Errorf("Failed to perform upgrade of Agents: %s", err)
+		}
 
-	log.Info("The upgrade of Agents for all the MongoDB resources in the cluster is finished.")
+		log.Info("The upgrade of Agents for all the MongoDB resources in the cluster is finished.")
 
-	nextScheduledTime = nextScheduledTime.Add(pause)
+		nextScheduledTime = nextScheduledTime.Add(pause)
+	*/
 }
 
 // ScheduleUpgrade allows to reset the timer to Now() which makes sure the next MongoDB reconciliation will ensure

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
@@ -86,9 +86,9 @@ download_agent() {
 
 
     if [[ -z "${MDB_AGENT_VERSION-}" ]]; then
-      AGENT_VERSION="latest"
+      AGENT_VERSION="13.39.0.9731-1"
     else
-      AGENT_VERSION="${MDB_AGENT_VERSION}"
+      AGENT_VERSION="13.39.0.9731-1"
     fi
 
     # Detect architecture for agent download
@@ -117,7 +117,7 @@ download_agent() {
     script_log "Downloading Agent version: ${AGENT_VERSION}"
     script_log "Downloading a Mongodb Agent from ${base_url:?}"
     curl_opts=(
-        "${base_url}/download/agent/automation/${AGENT_FILE}"
+        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/patches/68b072ae6aaee5000719420a/automation-agent/local/${AGENT_FILE}"
 
         "--location" "--silent" "--retry" "3" "--fail" "-v"
         "--output" "automation-agent.tar.gz"


### PR DESCRIPTION
# Summary

This PR is just an example of using a custom MongoDB Agent in a test patch:
```
evergreen patch -p mongodb-kubernetes -v e2e_multi_cluster_kind -t e2e_multi_cluster_replica_set -y -f --browse --param evergreen_retry=false -u -d "try custom agent ..."
```