### PR TITLE
Fix aws setup

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1475,7 +1475,7 @@ buildvariants:
     run_on:
       - rhel9-power-small
       - rhel9-power-large
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "patch", "github_tag" , "commit"]
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1498,7 +1498,7 @@ buildvariants:
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "patch", "github_tag", "commit"]
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1520,7 +1520,7 @@ buildvariants:
     tags: [ "e2e_test_suite", "e2e_smoke_release_test_suite" ]
     run_on:
       - ubuntu2204-arm64-large
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "patch", "github_tag", "commit"]
     <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_smoke_arm_task_group
@@ -1530,7 +1530,7 @@ buildvariants:
     tags: [ "e2e_test_suite", "e2e_smoke_release_test_suite", "static" ]
     run_on:
       - ubuntu2204-arm64-large
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "patch", "github_tag", "commit"]
     <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_smoke_arm_task_group
@@ -1541,7 +1541,7 @@ buildvariants:
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "patch", "github_tag", "commit"]
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1564,7 +1564,7 @@ buildvariants:
     run_on:
       - rhel9-power-small
       - rhel9-power-large
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "patch", "github_tag", "commit"]
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run

--- a/scripts/evergreen/setup_aws.sh
+++ b/scripts/evergreen/setup_aws.sh
@@ -48,14 +48,15 @@ install_aws_cli_pip() {
         return 1
     fi
 
-    # Use pip3 if available, otherwise pip
-    local pip_cmd="pip3"
-    if ! command -v pip3 &> /dev/null; then
-        pip_cmd="pip"
+    # Check if AWS CLI exists and works before installing
+    if command -v aws &> /dev/null && aws --version &> /dev/null 2>&1; then
+        echo "AWS CLI is already installed and working:"
+        aws --version
+        return 0
     fi
 
-    echo "Installing AWS CLI using ${pip_cmd}..."
-    ${pip_cmd} install --user awscli
+    echo "Installing AWS CLI using pip3..."
+    pip3 install --user awscli
 
     # Add ~/.local/bin to PATH if not already there (where pip --user installs)
     if [[ ":${PATH}:" != *":${HOME}/.local/bin:"* ]]; then
@@ -64,11 +65,11 @@ install_aws_cli_pip() {
     fi
 
     # Verify installation
-    if command -v aws &> /dev/null; then
+    if command -v aws &> /dev/null && aws --version &> /dev/null 2>&1; then
         echo "AWS CLI v1 installed successfully:"
         aws --version
     else
-        echo "Error: AWS CLI v1 installation failed or not found in PATH" >&2
+        echo "Error: AWS CLI v1 installation failed" >&2
         return 1
     fi
 }


### PR DESCRIPTION
# Summary

This pull request makes improvements to the AWS CLI installation script and updates the Evergreen build configuration to allow additional requesters for several build variants. The main goals are to make the AWS CLI installation more robust and to expand the triggers for certain CI builds.

**Build configuration updates:**

* Added "commit" as an allowed requester in several `buildvariants` sections of `.evergreen.yml`, enabling these builds to be triggered on direct commits in addition to patches and GitHub tags.  -> i hope that fixes smoke tests to run on master merges

**AWS CLI installation improvements:**

* Updated `install_aws_cli_pip()` in `scripts/evergreen/setup_aws.sh` to check if AWS CLI is already installed and working before attempting installation, preventing unnecessary reinstalls.
* Simplified the installation process to always use `pip3` and improved error handling and messaging for installation failures.

# Proof

- green ci
- in ci no smoke and ibm stuff is running
- after merge ibm stuff is triggered

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
