### PR TITLE
CLOUDP-290847: Improve agent certificate rotation

### DIFF
--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -195,7 +195,7 @@ func (m *MongoDB) GetSecretsMountedIntoDBPod() []string {
 			secrets = append(secrets, tls)
 		}
 	}
-	agentCerts := m.GetSecurity().AgentClientCertificateSecretName(m.Name).Name
+	agentCerts := m.GetSecurity().AgentClientCertificateSecretName(m.Name)
 	if agentCerts != "" {
 		secrets = append(secrets, agentCerts)
 	}
@@ -852,7 +852,7 @@ func (s *Security) ShouldUseX509(currentAgentAuthMode string) bool {
 // AgentClientCertificateSecretName returns the name of the Secret that holds the agent
 // client TLS certificates.
 // If no custom name has been defined, it returns the default one.
-func (s Security) AgentClientCertificateSecretName(resourceName string) corev1.SecretKeySelector {
+func (s Security) AgentClientCertificateSecretName(resourceName string) string {
 	secretName := util.AgentSecretName
 
 	if s.CertificatesSecretsPrefix != "" {
@@ -862,10 +862,7 @@ func (s Security) AgentClientCertificateSecretName(resourceName string) corev1.S
 		secretName = s.Authentication.Agents.ClientCertificateSecretRefWrap.ClientCertificateSecretRef.Name
 	}
 
-	return corev1.SecretKeySelector{
-		Key:                  util.AutomationAgentPemSecretKey,
-		LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-	}
+	return secretName
 }
 
 // The customer has set ClientCertificateSecretRef. This signals that client certs are required,

--- a/api/v1/mdb/mongodb_types_test.go
+++ b/api/v1/mdb/mongodb_types_test.go
@@ -382,15 +382,15 @@ func TestAgentClientCertificateSecretName(t *testing.T) {
 	rs := NewReplicaSetBuilder().SetSecurityTLSEnabled().EnableAuth([]AuthMode{util.X509}).Build()
 
 	// Default is the hardcoded "agent-certs"
-	assert.Equal(t, util.AgentSecretName, rs.GetSecurity().AgentClientCertificateSecretName(rs.Name).Name)
+	assert.Equal(t, util.AgentSecretName, rs.GetSecurity().AgentClientCertificateSecretName(rs.Name))
 
 	// If the top-level prefix is there, we use it
 	rs.Spec.Security.CertificatesSecretsPrefix = "prefix"
-	assert.Equal(t, fmt.Sprintf("prefix-%s-%s", rs.Name, util.AgentSecretName), rs.GetSecurity().AgentClientCertificateSecretName(rs.Name).Name)
+	assert.Equal(t, fmt.Sprintf("prefix-%s-%s", rs.Name, util.AgentSecretName), rs.GetSecurity().AgentClientCertificateSecretName(rs.Name))
 
 	// If the name is provided (deprecated) we return it
 	rs.GetSecurity().Authentication.Agents.ClientCertificateSecretRefWrap.ClientCertificateSecretRef.Name = "foo"
-	assert.Equal(t, "foo", rs.GetSecurity().AgentClientCertificateSecretName(rs.Name).Name)
+	assert.Equal(t, "foo", rs.GetSecurity().AgentClientCertificateSecretName(rs.Name))
 }
 
 func TestInternalClusterAuthSecretName(t *testing.T) {

--- a/changelog/20250909_feature_improved_agent_certificate_rotation.md
+++ b/changelog/20250909_feature_improved_agent_certificate_rotation.md
@@ -1,0 +1,7 @@
+---
+title: Improved agent certificate rotation
+kind: feature
+date: 2025-09-09
+---
+
+* Improve automation agent certificate rotation: the agent now restarts automatically when its certificate is renewed, ensuring smooth operation without manual intervention and allowing seamless certificate updates without requiring manual Pod restarts.

--- a/controllers/om/automation_config_test.go
+++ b/controllers/om/automation_config_test.go
@@ -365,7 +365,7 @@ func TestCanResetAgentSSL(t *testing.T) {
 	ac.AgentSSL = &AgentSSL{
 		ClientCertificateMode: util.OptionalClientCertficates,
 		CAFilePath:            util.CAFilePathInContainer,
-		AutoPEMKeyFilePath:    util.AutomationAgentPemFilePath,
+		AutoPEMKeyFilePath:    "/fake/path/to/pem",
 	}
 
 	if err := ac.Apply(); err != nil {
@@ -374,7 +374,7 @@ func TestCanResetAgentSSL(t *testing.T) {
 
 	tls := cast.ToStringMap(ac.Deployment["tls"])
 	assert.Equal(t, tls["clientCertificateMode"], util.OptionalClientCertficates)
-	assert.Equal(t, tls["autoPEMKeyFilePath"], util.AutomationAgentPemFilePath)
+	assert.Equal(t, tls["autoPEMKeyFilePath"], "/fake/path/to/pem")
 	assert.Equal(t, tls["CAFilePath"], util.CAFilePathInContainer)
 
 	ac.AgentSSL = &AgentSSL{

--- a/controllers/om/backup_agent_config.go
+++ b/controllers/om/backup_agent_config.go
@@ -49,8 +49,8 @@ func (bac *BackupAgentConfig) UnsetAgentPassword() {
 	bac.BackupAgentTemplate.Password = util.MergoDelete
 }
 
-func (bac *BackupAgentConfig) EnableX509Authentication(backupAgentSubject string) {
-	bac.BackupAgentTemplate.SSLPemKeyFile = util.AutomationAgentPemFilePath
+func (bac *BackupAgentConfig) EnableX509Authentication(backupAgentSubject, automationAgentPemFilePath string) {
+	bac.BackupAgentTemplate.SSLPemKeyFile = automationAgentPemFilePath
 	bac.SetAgentUserName(backupAgentSubject)
 }
 

--- a/controllers/om/backup_agent_test.go
+++ b/controllers/om/backup_agent_test.go
@@ -32,7 +32,7 @@ func TestFieldsAreUpdatedBackupConfig(t *testing.T) {
 
 func TestBackupFieldsAreNotLost(t *testing.T) {
 	config := getTestBackupConfig()
-	config.EnableX509Authentication("namespace")
+	config.EnableX509Authentication("namespace", "/fake/path/to/pem")
 
 	assert.Contains(t, config.BackingMap, "logPath")
 	assert.Contains(t, config.BackingMap, "logRotate")
@@ -48,7 +48,7 @@ func TestBackupFieldsAreNotLost(t *testing.T) {
 func TestNestedFieldsAreNotLost(t *testing.T) {
 	config := getTestBackupConfig()
 
-	config.EnableX509Authentication("namespace")
+	config.EnableX509Authentication("namespace", "/fake/path/to/pem")
 
 	_ = config.Apply()
 

--- a/controllers/om/monitoring_agent_config.go
+++ b/controllers/om/monitoring_agent_config.go
@@ -45,9 +45,9 @@ func (m *MonitoringAgentConfig) UnsetAgentPassword() {
 	m.MonitoringAgentTemplate.Password = util.MergoDelete
 }
 
-func (m *MonitoringAgentConfig) EnableX509Authentication(MonitoringAgentSubject string) {
-	m.MonitoringAgentTemplate.SSLPemKeyFile = util.AutomationAgentPemFilePath
-	m.SetAgentUserName(MonitoringAgentSubject)
+func (m *MonitoringAgentConfig) EnableX509Authentication(monitoringAgentSubject, automationAgentPemFilePath string) {
+	m.MonitoringAgentTemplate.SSLPemKeyFile = automationAgentPemFilePath
+	m.SetAgentUserName(monitoringAgentSubject)
 }
 
 func (m *MonitoringAgentConfig) DisableX509Authentication() {

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -538,7 +538,15 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 		return result.OK()
 	}
 
-	podVars, err := r.tryConfigureMonitoringInOpsManager(ctx, opsManager, opsManagerUserPassword, log)
+	var appdbSecretPath string
+	if r.VaultClient != nil {
+		appdbSecretPath = r.VaultClient.AppDBSecretPath()
+	}
+
+	agentCertSecretName := opsManager.Spec.AppDB.GetSecurity().AgentClientCertificateSecretName(opsManager.Spec.AppDB.GetName())
+	_, agentCertPath := r.agentCertHashAndPath(ctx, log, opsManager.Namespace, agentCertSecretName, appdbSecretPath)
+
+	podVars, err := r.tryConfigureMonitoringInOpsManager(ctx, opsManager, opsManagerUserPassword, agentCertPath, log)
 	// it's possible that Ops Manager will not be available when we attempt to configure AppDB monitoring
 	// in Ops Manager. This is not a blocker to continue with the rest of the reconciliation.
 	if err != nil {
@@ -613,10 +621,6 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 		return r.updateStatus(ctx, opsManager, workflowStatus, log, appDbStatusOption)
 	}
 
-	var appdbSecretPath string
-	if r.VaultClient != nil {
-		appdbSecretPath = r.VaultClient.AppDBSecretPath()
-	}
 	tlsSecretName := opsManager.Spec.AppDB.GetSecurity().MemberCertificateSecretName(opsManager.Spec.AppDB.Name())
 	certHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, opsManager.Namespace, tlsSecretName, appdbSecretPath, log)
 
@@ -1621,7 +1625,7 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbAgentApiKey(ctx context.Context, o
 
 // tryConfigureMonitoringInOpsManager attempts to configure monitoring in Ops Manager. This might not be possible if Ops Manager
 // has not been created yet, if that is the case, an empty PodVars will be returned.
-func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, opsManagerUserPassword string, log *zap.SugaredLogger) (env.PodEnvVars, error) {
+func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, opsManagerUserPassword string, agentCertPath string, log *zap.SugaredLogger) (env.PodEnvVars, error) {
 	var operatorVaultSecretPath string
 	if r.VaultClient != nil {
 		operatorVaultSecretPath = r.VaultClient.OperatorSecretPath()
@@ -1660,6 +1664,7 @@ func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(ctx contex
 		Mechanisms:         []string{util.SCRAM},
 		ClientCertificates: util.OptionalClientCertficates,
 		AutoUser:           util.AutomationAgentUserName,
+		AutoPEMKeyFilePath: agentCertPath,
 		CAFilePath:         util.CAFilePathInContainer,
 	}
 	err = authentication.Configure(conn, opts, false, log)

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -377,7 +377,7 @@ func TestTryConfigureMonitoringInOpsManager(t *testing.T) {
 	require.NoError(t, err)
 
 	// attempt configuring monitoring when there is no api key secret
-	podVars, err := reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", zap.S())
+	podVars, err := reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", "/fake/agent-cert/path", zap.S())
 	assert.NoError(t, err)
 
 	assert.Empty(t, podVars.ProjectID)
@@ -408,7 +408,7 @@ func TestTryConfigureMonitoringInOpsManager(t *testing.T) {
 	assert.NoError(t, err)
 
 	// once the secret exists, monitoring should be fully configured
-	podVars, err = reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", zap.S())
+	podVars, err = reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", "/fake/agent-cert/path", zap.S())
 	assert.NoError(t, err)
 
 	assert.Equal(t, om.TestGroupID, podVars.ProjectID)
@@ -522,7 +522,7 @@ func TestTryConfigureMonitoringInOpsManagerWithExternalDomains(t *testing.T) {
 	require.NoError(t, err)
 
 	// attempt configuring monitoring when there is no api key secret
-	podVars, err := reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", zap.S())
+	podVars, err := reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", "/fake/agent-cert/path", zap.S())
 	assert.NoError(t, err)
 
 	assert.Empty(t, podVars.ProjectID)
@@ -553,7 +553,7 @@ func TestTryConfigureMonitoringInOpsManagerWithExternalDomains(t *testing.T) {
 	assert.NoError(t, err)
 
 	// once the secret exists, monitoring should be fully configured
-	podVars, err = reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", zap.S())
+	podVars, err = reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", "/fake/agent-cert/path", zap.S())
 	assert.NoError(t, err)
 
 	assert.Equal(t, om.TestGroupID, podVars.ProjectID)

--- a/controllers/operator/authentication/authentication.go
+++ b/controllers/operator/authentication/authentication.go
@@ -43,6 +43,8 @@ type Options struct {
 	// so it is possible to use other auth mechanisms without needing to provide client certs.
 	ClientCertificates string
 
+	AutoPEMKeyFilePath string
+
 	CAFilePath string
 
 	// Use Agent Client Auth
@@ -348,7 +350,7 @@ func addOrRemoveAgentClientCertificate(conn om.Connection, opts Options, log *za
 
 		if opts.AgentsShouldUseClientAuthentication {
 			ac.AgentSSL = &om.AgentSSL{
-				AutoPEMKeyFilePath:    util.AutomationAgentPemFilePath,
+				AutoPEMKeyFilePath:    opts.AutoPEMKeyFilePath,
 				CAFilePath:            opts.CAFilePath,
 				ClientCertificateMode: opts.ClientCertificates,
 			}

--- a/controllers/operator/certs/certificates.go
+++ b/controllers/operator/certs/certificates.go
@@ -271,16 +271,6 @@ func validatePemData(data []byte, additionalDomains []string) error {
 	return errs
 }
 
-// validatePemSecret returns true if the given Secret contains a parsable certificate and contains all required domains.
-func validatePemSecret(secret corev1.Secret, key string, additionalDomains []string) error {
-	data, ok := secret.Data[key]
-	if !ok {
-		return xerrors.Errorf("the secret %s does not contain the expected key %s\n", secret.Name, key)
-	}
-
-	return validatePemData(data, additionalDomains)
-}
-
 // ValidateCertificates verifies the Secret containing the certificates and the keys is valid.
 func ValidateCertificates(ctx context.Context, secretGetter secret.Getter, name, namespace string, log *zap.SugaredLogger) error {
 	validateCertificates := func() (string, bool) {
@@ -309,14 +299,14 @@ func ValidateCertificates(ctx context.Context, secretGetter secret.Getter, name,
 
 // VerifyAndEnsureClientCertificatesForAgentsAndTLSType ensures that agent certs are present and correct, and returns whether they are of the kubernetes.io/tls type.
 // If the secret is of type kubernetes.io/tls, it creates a new secret containing the concatenation fo the tls.crt and tls.key fields
-func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, secretReadClient, secretWriteClient secrets.SecretClient, secret types.NamespacedName) error {
-	needToCreatePEM := false
+func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, secretReadClient, secretWriteClient secrets.SecretClient, secret types.NamespacedName, log *zap.SugaredLogger) error {
 	var secretData map[string][]byte
 	var s corev1.Secret
 	var err error
+	var databaseSecretPath string
 
 	if vault.IsVaultSecretBackend() {
-		needToCreatePEM = true
+		databaseSecretPath = secretReadClient.VaultClient.DatabaseSecretPath()
 		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", secretReadClient.VaultClient.DatabaseSecretPath(), secret.Namespace, secret.Name))
 		if err != nil {
 			return err
@@ -327,25 +317,19 @@ func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, s
 			return err
 		}
 
-		if s.Type == corev1.SecretTypeTLS {
-			needToCreatePEM = true
-			secretData = s.Data
+		if s.Type != corev1.SecretTypeTLS {
+			return xerrors.Errorf("the secret object %q containing agent certificate must be of type kubernetes.io/tls. Got: %q", s.Name, s.Type)
 		}
-	}
-	if needToCreatePEM {
-		data, err := VerifyTLSSecretForStatefulSet(secretData, Options{Replicas: 0})
-		if err != nil {
-			return err
-		}
-
-		dataMap := map[string]string{
-			util.AutomationAgentPemSecretKey: data,
-		}
-
-		return CreateOrUpdatePEMSecret(ctx, secretWriteClient, secret, dataMap, []metav1.OwnerReference{}, Database)
+		secretData = s.Data
 	}
 
-	return validatePemSecret(s, util.AutomationAgentPemSecretKey, nil)
+	data, err := VerifyTLSSecretForStatefulSet(secretData, Options{Replicas: 0})
+	if err != nil {
+		return err
+	}
+
+	secretHash := enterprisepem.ReadHashFromSecret(ctx, secretReadClient, secret.Namespace, secret.Name, databaseSecretPath, log)
+	return CreateOrUpdatePEMSecretWithPreviousCert(ctx, secretWriteClient, secret, secretHash, data, []metav1.OwnerReference{}, Database)
 }
 
 // EnsureSSLCertsForStatefulSet contains logic to ensure that all of the

--- a/controllers/operator/clusterchecks_test.go
+++ b/controllers/operator/clusterchecks_test.go
@@ -234,7 +234,8 @@ func (c *clusterChecks) checkAgentCertsSecret(ctx context.Context, certificatesS
 	sec := corev1.Secret{}
 	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, util.AgentSecretName)), &sec)
 	require.NoError(c.t, err, "clusterName: %s", c.clusterName)
-	require.Contains(c.t, sec.Data, util.AutomationAgentPemSecretKey, "clusterName: %s", c.clusterName)
+	require.Contains(c.t, sec.Data, util.LatestHashSecretKey, "clusterName: %s", c.clusterName)
+	require.Contains(c.t, sec.Data, string(sec.Data[util.LatestHashSecretKey]), "clusterName: %s", c.clusterName)
 }
 
 func (c *clusterChecks) checkMongosCertsSecret(ctx context.Context, certificatesSecretsPrefix string, resourceName string, shouldExist bool) {

--- a/controllers/operator/database_statefulset_options.go
+++ b/controllers/operator/database_statefulset_options.go
@@ -54,6 +54,13 @@ func CertificateHash(hash string) func(options *construct.DatabaseStatefulSetOpt
 	}
 }
 
+// AgentCertHash will assign the given AgentCertHash during StatefulSet construction.
+func AgentCertHash(hash string) func(options *construct.DatabaseStatefulSetOptions) {
+	return func(options *construct.DatabaseStatefulSetOptions) {
+		options.AgentCertHash = hash
+	}
+}
+
 // InternalClusterHash will assign the given InternalClusterHash during StatefulSet construction.
 func InternalClusterHash(hash string) func(options *construct.DatabaseStatefulSetOptions) {
 	return func(options *construct.DatabaseStatefulSetOptions) {

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -267,9 +267,12 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 		lastSpec = &mdbv1.MongoDbSpec{}
 	}
 
+	agentCertSecretName := s.GetSecurity().AgentClientCertificateSecretName(s.Name)
+	_, agentCertPath := r.agentCertHashAndPath(ctx, log, s.Namespace, agentCertSecretName, databaseSecretPath)
+
 	status := workflow.RunInGivenOrder(publishAutomationConfigFirst(ctx, r.client, *s, lastSpec, standaloneOpts, log),
 		func() workflow.Status {
-			return r.updateOmDeployment(ctx, conn, s, sts, false, log).OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
+			return r.updateOmDeployment(ctx, conn, s, sts, false, agentCertPath, log).OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
 		},
 		func() workflow.Status {
 			if err = create.DatabaseInKubernetes(ctx, r.client, *s, sts, standaloneOpts, log); err != nil {
@@ -314,15 +317,13 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 	return r.updateStatus(ctx, s, status, log, mdbstatus.NewBaseUrlOption(deployment.Link(conn.BaseURL(), conn.GroupID())))
 }
 
-func (r *ReconcileMongoDbStandalone) updateOmDeployment(ctx context.Context, conn om.Connection, s *mdbv1.MongoDB, set appsv1.StatefulSet, isRecovering bool, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileMongoDbStandalone) updateOmDeployment(ctx context.Context, conn om.Connection, s *mdbv1.MongoDB, set appsv1.StatefulSet, isRecovering bool, agentCertPath string, log *zap.SugaredLogger) workflow.Status {
 	if err := agents.WaitForRsAgentsToRegister(set, 0, s.Spec.GetClusterDomain(), conn, log, s); err != nil {
 		return workflow.Failed(err)
 	}
 
-	agentCertSecretSelector := s.GetSecurity().AgentClientCertificateSecretName(s.Name)
-
 	// TODO standalone PR
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, agentCertSecretSelector, "", "", isRecovering, log)
+	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, agentCertPath, "", "", isRecovering, log)
 	if !status.IsOK() {
 		return status
 	}

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_rs.py
@@ -53,3 +53,6 @@ class TestReplicaSetEnableAllOptions(KubernetesTester):
 
     def test_rotate_clusterfile(self, mdb: MongoDB, namespace: str):
         rotate_and_assert_certificates(mdb, namespace, "{}-clusterfile".format(MDB_RESOURCE))
+
+    def test_rotate_agent_certificate(self, mdb: MongoDB, namespace: str):
+        rotate_and_assert_certificates(mdb, namespace, "agent-certs")

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
@@ -98,3 +98,6 @@ class TestShardedClusterEnableAllOptions:
 
     def test_rotate_mongos_cert(self, sc: MongoDB, namespace: str):
         rotate_and_assert_certificates(sc, namespace, f"{MDB_RESOURCE_NAME}-mongos-cert")
+
+    def test_rotate_agent_certificate(self, sc: MongoDB, namespace: str):
+        rotate_and_assert_certificates(sc, namespace, "agent-certs")

--- a/docker/mongodb-kubernetes-tests/tests/users/users_addition_removal.py
+++ b/docker/mongodb-kubernetes-tests/tests/users/users_addition_removal.py
@@ -56,7 +56,8 @@ class TestReplicaSetUpgradeToTLSWithX509Project(KubernetesTester):
     def test_certificates_have_sane_subject(self, namespace):
         agent_certs = KubernetesTester.read_secret(namespace, "agent-certs-pem")
 
-        bytecert = bytes(agent_certs["mms-automation-agent-pem"], "utf-8")
+        latestHash = agent_certs["latestHash"]
+        bytecert = bytes(agent_certs[latestHash], "utf-8")
         cert = x509.load_pem_x509_certificate(bytecert, default_backend())
         names = get_names_from_certificate_attributes(cert)
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -122,9 +122,9 @@ const (
 	MmsPemKeyFileDirInContainer  = "/opt/mongodb/mms/secrets"
 	AppDBMmsCaFileDirInContainer = "/opt/mongodb/mms/ca/"
 
-	AutomationAgentName         = "mms-automation-agent"
-	AutomationAgentPemSecretKey = AutomationAgentName + "-pem"
-	AutomationAgentPemFilePath  = PvcMmsHomeMountPath + "/" + AgentSecretName + "/" + AutomationAgentPemSecretKey
+	AutomationAgentName = "mms-automation-agent"
+	// AgentCertMountPath defines where in the Pod the ca cert will be mounted.
+	AgentCertMountPath = PvcMmsHomeMountPath + "/" + AgentSecretName
 
 	// Key used in concatenated pem secrets to denote the hash of the latest certificate
 	LatestHashSecretKey   = "latestHash"

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -58,6 +58,7 @@ const (
 
 type DatabaseSecretsToInject struct {
 	AgentCerts            string
+	AgentCertsHash        string
 	AgentApiKey           string
 	InternalClusterAuth   string
 	InternalClusterHash   string
@@ -424,10 +425,20 @@ func (s DatabaseSecretsToInject) DatabaseAnnotations(namespace string) map[strin
 
 	if s.AgentCerts != "" {
 		agentCertsPath := fmt.Sprintf("%s/%s/%s", databaseSecretPath, namespace, s.AgentCerts)
+
 		annotations["vault.hashicorp.com/agent-inject-secret-mms-automation-agent-pem"] = agentCertsPath
-		annotations["vault.hashicorp.com/secret-volume-path-mms-automation-agent-pem"] = "/mongodb-automation/agent-certs"
+		annotations["vault.hashicorp.com/agent-inject-file-mms-automation-agent-pem"] = s.AgentCertsHash
+		annotations["vault.hashicorp.com/secret-volume-path-mms-automation-agent-pem"] = util.AgentCertMountPath
 		annotations["vault.hashicorp.com/agent-inject-template-mms-automation-agent-pem"] = fmt.Sprintf(
-			DEFAULT_AGENT_INJECT_TEMPLATE, agentCertsPath, util.AutomationAgentPemSecretKey)
+			DEFAULT_AGENT_INJECT_TEMPLATE, agentCertsPath, s.AgentCertsHash)
+
+		annotations["vault.hashicorp.com/agent-inject-secret-previous-mms-automation-agent-pem"] = agentCertsPath
+		annotations["vault.hashicorp.com/secret-volume-path-previous-mms-automation-agent-pem"] = util.AgentCertMountPath
+		annotations["vault.hashicorp.com/agent-inject-file-previous-mms-automation-agent-pem"] = util.PreviousHashSecretKey
+		annotations["vault.hashicorp.com/agent-inject-template-previous-mms-automation-agent-pem"] = fmt.Sprintf(
+			PREVIOUS_HASH_INJECT_TEMPLATE, agentCertsPath, util.PreviousHashSecretKey)
+		annotations["vault.hashicorp.com/agent-inject-command-previous-mms-automation-agent-pem"] = fmt.Sprintf(
+			PREVIOUS_HASH_INJECT_COMMAND, util.AgentCertMountPath, util.PreviousHashSecretKey)
 	}
 	if s.InternalClusterAuth != "" {
 		internalClusterPath := fmt.Sprintf("%s/%s/%s", databaseSecretPath, namespace, s.InternalClusterAuth)


### PR DESCRIPTION
# Summary

Pods now mount a secret containing both old and new certificates, with file names being the hash of the certificate. When it is time to rotate the certificate, the operator updates the automation config with a new path (including the hash) to the certificate. This eliminates the need to manually restart Pods during certificate rotation.

Other related PRs:
* https://github.com/mongodb/mongodb-kubernetes/pull/383 - removes cert hash annotations, simplifies how we pass cert hashes a bit.
* https://github.com/mongodb/mongodb-kubernetes/pull/378 - clean up around Opaque cert secrets which are no longer supported.
* https://github.com/mongodb/mongodb-kubernetes/pull/371 - preparation refactoring which made implementation of this PR a bit easier).
* https://github.com/mongodb/mongodb-kubernetes/pull/444 - this last one is not directly related to agent cert rotation. It just unifies tests so we don't restart STS in all the tests.

---

Copilot summary:

This pull request implements improved agent certificate rotation for database Pods, allowing seamless certificate updates without requiring manual Pod restarts. The main changes revolve around passing the agent certificate file path (which now includes a hash for rotation) through the operator's reconciliation and authentication logic, updating method signatures and tests accordingly, and simplifying how agent certificate secret names are handled.

**Agent certificate rotation and configuration enhancements:**

* Database Pods now mount a secret containing both old and new agent certificates, with filenames based on the certificate hash. The operator updates the automation config with the new certificate path (including the hash) during rotation, eliminating the need for manual Pod restarts.
* The agent certificate file path (`AutoPEMKeyFilePath`) is now passed through the reconciliation and authentication logic, allowing dynamic updates to the path as certificates rotate. This includes changes to method signatures, struct fields, and function calls in the operator and authentication code.

**API and method signature updates:**

* The `AgentClientCertificateSecretName` method now returns a string (the secret name) instead of a `SecretKeySelector`, simplifying its usage throughout the codebase. Corresponding updates were made to all call sites and tests.
* The `EnableX509Authentication` methods for backup and monitoring agent configs now accept the agent PEM file path as a parameter, ensuring the correct path (including hash) is set during configuration.

**Test updates:**

* Tests have been updated to reflect the new method signatures and to check that the correct (possibly hashed) PEM file path is being set and passed through during agent authentication and backup/monitoring configuration.

These changes collectively improve the robustness and automation of agent certificate rotation, reducing operational overhead and risk during certificate updates.

## Proof of Work

Existing tests `e2e_tls_x509_configure_all_options_rs` and `e2e_tls_x509_configure_all_options_sc` now have extra certificate rotation tests `test_rotate_agent_certificate` (same name in both) which prove that we update the automation config on certificate rotation.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Create a DOCSP ticket/a docs PR to clean [this leftover](https://www.mongodb.com/docs/kubernetes/current/reference/k8s-operator-specification/#mongodb-setting-spec.security.authentication.agents.clientCertificateSecretRef.name) about supporting opaque Kubernetes secrets for agent certs (this is no longer supported since MongoDB Enterprise Kubernetes Operator 1.17). Created [DOCSP-53906](https://jira.mongodb.org/browse/DOCSP-53906).
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
