### PR TITLE
fix: Community-Operator - Fight with external Pod mutations

### DIFF
--- a/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template.go
+++ b/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template.go
@@ -93,16 +93,20 @@ func WithInitContainer(name string, containerfunc func(*corev1.Container)) Modif
 	}
 }
 
-// WithInitContainerByIndex applies the modifications to the container with the provided index
-// if the index is out of range, a new container is added to accept these changes.
-func WithInitContainerByIndex(index int, funcs ...func(container *corev1.Container)) func(podTemplateSpec *corev1.PodTemplateSpec) {
+// WithPodLabels merges the provided labels with existing PodTemplateSpec labels.
+// This preserves labels added by external systems (like Kyverno policies) while
+// allowing the operator to add or override its own labels.
+func WithPodLabels(labels map[string]string) Modification {
+	if labels == nil {
+		labels = map[string]string{}
+	}
 	return func(podTemplateSpec *corev1.PodTemplateSpec) {
-		if index >= len(podTemplateSpec.Spec.InitContainers) {
-			podTemplateSpec.Spec.InitContainers = append(podTemplateSpec.Spec.InitContainers, corev1.Container{})
+		if podTemplateSpec.ObjectMeta.Labels == nil {
+			podTemplateSpec.ObjectMeta.Labels = map[string]string{}
 		}
-		c := &podTemplateSpec.Spec.InitContainers[index]
-		for _, f := range funcs {
-			f(c)
+
+		for k, v := range labels {
+			podTemplateSpec.ObjectMeta.Labels[k] = v
 		}
 	}
 }


### PR DESCRIPTION
### Summary:
<!---
Please describe your changes here:
Why did you open this PR? 
What are you trying to accomplish?
what have you done? 
Why in this particular way? 
--->

This PR mitigates runtime operator fights between mutators of the Pods generated by the MongoDB StatefulSet and the MongoDB Community Operator.

It preserves previous labels instead of hard-coding them. The previous logic of adding the `app` label is kept as-is. The MongoDB operator can still overwrite labels it wants to have in a specific form.

### All Submissions:

* [x] Have you opened an Issue before filing this PR? Please see: https://github.com/mongodb/mongodb-kubernetes-operator/issues/1732
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Closes: https://github.com/mongodb/mongodb-kubernetes-operator/issues/1732.