### PR TITLE
CLOUDP-342319 - Fix proxy env vars

### DIFF
--- a/changelog/20250902_fix_fix_proxy_environment_variables.md
+++ b/changelog/20250902_fix_fix_proxy_environment_variables.md
@@ -4,4 +4,4 @@ kind: fix
 date: 2025-09-02
 ---
 
-* Fixed an issue where MongoDB Agents were not using the NO_PROXY environment variable when set on the operator.
+* Fixed an issue where the MongoDB Agents did not adhere to the `NO_PROXY` environment variable configured on the operator.

--- a/changelog/20250902_fix_fix_proxy_environment_variables.md
+++ b/changelog/20250902_fix_fix_proxy_environment_variables.md
@@ -1,0 +1,7 @@
+---
+title: Fix proxy environment variables
+kind: fix
+date: 2025-09-02
+---
+
+* Fixed an issue where MongoDB Agents were not using the NO_PROXY environment variable when set on the operator.

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -144,6 +144,10 @@ else
     script_log "Mongodb Agent is configured to run in \"headless\" mode using local config file"
 fi
 
+# Removed setting the -httpProxy flag in case HTTP_PROXY is set.
+# The agent will not use the other proxy variables (such as NO_PROXY) if this flag is set.
+# Therefore, it is better to not set it, the agent will use the env vars directly (if they are set).
+# https://github.com/10gen/mms-automation/blob/19f44a18cc089ec3734e2b496fdde82b124cd945/go_planner/src/com.tengen/cm/backup/commonbackup/connections.go#L158
 
 if [[ -n "${SSL_TRUSTED_MMS_SERVER_CERTIFICATE-}" ]]; then
     agentOpts+=("-httpsCAFile=${SSL_TRUSTED_MMS_SERVER_CERTIFICATE}")

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -144,9 +144,10 @@ else
     script_log "Mongodb Agent is configured to run in \"headless\" mode using local config file"
 fi
 
-# Removed setting the -httpProxy flag in case HTTP_PROXY is set.
-# The agent will not use the other proxy variables (such as NO_PROXY) if this flag is set.
-# Therefore, it is better to not set it, the agent will use the env vars directly (if they are set).
+# We never set the -httpProxy flag.
+# Without the flag, the agent relies solely on standard environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY).
+# This avoids conflicts between environment settings and agent CLI parameters.
+# For reference, see the agent implementation:
 # https://github.com/10gen/mms-automation/blob/19f44a18cc089ec3734e2b496fdde82b124cd945/go_planner/src/com.tengen/cm/backup/commonbackup/connections.go#L158
 
 if [[ -n "${SSL_TRUSTED_MMS_SERVER_CERTIFICATE-}" ]]; then

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -145,11 +145,6 @@ else
 fi
 
 
-
-if [[ -n "${HTTP_PROXY-}" ]]; then
-    agentOpts+=("-httpProxy=${HTTP_PROXY}")
-fi
-
 if [[ -n "${SSL_TRUSTED_MMS_SERVER_CERTIFICATE-}" ]]; then
     agentOpts+=("-httpsCAFile=${SSL_TRUSTED_MMS_SERVER_CERTIFICATE}")
 fi

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_proxy.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_proxy.py
@@ -43,7 +43,10 @@ def operator_with_proxy(namespace: str, operator_installation_config: dict[str, 
     os.environ["HTTP_PROXY"] = os.environ["HTTPS_PROXY"] = squid_proxy
     helm_args = operator_installation_config.copy()
     helm_args["customEnvVars"] += (
-        f"\&MDB_PROPAGATE_PROXY_ENV=true" + f"\&HTTP_PROXY={squid_proxy}" + f"\&HTTPS_PROXY={squid_proxy}" + "\&NO_PROXY=cloud-qa.mongodb.com"
+        f"\&MDB_PROPAGATE_PROXY_ENV=true"
+        + f"\&HTTP_PROXY={squid_proxy}"
+        + f"\&HTTPS_PROXY={squid_proxy}"
+        + "\&NO_PROXY=cloud-qa.mongodb.com"
     )
     return Operator(namespace=namespace, helm_args=helm_args).install()
 


### PR DESCRIPTION
# Summary

This PR fixes a bug where the mongodb agents were not using the `NO_PROXY` environment variable set on the operator. This is an issue with the agent where setting the `httpProxy` flag will ignore the environment variables. Therefore, running the agent without that flag work properly whether the variables are set or not.

To make sure this is tested, the `e2e_operator_proxy` test was updated by adding a `NO_PROXY` variable set to cloud-qa and asserting that the proxy does not intercept those calls.

## Proof of Work

Ran a [patch](https://spruce.mongodb.com/version/68b6ca1169f9af0007311434/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) where the test was updated, but the fix was not added. It failed, proving that the setting the `NO_PROXY` variable did not work.

With the fix, the CI should be green.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
