### PR TITLE
Fix for wrong repository name for ops-manager in `build_info.json`

### DIFF
--- a/build_info.json
+++ b/build_info.json
@@ -287,7 +287,7 @@
       "dockerfile-path": "docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",
       "patch": {
         "version": "om-version-from-release.json",
-        "repositories": ["268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-enterprise-ops-manager"],
+        "repositories": ["268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-enterprise-ops-manager-ubi"],
         "platforms": [
           "linux/amd64"
         ]
@@ -295,7 +295,7 @@
       "staging": {
         "version": "om-version-from-release.json",
         "sign": true,
-        "repositories": ["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager"],
+        "repositories": ["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager-ubi"],
         "platforms": [
           "linux/amd64"
         ]
@@ -303,7 +303,7 @@
       "manual_release": {
         "sign": true,
         "olm-tag": true,
-        "repositories": ["quay.io/mongodb/mongodb-enterprise-ops-manager"],
+        "repositories": ["quay.io/mongodb/mongodb-enterprise-ops-manager-ubi"],
         "platforms": [
           "linux/amd64"
         ]

--- a/scripts/release/tests/build_info_test.py
+++ b/scripts/release/tests/build_info_test.py
@@ -306,7 +306,9 @@ def test_load_build_info_staging(git_repo: Repo):
                 sign=True,
             ),
             "ops-manager": ImageInfo(
-                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager-ubi"],
+                repositories=[
+                    "268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager-ubi"
+                ],
                 platforms=["linux/amd64"],
                 version="om-version-from-release.json",
                 dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",

--- a/scripts/release/tests/build_info_test.py
+++ b/scripts/release/tests/build_info_test.py
@@ -86,7 +86,7 @@ def test_load_build_info_development(git_repo: Repo):
                 dockerfile_path="docker/mongodb-agent/Dockerfile.atomic",
             ),
             "ops-manager": ImageInfo(
-                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-enterprise-ops-manager"],
+                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-enterprise-ops-manager-ubi"],
                 platforms=["linux/amd64"],
                 version="om-version-from-release.json",
                 dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",
@@ -187,7 +187,7 @@ def test_load_build_info_patch(git_repo: Repo):
                 dockerfile_path="docker/mongodb-agent/Dockerfile.atomic",
             ),
             "ops-manager": ImageInfo(
-                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-enterprise-ops-manager"],
+                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-enterprise-ops-manager-ubi"],
                 platforms=["linux/amd64"],
                 version="om-version-from-release.json",
                 dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",
@@ -306,7 +306,7 @@ def test_load_build_info_staging(git_repo: Repo):
                 sign=True,
             ),
             "ops-manager": ImageInfo(
-                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager"],
+                repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager-ubi"],
                 platforms=["linux/amd64"],
                 version="om-version-from-release.json",
                 dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",
@@ -437,7 +437,7 @@ def test_load_build_info_manual_release(git_repo: Repo):
                 sign=True,
             ),
             "ops-manager": ImageInfo(
-                repositories=["quay.io/mongodb/mongodb-enterprise-ops-manager"],
+                repositories=["quay.io/mongodb/mongodb-enterprise-ops-manager-ubi"],
                 platforms=["linux/amd64"],
                 version=None,  # Version is None for manual_release scenario
                 dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile.atomic",


### PR DESCRIPTION
# Summary

I've notices that we had a wrong repository name for ops-manager in `build_info.json` -> `mongodb-enterprise-ops-manager` instead of `mongodb-enterprise-ops-manager-ubi`. If we would run the OM release it would be pushed to the wrong repository where only context files reside.

## Proof of Work

Passing CI.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
