### PR TITLE
Fix `.gitignore` to not ignore `mongodb-kubernetes` dir/file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ public/architectures/**/certs/*
 public/architectures/**/secrets/*
 
 docker/mongodb-kubernetes-appdb/content/readinessprobe
-mongodb-kubernetes
 docker/mongodb-kubernetes-operator/content/mongodb-kubernetes-operator.tar
 docker/mongodb-kubernetes-tests/helm_chart/
 docker/mongodb-kubernetes-tests/public/


### PR DESCRIPTION


# Summary

As part of this PR https://github.com/mongodb/mongodb-kubernetes/pull/21 we changed all the occurrences of old repo to the new repo and in doing so we ended up adding `mongodb-kubernetes` to the `.gitignore` file.

Becauase of this, if we try to add any file to our new repo in dir `public/dockerfiles/mongodb-kubernetes` it would be ignored by default. This PR fixes that. We don't really need that in .gitignore.

## Proof of Work

Create a file in the dir `public/dockerfiles/mongodb-kubernetes` and make sure that it shows up in `git status`.
