### PR TITLE
change linking approach with directly running the probes

### DIFF
--- a/docker/mongodb-agent/dummy-probe.sh
+++ b/docker/mongodb-agent/dummy-probe.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
-# Dummy liveness probe that returns success to keep container alive during script copying
-# This prevents container from being killed while waiting for real probe scripts
-echo "Using dummy liveness probe - keeping container alive until real probe script is copied"
-exit 0
+set -e
+
+find_init_container() {
+  local pid
+  pid=$(pgrep -f "agent-utilities-holder_marker" | head -n1)
+  if [[ -n "$pid" && -d "/proc/$pid/root/probes" ]]; then
+    echo "$pid"
+    return 0
+  fi
+  return 1
+}
+
+execute_liveness_probe() {
+  local init_pid="$1"
+  local init_probe_path="/proc/$init_pid/root/probes/probe.sh"
+
+  if [[ -f "$init_probe_path" && -x "$init_probe_path" ]]; then
+    # Execute the actual probe script from the init-database container
+    # This works because of shared process namespace - the probe can see all processes
+    exec "$init_probe_path"
+  else
+    echo "ERROR: Liveness probe script not found or not executable at $init_probe_path"
+    exit 1
+  fi
+}
+
+# Main execution
+if init_pid=$(find_init_container); then
+  echo "Found init container with PID: $init_pid, executing liveness probe..."
+  execute_liveness_probe "$init_pid"
+else
+  echo "WARNING: Init container not found, falling back to basic liveness check"
+  # Fallback: if we can't find the init container, just check if this container is alive
+  # This prevents the pod from being killed during startup or init container restarts
+  exit 0
+fi

--- a/docker/mongodb-agent/dummy-probe.sh
+++ b/docker/mongodb-agent/dummy-probe.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+# Dynamic liveness probe that locates and executes the actual probe from init-database container
 
 find_init_container() {
   local pid

--- a/docker/mongodb-agent/dummy-probe.sh
+++ b/docker/mongodb-agent/dummy-probe.sh
@@ -15,13 +15,16 @@ execute_liveness_probe() {
   local init_pid="$1"
   local init_probe_path="/proc/$init_pid/root/probes/probe.sh"
 
-  if [[ -f "$init_probe_path" && -x "$init_probe_path" ]]; then
+  if [[ ! -f "$init_probe_path" ]]; then
+    echo "ERROR: Liveness probe script not found at $init_probe_path"
+    exit 1
+  elif [[ ! -x "$init_probe_path" ]]; then
+    echo "ERROR: Liveness probe script not executable at $init_probe_path"
+    exit 1
+  else
     # Execute the actual probe script from the init-database container
     # This works because of shared process namespace - the probe can see all processes
     exec "$init_probe_path"
-  else
-    echo "ERROR: Liveness probe script not found or not executable at $init_probe_path"
-    exit 1
   fi
 }
 

--- a/docker/mongodb-agent/dummy-readinessprobe
+++ b/docker/mongodb-agent/dummy-readinessprobe
@@ -18,11 +18,14 @@ execute_readiness_probe() {
   local init_pid="$1"
   local init_probe_path="/proc/$init_pid/root/probes/readinessprobe"
 
-  if [[ -f "$init_probe_path" && -x "$init_probe_path" ]]; then
-    exec "$init_probe_path"
-  else
-    echo "ERROR: Readiness probe binary not found or not executable at $init_probe_path"
+  if [[ ! -f "$init_probe_path" ]]; then
+    echo "ERROR: Readiness probe binary not found at $init_probe_path"
     exit 1
+  elif [[ ! -x "$init_probe_path" ]]; then
+    echo "ERROR: Readiness probe binary not executable at $init_probe_path"
+    exit 1
+  else
+    exec "$init_probe_path"
   fi
 }
 

--- a/docker/mongodb-agent/dummy-readinessprobe
+++ b/docker/mongodb-agent/dummy-readinessprobe
@@ -1,5 +1,37 @@
 #!/bin/bash
-# Dummy readiness probe that returns NOT READY until real probe is copied
-# Container should not be marked ready until real probe scripts are available
-echo "Using dummy readiness probe - container not ready until real probe script is copied"
-exit 1
+set -e
+
+# Function to find the init-database container PID
+find_init_container() {
+  local pid
+  pid=$(pgrep -f "agent-utilities-holder_marker" | head -n1)
+  if [[ -n "$pid" && -d "/proc/$pid/root/probes" ]]; then
+    echo "$pid"
+    return 0
+  fi
+  return 1
+}
+
+
+# Function to execute the actual readiness probe from init-database container
+execute_readiness_probe() {
+  local init_pid="$1"
+  local init_probe_path="/proc/$init_pid/root/probes/readinessprobe"
+
+  if [[ -f "$init_probe_path" && -x "$init_probe_path" ]]; then
+    exec "$init_probe_path"
+  else
+    echo "ERROR: Readiness probe binary not found or not executable at $init_probe_path"
+    exit 1
+  fi
+}
+
+# Main execution
+if init_pid=$(find_init_container); then
+  echo "Found init container with PID: $init_pid, executing readiness probe..."
+  execute_readiness_probe "$init_pid"
+else
+  echo "WARNING: Init container not found, container not ready"
+  # If we can't find the init container, the pod should not be marked as ready
+  exit 1
+fi

--- a/docker/mongodb-agent/dummy-readinessprobe
+++ b/docker/mongodb-agent/dummy-readinessprobe
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+# Dynamic readiness probe that locates and executes the actual probe from init-database container
 
 # Function to find the init-database container PID
 find_init_container() {

--- a/docker/mongodb-agent/setup-agent-files.sh
+++ b/docker/mongodb-agent/setup-agent-files.sh
@@ -38,20 +38,6 @@ link_agent_scripts() {
   done
 }
 
-# Verify probe scripts are available in init container
-verify_probe_scripts() {
-  local init_probes_dir="$1"
-
-  echo "Verifying probe scripts are available in init container..."
-  for probe in probe.sh readinessprobe; do
-    if [[ -f "$init_probes_dir/$probe" ]]; then
-      echo "Verified $probe exists in init container"
-    else
-      echo "WARNING: $probe not found in init container at $init_probes_dir/$probe"
-      echo "Dynamic probe scripts will handle runtime discovery"
-    fi
-  done
-}
 
 # Main function to set up all files
 main() {
@@ -78,14 +64,12 @@ main() {
 
     # Link scripts from init container
     link_agent_scripts "$init_scripts"
-    verify_probe_scripts "$init_probes"
 
     echo "File setup completed successfully"
     exit 0
   else
-    echo "WARNING: No init container found during setup"
-    echo "Dynamic probe scripts will attempt runtime discovery when called"
-    exit 0
+    echo "No init container found"
+    exit 1
   fi
 }
 

--- a/docker/mongodb-agent/setup-agent-files.sh
+++ b/docker/mongodb-agent/setup-agent-files.sh
@@ -38,18 +38,17 @@ link_agent_scripts() {
   done
 }
 
-# Link probe scripts from init container, replacing dummy ones
-link_probe_scripts() {
+# Verify probe scripts are available in init container
+verify_probe_scripts() {
   local init_probes_dir="$1"
 
-  echo "Linking probe scripts..."
+  echo "Verifying probe scripts are available in init container..."
   for probe in probe.sh readinessprobe; do
     if [[ -f "$init_probes_dir/$probe" ]]; then
-      ln -sf "$init_probes_dir/$probe" "$SCRIPTS_DIR/$probe"
-      echo "Replaced dummy $probe with real one"
+      echo "Verified $probe exists in init container"
     else
-      echo "WARNING: $probe not found in init container"
-      exit 1
+      echo "WARNING: $probe not found in init container at $init_probes_dir/$probe"
+      echo "Dynamic probe scripts will handle runtime discovery"
     fi
   done
 }
@@ -79,13 +78,14 @@ main() {
 
     # Link scripts from init container
     link_agent_scripts "$init_scripts"
-    link_probe_scripts "$init_probes"
+    verify_probe_scripts "$init_probes"
 
     echo "File setup completed successfully"
     exit 0
   else
-    echo "No init container found"
-    exit 1
+    echo "WARNING: No init container found during setup"
+    echo "Dynamic probe scripts will attempt runtime discovery when called"
+    exit 0
   fi
 }
 


### PR DESCRIPTION
# Summary

This pull request updates the probe scripts for the MongoDB agent container to dynamically locate and execute the actual probe scripts from the init-database container, instead of relying on static dummy scripts. This improves the reliability of liveness and readiness checks, especially during container startup and init container restarts. Additionally, the old logic for replacing dummy probe scripts with real ones via symlinking has been removed, as it is no longer needed.

**Dynamic probe execution:**

* [`docker/mongodb-agent/dummy-probe.sh`] Replaces the static dummy liveness probe with a dynamic script that locates and executes the real probe from the init-database container using the shared process namespace. 
* [`docker/mongodb-agent/dummy-readinessprobe`] Replaces the static dummy readiness probe with a dynamic script that locates and executes the real readiness probe from the init-database container.

**Removal of obsolete probe symlinking:**

## Proof of Work

- agent images have been replaced: [Link](https://spruce.mongodb.com/task/mongodb_kubernetes_manual_ecr_release_agent_currently_used_release_all_currently_used_agents_on_ecr_patch_85d4a0214a9e1e35c2da6675cbf0a96172413c1b_68baa8d3895ab10007931903_25_09_05_09_09_43/logs?execution=0). All ci tests are running with the new set of scripts
```
  Warning  Unhealthy         14m                kubelet            Readiness probe failed: Found init container with PID: 25, executing readiness probe...
{"level":"info","ts":"2025-09-05T14:09:13.862Z","msg":"logging configuration: &{Filename:/var/log/mongodb-mms-automation/readiness.log MaxSize:5 MaxAge:0 MaxBackups:5 LocalTime:false Compress:false size:0 file:<nil> mu:{_:{} mu:{state:0 sema:0}} millCh:<nil> startMill:{_:{} done:{_:{} v:0} m:{_:{} mu:{state:0 sema:0}}}}"}
{"level":"error","ts":"2025-09-05T14:09:13.863Z","msg":"health status file not avaible yet: open /var/log/mongodb-mms-automation/agent-health-status.json: no such file or directory "}
  Warning  Unhealthy  4m34s  kubelet  Readiness probe failed: Found init container with PID: 25, executing readiness probe...
{"level":"info","ts":"2025-09-05T14:19:38.866Z","msg":"logging configuration: &{Filename:/var/log/mongodb-mms-automation/readiness.log MaxSize:5 MaxAge:0 MaxBackups:5 LocalTime:false Compress:false size:0 file:<nil> mu:{_:{} mu:{state:0 sema:0}} millCh:<nil> startMill:{_:{} done:{_:{} v:0} m:{_:{} mu:{state:0 sema:0}}}}"}
```
 
- green ci
## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
