### PR TITLE
Add missing `allowed_requesters: [ "github_tag" ]` to release tasks

### DIFF
--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -4,7 +4,8 @@ include:
 tasks:
   - name: build_test_image_for_smoke_tests
     display_name: build_test_image_for_smoke_tests
-    tags: [ "e2e_smoke_release_test_suite" ]
+    tags: [ "image_release" ]
+    allowed_requesters: [ "patch", "github_tag" ]
     commands:
       - func: clone
       - func: setup_building_host

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -74,12 +74,14 @@ tasks:
 # Each task is selected by convention by running scripts/code_snippets/${task_name}_test.sh
   - name: task_gke_multi_cluster_snippets
     tags: [ "code_snippets" ]
+    allowed_requesters: [ "patch", "github_tag" ]
     commands:
       - func: test_code_snippets
       - func: sample_commit_output
 
   - name: task_gke_multi_cluster_no_mesh_snippets
     tags: [ "code_snippets" ]
+    allowed_requesters: [ "patch", "github_tag" ]
     commands:
       - func: test_code_snippets
       - func: sample_commit_output
@@ -789,6 +791,7 @@ tasks:
 
   - name: e2e_om_ops_manager_backup
     tags: [ "patch-run" ]
+    allowed_requesters: [ "github_tag", "patch" ]
     commands:
       - func: "e2e_test"
 


### PR DESCRIPTION
# Summary

In recent `1.3.0` release some of the tasks didn't start when the github tag was created, namely:
 - task_gke_multi_cluster_snippets
 - task_gke_multi_cluster_no_mesh_snippets
 - build_test_image_for_smoke_tests
 - e2e_smoke
 - e2e_static_smoke

The reason is (most probably) that the tasks didn't have `allowed_requesters: [ "patch", "github_tag" ]` set, only the **variants** had.

## Proof of Work

There is no easy way to test this unfortunately. The `allowed_requesters: [ "patch", "github_tag" ]` is the only difference between tasks that started successfully in https://spruce.mongodb.com/version/mongodb_kubernetes_1.3.0_68baae22f7d2690007feb541/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC and those that were missing.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
