### PR TITLE
separate arbiter and members resource creation

### DIFF
--- a/changelog/20250907_fix_separate_arbiter_and_members_resources.md
+++ b/changelog/20250907_fix_separate_arbiter_and_members_resources.md
@@ -1,0 +1,12 @@
+---
+title: Separate arbiter and members resources
+kind: fix
+date: 2025-09-07
+---
+
+**Issue:** Previously, arbiter StatefulSets were incorrectly using the same resource specifications as data-bearing members, which could lead to resource over-allocation or under-allocation for arbiters that have different resource requirements.
+- Separated resource creation logic for arbiters and data-bearing members
+- Implemented a default resource template specifically for arbiter nodes
+- Arbiters now use their own StatefulSet configuration instead of inheriting from `spec.statefulSet`
+- This ensures arbiters receive appropriate resource allocation based on their lighter workload requirements
+

--- a/mongodb-community-operator/controllers/replicaset_controller_test.go
+++ b/mongodb-community-operator/controllers/replicaset_controller_test.go
@@ -357,7 +357,7 @@ func TestBuildStatefulSet_ConfiguresUpdateStrategyCorrectly(t *testing.T) {
 		mdb.Spec.Version = "4.0.0"
 		mdb.Annotations[annotations.LastAppliedMongoDBVersion] = "4.0.0"
 		sts := appsv1.StatefulSet{}
-		buildStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")(&sts)
+		buildBaseStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage", false)(&sts)
 		assert.Equal(t, appsv1.RollingUpdateStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 	})
 	t.Run("On No Version Change, First Version", func(t *testing.T) {
@@ -365,7 +365,7 @@ func TestBuildStatefulSet_ConfiguresUpdateStrategyCorrectly(t *testing.T) {
 		mdb.Spec.Version = "4.0.0"
 		delete(mdb.Annotations, annotations.LastAppliedMongoDBVersion)
 		sts := appsv1.StatefulSet{}
-		buildStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")(&sts)
+		buildBaseStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage", false)(&sts)
 		assert.Equal(t, appsv1.RollingUpdateStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 	})
 	t.Run("On Version Change", func(t *testing.T) {
@@ -382,7 +382,7 @@ func TestBuildStatefulSet_ConfiguresUpdateStrategyCorrectly(t *testing.T) {
 
 		mdb.Annotations[annotations.LastAppliedMongoDBVersion] = string(bytes)
 		sts := appsv1.StatefulSet{}
-		buildStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")(&sts)
+		buildBaseStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage", false)(&sts)
 		assert.Equal(t, appsv1.OnDeleteStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 	})
 }


### PR DESCRIPTION
# Summary

<!-- Enter your issue summary here.-->

I previously described the problems and possible solutions in this issue:  
https://github.com/mongodb/mongodb-kubernetes-operator/issues/1737  

This branch implements the second proposed solution: **Context-Aware Default Templates**.  
The goal is to avoid unnecessary resource waste by providing separate defaults for arbiters vs. data members while keeping customization consistent.  
## Proof of Work

<!-- Enter your proof that it works here.-->


### Implementation:
* Pass an `isArbiter` boolean to the build function
* Apply arbiter-optimized defaults when `isArbiter=true`:
  - No PVC
  - Minimal resources
* Maintain current behavior for data members
* Keep `spec.statefulSet` for member customization only  

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ✅] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
