### PR TITLE
Run apt-update before installing skopeo for prepare openshift bundle

### DIFF
--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -146,7 +146,7 @@ buildvariants:
       - name: "*"
         variant: preflight_release_images
     run_on:
-      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
+      - ubuntu2404-small
     tasks:
       - name: run_conditionally_prepare_and_upload_openshift_bundles
 


### PR DESCRIPTION
# Summary

Before actually generating the OLM bundle we try to run `setup_prepare_openshift_bundles.sh` that installs `skopeo` using apt.
But the local apt repos are not updated and because of that the `skopeo` installation fails. This PR fixes that by running `apt update` before installing  `skopeo`.

More about this can be found [here](https://mongodb.slack.com/archives/CGLP6R2PQ/p1757074525568919?thread_ts=1756988558.169489&cid=CGLP6R2PQ).

## Proof of Work

After this change the task passed.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
