### PR TITLE
Increase instance size for `e2e_om_ops_manager_pod_spec`

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -864,6 +864,8 @@ tasks:
 
   - name: e2e_om_ops_manager_pod_spec
     tags: [ "patch-run" ]
+    run_on:
+      - ubuntu2404-large
     commands:
       - func: e2e_test
 


### PR DESCRIPTION
# Summary

`e2e_om_ops_manager_pod_spec` fails because backup daemon is not getting scheduled to a node
due to insufficient CPU on a current instance size.

## Proof of Work

`e2e_om_ops_manager_pod_spec` must pass now.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
