### PR TITLE
CLOUDP-290847: Do not trigger STS restarts in cert rotation E2Es

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb.py
@@ -216,26 +216,6 @@ class MongoDB(CustomObject, MongoDBCommon):
             self["metadata"]["annotations"].update({"mongodb.com/v1.architecture": "static"})
             self.update()
 
-    def trigger_sts_restart(self, component=""):
-        """
-        Adds or changes a label from the pod template to trigger a rolling restart of that StatefulSet.
-        Leave component to empty if a ReplicaSet deployment is used.
-        Set component to either "shard", "config", "mongos" to trigger a restart of the respective StatefulSet.
-        """
-        pod_spec = "podSpec"
-        if component == "shard":
-            pod_spec = "shardPodSpec"
-        elif component == "config":
-            pod_spec = "configSrvPodSpec"
-        elif component == "mongos":
-            pod_spec = "mongosPodSpec"
-
-        self.load()
-        self["spec"][pod_spec] = {
-            "podTemplate": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": str(time.time())}}}
-        }
-        self.update()
-
     def assert_connectivity_from_connection_string(self, cnx_string: str, tls: bool, ca_path: Optional[str] = None):
         """
         Tries to connect to a database using a connection string only.

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_rs.py
@@ -48,10 +48,8 @@ class TestReplicaSetEnableAllOptions(KubernetesTester):
         ac_tester.assert_internal_cluster_authentication_enabled()
         ac_tester.assert_authentication_enabled()
 
-    def test_rotate_certificate_with_sts_restarting(self, mdb: MongoDB, namespace: str):
-        mdb.trigger_sts_restart()
+    def test_rotate_certificate(self, mdb: MongoDB, namespace: str):
         rotate_and_assert_certificates(mdb, namespace, "{}-cert".format(MDB_RESOURCE))
 
-    def test_rotate_clusterfile_with_sts_restarting(self, mdb: MongoDB, namespace: str):
-        mdb.trigger_sts_restart()
+    def test_rotate_clusterfile(self, mdb: MongoDB, namespace: str):
         rotate_and_assert_certificates(mdb, namespace, "{}-clusterfile".format(MDB_RESOURCE))

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
@@ -90,14 +90,11 @@ class TestShardedClusterEnableAllOptions:
         ac_tester.assert_authentication_enabled()
         ac_tester.assert_expected_users(0)
 
-    def test_rotate_shard_cert_with_sts_restarting(self, sc: MongoDB, namespace: str):
-        sc.trigger_sts_restart("shard")
+    def test_rotate_shard_cert(self, sc: MongoDB, namespace: str):
         rotate_and_assert_certificates(sc, namespace, f"{MDB_RESOURCE_NAME}-0-cert")
 
-    def test_rotate_config_cert_with_sts_restarting(self, sc: MongoDB, namespace: str):
-        sc.trigger_sts_restart("config")
+    def test_rotate_config_cert(self, sc: MongoDB, namespace: str):
         rotate_and_assert_certificates(sc, namespace, f"{MDB_RESOURCE_NAME}-config-cert")
 
-    def test_rotate_mongos_cert_with_sts_restarting(self, sc: MongoDB, namespace: str):
-        sc.trigger_sts_restart("mongos")
+    def test_rotate_mongos_cert(self, sc: MongoDB, namespace: str):
         rotate_and_assert_certificates(sc, namespace, f"{MDB_RESOURCE_NAME}-mongos-cert")

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
@@ -390,7 +390,6 @@ def test_rotate_server_certs(replica_set: MongoDB, vault_namespace: str, vault_n
 def test_rotate_server_certs_with_sts_restarting(
     replica_set: MongoDB, vault_namespace: str, vault_name: str, namespace: str, issuer: str
 ):
-    replica_set.trigger_sts_restart()
     create_x509_mongodb_tls_certs(
         issuer,
         namespace,


### PR DESCRIPTION
# Summary

Our certificate rotation tests currently do two things:
1. Trigger STS restarts before doing anything by updating STS's `podTemplate` (adding/changing annotation).
2. Update the certificate and assert that the automation config received an update by asserting a version.

This change removes the step 1 because as it seems unnecessary.

Note: the certificate rotation itself happens without pod restarts (apart from agent certs, but it will be addressed in #389

## Proof of Work

Tests must pass even without STS restarts.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
