### PR TITLE
Make Dependabot add `skip-changelog` label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       - dependency-name: k8s.io/client-go
       - dependency-name: k8s.io/code-generator
       - dependency-name: sigs.k8s.io/controller-runtime
+    labels:
+      - dependencies
+      - go
+      - skip-changelog
 
   - package-ecosystem: pip
     directory: "/"
@@ -29,3 +33,7 @@ updates:
           - "*"
     ignore:
        - dependency-name: kubernetes
+    labels:
+      - dependencies
+      - python
+      - skip-changelog


### PR DESCRIPTION
# Summary

So we don't have to add it manually.

## Proof of Work

N/A

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
