### PR TITLE
CLOUDP-295785 - remove title from changelog file generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Each Pull Request usually has a changelog file that describes the changes made i
 Changelog files are placed in the `changelog/` directory and used to generate the Release Notes for the
 upcoming release. Preview of the Release Notes is automatically added as comment to each Pull Request.
 The changelog file needs to follow the naming convention
-`YYYYMMDD-<change_kind>-<short-description>.md`. To create changelog file please use the
+`YYYYMMDD-<change_kind>-<short-title>.md`. To create changelog file please use the
 `scripts/release/create_changelog.py` script. Example usage:
 
 ```console
@@ -34,7 +34,7 @@ usage: create_changelog.py [-h] [-c ] [-d ] [-e] -k  title
 Utility to easily create a new changelog entry file.
 
 positional arguments:
-  title                 Title for the changelog entry
+  title                 Short title used in changelog filename
 
 options:
   -h, --help            show this help message and exit

--- a/scripts/release/changelog.py
+++ b/scripts/release/changelog.py
@@ -35,10 +35,9 @@ class ChangeKind(StrEnum):
 
 
 class ChangeEntry:
-    def __init__(self, date: datetime, kind: ChangeKind, title: str, contents: str):
+    def __init__(self, date: datetime, kind: ChangeKind, contents: str):
         self.date = date
         self.kind = kind
-        self.title = title
         self.contents = contents
 
 
@@ -129,7 +128,7 @@ def extract_changelog_entry_from_contents(file_contents: str) -> ChangeEntry:
     ## Add newline to contents so the Markdown file also contains a newline at the end
     contents = data.content + "\n"
 
-    return ChangeEntry(date=date, title=str(data["title"]), kind=kind, contents=contents)
+    return ChangeEntry(date=date, kind=kind, contents=contents)
 
 
 def get_changelog_filename(title: str, kind: ChangeKind, date: datetime) -> str:

--- a/scripts/release/create_changelog.py
+++ b/scripts/release/create_changelog.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
   - '{str(ChangeKind.FIX)}' for bugfix entries
   - '{str(ChangeKind.OTHER)}' for other entries""",
     )
-    parser.add_argument("title", type=str, help="Title for the changelog entry")
+    parser.add_argument("title", type=str, help="Short title used in changelog filename")
     args = parser.parse_args()
 
     title = args.title
@@ -72,7 +72,6 @@ if __name__ == "__main__":
     with open(changelog_path, "w") as f:
         # Add frontmatter based on args
         f.write("---\n")
-        f.write(f"title: {title}\n")
         f.write(f"kind: {str(kind)}\n")
         f.write(f"date: {date_str}\n")
         f.write("---\n\n")

--- a/scripts/release/tests/changelog_test.py
+++ b/scripts/release/tests/changelog_test.py
@@ -69,7 +69,6 @@ date: 2025-07-10
 
     change_entry = extract_changelog_entry_from_contents(file_contents)
 
-    assert change_entry.title == "This is my change"
     assert change_entry.kind == ChangeKind.FEATURE
     assert change_entry.date == datetime.date(2025, 7, 10)
     assert (


### PR DESCRIPTION
# Summary

<!-- Enter your issue summary here.-->

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
