### PR TITLE
Remove `private_gke_code_snippets` from staging builds

### DIFF
--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -164,9 +164,10 @@ buildvariants:
     tasks:
       - name: kind_code_snippets_task_group
 
+    #TODO: this task was disabled from automatic runs due to GKE resource issues https://jira.mongodb.org/browse/CLOUDP-345083
   - name: private_gke_code_snippets
     display_name: private_gke_code_snippets
-    tags: [ "staging", "e2e_test_suite" ]
+    tags: [ "manual_patch", "e2e_test_suite" ]
     allowed_requesters: [ "patch" ]
     run_on:
       - ubuntu2404-small
@@ -177,7 +178,6 @@ buildvariants:
   - name: private_kind_code_snippets
     display_name: private_kind_code_snippets
     tags: [ "pr_patch", "staging", "e2e_test_suite" ]
-    allowed_requesters: [ "patch", "github_pr" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om8_dependency


### PR DESCRIPTION
# Summary

Based on discussion we had in [thread](https://mongodb.slack.com/archives/C090D3JTCCT/p1757945156066799?thread_ts=1757942958.119979&cid=C090D3JTCCT) I'm disabling the `private_gke_code_snippets` which are continuously failing on master due to GKE resource exhaustion.

## Proof of Work

no-op

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
