### PR TITLE
Move licenses to correct dir

### DIFF
--- a/docker/mongodb-agent/Dockerfile
+++ b/docker/mongodb-agent/Dockerfile
@@ -85,7 +85,7 @@ RUN mkdir -p /agent \
       && chmod ugo+rw /var/log/mongodb-mms-automation/readiness.log
 
 # Copy scripts to a safe location that won't be overwritten by volume mount
-COPY ./docker/mongodb-kubernetes-init-database/content/LICENSE /data/LICENSE
+COPY ./docker/mongodb-kubernetes-init-database/content/LICENSE /licenses/LICENSE
 COPY ./docker/mongodb-agent/agent-launcher-shim.sh /usr/local/bin/agent-launcher-shim.sh
 COPY ./docker/mongodb-agent/setup-agent-files.sh /usr/local/bin/setup-agent-files.sh
 COPY ./docker/mongodb-agent/dummy-probe.sh /usr/local/bin/dummy-probe.sh


### PR DESCRIPTION
# Summary

License files were placed incorrectly in mongodb agent images causing preflights to fail.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
