### PR TITLE
Add @vinilage to CODEOWNERS of `changelog/` dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @mongodb/kubernetes-hosted
+
+/changelog/ @mongodb/kubernetes-hosted @vinilage


### PR DESCRIPTION
# Summary

Automatically add @vinilage as required reviewer for `changelog/` files modification.

## Proof of Work

no-op

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
