### PR TITLE
Disable `e2e_om_ops_manager_queryable_backup` in OM8 e2e variant

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1110,6 +1110,17 @@ task_groups:
       - e2e_om_ops_manager_backup
     <<: *teardown_group
 
+  # TODO (CLOUDP-346008): Remove this task group once the issue with queryable backup task is resolved in OM8
+  - name: e2e_ops_manager_kind_5_0_only_task_group_without_queryable_backup
+    max_hosts: -1
+    <<: *setup_group
+    <<: *setup_and_teardown_task
+    tasks:
+      - e2e_om_remotemode
+      - e2e_om_ops_manager_backup_restore
+      - e2e_om_ops_manager_backup
+    <<: *teardown_group
+
   # Tests features only supported on OM60
   - name: e2e_ops_manager_kind_6_0_only_task_group
     max_hosts: -1
@@ -1325,7 +1336,8 @@ buildvariants:
     <<: *base_om8_dependency
     tasks:
       - name: e2e_ops_manager_kind_only_task_group
-      - name: e2e_ops_manager_kind_5_0_only_task_group
+      # TODO (CLOUDP-346008): Replace this task group with e2e_ops_manager_kind_5_0_only_task_group once the issue with queryable backup task is resolved in OM8
+      - name: e2e_ops_manager_kind_5_0_only_task_group_without_queryable_backup
       - name: e2e_ops_manager_kind_6_0_only_task_group
       - name: e2e_ops_manager_upgrade_only_task_group
 


### PR DESCRIPTION
# Summary

This pull request introduces a temporary workaround in the `.evergreen.yml` configuration to address an issue with the queryable backup task in OM8. A new task group is added that excludes the problematic task, and the build variant is updated to use this new group until the issue is resolved in [CLOUDP-346008](https://jira.mongodb.org/browse/CLOUDP-346008).

**Task group adjustments:**

* Added a new task group `e2e_ops_manager_kind_5_0_only_task_group_without_queryable_backup` that omits the queryable backup task, as a temporary measure while the OM8 issue is outstanding.

**Build variant updates:**

* Updated the build variant to use the new task group instead of the original, with a clear TODO to revert this once the OM8 issue is fixed.

## Proof of Work

We still run `e2e_om_ops_manager_queryable_backup` in OM6 and OM7 build variants, but not in OM8.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
