### PR TITLE
Fix: Use CLUSTER_DOMAIN environment variable instead of hardcoded cluster.local

### DIFF
--- a/changelog/20250925_fix_use_cluster_domain_environment_variable_instead_of.md
+++ b/changelog/20250925_fix_use_cluster_domain_environment_variable_instead_of.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2025-09-25
+---
+
+* Use CLUSTER_DOMAIN environment variable instead of the fixed value `cluster.local`

--- a/controllers/searchcontroller/community_search_source.go
+++ b/controllers/searchcontroller/community_search_source.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,8 +27,9 @@ type CommunitySearchSource struct {
 
 func (r *CommunitySearchSource) HostSeeds() []string {
 	seeds := make([]string, r.Spec.Members)
+	clusterDomain := env.ReadOrDefault("CLUSTER_DOMAIN", "cluster.local")
 	for i := range seeds {
-		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", r.Name, i, r.ServiceName(), r.Namespace, r.GetMongodConfiguration().GetDBPort())
+		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", r.Name, i, r.ServiceName(), r.Namespace, clusterDomain, r.GetMongodConfiguration().GetDBPort())
 	}
 	return seeds
 }

--- a/controllers/searchcontroller/enterprise_search_source.go
+++ b/controllers/searchcontroller/enterprise_search_source.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -24,8 +25,9 @@ func NewEnterpriseResourceSearchSource(mdb *mdbv1.MongoDB) SearchSourceDBResourc
 
 func (r EnterpriseResourceSearchSource) HostSeeds() []string {
 	seeds := make([]string, r.Spec.Members)
+	clusterDomain := env.ReadOrDefault("CLUSTER_DOMAIN", "cluster.local")
 	for i := range seeds {
-		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", r.Name, i, r.ServiceName(), r.Namespace, r.Spec.GetAdditionalMongodConfig().GetPortOrDefault())
+		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", r.Name, i, r.ServiceName(), r.Namespace, clusterDomain, r.Spec.GetAdditionalMongodConfig().GetPortOrDefault())
 	}
 	return seeds
 }

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/ghodss/yaml"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/fields"
@@ -405,7 +406,8 @@ func GetMongodConfigParameters(search *searchv1.MongoDBSearch) map[string]any {
 
 func mongotHostAndPort(search *searchv1.MongoDBSearch) string {
 	svcName := search.SearchServiceNamespacedName()
-	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", svcName.Name, svcName.Namespace, search.GetMongotPort())
+	clusterDomain := env.ReadOrDefault("CLUSTER_DOMAIN", "cluster.local")
+	return fmt.Sprintf("%s.%s.svc.%s:%d", svcName.Name, svcName.Namespace, clusterDomain, search.GetMongotPort())
 }
 
 func (r *MongoDBSearchReconcileHelper) ValidateSingleMongoDBSearchForSearchSource(ctx context.Context) error {


### PR DESCRIPTION
## Summary

  This PR replaces hardcoded `cluster.local` DNS suffix with a configurable `CLUSTER_DOMAIN` environment variable across the search controller components. This change improves flexibility for deployments in Kubernetes clusters that use custom cluster domains.

  **Changes:**
  - Modified `CommunitySearchSource.HostSeeds()` to use configurable cluster domain
  - Updated `EnterpriseResourceSearchSource.HostSeeds()` to use configurable cluster domain
  - Updated `mongotHostAndPort()` function to use configurable cluster domain
  - Added `env.ReadOrDefault("CLUSTER_DOMAIN", "cluster.local")` calls to maintain backward compatibility

  ## Proof of Work

  - ✅ All hardcoded `cluster.local` references in search controller replaced with environment variable
  - ✅ Backward compatibility maintained with default fallback to `cluster.local`
  - ✅ Changelog file added documenting the fix
  - ✅ Code follows existing patterns using `pkg/util/env.ReadOrDefault()`

  **Files modified:**
  - `controllers/searchcontroller/community_search_source.go:30`
  - `controllers/searchcontroller/enterprise_search_source.go:28`
  - `controllers/searchcontroller/mongodbsearch_reconcile_helper.go:409`

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

 The PR is ready! The commit already includes the changelog file as required by the contributing guidelines.