### PR TITLE
Fixes Operator crash when `securityContext.readOnlyRootFilesystem=true`

### DIFF
--- a/changelog/20250924_fix_provide_more_secure_pod_and_container.md
+++ b/changelog/20250924_fix_provide_more_secure_pod_and_container.md
@@ -4,11 +4,14 @@ date: 2025-09-24
 ---
 
 * To follow the [Pod Security Standards](https://v1-32.docs.kubernetes.io/docs/concepts/security/pod-security-standards/) more secure default pod `securityContext` settings were added.
-
-  Operator deployment `securityContext` settings that have changed:
+Operator deployment `securityContext` settings that have changed:
    - `allowPrivilegeEscalation: false`
    - `capabilities.drop: [ ALL ]`
    - `seccompProfile.type: RuntimeDefault`
 
   Other workloads:
-   - `capabilities.drop: [ ALL ]`
+   - `capabilities.drop: [ ALL ]` - container level
+   - `seccompProfile.type: RuntimeDefault` - pod level
+
+   > **Note**: If you require less restrictive `securityContext` settings please use `template` or `podTemplate` overrides.
+   > Detailed information about overrides can be found in [Modify Ops Manager or MongoDB Kubernetes Resource Containers](https://www.mongodb.com/docs/kubernetes/current/tutorial/modify-resource-image/).

--- a/changelog/20250924_fix_provide_more_secure_pod_and_container.md
+++ b/changelog/20250924_fix_provide_more_secure_pod_and_container.md
@@ -3,10 +3,12 @@ kind: fix
 date: 2025-09-24
 ---
 
-* To follow the [Pod Security Standards](https://v1-32.docs.kubernetes.io/docs/concepts/security/pod-security-standards/) more secure default pod and container securitContext settings were added. 
-  Operator deployment securityContext settings that were added:
+* To follow the [Pod Security Standards](https://v1-32.docs.kubernetes.io/docs/concepts/security/pod-security-standards/) more secure default pod `securityContext` settings were added.
+
+  Operator deployment `securityContext` settings that have changed:
    - `allowPrivilegeEscalation: false`
    - `capabilities.drop: [ ALL ]`
    - `seccompProfile.type: RuntimeDefault`
+
   Other workloads:
-   - `capabilities.drop: [ ALL ]` 
+   - `capabilities.drop: [ ALL ]`

--- a/changelog/20250924_fix_provide_more_secure_pod_and_container.md
+++ b/changelog/20250924_fix_provide_more_secure_pod_and_container.md
@@ -1,0 +1,12 @@
+---
+kind: fix
+date: 2025-09-24
+---
+
+* To follow the [Pod Security Standards](https://v1-32.docs.kubernetes.io/docs/concepts/security/pod-security-standards/) more secure default pod and container securitContext settings were added. 
+  Operator deployment securityContext settings that were added:
+   - `allowPrivilegeEscalation: false`
+   - `capabilities.drop: [ ALL ]`
+   - `seccompProfile.type: RuntimeDefault`
+  Other workloads:
+   - `capabilities.drop: [ ALL ]` 

--- a/changelog/20250924_fix_provide_more_secure_pod_and_container.md
+++ b/changelog/20250924_fix_provide_more_secure_pod_and_container.md
@@ -13,5 +13,5 @@ Operator deployment `securityContext` settings that have changed:
    - `capabilities.drop: [ ALL ]` - container level
    - `seccompProfile.type: RuntimeDefault` - pod level
 
-   > **Note**: If you require less restrictive `securityContext` settings please use `template` or `podTemplate` overrides.
-   > Detailed information about overrides can be found in [Modify Ops Manager or MongoDB Kubernetes Resource Containers](https://www.mongodb.com/docs/kubernetes/current/tutorial/modify-resource-image/).
+> **Note**: If you require less restrictive `securityContext` settings please use `template` or `podTemplate` overrides.
+> Detailed information about overrides can be found in [Modify Ops Manager or MongoDB Kubernetes Resource Containers](https://www.mongodb.com/docs/kubernetes/current/tutorial/modify-resource-image/).

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,9 @@ spec:
             - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server
+              name: webhook-server-dir
           resources:
             limits:
               cpu: 1100m
@@ -313,3 +316,6 @@ spec:
               value: "mongodb-search"
             - name: MDB_SEARCH_VERSION
               value: "0.53.1"
+      volumes:
+        - name: webhook-server-dir
+          emptyDir: {}

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -45,6 +45,9 @@ func Test_buildDatabaseInitContainer(t *testing.T) {
 		SecurityContext: &corev1.SecurityContext{
 			ReadOnlyRootFilesystem:   ptr.To(true),
 			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 	}
 	assert.Equal(t, expectedContainer, container)

--- a/controllers/operator/construct/opsmanager_construction_test.go
+++ b/controllers/operator/construct/opsmanager_construction_test.go
@@ -46,6 +46,9 @@ func Test_buildOpsManagerAndBackupInitContainer(t *testing.T) {
 		SecurityContext: &corev1.SecurityContext{
 			ReadOnlyRootFilesystem:   ptr.To(true),
 			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 	}
 	assert.Equal(t, expectedContainer, containerObj)

--- a/docker/mongodb-kubernetes-tests/kubetester/__init__.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/__init__.py
@@ -273,6 +273,13 @@ def delete_namespace(name: str):
     c = client.CoreV1Api()
     c.delete_namespace(name, body=c.V1DeleteOptions())
 
+def label_namespace(name: str, labels: dict):
+    body = {
+        "metadata": {
+            "labels": labels
+        }
+    }
+    client.CoreV1Api().patch_namespace(name, body)
 
 def get_deployments(namespace: str):
     return client.AppsV1Api().list_namespaced_deployment(namespace)

--- a/docker/mongodb-kubernetes-tests/kubetester/__init__.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/__init__.py
@@ -273,13 +273,11 @@ def delete_namespace(name: str):
     c = client.CoreV1Api()
     c.delete_namespace(name, body=c.V1DeleteOptions())
 
+
 def label_namespace(name: str, labels: dict):
-    body = {
-        "metadata": {
-            "labels": labels
-        }
-    }
+    body = {"metadata": {"labels": labels}}
     client.CoreV1Api().patch_namespace(name, body)
+
 
 def get_deployments(namespace: str):
     return client.AppsV1Api().list_namespaced_deployment(namespace)

--- a/docker/mongodb-kubernetes-tests/kubetester/helm.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/helm.py
@@ -28,7 +28,8 @@ def helm_template(
     args = ("helm", "template", *(command_args), _helm_chart_dir(helm_chart_path))
     logger.info(" ".join(args))
 
-    yaml_file_name = "{}.yaml".format(str(uuid.uuid4()))
+    home = os.getenv("HOME")
+    yaml_file_name = os.path.join(home, "{}.yaml".format(str(uuid.uuid4())))
     with open(yaml_file_name, "w") as output:
         process_run_and_check(" ".join(args), stdout=output, check=True, shell=True)
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
@@ -5,8 +5,9 @@ from kubernetes.client.rest import ApiException
 from kubetester import (
     create_or_update_secret,
     get_default_storage_class,
+    label_namespace,
     try_load,
-    wait_until, create_or_update_namespace, label_namespace,
+    wait_until,
 )
 from kubetester.awss3client import AwsS3Client
 from kubetester.kubetester import KubernetesTester, ensure_ent_version
@@ -54,10 +55,9 @@ def ops_manager(
     )
 
     # Change pod-security mode from warn to enforce. This will make test fail if operator and deployments don't support enforce mode
-    label_namespace(namespace, {
-        "pod-security.kubernetes.io/enforce": None,
-        "pod-security.kubernetes.io/warn": "restricted"
-    })
+    label_namespace(
+        namespace, {"pod-security.kubernetes.io/enforce": None, "pod-security.kubernetes.io/warn": "restricted"}
+    )
 
     try_load(resource)
     return resource
@@ -241,7 +241,7 @@ class TestBackupDatabasesAdded:
         ops_manager.backup_status().assert_reaches_phase(
             Phase.Failed,
             msg_regexp=".*is configured to use SCRAM-SHA authentication mode, the user "
-                       "must be specified using 'mongodbUserRef'",
+            "must be specified using 'mongodbUserRef'",
         )
 
     def test_fix_om(self, ops_manager: MongoDBOpsManager, oplog_user: MongoDBUser):

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
@@ -55,9 +55,11 @@ def ops_manager(
     )
 
     # Change pod-security mode from warn to enforce. This will make test fail if operator and deployments don't support enforce mode
-    label_namespace(
-        namespace, {"pod-security.kubernetes.io/enforce": None, "pod-security.kubernetes.io/warn": "restricted"}
-    )
+    # This will not work in multi-cluster, because Istio injects sidecar and that breaks restricted level
+    if not is_multi_cluster():
+        label_namespace(
+            namespace, {"pod-security.kubernetes.io/enforce": None, "pod-security.kubernetes.io/warn": "restricted"}
+        )
 
     try_load(resource)
     return resource

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
@@ -44,22 +44,25 @@ def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
 
 
 @fixture(scope="module")
+def enforced_pss_namespace(namespace: str) -> str:
+    # Change pod-security mode from warn to enforce. This will make test fail if operator and deployments don't support enforce mode
+    # This will not work in multi-cluster, because Istio injects sidecar and that breaks restricted level
+    if not is_multi_cluster():
+        label_namespace(namespace, {"pod-security.kubernetes.io/enforce": "restricted"})
+
+    return namespace
+
+
+@fixture(scope="module")
 def ops_manager(
-    namespace: str,
+    enforced_pss_namespace: str,
     s3_bucket: str,
     custom_version: Optional[str],
     custom_appdb_version: str,
 ) -> MongoDBOpsManager:
     resource: MongoDBOpsManager = MongoDBOpsManager.from_yaml(
-        yaml_fixture("om_ops_manager_backup.yaml"), namespace=namespace
+        yaml_fixture("om_ops_manager_backup.yaml"), namespace=enforced_pss_namespace
     )
-
-    # Change pod-security mode from warn to enforce. This will make test fail if operator and deployments don't support enforce mode
-    # This will not work in multi-cluster, because Istio injects sidecar and that breaks restricted level
-    if not is_multi_cluster():
-        label_namespace(
-            namespace, {"pod-security.kubernetes.io/enforce": None, "pod-security.kubernetes.io/warn": "restricted"}
-        )
 
     try_load(resource)
     return resource

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -36,8 +36,10 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+        seccompProfile:
+          type: RuntimeDefault
 {{- end }}
-{{- if .Values.registry.imagePullSecrets}}
+{{- if .Values.registry.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.registry.imagePullSecrets }}
 {{- end }}
@@ -74,6 +76,13 @@ spec:
             requests:
               cpu: {{ .Values.operator.resources.requests.cpu }}
               memory: {{ .Values.operator.resources.requests.memory }}
+          {{- if not .Values.managedSecurityContext }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          {{- end }}
           env:
             - name: OPERATOR_ENV
               value: {{ .Values.operator.env }}

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -36,6 +36,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
         seccompProfile:
           type: RuntimeDefault
 {{- end }}
@@ -64,8 +66,10 @@ spec:
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
           {{- end }}
-          {{- if .Values.multiCluster.clusters }}
           volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server
+              name: webhook-server-dir
+          {{- if .Values.multiCluster.clusters }}
             - mountPath: /etc/config/kubeconfig
               name: kube-config-volume
           {{- end }}
@@ -79,6 +83,7 @@ spec:
           {{- if not .Values.managedSecurityContext }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -290,13 +295,15 @@ spec:
               value: '{{ (split "=" .)._1 }}'
       {{- end }}
     {{- end }}
-{{- if .Values.multiCluster.clusters }}
       volumes:
+        - name: webhook-server-dir
+          emptyDir: {}
+        {{- if .Values.multiCluster.clusters }}
         - name: kube-config-volume
           secret:
             defaultMode: 420
             secretName: {{ .Values.multiCluster.kubeConfigSecretName }}
-{{- end }}
+        {{- end }}
 
 {{- with .Values.operator }}
   {{- with .nodeSelector }}

--- a/mongodb-community-operator/pkg/kube/container/containers.go
+++ b/mongodb-community-operator/pkg/kube/container/containers.go
@@ -206,5 +206,11 @@ func WithSecurityContext(context corev1.SecurityContext) Modification {
 func DefaultSecurityContext() corev1.SecurityContext {
 	readOnlyRootFilesystem := true
 	allowPrivilegeEscalation := false
-	return corev1.SecurityContext{ReadOnlyRootFilesystem: &readOnlyRootFilesystem, AllowPrivilegeEscalation: &allowPrivilegeEscalation}
+	return corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
 }

--- a/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template.go
+++ b/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template.go
@@ -197,7 +197,13 @@ func DefaultPodSecurityContext() corev1.PodSecurityContext {
 	runAsNonRoot := true
 	runAsUser := int64(2000)
 	fsGroup := int64(2000)
-	return corev1.PodSecurityContext{RunAsUser: &runAsUser, RunAsNonRoot: &runAsNonRoot, FSGroup: &fsGroup}
+
+	return corev1.PodSecurityContext{
+		RunAsUser:      &runAsUser,
+		RunAsNonRoot:   &runAsNonRoot,
+		FSGroup:        &fsGroup,
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
 }
 
 // WithImagePullSecrets adds an ImagePullSecrets local reference with the given name

--- a/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template_test.go
+++ b/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -441,6 +442,12 @@ func TestMergeContainer(t *testing.T) {
 			},
 		},
 		ReadinessProbe: otherDefaultContainer.ReadinessProbe,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
 	}
 	assert.Equal(t, secondExpected, mergedSpec.Spec.Containers[2])
 }

--- a/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template_test.go
+++ b/mongodb-community-operator/pkg/kube/podtemplatespec/podspec_template_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -442,12 +441,6 @@ func TestMergeContainer(t *testing.T) {
 			},
 		},
 		ReadinessProbe: otherDefaultContainer.ReadinessProbe,
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-		},
 	}
 	assert.Equal(t, secondExpected, mergedSpec.Spec.Containers[2])
 }

--- a/mongodb-community-operator/scripts/dev/e2e.py
+++ b/mongodb-community-operator/scripts/dev/e2e.py
@@ -45,7 +45,9 @@ def _prepare_test_environment(namespace) -> None:
 
     print("Creating Namespace")
     k8s_conditions.ignore_if_already_exists(
-        lambda: corev1.create_namespace(client.V1Namespace(metadata=dict(name=namespace)))
+        lambda: corev1.create_namespace(
+            client.V1Namespace(metadata=dict(name=namespace, labels={"pod-security.kubernetes.io/warn": "restricted"}))
+        )
     )
 
     print("Creating Cluster Role Binding and Service Account for test pod")

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -329,6 +329,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -346,6 +348,8 @@ spec:
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
           volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server
+              name: webhook-server-dir
             - mountPath: /etc/config/kubeconfig
               name: kube-config-volume
           resources:
@@ -357,6 +361,7 @@ spec:
               memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -445,6 +450,8 @@ spec:
             - name: MDB_SEARCH_VERSION
               value: "0.53.1"
       volumes:
+        - name: webhook-server-dir
+          emptyDir: {}
         - name: kube-config-volume
           secret:
             defaultMode: 420

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -329,6 +329,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
           image: "quay.io/mongodb/mongodb-kubernetes:1.4.0"
@@ -353,6 +355,11 @@ spec:
             requests:
               cpu: 500m
               memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: OPERATOR_ENV
               value: prod

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -339,6 +339,9 @@ spec:
             - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server
+              name: webhook-server-dir
           resources:
             limits:
               cpu: 1100m
@@ -617,3 +620,6 @@ spec:
               value: "mongodb-search"
             - name: MDB_SEARCH_VERSION
               value: "0.53.1"
+      volumes:
+        - name: webhook-server-dir
+          emptyDir: {}

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -329,6 +329,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -344,6 +346,9 @@ spec:
             - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server
+              name: webhook-server-dir
           resources:
             limits:
               cpu: 1100m
@@ -353,6 +358,7 @@ spec:
               memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -440,3 +446,6 @@ spec:
               value: "mongodb-search"
             - name: MDB_SEARCH_VERSION
               value: "0.53.1"
+      volumes:
+        - name: webhook-server-dir
+          emptyDir: {}

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -329,6 +329,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator
           image: "quay.io/mongodb/mongodb-kubernetes:1.4.0"
@@ -349,6 +351,11 @@ spec:
             requests:
               cpu: 500m
               memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: OPERATOR_ENV
               value: prod

--- a/scripts/evergreen/deployments/test-app/templates/mongodb-enterprise-tests.yaml
+++ b/scripts/evergreen/deployments/test-app/templates/mongodb-enterprise-tests.yaml
@@ -42,6 +42,8 @@ spec:
       emptyDir: { }
     - name: diagnostics
       emptyDir: { }
+    - name: tests-home-dir
+      emptyDir: { }
   {{ if .Values.multiCluster.memberClusters }}
     - name: kube-config-volume
       secret:
@@ -52,6 +54,12 @@ spec:
         defaultMode: 420
         secretName: test-pod-multi-cluster-config
   {{ end }}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 2000
+    fsGroup: 2000
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - image: public.ecr.aws/docker/library/busybox:1.37.0
     name: keepalive
@@ -61,6 +69,11 @@ spec:
         mountPath: /tmp/results
       - name: diagnostics
         mountPath: /tmp/diagnostics
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
   - name: mongodb-enterprise-operator-tests
     env:
     # OTEL env vars can either be used to construct custom spans or are used by pytest opentelemetry dynamic instrumentation
@@ -190,6 +203,9 @@ spec:
       value: {{ .Values.cognito_workload_url }}
     - name: cognito_workload_user_id
       value: {{ .Values.cognito_workload_user_id }}
+    # Used by helm to create .config and .cache directories. Also used by some tests that need to write files.
+    - name: HOME
+      value: /home/tests-home
     image: {{ .Values.repo }}/mongodb-kubernetes-tests:{{ .Values.tag }}
     # Options to pytest command should go in the pytest.ini file.
     command: ["pytest"]
@@ -206,9 +222,16 @@ spec:
         mountPath: /tmp/results
       - name: diagnostics
         mountPath: /tmp/diagnostics
+      - name: tests-home-dir
+        mountPath: /home/tests-home
     {{ if .Values.multiCluster.memberClusters }}
       - mountPath: /etc/config
         name: kube-config-volume
       - mountPath: /etc/multicluster
         name: multi-cluster-config
     {{ end }}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL

--- a/scripts/funcs/kubernetes
+++ b/scripts/funcs/kubernetes
@@ -17,6 +17,7 @@ metadata:
   name: ${namespace}
   labels:
     evg: task
+    pod-security.kubernetes.io/warn: "restricted"
   annotations:
     evg/version: "https://evergreen.mongodb.com/version/${version_id:-'not-specified'}"
     evg/task-name: ${TASK_NAME:-'not-specified'}
@@ -98,7 +99,7 @@ create_image_registries_secret() {
     context=$1
     namespace=$2
     secret_name=$3
-    
+
     # Detect the correct config file path based on container runtime
     local config_file
     local temp_config_file=""
@@ -106,7 +107,7 @@ create_image_registries_secret() {
       # For Podman, use root's auth.json since minikube uses sudo podman
       config_file="/root/.config/containers/auth.json"
       echo "Using Podman config: ${config_file}"
-      
+
       # Create a temporary copy that the current user can read
       temp_config_file=$(mktemp)
       sudo cp "${config_file}" "${temp_config_file}"
@@ -117,7 +118,7 @@ create_image_registries_secret() {
       config_file="${HOME}/.docker/config.json"
       echo "Using Docker config: ${config_file}"
     fi
-    
+
     # shellcheck disable=SC2154
     if kubectl --context "${context}" get namespace "${namespace}"; then
       kubectl --context "${context}" -n "${namespace}" delete secret "${secret_name}" --ignore-not-found
@@ -127,7 +128,7 @@ create_image_registries_secret() {
     else
       echo "Skipping creating pull secret in ${context}/${namespace}. The namespace doesn't exist yet."
     fi
-    
+
     # Clean up temporary file
     if [[ -n "${temp_config_file}" ]] && [[ -f "${temp_config_file}" ]]; then
       rm -f "${temp_config_file}"


### PR DESCRIPTION
- **CLOUDP-347194 - enable Pod Security Admission at `restricted` level**
- **Fix unit tests + linter issues**
- **Disable enforce for multi-cluster test**
- **Add changelog file**
- **Fix enforcing the restricted mode**
- **Update the changelog**
- **Add more details about overrides in the changelog**
- **Update changelog syntax**
- **Fixes Operator crash when `securityContext.readOnlyRootFilesystem=true`**

# Summary

<!-- Enter your issue summary here.-->

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
