### PR TITLE
Reduce Evergreen retries to 1

### DIFF
--- a/scripts/evergreen/retry-evergreen.sh
+++ b/scripts/evergreen/retry-evergreen.sh
@@ -33,7 +33,7 @@ if [ -z "${EVERGREEN_API_KEY}" ]; then
 fi
 
 EVERGREEN_API="https://evergreen.mongodb.com/api"
-MAX_RETRIES="${EVERGREEN_MAX_RETRIES:-3}"
+MAX_RETRIES=1
 
 # Define build variants to exclude
 # We ignore openshift because they only run one test at a time.
@@ -49,7 +49,7 @@ BUILD_IDS=($(curl -s -H "Api-User: ${EVERGREEN_USER}" -H "Api-Key: ${EVERGREEN_A
 for BUILD_ID in "${BUILD_IDS[@]}"; do
   echo "Finding failed tasks in BUILD ID: ${BUILD_ID}"
   # shellcheck disable=SC2207
-  TASK_IDS=($(curl -s -H "Api-User: ${EVERGREEN_USER}" -H "Api-Key: ${EVERGREEN_API_KEY}" ${EVERGREEN_API}/rest/v2/builds/"${BUILD_ID}"/tasks | jq ".[] | select(.status == \"failed\" and .execution <= ${MAX_RETRIES})" | jq -r '.task_id'))
+  TASK_IDS=($(curl -s -H "Api-User: ${EVERGREEN_USER}" -H "Api-Key: ${EVERGREEN_API_KEY}" ${EVERGREEN_API}/rest/v2/builds/"${BUILD_ID}"/tasks | jq ".[] | select(.status == \"failed\" and .execution < ${MAX_RETRIES})" | jq -r '.task_id'))
 
   for TASK_ID in "${TASK_IDS[@]}"; do
     echo "Retriggering TASK ID: ${TASK_ID}"


### PR DESCRIPTION
# Summary

Instead of 5 total tentatives for E2E tests, let's reduce it to 2.

## Proof of Work

Failing tests must restart only once.
