### PR TITLE
Disable multi-arch tests

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1369,6 +1369,7 @@ buildvariants:
       - rhel9-power-small
       - rhel9-power-large
     allowed_requesters: [ "patch", "commit" ]
+    disable: true
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1392,6 +1393,7 @@ buildvariants:
       - rhel9-power-small
       - rhel9-power-large
     allowed_requesters: [ "patch", "commit" ]
+    disable: true
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1415,6 +1417,7 @@ buildvariants:
       - rhel9-zseries-small
       - rhel9-zseries-large
     allowed_requesters: [ "patch", "commit" ]
+    disable: true
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1434,6 +1437,7 @@ buildvariants:
   - name: e2e_static_smoke_ibm_z
     display_name: e2e_static_smoke_ibm_z
     tags: [ "staging", "e2e_smoke_test_suite", "static" ]
+    disable: true
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
@@ -1460,6 +1464,7 @@ buildvariants:
     run_on:
       - ubuntu2404-arm64-large
     allowed_requesters: [ "patch", "commit" ]
+    disable: true
     <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_smoke_arm_task_group
@@ -1470,6 +1475,7 @@ buildvariants:
     run_on:
       - ubuntu2404-arm64-large
     allowed_requesters: [ "patch", "commit" ]
+    disable: true
     <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_smoke_arm_task_group


### PR DESCRIPTION
# Summary

Disabling the multi-arch test on master builds until staging is ready.

## Proof of Work

Runing the following will return the error `cannot finalize patch with no tasks`
```
evergreen patch -p mongodb-kubernetes -v e2e_smoke_arm,e2e_static_smoke_arm,e2e_smoke_ibm_power,e2e_static_smoke_ibm_power,e2e_smoke_ibm_z,e2e_static_smoke_ibm_z -t all -y -f -u --browse 
```

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
