### PR TITLE
CLOUDP-349096 - Disable ibm init variants

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1698,6 +1698,9 @@ buildvariants:
     display_name: init_test_run_ibm_power
     max_hosts: -1
     tags: [ "staging" ]
+    # TODO: Re-enable when staging is added to pipeline
+    # https://jira.mongodb.org/browse/CLOUDP-349096
+    disable: true
     run_on:
       - rhel9-power-small
       - rhel9-power-large
@@ -1708,6 +1711,9 @@ buildvariants:
     display_name: init_test_run_ibm_z
     max_hosts: -1
     tags: [ "staging" ]
+    # TODO: Re-enable when staging is added to pipeline
+    # https://jira.mongodb.org/browse/CLOUDP-349096
+    disable: true
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large


### PR DESCRIPTION
# Summary

This PR temporarily disables the init variants for ibm tests. While the tests are not running anymore on master, the init task was still running unnecessarily.

## Proof of Work

n/a

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
