### PR TITLE
CLOUDP-350197: allow to create a custom role with cluster: true

### DIFF
--- a/api/v1/mdb/mongodb_roles_validation.go
+++ b/api/v1/mdb/mongodb_roles_validation.go
@@ -246,7 +246,7 @@ func validatePrivilege(privilege Privilege, mdbVersion string) v1.ValidationResu
 		if !*privilege.Resource.Cluster {
 			return v1.ValidationError("The only valid value for privilege.cluster, if set, is true")
 		}
-		if privilege.Resource.Collection != "" || privilege.Resource.Db != "" {
+		if privilege.Resource.Collection != nil || privilege.Resource.Db != nil {
 			return v1.ValidationError("Cluster: true is not compatible with setting db/collection")
 		}
 		if res := validateClusterPrivilegeActions(privilege.Actions, mdbVersion); res.Level == v1.ErrorLevel {

--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -961,10 +961,10 @@ type AuthenticationRestriction struct {
 
 type Resource struct {
 	// +optional
-	Db string `json:"db"`
+	Db *string `json:"db,omitempty"`
 	// +optional
-	Collection string `json:"collection"`
-	Cluster    *bool  `json:"cluster,omitempty"`
+	Collection *string `json:"collection,omitempty"`
+	Cluster    *bool   `json:"cluster,omitempty"`
 }
 
 type Privilege struct {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -490,7 +490,7 @@ func SearchCoordinatorRole() mdbv1.MongoDBRole {
 		Privileges: []mdbv1.Privilege{
 			{
 				Resource: mdbv1.Resource{
-					Db: "__mdb_internal_search",
+					Db: ptr.To("__mdb_internal_search"),
 				},
 				Actions: []string{
 					"changeStream", "collStats", "dbHash", "dbStats", "find",

--- a/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/cluster-mongodb-role.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/cluster-mongodb-role.yaml
@@ -21,6 +21,10 @@ spec:
       actions:
         - "find"
         - "update"
+    - resource:
+        cluster: true
+      actions:
+        - setUserWriteBlockMode
   authenticationRestrictions:
     - clientSource:
         - "127.0.0.0/8"

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -135,3 +135,5 @@ export OPERATOR_NAME="mongodb-kubernetes-operator"
 # Variables used for release process
 export RELEASE_INITIAL_COMMIT_SHA="9ed5f98fc70c5b3442f633d2393265fb8a2aba0c"
 export RELEASE_INITIAL_VERSION="1.3.0"
+
+export CLUSTER_TYPE=kind


### PR DESCRIPTION
# Summary

<!-- Enter your issue summary here.-->

## Proof of Work

e2e test failing when tried to add cluster: true role on master: 
```
"result=null identityUsed=<nil> : (FailedToParse) resource must have exactly db and collection set, 
or have only cluster set  or have only anyResource set"
```
[evg link](https://parsley-beta.corp.mongodb.com/taskFile/mongodb_kubernetes_e2e_multi_cluster_kind_e2e_mongodb_custom_roles_patch_c5839ff5b5d5b5b1e338b476c9d299513525f506_68e654e28666b500076ff417_25_10_08_12_11_15/0/kind-e2e-cluster-1__a-1759926638-n8v7t9o3ckz_multi-replica-set-0-0-agent-verbose.log?bookmarks=0%2C1038&selectedLineRange=L350&shareLine=350)

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
