### PR TITLE
CLOUDP-350375: `MongoDBMultiCluster`: Add annotation to disable reconciliation

### DIFF
--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -135,6 +135,11 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 		return reconcileResult, err
 	}
 
+	if val, ok := mrs.Annotations[util.DisableReconciliation]; ok && val == util.DisableReconciliationValue {
+		log.Info("Reconciliation disabled")
+		return r.updateStatus(ctx, &mrs, workflow.Disabled(), log)
+	}
+
 	if !architectures.IsRunningStaticArchitecture(mrs.Annotations) {
 		agents.UpgradeAllIfNeeded(ctx, agents.ClientSecret{Client: r.client, SecretClient: r.SecretClient}, r.omConnectionFactory, GetWatchedNamespace(), true)
 	}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -285,6 +285,9 @@ const (
 	LastAchievedSpec        = "mongodb.com/v1.lastSuccessfulConfiguration"
 	LastAchievedRsMemberIds = "mongodb.com/v1.lastAchievedRsMemberIds"
 
+	DisableReconciliation      = "mongodb.com/v1.disableReconciliation"
+	DisableReconciliationValue = "true"
+
 	// SecretVolumeName is the name of the volume resource.
 	SecretVolumeName = "secret-certs"
 


### PR DESCRIPTION
# Summary

The new `mongodb.com/v1.disable-reconciliation` annotation allows disabling reconciliation for `MongoDBMultiCluster` objects.

This will be used later when migrating multi-cluster replica sets from `MongoDBMultiCluster` to `MongoDB`.

## Proof of Work

1. Add `mongodb.com/v1.disableReconciliation` to any `MongoDBMultiCluster`
2. Run `kubectl wait mongodbmulticluster NAME -n NAMESPACE --for=jsonpath='{.status.phase}'=Disabled`.
3. Check that the `kubectl wait` command prints `mongodbmulticluster.mongodb.com/NAME condition met`.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
