### PR TITLE
Add Release Notes disclaimer only for PRs

### DIFF
--- a/.github/workflows/preview_release_notes.yml
+++ b/.github/workflows/preview_release_notes.yml
@@ -37,7 +37,8 @@ jobs:
           # not be available in the pull requests running from forks.
           RELEASE_INITIAL_COMMIT_SHA: ${{ env.RELEASE_INITIAL_COMMIT_SHA }}
           RELEASE_INITIAL_VERSION: ${{ env.RELEASE_INITIAL_VERSION }}
-      - name: Add disclaimer to release notes preview
+      - name: Add disclaimer to release notes preview for Pull Requests
+        if: github.event_name == 'pull_request'
         run: |
           echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current master branch)_\n" > release_notes_preview.md
           cat release_notes_tmp.md >> release_notes_preview.md


### PR DESCRIPTION
# Summary

Previously we were adding the disclaimer also for master commits, which can be misleading -> https://github.com/mongodb/mongodb-kubernetes/actions/runs/18402911248/attempts/1#summary-52436112489

## Proof of Work

Workflow validation is enough.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
