### PR TITLE
Fixed failing recreate-kind-clusters

### DIFF
--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -47,7 +47,6 @@ export OPS_MANAGER_NAMESPACE="operator-testing-50-current"
 export LOCAL_RUN=true
 
 if [[ "${OVERRIDE_VERSION_ID:-}" != "" ]]; then
-  echo "Overriding operator related versions with ${OVERRIDE_VERSION_ID}"
   OPERATOR_VERSION="${OVERRIDE_VERSION_ID}"
   READINESS_PROBE_VERSION="${OVERRIDE_VERSION_ID}"
   VERSION_UPGRADE_HOOK_VERSION="${OVERRIDE_VERSION_ID}"

--- a/scripts/dev/evg_host.sh
+++ b/scripts/dev/evg_host.sh
@@ -38,7 +38,7 @@ fi
 kubeconfig_path="${HOME}/.operator-dev/evg-host.kubeconfig"
 
 configure() {
-  shift 1
+  shift || true
   auto_recreate="false"
 
   # Parse arguments
@@ -64,7 +64,7 @@ configure() {
     jq '. | with_entries(select(.key == "auths"))' "${HOME}/.docker/config.json" | ssh -T -q "${host_url}" 'cat > /home/ubuntu/.docker/config.json'
   fi
 
-  sync
+  sync | prepend "sync"
 
   ssh -T -q "${host_url}" "cd ~/mongodb-kubernetes; scripts/dev/switch_context.sh root-context; scripts/dev/setup_evg_host.sh ${auto_recreate}"
 }

--- a/scripts/dev/setup_evg_host.sh
+++ b/scripts/dev/setup_evg_host.sh
@@ -5,6 +5,7 @@
 set -Eeou pipefail
 
 source scripts/funcs/install
+source scripts/funcs/printing
 
 set_limits() {
   echo "Increasing fs.inotify.max_user_instances"
@@ -61,14 +62,14 @@ download_helm() {
   rm -rf linux-"${ARCH}/"
 }
 
-set_limits
-download_kind &
-download_kubectl &
-download_helm &
+set_limits | prepend "set_limits"
+download_kind | prepend "download_kind" &
+download_kubectl | prepend "download_kubectl" &
+download_helm | prepend "download_helm" &
 
 AUTO_RECREATE=${1:-false}
 if [[ "${AUTO_RECREATE}" == "true" ]]; then
-  set_auto_recreate &
+  set_auto_recreate | prepend "set_auto_recreate" &
 fi
 
 wait


### PR DESCRIPTION
# Summary

This PR:
* removes unnecessary echo in root-context which prevented to switch context in case of non empty OVERRIDE_VERSION_ID (we cannot echo anything in context files)
* fixes evg_host.sh recreate_kind_clusters as `configure` called from it always expected to have arguments and shift command failed in case there are none.

## Proof of Work

Only tested locally. 

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
