### PR TITLE
Add new cluster types to telemetry

### DIFF
--- a/pkg/telemetry/cluster.go
+++ b/pkg/telemetry/cluster.go
@@ -26,6 +26,7 @@ const (
 	evg       = "Evergreen"
 	minikube  = "Minikube"
 	k3s       = "K3s"
+	microk8s  = "MicroK8s"
 )
 
 var kubernetesFlavourLabelsMapping = map[string]string{
@@ -35,6 +36,7 @@ var kubernetesFlavourLabelsMapping = map[string]string{
 	"node.openshift.io/os_id":        openshift,
 	"mongodb.com/evergreen":          evg,
 	"minikube.k8s.io/name":           minikube,
+	"microk8s.io/cluster":            microk8s,
 }
 
 var kubernetesFlavourAnnotationsMapping = map[string]string{

--- a/pkg/telemetry/cluster.go
+++ b/pkg/telemetry/cluster.go
@@ -43,6 +43,7 @@ var kubernetesFlavourAnnotationsMapping = map[string]string{
 	"rke.cattle.io/external-ip": rke,
 	"rke.cattle.io/internal-ip": rke,
 	"k3s.io/hostname":           k3s,
+	"k3s.io/internal-ip":        k3s,
 }
 
 // detectClusterInfo detects the Kubernetes version and cluster flavor
@@ -109,6 +110,8 @@ func detectKubernetesFlavour(ctx context.Context, uncachedClient kubeclient.Read
 		return eks
 	case strings.Contains(kubeGitApiVersion, "+vmware"):
 		return vmware
+	case strings.Contains(kubeGitApiVersion, "+k3s"):
+		return k3s
 	}
 
 	// Limit is propagated to the apiserver which propagates to etcd as it is. Thus, there is not a lot of

--- a/pkg/telemetry/cluster.go
+++ b/pkg/telemetry/cluster.go
@@ -23,6 +23,9 @@ const (
 	openshift = "Openshift"
 	rke       = "RKE"
 	rke2      = "RKE2"
+	evg       = "Evergreen"
+	minikube  = "Minikube"
+	k3s       = "K3s"
 )
 
 var kubernetesFlavourLabelsMapping = map[string]string{
@@ -30,11 +33,14 @@ var kubernetesFlavourLabelsMapping = map[string]string{
 	"cloud.google.com/gke-nodepool":  gke,
 	"kubernetes.azure.com/agentpool": aks,
 	"node.openshift.io/os_id":        openshift,
+	"mongodb.com/evergreen":          evg,
+	"minikube.k8s.io/name":           minikube,
 }
 
 var kubernetesFlavourAnnotationsMapping = map[string]string{
 	"rke.cattle.io/external-ip": rke,
 	"rke.cattle.io/internal-ip": rke,
+	"k3s.io/hostname":           k3s,
 }
 
 // detectClusterInfo detects the Kubernetes version and cluster flavor

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -183,7 +183,7 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 		KubernetesClusterIDs: kubeClusterUUIDList,
 		OperatorID:           operatorUUID,
 		OperatorVersion:      versionutil.StaticContainersOperatorVersion(),
-		OperatorType:         MEKO,
+		OperatorType:         MCK,
 		OperatorArchitecture: runtime.GOARCH,
 		OperatorOS:           runtime.GOOS,
 	}

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1389,7 +1389,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 			},
 			expectedProps: OperatorUsageSnapshotProperties{
 				OperatorID:           testOperatorUUID,
-				OperatorType:         MEKO,
+				OperatorType:         MCK,
 				OperatorArchitecture: runtime.GOARCH,
 				OperatorOS:           runtime.GOOS,
 			},
@@ -1423,7 +1423,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 			assert.Equal(t, runtime.GOARCH, event.Properties["operatorArchitecture"])
 			assert.Equal(t, runtime.GOOS, event.Properties["operatorOS"])
 			assert.Equal(t, testOperatorUUID, event.Properties["operatorID"])
-			assert.Equal(t, string(MEKO), event.Properties["operatorType"])
+			assert.Equal(t, string(MCK), event.Properties["operatorType"])
 
 			assert.Contains(t, event.Properties, "kubernetesClusterID")
 			assert.Contains(t, event.Properties, "kubernetesClusterIDs")

--- a/scripts/dev/setup_kind_cluster.sh
+++ b/scripts/dev/setup_kind_cluster.sh
@@ -82,31 +82,43 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json
 - role: control-plane
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json
 - role: control-plane
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json
 - role: worker
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json
 - role: worker
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json
 - role: worker
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json
@@ -133,6 +145,8 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   image: ${kind_image}
+  labels:
+    mongodb.com/evergreen: true
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: ${HOME}/.docker/config.json


### PR DESCRIPTION
# Summary

This extends the cluster types we recognize in telemetry. Especially added a label for the kind clusters we create. This is to detect if we start sending data to prod telemetry.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
