### PR TITLE
Use const for `helm_chart` local chart dir

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 from typing import Dict, List, Optional
 
@@ -18,7 +17,7 @@ from kubetester.helm import (
     helm_upgrade,
 )
 from tests import test_logger
-from tests.conftest import LOCAL_HELM_CHART_DIR
+from tests.constants import LOCAL_HELM_CHART_DIR
 
 OPERATOR_CRDS = (
     "mongodb.mongodb.com",

--- a/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
@@ -35,13 +35,13 @@ from tests.common.multicluster.multicluster_utils import (
     multi_cluster_service_names,
 )
 from tests.conftest import (
-    LEGACY_CENTRAL_CLUSTER_NAME,
     get_central_cluster_client,
     get_member_cluster_api_client,
     get_member_cluster_client_map,
     is_member_cluster,
     read_deployment_state,
 )
+from tests.constants import LEGACY_CENTRAL_CLUSTER_NAME
 
 logger = test_logger.get_test_logger(__name__)
 TRACER = trace.get_tracer("evergreen-agent")

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_feature_controls.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_feature_controls.py
@@ -4,7 +4,7 @@ from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import OPERATOR_NAME
+from tests.constants import OPERATOR_NAME
 
 
 @fixture(scope="function")

--- a/docker/mongodb-kubernetes-tests/tests/common/ops_manager/multi_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/ops_manager/multi_cluster.py
@@ -3,7 +3,7 @@ from kubetester.awss3client import s3_endpoint
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.opsmanager import MongoDBOpsManager
 from tests.common.constants import S3_BLOCKSTORE_NAME, S3_OPLOG_NAME
-from tests.conftest import AWS_REGION
+from tests.constants import AWS_REGION
 
 
 def ops_manager_multi_cluster_with_tls_s3_backups(

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -31,48 +31,28 @@ from opentelemetry.trace import NonRecordingSpan
 from pymongo.errors import ServerSelectionTimeoutError
 from pytest import fixture
 from tests import test_logger
+from tests.constants import (
+    CLUSTER_HOST_MAPPING,
+    KUBECONFIG_FILEPATH,
+    LEGACY_CENTRAL_CLUSTER_NAME,
+    LEGACY_DEPLOYMENT_STATE_VERSION,
+    LEGACY_OPERATOR_CHART,
+    LEGACY_OPERATOR_IMAGE_NAME,
+    LEGACY_OPERATOR_NAME,
+    LOCAL_HELM_CHART_DIR,
+    MCK_HELM_CHART,
+    MONITOR_APPDB_E2E_DEFAULT,
+    MULTI_CLUSTER_CONFIG_DIR,
+    MULTI_CLUSTER_OPERATOR_NAME,
+    OFFICIAL_OPERATOR_IMAGE_NAME,
+    OPERATOR_NAME,
+)
 from tests.multicluster import prepare_multi_cluster_namespaces
 
 try:
     kubernetes.config.load_kube_config()
 except Exception:
     kubernetes.config.load_incluster_config()
-
-AWS_REGION = "us-east-1"
-
-KUBECONFIG_FILEPATH = "/etc/config/kubeconfig"
-MULTI_CLUSTER_CONFIG_DIR = "/etc/multicluster"
-# AppDB monitoring is disabled by default for e2e tests.
-# If monitoring is needed use monitored_appdb_operator_installation_config / operator_with_monitored_appdb
-MONITOR_APPDB_E2E_DEFAULT = "true"
-CLUSTER_HOST_MAPPING = {
-    "us-central1-c_central": "https://35.232.85.244",
-    "us-east1-b_member-1a": "https://35.243.222.230",
-    "us-east1-c_member-2a": "https://34.75.94.207",
-    "us-west1-a_member-3a": "https://35.230.121.15",
-}
-
-LEGACY_CENTRAL_CLUSTER_NAME: str = "__default"
-LEGACY_DEPLOYMENT_STATE_VERSION: str = "1.27.0"
-
-# Helm charts
-LEGACY_OPERATOR_CHART = "mongodb/enterprise-operator"
-MCK_HELM_CHART = "mongodb/mongodb-kubernetes"
-LOCAL_HELM_CHART_DIR = "helm_chart"
-
-OFFICIAL_OPERATOR_IMAGE_NAME = "mongodb-kubernetes"
-LEGACY_OPERATOR_IMAGE_NAME = "mongodb-enterprise-operator-ubi"
-
-# Names for operator and RBAC
-OPERATOR_NAME = "mongodb-kubernetes-operator"
-MULTI_CLUSTER_OPERATOR_NAME = OPERATOR_NAME + "-multi-cluster"
-LEGACY_OPERATOR_NAME = "mongodb-enterprise-operator"
-LEGACY_MULTI_CLUSTER_OPERATOR_NAME = LEGACY_OPERATOR_NAME + "-multi-cluster"
-APPDB_SA_NAME = "mongodb-kubernetes-appdb"
-DATABASE_SA_NAME = "mongodb-kubernetes-database-pods"
-OM_SA_NAME = "mongodb-kubernetes-ops-manager"
-TELEMETRY_CONFIGMAP_NAME = LEGACY_OPERATOR_NAME + "-telemetry"
-MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP = OPERATOR_NAME + "-member-list"
 
 logger = test_logger.get_test_logger(__name__)
 

--- a/docker/mongodb-kubernetes-tests/tests/constants.py
+++ b/docker/mongodb-kubernetes-tests/tests/constants.py
@@ -1,0 +1,35 @@
+AWS_REGION = "us-east-1"
+
+KUBECONFIG_FILEPATH = "/etc/config/kubeconfig"
+MULTI_CLUSTER_CONFIG_DIR = "/etc/multicluster"
+# AppDB monitoring is disabled by default for e2e tests.
+# If monitoring is needed use monitored_appdb_operator_installation_config / operator_with_monitored_appdb
+MONITOR_APPDB_E2E_DEFAULT = "true"
+CLUSTER_HOST_MAPPING = {
+    "us-central1-c_central": "https://35.232.85.244",
+    "us-east1-b_member-1a": "https://35.243.222.230",
+    "us-east1-c_member-2a": "https://34.75.94.207",
+    "us-west1-a_member-3a": "https://35.230.121.15",
+}
+
+LEGACY_CENTRAL_CLUSTER_NAME: str = "__default"
+LEGACY_DEPLOYMENT_STATE_VERSION: str = "1.27.0"
+
+# Helm charts
+LEGACY_OPERATOR_CHART = "mongodb/enterprise-operator"
+MCK_HELM_CHART = "mongodb/mongodb-kubernetes"
+LOCAL_HELM_CHART_DIR = "helm_chart"
+
+OFFICIAL_OPERATOR_IMAGE_NAME = "mongodb-kubernetes"
+LEGACY_OPERATOR_IMAGE_NAME = "mongodb-enterprise-operator-ubi"
+
+# Names for operator and RBAC
+OPERATOR_NAME = "mongodb-kubernetes-operator"
+MULTI_CLUSTER_OPERATOR_NAME = OPERATOR_NAME + "-multi-cluster"
+LEGACY_OPERATOR_NAME = "mongodb-enterprise-operator"
+LEGACY_MULTI_CLUSTER_OPERATOR_NAME = LEGACY_OPERATOR_NAME + "-multi-cluster"
+APPDB_SA_NAME = "mongodb-kubernetes-appdb"
+DATABASE_SA_NAME = "mongodb-kubernetes-database-pods"
+OM_SA_NAME = "mongodb-kubernetes-ops-manager"
+TELEMETRY_CONFIGMAP_NAME = LEGACY_OPERATOR_NAME + "-telemetry"
+MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP = OPERATOR_NAME + "-member-list"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/__init__.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/__init__.py
@@ -5,7 +5,7 @@ from kubetester.create_or_replace_from_yaml import create_or_replace_from_yaml
 from kubetester.helm import helm_template
 from kubetester.multicluster_client import MultiClusterClient
 from tests import test_logger
-from tests.conftest import LOCAL_HELM_CHART_DIR
+from tests.constants import LOCAL_HELM_CHART_DIR
 
 logger = test_logger.get_test_logger(__name__)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_cli_recover.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_cli_recover.py
@@ -9,10 +9,10 @@ from kubetester.multicluster_client import MultiClusterClient
 from kubetester.operator import Operator
 from kubetester.phase import Phase
 from tests.conftest import (
-    MULTI_CLUSTER_OPERATOR_NAME,
     run_kube_config_creation_tool,
     run_multi_cluster_recovery_tool,
 )
+from tests.constants import MULTI_CLUSTER_OPERATOR_NAME
 from tests.multicluster.conftest import cluster_spec_list
 
 RESOURCE_NAME = "multi-replica-set"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
@@ -13,11 +13,11 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import (
-    MULTI_CLUSTER_OPERATOR_NAME,
     _install_multi_cluster_operator,
     run_kube_config_creation_tool,
 )
 
+from ..constants import MULTI_CLUSTER_OPERATOR_NAME
 from . import prepare_multi_cluster_namespaces
 from .conftest import cluster_spec_list, create_namespace
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
@@ -15,12 +15,11 @@ from kubetester.operator import Operator
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from tests.conftest import (
-    MULTI_CLUSTER_OPERATOR_NAME,
-    TELEMETRY_CONFIGMAP_NAME,
     get_central_cluster_client,
     get_custom_mdb_version,
     get_member_cluster_names,
 )
+from tests.constants import MULTI_CLUSTER_OPERATOR_NAME, TELEMETRY_CONFIGMAP_NAME
 from tests.multicluster.conftest import cluster_spec_list
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_clusterwide.py
@@ -22,13 +22,12 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import (
-    MULTI_CLUSTER_OPERATOR_NAME,
-    OPERATOR_NAME,
     _install_multi_cluster_operator,
     run_kube_config_creation_tool,
     run_multi_cluster_recovery_tool,
 )
 
+from ..constants import MULTI_CLUSTER_OPERATOR_NAME, OPERATOR_NAME
 from . import prepare_multi_cluster_namespaces
 from .conftest import cluster_spec_list, create_service_entries_objects
 from .multi_cluster_clusterwide import create_namespace

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_network_partition.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_network_partition.py
@@ -11,11 +11,11 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import (
-    MULTI_CLUSTER_OPERATOR_NAME,
     get_member_cluster_api_client,
     run_multi_cluster_recovery_tool,
 )
 
+from ..constants import MULTI_CLUSTER_OPERATOR_NAME
 from .conftest import cluster_spec_list, create_service_entries_objects
 
 FAILED_MEMBER_CLUSTER_NAME = "kind-e2e-cluster-3"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
@@ -12,7 +12,8 @@ from kubetester.mongotester import with_tls
 from kubetester.multicluster_client import MultiClusterClient
 from kubetester.operator import Operator
 from kubetester.phase import Phase
-from tests.conftest import MULTI_CLUSTER_OPERATOR_NAME, run_kube_config_creation_tool
+from tests.conftest import run_kube_config_creation_tool
+from tests.constants import MULTI_CLUSTER_OPERATOR_NAME
 from tests.multicluster.conftest import cluster_spec_list
 
 RESOURCE_NAME = "multi-replica-set"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_disaster_recovery.py
@@ -16,9 +16,9 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.conftest import (
-    MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP,
     get_member_cluster_api_client,
 )
+from tests.constants import MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP
 from tests.multicluster.conftest import cluster_spec_list
 
 FAILED_MEMBER_CLUSTER_NAME = "kind-e2e-cluster-3"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_s3_based_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_s3_based_backup_restore.py
@@ -22,7 +22,8 @@ from tests.common.constants import (
 from tests.common.ops_manager.multi_cluster import (
     ops_manager_multi_cluster_with_tls_s3_backups,
 )
-from tests.conftest import AWS_REGION, assert_data_got_restored
+from tests.conftest import assert_data_got_restored
+from tests.constants import AWS_REGION
 from tests.multicluster.conftest import cluster_spec_list
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
@@ -11,12 +11,14 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.conftest import (
-    LEGACY_MULTI_CLUSTER_OPERATOR_NAME,
-    MULTI_CLUSTER_OPERATOR_NAME,
     get_central_cluster_name,
     get_custom_appdb_version,
     install_legacy_deployment_state_meko,
     log_deployments_info,
+)
+from tests.constants import (
+    LEGACY_MULTI_CLUSTER_OPERATOR_NAME,
+    MULTI_CLUSTER_OPERATOR_NAME,
 )
 from tests.multicluster.conftest import cluster_spec_list
 from tests.upgrades import downscale_operator_deployment

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
@@ -22,7 +22,6 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import (
-    TELEMETRY_CONFIGMAP_NAME,
     assert_data_got_restored,
     get_central_cluster_client,
     get_member_cluster_clients,
@@ -39,6 +38,7 @@ from ..common.constants import MEMBER_CLUSTER_1, MEMBER_CLUSTER_2, MEMBER_CLUSTE
 from ..common.ops_manager.multi_cluster import (
     ops_manager_multi_cluster_with_tls_s3_backups,
 )
+from ..constants import TELEMETRY_CONFIGMAP_NAME
 from ..multicluster.conftest import cluster_spec_list
 
 # This test is for checking networking when OM is deployed without Service Mesh:

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
@@ -30,10 +30,10 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
 from tests.conftest import (
-    MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP,
     get_central_cluster_client,
     get_member_cluster_api_client,
 )
+from tests.constants import MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP
 from tests.multicluster.conftest import cluster_spec_list
 from tests.shardedcluster.conftest import (
     enable_multi_cluster_deployment,

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
@@ -13,7 +13,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture
 from tests import test_logger
-from tests.conftest import LEGACY_OPERATOR_NAME, OPERATOR_NAME
+from tests.constants import LEGACY_OPERATOR_NAME, OPERATOR_NAME
 from tests.olm.olm_test_commons import (
     get_catalog_image,
     get_catalog_source_resource,

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade.py
@@ -5,7 +5,7 @@ from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.kubetester import get_default_architecture
 from kubetester.mongodb import MongoDB
 from kubetester.opsmanager import MongoDBOpsManager
-from tests.conftest import OPERATOR_NAME
+from tests.constants import OPERATOR_NAME
 from tests.olm.olm_test_commons import (
     get_catalog_image,
     get_catalog_source_resource,

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
@@ -12,7 +12,7 @@ from kubetester.mongodb_user import MongoDBUser
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture
-from tests.conftest import OPERATOR_NAME
+from tests.constants import OPERATOR_NAME
 from tests.olm.olm_test_commons import (
     get_catalog_image,
     get_catalog_source_resource,

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup.py
@@ -23,7 +23,8 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from kubetester.test_identifiers import set_test_identifier
 from pytest import fixture, mark
-from tests.conftest import AWS_REGION, is_multi_cluster
+from tests.conftest import is_multi_cluster
+from tests.constants import AWS_REGION
 from tests.opsmanager.backup_snapshot_schedule_tests import BackupSnapshotScheduleTests
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_manual.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_manual.py
@@ -17,7 +17,8 @@ from kubetester.mongodb_user import MongoDBUser
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import AWS_REGION, is_multi_cluster
+from tests.conftest import is_multi_cluster
+from tests.constants import AWS_REGION
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 
 HEAD_PATH = "/head/"

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_s3_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_s3_tls.py
@@ -8,7 +8,8 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.common.constants import S3_BLOCKSTORE_NAME, S3_OPLOG_NAME
-from tests.conftest import AWS_REGION, is_multi_cluster
+from tests.conftest import is_multi_cluster
+from tests.constants import AWS_REGION
 from tests.opsmanager.om_ops_manager_backup import create_aws_secret, create_s3_bucket
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_feature_controls.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_feature_controls.py
@@ -7,7 +7,8 @@ from kubetester.mongodb import MongoDB
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import OPERATOR_NAME, is_multi_cluster
+from tests.conftest import is_multi_cluster
+from tests.constants import OPERATOR_NAME
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_queryable_backup.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_queryable_backup.py
@@ -20,7 +20,8 @@ from kubetester.om_queryable_backups import generate_queryable_pem
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import AWS_REGION, is_multi_cluster
+from tests.conftest import is_multi_cluster
+from tests.constants import AWS_REGION
 from tests.opsmanager.om_ops_manager_backup import create_aws_secret, create_s3_bucket
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
@@ -15,7 +15,8 @@ from kubetester.kubetester import is_default_architecture_static
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import APPDB_SA_NAME, OM_SA_NAME, is_multi_cluster
+from tests.conftest import is_multi_cluster
+from tests.constants import APPDB_SA_NAME, OM_SA_NAME
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 
 

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
@@ -17,13 +17,11 @@ from kubetester.mongotester import ReplicaSetTester
 from kubetester.phase import Phase
 from pytest import fixture
 from tests.conftest import (
-    DATABASE_SA_NAME,
-    LEGACY_OPERATOR_NAME,
-    OPERATOR_NAME,
     assert_log_rotation_backup_monitoring,
     assert_log_rotation_process,
     setup_log_rotate_for_agents,
 )
+from tests.constants import DATABASE_SA_NAME, LEGACY_OPERATOR_NAME, OPERATOR_NAME
 
 DEFAULT_BACKUP_VERSION = "11.12.0.7388-1"
 DEFAULT_MONITORING_AGENT_VERSION = "11.12.0.7388-1"

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_mongod_options.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_mongod_options.py
@@ -2,7 +2,7 @@ from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import OPERATOR_NAME
+from tests.constants import OPERATOR_NAME
 
 
 @fixture(scope="module")

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_pv.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_pv.py
@@ -6,7 +6,7 @@ from kubetester.kubetester import KubernetesTester, fcv_from_version
 from kubetester.kubetester import fixture as load_fixture
 from kubetester.mongodb import MongoDB
 from kubetester.phase import Phase
-from tests.conftest import LEGACY_OPERATOR_NAME, OPERATOR_NAME
+from tests.constants import LEGACY_OPERATOR_NAME, OPERATOR_NAME
 
 
 @pytest.mark.e2e_replica_set_pv

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/conftest.py
@@ -7,7 +7,6 @@ from kubetester.mongodb import MongoDB
 from kubetester.multicluster_client import MultiClusterClient
 from kubetester.operator import Operator
 from tests.conftest import (
-    LEGACY_CENTRAL_CLUSTER_NAME,
     get_central_cluster_client,
     get_central_cluster_name,
     get_default_operator,
@@ -19,6 +18,7 @@ from tests.conftest import (
     is_multi_cluster,
     read_deployment_state,
 )
+from tests.constants import LEGACY_CENTRAL_CLUSTER_NAME
 from tests.multicluster.conftest import cluster_spec_list
 
 

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_mongod_options.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_mongod_options.py
@@ -6,12 +6,12 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import (
-    OPERATOR_NAME,
     assert_log_rotation_backup_monitoring,
     assert_log_rotation_process,
     is_multi_cluster,
     setup_log_rotate_for_agents,
 )
+from tests.constants import OPERATOR_NAME
 from tests.shardedcluster.conftest import enable_multi_cluster_deployment
 
 

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
@@ -7,15 +7,17 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.conftest import (
+    get_default_operator,
+    get_multi_cluster_operator,
+    install_official_operator,
+    is_multi_cluster,
+)
+from tests.constants import (
     LEGACY_MULTI_CLUSTER_OPERATOR_NAME,
     LEGACY_OPERATOR_CHART,
     LEGACY_OPERATOR_IMAGE_NAME,
     LEGACY_OPERATOR_NAME,
     MULTI_CLUSTER_OPERATOR_NAME,
-    get_default_operator,
-    get_multi_cluster_operator,
-    install_official_operator,
-    is_multi_cluster,
 )
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 from tests.upgrades import downscale_operator_deployment

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -13,18 +13,18 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
-from tests.common.constants import MONGODB_PORT
 from tests.conftest import (
+    get_multi_cluster_operator,
+    is_multi_cluster,
+    log_deployments_info,
+)
+from tests.constants import (
     LEGACY_MULTI_CLUSTER_OPERATOR_NAME,
     LEGACY_OPERATOR_NAME,
     LOCAL_HELM_CHART_DIR,
     MULTI_CLUSTER_MEMBER_LIST_CONFIGMAP,
     MULTI_CLUSTER_OPERATOR_NAME,
     OPERATOR_NAME,
-    get_multi_cluster_operator,
-    is_multi_cluster,
-    log_deployments_info,
-    setup_log_rotate_for_agents,
 )
 from tests.multicluster.conftest import cluster_spec_list
 from tests.multicluster_appdb.multicluster_appdb_upgrade_downgrade_v1_27_to_mck import (

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/sharded_cluster_operator_upgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/sharded_cluster_operator_upgrade_v1_27_to_mck.py
@@ -13,13 +13,12 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from tests import test_logger
 from tests.conftest import (
-    LEGACY_OPERATOR_NAME,
-    OPERATOR_NAME,
     get_central_cluster_client,
     get_default_operator,
     install_legacy_deployment_state_meko,
     log_deployments_info,
 )
+from tests.constants import LEGACY_OPERATOR_NAME, OPERATOR_NAME
 from tests.upgrades import downscale_operator_deployment
 
 MDB_RESOURCE = "sh001-base"

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
@@ -27,7 +27,7 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
-from ..conftest import DATABASE_SA_NAME, OPERATOR_NAME
+from ..constants import DATABASE_SA_NAME, OPERATOR_NAME
 from . import run_command_in_vault, store_secret_in_vault
 
 MDB_RESOURCE = "my-replica-set"

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
@@ -24,7 +24,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
-from ..conftest import (
+from ..constants import (
     APPDB_SA_NAME,
     AWS_REGION,
     DATABASE_SA_NAME,

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
@@ -20,7 +20,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
-from ..conftest import APPDB_SA_NAME, OM_SA_NAME, OPERATOR_NAME
+from ..constants import APPDB_SA_NAME, OM_SA_NAME, OPERATOR_NAME
 from . import assert_secret_in_vault, run_command_in_vault, store_secret_in_vault
 
 OM_NAME = "om-basic"

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/vault_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/vault_tls.py
@@ -13,7 +13,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
-from ..conftest import APPDB_SA_NAME, DATABASE_SA_NAME, OM_SA_NAME, OPERATOR_NAME
+from ..constants import APPDB_SA_NAME, DATABASE_SA_NAME, OM_SA_NAME, OPERATOR_NAME
 from . import assert_secret_in_vault, run_command_in_vault, store_secret_in_vault
 
 MDB_RESOURCE = "my-replica-set"


### PR DESCRIPTION
# Summary

The local helm chart directory (`helm_chart`) that we use to install the operator is being used at a lot of places and we were using the dir name in line without using the defined constant. This would make it harder to use any other dir as helm chart dir/URL, that we are going to do when we start installing helm chart from OCI registry.
This PR changes that and tries to use the const everywhere we used the local chart dir (`helm_chart`).

edit: To make this work I had to move all constants from `tests.conftest` to `tests.constants` file to remove circular dependency.

## Proof of Work

CI in the PR.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
