### PR TITLE
Remove `def _helm_chart_dir` that used undefined env var

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/helm.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/helm.py
@@ -25,7 +25,7 @@ def helm_template(
         command_args.append("--show-only")
         command_args.append(templates)
 
-    args = ("helm", "template", *(command_args), _helm_chart_dir(helm_chart_path))
+    args = ("helm", "template", *(command_args), helm_chart_path)
     logger.info(" ".join(args))
 
     yaml_file_name = "{}.yaml".format(str(uuid.uuid4()))
@@ -51,7 +51,7 @@ def helm_install(
         f"--namespace={namespace}",
         *command_args,
         name,
-        _helm_chart_dir(helm_chart_path),
+        helm_chart_path,
     ]
     if custom_operator_version:
         args.append(f"--version={custom_operator_version}")
@@ -159,7 +159,7 @@ def helm_upgrade(
         logger.warning("Helm chart path is empty, defaulting to 'helm_chart'")
         helm_chart_path = "helm_chart"
 
-    chart_dir = helm_chart_path if helm_override_path else _helm_chart_dir(helm_chart_path)
+    chart_dir = helm_chart_path
 
     if apply_crds_first:
         apply_crds_from_chart(chart_dir)
@@ -230,7 +230,3 @@ def _create_helm_args(helm_args: Dict[str, str], helm_options: Optional[List[str
         command_args.extend(helm_options)
 
     return command_args
-
-
-def _helm_chart_dir(default: Optional[str] = "helm_chart") -> str:
-    return os.environ.get("HELM_CHART_DIR", default)


### PR DESCRIPTION
# Summary

In our source file we had a function 

```
def _helm_chart_dir(default: Optional[str] = "helm_chart") -> str:
    return os.environ.get("HELM_CHART_DIR", default)
```
The env var `HELM_CHART_DIR` is not set in our project anywhere that makes this function not needed. That's why this PR removes the function. 

From the function def we can see that it would always return what was passed to this function, that's why at the caller we are removing the function call and just using the argument.

## Proof of Work

CI in the PR.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
