### PR TITLE
[CLOUDP-352383] Add a build variant to release chart to OCI registry

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -227,6 +227,9 @@ functions:
     type: setup
     params:
       working_dir: src/github.com/mongodb/mongodb-kubernetes
+      include_expansions_in_env:
+        - quay_prod_username
+        - quay_prod_robot_token
       add_to_path:
         - ${workdir}/bin
         - ${PROJECT_DIR}/bin

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -129,6 +129,16 @@ tasks:
       - func: clone
       - func: python_venv
       - func: create_chart_release_pr
+  
+  - name: release_chart_to_oci_registry
+    tags: [ "release_chart_to_oci_registry" ]
+    commands:
+      - func: clone
+      - func: python_venv
+      - func: setup_kubectl
+      - func: setup_aws
+      - func: helm_registry_login
+      - func: publish_helm_chart
 
 ### Release build variants
 buildvariants:
@@ -255,3 +265,12 @@ buildvariants:
     allowed_requesters: [ "patch", "github_tag" ]
     tasks:
       - name: create_chart_release_pr
+
+  - name: release_chart_to_oci_registry
+    display_name: release_chart_to_oci_registry
+    tags: [ "release" ]
+    run_on:
+      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
+    allowed_requesters: [ "patch", "github_tag" ]
+    tasks:
+      - name: release_chart_to_oci_registry

--- a/scripts/release/helm_registry_login.py
+++ b/scripts/release/helm_registry_login.py
@@ -6,8 +6,11 @@ import sys
 from lib.base_logger import logger
 from scripts.release.build.build_info import load_build_info
 
+BUILD_SCENARIO_RELEASE="release"
+QUAY_USERNAME_ENV_VAR = "quay_prod_username"
+QUAY_PASSWORD_ENV_VAR = "quay_prod_robot_token"
 
-def helm_registry_login(helm_registry: str, region: str):
+def helm_registry_login_to_nonrelease(helm_registry: str, region: str):
     logger.info(f"Attempting to log into ECR registry: {helm_registry}, using helm registry login.")
 
     aws_command = ["aws", "ecr", "get-login-password", "--region", region]
@@ -67,7 +70,48 @@ def main():
 
     registry = build_info.helm_charts["mongodb-kubernetes"].registry
     region = build_info.helm_charts["mongodb-kubernetes"].region
-    return helm_registry_login(registry, region)
+
+    if build_scenario == BUILD_SCENARIO_RELEASE:
+        helm_registry_login_to_release(registry)
+
+    return helm_registry_login_to_nonrelease(registry, region)
+
+def helm_registry_login_to_release(registry):
+    username = os.environ.get(QUAY_USERNAME_ENV_VAR)
+    password = os.environ.get(QUAY_PASSWORD_ENV_VAR)
+
+    if not username:
+        raise Exception(f"Env var {QUAY_USERNAME_ENV_VAR} must be set with the quay username.")
+    if not password:
+        raise Exception(f"Env var {QUAY_PASSWORD_ENV_VAR} must be set with the quay password.")
+
+    command = [
+        "helm",
+        "registry",
+        "login",
+        "--username", username,
+        "--password-stdin",
+        registry
+    ]
+
+    try:
+        result = subprocess.run(
+                command,
+                input=password,  # Pass the password as input bytes
+                capture_output=True,
+                text=True,
+                check=False  # Do not raise an exception on non-zero exit code
+            )
+
+        if result.returncode == 0:
+            logger.info(f"Successfully logged into helm continer registry {registry}.")
+        else:
+            raise Exception(f"Helm registry login failed to {registry}. Stdout: {result.stderr.strip()}, Stderr: {result.stderr.strip()}")
+
+    except FileNotFoundError:
+        raise Exception("Error: 'helm' command not found. Ensure Helm CLI is installed and in your PATH.")
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred during execution: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

In one of the previous PRs we made sure that we are publishing our helm chart to OCI container registry, as part of the work where we are going to eventually move to the OCI container registry for our helm chart repo. 
After the chart is being published to to dev/staging registries, this PR makes sure that the chart get released to quay, as part of our release process.
We will keep publishing helm chart to the old github repo and quay container registry, for some time and will eventually move to just publishing it to OCI.

## Proof of Work

ToDo, evergreen seems to be broken.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
