### PR TITLE
Add missing `latest` tag configuration for operator image

### DIFF
--- a/build_info.json
+++ b/build_info.json
@@ -10,6 +10,7 @@
       },
       "staging": {
         "sign": true,
+        "latest-tag": true,
         "repositories": ["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-kubernetes"],
         "platforms": [
           "linux/arm64",

--- a/scripts/release/tests/build_info_test.py
+++ b/scripts/release/tests/build_info_test.py
@@ -204,6 +204,7 @@ def test_load_build_info_staging():
                 repositories=["268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-kubernetes"],
                 platforms=["linux/arm64", "linux/amd64", "linux/s390x", "linux/ppc64le"],
                 dockerfile_path="docker/mongodb-kubernetes-operator/Dockerfile",
+                latest_tag=True,
                 sign=True,
             ),
             "operator-race": ImageInfo(


### PR DESCRIPTION
# Summary

Add `latest` tag for operator images build in staging.

## Proof of Work

Passing unit tests is enough.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
