### PR TITLE
CLOUDP-349078: custom roles regression tests

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/cluster-mongodb-role-with-empty-strings.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/cluster-mongodb-role-with-empty-strings.yaml
@@ -1,0 +1,36 @@
+apiVersion: mongodb.com/v1
+kind: ClusterMongoDBRole
+metadata:
+  name: customrole-with-empty-strings
+spec:
+  role: "myClusterwideAdminWithEmptyStrings"
+  db: "admin"
+  roles:
+    - db: "admin"
+      role: "read"
+  privileges:
+    - resource:
+        db: "config"
+        collection: ""
+      actions:
+        - "find"
+        - "update"
+        - "insert"
+        - "remove"
+    - resource:
+        db: "users"
+        collection: "usersCollection"
+      actions:
+        - "update"
+        - "insert"
+        - "remove"
+    - resource:
+        db: ""
+        collection: ""
+      actions:
+        - "find"
+  authenticationRestrictions:
+    - clientSource:
+        - "127.0.0.0/8"
+      serverAddress:
+        - "10.0.0.0/8"

--- a/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/cluster-mongodb-role-without-empty-strings.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/cluster-mongodb-role-without-empty-strings.yaml
@@ -1,26 +1,31 @@
 apiVersion: mongodb.com/v1
 kind: ClusterMongoDBRole
 metadata:
-  name: test-customrole
+  name: customrole-without-empty-strings
 spec:
-  role: "test-customrole"
+  role: "myClusterwideAdminWithoutEmptyStrings"
   db: "admin"
   roles:
     - db: "admin"
-      role: "root"
+      role: "read"
   privileges:
     - resource:
-        db: "admin"
-        collection: "system.users"
+        db: "config"
       actions:
         - "find"
         - "update"
+        - "insert"
+        - "remove"
     - resource:
-        db: "admin"
-        collection: "system.roles"
+        db: "users"
+        collection: "usersCollection"
+      actions:
+        - "update"
+        - "insert"
+        - "remove"
+    - resource: {}
       actions:
         - "find"
-        - "update"
   authenticationRestrictions:
     - clientSource:
         - "127.0.0.0/8"

--- a/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/replica-set-scram.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/fixtures/replica-set-scram.yaml
@@ -12,7 +12,7 @@ spec:
       name: my-project
   credentials: my-credentials
   logLevel: DEBUG
-  persistent: false
+  persistent: true
   security:
     authentication:
       agents:

--- a/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
@@ -1,11 +1,11 @@
 from kubetester import (
     create_or_update_configmap,
     find_fixture,
-    random_k8s_name,
     read_configmap,
     try_load,
     wait_until,
 )
+from kubetester.automation_config_tester import AutomationConfigTester
 from kubetester.mongodb import MongoDB, Phase
 from kubetester.mongodb_multi import MongoDBMulti
 from kubetester.mongodb_role import ClusterMongoDBRole, ClusterMongoDBRoleKind
@@ -13,15 +13,65 @@ from pytest import fixture, mark
 from tests.multicluster.conftest import cluster_spec_list
 
 
-@fixture(scope="module")
-def project_name_prefix(namespace: str) -> str:
-    return random_k8s_name(f"{namespace}-project-")
+# fmt: off
+def get_expected_role(role_name: str) -> dict:
+    return {
+        "role": role_name,
+        "db": "admin",
+        "roles": [
+            {
+                "db": "admin",
+                "role": "read"
+            }
+        ],
+        "privileges": [
+            {
+                "resource": {
+                    "db": "config",
+                    "collection": ""
+                },
+                "actions": [
+                    "find",
+                    "update",
+                    "insert",
+                    "remove"
+                ]
+            },
+            {
+                "resource": {
+                    "db": "users",
+                    "collection": "usersCollection"
+                },
+                "actions": [
+                    "update",
+                    "insert",
+                    "remove"
+                ]
+            },
+            {
+                "resource": {
+                    "db": "",
+                    "collection": ""
+                },
+                "actions": [
+                    "find"
+                ]
+            },
+        ],
+        "authenticationRestrictions": [
+            {
+                "clientSource": ["127.0.0.0/8"],
+                "serverAddress": ["10.0.0.0/8"]
+            }
+        ],
+    }
+# fmt: on
 
 
-@fixture(scope="module")
-def first_project(namespace: str, project_name_prefix: str) -> str:
+@fixture(scope="function")
+def first_project(namespace: str) -> str:
     cm = read_configmap(namespace=namespace, name="my-project")
-    project_name = f"{project_name_prefix}-first"
+    project_name = f"{namespace}-first"
     return create_or_update_configmap(
         namespace=namespace,
         name=project_name,
@@ -33,10 +83,10 @@ def first_project(namespace: str, project_name_prefix: str) -> str:
     )
 
 
-@fixture(scope="module")
-def second_project(namespace: str, project_name_prefix: str) -> str:
+@fixture(scope="function")
+def second_project(namespace: str) -> str:
     cm = read_configmap(namespace=namespace, name="my-project")
-    project_name = f"{project_name_prefix}-second"
+    project_name = f"{namespace}-second"
     return create_or_update_configmap(
         namespace=namespace,
         name=project_name,
@@ -48,10 +98,10 @@ def second_project(namespace: str, project_name_prefix: str) -> str:
     )
 
 
-@fixture(scope="module")
-def third_project(namespace: str, project_name_prefix: str) -> str:
+@fixture(scope="function")
+def third_project(namespace: str) -> str:
     cm = read_configmap(namespace=namespace, name="my-project")
-    project_name = f"{project_name_prefix}-third"
+    project_name = f"{namespace}-third"
     return create_or_update_configmap(
         namespace=namespace,
         name=project_name,
@@ -63,18 +113,37 @@ def third_project(namespace: str, project_name_prefix: str) -> str:
     )
 
 
-@fixture(scope="module")
-def mongodb_role():
-    resource = ClusterMongoDBRole.from_yaml(find_fixture("cluster-mongodb-role.yaml"), cluster_scoped=True)
+@fixture(scope="function")
+def mongodb_role_with_empty_strings() -> ClusterMongoDBRole:
+    resource = ClusterMongoDBRole.from_yaml(
+        find_fixture("cluster-mongodb-role-with-empty-strings.yaml"), cluster_scoped=True
+    )
 
     if try_load(resource):
         return resource
 
-    return resource.update()
+    return resource
 
 
-@fixture(scope="module")
-def replica_set(namespace: str, mongodb_role: ClusterMongoDBRole, first_project: str) -> MongoDB:
+@fixture(scope="function")
+def mongodb_role_without_empty_strings() -> ClusterMongoDBRole:
+    resource = ClusterMongoDBRole.from_yaml(
+        find_fixture("cluster-mongodb-role-without-empty-strings.yaml"), cluster_scoped=True
+    )
+
+    if try_load(resource):
+        return resource
+
+    return resource
+
+
+@fixture(scope="function")
+def replica_set(
+    namespace: str,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
+    first_project: str,
+) -> MongoDB:
     resource = MongoDB.from_yaml(find_fixture("replica-set-scram.yaml"), namespace=namespace)
 
     if try_load(resource):
@@ -83,17 +152,26 @@ def replica_set(namespace: str, mongodb_role: ClusterMongoDBRole, first_project:
     resource["spec"]["members"] = 1
     resource["spec"]["security"]["roleRefs"] = [
         {
-            "name": mongodb_role.get_name(),
+            "name": mongodb_role_with_empty_strings.get_name(),
             "kind": ClusterMongoDBRoleKind,
-        }
+        },
+        {
+            "name": mongodb_role_without_empty_strings.get_name(),
+            "kind": ClusterMongoDBRoleKind,
+        },
     ]
     resource["spec"]["opsManager"]["configMapRef"]["name"] = first_project
 
     return resource
 
 
-@fixture(scope="module")
-def sharded_cluster(namespace: str, mongodb_role: ClusterMongoDBRole, second_project: str) -> MongoDB:
+@fixture(scope="function")
+def sharded_cluster(
+    namespace: str,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
+    second_project: str,
+) -> MongoDB:
     resource = MongoDB.from_yaml(find_fixture("sharded-cluster-scram-sha-1.yaml"), namespace=namespace)
 
     if try_load(resource):
@@ -105,17 +183,26 @@ def sharded_cluster(namespace: str, mongodb_role: ClusterMongoDBRole, second_pro
 
     resource["spec"]["security"]["roleRefs"] = [
         {
-            "name": mongodb_role.get_name(),
+            "name": mongodb_role_with_empty_strings.get_name(),
             "kind": ClusterMongoDBRoleKind,
-        }
+        },
+        {
+            "name": mongodb_role_without_empty_strings.get_name(),
+            "kind": ClusterMongoDBRoleKind,
+        },
     ]
     resource["spec"]["opsManager"]["configMapRef"]["name"] = second_project
 
     return resource
 
 
-@fixture(scope="module")
-def mc_replica_set(namespace: str, mongodb_role: ClusterMongoDBRole, third_project: str) -> MongoDBMulti:
+@fixture(scope="function")
+def mc_replica_set(
+    namespace: str,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
+    third_project: str,
+) -> MongoDBMulti:
     resource = MongoDBMulti.from_yaml(find_fixture("mongodb-multi.yaml"), namespace=namespace)
 
     if try_load(resource):
@@ -124,9 +211,13 @@ def mc_replica_set(namespace: str, mongodb_role: ClusterMongoDBRole, third_proje
     resource["spec"]["security"] = {
         "roleRefs": [
             {
-                "name": mongodb_role.get_name(),
+                "name": mongodb_role_with_empty_strings.get_name(),
                 "kind": ClusterMongoDBRoleKind,
-            }
+            },
+            {
+                "name": mongodb_role_without_empty_strings.get_name(),
+                "kind": ClusterMongoDBRoleKind,
+            },
         ]
     }
     resource["spec"]["opsManager"]["configMapRef"]["name"] = third_project
@@ -137,8 +228,15 @@ def mc_replica_set(namespace: str, mongodb_role: ClusterMongoDBRole, third_proje
 
 @mark.e2e_mongodb_custom_roles
 def test_create_resources(
-    mongodb_role: ClusterMongoDBRole, replica_set: MongoDB, sharded_cluster: MongoDB, mc_replica_set: MongoDBMulti
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
+    replica_set: MongoDB,
+    sharded_cluster: MongoDB,
+    mc_replica_set: MongoDBMulti,
 ):
+    mongodb_role_with_empty_strings.update()
+    mongodb_role_without_empty_strings.update()
+
     replica_set.update()
     sharded_cluster.update()
     mc_replica_set.update()
@@ -150,87 +248,115 @@ def test_create_resources(
 
 @mark.e2e_mongodb_custom_roles
 def test_automation_config_has_roles(
-    replica_set: MongoDB, sharded_cluster: MongoDB, mc_replica_set: MongoDBMulti, mongodb_role: ClusterMongoDBRole
+    replica_set: MongoDB,
+    sharded_cluster: MongoDB,
+    mc_replica_set: MongoDBMulti,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
+):
+    assert_expected_roles(
+        mc_replica_set,
+        replica_set,
+        sharded_cluster,
+        mongodb_role_with_empty_strings,
+        mongodb_role_without_empty_strings,
+    )
+
+
+def assert_expected_roles(
+    mc_replica_set: MongoDBMulti,
+    replica_set: MongoDB,
+    sharded_cluster: MongoDB,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
 ):
     rs_tester = replica_set.get_automation_config_tester()
-    rs_tester.assert_has_expected_number_of_roles(expected_roles=1)
-    rs_tester.assert_expected_role(role_index=0, expected_value=mongodb_role.get_role())
-
     sc_tester = sharded_cluster.get_automation_config_tester()
-    sc_tester.assert_has_expected_number_of_roles(expected_roles=1)
-    sc_tester.assert_expected_role(role_index=0, expected_value=mongodb_role.get_role())
-
     mcrs_tester = mc_replica_set.get_automation_config_tester()
-    mcrs_tester.assert_has_expected_number_of_roles(expected_roles=1)
-    mcrs_tester.assert_expected_role(role_index=0, expected_value=mongodb_role.get_role())
+    mcrs_tester.assert_has_expected_number_of_roles(expected_roles=2)
+    rs_tester.assert_has_expected_number_of_roles(expected_roles=2)
+    sc_tester.assert_has_expected_number_of_roles(expected_roles=2)
+
+    rs_tester.assert_expected_role(
+        role_index=0, expected_value=get_expected_role(mongodb_role_with_empty_strings["spec"]["role"])
+    )
+    # the second role created without specifying fields with "" should result in identical role to the one with explicitly specified db: "", collection: "".
+    rs_tester.assert_expected_role(
+        role_index=1, expected_value=get_expected_role(mongodb_role_without_empty_strings["spec"]["role"])
+    )
+    sc_tester.assert_expected_role(
+        role_index=0, expected_value=get_expected_role(mongodb_role_with_empty_strings["spec"]["role"])
+    )
+    sc_tester.assert_expected_role(
+        role_index=1, expected_value=get_expected_role(mongodb_role_without_empty_strings["spec"]["role"])
+    )
+    mcrs_tester.assert_expected_role(
+        role_index=0, expected_value=get_expected_role(mongodb_role_with_empty_strings["spec"]["role"])
+    )
+    mcrs_tester.assert_expected_role(
+        role_index=1, expected_value=get_expected_role(mongodb_role_without_empty_strings["spec"]["role"])
+    )
 
 
 @mark.e2e_mongodb_custom_roles
-def test_changing_role(
-    replica_set: MongoDB, sharded_cluster: MongoDB, mc_replica_set: MongoDBMulti, mongodb_role: ClusterMongoDBRole
+def test_change_inherited_role(
+    replica_set: MongoDB,
+    sharded_cluster: MongoDB,
+    mc_replica_set: MongoDBMulti,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
+    mongodb_role_without_empty_strings: ClusterMongoDBRole,
 ):
-    rs_version = replica_set.get_automation_config_tester().automation_config["version"]
-    sc_version = sharded_cluster.get_automation_config_tester().automation_config["version"]
-    mcrs_version = mc_replica_set.get_automation_config_tester().automation_config["version"]
+    mongodb_role_with_empty_strings["spec"]["roles"][0]["role"] = "readWrite"
+    mongodb_role_with_empty_strings.update()
 
-    mongodb_role["spec"]["roles"][0]["role"] = "readWrite"
-    mongodb_role.update()
+    def is_role_changed(ac_tester: AutomationConfigTester):
+        return (
+            ac_tester.get_role_at_index(0)["roles"][0]["role"] == "readWrite"
+            and ac_tester.get_role_at_index(1)["roles"][0]["role"] == "read"
+        )
 
-    wait_until(lambda: replica_set.get_automation_config_tester().reached_version(rs_version + 1), timeout=120)
-    wait_until(lambda: sharded_cluster.get_automation_config_tester().reached_version(sc_version + 1), timeout=120)
-    wait_until(lambda: mc_replica_set.get_automation_config_tester().reached_version(mcrs_version + 1), timeout=120)
-
-    replica_set.get_automation_config_tester().assert_expected_role(
-        role_index=0, expected_value=mongodb_role.get_role()
-    )
-    sharded_cluster.get_automation_config_tester().assert_expected_role(
-        role_index=0, expected_value=mongodb_role.get_role()
-    )
-    mc_replica_set.get_automation_config_tester().assert_expected_role(
-        role_index=0, expected_value=mongodb_role.get_role()
-    )
+    wait_until(lambda: is_role_changed(replica_set.get_automation_config_tester()))
+    wait_until(lambda: is_role_changed(sharded_cluster.get_automation_config_tester()))
+    wait_until(lambda: is_role_changed(mc_replica_set.get_automation_config_tester()))
 
 
 @mark.e2e_mongodb_custom_roles
 def test_deleting_role_does_not_remove_access(
-    mongodb_role: ClusterMongoDBRole, replica_set: MongoDB, sharded_cluster: MongoDB, mc_replica_set: MongoDBMulti
+    replica_set: MongoDB,
+    sharded_cluster: MongoDB,
+    mc_replica_set: MongoDBMulti,
+    mongodb_role_with_empty_strings: ClusterMongoDBRole,
 ):
-    mongodb_role.delete()
+    mongodb_role_with_empty_strings.delete()
 
-    assert try_load(mongodb_role) == False
+    assert try_load(mongodb_role_with_empty_strings) == False
 
     replica_set.assert_reaches_phase(
-        phase=Phase.Failed, msg_regexp=f"ClusterMongoDBRole '{mongodb_role.get_name()}' not found"
+        phase=Phase.Failed, msg_regexp=f"ClusterMongoDBRole '{mongodb_role_with_empty_strings.get_name()}' not found"
     )
     sharded_cluster.assert_reaches_phase(
-        phase=Phase.Failed, msg_regexp=f"ClusterMongoDBRole '{mongodb_role.get_name()}' not found"
+        phase=Phase.Failed, msg_regexp=f"ClusterMongoDBRole '{mongodb_role_with_empty_strings.get_name()}' not found"
     )
     mc_replica_set.assert_reaches_phase(
-        phase=Phase.Failed, msg_regexp=f"ClusterMongoDBRole '{mongodb_role.get_name()}' not found"
+        phase=Phase.Failed, msg_regexp=f"ClusterMongoDBRole '{mongodb_role_with_empty_strings.get_name()}' not found"
     )
 
     # The role should still exist in the automation config
-    replica_set.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=1)
-    sharded_cluster.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=1)
-    mc_replica_set.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=1)
+    replica_set.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=2)
+    sharded_cluster.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=2)
+    mc_replica_set.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=2)
 
 
 @mark.e2e_mongodb_custom_roles
 def test_removing_role_from_resources(replica_set: MongoDB, sharded_cluster: MongoDB, mc_replica_set: MongoDBMulti):
-    sc_version = sharded_cluster.get_automation_config_tester().automation_config["version"]
-    mcrs_version = mc_replica_set.get_automation_config_tester().automation_config["version"]
-
     sharded_cluster["spec"]["security"]["roleRefs"] = None
     sharded_cluster.update()
 
     mc_replica_set["spec"]["security"]["roleRefs"] = None
     mc_replica_set.update()
 
-    wait_until(lambda: sharded_cluster.get_automation_config_tester().reached_version(sc_version + 1), timeout=120)
-    wait_until(lambda: mc_replica_set.get_automation_config_tester().reached_version(mcrs_version + 1), timeout=120)
-
-    sharded_cluster.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=0)
-    mc_replica_set.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=0)
+    wait_until(lambda: len(sharded_cluster.get_automation_config_tester().automation_config["roles"]) == 0, timeout=120)
+    wait_until(lambda: len(mc_replica_set.get_automation_config_tester().automation_config["roles"]) == 0, timeout=120)
 
 
 @mark.e2e_mongodb_custom_roles
@@ -248,11 +374,8 @@ def test_replicaset_is_failed(replica_set: MongoDB):
 
 @mark.e2e_mongodb_custom_roles
 def test_replicaset_is_reconciled_without_rolerefs(replica_set: MongoDB):
-    rs_version = replica_set.get_automation_config_tester().automation_config["version"]
     replica_set["spec"]["security"]["roleRefs"] = None
     replica_set.update()
 
     replica_set.assert_reaches_phase(Phase.Running)
-    wait_until(lambda: replica_set.get_automation_config_tester().reached_version(rs_version + 1), timeout=120)
-
     replica_set.get_automation_config_tester().assert_has_expected_number_of_roles(expected_roles=0)

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -151,3 +151,6 @@ export OPERATOR_NAME="mongodb-kubernetes-operator"
 # Variables used for release process
 export RELEASE_INITIAL_COMMIT_SHA="9ed5f98fc70c5b3442f633d2393265fb8a2aba0c"
 export RELEASE_INITIAL_VERSION="1.3.0"
+
+export CLUSTER_TYPE=kind
+export OPERATOR_CLUSTER_SCOPED=false


### PR DESCRIPTION
# Summary

This PR adds regression test for custom roles ensuring we will keep backwards compatibility wrt handling empty strings vs omitted fields. 

In the subsequent #553 the serialization rules for custom roles will be changed. 

## Proof of Work
Tests passing.
