### PR TITLE
Add `.spec.clusterSpecList` field to `MongoDB`

### DIFF
--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -421,6 +421,13 @@ type DbCommonSpec struct {
 	// +kubebuilder:validation:Enum=SingleCluster;MultiCluster
 	// +optional
 	Topology string `json:"topology,omitempty"`
+
+	// ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+	// This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+	// are distributed across different clusters, including member counts, service configurations,
+	// and external access settings for each cluster.
+	// +optional
+	ClusterSpecList ClusterSpecList `json:"clusterSpecList,omitempty"`
 }
 
 type MongoDbSpec struct {

--- a/api/v1/mdbmulti/mongodb_multi_types.go
+++ b/api/v1/mdbmulti/mongodb_multi_types.go
@@ -227,8 +227,6 @@ type MongoDBMultiSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	mdbv1.DbCommonSpec `json:",inline"`
 
-	ClusterSpecList mdbv1.ClusterSpecList `json:"clusterSpecList,omitempty"`
-
 	// Mapping stores the deterministic index for a given cluster-name.
 	Mapping map[string]int `json:"-"`
 }

--- a/config/crd/bases/mongodb.com_mongodb.yaml
+++ b/config/crd/bases/mongodb.com_mongodb.yaml
@@ -396,6 +396,151 @@ spec:
               clusterDomain:
                 format: hostname
                 type: string
+              clusterSpecList:
+                description: |-
+                  ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+                  This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+                  are distributed across different clusters, including member counts, service configurations,
+                  and external access settings for each cluster.
+                items:
+                  description: |-
+                    ClusterSpecItem is the mongodb multi-cluster spec that is specific to a
+                    particular Kubernetes cluster, this maps to the statefulset created in each cluster
+                  properties:
+                    clusterName:
+                      description: |-
+                        ClusterName is name of the cluster where the MongoDB Statefulset will be scheduled, the
+                        name should have a one on one mapping with the service-account created in the central cluster
+                        to talk to the workload clusters.
+                      type: string
+                    externalAccess:
+                      description: ExternalAccessConfiguration provides external access
+                        configuration for Multi-Cluster.
+                      properties:
+                        externalDomain:
+                          description: An external domain that is used for exposing
+                            MongoDB to the outside world.
+                          type: string
+                        externalService:
+                          description: Provides a way to override the default (NodePort)
+                            Service
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: A map of annotations that shall be added
+                                to the externally available Service.
+                              type: object
+                            spec:
+                              description: A wrapper for the Service spec object.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    memberConfig:
+                      description: MemberConfig allows to specify votes, priorities
+                        and tags for each of the mongodb process.
+                      items:
+                        properties:
+                          priority:
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          votes:
+                            type: integer
+                        type: object
+                      type: array
+                    members:
+                      description: Amount of members for this MongoDB Replica Set
+                      type: integer
+                    podSpec:
+                      properties:
+                        persistence:
+                          description: Note, that this field is used by MongoDB resources
+                            only, let's keep it here for simplicity
+                          properties:
+                            multiple:
+                              properties:
+                                data:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                                journal:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                                logs:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                              type: object
+                            single:
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                storage:
+                                  type: string
+                                storageClass:
+                                  type: string
+                              type: object
+                          type: object
+                        podTemplate:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    service:
+                      description: this is an optional service, it will get the name
+                        "<rsName>-service" in case not provided
+                      type: string
+                    statefulSet:
+                      description: |-
+                        StatefulSetConfiguration holds the optional custom StatefulSet
+                        that should be merged into the operator created one.
+                      properties:
+                        metadata:
+                          description: StatefulSetMetadataWrapper is a wrapper around
+                            Labels and Annotations
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - spec
+                      type: object
+                  required:
+                  - members
+                  type: object
+                type: array
               configServerCount:
                 type: integer
               configSrv:

--- a/config/crd/bases/mongodb.com_mongodbmulticluster.yaml
+++ b/config/crd/bases/mongodb.com_mongodbmulticluster.yaml
@@ -388,6 +388,11 @@ spec:
                 format: hostname
                 type: string
               clusterSpecList:
+                description: |-
+                  ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+                  This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+                  are distributed across different clusters, including member counts, service configurations,
+                  and external access settings for each cluster.
                 items:
                   description: |-
                     ClusterSpecItem is the mongodb multi-cluster spec that is specific to a

--- a/controllers/operator/construct/multicluster/multicluster_replicaset_test.go
+++ b/controllers/operator/construct/multicluster/multicluster_replicaset_test.go
@@ -46,11 +46,11 @@ func getMultiClusterMongoDB() mdbmulti.MongoDBMultiCluster {
 				},
 				Roles: []mdb.MongoDBRole{},
 			},
-		},
-		ClusterSpecList: mdb.ClusterSpecList{
-			{
-				ClusterName: "foo",
-				Members:     3,
+			ClusterSpecList: mdb.ClusterSpecList{
+				{
+					ClusterName: "foo",
+					Members:     3,
+				},
 			},
 		},
 	}

--- a/helm_chart/crds/mongodb.com_mongodb.yaml
+++ b/helm_chart/crds/mongodb.com_mongodb.yaml
@@ -396,6 +396,151 @@ spec:
               clusterDomain:
                 format: hostname
                 type: string
+              clusterSpecList:
+                description: |-
+                  ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+                  This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+                  are distributed across different clusters, including member counts, service configurations,
+                  and external access settings for each cluster.
+                items:
+                  description: |-
+                    ClusterSpecItem is the mongodb multi-cluster spec that is specific to a
+                    particular Kubernetes cluster, this maps to the statefulset created in each cluster
+                  properties:
+                    clusterName:
+                      description: |-
+                        ClusterName is name of the cluster where the MongoDB Statefulset will be scheduled, the
+                        name should have a one on one mapping with the service-account created in the central cluster
+                        to talk to the workload clusters.
+                      type: string
+                    externalAccess:
+                      description: ExternalAccessConfiguration provides external access
+                        configuration for Multi-Cluster.
+                      properties:
+                        externalDomain:
+                          description: An external domain that is used for exposing
+                            MongoDB to the outside world.
+                          type: string
+                        externalService:
+                          description: Provides a way to override the default (NodePort)
+                            Service
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: A map of annotations that shall be added
+                                to the externally available Service.
+                              type: object
+                            spec:
+                              description: A wrapper for the Service spec object.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    memberConfig:
+                      description: MemberConfig allows to specify votes, priorities
+                        and tags for each of the mongodb process.
+                      items:
+                        properties:
+                          priority:
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          votes:
+                            type: integer
+                        type: object
+                      type: array
+                    members:
+                      description: Amount of members for this MongoDB Replica Set
+                      type: integer
+                    podSpec:
+                      properties:
+                        persistence:
+                          description: Note, that this field is used by MongoDB resources
+                            only, let's keep it here for simplicity
+                          properties:
+                            multiple:
+                              properties:
+                                data:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                                journal:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                                logs:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                              type: object
+                            single:
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                storage:
+                                  type: string
+                                storageClass:
+                                  type: string
+                              type: object
+                          type: object
+                        podTemplate:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    service:
+                      description: this is an optional service, it will get the name
+                        "<rsName>-service" in case not provided
+                      type: string
+                    statefulSet:
+                      description: |-
+                        StatefulSetConfiguration holds the optional custom StatefulSet
+                        that should be merged into the operator created one.
+                      properties:
+                        metadata:
+                          description: StatefulSetMetadataWrapper is a wrapper around
+                            Labels and Annotations
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - spec
+                      type: object
+                  required:
+                  - members
+                  type: object
+                type: array
               configServerCount:
                 type: integer
               configSrv:

--- a/helm_chart/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbmulticluster.yaml
@@ -388,6 +388,11 @@ spec:
                 format: hostname
                 type: string
               clusterSpecList:
+                description: |-
+                  ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+                  This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+                  are distributed across different clusters, including member counts, service configurations,
+                  and external access settings for each cluster.
                 items:
                   description: |-
                     ClusterSpecItem is the mongodb multi-cluster spec that is specific to a

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -353,19 +353,19 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbmulti.MongoDBMultiSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
-						},
-						ClusterSpecList: []mdbv1.ClusterSpecItem{
-							{
-								ClusterName: "cluster1",
-								Members:     1,
-							},
-							{
-								ClusterName: "cluster2",
-								Members:     3,
-							},
-							{
-								ClusterName: "cluster3",
-								Members:     3,
+							ClusterSpecList: []mdbv1.ClusterSpecItem{
+								{
+									ClusterName: "cluster1",
+									Members:     1,
+								},
+								{
+									ClusterName: "cluster2",
+									Members:     3,
+								},
+								{
+									ClusterName: "cluster3",
+									Members:     3,
+								},
 							},
 						},
 					}, ObjectMeta: metav1.ObjectMeta{
@@ -582,19 +582,19 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbmulti.MongoDBMultiSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
-						},
-						ClusterSpecList: []mdbv1.ClusterSpecItem{
-							{
-								ClusterName: "cluster1",
-								Members:     1,
-							},
-							{
-								ClusterName: "cluster2",
-								Members:     3,
-							},
-							{
-								ClusterName: "cluster3",
-								Members:     3,
+							ClusterSpecList: []mdbv1.ClusterSpecItem{
+								{
+									ClusterName: "cluster1",
+									Members:     1,
+								},
+								{
+									ClusterName: "cluster2",
+									Members:     3,
+								},
+								{
+									ClusterName: "cluster3",
+									Members:     3,
+								},
 							},
 						},
 					}, ObjectMeta: metav1.ObjectMeta{
@@ -609,19 +609,19 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 							ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
 								ExternalDomain: ptr.To("some.default.domain"),
 							},
-						},
-						ClusterSpecList: []mdbv1.ClusterSpecItem{
-							{
-								ClusterName: "cluster1",
-								Members:     1,
-							},
-							{
-								ClusterName: "cluster2",
-								Members:     3,
-							},
-							{
-								ClusterName: "cluster3",
-								Members:     3,
+							ClusterSpecList: []mdbv1.ClusterSpecItem{
+								{
+									ClusterName: "cluster1",
+									Members:     1,
+								},
+								{
+									ClusterName: "cluster2",
+									Members:     3,
+								},
+								{
+									ClusterName: "cluster3",
+									Members:     3,
+								},
 							},
 						},
 					}, ObjectMeta: metav1.ObjectMeta{
@@ -636,27 +636,27 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 							ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
 								ExternalDomain: ptr.To("some.default.domain"),
 							},
-						},
-						ClusterSpecList: []mdbv1.ClusterSpecItem{
-							{
-								ClusterName: "cluster1",
-								Members:     1,
-								ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
-									ExternalDomain: ptr.To("cluster1.domain"),
+							ClusterSpecList: []mdbv1.ClusterSpecItem{
+								{
+									ClusterName: "cluster1",
+									Members:     1,
+									ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+										ExternalDomain: ptr.To("cluster1.domain"),
+									},
 								},
-							},
-							{
-								ClusterName: "cluster2",
-								Members:     3,
-								ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
-									ExternalDomain: ptr.To("cluster2.domain"),
+								{
+									ClusterName: "cluster2",
+									Members:     3,
+									ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+										ExternalDomain: ptr.To("cluster2.domain"),
+									},
 								},
-							},
-							{
-								ClusterName: "cluster3",
-								Members:     3,
-								ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
-									ExternalDomain: ptr.To("cluster3.domain"),
+								{
+									ClusterName: "cluster3",
+									Members:     3,
+									ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+										ExternalDomain: ptr.To("cluster3.domain"),
+									},
 								},
 							},
 						},
@@ -669,27 +669,27 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbmulti.MongoDBMultiSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
-						},
-						ClusterSpecList: []mdbv1.ClusterSpecItem{
-							{
-								ClusterName: "cluster1",
-								Members:     1,
-								ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
-									ExternalDomain: ptr.To("cluster1.domain"),
+							ClusterSpecList: []mdbv1.ClusterSpecItem{
+								{
+									ClusterName: "cluster1",
+									Members:     1,
+									ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+										ExternalDomain: ptr.To("cluster1.domain"),
+									},
 								},
-							},
-							{
-								ClusterName: "cluster2",
-								Members:     3,
-								ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
-									ExternalDomain: ptr.To("cluster2.domain"),
+								{
+									ClusterName: "cluster2",
+									Members:     3,
+									ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+										ExternalDomain: ptr.To("cluster2.domain"),
+									},
 								},
-							},
-							{
-								ClusterName: "cluster3",
-								Members:     3,
-								ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
-									ExternalDomain: ptr.To("cluster3.domain"),
+								{
+									ClusterName: "cluster3",
+									Members:     3,
+									ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+										ExternalDomain: ptr.To("cluster3.domain"),
+									},
 								},
 							},
 						},

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -504,6 +504,151 @@ spec:
               clusterDomain:
                 format: hostname
                 type: string
+              clusterSpecList:
+                description: |-
+                  ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+                  This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+                  are distributed across different clusters, including member counts, service configurations,
+                  and external access settings for each cluster.
+                items:
+                  description: |-
+                    ClusterSpecItem is the mongodb multi-cluster spec that is specific to a
+                    particular Kubernetes cluster, this maps to the statefulset created in each cluster
+                  properties:
+                    clusterName:
+                      description: |-
+                        ClusterName is name of the cluster where the MongoDB Statefulset will be scheduled, the
+                        name should have a one on one mapping with the service-account created in the central cluster
+                        to talk to the workload clusters.
+                      type: string
+                    externalAccess:
+                      description: ExternalAccessConfiguration provides external access
+                        configuration for Multi-Cluster.
+                      properties:
+                        externalDomain:
+                          description: An external domain that is used for exposing
+                            MongoDB to the outside world.
+                          type: string
+                        externalService:
+                          description: Provides a way to override the default (NodePort)
+                            Service
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: A map of annotations that shall be added
+                                to the externally available Service.
+                              type: object
+                            spec:
+                              description: A wrapper for the Service spec object.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    memberConfig:
+                      description: MemberConfig allows to specify votes, priorities
+                        and tags for each of the mongodb process.
+                      items:
+                        properties:
+                          priority:
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          votes:
+                            type: integer
+                        type: object
+                      type: array
+                    members:
+                      description: Amount of members for this MongoDB Replica Set
+                      type: integer
+                    podSpec:
+                      properties:
+                        persistence:
+                          description: Note, that this field is used by MongoDB resources
+                            only, let's keep it here for simplicity
+                          properties:
+                            multiple:
+                              properties:
+                                data:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                                journal:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                                logs:
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    storage:
+                                      type: string
+                                    storageClass:
+                                      type: string
+                                  type: object
+                              type: object
+                            single:
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                storage:
+                                  type: string
+                                storageClass:
+                                  type: string
+                              type: object
+                          type: object
+                        podTemplate:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    service:
+                      description: this is an optional service, it will get the name
+                        "<rsName>-service" in case not provided
+                      type: string
+                    statefulSet:
+                      description: |-
+                        StatefulSetConfiguration holds the optional custom StatefulSet
+                        that should be merged into the operator created one.
+                      properties:
+                        metadata:
+                          description: StatefulSetMetadataWrapper is a wrapper around
+                            Labels and Annotations
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - spec
+                      type: object
+                  required:
+                  - members
+                  type: object
+                type: array
               configServerCount:
                 type: integer
               configSrv:
@@ -3247,6 +3392,11 @@ spec:
                 format: hostname
                 type: string
               clusterSpecList:
+                description: |-
+                  ClusterSpecList defines the configuration for MongoDB instances across multiple Kubernetes clusters.
+                  This field is used when Topology is set to "MultiCluster" and specifies how MongoDB members
+                  are distributed across different clusters, including member counts, service configurations,
+                  and external access settings for each cluster.
                 items:
                   description: |-
                     ClusterSpecItem is the mongodb multi-cluster spec that is specific to a


### PR DESCRIPTION
# Summary

Add `.spec.clusterSpecList` field to `MongoDB`. This will enable us to make `MongoDB` to be capable once we add controller handling of the new fields.

## Proof of Work

N/A - just a new field at the moment.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
