### PR TITLE
Use architecture suffix for all tags that are built

### DIFF
--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -77,19 +77,20 @@ def build_image(
     # Build the image once with all repository tags
     tags = []
     for registry in registries:
-        tag = f"{registry}:{build_configuration.version}"
+        arch_suffix = ""
+        if build_configuration.architecture_suffix and len(build_configuration.platforms) == 1:
+            arch_suffix = f"-{build_configuration.platforms[0].split("/")[1]}"
+
+        tag = f"{registry}:{build_configuration.version}{arch_suffix}"
         if build_configuration.skip_if_exists and check_if_image_exists(tag):
             logger.info(f"Image with tag {tag} already exists. Skipping it.")
         else:
             tags.append(tag)
             if build_configuration.latest_tag:
-                tags.append(f"{registry}:latest")
+                tags.append(f"{registry}:latest{arch_suffix}")
             if build_configuration.olm_tag:
                 olm_tag = create_olm_version_tag(build_configuration.version)
-                tags.append(f"{registry}:{olm_tag}")
-            if build_configuration.architecture_suffix and len(build_configuration.platforms) == 1:
-                arch = build_configuration.platforms[0].split("/")[1]
-                tags.append(f"{tag}-{arch}")
+                tags.append(f"{registry}:{olm_tag}{arch_suffix}")
 
     if not tags:
         logger.info("All specified image tags already exist. Skipping build.")


### PR DESCRIPTION
# Summary

Previously our `build_test_image_arm` task built not only `-arm64` suffixed task, but also the normal one. This overwritten the default amd64 image tag with arm64 tag and made some other tests fails.

<img width="685" height="211" alt="Screenshot 2025-10-29 at 13 31 39" src="https://github.com/user-attachments/assets/82fd166b-b28f-4d1f-94a8-151cbd0863cc" />


## Proof of Work

[Building](https://spruce.mongodb.com/version/69020a21047bfd0007b3897b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) arm64 now publishes all tags suffixed with `-arm64` and we have separate tag for regular amd64 (no suffix).

<img width="690" height="245" alt="Screenshot 2025-10-29 at 13 54 41" src="https://github.com/user-attachments/assets/4c6b6a73-fe23-43a7-b8c1-4154d1e3ff50" />


## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
