### PR TITLE
Enable mistakenly disabled image signing + conform to new cosign version

### DIFF
--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -195,6 +195,8 @@ def sign_image(repository: str, tag: str) -> None:
         "sign",
         f"--key={pkcs11_uri}",
         f"--sign-container-identity={image}",
+        f"--use-signing-config=false",
+        f"--new-bundle-format=false",
         f"--tlog-upload=false",
         image_ref,
     ]

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -241,7 +241,7 @@ Options: {", ".join(SUPPORTED_SCENARIOS)}. For '{BuildScenario.DEVELOPMENT}' the
     parser.add_argument(
         "-s",
         "--sign",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         help="If set force image signing. Default is to infer from build scenario.",
     )
     parser.add_argument(


### PR DESCRIPTION
# Summary

Image signing was disabled globally by mistake. This change fixes the issue while adjusting to the new cosign version.

## Proof of Work

On staging we now successfully signs images -> https://evergreen.mongodb.com/version/6903557435b1f60007ee8cfa?redirect_spruce_users=true

```
[2025/10/30 13:23:52.472] Login Succeeded
[2025/10/30 13:23:52.472] INFO     2025-10-30 12:23:52,472 [atomic_pipeline]  Signing image
[2025/10/30 13:23:52.472] DEBUG    2025-10-30 12:23:52,472 [image_signing]  Signing image 268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-kubernetes-init-appdb:1.6.0-mk
[2025/10/30 13:24:17.675] DEBUG    2025-10-30 12:24:17,675 [image_signing]  Signing successful
[2025/10/30 13:24:17.675] DEBUG    2025-10-30 12:24:17,675 [image_signing]  Verifying signature of 268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-kubernetes-init-appdb:1.6.0-mk
[2025/10/30 13:24:21.009] DEBUG    2025-10-30 12:24:18,491 [image_signing]  Successful verification
[2025/10/30 13:24:21.009] Finished command 'subprocess.exec' in function 'pipeline' (step 3 of 3) in 5m3.441945822s.
```

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
