### PR TITLE
Fix `kubectl-mongodb` download location and permissions required for Code Snippets

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -524,6 +524,8 @@ functions:
   download_multi_cluster_binary:
     - command: subprocess.exec
       params:
+        include_expansions_in_env:
+          - workdir
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         binary: scripts/release/kubectl_mongodb/download_kubectl_plugin.sh
         env:
@@ -791,6 +793,8 @@ functions:
           - code_snippets_reset
           - task_name
           - MDB_BASH_DEBUG
+        add_to_path:
+          - ${workdir}/bin
         script: |
           ./scripts/code_snippets/tests/${task_name}
 


### PR DESCRIPTION
# Summary

Multi cluster code snippets require `kubectl-mongodb` plugin being available in the PATH. Previous attempt https://github.com/mongodb/mongodb-kubernetes/pull/565 failed, because the file was not in the correct path (missing evg workdir) and didn't have required permissions (they were lost during `shutil.copyfiles` execution)

## Proof of Work

Passing prerelease code snippets tests -> https://spruce.mongodb.com/version/690db4a65b72a10007e62a47

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
