### PR TITLE
Fix release notes preview for non PRs

### DIFF
--- a/.github/workflows/preview_release_notes.yml
+++ b/.github/workflows/preview_release_notes.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Generate Release Notes
-        run: python -m scripts.release.release_notes -s $RELEASE_INITIAL_COMMIT_SHA -v $RELEASE_INITIAL_VERSION -o release_notes_tmp.md
+        run: python -m scripts.release.release_notes -s $RELEASE_INITIAL_COMMIT_SHA -v $RELEASE_INITIAL_VERSION -o release_notes_preview.md
         env:
           # We can not use environments set via GitHub UI because they will
           # not be available in the pull requests running from forks.
@@ -40,8 +40,9 @@ jobs:
       - name: Add disclaimer to release notes preview for Pull Requests
         if: github.event_name == 'pull_request'
         run: |
-          echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current master branch)_\n" > release_notes_preview.md
-          cat release_notes_tmp.md >> release_notes_preview.md
+          echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current master branch)_\n" > release_notes_tmp.md
+          cat release_notes_preview.md >> release_notes_tmp.md
+          mv -f release_notes_tmp.md release_notes_preview.md
       - name: Summarize results
         run: cat release_notes_preview.md >> $GITHUB_STEP_SUMMARY
       - name: Update PR comment


### PR DESCRIPTION
# Summary

Currently for master commits the Release Notes preview is failing:
```
Run cat release_notes_preview.md >> $GITHUB_STEP_SUMMARY
cat: release_notes_preview.md: No such file or directory
Error: Process completed with exit code 1.
```

## Proof of Work

Passing https://github.com/mongodb/mongodb-kubernetes/actions/runs/19334673064/job/55306298991?pr=592

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
