### PR TITLE
Add missing `${PROJECT_DIR}/bin` to `PATH`

### DIFF
--- a/scripts/dev/contexts/evg-private-context
+++ b/scripts/dev/contexts/evg-private-context
@@ -20,7 +20,8 @@ if [ -f "${ENV_FILE}" ]; then
   source "${ENV_FILE}"
 fi
 
-export PROJECT_DIR="${script_dir:-}/../../../"
+PROJECT_DIR=$(realpath "${script_dir:-}/../../../")
+export PROJECT_DIR
 
 export NAMESPACE_FILE="${workdir}/.namespace"
 if [ -f "${NAMESPACE_FILE}" ]; then
@@ -39,11 +40,15 @@ export EVG_HOST_NAME=""
 export GOROOT="/opt/golang/go1.24"
 
 if [[ ! ${PATH} =~ .*${workdir:-.}/bin.* ]]; then
-  export PATH=${PATH}:${workdir:-.}/bin
+  export PATH=${workdir:-.}/bin:${PATH}
+fi
+if [[ ! ${PATH} =~ .*${PROJECT_DIR}/bin.* ]]; then
+  export PATH=${PROJECT_DIR}/bin:${PATH}
 fi
 if [[ ! ${PATH} =~ .*${GOROOT}/bin.* ]]; then
   export PATH=${GOROOT}/bin:${PATH}
 fi
+echo "Setting PATH=${PATH}"
 
 export LOCAL_OPERATOR="false"
 


### PR DESCRIPTION
# Summary

We have started experiencing issues with running `helm unittests` in recent [evg patches](https://spruce.mongodb.com/task/mongodb_kubernetes_unit_tests_unit_tests_helm_patch_008b382112878ea4fd74e45d838eb151db3edc77_6915ddd14dcf7a0007f4a1a1_25_11_13_13_32_05/logs?execution=1):
```
[2025/11/13 14:44:38.644] Running command 'shell.exec' in function 'test_helm_unit' (step 1 of 1).
[2025/11/13 14:44:39.342] Error: plugin source does not support verification. Use --verify=false to skip verification
[2025/11/13 14:44:39.345] Running helm chart unit tests...
[2025/11/13 14:44:39.345] Installing helm-unittest plugin...
[2025/11/13 14:44:39.345] make: *** [Makefile:303: helm-tests] Error 1
[2025/11/13 14:44:39.345] Command 'shell.exec' in function 'test_helm_unit' (step 1 of 1) failed: shell script encountered problem: exit code 2.
```

This happened because we were not using helm binary that we installed, but rather the one from the `/snap/bin/helm` which was newest `4.0.0` major version. Helm API changed and required now to pass `--verify=false`  for plugins that don't support verification.

This change adds `${PROJECT_DIR}/bin` to `PATH` variable, where the helm binary is installed by our workflow.

## Proof of Work

Tested the [new PATH](https://spruce.mongodb.com/task/mongodb_kubernetes_unit_tests_unit_tests_helm_patch_008b382112878ea4fd74e45d838eb151db3edc77_6916f04ecdf92700077a4033_25_11_14_09_03_14/logs?execution=0) and helm is picked up from properly:
```
[2025/11/14 10:07:46.878] Running command 'shell.exec' in function 'test_helm_unit' (step 1 of 1).
[2025/11/14 10:07:47.997] Running helm chart unit tests...
[2025/11/14 10:07:47.997] Installing helm-unittest plugin...
[2025/11/14 10:07:47.997] /opt/golang/go1.24/bin:/data/mci/ec73a7fb49f0246365a3d6932c56eff3/src/github.com/mongodb/mongodb-kubernetes/bin:/data/mci/ec73a7fb49f0246365a3d6932c56eff3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
[2025/11/14 10:07:47.998] /data/mci/ec73a7fb49f0246365a3d6932c56eff3/src/github.com/mongodb/mongodb-kubernetes/bin/helm
[2025/11/14 10:07:48.027] version.BuildInfo{Version:"v3.17.1", GitCommit:"980d8ac1939e39138101364400756af2bdee1da5", GitTreeState:"clean", GoVersion:"go1.23.5"}
```

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
