### PR TITLE
CLOUDP-359476 - `kubectl-mongodb` promotion: Use short=8 format

### DIFF
--- a/scripts/release/kubectl_mongodb/promote_kubectl_plugin.py
+++ b/scripts/release/kubectl_mongodb/promote_kubectl_plugin.py
@@ -77,7 +77,7 @@ def get_commit_from_tag(tag: str) -> str:
         result = subprocess.run(
             # using --short because that's how staging version is figured out for staging build scenario
             # https://github.com/mongodb/mongodb-kubernetes/blob/1.5.0/scripts/dev/contexts/evg-private-context#L137
-            ["git", "rev-parse", "--short", f"{tag}^{{commit}}"],  # git rev-parse v1.1.1^{commit}
+            ["git", "rev-parse", "--short=8", f"{tag}^{{commit}}"],  # git rev-parse --short=8 v1.1.1^{commit}
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
# Summary

Issue [found](https://mongodb.slack.com/archives/CGLP6R2PQ/p1763130290007119?thread_ts=1763040755.109529&cid=CGLP6R2PQ) by @fealebenpae during latest release:

>I’m seeing a weird problem - build_kubectl_mongodb_plugin from the PR merge commit build on master publishes the kubectl plugin to s3://mongodb-kubernetes-staging/kubectl-mongodb/b3bb7bbb/kubectl-mongodb_darwin_amd64, but the release_kubectl_mongodb_plugin task in the git tag build is looking for it in s3://mongodb-kubernetes-staging/kubectl-mongodb/b3bb7bbba/kubectl-mongodb_darwin_amd64 and I can’t figure out why the version string is shorter like that in one case

## Proof of Work

N/A

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
