### PR TITLE
Fix "draft release note found" while promoting kubectl  plugin

### DIFF
--- a/scripts/release/kubectl_mongodb/promote_kubectl_plugin.py
+++ b/scripts/release/kubectl_mongodb/promote_kubectl_plugin.py
@@ -290,10 +290,15 @@ def upload_assets_to_github_release(asset_paths: list[str], release_version: str
         for r in repo.get_releases():
             if r.tag_name == release_version:
                 gh_release = r
+                break
+
+        if gh_release is None:
+            logger.error(
+                f"Could not find release (published or draft) with tag '{release_version}'. Please ensure the release exists."
+            )
+            sys.exit(2)
     except GithubException as e:
-        logger.debug(
-            f"ERROR: Could not find release with tag '{release_version}'. Please ensure release exists already. Error: {e}"
-        )
+        logger.debug(f"Failed to retrieve releases from the repository {GITHUB_REPO}. Error: {e}")
         sys.exit(2)
 
     for asset_path in asset_paths:


### PR DESCRIPTION
# Summary

In our release guide we ask to just create a draft release using the release tag and because of that the kubectl plugin promotion workflow was broken in the sense that the script was not able to upload the assets to the draft release. It was able to upload the assets just to the published releases.

This PR makes sure that the promotion script is able to upload the assets to even a draft release.

## Proof of Work

https://github.com/user-attachments/assets/78b9a4b6-9b6e-4b37-a371-0f6045ac9d08

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
