### PR TITLE
[CLOUDP-361632] Add functionality to upload release info to GitHub release assets

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -778,6 +778,18 @@ functions:
           GH_TOKEN: ${GH_TOKEN}
         binary: scripts/dev/run_python.sh scripts/release/create_chart_release_pr.py --chart_version ${OPERATOR_VERSION|*triggered_by_git_tag}
 
+  add_releaseinfo_to_github_assets:
+    - command: github.generate_token
+      params:
+        expansion_name: GH_TOKEN
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        env:
+          GH_TOKEN: ${GH_TOKEN}
+        binary: scripts/dev/run_python.sh scripts/release/release_info.py --version 1.0.1
+
   release_kubectl_mongodb_plugin:
     - command: github.generate_token
       params:

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -115,6 +115,12 @@ tasks:
       - func: install_macos_notarization_service
       - func: release_kubectl_mongodb_plugin
 
+  - name: add_releaseinfo_to_github_assets
+    commands:
+      - func: clone
+      - func: python_venv
+      - func: add_releaseinfo_to_github_assets
+
   - name: create_chart_release_pr
     tags: [ "helm_chart_release_pr" ]
     commands:
@@ -150,6 +156,18 @@ buildvariants:
       - name: release_database
       - name: release_readiness_probe
       - name: release_version_upgrade_hook
+
+  - name: add_releaseinfo_to_github_assets
+    display_name: add_releaseinfo_to_github_assets
+    tags: ["release"]
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: ["patch", "github_tag"]
+    # depends_on:
+    #   - name: "*"
+    #     variant: release_images
+    tasks:
+      - name: add_releaseinfo_to_github_assets
 
   - name: preflight_release_images
     display_name: preflight_release_images

--- a/scripts/release/release_info.py
+++ b/scripts/release/release_info.py
@@ -1,6 +1,6 @@
 import argparse
 import json
-import pathlib
+import os
 
 from scripts.release.build.build_info import (
     DATABASE_IMAGE,
@@ -10,9 +10,12 @@ from scripts.release.build.build_info import (
     OPERATOR_IMAGE,
     READINESS_PROBE_IMAGE,
     UPGRADE_HOOK_IMAGE,
+    OPS_MANAGER_IMAGE,
+    AGENT_IMAGE,
     BuildInfo,
     load_build_info,
 )
+from scripts.release.kubectl_mongodb.promote_kubectl_plugin import upload_assets_to_github_release
 from scripts.release.build.build_scenario import BuildScenario
 from scripts.release.constants import (
     DEFAULT_CHANGELOG_PATH,
@@ -20,71 +23,101 @@ from scripts.release.constants import (
     DEFAULT_REPOSITORY_PATH,
 )
 
+SEARCH_IMAGE = "search"
+SEARCH_IMAGE_REPOSITORY = "quay.io/mongodb/mongodb-search"
+
 RELEASE_INFO_IMAGES_ORDERED = [
-    OPERATOR_IMAGE,
-    INIT_DATABASE_IMAGE,
-    INIT_APPDB_IMAGE,
-    INIT_OPS_MANAGER_IMAGE,
-    DATABASE_IMAGE,
-    READINESS_PROBE_IMAGE,
-    UPGRADE_HOOK_IMAGE,
+    OPERATOR_IMAGE, # mongodb-kubernetes
+    INIT_DATABASE_IMAGE, # mongodb-kubernetes-init-database
+    INIT_APPDB_IMAGE, # mongodb-kubernetes-init-appdb
+    INIT_OPS_MANAGER_IMAGE, # mongodb-kubernetes-init-ops-manager
+    DATABASE_IMAGE, # mongodb-kubernetes-database
+    READINESS_PROBE_IMAGE, # mongodb-kubernetes-readinessprobe
+    UPGRADE_HOOK_IMAGE, # mongodb-kubernetes-operator-version-upgrade-post-start-hook
 ]
 
-# TODO: this is dummy version, to be replaced with actual versioning logic https://docs.google.com/document/d/1eJ8iKsI0libbpcJakGjxcPfbrTn8lmcZDbQH1UqMR_g/edit?tab=t.45ig7xr3e3w4#bookmark=id.748ik8snxcyl
-DUMMY_VERSION = "dummy_version"
+EXTERNAL_INFO_IMAGES = [
+    OPS_MANAGER_IMAGE,
+    AGENT_IMAGE
+]
 
-
-def create_release_info_json() -> str:
+def create_release_info_json(version: str) -> str:
     build_info = load_build_info(scenario=BuildScenario.RELEASE)
 
-    release_info_json = convert_to_release_info_json(build_info)
+    release_info_json = convert_to_release_info_json(build_info, version)
 
     return json.dumps(release_info_json, indent=2)
 
 
-def convert_to_release_info_json(build_info: BuildInfo) -> dict:
-    output = {
+def convert_to_release_info_json(build_info: BuildInfo, version: str) -> dict:
+    release_json_data = os.path.join(os.getcwd(), "release.json")
+    with open(release_json_data, "r") as fd:
+        release_data = json.load(fd)
+
+    release_info_output = {
         "images": {},
-        "binaries": {},
-        "helm-charts": {},
     }
     # Filter (and order) images to include only those relevant for release info
-    images = {name: build_info.images[name] for name in RELEASE_INFO_IMAGES_ORDERED}
+    images = {name: build_info.images[name] for name in RELEASE_INFO_IMAGES_ORDERED + EXTERNAL_INFO_IMAGES}
 
     for name, image in images.items():
-        output["images"][name] = {
+        release_info_output["images"][name] = {
             "repositories": image.repositories,
             "platforms": image.platforms,
-            "version": DUMMY_VERSION,
         }
+        
+        if name == OPS_MANAGER_IMAGE:
+            release_info_output["images"][name]["version"] = latest_om_version(release_data)
+            continue
 
-    for name, binary in build_info.binaries.items():
-        output["binaries"][name] = {
-            "platforms": binary.platforms,
-            "version": DUMMY_VERSION,
-        }
+        if name == AGENT_IMAGE:
+            release_info_output["images"][name]["version"] = latest_agent_version(release_data)
+            continue
 
-    for name, chart in build_info.helm_charts.items():
-        output["helm-charts"][name] = {
-            "registry": chart.registry,
-            "repository": chart.repository,
-            "version": DUMMY_VERSION,
-        }
+        release_info_output["images"][name]["version"] = version
+
+    # add search image detail
+    release_info_output["images"][SEARCH_IMAGE] = {
+                "repositories": SEARCH_IMAGE_REPOSITORY,
+                "platforms": ["linux/arm64", "linux/amd64"],
+                "version": latest_search_version(release_data)
+            }
+
+    release_info_output = add_om_agent_mappings(release_data, release_info_output)
+
+    return release_info_output
+
+def add_om_agent_mappings(release_data, output):
+    om_agent_mapping = release_data["supportedImages"]["latestOpsManagerAgentMapping"]
+    output["latestOpsManagerAgentMapping"] = om_agent_mapping
 
     return output
 
+def latest_om_version(release_data):
+    return release_data["supportedImages"]["ops-manager"]["versions"][-1]
+
+def latest_agent_version(release_data):
+    newest_om_version = release_data["supportedImages"]["ops-manager"]["versions"][-1]
+    newest_om_mapping = release_data["supportedImages"]["mongodb-agent"]["opsManagerMapping"]["ops_manager"][newest_om_version]
+    return newest_om_mapping["agent_version"]
+
+def latest_search_version(release_data):
+    return release_data["search"]["version"]
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Create relevant release artifacts information in JSON format.",
         formatter_class=argparse.RawTextHelpFormatter,
     )
+    parser.add_argument("--version", help="released MCK version", required=True)
     args = parser.parse_args()
 
-    release_info = create_release_info_json()
+    release_info_filename = f"release_info_{args.version}.json"
 
-    if args.output is not None:
-        with open(args.output, "w") as file:
+    release_info = create_release_info_json(args.version)
+
+    if release_info_filename is not None:
+        with open(release_info_filename, "w") as file:
             file.write(release_info)
-    else:
-        print(release_info)
+
+    upload_assets_to_github_release([release_info_filename], args.version)


### PR DESCRIPTION
# Summary

As discussed in the [base PR](https://github.com/mongodb/mongodb-kubernetes/pull/622), customers have been asking us to provide some details that can be used to figure out the container images that they need to deploy a specific version of MCK and MongoDB instance.
This PR does that. It add the functionality to add a new file called `release_info_<release-version>.json` to the GitHub release assets that would contain the details about MCK released images, OM, Agent, Search and the mapping between OM and agent's latest versions.

This is how the file loos like

https://gist.github.com/viveksinghggits/628d93d09c186c51292a44d0c1f522d9

## Proof of Work

Run the patch manually 

```
evergreen patch --path .evergreen.yml -p mongodb-kubernetes -v add_releaseinfo_to_github_assets -t add_releaseinfo_to_github_assets -f -y -u --browse -d "Test add release info to github assets"
```
and make sure the new file is added to the release.

https://github.com/user-attachments/assets/5e22d7fa-edaf-4d46-98f3-cce431c49f38


https://github.com/user-attachments/assets/b1a6d0a2-965e-4135-a15f-5d2550c773cf



## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file? (will show up later)
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
