### PR TITLE
CLOUDP-316923: Fix comment (one word change)

### DIFF
--- a/pkg/multicluster/memberwatch/clusterhealth.go
+++ b/pkg/multicluster/memberwatch/clusterhealth.go
@@ -67,7 +67,7 @@ func NewMemberHealthCheck(server string, ca []byte, token string, log *zap.Sugar
 }
 
 // IsMemberClusterHealthy checks if there are some member clusters that are not in a "healthy" state
-// by curl "ing" the healthz endpoint of the clusters.
+// by curl "ing" the /readyz endpoint of the clusters.
 func (m *MemberHeathCheck) IsClusterHealthy(log *zap.SugaredLogger) bool {
 	statusCode, err := check(m.Client, m.Server, m.Token)
 	if err != nil {


### PR DESCRIPTION
# Summary

Fix comment, we use the readyz endpoint and not healthz. See function `check(client *retryablehttp.Client, server string, token string)` below the method.
This led to confusion: https://jira.mongodb.org/browse/CLOUDP-316923

## Proof of Work

N/A

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
