### PR TITLE
Add release note for github asset `release_info_<mck-version>.json`

### DIFF
--- a/changelog/20251209_other_added_a_new_asset_in_github_releases_that_would.md
+++ b/changelog/20251209_other_added_a_new_asset_in_github_releases_that_would.md
@@ -1,0 +1,6 @@
+---
+kind: other
+date: 2025-12-09
+---
+
+* Added the functionality to add a new asset named `release_info_<version>.json`, to further GitHub releases, that would contain detailed information about released MCK (MongoDB controllers for Kubernetes) and other relevant container images.


### PR DESCRIPTION
# Summary

This PR adds release note for the feature where we are adding the functionality to add a new asset to GitHub releases. 
https://github.com/mongodb/mongodb-kubernetes/pull/624

## Proof of Work

NA

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
