### PR TITLE
Fix `is_default_architecture_static` call

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_upgrade.py
@@ -278,7 +278,7 @@ class TestOpsManagerVersionUpgrade:
     agent_version = None
 
     def test_agent_version(self, mdb: MongoDB):
-        if is_default_architecture_static:
+        if is_default_architecture_static():
             # Containers will not call the upgrade endpoint. Therefore, agent_version is not part of AC
             pod = client.CoreV1Api().read_namespaced_pod(mdb.name + "-0", mdb.namespace)
             image_tag = pod.spec.containers[0].image.split(":")[-1]


### PR DESCRIPTION
# Summary

`is_default_architecture_static` is not being called properly in the test condition.

## Proof of Work

Tests must pass.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
