### PR TITLE
Add dockerfiles to the public dir

### DIFF
--- a/public/dockerfiles/mongodb-agent/107.0.20.8807-1/ubi/Dockerfile
+++ b/public/dockerfiles/mongodb-agent/107.0.20.8807-1/ubi/Dockerfile
@@ -1,0 +1,113 @@
+FROM  --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal AS tools_downloader
+
+ARG TARGETPLATFORM
+ARG mongodb_tools_url
+ARG mongodb_tools_version_s390x
+ARG mongodb_tools_version_ppc64le
+ARG mongodb_tools_version_amd64
+ARG mongodb_tools_version_arm64
+
+RUN microdnf -y update --nodocs \
+  && microdnf -y install --nodocs tar gzip \
+  && microdnf clean all
+
+RUN case ${TARGETPLATFORM} in \
+     "linux/amd64")   export MONGODB_TOOLS_VERSION=${mongodb_tools_version_amd64}    ;; \
+     "linux/arm64")   export MONGODB_TOOLS_VERSION=${mongodb_tools_version_arm64}    ;; \
+     "linux/s390x")   export MONGODB_TOOLS_VERSION=${mongodb_tools_version_s390x}    ;; \
+     "linux/ppc64le") export MONGODB_TOOLS_VERSION=${mongodb_tools_version_ppc64le}  ;; \
+  esac \
+    && mkdir -p /tools \
+    && curl -o /tools/mongodb_tools.tgz "${mongodb_tools_url}/${MONGODB_TOOLS_VERSION}"
+
+RUN tar xfz /tools/mongodb_tools.tgz \
+    && mv mongodb-database-tools-*/bin/* /tools \
+    && chmod +x /tools/* \
+    && rm /tools/mongodb_tools.tgz \
+    && rm -r mongodb-database-tools-*
+
+FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal AS agent_downloader
+
+ARG TARGETPLATFORM
+ARG mongodb_agent_url
+ARG mongodb_agent_version_s390x
+ARG mongodb_agent_version_ppc64le
+ARG mongodb_agent_version_amd64
+ARG mongodb_agent_version_arm64
+
+RUN microdnf -y update --nodocs \
+  && microdnf -y install --nodocs tar gzip \
+  && microdnf clean all
+
+RUN case ${TARGETPLATFORM} in \
+     "linux/amd64")   export MONGODB_AGENT_VERSION=${mongodb_agent_version_amd64}    ;; \
+     "linux/arm64")   export MONGODB_AGENT_VERSION=${mongodb_agent_version_arm64}    ;; \
+     "linux/s390x")   export MONGODB_AGENT_VERSION=${mongodb_agent_version_s390x}    ;; \
+     "linux/ppc64le") export MONGODB_AGENT_VERSION=${mongodb_agent_version_ppc64le}  ;; \
+  esac \
+    && mkdir -p /agent \
+    && curl -o /agent/mongodb_agent.tgz "${mongodb_agent_url}/${MONGODB_AGENT_VERSION}"
+
+RUN tar xfz /agent/mongodb_agent.tgz \
+    && mv mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent \
+    && chmod +x /agent/mongodb-agent \
+    && rm /agent/mongodb_agent.tgz \
+    && rm -r mongodb-mms-automation-agent-*
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+# Replace libcurl-minimal and curl-minimal with the full versions
+# https://bugzilla.redhat.com/show_bug.cgi?id=1994521
+RUN  microdnf install -y libssh libpsl libbrotli \
+    && microdnf download curl libcurl \
+    && rpm -Uvh --nodeps --replacefiles "*curl*$( uname -i ).rpm" \
+    && microdnf remove -y libcurl-minimal curl-minimal
+
+RUN microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper
+# Copy-pasted from https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-red-hat-tarball/
+RUN microdnf install -y --disableplugin=subscription-manager \
+ cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs openldap openssl xz-libs
+# Dependencies for the Agent
+RUN microdnf install -y --disableplugin=subscription-manager  --setopt=install_weak_deps=0 \
+        net-snmp \
+        net-snmp-agent-libs
+RUN microdnf install -y --disableplugin=subscription-manager \
+    hostname tar gzip procps jq \
+    && microdnf upgrade -y  \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /agent \
+    && mkdir -p /var/lib/mongodb-mms-automation \
+      && mkdir -p /var/log/mongodb-mms-automation/ \
+      && chmod -R +wr /var/log/mongodb-mms-automation/ \
+      # ensure that the agent user can write the logs in OpenShift
+      && touch /var/log/mongodb-mms-automation/readiness.log \
+      && chmod ugo+rw /var/log/mongodb-mms-automation/readiness.log
+
+# Copy scripts to a safe location that won't be overwritten by volume mount
+COPY ./docker/mongodb-kubernetes-init-database/content/LICENSE /licenses/LICENSE
+COPY ./docker/mongodb-agent/agent-launcher-shim.sh /usr/local/bin/agent-launcher-shim.sh
+COPY ./docker/mongodb-agent/setup-agent-files.sh /usr/local/bin/setup-agent-files.sh
+COPY ./docker/mongodb-agent/dummy-probe.sh /usr/local/bin/dummy-probe.sh
+COPY ./docker/mongodb-agent/dummy-readinessprobe /usr/local/bin/dummy-readinessprobe
+
+RUN mkdir -p /var/lib/automation/config \
+    && chmod -R +r /var/lib/automation/config
+
+RUN mkdir -p /tools /agent
+
+COPY --from=tools_downloader "/tools/" /tools/
+COPY --from=agent_downloader "/agent/" /agent/
+
+ARG version
+
+LABEL name="MongoDB Agent" \
+      version="${version}" \
+      summary="MongoDB Agent" \
+      description="MongoDB Agent" \
+      vendor="MongoDB" \
+      release="1" \
+      maintainer="support@mongodb.com"
+
+USER 2000
+CMD ["/agent/mongodb-agent", "-cluster=/var/lib/automation/config/automation-config.json"]

--- a/public/dockerfiles/mongodb-agent/13.44.0.10034-1/ubi/Dockerfile
+++ b/public/dockerfiles/mongodb-agent/13.44.0.10034-1/ubi/Dockerfile
@@ -1,0 +1,113 @@
+FROM  --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal AS tools_downloader
+
+ARG TARGETPLATFORM
+ARG mongodb_tools_url
+ARG mongodb_tools_version_s390x
+ARG mongodb_tools_version_ppc64le
+ARG mongodb_tools_version_amd64
+ARG mongodb_tools_version_arm64
+
+RUN microdnf -y update --nodocs \
+  && microdnf -y install --nodocs tar gzip \
+  && microdnf clean all
+
+RUN case ${TARGETPLATFORM} in \
+     "linux/amd64")   export MONGODB_TOOLS_VERSION=${mongodb_tools_version_amd64}    ;; \
+     "linux/arm64")   export MONGODB_TOOLS_VERSION=${mongodb_tools_version_arm64}    ;; \
+     "linux/s390x")   export MONGODB_TOOLS_VERSION=${mongodb_tools_version_s390x}    ;; \
+     "linux/ppc64le") export MONGODB_TOOLS_VERSION=${mongodb_tools_version_ppc64le}  ;; \
+  esac \
+    && mkdir -p /tools \
+    && curl -o /tools/mongodb_tools.tgz "${mongodb_tools_url}/${MONGODB_TOOLS_VERSION}"
+
+RUN tar xfz /tools/mongodb_tools.tgz \
+    && mv mongodb-database-tools-*/bin/* /tools \
+    && chmod +x /tools/* \
+    && rm /tools/mongodb_tools.tgz \
+    && rm -r mongodb-database-tools-*
+
+FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal AS agent_downloader
+
+ARG TARGETPLATFORM
+ARG mongodb_agent_url
+ARG mongodb_agent_version_s390x
+ARG mongodb_agent_version_ppc64le
+ARG mongodb_agent_version_amd64
+ARG mongodb_agent_version_arm64
+
+RUN microdnf -y update --nodocs \
+  && microdnf -y install --nodocs tar gzip \
+  && microdnf clean all
+
+RUN case ${TARGETPLATFORM} in \
+     "linux/amd64")   export MONGODB_AGENT_VERSION=${mongodb_agent_version_amd64}    ;; \
+     "linux/arm64")   export MONGODB_AGENT_VERSION=${mongodb_agent_version_arm64}    ;; \
+     "linux/s390x")   export MONGODB_AGENT_VERSION=${mongodb_agent_version_s390x}    ;; \
+     "linux/ppc64le") export MONGODB_AGENT_VERSION=${mongodb_agent_version_ppc64le}  ;; \
+  esac \
+    && mkdir -p /agent \
+    && curl -o /agent/mongodb_agent.tgz "${mongodb_agent_url}/${MONGODB_AGENT_VERSION}"
+
+RUN tar xfz /agent/mongodb_agent.tgz \
+    && mv mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /agent/mongodb-agent \
+    && chmod +x /agent/mongodb-agent \
+    && rm /agent/mongodb_agent.tgz \
+    && rm -r mongodb-mms-automation-agent-*
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+# Replace libcurl-minimal and curl-minimal with the full versions
+# https://bugzilla.redhat.com/show_bug.cgi?id=1994521
+RUN  microdnf install -y libssh libpsl libbrotli \
+    && microdnf download curl libcurl \
+    && rpm -Uvh --nodeps --replacefiles "*curl*$( uname -i ).rpm" \
+    && microdnf remove -y libcurl-minimal curl-minimal
+
+RUN microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper
+# Copy-pasted from https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-red-hat-tarball/
+RUN microdnf install -y --disableplugin=subscription-manager \
+ cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs openldap openssl xz-libs
+# Dependencies for the Agent
+RUN microdnf install -y --disableplugin=subscription-manager  --setopt=install_weak_deps=0 \
+        net-snmp \
+        net-snmp-agent-libs
+RUN microdnf install -y --disableplugin=subscription-manager \
+    hostname tar gzip procps jq \
+    && microdnf upgrade -y  \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /agent \
+    && mkdir -p /var/lib/mongodb-mms-automation \
+      && mkdir -p /var/log/mongodb-mms-automation/ \
+      && chmod -R +wr /var/log/mongodb-mms-automation/ \
+      # ensure that the agent user can write the logs in OpenShift
+      && touch /var/log/mongodb-mms-automation/readiness.log \
+      && chmod ugo+rw /var/log/mongodb-mms-automation/readiness.log
+
+# Copy scripts to a safe location that won't be overwritten by volume mount
+COPY ./docker/mongodb-kubernetes-init-database/content/LICENSE /licenses/LICENSE
+COPY ./docker/mongodb-agent/agent-launcher-shim.sh /usr/local/bin/agent-launcher-shim.sh
+COPY ./docker/mongodb-agent/setup-agent-files.sh /usr/local/bin/setup-agent-files.sh
+COPY ./docker/mongodb-agent/dummy-probe.sh /usr/local/bin/dummy-probe.sh
+COPY ./docker/mongodb-agent/dummy-readinessprobe /usr/local/bin/dummy-readinessprobe
+
+RUN mkdir -p /var/lib/automation/config \
+    && chmod -R +r /var/lib/automation/config
+
+RUN mkdir -p /tools /agent
+
+COPY --from=tools_downloader "/tools/" /tools/
+COPY --from=agent_downloader "/agent/" /agent/
+
+ARG version
+
+LABEL name="MongoDB Agent" \
+      version="${version}" \
+      summary="MongoDB Agent" \
+      description="MongoDB Agent" \
+      vendor="MongoDB" \
+      release="1" \
+      maintainer="support@mongodb.com"
+
+USER 2000
+CMD ["/agent/mongodb-agent", "-cluster=/var/lib/automation/config/automation-config.json"]

--- a/public/dockerfiles/mongodb-enterprise-ops-manager/7.0.20/ubi/Dockerfile
+++ b/public/dockerfiles/mongodb-enterprise-ops-manager/7.0.20/ubi/Dockerfile
@@ -1,0 +1,95 @@
+# Build compilable stuff
+
+FROM public.ecr.aws/docker/library/golang:1.24 AS readiness_builder
+COPY . /go/src/github.com/mongodb/mongodb-kubernetes
+WORKDIR /go/src/github.com/mongodb/mongodb-kubernetes
+
+RUN CGO_ENABLED=0 go build -a -buildvcs=false -o /data/scripts/mmsconfiguration ./docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go
+RUN CGO_ENABLED=0 go build -a -buildvcs=false -o /data/scripts/backup-daemon-readiness-probe ./docker/mongodb-kubernetes-init-ops-manager/backupdaemon_readinessprobe/backupdaemon_readiness.go
+
+# Move binaries and scripts
+FROM scratch AS base
+
+COPY --from=readiness_builder /data/scripts/mmsconfiguration /data/scripts/mmsconfiguration
+COPY --from=readiness_builder /data/scripts/backup-daemon-readiness-probe /data/scripts/backup-daemon-readiness-probe
+
+# After v2.0, when non-Static Agent images will be removed, please ensure to copy those files
+# into ./docker/mongodb-enterprise-ops-manager directory. Leaving it this way will make the maintenance easier.
+COPY ./docker/mongodb-kubernetes-init-ops-manager/scripts/docker-entry-point.sh /data/scripts
+COPY ./docker/mongodb-kubernetes-init-ops-manager/scripts/backup-daemon-liveness-probe.sh /data/scripts
+COPY ./docker/mongodb-kubernetes-init-ops-manager/LICENSE /data/licenses/mongodb-enterprise-ops-manager
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+ARG version
+ARG om_download_url
+
+LABEL name="MongoDB Enterprise Ops Manager" \
+  maintainer="support@mongodb.com" \
+  vendor="MongoDB" \
+  version=${version} \
+  release="1" \
+  summary="MongoDB Enterprise Ops Manager Image" \
+  description="MongoDB Enterprise Ops Manager"
+
+ENV MMS_HOME=/mongodb-ops-manager
+ENV MMS_PROP_FILE=${MMS_HOME}/conf/conf-mms.properties
+ENV MMS_CONF_FILE=${MMS_HOME}/conf/mms.conf
+ENV MMS_LOG_DIR=${MMS_HOME}/logs
+ENV MMS_TMP_DIR=${MMS_HOME}/tmp
+
+EXPOSE 8080
+
+# OpsManager docker image needs to have the MongoDB dependencies because the
+# backup daemon is running its database locally
+
+# Replace libcurl-minimal and curl-minimal with the full versions
+# https://bugzilla.redhat.com/show_bug.cgi?id=1994521
+RUN microdnf install -y libssh libpsl libbrotli \
+    && microdnf download curl libcurl \
+    && rpm -Uvh --nodeps --replacefiles "*curl*$( uname -i ).rpm" \
+    && microdnf remove -y libcurl-minimal curl-minimal
+
+RUN microdnf install --disableplugin=subscription-manager -y \
+  cyrus-sasl \
+  cyrus-sasl-gssapi \
+  cyrus-sasl-plain \
+  krb5-libs \
+  libpcap \
+  lm_sensors-libs \
+  net-snmp \
+  net-snmp-agent-libs \
+  openldap \
+  openssl \
+  tar \
+  rpm-libs \
+  net-tools \
+  procps-ng \
+  ncurses
+
+COPY --from=base /data/licenses /licenses/
+COPY --from=base /data/scripts /opt/scripts
+
+RUN curl --fail -L -o ops_manager.tar.gz ${om_download_url} \
+  && tar -xzf ops_manager.tar.gz \
+  && rm ops_manager.tar.gz \
+  && mv mongodb-mms* "${MMS_HOME}"
+
+# permissions
+RUN chmod -R 0777 "${MMS_LOG_DIR}" \
+  && chmod -R 0777 "${MMS_TMP_DIR}" \
+  && chmod -R 0775 "${MMS_HOME}/conf" \
+  && chmod -R 0775 "${MMS_HOME}/jdk" \
+  && mkdir "${MMS_HOME}/mongodb-releases/" \
+  && chmod -R 0775 "${MMS_HOME}/mongodb-releases" \
+  && chmod -R 0777 "${MMS_CONF_FILE}" \
+  && chmod -R 0777 "${MMS_PROP_FILE}"
+
+# The "${MMS_HOME}/conf" will be populated by the docker-entry-point.sh.
+# For now we need to move into the templates directory.
+RUN cp -r "${MMS_HOME}/conf" "${MMS_HOME}/conf-template"
+
+USER 2000
+
+# operator to change the entrypoint to: /mongodb-ops-manager/bin/mongodb-mms start_mms (or a wrapper around this)
+ENTRYPOINT [ "sleep infinity" ]

--- a/public/dockerfiles/mongodb-enterprise-ops-manager/8.0.17/ubi/Dockerfile
+++ b/public/dockerfiles/mongodb-enterprise-ops-manager/8.0.17/ubi/Dockerfile
@@ -1,0 +1,95 @@
+# Build compilable stuff
+
+FROM public.ecr.aws/docker/library/golang:1.24 AS readiness_builder
+COPY . /go/src/github.com/mongodb/mongodb-kubernetes
+WORKDIR /go/src/github.com/mongodb/mongodb-kubernetes
+
+RUN CGO_ENABLED=0 go build -a -buildvcs=false -o /data/scripts/mmsconfiguration ./docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go
+RUN CGO_ENABLED=0 go build -a -buildvcs=false -o /data/scripts/backup-daemon-readiness-probe ./docker/mongodb-kubernetes-init-ops-manager/backupdaemon_readinessprobe/backupdaemon_readiness.go
+
+# Move binaries and scripts
+FROM scratch AS base
+
+COPY --from=readiness_builder /data/scripts/mmsconfiguration /data/scripts/mmsconfiguration
+COPY --from=readiness_builder /data/scripts/backup-daemon-readiness-probe /data/scripts/backup-daemon-readiness-probe
+
+# After v2.0, when non-Static Agent images will be removed, please ensure to copy those files
+# into ./docker/mongodb-enterprise-ops-manager directory. Leaving it this way will make the maintenance easier.
+COPY ./docker/mongodb-kubernetes-init-ops-manager/scripts/docker-entry-point.sh /data/scripts
+COPY ./docker/mongodb-kubernetes-init-ops-manager/scripts/backup-daemon-liveness-probe.sh /data/scripts
+COPY ./docker/mongodb-kubernetes-init-ops-manager/LICENSE /data/licenses/mongodb-enterprise-ops-manager
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+ARG version
+ARG om_download_url
+
+LABEL name="MongoDB Enterprise Ops Manager" \
+  maintainer="support@mongodb.com" \
+  vendor="MongoDB" \
+  version=${version} \
+  release="1" \
+  summary="MongoDB Enterprise Ops Manager Image" \
+  description="MongoDB Enterprise Ops Manager"
+
+ENV MMS_HOME=/mongodb-ops-manager
+ENV MMS_PROP_FILE=${MMS_HOME}/conf/conf-mms.properties
+ENV MMS_CONF_FILE=${MMS_HOME}/conf/mms.conf
+ENV MMS_LOG_DIR=${MMS_HOME}/logs
+ENV MMS_TMP_DIR=${MMS_HOME}/tmp
+
+EXPOSE 8080
+
+# OpsManager docker image needs to have the MongoDB dependencies because the
+# backup daemon is running its database locally
+
+# Replace libcurl-minimal and curl-minimal with the full versions
+# https://bugzilla.redhat.com/show_bug.cgi?id=1994521
+RUN microdnf install -y libssh libpsl libbrotli \
+    && microdnf download curl libcurl \
+    && rpm -Uvh --nodeps --replacefiles "*curl*$( uname -i ).rpm" \
+    && microdnf remove -y libcurl-minimal curl-minimal
+
+RUN microdnf install --disableplugin=subscription-manager -y \
+  cyrus-sasl \
+  cyrus-sasl-gssapi \
+  cyrus-sasl-plain \
+  krb5-libs \
+  libpcap \
+  lm_sensors-libs \
+  net-snmp \
+  net-snmp-agent-libs \
+  openldap \
+  openssl \
+  tar \
+  rpm-libs \
+  net-tools \
+  procps-ng \
+  ncurses
+
+COPY --from=base /data/licenses /licenses/
+COPY --from=base /data/scripts /opt/scripts
+
+RUN curl --fail -L -o ops_manager.tar.gz ${om_download_url} \
+  && tar -xzf ops_manager.tar.gz \
+  && rm ops_manager.tar.gz \
+  && mv mongodb-mms* "${MMS_HOME}"
+
+# permissions
+RUN chmod -R 0777 "${MMS_LOG_DIR}" \
+  && chmod -R 0777 "${MMS_TMP_DIR}" \
+  && chmod -R 0775 "${MMS_HOME}/conf" \
+  && chmod -R 0775 "${MMS_HOME}/jdk" \
+  && mkdir "${MMS_HOME}/mongodb-releases/" \
+  && chmod -R 0775 "${MMS_HOME}/mongodb-releases" \
+  && chmod -R 0777 "${MMS_CONF_FILE}" \
+  && chmod -R 0777 "${MMS_PROP_FILE}"
+
+# The "${MMS_HOME}/conf" will be populated by the docker-entry-point.sh.
+# For now we need to move into the templates directory.
+RUN cp -r "${MMS_HOME}/conf" "${MMS_HOME}/conf-template"
+
+USER 2000
+
+# operator to change the entrypoint to: /mongodb-ops-manager/bin/mongodb-mms start_mms (or a wrapper around this)
+ENTRYPOINT [ "sleep infinity" ]


### PR DESCRIPTION
# Summary

This is preparation to 1.6.1 release.

This covers recent OM and agent updates:
* https://github.com/mongodb/mongodb-kubernetes/pull/627
* https://github.com/mongodb/mongodb-kubernetes/pull/630
* https://github.com/mongodb/mongodb-kubernetes/pull/631

Note that OM 8.0.17 bump doesn't introduce a new agent image: we already have a `Dockerfile` for this OM version in `public/dockerfiles/mongodb-agent/108.0.16.8895-1/ubi/Dockerfile`.

## Proof of Work

N/A: just copies of docker files.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
