### PR TITLE
Fix the step publishing the draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           INITIAL_VERSION: ${{ vars.RELEASE_INITIAL_VERSION }}
       - name: Generate draft release
         run: |
-          gh release create $VERSION --target $COMMIT_SHA --draft --prerelease --latest --notes-file release_notes_final.md --title "Release of MCK $VERSION"
+          gh release create $VERSION --target $COMMIT_SHA --draft --latest --notes-file release_notes_final.md --title "Release of MCK $VERSION"
         env:
           VERSION: ${{ github.event.inputs.version }}
           COMMIT_SHA: ${{ github.event.inputs.commit_sha }}


### PR DESCRIPTION
# Summary

We currently set `prerelease` on the draft release in the `crate_draft_release_notes` job.

Later in the `publish_release` job we try to publish it, but it fails with the error: "Latest release cannot be draft or prerelease."

## Proof of Work

Failed job is here: https://github.com/mongodb/mongodb-kubernetes/actions/runs/20225170046/job/58055017402

After failing it, I edited the draft for 1.6.1 manually and unticked "Set as a pre-release " checkbox.

The [job succeed](https://github.com/mongodb/mongodb-kubernetes/actions/runs/20225170046) after a restart.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
