### PR TITLE
Removed unnecessary deps while building database image

### DIFF
--- a/docker/mongodb-kubernetes-database/Dockerfile
+++ b/docker/mongodb-kubernetes-database/Dockerfile
@@ -24,8 +24,6 @@ RUN microdnf install -y --disableplugin=subscription-manager \
         krb5-libs \
         libcurl \
         lm_sensors-libs \
-        net-snmp \
-        net-snmp-agent-libs \
         openldap \
         openssl \
         jq \


### PR DESCRIPTION
# Summary

Fixed building of mongodb-enterprise-database image. 

`net-snmp` and `net-snmp-agent-libs` caused problems. Upon a closer look those are unnecessary according to [docs](https://www.mongodb.com/docs/v8.0/tutorial/install-mongodb-enterprise-on-red-hat-tarball/#prerequisites).

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
