### PR TITLE
Fix pre-commit race conditions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,37 @@
 
 default_stages: [pre-commit]
 
-# everything is run serially except the generate-and-update hook
+# Hooks run serially in definition order. The following local hooks have
+# dependencies and must run in this order:
+#   1. update-release-json: writes release.json
+#   2. update-values-yaml: reads release.json, writes helm values files
+#   3. generate-standalone-yaml: reads helm values files
+#   4. generate-and-update: remaining parallel jobs
 repos:
-  # Runs the generation jobs are squashed together to run in parallel
   - repo: local
     hooks:
+      - id: update-release-json
+        name: update-release-json
+        entry: scripts/dev/generate_files.sh update_release
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: update-values-yaml
+        name: update-values-yaml
+        entry: scripts/dev/generate_files.sh update_values
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: generate-standalone-yaml
+        name: generate-standalone-yaml
+        entry: scripts/dev/generate_files.sh generate_standalone_yaml
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      # Remaining generation jobs run in parallel
       - id: generate-and-update
         name: generate-and-update (parallel)
         entry: scripts/dev/generate_files.sh generate_all


### PR DESCRIPTION
# Summary

Fixes race conditions in pre-commit hooks:

1. **git index.lock race** - Multiple parallel jobs running `git add` simultaneously caused "index.lock file exists" errors
2. **release.json race** - `update_values_yaml_files` reading `release.json` while `update_release_json` is writing to it caused JSONDecodeError
3. we don't need to rely on git add anymore since pre-commit verifies whether files have changed for us already
     * https://pre-commit.com/#new-hooks -> "The hook must exit nonzero on failure or modify files"

**Changes:**
- **Removed `git add`** - pre-commit binary already fails if files have been changed
- **Split `validate-snippets` and `validate-helm-charts` into separate pre-commit hooks** - allows them to run independently
- **Moved local hooks to top of `.pre-commit-config.yaml`** - ensures generation runs before other checks
- **Split release.json-related jobs into serial hooks** - ensures proper ordering:
  1. `update-release-json` (writes release.json)
  2. `update-values-yaml` (reads release.json, writes helm values files)
  5. `generate-standalone-yaml` (reads helm values files)
  6. `generate-and-update` (remaining parallel jobs)

## Proof of Work
- green lint repo in pr

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details