### PR TITLE
[CLOUDP-339048] Fix a bug in `regenerate_public_rbac_multi_cluster`

### DIFF
--- a/scripts/dev/generate_files.sh
+++ b/scripts/dev/generate_files.sh
@@ -83,19 +83,11 @@ update_release_json() {
 }
 
 regenerate_public_rbac_multi_cluster() {
-  if [[ -z "${EVERGREEN_MODE:-}" ]]; then
-    # According to the latest SSDLC recommendations, the CI needs to always check all the files. Not just delta.
-    git_last_changed=$(git ls-tree -r origin/master --name-only)
-  else
-    git_last_changed=$(git diff --cached --name-only --diff-filter=ACM origin/master)
-  fi
-
-  if echo "${git_last_changed}" | grep -e 'cmd/kubectl-mongodb' -e 'pkg/kubectl-mongodb' > /dev/null; then
-    echo 'regenerating multicluster RBAC public example'
-    pushd pkg/kubectl-mongodb/common/
-    EXPORT_RBAC_SAMPLES="true" go test ./... -run TestPrintingOutRolesServiceAccountsAndRoleBindings
-    popd
-  fi
+  echo 'regenerating multicluster RBAC public example'
+  pushd pkg/kubectl-mongodb/common/
+  EXPORT_RBAC_SAMPLES="true" go test ./... -run TestPrintingOutRolesServiceAccountsAndRoleBindings
+  popd
+  git add public/samples/multi-cluster-cli-gitops
 }
 
 update_licenses() {


### PR DESCRIPTION
# Summary


This PR removes the buggy check that we had to generate multi-cluster. The statement `if echo "${git_last_changed}" | grep -q -e 'cmd/kubectl-mongodb' -e 'pkg/kubectl-mongodb'; then` was failing sometimes because of root cause mentioned below. But even if we apply the fix we didn't achieve a lot time wise, that's why as a solution we are removing the check and alway generating the RBAC.

### Root cause

The function `regenerate_public_rbac_multi_cluster` from `generate_files.sh` was trying to list all the files from the git repo using [the command](https://github.com/mongodb/mongodb-kubernetes/blob/b4368564928c54fd15d19fa7884cf8b0e8b40ae0/scripts/dev/generate_files.sh#L104) 
```
git_last_changed=$(git ls-tree -r origin/master --name-only)
```
and then it was [trying to check](https://github.com/mongodb/mongodb-kubernetes/blob/b4368564928c54fd15d19fa7884cf8b0e8b40ae0/scripts/dev/generate_files.sh#L109) if the kubectl plugin related files are in the listed files. And if that was the cases we re-generated the RBAC for multi-cluster.
```
if echo "${git_last_changed}" | grep -q -e 'cmd/kubectl-mongodb' -e 'pkg/kubectl-mongodb'; then
    echo 'regenerating multicluster RBAC public example'
    pushd pkg/kubectl-mongodb/common/
    EXPORT_RBAC_SAMPLES="true" go test ./... -run TestPrintingOutRolesServiceAccountsAndRoleBindings
...
```

But this has a small problem, since we are running `git ls-tree` the output of the command can become quite big at times, and because of that when we run `echo "${git_last_changed}"` and then use `grep -q`, we some times get unexpected result, i.e., even though the files `cmd/kubectl-mongodb` and/or `pkg/kubectl-mongodb` were present in the output of `echo "${git_last_changed}"`, the output of the line `echo 'regenerating multicluster RBAC public example'` was not printed which resulted into the RBACs not getting generated.
The `if` statement behaved mysteriously because, if the size of `git_last_changed` is big, and the grep statement is satisfied, because of `-q` the grep statement will return and the pipe `|` will be closed but the echo is not done yet because of the size of `git_last_changed` and because of that it (`echo ${git_last_changed}`) will try to put more data to the pipe which will result into an error because the pipe is closed. This will result into `if` statement misbehaving.
https://biriukov.dev/docs/fd-pipe-session-terminal/2-pipes/#sigpipe-signal 

To fix that we are not using `-q` anymore so that the pipe is not closed and `SIGPIPE` is not sent to `echo`, which would result into everything working fine.

## Proof of Work

Manual test.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
