### PR TITLE
feat: make downloadbase configurable

### DIFF
--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -483,6 +483,13 @@ type DbCommonSpec struct {
 	// +optional
 	Topology string `json:"topology,omitempty"`
 
+	// DownloadBase is the directory on the MongoDB host where the automation agent
+	// downloads and extracts MongoDB binaries. It is always used by the operator, and
+	// the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+	// defaults to "/var/lib/mongodb-mms-automation".
+	// This field should only be set (and only if needed) when migrating an existing
+	// VM-based deployment to the operator.
+	// +optional
 	DownloadBase string `json:"downloadBase,omitempty"`
 }
 

--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -89,6 +89,10 @@ type MongoDB struct {
 	Spec   MongoDbSpec   `json:"spec"`
 }
 
+func (m *MongoDB) GetDownloadBase() string {
+	return m.Spec.GetDownloadBase()
+}
+
 func (m *MongoDB) IsAgentImageOverridden() bool {
 	if m.Spec.PodSpec.IsAgentImageOverridden() {
 		return true
@@ -478,6 +482,8 @@ type DbCommonSpec struct {
 	// +kubebuilder:validation:Enum=SingleCluster;MultiCluster
 	// +optional
 	Topology string `json:"topology,omitempty"`
+
+	DownloadBase string `json:"downloadBase,omitempty"`
 }
 
 type MongoDbSpec struct {
@@ -960,6 +966,13 @@ func (s *Security) GetTLSCAFilePath(defaultPath string) string {
 		return defaultPath
 	}
 	return s.TLSConfig.GetCAFilePath(defaultPath)
+}
+
+func (d *DbCommonSpec) GetDownloadBase() string {
+	if d.DownloadBase != "" {
+		return d.DownloadBase
+	}
+	return util.DefaultPvcMmsMountPath
 }
 
 func (s *Security) IsTLSEnabled() bool {

--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -927,6 +927,13 @@ func (d *DbCommonSpec) GetAdditionalMongodConfig() *AdditionalMongodConfig {
 	return d.AdditionalMongodConfig
 }
 
+func (d *DbCommonSpec) GetDownloadBase() string {
+	if d.DownloadBase != "" {
+		return d.DownloadBase
+	}
+	return util.DefaultPvcMmsMountPath
+}
+
 // GetExternalMembersHostnames returns the hostname list (host:port) the
 // caller should embed in this MongoDB resource's connection string:
 func (m *MongoDB) GetExternalMembersHostnames() []string {
@@ -973,13 +980,6 @@ func (s *Security) GetTLSCAFilePath(defaultPath string) string {
 		return defaultPath
 	}
 	return s.TLSConfig.GetCAFilePath(defaultPath)
-}
-
-func (d *DbCommonSpec) GetDownloadBase() string {
-	if d.DownloadBase != "" {
-		return d.DownloadBase
-	}
-	return util.DefaultPvcMmsMountPath
 }
 
 func (s *Security) IsTLSEnabled() bool {

--- a/api/v1/mdb/mongodb_types_test.go
+++ b/api/v1/mdb/mongodb_types_test.go
@@ -745,3 +745,15 @@ func TestGetExternalMembersHostnames_ShardedCluster_OnlyMongodMembers_ReturnsEmp
 	got := sc.GetExternalMembersHostnames()
 	assert.Empty(t, got, "sharded must drop non-mongos entries (mongod and untyped)")
 }
+
+func TestGetDownloadBase(t *testing.T) {
+	t.Run("returns default when unset", func(t *testing.T) {
+		spec := DbCommonSpec{}
+		assert.Equal(t, util.DefaultPvcMmsMountPath, spec.GetDownloadBase())
+	})
+
+	t.Run("returns configured value when set", func(t *testing.T) {
+		spec := DbCommonSpec{DownloadBase: "/custom/download/base"}
+		assert.Equal(t, "/custom/download/base", spec.GetDownloadBase())
+	})
+}

--- a/api/v1/mdb/mongodb_validation.go
+++ b/api/v1/mdb/mongodb_validation.go
@@ -383,6 +383,13 @@ func ldapGroupDnIsSetIfLdapAuthzIsEnabledAndAgentsAreExternal(d DbCommonSpec) v1
 	return v1.ValidationSuccess()
 }
 
+func downloadBaseImmutable(newObj, oldObj MongoDbSpec) v1.ValidationResult {
+	if newObj.GetDownloadBase() != oldObj.GetDownloadBase() {
+		return v1.ValidationError("'spec.downloadBase' cannot be changed once created")
+	}
+	return v1.ValidationSuccess()
+}
+
 func resourceTypeImmutable(newObj, oldObj MongoDbSpec) v1.ValidationResult {
 	if newObj.ResourceType != oldObj.ResourceType {
 		return v1.ValidationError("'resourceType' cannot be changed once created")
@@ -687,6 +694,7 @@ func (m *MongoDB) RunValidations(old *MongoDB) []v1.ValidationResult {
 
 	updateValidators := []func(newObj MongoDbSpec, oldObj MongoDbSpec) v1.ValidationResult{
 		resourceTypeImmutable,
+		downloadBaseImmutable,
 		noTopologyMigration,
 		noSimultaneousTLSDisablingAndScaling,
 		atMostOneMigrationChangeAtATime,

--- a/api/v1/mdb/mongodb_validation_test.go
+++ b/api/v1/mdb/mongodb_validation_test.go
@@ -193,6 +193,26 @@ func TestMongoDB_ResourceTypeImmutable(t *testing.T) {
 	assert.Errorf(t, err, "'resourceType' cannot be changed once created")
 }
 
+func TestMongoDB_DownloadBaseImmutable(t *testing.T) {
+	t.Run("Changing downloadBase is rejected", func(t *testing.T) {
+		oldRs := NewReplicaSetBuilder().AddDummyOpsManagerConfig().Build()
+		oldRs.Spec.DownloadBase = "/var/lib/mongodb-mms-automation"
+		newRs := NewReplicaSetBuilder().AddDummyOpsManagerConfig().Build()
+		newRs.Spec.DownloadBase = "/data/mongodb-mms-automation"
+		_, err := validator.ValidateUpdate(ctx, oldRs, newRs)
+		assert.EqualError(t, err, "'spec.downloadBase' cannot be changed once created")
+	})
+
+	t.Run("Keeping downloadBase unchanged is allowed", func(t *testing.T) {
+		oldRs := NewReplicaSetBuilder().AddDummyOpsManagerConfig().Build()
+		oldRs.Spec.DownloadBase = "/var/lib/mongodb-mms-automation"
+		newRs := NewReplicaSetBuilder().AddDummyOpsManagerConfig().Build()
+		newRs.Spec.DownloadBase = "/var/lib/mongodb-mms-automation"
+		_, err := validator.ValidateUpdate(ctx, oldRs, newRs)
+		assert.NoError(t, err)
+	})
+}
+
 func TestMongoDB_NoSimultaneousTLSDisablingAndScaling(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/api/v1/mdbmulti/mongodb_multi_types.go
+++ b/api/v1/mdbmulti/mongodb_multi_types.go
@@ -56,6 +56,10 @@ type MongoDBMultiCluster struct {
 	Spec   MongoDBMultiSpec   `json:"spec"`
 }
 
+func (m *MongoDBMultiCluster) GetDownloadBase() string {
+	return m.Spec.GetDownloadBase()
+}
+
 func (m *MongoDBMultiCluster) GetProjectConfigMapNamespace() string {
 	return m.Namespace
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator.go
@@ -123,9 +123,15 @@ func buildDbCommonSpec(ac *om.AutomationConfig, opts GenerateOptions, version, f
 		featureCompatibilityVersion = &fcv
 	}
 
+	var downloadBase string
+	if db := ac.Deployment.DownloadBase(); db != "" && db != util.DefaultPvcMmsMountPath {
+		downloadBase = db
+	}
+
 	return mdbv1.DbCommonSpec{
 		Version:                     version,
 		ResourceType:                resourceType,
+		DownloadBase:                downloadBase,
 		FeatureCompatibilityVersion: featureCompatibilityVersion,
 		ConnectionSpec: mdbv1.ConnectionSpec{
 			SharedConnectionSpec: mdbv1.SharedConnectionSpec{

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_fixture_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_fixture_test.go
@@ -165,6 +165,10 @@ func TestFixtureMatch_ReplicaSet(t *testing.T) {
 			name:    "member tags are preserved in externalMembers",
 			fixture: "singlecluster/replicaset/member_options/member_options",
 		},
+		{
+			name:    "non-default options.downloadBase is carried over to spec.downloadBase",
+			fixture: "singlecluster/replicaset/download_base/download_base",
+		},
 	}
 	runFixtureCases(t, cases)
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -12,6 +12,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/ldap"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 func secretsByName(objs []client.Object) map[string]string {
@@ -235,4 +236,29 @@ func TestGenerateMongoDBCR_ShardedMissingShardReplicaSet(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "shard0")
 	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestBuildDbCommonSpec_DownloadBase(t *testing.T) {
+	makeAC := func(downloadBase string) *om.AutomationConfig {
+		ac := baseValidReplicaSetAC()
+		options := ac.Deployment["options"].(map[string]interface{})
+		options["downloadBase"] = downloadBase
+		ac.Deployment["options"] = options
+		return ac
+	}
+	opts := GenerateOptions{ConfigMapName: "cm", CredentialsSecretName: "creds", Namespace: "mongodb"}
+
+	t.Run("non-default value is carried over", func(t *testing.T) {
+		ac := makeAC("/opt/mongodb/automation")
+		spec, err := buildDbCommonSpec(ac, opts, "7.0.12-ent", "", mdbv1.ReplicaSet, "my-rs")
+		require.NoError(t, err)
+		assert.Equal(t, "/opt/mongodb/automation", spec.DownloadBase)
+	})
+
+	t.Run("default value is not set", func(t *testing.T) {
+		ac := makeAC(util.DefaultPvcMmsMountPath)
+		spec, err := buildDbCommonSpec(ac, opts, "7.0.12-ent", "", mdbv1.ReplicaSet, "my-rs")
+		require.NoError(t, err)
+		assert.Equal(t, "", spec.DownloadBase)
+	})
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/download_base/download_base_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/download_base/download_base_input.json
@@ -1,0 +1,30 @@
+{
+  "options": {
+    "downloadBase": "/opt/mongodb/automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "download-base-rs"},
+        "storage": {"dbPath": "/data"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "download-base-rs-0.example.com",
+      "name": "download-base-rs-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "download-base-rs",
+      "members": [
+        {"_id": 0, "host": "download-base-rs-0", "priority": 1, "votes": 1}
+      ]
+    }
+  ],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/download_base/download_base_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/download_base/download_base_mongodb_cr.yaml
@@ -1,0 +1,22 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: download-base-rs
+  namespace: mongodb
+spec:
+  credentials: my-credentials
+  downloadBase: /opt/mongodb/automation
+  externalMembers:
+  - hostname: download-base-rs-0.example.com:27017
+    processName: download-base-rs-0
+    replicaSetName: download-base-rs
+    type: mongod
+  featureCompatibilityVersion: "7.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  type: ReplicaSet
+  version: 7.0.12-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/validation.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/validation.go
@@ -25,7 +25,6 @@ type ValidationResult struct {
 }
 
 var (
-	defaultKeyFile                = util.AutomationAgentKeyFilePathInContainer
 	defaultKeyFileWindows         = util.AutomationAgentWindowsKeyFilePath
 	defaultCAFilePath             = fmt.Sprintf("%s/ca-pem", util.TLSCaMountPath)
 	defaultDownloadBase           = util.DefaultPvcMmsMountPath
@@ -48,7 +47,7 @@ func ValidateMigration(ac *om.AutomationConfig, processMap map[string]om.Process
 		}
 	}
 
-	results = append(results, validateAuth(ac.Auth)...)
+	results = append(results, validateAuth(ac.Auth, ac.Deployment.DownloadBase())...)
 	results = append(results, validateScram(ac.Auth)...)
 	results = append(results, validateX509(ac.Auth, ac.AgentSSL)...)
 	results = append(results, validateAgentTLS(ac.AgentSSL)...)
@@ -183,7 +182,9 @@ func validateReplicaSetsExist(d om.Deployment) []ValidationResult {
 }
 
 // validateAuth checks autoUser, keyFile, and keyFileWindows against operator defaults.
-func validateAuth(auth *om.Auth) []ValidationResult {
+// keyFile is expected under the deployment's downloadBase, matching the operator
+// (common_controller.go: KeyfilePath = downloadBase + "/keyfile").
+func validateAuth(auth *om.Auth, downloadBase string) []ValidationResult {
 	if auth == nil || auth.Disabled {
 		return nil
 	}
@@ -196,10 +197,16 @@ func validateAuth(auth *om.Auth) []ValidationResult {
 			Message:  "auth.autoUser is empty. The operator requires an automation agent user when authentication is enabled.",
 		})
 	}
-	if auth.KeyFile != "" && auth.KeyFile != defaultKeyFile {
+
+	base := downloadBase
+	if base == "" {
+		base = defaultDownloadBase
+	}
+	expectedKeyFile := base + "/keyfile"
+	if auth.KeyFile != "" && auth.KeyFile != expectedKeyFile {
 		results = append(results, ValidationResult{
 			Severity: SeverityError,
-			Message:  fmt.Sprintf("auth.keyFile %q differs from the operator default %q. This value is not configurable via the Custom Resource.", auth.KeyFile, defaultKeyFile),
+			Message:  fmt.Sprintf("auth.keyFile %q differs from the expected path %q (derived from options.downloadBase). This value is not configurable via the Custom Resource.", auth.KeyFile, expectedKeyFile),
 		})
 	}
 	if auth.KeyFileWindows != "" && auth.KeyFileWindows != defaultKeyFileWindows {
@@ -355,15 +362,16 @@ func validateLDAP(ac *om.AutomationConfig) []ValidationResult {
 	return results
 }
 
-// validateProjectOptions checks options.downloadBase against the operator default.
+// validateProjectOptions carries options.downloadBase over to spec.downloadBase and warns the
+// user when it differs from the operator default so they can review the generated value.
 func validateProjectOptions(d om.Deployment) []ValidationResult {
 	downloadBase := d.DownloadBase()
 	if downloadBase == "" || downloadBase == defaultDownloadBase {
 		return nil
 	}
 	return []ValidationResult{{
-		Severity: SeverityError,
-		Message:  fmt.Sprintf("options.downloadBase %q differs from the operator default %q. This value is not configurable via the Custom Resource.", downloadBase, defaultDownloadBase),
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("options.downloadBase %q will be carried over to spec.downloadBase in the generated Custom Resource.", downloadBase),
 	}}
 }
 

--- a/cmd/kubectl-mongodb/migrate-to-mck/validation.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/validation.go
@@ -28,7 +28,7 @@ var (
 	defaultKeyFile                = util.AutomationAgentKeyFilePathInContainer
 	defaultKeyFileWindows         = util.AutomationAgentWindowsKeyFilePath
 	defaultCAFilePath             = fmt.Sprintf("%s/ca-pem", util.TLSCaMountPath)
-	defaultDownloadBase           = util.PvcMmsMountPath
+	defaultDownloadBase           = util.DefaultPvcMmsMountPath
 	defaultMonitoringAgentLogPath = fmt.Sprintf("%s/monitoring-agent.log", util.PvcMountPathLogs)
 	defaultBackupAgentLogPath     = fmt.Sprintf("%s/backup-agent.log", util.PvcMountPathLogs)
 	defaultAuthSchemaVersion      = om.CalculateAuthSchemaVersion()

--- a/cmd/kubectl-mongodb/migrate-to-mck/validation_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/validation_test.go
@@ -292,16 +292,62 @@ func TestValidation_NonDefaultDownloadBase(t *testing.T) {
 	options := ac.Deployment["options"].(map[string]interface{})
 	options["downloadBase"] = "/opt/mongodb/automation"
 	ac.Deployment["options"] = options
+	// keyFile tracks downloadBase, so keep it consistent to isolate the downloadBase check.
+	ac.Auth.KeyFile = "/opt/mongodb/automation/keyfile"
 
-	results, _ := ValidateMigration(ac, ac.Deployment.ProcessMap(), nil)
-	hasError := false
+	results, sourceProcess := ValidateMigration(ac, ac.Deployment.ProcessMap(), nil)
+
+	require.NotNil(t, sourceProcess, "non-default downloadBase must not abort validation")
+
+	hasWarning := false
 	for _, r := range results {
-		if r.Severity == SeverityError && strings.Contains(r.Message, "downloadBase") {
-			hasError = true
+		if r.Severity == SeverityError {
+			assert.NotContains(t, r.Message, "downloadBase", "downloadBase must not produce an error")
+			assert.NotContains(t, r.Message, "keyFile", "consistent keyFile must not produce an error")
+		}
+		if r.Severity == SeverityWarning && strings.Contains(r.Message, "downloadBase") {
+			hasWarning = true
 			assert.Contains(t, r.Message, "/opt/mongodb/automation")
+			assert.Contains(t, r.Message, "spec.downloadBase")
 		}
 	}
-	assert.True(t, hasError, "expected error when downloadBase differs from default")
+	assert.True(t, hasWarning, "expected a warning when downloadBase differs from default")
+}
+
+func TestValidation_KeyFileRelativeToDownloadBase(t *testing.T) {
+	t.Run("keyFile under non-default downloadBase is accepted", func(t *testing.T) {
+		ac := baseValidReplicaSetAC()
+		options := ac.Deployment["options"].(map[string]interface{})
+		options["downloadBase"] = "/opt/mongodb/automation"
+		ac.Deployment["options"] = options
+		ac.Auth.KeyFile = "/opt/mongodb/automation/keyfile"
+
+		results, sourceProcess := ValidateMigration(ac, ac.Deployment.ProcessMap(), nil)
+		require.NotNil(t, sourceProcess, "keyFile matching downloadBase must not abort validation")
+		for _, r := range results {
+			if r.Severity == SeverityError {
+				assert.NotContains(t, r.Message, "keyFile", "keyFile under downloadBase must not error")
+			}
+		}
+	})
+
+	t.Run("default keyFile with non-default downloadBase is rejected", func(t *testing.T) {
+		ac := baseValidReplicaSetAC()
+		options := ac.Deployment["options"].(map[string]interface{})
+		options["downloadBase"] = "/opt/mongodb/automation"
+		ac.Deployment["options"] = options
+		// keyFile left at the default path -- now a mismatch against the download base.
+
+		results, _ := ValidateMigration(ac, ac.Deployment.ProcessMap(), nil)
+		hasError := false
+		for _, r := range results {
+			if r.Severity == SeverityError && strings.Contains(r.Message, "keyFile") {
+				hasError = true
+				assert.Contains(t, r.Message, "/opt/mongodb/automation/keyfile")
+			}
+		}
+		assert.True(t, hasError, "expected a keyFile error when it does not match the download base")
+	})
 }
 
 func TestValidation_NonDefaultKeyFileWindows(t *testing.T) {

--- a/cmd/kubectl-mongodb/migrate-to-mck/validation_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/validation_test.go
@@ -28,7 +28,7 @@ func loadTestAutomationConfig(t *testing.T, filename string) *om.AutomationConfi
 // so the mutation is the only thing that can trip the validation.
 func baseValidReplicaSetAC() *om.AutomationConfig {
 	ac := om.NewAutomationConfig(om.Deployment{
-		"options": map[string]interface{}{"downloadBase": util.PvcMmsMountPath},
+		"options": map[string]interface{}{"downloadBase": util.DefaultPvcMmsMountPath},
 		"processes": []interface{}{
 			map[string]interface{}{
 				"name": "my-rs-0", "processType": string(om.ProcessTypeMongod),

--- a/config/crd/bases/mongodb.com_mongodb.yaml
+++ b/config/crd/bases/mongodb.com_mongodb.yaml
@@ -828,6 +828,8 @@ spec:
               credentials:
                 description: Name of the Secret holding credentials information
                 type: string
+              downloadBase:
+                type: string
               duplicateServiceObjects:
                 description: |-
                   In few service mesh options for ex: Istio, by default we would need to duplicate the

--- a/config/crd/bases/mongodb.com_mongodb.yaml
+++ b/config/crd/bases/mongodb.com_mongodb.yaml
@@ -829,6 +829,13 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               downloadBase:
+                description: |-
+                  DownloadBase is the directory on the MongoDB host where the automation agent
+                  downloads and extracts MongoDB binaries. It is always used by the operator, and
+                  the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+                  defaults to "/var/lib/mongodb-mms-automation".
+                  This field should only be set (and only if needed) when migrating an existing
+                  VM-based deployment to the operator.
                 type: string
               duplicateServiceObjects:
                 description: |-

--- a/config/crd/bases/mongodb.com_mongodbmulticluster.yaml
+++ b/config/crd/bases/mongodb.com_mongodbmulticluster.yaml
@@ -556,6 +556,8 @@ spec:
               credentials:
                 description: Name of the Secret holding credentials information
                 type: string
+              downloadBase:
+                type: string
               duplicateServiceObjects:
                 description: |-
                   In few service mesh options for ex: Istio, by default we would need to duplicate the

--- a/config/crd/bases/mongodb.com_mongodbmulticluster.yaml
+++ b/config/crd/bases/mongodb.com_mongodbmulticluster.yaml
@@ -557,6 +557,13 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               downloadBase:
+                description: |-
+                  DownloadBase is the directory on the MongoDB host where the automation agent
+                  downloads and extracts MongoDB binaries. It is always used by the operator, and
+                  the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+                  defaults to "/var/lib/mongodb-mms-automation".
+                  This field should only be set (and only if needed) when migrating an existing
+                  VM-based deployment to the operator.
                 type: string
               duplicateServiceObjects:
                 description: |-

--- a/controllers/om/automation_config.go
+++ b/controllers/om/automation_config.go
@@ -224,7 +224,7 @@ func (ac *AutomationConfig) SetVersion(configVersion int64) *AutomationConfig {
 
 // SetOptionsDownloadBase is needed only for the cluster config file when we use a headless agent
 func (ac *AutomationConfig) SetOptionsDownloadBase(downloadBase string) *AutomationConfig {
-	ac.Deployment["options"] = map[string]string{"downloadBase": downloadBase}
+	ac.Deployment["options"] = map[string]interface{}{"downloadBase": downloadBase}
 
 	return ac
 }

--- a/controllers/om/deployment.go
+++ b/controllers/om/deployment.go
@@ -718,7 +718,7 @@ func (d Deployment) Debug(l *zap.SugaredLogger) {
 }
 
 func (d Deployment) SetDownloadBase(downloadBase string) {
-	d["options"] = map[string]string{"downloadBase": downloadBase}
+	d["options"] = map[string]interface{}{"downloadBase": downloadBase}
 }
 
 // ProcessesCopy returns the COPY of processes in the deployment.

--- a/controllers/om/deployment.go
+++ b/controllers/om/deployment.go
@@ -718,6 +718,11 @@ func (d Deployment) Debug(l *zap.SugaredLogger) {
 }
 
 func (d Deployment) SetDownloadBase(downloadBase string) {
+	// Only persist options.downloadBase when it differs from the agent's default (see
+	// agent-launcher.sh), which matches util.DefaultPvcMmsMountPath.
+	if downloadBase == "" || downloadBase == util.DefaultPvcMmsMountPath {
+		return
+	}
 	d["options"] = map[string]interface{}{"downloadBase": downloadBase}
 }
 

--- a/controllers/om/deployment.go
+++ b/controllers/om/deployment.go
@@ -717,6 +717,10 @@ func (d Deployment) Debug(l *zap.SugaredLogger) {
 	l.Debugf(">> Deployment: \n %s \n", string(b))
 }
 
+func (d Deployment) SetDownloadBase(downloadBase string) {
+	d["options"] = map[string]string{"downloadBase": downloadBase}
+}
+
 // ProcessesCopy returns the COPY of processes in the deployment.
 func (d Deployment) ProcessesCopy() []Process {
 	return d.deepCopy().GetProcesses()

--- a/controllers/om/deployment_test.go
+++ b/controllers/om/deployment_test.go
@@ -1015,9 +1015,20 @@ func TestLimitVotingMembers_AppliesNormallyWhenNoExternalMembers(t *testing.T) {
 }
 
 func TestSetDownloadBase(t *testing.T) {
-	d := NewDeployment()
+	t.Run("custom download base is set", func(t *testing.T) {
+		d := NewDeployment()
 
-	d.SetDownloadBase("/custom/download/base")
+		d.SetDownloadBase("/custom/download/base")
 
-	assert.Equal(t, "/custom/download/base", d.DownloadBase())
+		assert.Equal(t, "/custom/download/base", d.DownloadBase())
+	})
+
+	t.Run("default download base is not set", func(t *testing.T) {
+		d := NewDeployment()
+
+		d.SetDownloadBase(util.DefaultPvcMmsMountPath)
+
+		assert.Empty(t, d.DownloadBase())
+		assert.NotContains(t, d, "options")
+	})
 }

--- a/controllers/om/deployment_test.go
+++ b/controllers/om/deployment_test.go
@@ -1013,3 +1013,11 @@ func TestLimitVotingMembers_AppliesNormallyWhenNoExternalMembers(t *testing.T) {
 	assert.Equal(t, 0, got[7].Votes(), "8th member should be zeroed")
 	assert.Equal(t, float32(0), got[7].Priority(), "8th member priority should be zeroed")
 }
+
+func TestSetDownloadBase(t *testing.T) {
+	d := NewDeployment()
+
+	d.SetDownloadBase("/custom/download/base")
+
+	assert.Equal(t, "/custom/download/base", d.DownloadBase())
+}

--- a/controllers/operator/authentication/authentication.go
+++ b/controllers/operator/authentication/authentication.go
@@ -69,6 +69,10 @@ type Options struct {
 	AutoLdapGroupDN string
 
 	MongoDBResource types.NamespacedName
+
+	DownloadBase string
+
+	KeyfilePath string
 }
 
 func Redact(o Options) Options {
@@ -208,7 +212,7 @@ func Disable(ctx context.Context, client kubernetesClient.Client, conn om.Connec
 		}
 		ac.Auth.AutoAuthMechanisms = []string{}
 		ac.Auth.DeploymentAuthMechanisms = []string{}
-		ac.Auth.KeyFile = util.AutomationAgentKeyFilePathInContainer
+		ac.Auth.KeyFile = opts.KeyfilePath
 		ac.Auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 		ac.Auth.AuthoritativeSet = opts.AuthoritativeSet
 		ac.AgentSSL.ClientCertificateMode = util.OptionalClientCertficates

--- a/controllers/operator/authentication/authentication.go
+++ b/controllers/operator/authentication/authentication.go
@@ -70,9 +70,16 @@ type Options struct {
 
 	MongoDBResource types.NamespacedName
 
-	DownloadBase string
-
 	KeyfilePath string
+}
+
+// GetKeyfilePath returns the configured keyfile path, falling back to the default
+// in-container path when KeyfilePath is not explicitly set by the caller.
+func (o Options) GetKeyfilePath() string {
+	if o.KeyfilePath == "" {
+		return util.AutomationAgentKeyFilePathInContainer
+	}
+	return o.KeyfilePath
 }
 
 func Redact(o Options) Options {
@@ -212,7 +219,7 @@ func Disable(ctx context.Context, client kubernetesClient.Client, conn om.Connec
 		}
 		ac.Auth.AutoAuthMechanisms = []string{}
 		ac.Auth.DeploymentAuthMechanisms = []string{}
-		ac.Auth.KeyFile = opts.KeyfilePath
+		ac.Auth.KeyFile = opts.GetKeyfilePath()
 		ac.Auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 		ac.Auth.AuthoritativeSet = opts.AuthoritativeSet
 		ac.AgentSSL.ClientCertificateMode = util.OptionalClientCertficates

--- a/controllers/operator/authentication/ldap.go
+++ b/controllers/operator/authentication/ldap.go
@@ -28,7 +28,7 @@ func (l *ldapAuthMechanism) EnableAgentAuthentication(_ context.Context, _ kuber
 		auth.AutoPwd = opts.AutoPwd
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
-		auth.KeyFile = util.AutomationAgentKeyFilePathInContainer
+		auth.KeyFile = opts.KeyfilePath
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 
 		auth.AutoUser = opts.AutomationSubject

--- a/controllers/operator/authentication/ldap.go
+++ b/controllers/operator/authentication/ldap.go
@@ -28,7 +28,7 @@ func (l *ldapAuthMechanism) EnableAgentAuthentication(_ context.Context, _ kuber
 		auth.AutoPwd = opts.AutoPwd
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
-		auth.KeyFile = opts.KeyfilePath
+		auth.KeyFile = opts.GetKeyfilePath()
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 
 		auth.AutoUser = opts.AutomationSubject

--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -33,7 +33,7 @@ func (s *automationConfigScramSha) EnableAgentAuthentication(ctx context.Context
 		auth := ac.Auth
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
-		auth.KeyFile = util.AutomationAgentKeyFilePathInContainer
+		auth.KeyFile = opts.KeyfilePath
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 
 		// We can only have a single agent authentication mechanism specified at a given time

--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -33,7 +33,7 @@ func (s *automationConfigScramSha) EnableAgentAuthentication(ctx context.Context
 		auth := ac.Auth
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
-		auth.KeyFile = opts.KeyfilePath
+		auth.KeyFile = opts.GetKeyfilePath()
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 
 		// We can only have a single agent authentication mechanism specified at a given time

--- a/controllers/operator/authentication/x509.go
+++ b/controllers/operator/authentication/x509.go
@@ -28,7 +28,7 @@ func (x *connectionX509) EnableAgentAuthentication(_ context.Context, _ kubernet
 		auth.AutoPwd = util.MergoDelete
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
-		auth.KeyFile = util.AutomationAgentKeyFilePathInContainer
+		auth.KeyFile = opts.KeyfilePath
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 		ac.AgentSSL = &om.AgentSSL{
 			AutoPEMKeyFilePath:    opts.AutoPEMKeyFilePath,

--- a/controllers/operator/authentication/x509.go
+++ b/controllers/operator/authentication/x509.go
@@ -28,7 +28,7 @@ func (x *connectionX509) EnableAgentAuthentication(_ context.Context, _ kubernet
 		auth.AutoPwd = util.MergoDelete
 		auth.Disabled = false
 		auth.AuthoritativeSet = opts.AuthoritativeSet
-		auth.KeyFile = opts.KeyfilePath
+		auth.KeyFile = opts.GetKeyfilePath()
 		auth.KeyFileWindows = util.AutomationAgentWindowsKeyFilePath
 		ac.AgentSSL = &om.AgentSSL{
 			AutoPEMKeyFilePath:    opts.AutoPEMKeyFilePath,

--- a/controllers/operator/authentication_test.go
+++ b/controllers/operator/authentication_test.go
@@ -91,7 +91,7 @@ func TestUpdateOmAuthentication_NoAuthenticationEnabled(t *testing.T) {
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
-	r.updateOmAuthentication(ctx, conn, processNames, rs, "", "", "", false, zap.S())
+	r.updateOmAuthentication(ctx, conn, processNames, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 
 	ac, _ := conn.ReadAutomationConfig()
 
@@ -112,7 +112,7 @@ func TestUpdateOmAuthentication_EnableX509_TlsNotEnabled(t *testing.T) {
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, conn, []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, conn, []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 
 	assert.True(t, status.IsOK(), "configuring both options at once should not result in a failed status")
 	assert.True(t, isMultiStageReconciliation, "configuring both tls and x509 at once should result in a multi stage reconciliation")
@@ -124,7 +124,7 @@ func TestUpdateOmAuthentication_EnableX509_WithTlsAlreadyEnabled(t *testing.T) {
 	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)))
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 
 	assert.True(t, status.IsOK(), "configuring x509 when tls has already been enabled should not result in a failed status")
 	assert.False(t, isMultiStageReconciliation, "if tls is already enabled, we should be able to configure x509 is a single reconciliation")
@@ -140,7 +140,7 @@ func TestUpdateOmAuthentication_AuthenticationIsNotConfigured_IfAuthIsNotSet(t *
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
 
-	status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 	assert.True(t, status.IsOK(), "no authentication should have been configured")
 
 	ac, _ := omConnectionFactory.GetConnection().ReadAutomationConfig()
@@ -212,7 +212,7 @@ func TestUpdateOmAuthentication_EnableX509_FromEmptyDeployment(t *testing.T) {
 	secretName := util.AgentSecretName
 	createAgentCSRs(t, ctx, r.client, secretName, certsv1.CertificateApproved)
 
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 	assert.True(t, status.IsOK(), "configuring x509 and tls when there are no processes should not result in a failed status")
 	assert.False(t, isMultiStageReconciliation, "if we are enabling tls and x509 at once, this should be done in a single reconciliation")
 }
@@ -871,4 +871,36 @@ func createMockCSRBytes() []byte {
 	}
 
 	return certRequestPemBytes.Bytes()
+}
+
+func TestUpdateOmAuthentication_KeyFileFollowsDownloadBase(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("custom download base", func(t *testing.T) {
+		rs := DefaultReplicaSetBuilder().SetName("my-rs").SetMembers(3).EnableTLS().Build()
+		omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)))
+		kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
+		r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
+
+		status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", "/custom/download/base", false, zap.S())
+		assert.True(t, status.IsOK())
+
+		ac, err := omConnectionFactory.GetConnection().ReadAutomationConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/download/base/keyfile", ac.Auth.KeyFile)
+	})
+
+	t.Run("default download base preserves the legacy keyfile path", func(t *testing.T) {
+		rs := DefaultReplicaSetBuilder().SetName("my-rs").SetMembers(3).EnableTLS().Build()
+		omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)))
+		kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
+		r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
+
+		status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
+		assert.True(t, status.IsOK())
+
+		ac, err := omConnectionFactory.GetConnection().ReadAutomationConfig()
+		require.NoError(t, err)
+		assert.Equal(t, util.AutomationAgentKeyFilePathInContainer, ac.Auth.KeyFile)
+	})
 }

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -868,7 +868,7 @@ func getSubjectFromCertificate(cert string) (string, error) {
 // enables/disables authentication. If the authentication can't be fully configured, a boolean value indicating that
 // an additional reconciliation needs to be queued up to fully make the authentication changes is returned.
 // Note: updateOmAuthentication needs to be called before reconciling other auth related settings.
-func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, conn om.Connection, processNames []string, ar authentication.AuthResource, agentCertPath, caFilepath, clusterFilePath string, isRecovering bool, log *zap.SugaredLogger) (status workflow.Status, multiStageReconciliation bool) {
+func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, conn om.Connection, processNames []string, ar authentication.AuthResource, agentCertPath, caFilepath, clusterFilePath, downloadBase string, isRecovering bool, log *zap.SugaredLogger) (status workflow.Status, multiStageReconciliation bool) {
 	// don't touch authentication settings if resource has not been configured with them
 	if ar.GetSecurity() == nil || ar.GetSecurity().Authentication == nil {
 		return workflow.OK(), false
@@ -912,6 +912,8 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 		AutoLdapGroupDN:    ar.GetSecurity().Authentication.Agents.AutomationLdapGroupDN,
 		CAFilePath:         caFilepath,
 		MongoDBResource:    types.NamespacedName{Namespace: ar.GetNamespace(), Name: ar.GetName()},
+		DownloadBase:       downloadBase,
+		KeyfilePath:        downloadBase + "/keyfile",
 	}
 	var databaseSecretPath string
 	if r.VaultClient != nil {
@@ -1468,6 +1470,8 @@ func ReconcileReplicaSetAC(ctx context.Context, d om.Deployment, spec mdbv1.DbCo
 		// Prometheus can't be enabled.
 		_ = UpdatePrometheus(ctx, &d, pc.conn, pc.prometheus, pc.secretsClient, pc.namespace, pc.prometheusCertHash, log)
 	}
+
+	d.SetDownloadBase(spec.GetDownloadBase())
 
 	return nil
 }

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -912,7 +912,6 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 		AutoLdapGroupDN:    ar.GetSecurity().Authentication.Agents.AutomationLdapGroupDN,
 		CAFilePath:         caFilepath,
 		MongoDBResource:    types.NamespacedName{Namespace: ar.GetNamespace(), Name: ar.GetName()},
-		DownloadBase:       downloadBase,
 		KeyfilePath:        downloadBase + "/keyfile",
 	}
 	var databaseSecretPath string

--- a/controllers/operator/construct/construction_test.go
+++ b/controllers/operator/construct/construction_test.go
@@ -81,7 +81,7 @@ func TestBuildStatefulSet_PersistentVolumeClaimSingle(t *testing.T) {
 	checkMounts(t, set, []corev1.VolumeMount{
 		{Name: util.PvMms, MountPath: util.PvcMmsHomeMountPath, SubPath: util.PvcMmsHome},
 		{Name: util.PvMms, MountPath: util.PvcMountPathTmp, SubPath: util.PvcNameTmp},
-		{Name: util.PvMms, MountPath: util.PvcMmsMountPath, SubPath: util.PvcMms},
+		{Name: util.PvMms, MountPath: util.DefaultPvcMmsMountPath, SubPath: util.PvcMms},
 		{Name: AgentAPIKeyVolumeName, MountPath: AgentAPIKeySecretPath},
 		{Name: util.PvcNameData, MountPath: util.PvcMountPathData, SubPath: util.PvcNameData},
 		{Name: util.PvcNameData, MountPath: util.PvcMountPathJournal, SubPath: util.PvcNameJournal},
@@ -106,7 +106,7 @@ func TestBuildStatefulSet_PersistentVolumeClaimSingleStatic(t *testing.T) {
 	checkMounts(t, set, []corev1.VolumeMount{
 		{Name: util.PvMms, MountPath: util.PvcMmsHomeMountPath, SubPath: util.PvcMmsHome},
 		{Name: util.PvMms, MountPath: util.PvcMountPathTmp, SubPath: util.PvcNameTmp},
-		{Name: util.PvMms, MountPath: util.PvcMmsMountPath, SubPath: util.PvcMms},
+		{Name: util.PvMms, MountPath: util.DefaultPvcMmsMountPath, SubPath: util.PvcMms},
 		{Name: AgentAPIKeyVolumeName, MountPath: AgentAPIKeySecretPath},
 		{Name: util.PvcNameData, MountPath: util.PvcMountPathData, SubPath: util.PvcNameData},
 		{Name: util.PvcNameData, MountPath: util.PvcMountPathJournal, SubPath: util.PvcNameJournal},
@@ -138,7 +138,7 @@ func TestBuildStatefulSet_PersistentVolumeClaimMultiple(t *testing.T) {
 	checkMounts(t, set, []corev1.VolumeMount{
 		{Name: util.PvMms, MountPath: util.PvcMmsHomeMountPath, SubPath: util.PvcMmsHome},
 		{Name: util.PvMms, MountPath: util.PvcMountPathTmp, SubPath: util.PvcNameTmp},
-		{Name: util.PvMms, MountPath: util.PvcMmsMountPath, SubPath: util.PvcMms},
+		{Name: util.PvMms, MountPath: util.DefaultPvcMmsMountPath, SubPath: util.PvcMms},
 		{Name: AgentAPIKeyVolumeName, MountPath: AgentAPIKeySecretPath},
 		{Name: util.PvcNameData, MountPath: util.PvcMountPathData},
 		{Name: PvcNameDatabaseScripts, MountPath: PvcMountPathScripts, ReadOnly: true},
@@ -167,7 +167,7 @@ func TestBuildStatefulSet_PersistentVolumeClaimMultipleDefaults(t *testing.T) {
 	checkMounts(t, set, []corev1.VolumeMount{
 		{Name: util.PvMms, MountPath: util.PvcMmsHomeMountPath, SubPath: util.PvcMmsHome},
 		{Name: util.PvMms, MountPath: util.PvcMountPathTmp, SubPath: util.PvcNameTmp},
-		{Name: util.PvMms, MountPath: util.PvcMmsMountPath, SubPath: util.PvcMms},
+		{Name: util.PvMms, MountPath: util.DefaultPvcMmsMountPath, SubPath: util.PvcMms},
 		{Name: AgentAPIKeyVolumeName, MountPath: AgentAPIKeySecretPath},
 		{Name: util.PvcNameData, MountPath: util.PvcMountPathData},
 		{Name: PvcNameDatabaseScripts, MountPath: PvcMountPathScripts, ReadOnly: true},

--- a/controllers/operator/construct/construction_test.go
+++ b/controllers/operator/construct/construction_test.go
@@ -332,6 +332,42 @@ func defaultPodVars() *env.PodEnvVars {
 	return &env.PodEnvVars{BaseURL: "http://localhost:8080", ProjectID: "myProject", User: "user@some.com"}
 }
 
+// assertAgentDownloadMount asserts that exactly one volume mount uses the agent
+// empty-dir volume with the download-base subpath, mounted at expectedPath.
+func assertAgentDownloadMount(t *testing.T, set appsv1.StatefulSet, expectedPath string) {
+	found := false
+	for _, c := range set.Spec.Template.Spec.Containers {
+		for _, m := range c.VolumeMounts {
+			if m.Name == util.PvMms && m.SubPath == util.PvcMms {
+				assert.Equal(t, expectedPath, m.MountPath, "agent download volume mount path")
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "expected an agent download volume mount (%s/%s)", util.PvMms, util.PvcMms)
+}
+
+func TestBuildStatefulSet_CustomDownloadBase(t *testing.T) {
+	t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.NonStatic))
+
+	rs := mdbv1.NewReplicaSetBuilder().Build()
+	rs.Spec.DownloadBase = "/custom/download/base"
+
+	set := DatabaseStatefulSet(*rs, ReplicaSetOptions(GetPodEnvOptions()), zap.S())
+
+	assertAgentDownloadMount(t, set, "/custom/download/base")
+}
+
+func TestBuildStatefulSet_DefaultDownloadBase(t *testing.T) {
+	t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.NonStatic))
+
+	rs := mdbv1.NewReplicaSetBuilder().Build()
+
+	set := DatabaseStatefulSet(*rs, ReplicaSetOptions(GetPodEnvOptions()), zap.S())
+
+	assertAgentDownloadMount(t, set, util.DefaultPvcMmsMountPath)
+}
+
 func TestPodAntiAffinityOverride(t *testing.T) {
 	podAntiAffinity := defaultPodAntiAffinity()
 

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -69,6 +69,7 @@ const (
 	LogFileMongoDBEnv                = "MDB_LOG_FILE_MONGODB"
 	LogFileAgentMonitoringEnv        = "MDB_LOG_FILE_MONITORING_AGENT"
 	LogFileAgentBackupEnv            = "MDB_LOG_FILE_BACKUP_AGENT"
+	DownloadBaseEnv                  = "MMS_DOWNLOAD_BASE"
 )
 
 type StsType int
@@ -134,6 +135,8 @@ type DatabaseStatefulSetOptions struct {
 
 	AgentDebug      bool
 	AgentDebugImage string
+
+	DownloadBase string
 }
 
 func (d DatabaseStatefulSetOptions) IsMongos() bool {
@@ -158,6 +161,8 @@ type databaseStatefulSetSource interface {
 	GetPrometheus() *mdbcv1.Prometheus
 
 	GetAnnotations() map[string]string
+
+	GetDownloadBase() string
 }
 
 // StandaloneOptions returns a set of options which will configure a Standalone StatefulSet
@@ -212,6 +217,7 @@ func ReplicaSetOptions(additionalOpts ...func(options *DatabaseStatefulSetOption
 			Labels:                  mdb.Labels,
 			MultiClusterMode:        mdb.Spec.IsMultiCluster(),
 			StsType:                 ReplicaSet,
+			DownloadBase:            mdb.Spec.GetDownloadBase(),
 		}
 
 		if mdb.Spec.DbCommonSpec.GetExternalDomain() != nil {
@@ -714,7 +720,7 @@ func getVolumesAndVolumeMounts(mdb databaseStatefulSetSource, databaseOpts Datab
 		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(AgentAPIKeyVolumeName, AgentAPIKeySecretPath))
 	}
 
-	volumesToAdd, volumeMounts = GetNonPersistentAgentVolumeMounts(volumesToAdd, volumeMounts)
+	volumesToAdd, volumeMounts = GetNonPersistentAgentVolumeMounts(volumesToAdd, volumeMounts, databaseOpts.DownloadBase)
 
 	return volumesToAdd, volumeMounts
 }
@@ -763,12 +769,14 @@ func buildStaticArchitecturePodTemplateSpec(opts DatabaseStatefulSetOptions, mdb
 		container.WithResourceRequirements(buildRequirementsFromPodSpec(*opts.PodSpec)),
 		container.WithImage(opts.MongodbImage),
 		container.WithEnvs(databaseEnvVars(opts)...),
+		//container.WithEnvs(logConfigurationToEnvVars(opts.AgentConfig.StartupParameters, opts.AdditionalMongodConfig)...),
 		container.WithCommand([]string{"bash", "-c", "tail -F -n0 ${MDB_LOG_FILE_MONGODB} mongodb_marker"}),
 		configureContainerSecurityContext,
 	)}
 
 	agentUtilitiesHolderModifications := []func(*corev1.Container){container.Apply(
 		container.WithName(util.AgentContainerUtilitiesName),
+		container.WithImagePullPolicy(corev1.PullPolicy(env.ReadOrPanic(util.AutomationAgentImagePullPolicy))),
 		container.WithArgs([]string{""}),
 		container.WithImage(opts.InitDatabaseImage),
 		container.WithEnvs(databaseEnvVars(opts)...),
@@ -955,6 +963,7 @@ func staticContainersEnvVars(mdb databaseStatefulSetSource) []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 	if architectures.IsRunningStaticArchitecture(mdb.GetAnnotations()) {
 		envVars = append(envVars, corev1.EnvVar{Name: "MDB_STATIC_CONTAINERS_ARCHITECTURE", Value: "true"})
+		envVars = append(envVars, corev1.EnvVar{Name: DownloadBaseEnv, Value: mdb.GetDownloadBase()})
 	}
 	return envVars
 }
@@ -1132,12 +1141,12 @@ func GetNonPersistentMongoDBVolumeMounts(volumes []corev1.Volume, volumeMounts [
 }
 
 // GetNonPersistentAgentVolumeMounts returns two arrays of non-persistent, empty volumes and corresponding mounts for the Agent container.
-func GetNonPersistentAgentVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount) {
+func GetNonPersistentAgentVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, downloadBase string) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumes = append(volumes, statefulset.CreateVolumeFromEmptyDir(util.PvMms))
 
 	// The agent reads and writes into its own directory. It also contains a subdirectory called downloads.
 	// This one is published by the Dockerfile
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvMms, util.PvcMmsMountPath, statefulset.WithSubPath(util.PvcMms)))
+	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvMms, downloadBase, statefulset.WithSubPath(util.PvcMms)))
 
 	// Runtime data for MMS
 	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvMms, util.PvcMmsHomeMountPath, statefulset.WithSubPath(util.PvcMmsHome)))

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -263,6 +263,7 @@ func shardedOptions(cfg shardedOptionCfg, additionalOpts ...func(options *Databa
 		MultiClusterMode:        cfg.mdb.Spec.IsMultiCluster(),
 		Persistent:              cfg.persistent,
 		StsType:                 cfg.stsType,
+		DownloadBase:            cfg.mdb.Spec.GetDownloadBase(),
 	}
 
 	if cfg.mdb.Spec.IsMultiCluster() {

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -770,14 +770,13 @@ func buildStaticArchitecturePodTemplateSpec(opts DatabaseStatefulSetOptions, mdb
 		container.WithResourceRequirements(buildRequirementsFromPodSpec(*opts.PodSpec)),
 		container.WithImage(opts.MongodbImage),
 		container.WithEnvs(databaseEnvVars(opts)...),
-		//container.WithEnvs(logConfigurationToEnvVars(opts.AgentConfig.StartupParameters, opts.AdditionalMongodConfig)...),
+		container.WithEnvs(logConfigurationToEnvVars(opts.AgentConfig.StartupParameters, opts.AdditionalMongodConfig)...),
 		container.WithCommand([]string{"bash", "-c", "tail -F -n0 ${MDB_LOG_FILE_MONGODB} mongodb_marker"}),
 		configureContainerSecurityContext,
 	)}
 
 	agentUtilitiesHolderModifications := []func(*corev1.Container){container.Apply(
 		container.WithName(util.AgentContainerUtilitiesName),
-		container.WithImagePullPolicy(corev1.PullPolicy(env.ReadOrPanic(util.AutomationAgentImagePullPolicy))),
 		container.WithArgs([]string{""}),
 		container.WithImage(opts.InitDatabaseImage),
 		container.WithEnvs(databaseEnvVars(opts)...),
@@ -964,7 +963,6 @@ func staticContainersEnvVars(mdb databaseStatefulSetSource) []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 	if architectures.IsRunningStaticArchitecture(mdb.GetAnnotations()) {
 		envVars = append(envVars, corev1.EnvVar{Name: "MDB_STATIC_CONTAINERS_ARCHITECTURE", Value: "true"})
-		envVars = append(envVars, corev1.EnvVar{Name: DownloadBaseEnv, Value: mdb.GetDownloadBase()})
 	}
 	return envVars
 }
@@ -1071,6 +1069,13 @@ func databaseEnvVars(opts DatabaseStatefulSetOptions) []corev1.EnvVar {
 		// Non-static pods download the agent
 		zap.S().Debugf("using external agent version for: %s", opts.ExternalAgentVersion)
 		vars = append(vars, corev1.EnvVar{Name: util.EnvVarAgentVersion, Value: opts.ExternalAgentVersion})
+	}
+
+	// The agent extracts MongoDB binaries and places the keyfile under this directory. It must match
+	// the volume mount path (see GetNonPersistentAgentVolumeMounts) and options.downloadBase in the
+	// automation config, in both static and non-static architectures.
+	if opts.DownloadBase != "" {
+		vars = append(vars, corev1.EnvVar{Name: DownloadBaseEnv, Value: opts.DownloadBase})
 	}
 
 	// append any additional env vars specified.

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -1074,8 +1074,10 @@ func databaseEnvVars(opts DatabaseStatefulSetOptions) []corev1.EnvVar {
 	// The agent extracts MongoDB binaries and places the keyfile under this directory. It must match
 	// the volume mount path (see GetNonPersistentAgentVolumeMounts) and options.downloadBase in the
 	// automation config, in both static and non-static architectures.
-	if opts.DownloadBase != "" {
-		vars = append(vars, corev1.EnvVar{Name: DownloadBaseEnv, Value: opts.DownloadBase})
+	// Only set the env var when it differs from the launcher's default (see agent-launcher.sh),
+	// which matches util.DefaultPvcMmsMountPath.
+	if downloadBase := opts.GetDownloadBase(); downloadBase != util.DefaultPvcMmsMountPath {
+		vars = append(vars, corev1.EnvVar{Name: DownloadBaseEnv, Value: downloadBase})
 	}
 
 	// append any additional env vars specified.

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -150,6 +150,16 @@ func (d DatabaseStatefulSetOptions) GetStatefulSetName() string {
 	return d.Name
 }
 
+// GetDownloadBase returns the configured download base, falling back to util.DefaultPvcMmsMountPath
+// when unset. Leaving DownloadBase empty in the struct therefore yields the same behavior as before
+// the field was introduced.
+func (d DatabaseStatefulSetOptions) GetDownloadBase() string {
+	if d.DownloadBase != "" {
+		return d.DownloadBase
+	}
+	return util.DefaultPvcMmsMountPath
+}
+
 // databaseStatefulSetSource is an interface which provides all the required fields to fully construct
 // a database StatefulSet.
 type databaseStatefulSetSource interface {
@@ -185,6 +195,8 @@ func StandaloneOptions(additionalOpts ...func(options *DatabaseStatefulSetOption
 			StatefulSetSpecOverride: stsSpec,
 			MultiClusterMode:        mdb.Spec.IsMultiCluster(),
 			StsType:                 Standalone,
+			// Standalone deliberately leaves DownloadBase unset: it does not support configuring the
+			// download base (used only for VM migration), so GetDownloadBase falls back to the default.
 		}
 
 		for _, opt := range additionalOpts {
@@ -721,7 +733,7 @@ func getVolumesAndVolumeMounts(mdb databaseStatefulSetSource, databaseOpts Datab
 		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(AgentAPIKeyVolumeName, AgentAPIKeySecretPath))
 	}
 
-	volumesToAdd, volumeMounts = GetNonPersistentAgentVolumeMounts(volumesToAdd, volumeMounts, databaseOpts.DownloadBase)
+	volumesToAdd, volumeMounts = GetNonPersistentAgentVolumeMounts(volumesToAdd, volumeMounts, databaseOpts.GetDownloadBase())
 
 	return volumesToAdd, volumeMounts
 }

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -404,6 +404,67 @@ func TestGetAutomationLogEnvVars(t *testing.T) {
 	})
 }
 
+func TestDatabaseStatefulSet_DownloadBaseEnvVar(t *testing.T) {
+	t.Run("static architecture sets MMS_DOWNLOAD_BASE to the configured value", func(t *testing.T) {
+		t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.Static))
+
+		mdb := mdbv1.NewReplicaSetBuilder().Build()
+		mdb.Spec.DownloadBase = "/custom/download/base"
+
+		sts := DatabaseStatefulSet(*mdb, ReplicaSetOptions(GetPodEnvOptions()), zap.S())
+
+		agentIdx := slices.IndexFunc(sts.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
+			return c.Name == util.AgentContainerName
+		})
+		require.NotEqual(t, -1, agentIdx)
+		assert.Contains(t, sts.Spec.Template.Spec.Containers[agentIdx].Env,
+			corev1.EnvVar{Name: DownloadBaseEnv, Value: "/custom/download/base"})
+	})
+
+	t.Run("non-static architecture does not set MMS_DOWNLOAD_BASE", func(t *testing.T) {
+		t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.NonStatic))
+
+		mdb := mdbv1.NewReplicaSetBuilder().Build()
+
+		sts := DatabaseStatefulSet(*mdb, ReplicaSetOptions(GetPodEnvOptions()), zap.S())
+
+		for _, c := range sts.Spec.Template.Spec.Containers {
+			for _, e := range c.Env {
+				assert.NotEqual(t, DownloadBaseEnv, e.Name, "MMS_DOWNLOAD_BASE should not be set in non-static architecture")
+			}
+		}
+	})
+}
+
+func TestBuildStatefulSet_ShardedCustomDownloadBase(t *testing.T) {
+	t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.NonStatic))
+
+	sc := mdbv1.NewClusterBuilder().Build()
+	sc.Spec.DownloadBase = "/custom/download/base"
+
+	kubeClient, _ := mock.NewDefaultFakeClient(sc)
+	shardSpec, memberCluster := createShardSpecAndDefaultCluster(kubeClient, sc)
+	configServerSpec := createConfigSrvSpec(sc)
+	mongosSpec := createMongosSpec(sc)
+
+	withPodVars := func(options *DatabaseStatefulSetOptions) {
+		options.PodVars = defaultPodVars()
+	}
+
+	cases := map[string]func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions{
+		"shard":        ShardOptions(0, shardSpec, memberCluster.Name, withPodVars),
+		"configserver": ConfigServerOptions(configServerSpec, memberCluster.Name, withPodVars),
+		"mongos":       MongosOptions(mongosSpec, memberCluster.Name, withPodVars),
+	}
+
+	for name, optFunc := range cases {
+		t.Run(name, func(t *testing.T) {
+			set := DatabaseStatefulSet(*sc, optFunc, zap.S())
+			assertAgentDownloadMount(t, set, "/custom/download/base")
+		})
+	}
+}
+
 func TestDatabaseStatefulSet_StaticContainersEnvVars(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -421,18 +421,20 @@ func TestDatabaseStatefulSet_DownloadBaseEnvVar(t *testing.T) {
 			corev1.EnvVar{Name: DownloadBaseEnv, Value: "/custom/download/base"})
 	})
 
-	t.Run("non-static architecture does not set MMS_DOWNLOAD_BASE", func(t *testing.T) {
+	t.Run("non-static architecture sets MMS_DOWNLOAD_BASE to the configured value", func(t *testing.T) {
 		t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.NonStatic))
 
 		mdb := mdbv1.NewReplicaSetBuilder().Build()
+		mdb.Spec.DownloadBase = "/custom/download/base"
 
 		sts := DatabaseStatefulSet(*mdb, ReplicaSetOptions(GetPodEnvOptions()), zap.S())
 
-		for _, c := range sts.Spec.Template.Spec.Containers {
-			for _, e := range c.Env {
-				assert.NotEqual(t, DownloadBaseEnv, e.Name, "MMS_DOWNLOAD_BASE should not be set in non-static architecture")
-			}
-		}
+		agentIdx := slices.IndexFunc(sts.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
+			return c.Name == util.DatabaseContainerName
+		})
+		require.NotEqual(t, -1, agentIdx)
+		assert.Contains(t, sts.Spec.Template.Spec.Containers[agentIdx].Env,
+			corev1.EnvVar{Name: DownloadBaseEnv, Value: "/custom/download/base"})
 	})
 }
 

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -436,6 +436,23 @@ func TestDatabaseStatefulSet_DownloadBaseEnvVar(t *testing.T) {
 		assert.Contains(t, sts.Spec.Template.Spec.Containers[agentIdx].Env,
 			corev1.EnvVar{Name: DownloadBaseEnv, Value: "/custom/download/base"})
 	})
+
+	t.Run("default download base does not set MMS_DOWNLOAD_BASE", func(t *testing.T) {
+		t.Setenv(architectures.DefaultEnvArchitecture, string(architectures.NonStatic))
+
+		// No DownloadBase configured, so GetDownloadBase returns util.DefaultPvcMmsMountPath.
+		mdb := mdbv1.NewReplicaSetBuilder().Build()
+
+		sts := DatabaseStatefulSet(*mdb, ReplicaSetOptions(GetPodEnvOptions()), zap.S())
+
+		agentIdx := slices.IndexFunc(sts.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
+			return c.Name == util.DatabaseContainerName
+		})
+		require.NotEqual(t, -1, agentIdx)
+		for _, env := range sts.Spec.Template.Spec.Containers[agentIdx].Env {
+			assert.NotEqual(t, DownloadBaseEnv, env.Name)
+		}
+	})
 }
 
 func TestBuildStatefulSet_ShardedCustomDownloadBase(t *testing.T) {

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -760,7 +760,7 @@ func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Conte
 
 	caFilePath := mrs.GetSecurity().GetTLSCAFilePath(path.Join(util.TLSCaMountPath, tls.CAConfigMapKey))
 
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, rs.GetProcessNames(), &mrs, agentCertPath, caFilePath, internalClusterCertPath, isRecovering, log)
+	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, rs.GetProcessNames(), &mrs, agentCertPath, caFilePath, internalClusterCertPath, mrs.Spec.GetDownloadBase(), isRecovering, log)
 	if !status.IsOK() && !isRecovering {
 		return xerrors.Errorf("failed to enable Authentication for MongoDB Multi Replicaset")
 	}

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -808,7 +808,7 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 	replicaSet := replicaset.BuildFromMongoDBWithReplicas(reconciler.imageUrls[mcoConstruct.MongodbImageEnv], reconciler.forceEnterprise, rs, replicasTarget, rs.CalculateFeatureCompatibilityVersion(), tlsCertPath, processIds)
 	processNames := replicaSet.GetProcessNames()
 
-	status, additionalReconciliationRequired := reconciler.updateOmAuthentication(ctx, conn, processNames, rs, deploymentOptions.agentCertPath, caFilePath, internalClusterCertPath, isRecovering, log)
+	status, additionalReconciliationRequired := reconciler.updateOmAuthentication(ctx, conn, processNames, rs, deploymentOptions.agentCertPath, caFilePath, internalClusterCertPath, rs.Spec.GetDownloadBase(), isRecovering, log)
 	if !status.IsOK() && !isRecovering {
 		return status
 	}

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -2230,6 +2230,8 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 			d.ConfigureMonitoringAndBackup(log, sc.Spec.GetSecurity().IsTLSEnabled(), opts.caFilePath)
 			d.ConfigureTLS(sc.Spec.GetSecurity(), opts.caFilePath)
 
+			d.SetDownloadBase(sc.Spec.GetDownloadBase())
+
 			setupInternalClusterAuth(d, sc.GetShardedClusterName(), sc.GetSecurity().GetInternalClusterAuthenticationMode(),
 				configSrvInternalClusterPath, mongosInternalClusterPath, sc.ShardACRsNames(), shardInternalClusterPaths)
 

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -2167,7 +2167,7 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 
 	logDiffOfProcessNames(opts.processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "updateOmAuthentication"))
 
-	workflowStatus, additionalReconciliationRequired := r.commonController.updateOmAuthentication(ctx, conn, healthyProcessesToWaitForReadyState, sc, opts.agentCertPath, opts.caFilePath, "", isRecovering, log)
+	workflowStatus, additionalReconciliationRequired := r.commonController.updateOmAuthentication(ctx, conn, healthyProcessesToWaitForReadyState, sc, opts.agentCertPath, opts.caFilePath, "", sc.Spec.GetDownloadBase(), isRecovering, log)
 	if !workflowStatus.IsOK() {
 		if !isRecovering {
 			return nil, false, workflowStatus

--- a/controllers/operator/mongodbshardedcluster_controller_test.go
+++ b/controllers/operator/mongodbshardedcluster_controller_test.go
@@ -2428,3 +2428,17 @@ func TestShardedRSK8sConfigMatchesDesiredConfiguration(t *testing.T) {
 		assert.Equal(t, desired.MemberConfig, memberConfig, "shard %d memberConfig", shardIdx)
 	}
 }
+
+func TestReconcileShardedCluster_SetsDownloadBase(t *testing.T) {
+	ctx := context.Background()
+	sc := test.DefaultClusterBuilder().Build()
+	sc.Spec.DownloadBase = "/custom/download/base"
+
+	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay)
+	require.NoError(t, err)
+
+	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
+
+	mockedConn := omConnectionFactory.GetConnection().(*om.MockedOmConnection)
+	assert.Equal(t, "/custom/download/base", mockedConn.GetDeployment().DownloadBase())
+}

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -362,7 +362,7 @@ func (r *ReconcileMongoDbStandalone) updateOmDeployment(ctx context.Context, con
 	}
 
 	// TODO standalone PR
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, agentCertPath, "", "", isRecovering, log)
+	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, agentCertPath, "", "", util.DefaultPvcMmsMountPath, isRecovering, log)
 	if !status.IsOK() {
 		return status
 	}

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -8,6 +8,10 @@ MDB_STATIC_CONTAINERS_ARCHITECTURE="${MDB_STATIC_CONTAINERS_ARCHITECTURE:-}"
 MMS_HOME=${MMS_HOME:-/mongodb-automation}
 MMS_LOG_DIR=${MMS_LOG_DIR:-/var/log/mongodb-mms-automation}
 
+# This is the directory corresponding to 'options.downloadBase' in the automation config - the directory where
+# the agent will extract MongoDB binaries to
+MMS_DOWNLOAD_BASE=${MMS_DOWNLOAD_BASE:-/var/lib/mongodb-mms-automation}
+
 if [ -z "${MDB_STATIC_CONTAINERS_ARCHITECTURE}" ]; then
   AGENT_BINARY_PATH="${MMS_HOME}/files/mongodb-mms-automation-agent"
 else
@@ -32,16 +36,13 @@ tail -F -n0 "${MDB_LOG_FILE_BACKUP_AGENT}" 2> /dev/null | json_log 'backup-agent
 tail -F -n0 "${MDB_LOG_FILE_MONGODB}" 2> /dev/null | json_log 'mongodb' &
 tail -F -n0 "${MDB_LOG_FILE_MONGODB_AUDIT}" 2> /dev/null | json_log 'mongodb-audit' &
 
-# This is the directory corresponding to 'options.downloadBase' in the automation config - the directory where
-# the agent will extract MongoDB binaries to
-mdb_downloads_dir="/var/lib/mongodb-mms-automation"
-
 # The path to the automation config file in case the agent is run in headless mode
 cluster_config_file="/var/lib/mongodb-automation/cluster-config.json"
 
+# TODO seems to be redundant, ensure before removing
 # file required by Automation Agents of authentication is enabled.
-touch "${mdb_downloads_dir}/keyfile"
-chmod 600 "${mdb_downloads_dir}/keyfile"
+#touch "${MMS_DOWNLOAD_BASE}/keyfile"
+#chmod 600 "${MMS_DOWNLOAD_BASE}/keyfile"
 
 ensure_certs_symlinks
 
@@ -208,22 +209,22 @@ else
   if [ -n "${MONGOD_PID}" ] && [ "${MONGOD_PID}" -ne 0 ]; then
     echo "Mongod PID: ${MONGOD_PID}"
     MONGOD_ROOT="/proc/${MONGOD_PID}/root"
-    mkdir -p "${mdb_downloads_dir}/mongod"
-    mkdir -p "${mdb_downloads_dir}/mongod/bin"
-    ln -sf "${MONGOD_ROOT}/bin/mongo" ${mdb_downloads_dir}/mongod/bin/mongo
-    ln -sf "${MONGOD_ROOT}/bin/mongod" ${mdb_downloads_dir}/mongod/bin/mongod
-    ln -sf "${MONGOD_ROOT}/bin/mongos" ${mdb_downloads_dir}/mongod/bin/mongos
+    mkdir -p "${MMS_DOWNLOAD_BASE}/mongod"
+    mkdir -p "${MMS_DOWNLOAD_BASE}/mongod/bin"
+    ln -sf "${MONGOD_ROOT}/bin/mongo" ${MMS_DOWNLOAD_BASE}/mongod/bin/mongo
+    ln -sf "${MONGOD_ROOT}/bin/mongod" ${MMS_DOWNLOAD_BASE}/mongod/bin/mongod
+    ln -sf "${MONGOD_ROOT}/bin/mongos" ${MMS_DOWNLOAD_BASE}/mongod/bin/mongos
 
     for tool in mongoimport mongodump mongorestore mongoexport; do
       [ -e "/tools/${tool}" ] || { echo "/tools/${tool} not found"; exit 1; }
-      ln -sf "/tools/${tool}" ${mdb_downloads_dir}/mongod/bin/${tool}
+      ln -sf "/tools/${tool}" ${MMS_DOWNLOAD_BASE}/mongod/bin/${tool}
     done
   else
     echo "Mongod PID not found within the specified time."
     exit 1
   fi
 
-  agentOpts+=("-binariesFixedPath=${mdb_downloads_dir}/mongod/bin")
+  agentOpts+=("-binariesFixedPath=${MMS_DOWNLOAD_BASE}/mongod/bin")
 fi
 
 # Note, that we do logging in subshell - this allows us to save the correct PID to variable (not the logging one)

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -210,13 +210,13 @@ else
     MONGOD_ROOT="/proc/${MONGOD_PID}/root"
     mkdir -p "${MMS_DOWNLOAD_BASE}/mongod"
     mkdir -p "${MMS_DOWNLOAD_BASE}/mongod/bin"
-    ln -sf "${MONGOD_ROOT}/bin/mongo" ${MMS_DOWNLOAD_BASE}/mongod/bin/mongo
-    ln -sf "${MONGOD_ROOT}/bin/mongod" ${MMS_DOWNLOAD_BASE}/mongod/bin/mongod
-    ln -sf "${MONGOD_ROOT}/bin/mongos" ${MMS_DOWNLOAD_BASE}/mongod/bin/mongos
+    ln -sf "${MONGOD_ROOT}/bin/mongo" "${MMS_DOWNLOAD_BASE}/mongod/bin/mongo"
+    ln -sf "${MONGOD_ROOT}/bin/mongod" "${MMS_DOWNLOAD_BASE}/mongod/bin/mongod"
+    ln -sf "${MONGOD_ROOT}/bin/mongos" "${MMS_DOWNLOAD_BASE}/mongod/bin/mongos"
 
     for tool in mongoimport mongodump mongorestore mongoexport; do
       [ -e "/tools/${tool}" ] || { echo "/tools/${tool} not found"; exit 1; }
-      ln -sf "/tools/${tool}" ${MMS_DOWNLOAD_BASE}/mongod/bin/${tool}
+      ln -sf "/tools/${tool}" "${MMS_DOWNLOAD_BASE}/mongod/bin/${tool}"
     done
   else
     echo "Mongod PID not found within the specified time."

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -39,10 +39,9 @@ tail -F -n0 "${MDB_LOG_FILE_MONGODB_AUDIT}" 2> /dev/null | json_log 'mongodb-aud
 # The path to the automation config file in case the agent is run in headless mode
 cluster_config_file="/var/lib/mongodb-automation/cluster-config.json"
 
-# TODO seems to be redundant, ensure before removing
 # file required by Automation Agents of authentication is enabled.
-#touch "${MMS_DOWNLOAD_BASE}/keyfile"
-#chmod 600 "${MMS_DOWNLOAD_BASE}/keyfile"
+touch "${MMS_DOWNLOAD_BASE}/keyfile"
+chmod 600 "${MMS_DOWNLOAD_BASE}/keyfile"
 
 ensure_certs_symlinks
 

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256.py
@@ -38,6 +38,7 @@ from tests.vm_migration.vm_migration_replicaset_helper import (
 )
 
 RS_NAME = "vm-mongodb-rs"
+DOWNLOAD_BASE = "/var/lib/custom-mms-automation"
 APP_USER_PASSWORD = "appUser123!"
 REPORTING_USER_PASSWORD = "reporting456!"
 
@@ -129,9 +130,10 @@ def _configure_ac(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service:
         "autoAuthRestrictions": [],
         "autoPwd": "mms-automation-agent-password",
         "key": "bXlrZXlmaWxlY29udGVudHM=",
-        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfile": f"{DOWNLOAD_BASE}/keyfile",
         "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
     }
+    ac["options"] = {"downloadBase": DOWNLOAD_BASE}
 
     ac["roles"] = [
         {
@@ -361,6 +363,14 @@ def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, v
 
 
 @mark.e2e_vm_migration_replicaset_scram_sha256
+def test_download_base_carried_over(generated_cr: dict):
+    """The non-default options.downloadBase is carried into spec.downloadBase."""
+    assert (
+        generated_cr["spec"].get("downloadBase") == DOWNLOAD_BASE
+    ), f"Expected spec.downloadBase={DOWNLOAD_BASE}, got: {generated_cr['spec'].get('downloadBase')}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
 def test_user_crs_emitted(generated_cr_yaml: str):
     user_docs = generated_user_docs(generated_cr_yaml)
     usernames = {d["spec"]["username"] for d in user_docs}
@@ -415,6 +425,33 @@ def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
 def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
     mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
     assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_keyfile_placed_in_operator_pods(namespace: str, vm_sts: dict, mdb_migration: MongoDB):
+    """The operator places the keyfile at <downloadBase>/keyfile in every migrated pod."""
+    keyfile_path = f"{DOWNLOAD_BASE}/keyfile"
+    for i in range(vm_sts["spec"]["replicas"]):
+        pod_name = f"{RS_NAME}-{i}"
+        output = KubernetesTester.run_command_in_pod_container(
+            pod_name,
+            namespace,
+            ["sh", "-c", f"test -f {keyfile_path} && echo FOUND"],
+            container="mongodb-enterprise-database",
+        )
+        assert "FOUND" in output, f"keyfile not found at {keyfile_path} in pod {pod_name}; got: {output!r}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_operator_preserves_download_base_and_keyfile(om_tester: OMTester):
+    """After the operator takes over, the automation config keeps the custom downloadBase/keyfile."""
+    ac = om_tester.api_get_automation_config()
+    assert (
+        ac.get("options", {}).get("downloadBase") == DOWNLOAD_BASE
+    ), f"Expected options.downloadBase={DOWNLOAD_BASE}, got: {ac.get('options', {}).get('downloadBase')}"
+    assert (
+        ac.get("auth", {}).get("keyfile") == f"{DOWNLOAD_BASE}/keyfile"
+    ), f"Expected auth.keyfile={DOWNLOAD_BASE}/keyfile, got: {ac.get('auth', {}).get('keyfile')}"
 
 
 @mark.e2e_vm_migration_replicaset_scram_sha256

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/shardedcluster/vm_migration_shardedcluster_scram_sha256.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/shardedcluster/vm_migration_shardedcluster_scram_sha256.py
@@ -52,6 +52,7 @@ CONFIGSRV_SVC_NAME = "vm-sharded-configsrv"
 SHARD_SVC_NAME = "vm-sharded-shard"
 MONGOS_SVC_NAME = "vm-sharded-mongos"
 MDB_RESOURCE_NAME = "sharded-migration"
+DOWNLOAD_BASE = "/var/lib/custom-mms-automation"
 VM_CONFIG_RS_NAME = "vm-config"
 VM_SHARD_RS_NAME = "vm-shard-0"
 VM_MONGOS_NAME = "vm-mongos"
@@ -160,9 +161,11 @@ def _configure_ac_scram_sha256(namespace: str, om_tester: OMTester, mdb_version:
         "autoAuthRestrictions": [],
         "autoPwd": "mms-automation-agent-password",
         "key": "bXlrZXlmaWxlY29udGVudHM=",
-        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfile": f"{DOWNLOAD_BASE}/keyfile",
         "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
     }
+
+    ac["options"] = {"downloadBase": DOWNLOAD_BASE}
 
     ac["roles"] = [
         {
@@ -326,6 +329,14 @@ def test_custom_roles_in_generated_cr(generated_cr: dict):
 
 
 @mark.e2e_vm_migration_shardedcluster_scram_sha256
+def test_download_base_carried_over(generated_cr: dict):
+    """The non-default options.downloadBase is carried into spec.downloadBase."""
+    assert (
+        generated_cr["spec"].get("downloadBase") == DOWNLOAD_BASE
+    ), f"Expected spec.downloadBase={DOWNLOAD_BASE}, got: {generated_cr['spec'].get('downloadBase')}"
+
+
+@mark.e2e_vm_migration_shardedcluster_scram_sha256
 def test_vm_deployment_automation_config(om_tester: OMTester):
     ac_tester = om_tester.get_automation_config_tester()
     vm_total = MIN_VM_CONFIGSRV + MIN_VM_SHARD + MIN_VM_MONGOS
@@ -347,6 +358,44 @@ def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
 @mark.e2e_vm_migration_shardedcluster_scram_sha256
 def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
     mdb_migration.assert_reaches_phase(Phase.Running, timeout=1800)
+
+
+@mark.e2e_vm_migration_shardedcluster_scram_sha256
+def test_keyfile_placed_in_operator_pods(namespace: str, mdb_migration: MongoDB):
+    """The operator places the keyfile at <downloadBase>/keyfile in every migrated sharded pod."""
+    keyfile_path = f"{DOWNLOAD_BASE}/keyfile"
+    name = mdb_migration.name
+    spec = mdb_migration["spec"]
+
+    pod_names = []
+    for i in range(spec["configServerCount"]):
+        pod_names.append(f"{name}-config-{i}")
+    for shard in range(spec["shardCount"]):
+        for i in range(spec["mongodsPerShardCount"]):
+            pod_names.append(f"{name}-{shard}-{i}")
+    for i in range(spec["mongosCount"]):
+        pod_names.append(f"{name}-mongos-{i}")
+
+    for pod_name in pod_names:
+        output = KubernetesTester.run_command_in_pod_container(
+            pod_name,
+            namespace,
+            ["sh", "-c", f"test -f {keyfile_path} && echo FOUND"],
+            container="mongodb-enterprise-database",
+        )
+        assert "FOUND" in output, f"keyfile not found at {keyfile_path} in pod {pod_name}; got: {output!r}"
+
+
+@mark.e2e_vm_migration_shardedcluster_scram_sha256
+def test_operator_preserves_download_base_and_keyfile(om_tester: OMTester):
+    """After the operator takes over, the automation config keeps the custom downloadBase/keyfile."""
+    ac = om_tester.api_get_automation_config()
+    assert (
+        ac.get("options", {}).get("downloadBase") == DOWNLOAD_BASE
+    ), f"Expected options.downloadBase={DOWNLOAD_BASE}, got: {ac.get('options', {}).get('downloadBase')}"
+    assert (
+        ac.get("auth", {}).get("keyfile") == f"{DOWNLOAD_BASE}/keyfile"
+    ), f"Expected auth.keyfile={DOWNLOAD_BASE}/keyfile, got: {ac.get('auth', {}).get('keyfile')}"
 
 
 @mark.e2e_vm_migration_shardedcluster_scram_sha256

--- a/helm_chart/crds/mongodb.com_mongodb.yaml
+++ b/helm_chart/crds/mongodb.com_mongodb.yaml
@@ -828,6 +828,8 @@ spec:
               credentials:
                 description: Name of the Secret holding credentials information
                 type: string
+              downloadBase:
+                type: string
               duplicateServiceObjects:
                 description: |-
                   In few service mesh options for ex: Istio, by default we would need to duplicate the

--- a/helm_chart/crds/mongodb.com_mongodb.yaml
+++ b/helm_chart/crds/mongodb.com_mongodb.yaml
@@ -829,6 +829,13 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               downloadBase:
+                description: |-
+                  DownloadBase is the directory on the MongoDB host where the automation agent
+                  downloads and extracts MongoDB binaries. It is always used by the operator, and
+                  the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+                  defaults to "/var/lib/mongodb-mms-automation".
+                  This field should only be set (and only if needed) when migrating an existing
+                  VM-based deployment to the operator.
                 type: string
               duplicateServiceObjects:
                 description: |-

--- a/helm_chart/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbmulticluster.yaml
@@ -556,6 +556,8 @@ spec:
               credentials:
                 description: Name of the Secret holding credentials information
                 type: string
+              downloadBase:
+                type: string
               duplicateServiceObjects:
                 description: |-
                   In few service mesh options for ex: Istio, by default we would need to duplicate the

--- a/helm_chart/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbmulticluster.yaml
@@ -557,6 +557,13 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               downloadBase:
+                description: |-
+                  DownloadBase is the directory on the MongoDB host where the automation agent
+                  downloads and extracts MongoDB binaries. It is always used by the operator, and
+                  the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+                  defaults to "/var/lib/mongodb-mms-automation".
+                  This field should only be set (and only if needed) when migrating an existing
+                  VM-based deployment to the operator.
                 type: string
               duplicateServiceObjects:
                 description: |-

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -113,12 +113,12 @@ const (
 	KMIPClientSecretNamePrefix     = "kmip-client-" //nolint
 	KMIPCAFileInContainer          = KMIPServerCAHome + "/ca.pem"
 	PvcMms                         = "mongodb-mms-automation"
-	PvcMmsMountPath                = "/var/lib/mongodb-mms-automation"
+	DefaultPvcMmsMountPath         = "/var/lib/mongodb-mms-automation"
 	PvMms                          = "agent"
-	AgentDownloadsDir              = PvcMmsMountPath + "/downloads"
-	AgentAuthenticationKeyfilePath = PvcMmsMountPath + "/keyfile"
+	AgentDownloadsDir              = DefaultPvcMmsMountPath + "/downloads"
+	AgentAuthenticationKeyfilePath = DefaultPvcMmsMountPath + "/keyfile"
 	AutomationConfigFilePath       = PvcMountPathData + "/automation-mongod.conf"
-	MongosConfigFileDirPath        = PvcMmsMountPath + "/workspace"
+	MongosConfigFileDirPath        = DefaultPvcMmsMountPath + "/workspace"
 
 	MmsPemKeyFileDirInContainer  = "/opt/mongodb/mms/secrets"
 	AppDBMmsCaFileDirInContainer = "/opt/mongodb/mms/ca/"
@@ -177,7 +177,7 @@ const (
 
 	// AutomationAgentKeyFilePathInContainer is the default path of the keyfile and should be
 	// kept as is for the same reason as above
-	AutomationAgentKeyFilePathInContainer = PvcMmsMountPath + "/keyfile"
+	AutomationAgentKeyFilePathInContainer = DefaultPvcMmsMountPath + "/keyfile"
 
 	// Operator Env configuration properties. Please note that when adding environment variables to this list,
 	// make sure you append them to util.go:PrintEnvVars function's `printableEnvPrefixes` if you need the

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -936,6 +936,8 @@ spec:
               credentials:
                 description: Name of the Secret holding credentials information
                 type: string
+              downloadBase:
+                type: string
               duplicateServiceObjects:
                 description: |-
                   In few service mesh options for ex: Istio, by default we would need to duplicate the
@@ -3574,6 +3576,8 @@ spec:
                 type: object
               credentials:
                 description: Name of the Secret holding credentials information
+                type: string
+              downloadBase:
                 type: string
               duplicateServiceObjects:
                 description: |-

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -937,6 +937,13 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               downloadBase:
+                description: |-
+                  DownloadBase is the directory on the MongoDB host where the automation agent
+                  downloads and extracts MongoDB binaries. It is always used by the operator, and
+                  the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+                  defaults to "/var/lib/mongodb-mms-automation".
+                  This field should only be set (and only if needed) when migrating an existing
+                  VM-based deployment to the operator.
                 type: string
               duplicateServiceObjects:
                 description: |-
@@ -3578,6 +3585,13 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               downloadBase:
+                description: |-
+                  DownloadBase is the directory on the MongoDB host where the automation agent
+                  downloads and extracts MongoDB binaries. It is always used by the operator, and
+                  the keyfile path is derived from it (<downloadBase>/keyfile). If empty, it
+                  defaults to "/var/lib/mongodb-mms-automation".
+                  This field should only be set (and only if needed) when migrating an existing
+                  VM-based deployment to the operator.
                 type: string
               duplicateServiceObjects:
                 description: |-


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #800

## Chain of upstream PRs as of 2026-06-03

* PR #800:
  `master` ← `vm-migration-feature-branch`

  * **PR #837 (THIS ONE)**:
    `vm-migration-feature-branch` ← `vm-migration-feature-branch-downloadbase`

<!-- end git-machete generated -->

Previously the operator hardcoded the value for options.downloadBase and auth.keyfilePath.

- /var/lib/mongodb-mms-automation
- /var/lib/mongodb-mms-automation/keyfile

The hard-coded values are also the default values for non-mck deployments. It is important to note that there is a relationship between downloadBase and keyfilePath. When changing downloadBase in the UI, keyfilePath also gets updated to downloadBase + “/keyfile”. Note that this relationship does not exist when setting downloadBase via the API.

Solution:

- New optional CRD field:
    - spec.downloadBase
- Setting downloadBase also sets keyfilePath to downloadBase + “/keyfile”
- This field MUST only be used on new deployments, prefferably only for migrations. The deployemnts will not return back to running is the field is changed on a runnin deployment.

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in [CONTRIBUTING.md](http://CONTRIBUTING.md) for more details