### PR TITLE
Commit .idea files and run configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 .dir-locals.el
-.idea/
+.idea/workspace.xml
+.idea/usage.statistics.xml
+.idea/shelf
+.idea/AugmentWebviewStateStore.xml
+.idea/go.imports.xml
+
+
 
 /pkg/client
 /vendor/
@@ -22,7 +28,6 @@ venv
 **/pytest_cache/
 tmp/*
 bin/*
-**/*.iml
 helm_out
 .redo-last-namespace
 exports.do

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+mongodb-kubernetes

--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="false" />
+  </component>
+</project>

--- a/.idea/libraries/redhat_connect_zip_files.xml
+++ b/.idea/libraries/redhat_connect_zip_files.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="redhat_connect_zip_files">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/deploy/redhat_connect_zip_files/mongodb-enterprise.v1.8.0.zip!/" />
+      <root url="jar://$PROJECT_DIR$/deploy/redhat_connect_zip_files/mongodb-enterprise.v1.7.0.zip!/" />
+      <root url="jar://$PROJECT_DIR$/deploy/redhat_connect_zip_files/mongodb-enterprise.v1.7.1.zip!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 (venv)" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="Python 3.13 (lsierant_intellij-settings)" project-jdk-type="Python SDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.13 (venv)" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="Python 3.13 (lsierant_intellij-settings)" project-jdk-type="Python SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="Python 3.13" project-jdk-type="Python SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/mongodb-kubernetes.iml" filepath="$PROJECT_DIR$/.idea/mongodb-kubernetes.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/mongodb-kubernetes.iml
+++ b/.idea/mongodb-kubernetes.iml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/docker/mongodb-kubernetes-tests" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/scripts/python" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/helm_chart/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.run/Operator multi-cluster.run.xml
+++ b/.run/Operator multi-cluster.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Operator multi-cluster" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="mongodb-kubernetes" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="-watch-resource=mongodb -watch-resource=opsmanagers -watch-resource=mongodbusers -watch-resource=mongodbcommunity -watch-resource=mongodbsearch -watch-resource=clustermongodbroles -watch-resource=mongodbmulticluster" />
+    <kind value="FILE" />
+    <package value="github.com/mongodb/mongodb-kubernetes" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Operator single-cluster.run.xml
+++ b/.run/Operator single-cluster.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Operator single-cluster" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="mongodb-kubernetes" />
+    <working_directory value="$PROJECT_DIR$" />
+    <kind value="FILE" />
+    <package value="github.com/mongodb/mongodb-kubernetes" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Template Python tests.run.xml
+++ b/.run/Template Python tests.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="tests" factoryName="py.test">
+    <module name="mongodb-kubernetes" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docker/mongodb-kubernetes-tests" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="_new_keywords" value="&quot;&quot;" />
+    <option name="_new_parameters" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
This PR commits common IntelliJ settings to git allowing for _quicker_ IDE setup when cloning fresh or adding a new git worktree.

Running `idea .` from a new git worktree will require the following manual steps in order to fully setup the instance (if you know how to automate it - please let me know):

1. setup Go SDK, the easiest way is to open any main.go and click Setup GOROOT:
<img width="1159" height="268" alt="image" src="https://github.com/user-attachments/assets/f4c82992-e102-4ace-b6ce-e340143c765c" />

2. run `scripts/dev/recreate_python_venv.sh`, copy full the path to python printed at the end  
```
Python venv was recreated successfully.
Using Python: /Users/lukasz.sierant/mdb/feature_mc-installation-ux/venv/bin/python (Python 3.13.7)
```

3. setup Python venv, open project settings (cmd+; in my case) -> `project` -> SDK -> pick "Add Python SDK from disk" -> create new venv and paste the copied link to python
<img width="1069" height="958" alt="image" src="https://github.com/user-attachments/assets/7731d245-ddc4-431f-b801-d47b843c975c" />

Now you should see operator run scenarios:
<img width="286" height="165" alt="image" src="https://github.com/user-attachments/assets/bc6a0adf-58d0-4132-a53c-cba5ce170762" />

and directly running any of e2e test should create a correct run configuration with the preconfigured template: 
<img width="542" height="401" alt="image" src="https://github.com/user-attachments/assets/4899f150-1dad-4ee9-9265-d767f6ff26c0" />
or even any single test function: 
<img width="535" height="141" alt="image" src="https://github.com/user-attachments/assets/ffc819c8-8dac-48d5-897c-4a753819811b" />

Most importantly, our tests works correctly only when running from the `docker/mongodb-kubernetes-tests` directory. 
<img width="1154" height="377" alt="image" src="https://github.com/user-attachments/assets/0d767c9b-c61f-4dc0-811a-6dbf41c81361" />


Also make sure you have pytest set as the default pytest runner in general IDE preferences:
<img width="977" height="265" alt="image" src="https://github.com/user-attachments/assets/1142fc2e-5e59-4571-8899-407e0e3050c0" />
 
