### PR TITLE
PoC: Add installation NS name into cluster scoped CRs

### DIFF
--- a/config/rbac/operator-roles-base.yaml
+++ b/config/rbac/operator-roles-base.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
   namespace: mongodb
 rules:
   - apiGroups:
@@ -85,12 +85,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator

--- a/config/rbac/operator-roles-pvc-resize.yaml
+++ b/config/rbac/operator-roles-pvc-resize.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-pvc-resize
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize
   namespace: mongodb
 rules:
   - apiGroups:
@@ -22,12 +22,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-pvc-resize-binding
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize-binding
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator-pvc-resize
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator

--- a/config/rbac/operator-roles-telemetry.yaml
+++ b/config/rbac/operator-roles-telemetry.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-cluster-telemetry
+  name: mongodb-kubernetes-operator-mongodb-cluster-telemetry
 rules:
   # Non-resource URL permissions
   - nonResourceURLs:
@@ -36,7 +36,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mongodb-kubernetes-operator-cluster-telemetry
+  name: mongodb-kubernetes-operator-mongodb-cluster-telemetry
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator

--- a/helm_chart/templates/operator-roles-base.yaml
+++ b/helm_chart/templates/operator-roles-base.yaml
@@ -1,8 +1,9 @@
+{{ $ns := include "mongodb-kubernetes-operator.namespace" .  -}}
 {{ if .Values.operator.createOperatorServiceAccount }}
-{{- $watchNamespace := include "mongodb-kubernetes-operator.namespace" . | list }}
+{{- $watchNamespace := list $ns }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
-{{- $watchNamespace = concat $watchNamespace (include "mongodb-kubernetes-operator.namespace" . | list) | uniq }}
+{{- $watchNamespace = concat $watchNamespace (list $ns) | uniq }}
 {{- end }}
 
 {{- $roleScope := "Role" -}}
@@ -13,9 +14,9 @@
 kind: {{ $roleScope }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.operator.name }}
+  name: {{ .Values.operator.name }}-{{ $ns }}
 {{- if eq $roleScope "Role" }}
-  namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
+  namespace: {{ $ns }}
 {{- end }}
 rules:
   - apiGroups:
@@ -116,16 +117,16 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $.Values.operator.name }}
+  name: {{ $.Values.operator.name }}-{{ $ns }}
   {{ $namespaceBlock }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ $roleScope }}
-  name: {{ $.Values.operator.name }}
+  name: {{ $.Values.operator.name }}-{{ $ns }}
 subjects:
   - kind: ServiceAccount
     name: {{ $.Values.operator.name }}
-    namespace: {{ include "mongodb-kubernetes-operator.namespace" $ }}
+    namespace: {{ $ns }}
 {{- end }}
 
 {{- end }}

--- a/helm_chart/templates/operator-roles-clustermongodbroles.yaml
+++ b/helm_chart/templates/operator-roles-clustermongodbroles.yaml
@@ -1,10 +1,12 @@
+{{ $ns := include "mongodb-kubernetes-operator.namespace" .  -}}
+
 {{ if .Values.operator.createOperatorServiceAccount }}
 {{- if .Values.operator.enableClusterMongoDBRoles }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.operator.name }}-{{ include "mongodb-kubernetes-operator.namespace" . }}-cluster-mongodb-role
+  name: {{ .Values.operator.name }}-{{ $ns }}-cluster-mongodb-role
 rules:
   - apiGroups:
       - mongodb.com
@@ -16,15 +18,15 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.operator.name }}-{{ include "mongodb-kubernetes-operator.namespace" . }}-cluster-mongodb-role-binding
+  name: {{ .Values.operator.name }}-{{ $ns }}-cluster-mongodb-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.operator.name }}-{{ include "mongodb-kubernetes-operator.namespace" . }}-cluster-mongodb-role
+  name: {{ .Values.operator.name }}-{{ $ns }}-cluster-mongodb-role
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.operator.name }}
-    namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
+    namespace: {{ $ns }}
 
 {{- end }}{{/* if .Values.operator.enableClusterMongoDBRoles */}}
 {{- end }}{{/* if .Values.operator.createOperatorServiceAccount */}}

--- a/helm_chart/templates/operator-roles-pvc-resize.yaml
+++ b/helm_chart/templates/operator-roles-pvc-resize.yaml
@@ -1,10 +1,11 @@
+{{ $ns := include "mongodb-kubernetes-operator.namespace" .  -}}
 {{ if .Values.operator.createOperatorServiceAccount }}
 {{ if .Values.operator.enablePVCResize }}
 
-{{- $watchNamespace := include "mongodb-kubernetes-operator.namespace" . | list }}
+{{- $watchNamespace := list $ns }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
-{{- $watchNamespace = concat $watchNamespace (include "mongodb-kubernetes-operator.namespace" . | list) | uniq }}
+{{- $watchNamespace = concat $watchNamespace (list $ns) | uniq }}
 {{- end }}
 
 
@@ -16,9 +17,9 @@
 kind: {{ $roleScope }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.operator.name }}-pvc-resize
+  name: {{ .Values.operator.name }}-{{ $ns }}-pvc-resize
 {{- if eq $roleScope "Role" }}
-  namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
+  namespace: {{ $ns }}
 {{- end }}
 rules:
   - apiGroups:
@@ -47,16 +48,16 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $.Values.operator.name }}-pvc-resize-binding
+  name: {{ $.Values.operator.name }}-{{ $ns }}-pvc-resize-binding
   {{ $namespaceBlock }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ $roleScope }}
-  name: {{ $.Values.operator.name }}-pvc-resize
+  name: {{ $.Values.operator.name }}-{{ $ns }}-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: {{ $.Values.operator.name }}
-    namespace: {{ include "mongodb-kubernetes-operator.namespace" $ }}
+    namespace: {{ $ns }}
 {{- end }}
 
 {{- end}}{{/* if .Values.operator.enablePVCResize */}}

--- a/helm_chart/templates/operator-roles-telemetry.yaml
+++ b/helm_chart/templates/operator-roles-telemetry.yaml
@@ -1,4 +1,5 @@
-{{- $clusterRoleName := printf "%s-cluster-telemetry" .Values.operator.name }}
+{{ $ns := include "mongodb-kubernetes-operator.namespace" .  -}}
+{{- $clusterRoleName := printf "%s-%s-cluster-telemetry" .Values.operator.name $ns }}
 {{- $telemetry := default dict .Values.operator.telemetry }}
 
 {{/* We can't use default here, as 0, false and nil as determined as unset and thus set the default value */}}
@@ -37,7 +38,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.operator.name }}-{{ include "mongodb-kubernetes-operator.namespace" . }}-cluster-telemetry-binding
+  name: {{ .Values.operator.name }}-{{ $ns }}-cluster-telemetry-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -45,6 +46,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.operator.name }}
-    namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
+    namespace: {{ $ns }}
   {{- end}}{{/* if ne $telemetry.installClusterRole false */}}
 {{- end }}{{/* if ne $telemetry.enabled false */}}

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -1,4 +1,4 @@
-{{ $ns :=  include "mongodb-kubernetes-operator.namespace" .  -}}
+{{ $ns := include "mongodb-kubernetes-operator.namespace" .  -}}
 
 ---
 apiVersion: apps/v1

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-multi-cluster
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb
   namespace: mongodb
 rules:
   - apiGroups:
@@ -85,12 +85,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-multi-cluster
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator-multi-cluster
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator-multi-cluster
@@ -127,7 +127,7 @@ subjects:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-multi-cluster-pvc-resize
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb-pvc-resize
   namespace: mongodb
 rules:
   - apiGroups:
@@ -146,12 +146,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-multi-cluster-pvc-resize-binding
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb-pvc-resize-binding
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator-multi-cluster-pvc-resize
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator-multi-cluster
@@ -162,7 +162,7 @@ subjects:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-multi-cluster-cluster-telemetry
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb-cluster-telemetry
 rules:
   # Non-resource URL permissions
   - nonResourceURLs:
@@ -194,7 +194,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mongodb-kubernetes-operator-multi-cluster-cluster-telemetry
+  name: mongodb-kubernetes-operator-multi-cluster-mongodb-cluster-telemetry
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator-multi-cluster

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
   namespace: mongodb
 rules:
   - apiGroups:
@@ -85,12 +85,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator
@@ -127,7 +127,7 @@ subjects:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-pvc-resize
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize
   namespace: mongodb
 rules:
   - apiGroups:
@@ -146,12 +146,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-pvc-resize-binding
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize-binding
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator-pvc-resize
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator
@@ -162,7 +162,7 @@ subjects:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-cluster-telemetry
+  name: mongodb-kubernetes-operator-mongodb-cluster-telemetry
 rules:
   # Non-resource URL permissions
   - nonResourceURLs:
@@ -194,7 +194,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mongodb-kubernetes-operator-cluster-telemetry
+  name: mongodb-kubernetes-operator-mongodb-cluster-telemetry
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
   namespace: mongodb
 rules:
   - apiGroups:
@@ -85,12 +85,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator
+  name: mongodb-kubernetes-operator-mongodb
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator
@@ -127,7 +127,7 @@ subjects:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-pvc-resize
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize
   namespace: mongodb
 rules:
   - apiGroups:
@@ -146,12 +146,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-pvc-resize-binding
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize-binding
   namespace: mongodb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: mongodb-kubernetes-operator-pvc-resize
+  name: mongodb-kubernetes-operator-mongodb-pvc-resize
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator
@@ -162,7 +162,7 @@ subjects:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mongodb-kubernetes-operator-cluster-telemetry
+  name: mongodb-kubernetes-operator-mongodb-cluster-telemetry
 rules:
   # Non-resource URL permissions
   - nonResourceURLs:
@@ -194,7 +194,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mongodb-kubernetes-operator-cluster-telemetry
+  name: mongodb-kubernetes-operator-mongodb-cluster-telemetry
 subjects:
   - kind: ServiceAccount
     name: mongodb-kubernetes-operator


### PR DESCRIPTION
# Summary

This pull request updates the Helm chart templates to ensure that all generated Kubernetes RBAC resource names and namespaces are consistently scoped to the operator's namespace. This change prevents potential naming collisions when deploying multiple operators in different namespaces.

## Proof of Work

N/A - just a proof of concept.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
