### PR TITLE
migration - Make automation config (AC) username configurable

### DIFF
--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -1018,6 +1018,15 @@ type AgentAuthentication struct {
 	ClientCertificateSecretRefWrap common.ClientCertificateSecretRefWrapper `json:"clientCertificateSecretRef,omitempty"`
 }
 
+// GetAutomationUserName returns the configured automation agent username,
+// or the default value if not specified
+func (a *AgentAuthentication) GetAutomationUserName() string {
+	if a == nil || a.AutomationUserName == "" {
+		return util.AutomationAgentUserName
+	}
+	return a.AutomationUserName
+}
+
 // IsX509Enabled determines if X509 is to be enabled at the project level
 // it does not necessarily mean that the agents are using X509 authentication
 func (a *Authentication) IsX509Enabled() bool {

--- a/controllers/operator/authentication/authentication.go
+++ b/controllers/operator/authentication/authentication.go
@@ -203,14 +203,7 @@ func Disable(ctx context.Context, client kubernetesClient.Client, conn om.Connec
 			ac.Auth.AutoUser = util.MergoDelete
 			ac.Auth.AutoPwd = util.MergoDelete
 		} else {
-			// Preserve AutoUser and AutoPwd so agents can re-authenticate when auth is re-enabled.
-			// Use the configured username from opts.AutoUser to support custom automation agent usernames.
-			// Default to util.AutomationAgentName if opts.AutoUser is not set.
-			autoUser := opts.AutoUser
-			if autoUser == "" {
-				autoUser = util.AutomationAgentName
-			}
-			ac.Auth.AutoUser = autoUser
+			ac.Auth.AutoUser =  opts.AutoUser
 		}
 		ac.Auth.AutoAuthMechanisms = []string{}
 		ac.Auth.DeploymentAuthMechanisms = []string{}

--- a/controllers/operator/authentication/authentication.go
+++ b/controllers/operator/authentication/authentication.go
@@ -204,7 +204,13 @@ func Disable(ctx context.Context, client kubernetesClient.Client, conn om.Connec
 			ac.Auth.AutoPwd = util.MergoDelete
 		} else {
 			// Preserve AutoUser and AutoPwd so agents can re-authenticate when auth is re-enabled.
-			ac.Auth.AutoUser = util.AutomationAgentName
+			// Use the configured username from opts.AutoUser to support custom automation agent usernames.
+			// Default to util.AutomationAgentName if opts.AutoUser is not set.
+			autoUser := opts.AutoUser
+			if autoUser == "" {
+				autoUser = util.AutomationAgentName
+			}
+			ac.Auth.AutoUser = autoUser
 		}
 		ac.Auth.AutoAuthMechanisms = []string{}
 		ac.Auth.DeploymentAuthMechanisms = []string{}

--- a/controllers/operator/authentication/configure_authentication_test.go
+++ b/controllers/operator/authentication/configure_authentication_test.go
@@ -224,7 +224,12 @@ func TestDisableAuthenticationWithoutDeleteUsers(t *testing.T) {
 	}, zap.S())
 
 	// Disable with deleteUsers=false (auth transition)
-	if err := Disable(ctx, kubeClient, conn, Options{MongoDBResource: mongoDBResource}, false, zap.S()); err != nil {
+	// Pass the configured AutoUser to preserve it during auth transitions
+	opts := Options{
+		MongoDBResource: mongoDBResource,
+		AutoUser:        util.AutomationAgentName,
+	}
+	if err := Disable(ctx, kubeClient, conn, opts, false, zap.S()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,6 +240,44 @@ func TestDisableAuthenticationWithoutDeleteUsers(t *testing.T) {
 
 	// When deleteUsers=false, AutoUser should be kept for agent validation
 	assert.Equal(t, util.AutomationAgentName, ac.Auth.AutoUser, "AutoUser should be set when deleteUsers=false")
+	// Password should NOT be cleared during auth transitions - agent needs it to re-authenticate
+	assert.Equal(t, "some-password", ac.Auth.AutoPwd, "AutoPwd should be preserved when deleteUsers=false")
+}
+
+func TestDisableAuthenticationWithCustomUsername(t *testing.T) {
+	ctx := context.Background()
+	kubeClient, _ := mock.NewDefaultFakeClient()
+	mongoDBResource := types.NamespacedName{Namespace: "test", Name: "test"}
+
+	dep := om.NewDeployment()
+	conn := om.NewMockedOmConnection(dep)
+
+	customUsername := "custom-automation-agent"
+
+	// enable authentication with custom username
+	_ = conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
+		ac.Auth.Enable()
+		ac.Auth.AutoUser = customUsername
+		ac.Auth.AutoPwd = "some-password"
+		return nil
+	}, zap.S())
+
+	// Disable with deleteUsers=false (auth transition) using custom username
+	opts := Options{
+		MongoDBResource: mongoDBResource,
+		AutoUser:        customUsername,
+	}
+	if err := Disable(ctx, kubeClient, conn, opts, false, zap.S()); err != nil {
+		t.Fatal(err)
+	}
+
+	ac, err := conn.ReadAutomationConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// When deleteUsers=false, custom AutoUser should be preserved for agent validation
+	assert.Equal(t, customUsername, ac.Auth.AutoUser, "Custom AutoUser should be preserved when deleteUsers=false")
 	// Password should NOT be cleared during auth transitions - agent needs it to re-authenticate
 	assert.Equal(t, "some-password", ac.Auth.AutoPwd, "AutoPwd should be preserved when deleteUsers=false")
 }

--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -101,12 +101,7 @@ func configureScramAgentUsers(ctx context.Context, client kubernetesClient.Clien
 	}
 	auth := ac.Auth
 	if auth.AutoUser == "" {
-		// Use configured username from authOpts, defaulting to util.AutomationAgentName if not set
-		autoUser := authOpts.AutoUser
-		if autoUser == "" {
-			autoUser = util.AutomationAgentName
-		}
-		auth.AutoUser = autoUser
+		auth.AutoUser = authOpts.AutoUser
 	}
 	auth.AutoPwd = agentPassword
 

--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -65,7 +65,7 @@ func (s *automationConfigScramSha) EnableDeploymentAuthentication(conn om.Connec
 	}, log)
 }
 
-func (s *automationConfigScramSha) IsAgentAuthenticationConfigured(ac *om.AutomationConfig, _ Options) bool {
+func (s *automationConfigScramSha) IsAgentAuthenticationConfigured(ac *om.AutomationConfig, opts Options) bool {
 	if ac.Auth.Disabled {
 		return false
 	}
@@ -74,7 +74,7 @@ func (s *automationConfigScramSha) IsAgentAuthenticationConfigured(ac *om.Automa
 		return false
 	}
 
-	if ac.Auth.AutoUser != util.AutomationAgentName || (ac.Auth.AutoPwd == "" || ac.Auth.AutoPwd == util.MergoDelete) {
+	if ac.Auth.AutoUser != opts.AutoUser || (ac.Auth.AutoPwd == "" || ac.Auth.AutoPwd == util.MergoDelete) {
 		return false
 	}
 
@@ -101,7 +101,12 @@ func configureScramAgentUsers(ctx context.Context, client kubernetesClient.Clien
 	}
 	auth := ac.Auth
 	if auth.AutoUser == "" {
-		auth.AutoUser = authOpts.AutoUser
+		// Use configured username from authOpts, defaulting to util.AutomationAgentName if not set
+		autoUser := authOpts.AutoUser
+		if autoUser == "" {
+			autoUser = util.AutomationAgentName
+		}
+		auth.AutoUser = autoUser
 	}
 	auth.AutoPwd = agentPassword
 

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -544,11 +544,7 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 		clientCerts = util.RequireClientCertificates
 	}
 
-	scramAgentUserName := util.AutomationAgentUserName
-	// only use the default name if there is not already a configured username
-	if ac.Auth.AutoUser != "" && ac.Auth.AutoUser != scramAgentUserName {
-		scramAgentUserName = ac.Auth.AutoUser
-	}
+	scramAgentUserName := ar.GetSecurity().Authentication.Agents.GetAutomationUserName()
 
 	authOpts := authentication.Options{
 		Mechanisms:         mdbv1.ConvertAuthModesToStrings(ar.GetSecurity().Authentication.Modes),
@@ -617,7 +613,7 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 
 			authOpts.AutoPwd = autoConfigPassword
 			userOpts := authentication.UserOptions{}
-			agentName := ar.GetSecurity().Authentication.Agents.AutomationUserName
+			agentName := ar.GetSecurity().Authentication.Agents.GetAutomationUserName()
 			userOpts.AutomationSubject = agentName
 			authOpts.UserOptions = userOpts
 		}


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #800

## Chain of upstream PRs as of 2026-06-03

* PR #800:
  `master` ← `vm-migration-feature-branch`

  * **PR #880 (THIS ONE)**:
    `vm-migration-feature-branch` ← `make-ac-configurable-pr`

<!-- end git-machete generated -->

# Summary

This change allows the automation agent username to be configured instead of using a fixed value, so deployments can use a custom automation agent identity when required (e.g. for VM migration or environment-specific naming).

Changes:
- Add `AutomationConfigUsername` (and related wiring) so the operator can set a custom automation agent username in the automation config.
- When not set, behavior is unchanged and `util.AutomationAgentName` is used.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
