### PR TITLE
Use ty for statically check python types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,22 +131,12 @@ repos:
 
   - repo: local
     hooks:
-      - id: ty-search
-        name: ty (search tests)
-        entry: bash -c 'cd docker/mongodb-kubernetes-tests && uvx ty check tests/search/ tests/common/search/'
+      - id: ty
+        name: ty
+        entry: bash -c 'cd docker/mongodb-kubernetes-tests && uvx ty check tests/'
         language: system
         pass_filenames: false
-        files: docker/mongodb-kubernetes-tests/tests/(common/)?search/.*\.py$
-        stages: [pre-commit]
-
-  - repo: local
-    hooks:
-      - id: govulncheck
-        name: govulncheck
-        entry: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
-        language: system
-        pass_filenames: false
-        files: (\.go$|^go\.(mod|sum)$)
+        files: docker/mongodb-kubernetes-tests/tests/.*\.py$
         stages: [pre-commit]
 
   - repo: https://github.com/golangci/golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,16 @@ repos:
         files: docker/mongodb-kubernetes-tests/tests/.*\.py$
         stages: [pre-commit]
 
+  - repo: local
+    hooks:
+      - id: govulncheck
+        name: govulncheck
+        entry: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        language: system
+        pass_filenames: false
+        files: (\.go$|^go\.(mod|sum)$)
+        stages: [pre-commit]
+
   - repo: https://github.com/golangci/golangci-lint
     rev: v2.0.2
     hooks:

--- a/docker/mongodb-kubernetes-tests/kubeobject/customobject.py
+++ b/docker/mongodb-kubernetes-tests/kubeobject/customobject.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from datetime import datetime, timedelta
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Self
 
 import yaml
 from kubernetes import client
@@ -43,6 +43,7 @@ class CustomObject:
                 version=version,
                 api_client=api_client,
             )
+            assert crd is not None, "Could not find CRD matching the given parameters"
             self.kind = crd.spec.names.kind
             self.plural = crd.spec.names.plural
             self.group = crd.spec.group
@@ -71,7 +72,7 @@ class CustomObject:
         self.auto_reload_period = timedelta(seconds=2)
 
         # Last time this object was updated
-        self.last_update: datetime = None
+        self.last_update: Optional[datetime] = None
 
         # Sets the API used for this particular type of object
         self.api = client.CustomObjectsApi(api_client=api_client)
@@ -85,7 +86,7 @@ class CustomObject:
                 "status": {},
             }
 
-    def load(self) -> CustomObject:
+    def load(self) -> Self:
         """Loads this object from the API."""
 
         obj = self.api.get_namespaced_custom_object(self.group, self.version, self.namespace, self.plural, self.name)
@@ -202,7 +203,7 @@ class CustomObject:
 
     @classmethod
     def define(
-        cls: CustomObject,
+        cls,
         name: str,
         kind: Optional[str] = None,
         plural: Optional[str] = None,
@@ -284,7 +285,7 @@ def get_crd_names(
     group: Optional[str] = None,
     version: Optional[str] = None,
     api_client: Optional[client.ApiClient] = None,
-) -> Optional[Dict]:
+) -> Optional[Any]:
     """Gets the CRD entry that matches all the parameters passed."""
     api = client.ApiextensionsV1Api(api_client=api_client)
 
@@ -312,6 +313,8 @@ def get_crd_names(
 
         if found:
             return crd
+
+    return None
 
 
 def create_or_update(resource: CustomObject) -> CustomObject:

--- a/docker/mongodb-kubernetes-tests/kubetester/__init__.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/__init__.py
@@ -148,6 +148,13 @@ def create_or_update_service(
     service: Optional[client.V1Service] = None,
 ) -> str:
     print("Logging inside create_or_update_service")
+    if service_name is None and service is not None:
+        if isinstance(service, dict):
+            service_name = service.get("metadata", {}).get("name")
+        elif hasattr(service, "metadata") and service.metadata is not None:
+            service_name = service.metadata.name
+    if service_name is None:
+        raise ValueError("service_name must not be None")
     try:
         create_service(namespace, service_name, cluster_ip=cluster_ip, ports=ports, selector=selector, service=service)
     except kubernetes.client.ApiException as e:
@@ -247,8 +254,8 @@ def delete_pod(namespace: str, name: str, api_client: Optional[kubernetes.client
 
 def create_or_update_namespace(
     namespace: str,
-    labels: dict = None,
-    annotations: dict = None,
+    labels: Optional[dict] = None,
+    annotations: Optional[dict] = None,
     api_client: Optional[kubernetes.client.ApiClient] = None,
 ):
     namespace_resource = client.V1Namespace(
@@ -368,7 +375,7 @@ def get_pod_when_ready(
     """
     cnt = 0
 
-    while True and cnt < default_retry:
+    while default_retry is not None and cnt < default_retry:
         print(f"get_pod_when_ready: namespace={namespace}, label_selector={label_selector}")
 
         if cnt > 0:
@@ -429,7 +436,7 @@ def is_pod_ready(
     return None
 
 
-def get_default_storage_class() -> str:
+def get_default_storage_class() -> Optional[str]:
     default_class_annotations = (
         "storageclass.kubernetes.io/is-default-class",  # storage.k8s.io/v1
         "storageclass.beta.kubernetes.io/is-default-class",  # storage.k8s.io/v1beta1
@@ -440,6 +447,7 @@ def get_default_storage_class() -> str:
             sc.metadata.annotations.get(a) == "true" for a in default_class_annotations
         ):
             return sc.metadata.name
+    return None
 
 
 def decode_secret(data: Dict[str, str]) -> Dict[str, str]:

--- a/docker/mongodb-kubernetes-tests/kubetester/automation_config_tester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/automation_config_tester.py
@@ -104,6 +104,7 @@ class AutomationConfigTester:
         assert len(self.automation_config["oidcProviderConfigs"]) == expected_size
 
     def assert_oidc_configuration(self, oidc_config: Optional[Dict] = None):
+        assert oidc_config is not None, "oidc_config must not be None"
         actual_configs = self.automation_config["oidcProviderConfigs"]
         assert len(actual_configs) == len(
             oidc_config

--- a/docker/mongodb-kubernetes-tests/kubetester/certs.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/certs.py
@@ -81,14 +81,14 @@ class Issuer(IssuerType, WaitForConditions):
     Reason = "KeyPairVerified"
 
 
-class ClusterIssuer(ClusterIssuerType, WaitForConditions):
+class ClusterIssuer(ClusterIssuerType, WaitForConditions):  # type: ignore[valid-type, misc]
     Reason = "KeyPairVerified"
 
 
 def generate_cert(
     namespace: str,
-    pod: str,
-    dns: str,
+    pod: str | list[str],
+    dns: str | list[str],
     issuer: str,
     spec: Optional[Dict] = None,
     additional_domains: Optional[List[str]] = None,
@@ -113,15 +113,18 @@ def generate_cert(
     cert = Certificate(namespace=namespace, name=secret_name)
 
     if multi_cluster_mode:
-        dns_names = dns_list
+        dns_names = dns_list if dns_list is not None else []
     else:
-        dns_names = [dns]
+        dns_names = dns if isinstance(dns, list) else [dns]
 
     if not multi_cluster_mode:
-        dns_names.append(pod)
+        if isinstance(pod, list):
+            dns_names.extend(pod)
+        else:
+            dns_names.append(pod)
 
     if additional_domains is not None:
-        dns_names += additional_domains
+        dns_names = dns_names + additional_domains
 
     issuerRef = {"name": issuer, "kind": "Issuer"}
     if clusterwide:
@@ -176,8 +179,8 @@ def create_tls_certs(
     namespace: str,
     resource_name: str,
     replicas: int = 3,
-    replicas_cluster_distribution: Optional[List[int]] = None,
-    service_name: str = None,
+    replicas_cluster_distribution: Optional[List[Optional[int]]] = None,
+    service_name: Optional[str] = None,
     spec: Optional[Dict] = None,
     secret_name: Optional[str] = None,
     additional_domains: Optional[List[str]] = None,
@@ -308,8 +311,8 @@ def create_mongodb_tls_certs(
     resource_name: str,
     bundle_secret_name: str,
     replicas: int = 3,
-    replicas_cluster_distribution: Optional[List[int]] = None,
-    service_name: str = None,
+    replicas_cluster_distribution: Optional[List[Optional[int]]] = None,
+    service_name: Optional[str] = None,
     spec: Optional[Dict] = None,
     additional_domains: Optional[List[str]] = None,
     secret_backend: Optional[str] = None,
@@ -342,7 +345,7 @@ def create_mongodb_tls_certs(
 def multi_cluster_service_fqdns(
     resource_name: str,
     namespace: str,
-    external_domain: str,
+    external_domain: Optional[str],
     cluster_index: int,
     replicas: int,
 ) -> List[str]:
@@ -374,11 +377,14 @@ def create_x509_mongodb_tls_certs(
     resource_name: str,
     bundle_secret_name: str,
     replicas: int = 3,
-    replicas_cluster_distribution: Optional[List[int]] = None,
-    service_name: str = None,
+    replicas_cluster_distribution: Optional[List[Optional[int]]] = None,
+    service_name: Optional[str] = None,
+    spec: Optional[Dict] = None,
     additional_domains: Optional[List[str]] = None,
     secret_backend: Optional[str] = None,
     vault_subpath: Optional[str] = None,
+    process_hostnames: Optional[List[str]] = None,
+    clusterwide: bool = False,
 ) -> str:
     spec = get_mongodb_x509_subject(namespace)
 
@@ -394,6 +400,8 @@ def create_x509_mongodb_tls_certs(
         additional_domains=additional_domains,
         secret_backend=secret_backend,
         vault_subpath=vault_subpath,
+        process_hostnames=process_hostnames,
+        clusterwide=clusterwide,
     )
 
 
@@ -484,9 +492,9 @@ def create_sharded_cluster_certs(
     additional_domains: Optional[List[str]] = None,
     secret_prefix: Optional[str] = None,
     secret_backend: Optional[str] = None,
-    shard_distribution: Optional[List[int]] = None,
-    mongos_distribution: Optional[List[int]] = None,
-    config_srv_distribution: Optional[List[int]] = None,
+    shard_distribution: Optional[List[Optional[int]]] = None,
+    mongos_distribution: Optional[List[Optional[int]]] = None,
+    config_srv_distribution: Optional[List[Optional[int]]] = None,
     mongos_service_dns_names: Optional[List[str]] = None,
 ):
     cert_generation_func = create_mongodb_tls_certs

--- a/docker/mongodb-kubernetes-tests/kubetester/certs_mongodb_multi.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/certs_mongodb_multi.py
@@ -128,7 +128,7 @@ def create_multi_cluster_tls_certs(
     secret_name: str,
     central_cluster_client: kubernetes.client.ApiClient,
     member_clients: List[MultiClusterClient],
-    mongodb_multi: Optional[CustomObject] = None,
+    mongodb_multi: Optional[MongoDBMulti] = None,
     namespace: Optional[str] = None,
     secret_backend: Optional[str] = None,
     additional_domains: Optional[List[str]] = None,
@@ -137,6 +137,7 @@ def create_multi_cluster_tls_certs(
     spec: Optional[dict] = None,
 ) -> str:
     if service_fqdns is None:
+        assert mongodb_multi is not None, "mongodb_multi is required when service_fqdns is not provided"
         service_fqdns = [f"{mongodb_multi.name}-svc.{mongodb_multi.namespace}.svc.cluster.local"]
 
         for client in member_clients:
@@ -145,6 +146,7 @@ def create_multi_cluster_tls_certs(
                 external_domain = cluster_spec["externalAccess"]["externalDomain"]
             except KeyError:
                 external_domain = None
+            assert client.cluster_index is not None
             service_fqdns.extend(
                 multi_cluster_service_fqdns(
                     mongodb_multi.name,
@@ -156,6 +158,7 @@ def create_multi_cluster_tls_certs(
             )
 
     if namespace is None:
+        assert mongodb_multi is not None, "mongodb_multi is required when namespace is not provided"
         namespace = mongodb_multi.namespace
 
     generate_cert(

--- a/docker/mongodb-kubernetes-tests/kubetester/crypto.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/crypto.py
@@ -49,7 +49,7 @@ def generate_csr(namespace: str, host: str, servicename: str):
     )
 
 
-def get_pem_certificate(name: str) -> Optional[str]:
+def get_pem_certificate(name: str) -> Optional[bytes]:
     body = client.CertificatesV1Api().read_certificate_signing_request_status(name)
     if body.status.certificate is None:
         return None

--- a/docker/mongodb-kubernetes-tests/kubetester/helm.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/helm.py
@@ -32,6 +32,7 @@ def helm_template(
         command_args.append("--show-only")
         command_args.append(templates)
 
+    helm_chart_path = helm_chart_path or "helm_chart"
     args = ("helm", "template", *command_args, helm_chart_path)
     logger.info(" ".join(args))
 
@@ -51,6 +52,7 @@ def helm_install(
     custom_operator_version: Optional[str] = None,
 ):
     command_args = _create_helm_args(helm_args, helm_options)
+    helm_chart_path = helm_chart_path or "helm_chart"
     args = [
         "helm",
         "upgrade",
@@ -174,7 +176,8 @@ def helm_registry_login_to_ecr(helm_registry: str, region: str):
 
         # Close the stdout stream of aws_proc in the parent process
         # to prevent resource leakage (only needed if you plan to do more processing)
-        aws_proc.stdout.close()
+        if aws_proc.stdout:
+            aws_proc.stdout.close()
 
         # Wait for the Helm command (helm_proc) to finish and capture its output
         helm_stdout, helm_stderr = helm_proc.communicate()
@@ -295,14 +298,14 @@ def _create_helm_args(helm_args: Dict[str, str], helm_options: Optional[List[str
 def helm_chart_path_and_version(helm_chart_path: str, operator_version: str) -> tuple[str, str]:
     # if helm_chart_path is not passed, use the default value from DEFAULT_HELM_CHART_PATH
     if not helm_chart_path:
-        helm_chart_path = os.getenv(DEFAULT_HELM_CHART_PATH_ENV_VAR_NAME)
+        helm_chart_path = os.getenv(DEFAULT_HELM_CHART_PATH_ENV_VAR_NAME, "")
 
     if helm_chart_path.startswith("oci://"):
         # If operator_version is not passed, we want to install the current version.
         if not operator_version:
-            operator_version = os.environ.get(OCI_HELM_VERSION_ENV_VAR_NAME)
+            operator_version = os.environ.get(OCI_HELM_VERSION_ENV_VAR_NAME, "")
 
-        registry = os.environ.get(OCI_HELM_REGISTRY_ENV_VAR_NAME)
+        registry = os.environ.get(OCI_HELM_REGISTRY_ENV_VAR_NAME, "")
         # If ECR we need to login first to the OCI container registry
         if registry and ".ecr." in registry and registry.endswith(".amazonaws.com"):
             region = registry.split(".")[3]

--- a/docker/mongodb-kubernetes-tests/kubetester/http.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/http.py
@@ -30,7 +30,7 @@ def get_retriable_https_session(*, tls_verify: bool) -> requests.Session:
     return get_retriable_session("https", tls_verify)
 
 
-def https_endpoint_is_reachable(url: str, auth: Tuple[str], *, tls_verify: bool) -> bool:
+def https_endpoint_is_reachable(url: str, auth: Tuple[str, str], *, tls_verify: bool) -> bool:
     """
     Checks that `url` is reachable, using `auth` basic credentials.
     """

--- a/docker/mongodb-kubernetes-tests/kubetester/kmip.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kmip.py
@@ -124,7 +124,7 @@ class KMIPDeployment(object):
         resource_name: str,
         bundle_secret_name: str,
         replicas: int = 3,
-        service_name: str = None,
+        service_name: Optional[str] = None,
         spec: Optional[Dict] = None,
     ) -> str:
         ca = read_configmap(namespace, self.ca_configmap)
@@ -135,7 +135,7 @@ class KMIPDeployment(object):
             replicas=replicas,
             service_name=service_name,
             spec=spec,
-            additional_domains=[service_name],
+            additional_domains=[service_name] if service_name else None,
         )
         secret = read_secret(namespace, cert_secret_name)
         create_or_update_secret(

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -108,7 +108,7 @@ def assert_statefulset_architecture(statefulset: client.V1StatefulSet, architect
         static_env_var = next(
             (env for env in agent_container.env if env.name == "MDB_STATIC_CONTAINERS_ARCHITECTURE"), None
         )
-        assert static_env_var.value == "true"
+        assert static_env_var is not None and static_env_var.value == "true"
 
 
 skip_if_static_containers = pytest.mark.skipif(
@@ -233,7 +233,7 @@ class KubernetesTester(object):
         cls,
         namespace: str,
         name: str,
-        container: str = None,
+        container: Optional[str] = None,
         api_client: Optional[client.ApiClient] = None,
     ) -> str:
         return cls.clients("corev1", api_client=api_client).read_namespaced_pod_log(
@@ -246,7 +246,7 @@ class KubernetesTester(object):
         return cls.read_pod_labels(namespace, label_selector).items[0]
 
     @classmethod
-    def read_pod_labels(cls, namespace: str, label_selector: Optional[str] = None) -> Dict[str, str]:
+    def read_pod_labels(cls, namespace: str, label_selector: Optional[str] = None):
         """Reads a Pod by labels."""
         return cls.clients("corev1").list_namespaced_pod(namespace=namespace, label_selector=label_selector)
 
@@ -308,7 +308,7 @@ class KubernetesTester(object):
         cls,
         namespace: str,
         body: Dict,
-        storage_class_name: str = None,
+        storage_class_name: Optional[str] = None,
         api_client: Optional[kubernetes.client.ApiClient] = None,
     ):
         if storage_class_name is not None:
@@ -1339,7 +1339,7 @@ class KubernetesTester(object):
         options = {}
         if ssl:
             options = {"ssl": True, "tlsCAFile": SSL_CA_CERT}
-        client = pymongo.MongoClient(mongodburi, **options, serverSelectionTimeoutMs=300000)
+        client: pymongo.MongoClient = pymongo.MongoClient(mongodburi, **options, serverSelectionTimeoutMs=300000)  # type: ignore[arg-type]
 
         # The ismaster command is cheap and does not require auth.
         client.admin.command("ismaster")
@@ -1570,11 +1570,11 @@ def build_om_org_endpoint(base_url):
     return "{}/api/public/v1.0/orgs".format(base_url)
 
 
-def build_om_org_list_endpoint(base_url: string, page_num: int):
+def build_om_org_list_endpoint(base_url: str, page_num: int):
     return "{}/api/public/v1.0/orgs?itemsPerPage=500&pageNum={}".format(base_url, page_num)
 
 
-def build_om_org_list_by_name_endpoint(base_url: string, name: string):
+def build_om_org_list_by_name_endpoint(base_url: str, name: str):
     return "{}/api/public/v1.0/orgs?name={}".format(base_url, name)
 
 
@@ -1586,7 +1586,7 @@ def build_om_groups_in_org_endpoint(base_url, org_id, page_num):
     return "{}/api/public/v1.0/orgs/{}/groups?itemsPerPage=500&pageNum={}".format(base_url, org_id, page_num)
 
 
-def build_om_groups_in_org_by_name_endpoint(base_url: string, org_id: string, name: string):
+def build_om_groups_in_org_by_name_endpoint(base_url: str, org_id: str, name: str):
     return "{}/api/public/v1.0/orgs/{}/groups?name={}".format(base_url, org_id, name)
 
 

--- a/docker/mongodb-kubernetes-tests/kubetester/ldap.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/ldap.py
@@ -25,7 +25,7 @@ class LDAPUser:
     uid: str
     password: str
     ldap_base: str = LDAP_BASE
-    ou: str = None
+    ou: Optional[str] = None
 
     @property
     def username(self):

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 import urllib.parse
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Self, cast
 
 import semver
 from kubeobject import CustomObject
@@ -43,8 +43,8 @@ class MongoDB(CustomObject, MongoDBCommon):
         super(MongoDB, self).__init__(*args, **with_defaults)
 
     @classmethod
-    def from_yaml(cls, yaml_file, name=None, namespace=None, with_mdb_version_from_env=True) -> MongoDB:
-        resource = super().from_yaml(yaml_file=yaml_file, name=name, namespace=namespace)
+    def from_yaml(cls, yaml_file, name=None, namespace=None, with_mdb_version_from_env=True) -> Self:
+        resource = cast(Self, super().from_yaml(yaml_file=yaml_file, name=name, namespace=namespace))
         # `with_mdb_version_from_env` flag enables to skip the custom version setting for class inheriting from MongoDB
         # for example, community must not have an enterprise version set, but we can inherit the from_yaml (itself
         # inherited from CustomObject class
@@ -157,9 +157,11 @@ class MongoDB(CustomObject, MongoDBCommon):
 
     def assert_status_resource_not_ready(self, name: str, kind: str = "StatefulSet", msg_regexp=None, idx=0):
         """Checks the element in 'resources_not_ready' field by index 'idx'"""
-        assert self.get_status_resources_not_ready()[idx]["kind"] == kind
-        assert self.get_status_resources_not_ready()[idx]["name"] == name
-        assert re.search(msg_regexp, self.get_status_resources_not_ready()[idx]["message"]) is not None
+        resources = self.get_status_resources_not_ready()
+        assert resources is not None, "resources_not_ready is None"
+        assert resources[idx]["kind"] == kind
+        assert resources[idx]["name"] == name
+        assert re.search(msg_regexp, resources[idx]["message"]) is not None
 
     @property
     def type(self) -> str:
@@ -170,7 +172,7 @@ class MongoDB(CustomObject, MongoDBCommon):
         ca_path: Optional[str] = None,
         srv: bool = False,
         use_ssl: Optional[bool] = None,
-        service_names: list[str] = None,
+        service_names: Optional[list[str]] = None,
     ):
         """Returns a Tester instance for this type of deployment."""
         if self.type == "ReplicaSet" and "clusterSpecList" in self["spec"]:
@@ -249,7 +251,7 @@ class MongoDB(CustomObject, MongoDBCommon):
         om: Optional[MongoDBOpsManager],
         project_name: str,
         api_client: Optional[client.ApiClient] = None,
-    ) -> MongoDB:
+    ) -> Self:
         if om is not None:
             return self.configure_ops_manager(om, project_name, api_client=api_client)
         else:
@@ -257,10 +259,10 @@ class MongoDB(CustomObject, MongoDBCommon):
 
     def configure_ops_manager(
         self,
-        om: Optional[MongoDBOpsManager],
+        om: MongoDBOpsManager,
         project_name: str,
         api_client: Optional[client.ApiClient] = None,
-    ) -> MongoDB:
+    ) -> Self:
         if "project" in self["spec"]:
             del self["spec"]["project"]
 
@@ -278,7 +280,7 @@ class MongoDB(CustomObject, MongoDBCommon):
         self,
         project_name,
         api_client: Optional[client.ApiClient] = None,
-    ) -> MongoDB:
+    ) -> Self:
         if "opsManager" in self["spec"]:
             del self["spec"]["opsManager"]
 
@@ -297,7 +299,7 @@ class MongoDB(CustomObject, MongoDBCommon):
 
         return self
 
-    def configure_backup(self, mode: str = "enabled") -> MongoDB:
+    def configure_backup(self, mode: str = "enabled") -> Self:
         ensure_nested_objects(self, ["spec", "backup"])
         self["spec"]["backup"]["mode"] = mode
         return self
@@ -336,6 +338,7 @@ class MongoDB(CustomObject, MongoDBCommon):
         auth = ""
         params = {"connectTimeoutMS": "20000", "serverSelectionTimeoutMS": "20000"}
         if "SCRAM" in self.get_authentication_modes():
+            assert user_name is not None and password is not None, "user_name and password are required for SCRAM"
             auth = "{}:{}@".format(
                 urllib.parse.quote(user_name, safe=""),
                 urllib.parse.quote(password, safe=""),
@@ -374,7 +377,7 @@ class MongoDB(CustomObject, MongoDBCommon):
         except KeyError:
             return "{}-svc".format(self.name)
 
-    def get_cluster_domain(self) -> Optional[str]:
+    def get_cluster_domain(self) -> str:
         try:
             return self["spec"]["clusterDomain"]
         except KeyError:
@@ -394,7 +397,7 @@ class MongoDB(CustomObject, MongoDBCommon):
         self["spec"]["version"] = version
         return self
 
-    def get_authentication(self) -> Optional[Dict]:
+    def get_authentication(self) -> Dict:
         try:
             return self["spec"]["security"]["authentication"]
         except KeyError:
@@ -430,7 +433,7 @@ class MongoDB(CustomObject, MongoDBCommon):
 
         return self
 
-    def get_authentication_modes(self) -> Optional[Dict]:
+    def get_authentication_modes(self) -> Dict:
         try:
             return self.get_authentication()["modes"]
         except KeyError:
@@ -577,7 +580,7 @@ class MongoDB(CustomObject, MongoDBCommon):
             return f"{self.name}-mongos-{cluster_idx}"
         return f"{self.name}-mongos"
 
-    def mongos_pod_name(self, member_idx: int, cluster_idx: Optional[int] = None) -> str:
+    def mongos_pod_name(self, member_idx: Optional[int] = None, cluster_idx: Optional[int] = None) -> str:
         if self.is_multicluster():
             return f"{self.name}-mongos-{cluster_idx}-{member_idx}"
         return f"{self.name}-mongos-{member_idx}"

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_common.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_common.py
@@ -10,6 +10,8 @@ TRACER = trace.get_tracer("evergreen-agent")
 
 
 class MongoDBCommon:
+    backing_obj: dict
+
     @TRACER.start_as_current_span("wait_for")
     def wait_for(self, fn, timeout=None, should_raise=True, persist_for=1):
         """

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_user.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_user.py
@@ -16,6 +16,8 @@ TRACER = trace.get_tracer("evergreen-agent")
 
 
 class MongoDBUser(CustomObject, MongoDBCommon):
+    _password: Optional[str] = None
+
     def __init__(self, *args, **kwargs):
         with_defaults = {
             "plural": "mongodbusers",
@@ -80,6 +82,7 @@ class MongoDBUser(CustomObject, MongoDBCommon):
     def add_role(self, role: Role) -> MongoDBUser:
         self["spec"]["roles"] = self["spec"].get("roles", [])
         self["spec"]["roles"].append({"db": role.db, "name": role.role})
+        return self
 
     def add_roles(self, roles: List[Role]):
         for role in roles:

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_utils_state.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_utils_state.py
@@ -13,11 +13,11 @@ logger = test_logger.get_test_logger(__name__)
 
 @TRACER.start_as_current_span("in_desired_state")
 def in_desired_state(
-    current_state: Phase,
+    current_state: Optional[Phase],
     desired_state: Phase,
     current_generation: int,
-    observed_generation: int,
-    current_message: str,
+    observed_generation: Optional[int],
+    current_message: Optional[str],
     msg_regexp: Optional[str] = None,
     ignore_errors=False,
     intermediate_events: Tuple = (),
@@ -34,7 +34,7 @@ def in_desired_state(
     if current_state == Phase.Failed and not desired_state == Phase.Failed and not ignore_errors:
         found = False
         for event in intermediate_events:
-            if event in current_message:
+            if current_message is not None and event in current_message:
                 found = True
                 logger.debug(
                     f"Found intermediate event in failure: {event} in {current_message}. Skipping the failure state"
@@ -47,6 +47,8 @@ def in_desired_state(
     if msg_regexp is not None:
         print("msg_regexp: " + str(msg_regexp))
         regexp = re.compile(msg_regexp)
-        is_in_desired_state = is_in_desired_state and current_message is not None and regexp.match(current_message)
+        is_in_desired_state = bool(
+            is_in_desired_state and current_message is not None and regexp.match(current_message)
+        )
 
     return is_in_desired_state

--- a/docker/mongodb-kubernetes-tests/kubetester/mongotester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongotester.py
@@ -6,7 +6,7 @@ import random
 import string
 import threading
 import time
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import pymongo
 from kubetester import kubetester
@@ -24,10 +24,10 @@ TEST_DB = "test-db"
 TEST_COLLECTION = "test-collection"
 
 
-def with_tls(use_tls: bool = False, ca_path: Optional[str] = None) -> Dict[str, str]:
+def with_tls(use_tls: bool = False, ca_path: Optional[str] = None) -> Dict[str, Any]:
     # SSL is set to true by default if using mongodb+srv, it needs to be explicitely set to false
     # https://docs.mongodb.com/manual/reference/program/mongo/index.html#cmdoption-mongo-host
-    options = {"tls": use_tls}
+    options: Dict[str, Any] = {"tls": use_tls}
 
     if use_tls:
         options["tlsCAFile"] = kubetester.SSL_CA_CERT if ca_path is None else ca_path
@@ -46,7 +46,7 @@ def with_scram(username: str, password: str, auth_mechanism: str = "SCRAM-SHA-25
     }
 
 
-def with_x509(cert_file_name: str, ca_path: Optional[str] = None) -> Dict[str, str]:
+def with_x509(cert_file_name: str, ca_path: Optional[str] = None) -> Dict[str, Any]:
     options = with_tls(True, ca_path=ca_path)
     options.update(
         {
@@ -58,7 +58,7 @@ def with_x509(cert_file_name: str, ca_path: Optional[str] = None) -> Dict[str, s
     return options
 
 
-def with_ldap(ssl_certfile: Optional[str] = None, tls_ca_file: Optional[str] = None) -> Dict[str, str]:
+def with_ldap(ssl_certfile: Optional[str] = None, tls_ca_file: Optional[str] = None) -> Dict[str, Any]:
     options = {}
     if tls_ca_file is not None:
         options.update(with_tls(True, tls_ca_file))
@@ -164,7 +164,7 @@ class MongoTester:
     def client(self, value):
         self._client = value
 
-    def _merge_options(self, opts: List[Dict[str, str]]) -> Dict[str, str]:
+    def _merge_options(self, opts: List[Dict[str, Any]]) -> Dict[str, Any]:
         options = copy.deepcopy(self.default_opts)
         for opt in opts:
             options.update(opt)
@@ -179,8 +179,8 @@ class MongoTester:
         attempts: int = 50,
         db: str = "admin",
         col: str = "myCol",
-        opts: Optional[List[Dict[str, any]]] = None,
-        write_concern: pymongo.WriteConcern = None,
+        opts: Optional[List[Dict[str, Any]]] = None,
+        write_concern: Optional[pymongo.WriteConcern] = None,
     ):
         if opts is None:
             opts = []
@@ -344,7 +344,7 @@ class MongoTester:
         db: str = "admin",
         collection: str = "myCol",
         tls_ca_file: Optional[str] = None,
-        ssl_certfile: str = None,
+        ssl_certfile: Optional[str] = None,
         attempts: int = 50,
     ):
         _wait_for_mongodbuser_reconciliation()
@@ -508,7 +508,7 @@ class MultiReplicaSetTester(MongoTester):
         self,
         service_names: List[str],
         port: str,
-        ssl: Optional[bool] = False,
+        ssl: bool = False,
         ca_path: Optional[str] = None,
         namespace: Optional[str] = None,
         external: bool = False,
@@ -533,7 +533,7 @@ class ShardedClusterTester(MongoTester):
         cluster_domain: str = "cluster.local",
         multi_cluster: Optional[bool] = False,
         service_names: Optional[list[str]] = None,
-        external_domain: str = None,
+        external_domain: Optional[str] = None,
     ):
         mdb_name = mdb_resource_name + "-mongos"
         servicename = mdb_resource_name + "-svc"
@@ -660,7 +660,7 @@ class BackgroundHealthChecker(threading.Thread):
 
         allowed_failures = self.allowed_sequential_failures
         if allowed_rate_of_failure is not None:
-            allowed_failures = self.number_of_runs * allowed_rate_of_failure
+            allowed_failures = int(self.number_of_runs * allowed_rate_of_failure)
 
         # Automatically get the caller file information
         caller_info = inspect.stack()[1]  # Stack frame of the caller
@@ -708,9 +708,9 @@ def build_mongodb_connection_uri(
     namespace: str,
     members: int,
     port: str,
-    servicename: str = None,
+    servicename: Optional[str] = None,
     srv: bool = False,
-    external_domain: str = None,
+    external_domain: Optional[str] = None,
     cluster_domain: str = "cluster.local",
 ) -> str:
     if servicename is None:
@@ -727,8 +727,8 @@ def build_mongodb_connection_uri(
 
 
 def build_mongodb_multi_connection_uri(
-    namespace: str,
-    service_names: List[str],
+    namespace: Optional[str],
+    service_names: Optional[List[str]],
     port: str,
     external: bool = False,
     cluster_domain: str = "cluster.local",
@@ -754,10 +754,17 @@ def build_list_of_hosts_with_external_domain(
 
 
 def build_list_of_multi_hosts(
-    namespace: str, service_names: List[str], port, external: bool = False, cluster_domain: str = "cluster.local"
+    namespace: Optional[str],
+    service_names: Optional[List[str]],
+    port,
+    external: bool = False,
+    cluster_domain: str = "cluster.local",
 ) -> List[str]:
+    if not service_names:
+        return []
     if external:
         return [f"{service_name}:{port}" for service_name in service_names]
+    assert namespace is not None
     return [
         build_host_service_fqdn(service_name, namespace, port, cluster_domain=cluster_domain)
         for service_name in service_names

--- a/docker/mongodb-kubernetes-tests/kubetester/omtester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/omtester.py
@@ -243,6 +243,7 @@ class OMTester(object):
         for cluster in clusters:
             if cluster["typeName"] == "SHARDED_REPLICA_SET":
                 return cluster["id"]
+        raise AssertionError("No SHARDED_REPLICA_SET cluster found")
 
     def assert_healthiness(self):
         self.do_assert_healthiness(self.context.base_url)
@@ -360,11 +361,11 @@ class OMTester(object):
     def assert_om_version(self, expected_version: str):
         assert self.api_get_om_version() == expected_version
 
-    def check_healthiness(self) -> tuple[str, str]:
+    def check_healthiness(self) -> tuple[int, str]:
         return OMTester.request_health(self.context.base_url)
 
     @staticmethod
-    def request_health(base_url: str) -> tuple[str, str]:
+    def request_health(base_url: str) -> tuple[int, str]:
         endpoint = base_url + "/monitor/health"
         response = requests.request("get", endpoint, verify=False)
         return response.status_code, response.text
@@ -592,7 +593,7 @@ class OMTester(object):
             "results"
         ]
 
-    def api_get_clusters(self) -> List:
+    def api_get_clusters(self) -> Dict:
         return self.om_request("get", f"/groups/{self.context.project_id}/clusters/").json()
 
     def api_create_restore_job_pit(self, cluster_id: str, pit_milliseconds: int):
@@ -678,7 +679,7 @@ class OMTester(object):
         clientPem.write(connParams.client_pem)
         clientPem.flush()
 
-        dbClient = pymongo.MongoClient(
+        dbClient: pymongo.database.Database = pymongo.MongoClient(
             host=connParams.host,
             tls=True,
             tlsCAFile=caPem.name,

--- a/docker/mongodb-kubernetes-tests/kubetester/omtester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/omtester.py
@@ -6,7 +6,7 @@ import re
 import tempfile
 import time
 import urllib.parse
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -191,7 +191,7 @@ class OMTester(object):
                 snapshot_timestamp = latest_snapshot["created"]["date"]
                 print(f"Current Backup Snapshots: {snapshots}")
                 self.set_latest_backup_completion_time(
-                    time_to_millis(datetime.fromisoformat(snapshot_timestamp.replace("Z", "")))
+                    time_to_millis(datetime.fromisoformat(snapshot_timestamp.replace("Z", "+00:00")))
                 )
                 return
             time.sleep(3)
@@ -873,6 +873,6 @@ def should_include_tag(version: Optional[Dict[str, str]]) -> bool:
 
 def time_to_millis(date_time) -> int:
     """https://stackoverflow.com/a/11111177/614239"""
-    epoch = datetime.utcfromtimestamp(0)
+    epoch = datetime.fromtimestamp(0, tz=timezone.utc)
     pit_millis = (date_time - epoch).total_seconds() * 1000
     return pit_millis

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -52,7 +52,7 @@ class Operator(object):
         # The Operator will be installed from the following repo, so adding it first
         helm_repo_add("mongodb", "https://mongodb.github.io/helm-charts")
 
-        helm_chart_path, operator_version = helm_chart_path_and_version(helm_chart_path, operator_version)
+        helm_chart_path, operator_version = helm_chart_path_and_version(helm_chart_path or "", operator_version or "")
 
         if helm_args is None:
             helm_args = {}
@@ -90,7 +90,7 @@ class Operator(object):
             custom_operator_version = self.operator_version
 
         helm_install(
-            self.name,
+            self.name or "",
             self.namespace,
             self.helm_arguments,
             helm_chart_path=self.helm_chart_path,
@@ -110,7 +110,7 @@ class Operator(object):
             custom_operator_version = self.operator_version
 
         helm_upgrade(
-            self.name,
+            self.name or "",
             self.namespace,
             self.helm_arguments,
             helm_chart_path=self.helm_chart_path,

--- a/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
@@ -4,9 +4,12 @@ import json
 import re
 import time
 from base64 import b64decode
-from typing import Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import kubernetes.client
+
+if TYPE_CHECKING:
+    from kubetester.mongodb import MongoDB
 import requests
 from kubeobject import CustomObject
 from kubernetes.client.rest import ApiException
@@ -216,7 +219,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
             timeout=timeout,
         )
 
-    def get_appdb_resource(self) -> CustomObject:
+    def get_appdb_resource(self) -> "MongoDB":
         from kubetester.mongodb import MongoDB
 
         mdb = MongoDB(name=self.app_db_name(), namespace=self.namespace)
@@ -250,7 +253,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         return [services[0], services[1]]
 
-    def read_statefulset(self, member_cluster_name: str = None) -> kubernetes.client.V1StatefulSet:
+    def read_statefulset(self, member_cluster_name: Optional[str] = None) -> kubernetes.client.V1StatefulSet:
         if member_cluster_name is None:
             member_cluster_name = self.pick_one_om_member_cluster_name()
 
@@ -330,7 +333,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         return pod_names_per_cluster
 
-    def get_om_cluster_spec_item(self, member_cluster_name: str) -> dict[str, any]:
+    def get_om_cluster_spec_item(self, member_cluster_name: str) -> dict[str, Any]:
         cluster_spec_items = [
             cluster_spec_item
             for idx, cluster_spec_item in self.get_om_indexed_cluster_spec_items()
@@ -400,7 +403,9 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
             cluster_name = cluster_spec_item["clusterName"]
             if member_cluster_name is not None and cluster_name != member_cluster_name:
                 continue
-            members_in_cluster = cluster_spec_item.get("backup", {}).get(
+            _backup = cluster_spec_item.get("backup")
+            backup_spec: dict = _backup if isinstance(_backup, dict) else {}
+            members_in_cluster = backup_spec.get(
                 "members", self.get_backup_members_count(member_cluster_name=cluster_name)
             )
             pod_names = [
@@ -483,7 +488,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         return hostnames
 
-    def get_appdb_indexed_cluster_spec_items(self) -> list[tuple[int, dict[str, any]]]:
+    def get_appdb_indexed_cluster_spec_items(self) -> list[tuple[int, dict[str, Any]]]:
         """Returns ordered list (by cluster index) of tuples (cluster index, clusterSpecItem) from spec.applicationDatabase.clusterSpecList.
         Cluster indexes are read from -cluster-mapping config map.
         """
@@ -504,7 +509,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         return sorted(result, key=lambda x: x[0])
 
-    def get_om_indexed_cluster_spec_items(self) -> list[tuple[int, dict[str, str]]]:
+    def get_om_indexed_cluster_spec_items(self) -> list[tuple[int, dict[str, Any]]]:
         """Returns an ordered list (by cluster index) of tuples (cluster index, clusterSpecItem) from spec.clusterSpecList.
         Cluster indexes are read from -cluster-mapping config map.
         """
@@ -524,7 +529,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         return sorted(result, key=lambda x: x[0])
 
     @staticmethod
-    def get_legacy_central_cluster(replicas: int) -> list[tuple[int, dict[str, str]]]:
+    def get_legacy_central_cluster(replicas: int) -> list[tuple[int, dict[str, Any]]]:
         return [(0, {"clusterName": LEGACY_CENTRAL_CLUSTER_NAME, "members": str(replicas)})]
 
     def read_appdb_pods(self) -> list[tuple[kubernetes.client.ApiClient, kubernetes.client.V1Pod]]:
@@ -636,7 +641,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         )
         return KubernetesTester.decode_secret(secret.data)["connectionString"]
 
-    def read_appdb_members_from_connection_url_secret(self) -> str:
+    def read_appdb_members_from_connection_url_secret(self) -> list[str]:
         return re.findall(r"[@,]([^@,\/]+)", self.read_appdb_connection_url())
 
     def create_admin_secret(
@@ -659,6 +664,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         api_client = None
         if self.is_appdb_multi_cluster():
             cluster_name = self.pick_one_appdb_member_cluster_name()
+            assert cluster_name is not None
             api_client = get_member_cluster_client_map()[cluster_name].api_client
 
         secret = (
@@ -678,8 +684,11 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
     ) -> str:
         """Creates the configmap containing the information needed to connect to OM"""
         config_map_name = f"{mongodb_name}-config"
+        base_url = self.om_status().get_url()
+        if base_url is None:
+            raise RuntimeError("OpsManager URL must not be None; is OM in Running phase?")
         data = {
-            "baseUrl": self.om_status().get_url(),
+            "baseUrl": base_url,
             "projectName": project_name,
             "orgId": "",
         }
@@ -737,6 +746,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         cluster_indexes_with_members = self.get_appdb_member_cluster_indexes_with_member_count()
         for _, cluster_spec_item in self.get_appdb_indexed_cluster_spec_items():
             return multi_cluster_service_names(self.app_db_name(), cluster_indexes_with_members)
+        return []
 
     def get_appdb_member_cluster_indexes_with_member_count(self) -> list[tuple[int, int]]:
         return [
@@ -753,9 +763,11 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
                 **kwargs,
             )
         else:
+            members = self.appdb_status().get_members()
+            assert members is not None, "appdb members count must not be None"
             return ReplicaSetTester(
                 self.app_db_name(),
-                replicas_count=self.appdb_status().get_members(),
+                replicas_count=members,
                 **kwargs,
             )
 
@@ -833,7 +845,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
     def __repr__(self):
         # FIX: this should be __unicode__
-        return "MongoDBOpsManager| status:".format(self.get_status())
+        return "MongoDBOpsManager| status: {}".format(self.get_status())
 
     def get_appdb_members_count(self) -> int:
         if self.is_appdb_multi_cluster():
@@ -847,10 +859,11 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         if not self.is_om_multi_cluster():
             return self["spec"]["replicas"]
 
-        return sum([item["members"] for _, item in self.get_om_indexed_cluster_spec_items()])
+        return sum(int(item["members"]) for _, item in self.get_om_indexed_cluster_spec_items())
 
     def get_om_replicas_in_member_cluster(self, member_cluster_name: Optional[str] = None) -> int:
         if is_member_cluster(member_cluster_name):
+            assert member_cluster_name is not None
             return self.get_om_cluster_spec_item(member_cluster_name)["members"]
 
         return self["spec"]["replicas"]
@@ -860,6 +873,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
             return 0
 
         if is_member_cluster(member_cluster_name):
+            assert member_cluster_name is not None
             cluster_spec_item = self.get_om_cluster_spec_item(member_cluster_name)
             members = cluster_spec_item.get("backup", {}).get("members", None)
             if members is not None:
@@ -873,7 +887,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
     def get_version(self) -> str:
         return self["spec"]["version"]
 
-    def get_status(self) -> Optional[str]:
+    def get_status(self) -> Optional[dict]:
         if "status" not in self:
             return None
         return self["status"]
@@ -890,7 +904,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         return old_secret_name
 
-    def agent_api_key(self, api_client: Optional[kubernetes.client.ApiClient] = None) -> str:
+    def agent_api_key(self, api_client: Optional[kubernetes.client.ApiClient] = None) -> Optional[str]:
         secret_name = None
         member_cluster = self.pick_one_appdb_member_cluster_name()
         appdb_sts = self.read_appdb_statefulset(member_cluster_name=member_cluster)
@@ -907,6 +921,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
     def om_sts_name(self, member_cluster_name: Optional[str] = None) -> str:
         if is_member_cluster(member_cluster_name):
+            assert member_cluster_name is not None
             cluster_idx = self.get_om_member_cluster_index(member_cluster_name)
             return f"{self.name}-{cluster_idx}"
         else:
@@ -924,6 +939,7 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
     def app_db_sts_name(self, member_cluster_name: Optional[str] = None) -> str:
         if is_member_cluster(member_cluster_name):
+            assert member_cluster_name is not None
             cluster_idx = self.get_appdb_member_cluster_index(member_cluster_name)
             return f"{self.name}-db-{cluster_idx}"
         else:
@@ -1007,6 +1023,24 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         return self["spec"].get("topology", "") == "MultiCluster"
 
     class StatusCommon:
+        ops_manager: "MongoDBOpsManager"
+
+        def _status(self) -> dict:
+            """Returns the status dict, or empty dict if not available."""
+            return self.ops_manager.get_status() or {}
+
+        def get_phase(self) -> Optional[Phase]:
+            raise NotImplementedError
+
+        def get_message(self) -> Optional[str]:
+            raise NotImplementedError
+
+        def get_observed_generation(self) -> Optional[int]:
+            raise NotImplementedError
+
+        def get_resources_not_ready(self) -> Optional[List[Dict]]:
+            raise NotImplementedError
+
         @TRACER.start_as_current_span("assert_reaches_phase")
         def assert_reaches_phase(self, phase: Phase, msg_regexp=None, timeout=None, ignore_errors=False):
             intermediate_events = (
@@ -1091,9 +1125,11 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         def assert_status_resource_not_ready(self, name: str, kind: str = "StatefulSet", msg_regexp=None, idx=0):
             """Checks the element in 'resources_not_ready' field by index 'idx'"""
-            assert self.get_resources_not_ready()[idx]["kind"] == kind
-            assert self.get_resources_not_ready()[idx]["name"] == name
-            assert re.search(msg_regexp, self.get_resources_not_ready()[idx]["message"]) is not None
+            resources = self.get_resources_not_ready()
+            assert resources is not None, "resources_not_ready is None"
+            assert resources[idx]["kind"] == kind
+            assert resources[idx]["name"] == name
+            assert re.search(msg_regexp, resources[idx]["message"]) is not None
 
         def assert_empty_status_resources_not_ready(self):
             assert self.get_resources_not_ready() is None
@@ -1110,25 +1146,25 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         def get_phase(self) -> Optional[Phase]:
             try:
-                return Phase[self.ops_manager.get_status()["backup"]["phase"]]
+                return Phase[self._status()["backup"]["phase"]]
             except (KeyError, TypeError):
                 return None
 
         def get_message(self) -> Optional[str]:
             try:
-                return self.ops_manager.get_status()["backup"]["message"]
+                return self._status()["backup"]["message"]
             except (KeyError, TypeError):
                 return None
 
         def get_observed_generation(self) -> Optional[int]:
             try:
-                return self.ops_manager.get_status()["backup"]["observedGeneration"]
+                return self._status()["backup"]["observedGeneration"]
             except (KeyError, TypeError):
                 return None
 
         def get_resources_not_ready(self) -> Optional[List[Dict]]:
             try:
-                return self.ops_manager.get_status()["backup"]["resourcesNotReady"]
+                return self._status()["backup"]["resourcesNotReady"]
             except (KeyError, TypeError):
                 return None
 
@@ -1147,37 +1183,37 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         def get_phase(self) -> Optional[Phase]:
             try:
-                return Phase[self.ops_manager.get_status()["applicationDatabase"]["phase"]]
+                return Phase[self._status()["applicationDatabase"]["phase"]]
             except (KeyError, TypeError):
                 return None
 
         def get_message(self) -> Optional[str]:
             try:
-                return self.ops_manager.get_status()["applicationDatabase"]["message"]
+                return self._status()["applicationDatabase"]["message"]
             except (KeyError, TypeError):
                 return None
 
         def get_observed_generation(self) -> Optional[int]:
             try:
-                return self.ops_manager.get_status()["applicationDatabase"]["observedGeneration"]
+                return self._status()["applicationDatabase"]["observedGeneration"]
             except (KeyError, TypeError):
                 return None
 
         def get_version(self) -> Optional[str]:
             try:
-                return self.ops_manager.get_status()["applicationDatabase"]["version"]
+                return self._status()["applicationDatabase"]["version"]
             except (KeyError, TypeError):
                 return None
 
         def get_members(self) -> Optional[int]:
             try:
-                return self.ops_manager.get_status()["applicationDatabase"]["members"]
+                return self._status()["applicationDatabase"]["members"]
             except (KeyError, TypeError):
                 return None
 
         def get_resources_not_ready(self) -> Optional[List[Dict]]:
             try:
-                return self.ops_manager.get_status()["applicationDatabase"]["resourcesNotReady"]
+                return self._status()["applicationDatabase"]["resourcesNotReady"]
             except (KeyError, TypeError):
                 return None
 
@@ -1196,42 +1232,42 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
 
         def get_phase(self) -> Optional[Phase]:
             try:
-                return Phase[self.ops_manager.get_status()["opsManager"]["phase"]]
+                return Phase[self._status()["opsManager"]["phase"]]
             except (KeyError, TypeError):
                 return None
 
         def get_message(self) -> Optional[str]:
             try:
-                return self.ops_manager.get_status()["opsManager"]["message"]
+                return self._status()["opsManager"]["message"]
             except (KeyError, TypeError):
                 return None
 
         def get_observed_generation(self) -> Optional[int]:
             try:
-                return self.ops_manager.get_status()["opsManager"]["observedGeneration"]
+                return self._status()["opsManager"]["observedGeneration"]
             except (KeyError, TypeError):
                 return None
 
         def get_last_transition(self) -> Optional[int]:
             try:
-                return self.ops_manager.get_status()["opsManager"]["lastTransition"]
+                return self._status()["opsManager"]["lastTransition"]
             except (KeyError, TypeError):
                 return None
 
         def get_url(self) -> Optional[str]:
             try:
-                return self.ops_manager.get_status()["opsManager"]["url"]
+                return self._status()["opsManager"]["url"]
             except (KeyError, TypeError):
                 return None
 
         def get_replicas(self) -> Optional[int]:
             try:
-                return self.ops_manager.get_status()["opsManager"]["replicas"]
+                return self._status()["opsManager"]["replicas"]
             except (KeyError, TypeError):
                 return None
 
         def get_resources_not_ready(self) -> Optional[List[Dict]]:
             try:
-                return self.ops_manager.get_status()["opsManager"]["resourcesNotReady"]
+                return self._status()["opsManager"]["resourcesNotReady"]
             except (KeyError, TypeError):
                 return None

--- a/docker/mongodb-kubernetes-tests/kubetester/test_identifiers.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/test_identifiers.py
@@ -4,7 +4,7 @@ from typing import Any
 import yaml
 from kubetester.kubetester import running_locally
 
-test_identifiers: dict = None
+test_identifiers: dict[str, Any] | None = None
 
 
 def set_test_identifier(identifier: str, value: Any) -> Any:

--- a/docker/mongodb-kubernetes-tests/pyproject.toml
+++ b/docker/mongodb-kubernetes-tests/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ty.environment]
+extra-paths = ["."]

--- a/docker/mongodb-kubernetes-tests/tests/authentication/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/conftest.py
@@ -40,10 +40,11 @@ def openldap_install(
     name: str = LDAP_NAME,
     cluster_client: Optional[client.ApiClient] = None,
     cluster_name: Optional[str] = None,
-    helm_args: Dict[str, str] = None,
+    helm_args: Optional[Dict[str, str]] = None,
     tls: bool = False,
 ) -> OpenLDAP:
     if is_member_cluster(cluster_name):
+        assert cluster_name is not None
         os.environ["HELM_KUBECONTEXT"] = cluster_name
 
     if helm_args is None:

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_ldap_agent_client_certs.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_ldap_agent_client_certs.py
@@ -1,4 +1,5 @@
 import tempfile
+from typing import Iterator
 
 from kubetester import create_secret, delete_secret, find_fixture, read_secret, try_load
 from kubetester.certs import ISSUER_CA_NAME, create_mongodb_tls_certs, generate_cert
@@ -49,7 +50,7 @@ def client_cert_path(issuer: str, namespace: str):
 
 
 @fixture(scope="module")
-def agent_client_cert(issuer: str, namespace: str) -> str:
+def agent_client_cert(issuer: str, namespace: str) -> Iterator[str]:
     spec = {
         "commonName": "mms-automation-client-cert",
         "subject": {"organizationalUnits": ["mongodb.com"]},
@@ -133,7 +134,8 @@ def ldap_user_mongodb(replica_set: MongoDB, namespace: str, ldap_mongodb_user: L
         ]
     )
 
-    return user.update()
+    user.update()
+    return user
 
 
 @mark.e2e_replica_set_ldap_agent_client_certs

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_oidc_m2m_group.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_oidc_m2m_group.py
@@ -16,6 +16,7 @@ def replica_set(namespace: str, custom_mdb_version: str) -> MongoDB:
     resource = MongoDB.from_yaml(find_fixture("oidc/replica-set.yaml"), namespace=namespace)
 
     oidc_provider_configs = resource.get_oidc_provider_configs()
+    assert oidc_provider_configs
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_oidc_m2m_user.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_oidc_m2m_user.py
@@ -18,6 +18,7 @@ def replica_set(namespace: str, custom_mdb_version: str) -> MongoDB:
     resource = MongoDB.from_yaml(find_fixture("oidc/replica-set-m2m-user.yaml"), namespace=namespace)
 
     oidc_provider_configs = resource.get_oidc_provider_configs()
+    assert oidc_provider_configs
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_oidc_workforce.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_oidc_workforce.py
@@ -18,7 +18,7 @@ def replica_set(namespace: str, custom_mdb_version: str) -> MongoDB:
     resource = MongoDB.from_yaml(load_fixture("oidc/replica-set-workforce.yaml"), namespace=namespace)
 
     oidc_provider_configs = resource.get_oidc_provider_configs()
-
+    assert oidc_provider_configs
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sha1_connectivity_tests.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sha1_connectivity_tests.py
@@ -132,7 +132,7 @@ class SHA1ConnectivityTests:
             auth_mechanism="SCRAM-SHA-1",
         )
 
-    def test_authentication_is_disabled_once_resource_is_deleted(namespace: str, mdb: MongoDB):
+    def test_authentication_is_disabled_once_resource_is_deleted(self, namespace: str, mdb: MongoDB):
         mdb.delete()
 
         def resource_is_deleted() -> bool:

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_oidc_m2m_group.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_oidc_m2m_group.py
@@ -19,7 +19,7 @@ def sharded_cluster(namespace: str, custom_mdb_version: str) -> MongoDB:
     resource = MongoDB.from_yaml(find_fixture("oidc/sharded-cluster-replica-set.yaml"), namespace=namespace)
 
     oidc_provider_configs = resource.get_oidc_provider_configs()
-
+    assert oidc_provider_configs
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()
@@ -46,7 +46,7 @@ class TestCreateOIDCShardedCluster(KubernetesTester):
         sharded_cluster.assert_reaches_phase(Phase.Running, timeout=800)
 
     def test_assert_connectivity(self, sharded_cluster: MongoDB):
-        service_names = None
+        service_names: list[str] | None = None
         if is_multi_cluster():
             service_names = get_mongos_service_names(sharded_cluster)
         tester = sharded_cluster.tester(service_names=service_names)

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_oidc_m2m_user.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_oidc_m2m_user.py
@@ -20,7 +20,7 @@ def sharded_cluster(namespace: str, custom_mdb_version: str) -> MongoDB:
     resource = MongoDB.from_yaml(find_fixture("oidc/sharded-cluster-m2m-user.yaml"), namespace=namespace)
 
     oidc_provider_configs = resource.get_oidc_provider_configs()
-
+    assert oidc_provider_configs
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
@@ -61,7 +61,7 @@ class TestCreateOIDCShardedCluster(KubernetesTester):
         oidc_user.assert_reaches_phase(Phase.Updated, timeout=400)
 
     def test_assert_connectivity(self, sharded_cluster: MongoDB):
-        service_names = None
+        service_names: list[str] | None = None
         if is_multi_cluster():
             service_names = get_mongos_service_names(sharded_cluster)
         tester = sharded_cluster.tester(service_names=service_names)

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
@@ -78,7 +78,7 @@ def _create_automation_agent_user(namespace: str, resource_name: str, ca_path: s
 
     # First, check if the user already exists by trying to authenticate via pymongo
     try:
-        client = MongoClient(
+        client: MongoClient = MongoClient(
             config_server_host,
             username="mms-automation-agent",
             password=password,

--- a/docker/mongodb-kubernetes-tests/tests/clusterwideoperator/om_multiple.py
+++ b/docker/mongodb-kubernetes-tests/tests/clusterwideoperator/om_multiple.py
@@ -51,7 +51,7 @@ def install_database_roles(
         raise e
 
 
-def create_om_admin_secret(ops_manager_namespace: str, api_client: kubernetes.client.ApiClient = None):
+def create_om_admin_secret(ops_manager_namespace: str, api_client: kubernetes.client.ApiClient | None = None):
     data = dict(
         Username="test-user",
         Password="@Sihjifutestpass21nnH",

--- a/docker/mongodb-kubernetes-tests/tests/common/cert/cert_issuer.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/cert/cert_issuer.py
@@ -11,7 +11,7 @@ def create_appdb_certs(
     namespace: str,
     issuer: str,
     appdb_name: str,
-    cluster_index_with_members: list[tuple[int, int]] = None,
+    cluster_index_with_members: Optional[list[tuple[int, int]]] = None,
     cert_prefix="appdb",
     clusterwide: bool = False,
     additional_domains: Optional[List[str]] = None,

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from dotenv import load_dotenv
 
@@ -41,6 +41,7 @@ def _load_env_from_local_file_for_development():
 _load_env_from_local_file_for_development()
 
 import kubernetes
+import kubernetes.client.rest
 import requests
 from kubernetes import client
 from kubernetes.client import ApiextensionsV1Api
@@ -345,7 +346,10 @@ def multi_cluster_issuer_ca_configmap(
 
 
 def create_issuer_ca_configmap(
-    issuer_ca_filepath: str, namespace: str, name: str = "issuer-ca", api_client: kubernetes.client.ApiClient = None
+    issuer_ca_filepath: str,
+    namespace: str,
+    name: str = "issuer-ca",
+    api_client: kubernetes.client.ApiClient | None = None,
 ):
     """This is the CA file which verifies the certificates signed by it."""
     ca = open(issuer_ca_filepath).read()
@@ -402,7 +406,7 @@ def app_db_issuer_ca_configmap(issuer_ca_filepath: str, namespace: str) -> str:
 
 
 @fixture(scope="module")
-def issuer_ca_plus(issuer_ca_filepath: str, namespace: str) -> str:
+def issuer_ca_plus(issuer_ca_filepath: str, namespace: str) -> Iterator[str]:
     """Returns the name of a ConfigMap which includes a custom CA and the full
     certificate chain for downloads.mongodb.com, fastdl.mongodb.org,
     downloads.mongodb.org. This allows for the use of a custom CA while still
@@ -578,7 +582,7 @@ def member_cluster_names() -> List[str]:
     return get_member_cluster_names()
 
 
-def get_member_cluster_clients(cluster_mapping: dict[str, int] = None) -> List[MultiClusterClient]:
+def get_member_cluster_clients(cluster_mapping: Optional[dict[str, int]] = None) -> List[MultiClusterClient]:
     if not is_multi_cluster():
         return [MultiClusterClient(kubernetes.client.ApiClient(), LEGACY_CENTRAL_CLUSTER_NAME)]
 
@@ -596,7 +600,7 @@ def get_member_cluster_clients(cluster_mapping: dict[str, int] = None) -> List[M
     return member_cluster_clients
 
 
-def get_member_cluster_client_map(deployment_state: dict[str, Any] = None) -> dict[str, MultiClusterClient]:
+def get_member_cluster_client_map(deployment_state: Optional[dict[str, Any]] = None) -> dict[str, MultiClusterClient]:
     return {
         multi_cluster_client.cluster_name: multi_cluster_client
         for multi_cluster_client in get_member_cluster_clients(deployment_state)
@@ -607,6 +611,7 @@ def get_member_cluster_api_client(
     member_cluster_name: Optional[str],
 ) -> kubernetes.client.ApiClient:
     if is_member_cluster(member_cluster_name):
+        assert member_cluster_name is not None
         return get_cluster_clients()[member_cluster_name]
     else:
         return kubernetes.client.ApiClient()
@@ -848,7 +853,9 @@ def _install_multi_cluster_operator(
     # The Operator will be installed from the following repo, so adding it first
     helm_repo_add("mongodb", "https://mongodb.github.io/helm-charts")
 
-    helm_chart_path, operator_version = helm_chart_path_and_version(helm_chart_path, custom_operator_version)
+    helm_chart_path, operator_version = helm_chart_path_and_version(
+        helm_chart_path or "", custom_operator_version or ""
+    )
 
     prepare_multi_cluster_namespaces(
         namespace,
@@ -1012,6 +1019,7 @@ def install_official_operator(
     # Note, that we don't intend to install the official Operator to standalone clusters (kops/openshift) as we want to
     # avoid damaged CRDs. But we may need to install the "openshift like" environment to Kind instead of the "ubi"
     # images are used for installing the dev Operator
+    assert operator_image is not None
     helm_args["operator.operator_image_name"] = operator_image
 
     # Note:
@@ -1036,6 +1044,9 @@ def install_official_operator(
     """
 
     if is_multi_cluster():
+        assert member_cluster_names is not None
+        assert operator_name is not None
+        assert central_cluster_name is not None
         os.environ["HELM_KUBECONTEXT"] = central_cluster_name
         # when running with the local operator, this is executed by scripts/dev/prepare_local_e2e_run.sh
         if not local_operator():
@@ -1059,6 +1070,8 @@ def install_official_operator(
         # The "official" Operator will be installed from the Helm Repo ("mongodb/enterprise-operator")
         # but workload images (OpsManager, Agent, etc.) will use dev registries from operator_installation_config
         # to support testing unreleased versions in patch builds.
+        assert member_cluster_clients is not None
+        assert central_cluster_client is not None
         return _install_multi_cluster_operator(
             namespace,
             helm_args,
@@ -1096,14 +1109,14 @@ def log_deployment_and_images(deployments):
 
 # Extract container images and deployments names from the nested dict returned by kubetester
 # Handles any missing key gracefully
-def extract_container_images_and_deployments(deployments) -> (dict[str, str], List[str]):
-    deployment_images = {}
-    deployment_names = []
+def extract_container_images_and_deployments(deployments) -> tuple[dict[str, list[str]], list[str]]:
+    deployment_images: dict[str, list[str]] = {}
+    deployment_names: list[str] = []
     deployments = deployments.to_dict()
 
     if "items" not in deployments:
         logger.debug("Error: 'items' field not found in the response.")
-        return deployment_images
+        return deployment_images, deployment_names
 
     for deployment in deployments.get("items", []):
         try:
@@ -1215,6 +1228,7 @@ def install_cert_manager(
 ) -> str:
     if is_member_cluster(cluster_name):
         # ensure we cert-manager in the member clusters.
+        assert cluster_name is not None
         os.environ["HELM_KUBECONTEXT"] = cluster_name
 
     install_required = True
@@ -1323,12 +1337,12 @@ def run_kube_config_creation_tool(
     member_namespace: str,
     member_cluster_names: List[str],
     cluster_scoped: Optional[bool] = False,
-    service_account_name: Optional[str] = "mongodb-kubernetes-operator-multi-cluster",
-    operator_name: Optional[str] = OPERATOR_NAME,
+    service_account_name: str = "mongodb-kubernetes-operator-multi-cluster",
+    operator_name: str = OPERATOR_NAME,
 ):
     central_cluster = _read_multi_cluster_config_value("central_cluster")
     member_clusters_str = ",".join(member_clusters)
-    args = [
+    args: list[str] = [
         os.getenv(
             "MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH",
             "multi-cluster-kube-config-creator",
@@ -1402,12 +1416,12 @@ def run_multi_cluster_recovery_tool(
     central_namespace: str,
     member_namespace: str,
     cluster_scoped: Optional[bool] = False,
-    service_account_name: Optional[str] = "mongodb-kubernetes-operator-multi-cluster",
-    operator_name: Optional[str] = OPERATOR_NAME,
+    service_account_name: str = "mongodb-kubernetes-operator-multi-cluster",
+    operator_name: str = OPERATOR_NAME,
 ) -> int:
     central_cluster = _read_multi_cluster_config_value("central_cluster")
     member_clusters_str = ",".join(member_clusters)
-    args = [
+    args: list[str] = [
         os.getenv(
             "MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH",
             "multi-cluster-kube-config-creator",
@@ -1536,7 +1550,7 @@ def update_coredns_hosts(
     host_mappings: list[tuple[str, str]],
     cluster_name: Optional[str] = None,
     api_client: Optional[kubernetes.client.ApiClient] = None,
-    additional_rules: list[str] = None,
+    additional_rules: Optional[list[str]] = None,
 ):
     """Updates kube-system/coredns config map with given host_mappings."""
 
@@ -1561,7 +1575,7 @@ def update_coredns_hosts(
     update_configmap("kube-system", "coredns", config_data, api_client=api_client)
 
 
-def coredns_config(tld: str, mappings: str, additional_rules: str = None):
+def coredns_config(tld: str, mappings: str, additional_rules: Optional[str] = None):
     """Returns coredns config map data with mappings inserted."""
     return f"""
 .:53 {{
@@ -1599,6 +1613,8 @@ def pytest_sessionfinish(session, exitstatus):
     project_id = os.environ.get("OM_PROJECT_ID", "")
     if project_id:
         base_url = os.environ.get("OM_HOST")
+        if base_url is None:
+            return
         user = os.environ.get("OM_USER")
         key = os.environ.get("OM_API_KEY")
         ids = project_id.split(",")
@@ -1651,10 +1667,10 @@ def install_multi_cluster_operator_cluster_scoped(
     namespace: str = get_namespace(),
     central_cluster_name: str = get_central_cluster_name(),
     central_cluster_client: client.ApiClient = get_central_cluster_client(),
-    multi_cluster_operator_installation_config: dict[str, str] = None,
-    member_cluster_clients: list[kubernetes.client.ApiClient] = None,
-    cluster_clients: dict[str, kubernetes.client.ApiClient] = None,
-    member_cluster_names: list[str] = None,
+    multi_cluster_operator_installation_config: Optional[dict[str, str]] = None,
+    member_cluster_clients: Optional[list[MultiClusterClient]] = None,
+    cluster_clients: Optional[dict[str, kubernetes.client.ApiClient]] = None,
+    member_cluster_names: Optional[list[str]] = None,
 ) -> Operator:
     if multi_cluster_operator_installation_config is None:
         multi_cluster_operator_installation_config = get_multi_cluster_operator_installation_config(namespace).copy()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/conftest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import ipaddress
 import urllib
+import urllib.parse
 from typing import Dict, Generator, List, Optional
-from urllib import parse
 
 import kubernetes
 from kubeobject import CustomObject
@@ -77,7 +77,7 @@ def multicluster_openldap_tls(
     member_cluster_clients: List[MultiClusterClient],
     multicluster_openldap_cert: str,
     ca_path: str,
-) -> Generator[OpenLDAP, None, None]:
+) -> OpenLDAP:
     member_cluster_one = member_cluster_clients[0]
     helm_args = {
         "tls.enabled": "true",
@@ -157,7 +157,7 @@ def service_entries(
 
 
 @fixture(scope="module")
-def test_patch_central_namespace(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> str:
+def test_patch_central_namespace(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> None:
     corev1 = kubernetes.client.CoreV1Api(api_client=central_cluster_client)
     ns = corev1.read_namespace(namespace)
     ns.metadata.labels["istio-injection"] = "enabled"
@@ -216,10 +216,12 @@ def create_service_entries_objects(
                     "protocol": "HTTPS",
                 }
             )
-        if check_valid_ip(host_parse_result.hostname):
-            addresses.add(host_parse_result.hostname)
-        else:
-            hosts.add(host_parse_result.hostname)
+        hostname = host_parse_result.hostname
+        if hostname is not None:
+            if check_valid_ip(hostname):
+                addresses.add(hostname)
+            else:
+                hosts.add(hostname)
 
     allowed_hosts_service_entry["spec"] = {
         # by default the access mode is set to "REGISTRY_ONLY" which means only the hosts specified
@@ -249,28 +251,28 @@ def create_service_entries_objects(
 
 def cluster_spec_list(
     member_cluster_names: List[str],
-    members: List[int],
+    members: List[int | None],
     member_configs: Optional[List[List[Dict]]] = None,
     backup_configs: Optional[List[Dict]] = None,
 ):
 
     if member_configs is None and backup_configs is None:
         result = []
-        for name, members in zip(member_cluster_names, members):
-            if members is not None:
-                result.append({"clusterName": name, "members": members})
+        for name, member_count in zip(member_cluster_names, members):
+            if member_count is not None:
+                result.append({"clusterName": name, "members": member_count})
         return result
     elif member_configs is not None:
         result = []
-        for name, members, memberConfig in zip(member_cluster_names, members, member_configs):
-            if members is not None:
-                result.append({"clusterName": name, "members": members, "memberConfig": memberConfig})
+        for name, member_count, memberConfig in zip(member_cluster_names, members, member_configs):
+            if member_count is not None:
+                result.append({"clusterName": name, "members": member_count, "memberConfig": memberConfig})
         return result
     elif backup_configs is not None:
         result = []
-        for name, members, backupConfig in zip(member_cluster_names, members, backup_configs):
-            if members is not None:
-                result.append({"clusterName": name, "members": members, "backup": backupConfig})
+        for name, member_count, backupConfig in zip(member_cluster_names, members, backup_configs):
+            if member_count is not None:
+                result.append({"clusterName": name, "members": member_count, "backup": backupConfig})
         return result
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/manual_multi_cluster_tls_no_mesh_2_clusters_eks_gke.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/manual_multi_cluster_tls_no_mesh_2_clusters_eks_gke.py
@@ -108,7 +108,8 @@ def mongodb_multi(
     }
     mongodb_multi_unmarshalled.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
 
-    return mongodb_multi_unmarshalled.update()
+    mongodb_multi_unmarshalled.update()
+    return mongodb_multi_unmarshalled
 
 
 @fixture(scope="module")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_agent_flags.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_agent_flags.py
@@ -84,6 +84,7 @@ def test_placeholders_in_external_services(
         members = mongodb_multi.get_item_spec(member_cluster_client.cluster_name)["members"]
         for pod_idx in range(0, members):
             cluster_idx = member_cluster_client.cluster_index
+            assert cluster_idx is not None
             service = client.CoreV1Api(api_client=member_cluster_client.api_client).read_namespaced_service(
                 f"{name}-{cluster_idx}-{pod_idx}-svc-external", namespace
             )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
@@ -65,8 +65,10 @@ def ops_manager_certs(
 
 def create_project_config_map(om: MongoDBOpsManager, mdb_name, project_name, client, custom_ca):
     name = f"{mdb_name}-config"
-    data = {
-        "baseUrl": om.om_status().get_url(),
+    base_url = om.om_status().get_url()
+    assert base_url is not None, "OpsManager URL must not be None"
+    data: dict[str, str] = {
+        "baseUrl": base_url,
         "projectName": project_name,
         "sslMMSCAConfigMap": custom_ca,
         "orgId": "",
@@ -516,6 +518,6 @@ class TestBackupForMongodb:
 
 def time_to_millis(date_time) -> int:
     """https://stackoverflow.com/a/11111177/614239"""
-    epoch = datetime.datetime.utcfromtimestamp(0)
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     pit_millis = (date_time - epoch).total_seconds() * 1000
     return pit_millis

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
@@ -492,14 +492,14 @@ class TestBackupForMongodb:
 
     @mark.e2e_multi_cluster_backup_restore
     def test_change_mdb_data(self, mongodb_multi_one_collection):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
         time.sleep(30)
         mongodb_multi_one_collection.insert_one({"foo": "bar"})
 
     @mark.e2e_multi_cluster_backup_restore
     def test_pit_restore(self, project_one: OMTester):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
 
         backup_completion_time = project_one.get_latest_backup_completion_time()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
@@ -652,17 +652,17 @@ class TestBackupForMongodb:
 
     @mark.e2e_multi_cluster_backup_restore_no_mesh
     def test_change_mdb_data(self, mongodb_multi_one_collection):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
         time.sleep(30)
         mongodb_multi_one_collection.insert_one({"foo": "bar"})
 
     @mark.e2e_multi_cluster_backup_restore_no_mesh
     def test_pit_restore(self, project_one: OMTester):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
 
-        pit_datetme = datetime.datetime.now() - datetime.timedelta(seconds=15)
+        pit_datetme = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=15)
         pit_millis = time_to_millis(pit_datetme)
         print("Restoring back to the moment 15 seconds ago (millis): {}".format(pit_millis))
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
@@ -65,8 +65,10 @@ def ops_manager_certs(
 
 def create_project_config_map(om: MongoDBOpsManager, mdb_name, project_name, client, custom_ca):
     name = f"{mdb_name}-config"
-    data = {
-        "baseUrl": om.om_status().get_url(),
+    base_url = om.om_status().get_url()
+    assert base_url is not None, "OpsManager URL must not be None"
+    data: dict[str, str] = {
+        "baseUrl": base_url,
         "projectName": project_name,
         "sslMMSCAConfigMap": custom_ca,
         "orgId": "",
@@ -459,9 +461,9 @@ class TestBackupForMongodb:
             external=True,
         )
 
-        collection = pymongo.MongoClient(tester.cnx_string, **tester.default_opts)["testdb"]
+        db: pymongo.database.Database = pymongo.MongoClient(tester.cnx_string, **tester.default_opts)["testdb"]
 
-        return collection["testcollection"]
+        return db["testcollection"]
 
     @fixture(scope="module")
     def mongodb_multi_one(
@@ -681,6 +683,6 @@ class TestBackupForMongodb:
 
 def time_to_millis(date_time) -> int:
     """https://stackoverflow.com/a/11111177/614239"""
-    epoch = datetime.datetime.utcfromtimestamp(0)
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     pit_millis = (date_time - epoch).total_seconds() * 1000
     return pit_millis

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
@@ -86,7 +86,7 @@ def install_operator(
     central_cluster_name: str,
     multi_cluster_operator_installation_config: Dict[str, str],
     central_cluster_client: client.ApiClient,
-    member_cluster_clients: List[kubernetes.client.ApiClient],
+    member_cluster_clients: List[MultiClusterClient],
     cluster_clients: Dict[str, kubernetes.client.ApiClient],
     member_cluster_names: List[str],
     mdba_ns: str,
@@ -182,7 +182,7 @@ def test_deploy_operator(multi_cluster_operator_clustermode: Operator):
 
 
 @mark.e2e_multi_cluster_specific_namespaces
-def test_deploy_operator(install_operator: Operator):
+def test_deploy_operator_specific_namespaces(install_operator: Operator):
     install_operator.assert_is_running()
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_group.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_group.py
@@ -23,7 +23,7 @@ def mongodb_multi(
 ) -> MongoDBMulti:
     resource = MongoDBMulti.from_yaml(yaml_fixture("oidc/mongodb-multi-m2m-group.yaml"), MDB_RESOURCE, namespace)
     oidc_provider_configs = resource.get_oidc_provider_configs()
-
+    assert oidc_provider_configs
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_user.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_user.py
@@ -24,7 +24,7 @@ def mongodb_multi(
 ) -> MongoDBMulti:
     resource = MongoDBMulti.from_yaml(yaml_fixture("oidc/mongodb-multi-m2m-user.yaml"), MDB_RESOURCE, namespace)
     oidc_provider_configs = resource.get_oidc_provider_configs()
-
+    assert oidc_provider_configs
     oidc_provider_configs[0]["clientId"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["audience"] = oidc.get_cognito_workload_client_id()
     oidc_provider_configs[0]["issuerURI"] = oidc.get_cognito_workload_url()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
@@ -343,11 +343,13 @@ def test_telemetry_configmap(namespace: str):
     config = KubernetesTester.read_configmap(namespace, TELEMETRY_CONFIGMAP_NAME)
     for ts_key in ["lastSendTimestampClusters", "lastSendTimestampDeployments", "lastSendTimestampOperators"]:
         ts_cm = config.get(ts_key)
+        assert ts_cm is not None
         assert ts_cm.isdigit()  # it should be a timestamp
 
     for ps_key in ["lastSendPayloadClusters", "lastSendPayloadDeployments", "lastSendPayloadOperators"]:
         try:
             payload_string = config.get(ps_key)
+            assert payload_string is not None
             payload = json.loads(payload_string)
             # Perform a rudimentary check
             assert isinstance(payload, list), "payload should be a list"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_up.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_up.py
@@ -88,26 +88,32 @@ def test_statefulsets_have_been_created_correctly(
     # checking the expected number of replicas for STS makes the test flaky because of an issue mentioned in detail in this ticket https://jira.mongodb.org/browse/CLOUDP-329231.
     # That's why we are waiting for STS to have expected number of replicas. This change can be reverted when we make the proper fix as
     # mentioned in the above ticket.
-    def fn():
+    def fn_cluster_one():
         cluster_one_client = member_cluster_clients[0]
         cluster_one_statefulsets = mongodb_multi.read_statefulsets([cluster_one_client])
         return cluster_one_statefulsets[cluster_one_client.cluster_name].status.ready_replicas == 1
 
-    kubetester.wait_until(fn, timeout=60, message="Verifying sts has correct number of replicas in cluster one")
+    kubetester.wait_until(
+        fn_cluster_one, timeout=60, message="Verifying sts has correct number of replicas in cluster one"
+    )
 
-    def fn():
+    def fn_cluster_two():
         cluster_two_client = member_cluster_clients[1]
         cluster_two_statefulsets = mongodb_multi.read_statefulsets([cluster_two_client])
         return cluster_two_statefulsets[cluster_two_client.cluster_name].status.ready_replicas == 1
 
-    kubetester.wait_until(fn, timeout=60, message="Verifying sts has correct number of replicas in cluster two")
+    kubetester.wait_until(
+        fn_cluster_two, timeout=60, message="Verifying sts has correct number of replicas in cluster two"
+    )
 
-    def fn():
+    def fn_cluster_three():
         cluster_three_client = member_cluster_clients[2]
         cluster_three_statefulsets = mongodb_multi.read_statefulsets([cluster_three_client])
         return cluster_three_statefulsets[cluster_three_client.cluster_name].status.ready_replicas == 1
 
-    kubetester.wait_until(fn, timeout=60, message="Verifying sts has correct number of replicas in cluster three")
+    kubetester.wait_until(
+        fn_cluster_three, timeout=60, message="Verifying sts has correct number of replicas in cluster three"
+    )
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_up
@@ -136,31 +142,33 @@ def test_statefulsets_have_been_scaled_up_correctly(
     # checking the expected number of replicas for STS makes the test flaky because of an issue mentioned in detail in this ticket https://jira.mongodb.org/browse/CLOUDP-329231.
     # That's why we are waiting for STS to have expected number of replicas. This change can be reverted when we make the proper fix as
     # mentioned in the above ticket.
-    def fn():
+    def fn_cluster_one():
         cluster_one_client = member_cluster_clients[0]
         cluster_one_statefulsets = mongodb_multi.read_statefulsets([cluster_one_client])
         return cluster_one_statefulsets[cluster_one_client.cluster_name].status.ready_replicas == 2
 
     kubetester.wait_until(
-        fn, timeout=60, message="Verifying sts has correct number of replicas after scale up in cluster one"
+        fn_cluster_one, timeout=60, message="Verifying sts has correct number of replicas after scale up in cluster one"
     )
 
-    def fn():
+    def fn_cluster_two():
         cluster_two_client = member_cluster_clients[1]
         cluster_two_statefulsets = mongodb_multi.read_statefulsets([cluster_two_client])
         return cluster_two_statefulsets[cluster_two_client.cluster_name].status.ready_replicas == 1
 
     kubetester.wait_until(
-        fn, timeout=60, message="Verifying sts has correct number of replicas after scale up in cluster two"
+        fn_cluster_two, timeout=60, message="Verifying sts has correct number of replicas after scale up in cluster two"
     )
 
-    def fn():
+    def fn_cluster_three():
         cluster_three_client = member_cluster_clients[2]
         cluster_three_statefulsets = mongodb_multi.read_statefulsets([cluster_three_client])
         return cluster_three_statefulsets[cluster_three_client.cluster_name].status.ready_replicas == 2
 
     kubetester.wait_until(
-        fn, timeout=60, message="Verifying sts has correct number of replicas after scale up in cluster three"
+        fn_cluster_three,
+        timeout=60,
+        message="Verifying sts has correct number of replicas after scale up in cluster three",
     )
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
@@ -135,7 +135,8 @@ def mongodb_multi(
     }
     mongodb_multi_unmarshalled.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
 
-    return mongodb_multi_unmarshalled.update()
+    mongodb_multi_unmarshalled.update()
+    return mongodb_multi_unmarshalled
 
 
 @fixture(scope="module")
@@ -279,6 +280,7 @@ def test_placeholders_in_external_services(
         members = mongodb_multi.get_item_spec(member_cluster_client.cluster_name)["members"]
         for pod_idx in range(0, members):
             cluster_idx = member_cluster_client.cluster_index
+            assert cluster_idx is not None
             service = client.CoreV1Api(api_client=member_cluster_client.api_client).read_namespaced_service(
                 f"{name}-{cluster_idx}-{pod_idx}-svc-external", namespace
             )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/conftest.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 import kubernetes
 from kubetester.awss3client import AwsS3Client
 from pytest import fixture
@@ -10,7 +12,7 @@ def s3_bucket_oplog(
     aws_s3_client: AwsS3Client,
     namespace: str,
     central_cluster_client: kubernetes.client.ApiClient,
-) -> str:
+) -> Iterator[str]:
     yield from create_s3_bucket_oplog(namespace, aws_s3_client, central_cluster_client)
 
 
@@ -24,7 +26,7 @@ def s3_bucket_blockstore(
     aws_s3_client: AwsS3Client,
     namespace: str,
     central_cluster_client: kubernetes.client.ApiClient,
-) -> str:
+) -> Iterator[str]:
     yield from create_s3_bucket_blockstore(namespace, aws_s3_client, api_client=central_cluster_client)
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
@@ -71,8 +71,8 @@ def ops_manager(
     appdb_certs_secret: str,
     ops_manager_unmarshalled: MongoDBOpsManager,
 ) -> MongoDBOpsManager:
-    resource = ops_manager_unmarshalled.update()
-    return resource
+    ops_manager_unmarshalled.update()
+    return ops_manager_unmarshalled
 
 
 @mark.e2e_multi_cluster_appdb

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_disaster_recovery.py
@@ -165,7 +165,7 @@ def test_delete_om_and_appdb_statefulset_in_failed_cluster(
         if e.status != 404:
             raise e
 
-    def statefulset_is_deleted(namespace: str, name: str, api_client=Optional[kubernetes.client.ApiClient]):
+    def statefulset_is_deleted(namespace: str, name: str, api_client: Optional[kubernetes.client.ApiClient] = None):
         try:
             get_statefulset(namespace, name, api_client=api_client)
             return False

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_s3_based_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_s3_based_backup_restore.py
@@ -27,8 +27,10 @@ def appdb_member_cluster_names() -> list[str]:
 
 def create_project_config_map(om: MongoDBOpsManager, mdb_name, project_name, client, custom_ca):
     name = f"{mdb_name}-config"
-    data = {
-        "baseUrl": om.om_status().get_url(),
+    base_url = om.om_status().get_url()
+    assert base_url is not None, "OpsManager URL must not be None"
+    data: dict[str, str] = {
+        "baseUrl": base_url,
         "projectName": project_name,
         "sslMMSCAConfigMap": custom_ca,
         "orgId": "",
@@ -160,12 +162,12 @@ class TestBackupForMongodb:
     @fixture(scope="module")
     def mongodb_multi_one_collection(self, mongodb_multi_one: MongoDBMulti):
         # we instantiate the pymongo client per test to avoid flakiness as the primary and secondary might swap
-        collection = pymongo.MongoClient(
+        db: pymongo.database.Database = pymongo.MongoClient(
             mongodb_multi_one.tester(port=MONGODB_PORT).cnx_string,
             **mongodb_multi_one.tester(port=MONGODB_PORT).default_opts,
         )["testdb"]
 
-        return collection["testcollection"]
+        return db["testcollection"]
 
     @fixture(scope="module")
     def mongodb_multi_one(
@@ -229,6 +231,6 @@ class TestBackupForMongodb:
 
 def time_to_millis(date_time) -> int:
     """https://stackoverflow.com/a/11111177/614239"""
-    epoch = datetime.datetime.utcfromtimestamp(0)
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     pit_millis = (date_time - epoch).total_seconds() * 1000
     return pit_millis

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_s3_based_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_s3_based_backup_restore.py
@@ -210,16 +210,16 @@ class TestBackupForMongodb:
         project_one.wait_until_backup_snapshots_are_ready(expected_count=1)
 
     def test_change_mdb_data(self, mongodb_multi_one_collection):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
         time.sleep(30)
         mongodb_multi_one_collection.insert_one({"foo": "bar"})
 
     def test_pit_restore(self, project_one: OMTester):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
 
-        pit_datetme = datetime.datetime.now() - datetime.timedelta(seconds=15)
+        pit_datetme = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=15)
         pit_millis = time_to_millis(pit_datetme)
         print("Restoring back to the moment 15 seconds ago (millis): {}".format(pit_millis))
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_om_networking_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_om_networking_clusterwide.py
@@ -262,6 +262,7 @@ def test_enable_external_connectivity(ops_manager: MongoDBOpsManager):
 @mark.e2e_multi_cluster_om_networking_clusterwide
 def test_external_services_are_created(ops_manager: MongoDBOpsManager):
     _, external = ops_manager.services(MEMBER_CLUSTER_1)
+    assert external is not None
     assert external.spec.type == "NodePort"
     assert external.metadata.annotations == {"test-annotation": "test-value"}
     assert len(external.spec.ports) == 2
@@ -269,12 +270,14 @@ def test_external_services_are_created(ops_manager: MongoDBOpsManager):
     assert external.spec.ports[0].target_port == 8443
 
     _, external = ops_manager.services(MEMBER_CLUSTER_2)
+    assert external is not None
     assert external.spec.type == "LoadBalancer"
     assert len(external.spec.ports) == 2
     assert external.spec.ports[0].port == 5000
     assert external.spec.ports[0].target_port == 8443
 
     _, external = ops_manager.services(MEMBER_CLUSTER_3)
+    assert external is not None
     assert external.spec.type == "LoadBalancer"
     assert len(external.spec.ports) == 2
     assert external.spec.ports[0].port == 9000

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
@@ -403,9 +403,9 @@ def mongodb_multi_collection(mongodb_multi: MongoDBMulti, ca_path: str):
         ca_path=ca_path,
     )
 
-    collection = pymongo.MongoClient(tester.cnx_string, **tester.default_opts)["testdb"]
+    db: pymongo.database.Database = pymongo.MongoClient(tester.cnx_string, **tester.default_opts)["testdb"]
 
-    return collection["testcollection"]
+    return db["testcollection"]
 
 
 @fixture(scope="function")
@@ -518,8 +518,10 @@ def mongodb_multi(
 
 def create_project_config_map(om: MongoDBOpsManager, mdb_name, project_name, client, custom_ca):
     name = f"{mdb_name}-config"
-    data = {
-        "baseUrl": om.om_status().get_url(),
+    base_url = om.om_status().get_url()
+    assert base_url is not None, "OpsManager URL must not be None"
+    data: dict[str, str] = {
+        "baseUrl": base_url,
         "projectName": project_name,
         "sslMMSCAConfigMap": custom_ca,
         "orgId": "",
@@ -608,6 +610,7 @@ def test_telemetry_configmap(namespace: str):
 
     try:
         payload_string = config.get("lastSendPayloadDeployments")
+        assert payload_string is not None
         payload = json.loads(payload_string)
         # Perform a rudimentary check
         assert isinstance(payload, list), "payload should be a list"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/__init__.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import kubernetes
 import pytest
@@ -70,7 +70,9 @@ def validate_member_count_in_ac(sharded_cluster: MongoDB, automation_config):
     logger.debug(f"{shard_count} shards, {mongos_count} mongos, {config_server_count} configs")
 
 
-def assert_member_configs(expected_member_configs: List[Dict[str, str]], ac_members: List[Dict], ac_shard_name: str):
+def assert_member_configs(
+    expected_member_configs: Optional[List[Dict[str, str]]], ac_members: List[Dict], ac_shard_name: str
+):
     logger.debug(f"Ensuring member config correctness of shard {ac_shard_name}")
     if expected_member_configs:
         for idx, ac_member in enumerate(ac_members):
@@ -221,7 +223,7 @@ def build_expected_statefulsets_multi(sc: MongoDB, cluster_mapping: Dict[str, in
     shard_override_map = expand_shard_overrides(sc_spec)
 
     # Dict holding expected sts per cluster: {cluster_name: {sts_name: replica_count}}
-    expected_clusters_sts = {}
+    expected_clusters_sts: Dict[str, Dict[str, int]] = {}
 
     # Process each shard
     for i in range(shard_count):
@@ -311,21 +313,27 @@ def assert_correct_automation_config_after_scaling(sc: MongoDB):
 
 def assert_shard_sts_members_count(sc: MongoDB, shard_in_cluster_distribution: List[List[int]]):
     for cluster_member_client in get_member_cluster_clients_using_cluster_mapping(sc.name, sc.namespace):
+        cluster_index = cluster_member_client.cluster_index
+        assert cluster_index is not None
         for shard_idx, shard_distribution in enumerate(shard_in_cluster_distribution):
-            sts_name = sc.shard_statefulset_name(shard_idx, cluster_member_client.cluster_index)
-            expected_shard_members_in_cluster = shard_distribution[cluster_member_client.cluster_index]
+            sts_name = sc.shard_statefulset_name(shard_idx, cluster_index)
+            expected_shard_members_in_cluster = shard_distribution[cluster_index]
             cluster_member_client.assert_sts_members_count(sts_name, sc.namespace, expected_shard_members_in_cluster)
 
 
 def assert_config_srv_sts_members_count(sc: MongoDB, config_srv_distribution: List[int]):
     for cluster_member_client in get_member_cluster_clients_using_cluster_mapping(sc.name, sc.namespace):
-        sts_name = sc.config_srv_statefulset_name(cluster_member_client.cluster_index)
-        expected_config_srv_members_in_cluster = config_srv_distribution[cluster_member_client.cluster_index]
+        cluster_index = cluster_member_client.cluster_index
+        assert cluster_index is not None
+        sts_name = sc.config_srv_statefulset_name(cluster_index)
+        expected_config_srv_members_in_cluster = config_srv_distribution[cluster_index]
         cluster_member_client.assert_sts_members_count(sts_name, sc.namespace, expected_config_srv_members_in_cluster)
 
 
 def assert_mongos_sts_members_count(sc: MongoDB, mongos_distribution: List[int]):
     for cluster_member_client in get_member_cluster_clients_using_cluster_mapping(sc.name, sc.namespace):
-        sts_name = sc.mongos_statefulset_name(cluster_member_client.cluster_index)
-        expected_mongos_members_in_cluster = mongos_distribution[cluster_member_client.cluster_index]
+        cluster_index = cluster_member_client.cluster_index
+        assert cluster_index is not None
+        sts_name = sc.mongos_statefulset_name(cluster_index)
+        expected_mongos_members_in_cluster = mongos_distribution[cluster_index]
         cluster_member_client.assert_sts_members_count(sts_name, sc.namespace, expected_mongos_members_in_cluster)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
@@ -132,11 +132,6 @@ def config_version_store():
 
 
 @mark.e2e_multi_cluster_sharded_disaster_recovery
-def test_install_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
-
-
-@mark.e2e_multi_cluster_sharded_disaster_recovery
 class TestDeployShardedClusterWithFailedCluster:
     def test_create_sharded_cluster(self, sc: MongoDB, config_version_store):
         sc.update()
@@ -206,7 +201,7 @@ class TestDeployShardedClusterWithFailedCluster:
                 if e.status != 404:
                     raise e
 
-        def statefulset_is_deleted(namespace: str, name: str, api_client=Optional[kubernetes.client.ApiClient]):
+        def statefulset_is_deleted(namespace: str, name: str, api_client: Optional[kubernetes.client.ApiClient] = None):
             try:
                 get_statefulset(namespace, name, api_client=api_client)
                 return False

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_external_access_no_ext_domain.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_external_access_no_ext_domain.py
@@ -84,8 +84,8 @@ def test_services_were_created(sharded_cluster: MongoDB, namespace: str):
         logger.debug(f"Services: {services}")
 
     # Assert that each expected service exists in its corresponding cluster and no extra services exist
-    for cluster, expected_services in expected_services.items():
+    for cluster, cluster_expected_services in expected_services.items():
         api_client = get_member_cluster_api_client(cluster)  # Retrieve the API client for the cluster
         svc_list = client.CoreV1Api(api_client=api_client).list_namespaced_service(namespace)
         actual_services = map(lambda x: x.metadata.name, svc_list.items)
-        assert sorted(expected_services) == sorted(actual_services)
+        assert sorted(cluster_expected_services) == sorted(actual_services)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_snippets.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_snippets.py
@@ -21,13 +21,13 @@ SNIPPETS_FILES = [
 logger = test_logger.get_test_logger(__name__)
 
 
-def load_resource(namespace: str, file_path: str, resource_name: str = None) -> MongoDB:
+def load_resource(namespace: str, file_path: str, resource_name: str | None = None) -> MongoDB:
     resource = MongoDB.from_yaml(file_path, namespace=namespace, name=resource_name)
     return resource
 
 
 def get_project_directory() -> str:
-    project_dir = os.environ.get("PROJECT_DIR")
+    project_dir = os.environ["PROJECT_DIR"]
     logger.debug(f"PROJECT_DIR: {project_dir}")
     return project_dir
 

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 import kubernetes
 import pytest
 from kubeobject import CustomObject
@@ -154,7 +156,7 @@ def ops_manager(namespace: str) -> MongoDBOpsManager:
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, "my-s3-secret", namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-s3")
 

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 import kubernetes
 import pytest
 from kubeobject import CustomObject
@@ -116,7 +118,7 @@ def ops_manager(namespace: str) -> MongoDBOpsManager:
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, "my-s3-secret", namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-s3")
 

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_test_commons.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_test_commons.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 import tempfile
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import kubetester
 import requests
@@ -59,7 +59,7 @@ def get_catalog_source_resource(namespace: str, image: str) -> CustomObject:
     return resource
 
 
-def get_subscription_custom_object(name: str, namespace: str, spec: dict[str, str]) -> CustomObject:
+def get_subscription_custom_object(name: str, namespace: str, spec: dict[str, Any]) -> CustomObject:
     resource = CustomObject(
         name,
         namespace,
@@ -129,7 +129,7 @@ def get_release_json_path() -> str:
             )
 
 
-def get_release_json() -> dict[str, any]:
+def get_release_json() -> dict[str, Any]:
     with open(get_release_json_path()) as f:
         return json.load(f)
 

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_clusterwide.py
@@ -1,6 +1,7 @@
 import time
 from typing import Dict
 
+import kubernetes.client.rest
 import pytest
 from kubernetes import client
 from kubetester import create_secret, read_secret, try_load

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/conftest.py
@@ -70,7 +70,7 @@ def mino_operator_install(
     operator_name: str = MINIO_OPERATOR,
     cluster_client: Optional[client.ApiClient] = None,
     cluster_name: Optional[str] = None,
-    helm_args: Dict[str, str] = None,
+    helm_args: Optional[Dict[str, str]] = None,
     version="5.0.6",
 ):
     if cluster_name is not None:
@@ -178,7 +178,7 @@ def mino_tenant_install(
     tenant_name: str = MINIO_TENANT,
     cluster_client: Optional[client.ApiClient] = None,
     cluster_name: Optional[str] = None,
-    helm_args: Dict[str, str] = None,
+    helm_args: Optional[Dict[str, str]] = None,
     version="5.0.6",
     issuer_ca_filepath: Optional[str] = os.getenv("MINIO_ISSUER_CA_FILEPATH", None),
 ):

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_connectivity.py
@@ -128,7 +128,7 @@ def test_add_annotations(opsmanager: MongoDBOpsManager):
 
     for _, cluster_spec_item in opsmanager.get_om_indexed_cluster_spec_items():
         internal, external = opsmanager.services(cluster_spec_item["clusterName"])
-
+        assert external is not None
         ant = external.metadata.annotations
         assert len(ant) == 3
         assert "first-annotation" in ant
@@ -153,6 +153,8 @@ def test_service_set_node_port(opsmanager: MongoDBOpsManager):
 
     for _, cluster_spec_item in opsmanager.get_om_indexed_cluster_spec_items():
         internal, external = opsmanager.services(cluster_spec_item["clusterName"])
+        assert internal is not None
+        assert external is not None
         assert internal.spec.type == "ClusterIP"
         assert external.spec.type == "NodePort"
         assert external.spec.ports[0].node_port == node_port
@@ -170,6 +172,7 @@ def test_service_set_node_port(opsmanager: MongoDBOpsManager):
 
     for _, cluster_spec_item in opsmanager.get_om_indexed_cluster_spec_items():
         _, external = opsmanager.services(cluster_spec_item["clusterName"])
+        assert external is not None
         assert external.spec.type == "LoadBalancer"
         assert external.spec.ports[0].port == 443
         assert external.spec.ports[0].target_port == 8080
@@ -178,7 +181,7 @@ def test_service_set_node_port(opsmanager: MongoDBOpsManager):
 def service_is_changed_to_nodeport(om: MongoDBOpsManager) -> bool:
     for _, cluster_spec_item in om.get_om_indexed_cluster_spec_items():
         svc = om.services(cluster_spec_item["clusterName"])[1]
-        if svc.spec.type != "NodePort":
+        if svc is None or svc.spec.type != "NodePort":
             return False
 
     return True
@@ -187,7 +190,7 @@ def service_is_changed_to_nodeport(om: MongoDBOpsManager) -> bool:
 def service_is_changed_to_loadbalancer(om: MongoDBOpsManager) -> bool:
     for _, cluster_spec_item in om.get_om_indexed_cluster_spec_items():
         svc = om.services(cluster_spec_item["clusterName"])[1]
-        if svc.spec.type != "LoadBalancer":
+        if svc is None or svc.spec.type != "LoadBalancer":
             return False
 
     return True

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup.py
@@ -1,5 +1,5 @@
 from operator import attrgetter
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional
 
 from kubernetes import client
 from kubernetes.client import ApiException
@@ -79,7 +79,7 @@ def new_om_data_store(
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-s3")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_kmip.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_kmip.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Iterator, Optional
 
 import pymongo
 from kubetester import create_or_update_secret, read_secret, try_load
@@ -31,13 +31,13 @@ def kmip(issuer, issuer_ca_configmap, namespace: str) -> KMIPDeployment:
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, bucket_prefix="test-s3-bucket")
 
 
 @fixture(scope="module")
-def oplog_s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def oplog_s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, OPLOG_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, bucket_prefix="test-s3-bucket-oplog")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_object_lock.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_object_lock.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional
 
 from kubetester import run_periodically, try_load
 from kubetester.awss3client import AwsS3Client, s3_endpoint
@@ -67,7 +67,7 @@ def oplog_replica_set(ops_manager, namespace, custom_mdb_version) -> MongoDB:
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-s3")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-from typing import Optional
+from typing import Iterator, Optional
 
 import pymongo
 from kubetester import try_load
@@ -29,13 +29,13 @@ OPLOG_SECRET_NAME = S3_SECRET_NAME + "-oplog"
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-s3")
 
 
 @fixture(scope="module")
-def oplog_s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def oplog_s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, OPLOG_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-oplog")
 
@@ -249,6 +249,6 @@ class TestBackupRestoreFromSnapshot:
 
 def time_to_millis(date_time) -> int:
     """https://stackoverflow.com/a/11111177/614239"""
-    epoch = datetime.datetime.utcfromtimestamp(0)
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     pit_millis = (date_time - epoch).total_seconds() * 1000
     return pit_millis

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore.py
@@ -181,7 +181,7 @@ class TestBackupRestorePIT:
         """Changes the MDB documents to check that restore rollbacks this change later.
         Note, that we need to wait for some time to ensure the PIT timestamp gets to the range
         [snapshot_created <= PIT <= changes_applied]"""
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
         time.sleep(30)
 
@@ -189,10 +189,10 @@ class TestBackupRestorePIT:
         mdb_latest_test_collection.insert_one({"foo": "bar"})
 
     def test_mdbs_pit_restore(self, mdb_prev_project: OMTester, mdb_latest_project: OMTester):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
 
-        pit_datetme = datetime.datetime.now() - datetime.timedelta(seconds=15)
+        pit_datetme = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=15)
         pit_millis = time_to_millis(pit_datetme)
         print("Restoring back to the moment 15 seconds ago (millis): {}".format(pit_millis))
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore_minio.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore_minio.py
@@ -365,7 +365,7 @@ class TestBackupRestorePIT:
         """Changes the MDB documents to check that restore rollbacks this change later.
         Note, that we need to wait for some time to ensure the PIT timestamp gets to the range
         [snapshot_created <= PIT <= changes_applied]"""
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
         time.sleep(30)
 
@@ -373,10 +373,10 @@ class TestBackupRestorePIT:
         mdb_latest_test_collection.insert_one({"foo": "bar"})
 
     def test_mdbs_pit_restore(self, mdb_prev_project: OMTester, mdb_latest_project: OMTester):
-        now_millis = time_to_millis(datetime.datetime.now())
+        now_millis = time_to_millis(datetime.datetime.now(tz=datetime.timezone.utc))
         print("\nCurrent time (millis): {}".format(now_millis))
 
-        pit_datetme = datetime.datetime.now() - datetime.timedelta(seconds=15)
+        pit_datetme = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=15)
         pit_millis = time_to_millis(pit_datetme)
         print("Restoring back to the moment 15 seconds ago (millis): {}".format(pit_millis))
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore_minio.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_restore_minio.py
@@ -433,6 +433,6 @@ class TestBackupRestoreFromSnapshot:
 
 def time_to_millis(date_time) -> int:
     """https://stackoverflow.com/a/11111177/614239"""
-    epoch = datetime.datetime.utcfromtimestamp(0)
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     pit_millis = (date_time - epoch).total_seconds() * 1000
     return pit_millis

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_s3_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_s3_tls.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Iterator, Optional
 
 from kubetester import create_or_update_secret, try_load
 from kubetester.awss3client import AwsS3Client, s3_endpoint
@@ -28,13 +28,13 @@ def appdb_certs_secret(namespace: str, issuer: str):
 
 
 @fixture(scope="module")
-def s3_bucket_oplog(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket_oplog(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_OPLOG_NAME + "-secret", namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-oplog-")
 
 
 @fixture(scope="module")
-def s3_bucket_blockstore(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket_blockstore(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_BLOCKSTORE_NAME + "-secret", namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-blockstorage-")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_sharded_cluster.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional
+from typing import Iterator, Optional
 
 from kubernetes.client.rest import ApiException
 from kubetester import create_or_update_secret, get_default_storage_class, try_load, wait_until
@@ -28,7 +28,7 @@ USER_PASSWORD = "/qwerty@!#:"
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-sharded-")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https.py
@@ -85,8 +85,10 @@ def test_om_created_no_tls(ops_manager: MongoDBOpsManager):
 
     ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=900)
 
-    assert ops_manager.om_status().get_url().startswith("http://")
-    assert ops_manager.om_status().get_url().endswith(":8080")
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("http://")
+    assert om_url.endswith(":8080")
 
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
 
@@ -151,7 +153,7 @@ def test_enable_https_on_opsmanager(
     # probably need to be done above and if only test replicaset1 since that one already has tls setup or test below
     #  custom ca setup
     # only run this test if om > 6.0.18
-    if custom_version >= "6.0.18":
+    if custom_version is not None and custom_version >= "6.0.18":
         print("verifying download signature for OM!")
         ops_manager["spec"]["configuration"]["mms.featureFlag.automation.verifyDownloads"] = "enabled"
 
@@ -159,8 +161,10 @@ def test_enable_https_on_opsmanager(
 
     ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=900)
 
-    assert ops_manager.om_status().get_url().startswith("https://")
-    assert ops_manager.om_status().get_url().endswith(":8443")
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("https://")
+    assert om_url.endswith(":8443")
 
 
 @mark.e2e_om_ops_manager_https_enabled
@@ -201,8 +205,10 @@ def test_change_om_certificate_and_wait_for_running(ops_manager: MongoDBOpsManag
     rotate_cert(namespace, certificate_name="prefix-om-with-https-cert")
     ops_manager.om_status().assert_abandons_phase(Phase.Running, timeout=600)
     ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=600)
-    assert ops_manager.om_status().get_url().startswith("https://")
-    assert ops_manager.om_status().get_url().endswith(":8443")
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("https://")
+    assert om_url.endswith(":8443")
 
 
 @mark.e2e_om_ops_manager_https_enabled
@@ -217,8 +223,10 @@ def test_change_om_certificate_with_sts_restarting(ops_manager: MongoDBOpsManage
     ops_manager.trigger_om_sts_restart()
     rotate_cert(namespace, certificate_name="prefix-om-with-https-cert")
     ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=900)
-    assert ops_manager.om_status().get_url().startswith("https://")
-    assert ops_manager.om_status().get_url().endswith(":8443")
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("https://")
+    assert om_url.endswith(":8443")
 
 
 @mark.e2e_om_ops_manager_https_enabled

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https_internet_mode.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https_internet_mode.py
@@ -89,8 +89,10 @@ def test_enable_https_on_opsmanager(ops_manager: MongoDBOpsManager):
     ops_manager.update()
     ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=900)
 
-    assert ops_manager.om_status().get_url().startswith("https://")
-    assert ops_manager.om_status().get_url().endswith(":8443")
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("https://")
+    assert om_url.endswith(":8443")
 
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https_prefix.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https_prefix.py
@@ -47,5 +47,7 @@ def ops_manager(
 def test_om_created(ops_manager: MongoDBOpsManager):
     ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=900)
 
-    assert ops_manager.om_status().get_url().startswith("https://")
-    assert ops_manager.om_status().get_url().endswith(":8443")
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("https://")
+    assert om_url.endswith(":8443")

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_queryable_backup.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_queryable_backup.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from operator import attrgetter
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional
 
 from kubernetes import client
 from kubetester import (
@@ -95,7 +95,7 @@ def new_om_data_store(
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, "test-bucket-s3")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_scale.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_scale.py
@@ -76,6 +76,7 @@ class TestOpsManagerCreation:
         for _, cluster_spec_item in ops_manager.get_om_indexed_cluster_spec_items():
             internal, external = ops_manager.services(cluster_spec_item["clusterName"])
             assert external is None
+            assert internal is not None
             assert internal.spec.type == "ClusterIP"
             if not ops_manager.is_om_multi_cluster():
                 assert internal.spec.cluster_ip == "None"

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_upgrade.py
@@ -1,5 +1,5 @@
 from time import sleep
-from typing import Optional
+from typing import Iterator, Optional
 
 import pytest
 import semver
@@ -28,7 +28,7 @@ logger = test_logger.get_test_logger(__name__)
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, bucket_prefix="test-s3-bucket-")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_remotemode.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_remotemode.py
@@ -208,12 +208,6 @@ def test_client_can_connect_to_mongodb_ent(replica_set_ent: MongoDB):
     replica_set_ent.assert_connectivity()
 
 
-@skip_if_local
-@mark.e2e_om_remotemode
-def test_client_can_connect_to_mongodb_ent(replica_set_ent: MongoDB):
-    replica_set_ent.assert_connectivity()
-
-
 @mark.e2e_om_remotemode
 def test_restart_ops_manager_pod(ops_manager: MongoDBOpsManager):
     ops_manager.load()

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/conftest.py
@@ -32,8 +32,8 @@ def get_om_member_cluster_names():
 
 def enable_multi_cluster_deployment(
     resource: MongoDBOpsManager,
-    om_cluster_spec_list: Optional[list[int]] = None,
-    appdb_cluster_spec_list: Optional[list[int]] = None,
+    om_cluster_spec_list: Optional[list[int | None]] = None,
+    appdb_cluster_spec_list: Optional[list[int | None]] = None,
     appdb_member_configs: Optional[list[list[dict]]] = None,
 ):
     resource["spec"]["topology"] = "MultiCluster"

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_external_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_external_connectivity.py
@@ -120,6 +120,7 @@ def test_service_exists(namespace: str):
             namespace,
             f"{APPDB_NAME}-{i}-svc-external",
         )
+        assert service is not None
         assert service.spec.type == "LoadBalancer"
         assert service.spec.ports[0].port == 27017
         assert service.spec.ports[1].port == 27018
@@ -139,6 +140,7 @@ def test_placeholders_in_external_services(ops_manager: MongoDBOpsManager, names
 
     for pod_idx in range(3):
         service = get_service(namespace, f"{APPDB_NAME}-{pod_idx}-svc-external")
+        assert service is not None
         assert (
             service.metadata.annotations
             == placeholders.get_expected_annotations_single_cluster_with_external_domain(

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_appdb_monitoring_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_appdb_monitoring_tls.py
@@ -90,7 +90,7 @@ def test_appdb_password_can_be_changed(ops_manager: MongoDBOpsManager):
 def test_new_database_is_monitored_after_restart(ops_manager: MongoDBOpsManager):
     # Connect with the new connection string
     connection_string = ops_manager.read_appdb_connection_url()
-    client = pymongo.MongoClient(connection_string, tlsAllowInvalidCertificates=True)
+    client: pymongo.MongoClient = pymongo.MongoClient(connection_string, tlsAllowInvalidCertificates=True)
     database_name = "new_database"
     database = client[database_name]
     collection = database["new_collection"]

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_backup_light.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_backup_light.py
@@ -1,7 +1,8 @@
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional
 
 import jsonpatch
 import kubernetes.client
+import kubernetes.client.rest
 from kubernetes import client
 from kubetester import try_load, wait_until
 from kubetester.awss3client import AwsS3Client
@@ -31,7 +32,7 @@ Note, that it doesn't check for mongodb backup as it's done in 'e2e_om_ops_manag
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, bucket_prefix="test-s3-bucket-")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_backup_liveness_probe.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_backup_liveness_probe.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Iterator, Optional
 
 from kubernetes import client
 from kubetester import try_load
@@ -30,7 +30,7 @@ Note, that it doesn't check for mongodb backup as it's done in 'e2e_om_ops_manag
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, namespace)
     yield from create_s3_bucket(aws_s3_client, bucket_prefix="test-s3-bucket-")
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
@@ -267,8 +267,9 @@ class TestOpsManagerCreation:
                 continue
             assert om_container[k] == expected_spec[k]
 
+        volume_mounts = list(expected_spec["volume_mounts"])
         if not is_default_architecture_static():
-            expected_spec["volume_mounts"].append(
+            volume_mounts.append(
                 {
                     "name": "ops-manager-scripts",
                     "mount_path": "/opt/scripts",
@@ -280,7 +281,7 @@ class TestOpsManagerCreation:
                 },
             )
 
-        assert_volume_mounts_are_equal(om_container["volume_mounts"], expected_spec["volume_mounts"])
+        assert_volume_mounts_are_equal(om_container["volume_mounts"], volume_mounts)
 
         # new volume was added and the old ones ('gen-key' and 'ops-manager-scripts') stayed there
         if is_default_architecture_static():

--- a/docker/mongodb-kubernetes-tests/tests/otel_plugin.py
+++ b/docker/mongodb-kubernetes-tests/tests/otel_plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from _pytest.main import Session
@@ -7,13 +7,12 @@ from _pytest.nodes import Node
 from _pytest.reports import TestReport
 from _pytest.runner import CallInfo
 from opentelemetry import trace
-from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
-from opentelemetry.trace import NonRecordingSpan
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerProvider
 from pytest_opentelemetry.instrumentation import OpenTelemetryPlugin
 
 
 class PrefixProcessor(SpanProcessor):
-    def on_start(self, span: trace.Span, parent_context=None):
+    def on_start(self, span: Span, parent_context=None):
         # Create a new dictionary for updated attributes, span.attribute is immutable
         prefixed_attributes = EnhancedOpenTelemetryPlugin._prefix_attributes(span.attributes)
         span.set_attributes(prefixed_attributes)
@@ -27,7 +26,7 @@ class PrefixProcessor(SpanProcessor):
 class EnhancedOpenTelemetryPlugin(OpenTelemetryPlugin):
     # This ensures that our pytest finish runs first before the plugins and we can attach spans before
     # they are getting flushed.
-    def pytest_sessionfinish(self, session: Session, exitstatus: int = None) -> None:
+    def pytest_sessionfinish(self, session: Session, exitstatus: Optional[int] = None) -> None:
         # Add the exit status as an attribute if available
         self.session_span.set_attribute("mck.pytest.overall_exit_status", int(session.exitstatus))
 
@@ -41,7 +40,7 @@ class EnhancedOpenTelemetryPlugin(OpenTelemetryPlugin):
         report: TestReport,
     ) -> None:
         current_span = trace.get_current_span()
-        if isinstance(current_span, NonRecordingSpan):
+        if not isinstance(current_span, ReadableSpan):
             return
         prefixed_attributes = EnhancedOpenTelemetryPlugin._prefix_attributes(current_span.attributes)
         prefixed_attributes["mck.pytest.error_details"] = str(report.longrepr)

--- a/docker/mongodb-kubernetes-tests/tests/pod_logs.py
+++ b/docker/mongodb-kubernetes-tests/tests/pod_logs.py
@@ -25,7 +25,7 @@ def get_structured_json_pod_logs(
     namespace: str,
     pod_name: str,
     container_name: str,
-    api_client: kubernetes.client.ApiClient,
+    api_client: Optional[kubernetes.client.ApiClient] = None,
 ) -> dict[str, list[str]]:
     """Read logs from pod_name and groups the lines by logType."""
     pod_logs_str = KubernetesTester.read_pod_logs(namespace, pod_name, container_name, api_client=api_client)
@@ -80,7 +80,6 @@ def assert_log_types_in_structured_json_pod_log(
     if not is_default_architecture_static():
         container_name = "mongodb-enterprise-database"
 
-    assert api_client is not None, "api_client must not be None"
     pod_logs = get_structured_json_pod_logs(namespace, pod_name, container_name, api_client=api_client)
 
     unwanted_log_types = set(pod_logs.keys()) - (expected_log_types or set())

--- a/docker/mongodb-kubernetes-tests/tests/pod_logs.py
+++ b/docker/mongodb-kubernetes-tests/tests/pod_logs.py
@@ -1,12 +1,12 @@
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import kubernetes
 from kubetester.kubetester import KubernetesTester, is_default_architecture_static
 
 
-def parse_json_pod_logs(pod_logs: str) -> list[dict[str, any]]:
+def parse_json_pod_logs(pod_logs: str) -> list[dict[str, Any]]:
     """Parses pod logs returned asa string and returns list of lines parsed from structured json."""
     lines = pod_logs.strip().split("\n")
     log_lines = []
@@ -31,7 +31,7 @@ def get_structured_json_pod_logs(
     pod_logs_str = KubernetesTester.read_pod_logs(namespace, pod_name, container_name, api_client=api_client)
     log_lines = parse_json_pod_logs(pod_logs_str)
 
-    log_contents_by_type = {}
+    log_contents_by_type: dict[str, list[str]] = {}
 
     for log_line in log_lines:
         if "logType" not in log_line or "contents" not in log_line:
@@ -80,10 +80,11 @@ def assert_log_types_in_structured_json_pod_log(
     if not is_default_architecture_static():
         container_name = "mongodb-enterprise-database"
 
+    assert api_client is not None, "api_client must not be None"
     pod_logs = get_structured_json_pod_logs(namespace, pod_name, container_name, api_client=api_client)
 
-    unwanted_log_types = pod_logs.keys() - expected_log_types
-    missing_log_types = expected_log_types - pod_logs.keys()
+    unwanted_log_types = set(pod_logs.keys()) - (expected_log_types or set())
+    missing_log_types = (expected_log_types or set()) - set(pod_logs.keys())
     assert len(unwanted_log_types) == 0, f"pod {namespace}/{pod_name} contains unwanted log types: {unwanted_log_types}"
     assert (
         len(missing_log_types) == 0

--- a/docker/mongodb-kubernetes-tests/tests/probes/replication_state_awareness.py
+++ b/docker/mongodb-kubernetes-tests/tests/probes/replication_state_awareness.py
@@ -10,7 +10,7 @@ import logging
 import random
 import string
 import time
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import pymongo
 import yaml
@@ -40,7 +40,7 @@ def large_json_generator() -> Callable[[], Dict]:
     return inner
 
 
-async def upload_random_data_async(client: pymongo.MongoClient, task_name: str = None, count: int = 50_000):
+async def upload_random_data_async(client: pymongo.MongoClient, task_name: Optional[str] = None, count: int = 50_000):
     fn = functools.partial(
         upload_random_data,
         client=client,
@@ -59,11 +59,13 @@ def create_writing_task(client: pymongo.MongoClient, name: str, count: int) -> a
     return asyncio.create_task(upload_random_data_async(client, name, count))
 
 
-def create_writing_tasks(client: pymongo.MongoClient, prefix: str, task_sizes: List[int] = None) -> asyncio:
+def create_writing_tasks(
+    client: pymongo.MongoClient, prefix: str, task_sizes: Optional[List[int]] = None
+) -> list[asyncio.Task]:
     """
     Creates many async tasks to upload documents to a MongoDB database.
     """
-    return [create_writing_task(client, prefix + str(task), task) for task in task_sizes]
+    return [create_writing_task(client, prefix + str(task), task) for task in (task_sizes or [])]
 
 
 @fixture(scope="module")

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/manual/replica_set_override_agent_launcher_script.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/manual/replica_set_override_agent_launcher_script.py
@@ -34,7 +34,7 @@ def ops_manager(namespace: str, custom_version: str, custom_appdb_version) -> Mo
 
 
 @fixture(scope="function")
-def replica_set(ops_manager: str, namespace: str, custom_mdb_version: str) -> MongoDB:
+def replica_set(ops_manager: MongoDBOpsManager, namespace: str, custom_mdb_version: str) -> MongoDB:
     resource = MongoDB.from_yaml(
         find_fixture("replica-set-override-agent-launcher-script.yaml"),
         namespace=namespace,

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import kubernetes.client.rest
 import pytest
 from kubernetes import client
 from kubetester import assert_pod_container_security_context, assert_pod_security_context, try_load
@@ -381,7 +382,7 @@ class TestReplicaSetScaleUp(KubernetesTester):
         sts = self.appsv1.read_namespaced_stateful_set(RESOURCE_NAME, self.namespace)
         assert sts.spec.replicas == 5
 
-    def _get_pods(self, podname, qty):
+    def _get_pods(self, podname, qty=3):
         return [podname.format(i) for i in range(qty)]
 
     def test_replica_set_pods_exists(self):

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_custom_sa.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_custom_sa.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 from kubetester import create_service_account, delete_service_account, try_load
 from kubetester.kubetester import KubernetesTester
 from kubetester.kubetester import fixture as yaml_fixture
@@ -12,7 +14,7 @@ def create_custom_sa(namespace: str) -> str:
 
 
 @fixture(scope="module")
-def replica_set(namespace: str, custom_mdb_version: str, create_custom_sa: str) -> MongoDB:
+def replica_set(namespace: str, custom_mdb_version: str, create_custom_sa: str) -> Iterator[MongoDB]:
     resource = MongoDB.from_yaml(yaml_fixture("replica-set.yaml"), namespace=namespace)
 
     resource["spec"]["podSpec"] = {"podTemplate": {"spec": {"serviceAccountName": "test-sa"}}}

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_exposed_externally.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_exposed_externally.py
@@ -1,3 +1,4 @@
+import kubernetes.client.rest
 import pytest
 from kubernetes import client
 from kubetester import try_load

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_groups.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_groups.py
@@ -16,8 +16,8 @@ class TestReplicaSetOrganizationsPagination(KubernetesTester):
       The test is skipped for cloud manager as we cannot create organizations there ("API_KEY_CANNOT_CREATE_ORG")
     """
 
-    all_orgs_ids = []
-    all_groups_ids = []
+    all_orgs_ids: list[str] = []
+    all_groups_ids: list[str] = []
     org_id = None
     group_name = None
 

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_pv.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_pv.py
@@ -1,3 +1,4 @@
+import kubernetes.client.rest
 import pytest
 from kubernetes import client
 from kubetester.kubetester import KubernetesTester, fcv_from_version

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/conftest.py
@@ -1,5 +1,5 @@
 from ipaddress import IPv4Address
-from typing import List
+from typing import List, Optional
 
 import kubernetes
 import pytest
@@ -39,9 +39,9 @@ def operator(namespace: str) -> Operator:
 
 def enable_multi_cluster_deployment(
     resource: MongoDB,
-    shard_members_array: list[int] = None,
-    mongos_members_array: list[int] = None,
-    configsrv_members_array: list[int] = None,
+    shard_members_array: Optional[list[int | None]] = None,
+    mongos_members_array: Optional[list[int | None]] = None,
+    configsrv_members_array: Optional[list[int | None]] = None,
 ):
     resource["spec"]["topology"] = "MultiCluster"
     resource["spec"]["mongodsPerShardCount"] = None
@@ -55,9 +55,12 @@ def enable_multi_cluster_deployment(
         if "memberConfig" in resource["spec"]["shards"][idx]:
             resource["spec"]["shardOverrides"][idx]["memberConfig"] = None
 
-    setup_cluster_spec_list(resource, "shard", shard_members_array or [1, 1, 1])
-    setup_cluster_spec_list(resource, "configSrv", configsrv_members_array or [1, 1, 1])
-    setup_cluster_spec_list(resource, "mongos", mongos_members_array or [1, 1, 1])
+    shard_members: list[int | None] = shard_members_array if shard_members_array is not None else [1, 1, 1]
+    configsrv_members: list[int | None] = configsrv_members_array if configsrv_members_array is not None else [1, 1, 1]
+    mongos_members: list[int | None] = mongos_members_array if mongos_members_array is not None else [1, 1, 1]
+    setup_cluster_spec_list(resource, "shard", shard_members)
+    setup_cluster_spec_list(resource, "configSrv", configsrv_members)
+    setup_cluster_spec_list(resource, "mongos", mongos_members)
 
     resource.api = kubernetes.client.CustomObjectsApi(api_client=get_central_cluster_client())
 
@@ -209,7 +212,7 @@ def get_dns_hosts_for_external_access(resource: MongoDB, cluster_member_list: Li
     return hosts
 
 
-def setup_cluster_spec_list(resource: MongoDB, cluster_spec_type: str, members_array: list[int]):
+def setup_cluster_spec_list(resource: MongoDB, cluster_spec_type: str, members_array: list[int | None]):
     if cluster_spec_type not in resource["spec"]:
         resource["spec"][cluster_spec_type] = {}
 

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_mongod_options.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_mongod_options.py
@@ -174,6 +174,6 @@ def test_backup_log_rotation():
 
 
 @mark.e2e_sharded_cluster_mongod_options_and_log_rotation
-def test_backup_log_rotation():
+def test_monitoring_log_rotation():
     mc = KubernetesTester.get_monitoring_config()
     assert_log_rotation_backup_monitoring(mc)

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_shard_overrides.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_shard_overrides.py
@@ -73,11 +73,11 @@ class TestShardedClusterShardOverrides:
             # We need the unique cluster index, stored in the state configmap, for computing expected sts names
             cluster_mapping = read_deployment_state(sc.name, namespace, get_central_cluster_client())["clusterMapping"]
             logger.debug(f"Cluster mapping in state: {cluster_mapping}")
-            expected_statefulsets = build_expected_statefulsets_multi(sc, cluster_mapping)
-            validate_correct_sts_in_cluster_multi(expected_statefulsets, namespace, member_cluster_clients)
+            expected_multi = build_expected_statefulsets_multi(sc, cluster_mapping)
+            validate_correct_sts_in_cluster_multi(expected_multi, namespace, member_cluster_clients)
         else:
-            expected_statefulsets = build_expected_statefulsets(sc)
-            validate_correct_sts_in_cluster(expected_statefulsets, namespace, "__default", central_cluster_client)
+            expected_single = build_expected_statefulsets(sc)
+            validate_correct_sts_in_cluster(expected_single, namespace, "__default", central_cluster_client)
 
     def test_scale_shard_overrides(self, sc: MongoDB):
         if is_multi_cluster():
@@ -128,8 +128,8 @@ class TestShardedClusterShardOverrides:
             # We need the unique cluster index, stored in the state configmap, for computing expected sts names
             cluster_mapping = read_deployment_state(sc.name, namespace, get_central_cluster_client())["clusterMapping"]
             logger.debug(f"Cluster mapping in state: {cluster_mapping}")
-            expected_statefulsets = build_expected_statefulsets_multi(sc, cluster_mapping)
-            validate_correct_sts_in_cluster_multi(expected_statefulsets, namespace, member_cluster_clients)
+            expected_multi = build_expected_statefulsets_multi(sc, cluster_mapping)
+            validate_correct_sts_in_cluster_multi(expected_multi, namespace, member_cluster_clients)
         else:
-            expected_statefulsets = build_expected_statefulsets(sc)
-            validate_correct_sts_in_cluster(expected_statefulsets, namespace, "__default", central_cluster_client)
+            expected_single = build_expected_statefulsets(sc)
+            validate_correct_sts_in_cluster(expected_single, namespace, "__default", central_cluster_client)

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_statefulset_status.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_statefulset_status.py
@@ -105,7 +105,7 @@ def cluster_reaches_not_ready(sc: MongoDB, sts_name: str):
         if s.get_status_resources_not_ready() is None:
             return False
 
-        for idx, resource in enumerate(s.get_status_resources_not_ready()):
+        for idx, resource in enumerate(s.get_status_resources_not_ready() or []):
             if resource["name"] == sts_name:
                 assert resource["kind"] == "StatefulSet"
                 assert re.search("Not all the Pods are ready \(wanted: 1.*\)", resource["message"]) is not None

--- a/docker/mongodb-kubernetes-tests/tests/standalone/standalone_config_map.py
+++ b/docker/mongodb-kubernetes-tests/tests/standalone/standalone_config_map.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 import pytest
 from kubernetes import client
 from kubernetes.client import V1ConfigMap
@@ -17,7 +19,7 @@ def standalone(namespace: str) -> MongoDB:
 
 
 @fixture(scope="module")
-def new_project_name(standalone: MongoDB) -> str:
+def new_project_name(standalone: MongoDB) -> Iterator[str]:
     yield KubernetesTester.random_om_project_name()
     # Cleaning the new group in any case - the updated config map will be used to get the new name
     print("\nRemoving the generated group from Ops Manager/Cloud Manager")

--- a/docker/mongodb-kubernetes-tests/tests/tls/e2e_configure_tls_and_x509_simultaneously_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/e2e_configure_tls_and_x509_simultaneously_sc.py
@@ -15,9 +15,9 @@ CERT_SECRET_PREFIX = "prefix"
 
 @pytest.fixture(scope="module")
 def server_certs(issuer: str, namespace: str):
-    shard_distribution = None
-    mongos_distribution = None
-    config_srv_distribution = None
+    shard_distribution: list[int | None] | None = None
+    mongos_distribution: list[int | None] | None = None
+    config_srv_distribution: list[int | None] | None = None
     if is_multi_cluster():
         shard_distribution = [1, 1, 1]
         mongos_distribution = [1, 1, None]

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_additional_certs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_additional_certs.py
@@ -20,9 +20,9 @@ MDB_RESOURCE_NAME = "test-tls-sc-additional-domains"
 
 @pytest.fixture(scope="module")
 def server_certs(issuer: str, namespace: str):
-    shard_distribution = None
-    mongos_distribution = None
-    config_srv_distribution = None
+    shard_distribution: list[int | None] | None = None
+    mongos_distribution: list[int | None] | None = None
+    config_srv_distribution: list[int | None] | None = None
     if is_multi_cluster():
         shard_distribution = [1, 1, 1]
         mongos_distribution = [1, 1, None]

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_requiressl_custom_ca.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_requiressl_custom_ca.py
@@ -15,9 +15,9 @@ MDB_RESOURCE_NAME = "test-tls-base-sc-require-ssl"
 
 @pytest.fixture(scope="module")
 def server_certs(issuer: str, namespace: str):
-    shard_distribution = None
-    mongos_distribution = None
-    config_srv_distribution = None
+    shard_distribution: list[int | None] | None = None
+    mongos_distribution: list[int | None] | None = None
+    config_srv_distribution: list[int | None] | None = None
     if is_multi_cluster():
         shard_distribution = [1, 1, 1]
         mongos_distribution = [1, 1, None]

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_sharded_cluster_certs_prefix.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_sharded_cluster_certs_prefix.py
@@ -18,9 +18,9 @@ MDB_RESOURCE = "sharded-cluster-custom-certs"
 def all_certs(central_cluster_client: kubernetes.client.ApiClient, issuer: str, namespace: str) -> None:
     """Generates all required TLS certificates: Servers and Client/Member."""
 
-    shard_distribution = None
-    mongos_distribution = None
-    config_srv_distribution = None
+    shard_distribution: list[int | None] | None = None
+    mongos_distribution: list[int | None] | None = None
+    config_srv_distribution: list[int | None] | None = None
     if is_multi_cluster():
         shard_distribution = [1, 1, 1]
         mongos_distribution = [1, 1, None]

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
@@ -22,9 +22,9 @@ def agent_certs(issuer: str, namespace: str) -> str:
 
 @fixture(scope="module")
 def server_certs(issuer: str, namespace: str):
-    shard_distribution = None
-    mongos_distribution = None
-    config_srv_distribution = None
+    shard_distribution: list[int | None] | None = None
+    mongos_distribution: list[int | None] | None = None
+    config_srv_distribution: list[int | None] | None = None
     if is_multi_cluster():
         shard_distribution = [1, 1, 1]
         mongos_distribution = [1, 1, 1]

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_sc.py
@@ -13,9 +13,9 @@ MDB_RESOURCE_NAME = "test-x509-sc"
 
 @pytest.fixture(scope="module")
 def server_certs(issuer: str, namespace: str):
-    shard_distribution = None
-    mongos_distribution = None
-    config_srv_distribution = None
+    shard_distribution: list[int | None] | None = None
+    mongos_distribution: list[int | None] | None = None
+    config_srv_distribution: list[int | None] | None = None
     if is_multi_cluster():
         shard_distribution = [1, 1, 1]
         mongos_distribution = [1, 1, None]

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -47,7 +47,7 @@ def replica_set(
     central_cluster_client: client.ApiClient,
 ) -> MongoDB:
     if is_multi_cluster():
-        resource = MongoDBMulti.from_yaml(
+        resource: MongoDB = MongoDBMulti.from_yaml(
             yaml_fixture("mongodb-multi-cluster.yaml"),
             "multi-replica-set",
             namespace,

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_ops_manager.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_ops_manager.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Iterator, Optional
 
 from kubetester import try_load
 from kubetester.awss3client import AwsS3Client
@@ -15,7 +15,7 @@ from tests.conftest import get_default_operator, operator_installation_config
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str) -> Iterator[str]:
     """creates a s3 bucket and a s3 config"""
 
     bucket_name = KubernetesTester.random_k8s_name("test-bucket-")

--- a/docker/mongodb-kubernetes-tests/tests/users/users_addition_removal.py
+++ b/docker/mongodb-kubernetes-tests/tests/users/users_addition_removal.py
@@ -109,6 +109,6 @@ class TestTheCorrectUserIsDeleted(KubernetesTester):
         assert "CN=mms-user-4,OU=cloud,O=MongoDB,L=New York,ST=New York,C=US" not in [user["user"] for user in users]
 
 
-def get_user_pkix_names(ac, agent_name: str) -> str:
+def get_user_pkix_names(ac, agent_name: str) -> dict[str, str]:
     subject = [u["user"] for u in ac["auth"]["usersWanted"] if agent_name in u["user"]][0]
     return dict(name.split("=") for name in subject.split(","))

--- a/docker/mongodb-kubernetes-tests/tests/users/users_finalizer.py
+++ b/docker/mongodb-kubernetes-tests/tests/users/users_finalizer.py
@@ -47,7 +47,7 @@ class TestReplicaSetIsRunning(KubernetesTester):
 @pytest.mark.e2e_users_finalizer
 class TestUserIsAdded(KubernetesTester):
 
-    def test_user_is_ready(mdb: MongoDB, scram_user: MongoDBUser):
+    def test_user_is_ready(self, mdb: MongoDB, scram_user: MongoDBUser):
         scram_user.update()
         scram_user.assert_reaches_phase(Phase.Updated)
 

--- a/docker/mongodb-kubernetes-tests/tests/users/users_finalizer_removal.py
+++ b/docker/mongodb-kubernetes-tests/tests/users/users_finalizer_removal.py
@@ -1,3 +1,4 @@
+import kubernetes.client.rest
 import pytest
 from kubernetes import client
 from kubernetes.client.exceptions import ApiException
@@ -46,7 +47,7 @@ class TestReplicaSetIsRunning(KubernetesTester):
 @pytest.mark.e2e_users_finalizer_removal
 class TestUserIsAdded(KubernetesTester):
 
-    def test_user_is_ready(mdb: MongoDB, scram_user: MongoDBUser):
+    def test_user_is_ready(self, mdb: MongoDB, scram_user: MongoDBUser):
         scram_user.update()
         scram_user.assert_reaches_phase(Phase.Updated)
 

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/conftest.py
@@ -87,6 +87,8 @@ def vault_tls(namespace: str, issuer: str, vault_namespace: str, version="v0.17.
         label_selector=f"app.kubernetes.io/instance={name},app.kubernetes.io/name=vault-agent-injector",
     )
 
+    return name
+
 
 def perform_vault_initialization(namespace: str, name: str):
 
@@ -106,15 +108,15 @@ def perform_vault_initialization(namespace: str, name: str):
 
     response = run_command_in_vault(name, name, ["vault", "operator", "init"], ["Unseal"])
 
-    response = response.split("\n")
+    response_lines = response.split("\n")
     unseal_keys = []
     for i in range(5):
-        unseal_keys.append(response[i].split(": ")[1])
+        unseal_keys.append(response_lines[i].split(": ")[1])
 
     for i in range(3):
         run_command_in_vault(name, name, ["vault", "operator", "unseal", unseal_keys[i]], [])
 
-    token = response[6].split(": ")[1]
+    token = response_lines[6].split(": ")[1]
     run_command_in_vault(name, name, ["vault", "login", token])
 
     run_command_in_vault(name, name, ["vault", "secrets", "enable", "-path=secret/", "kv-v2"])

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
@@ -92,7 +92,7 @@ def agent_certs(issuer: str, namespace: str) -> str:
 
 @fixture(scope="module")
 def server_certs(vault_namespace: str, vault_name: str, namespace: str, issuer: str) -> str:
-    create_x509_mongodb_tls_certs(
+    return create_x509_mongodb_tls_certs(
         issuer,
         namespace,
         MDB_RESOURCE,
@@ -104,7 +104,7 @@ def server_certs(vault_namespace: str, vault_name: str, namespace: str, issuer: 
 
 @fixture(scope="module")
 def clusterfile_certs(vault_namespace: str, vault_name: str, namespace: str, issuer: str) -> str:
-    create_x509_mongodb_tls_certs(
+    return create_x509_mongodb_tls_certs(
         issuer,
         namespace,
         MDB_RESOURCE,
@@ -238,8 +238,8 @@ def test_enable_kubernetes_auth(vault_name: str, vault_namespace: str):
 
     response = run_command_in_vault(vault_namespace, vault_name, cmd, expected_message=[])
 
-    response = response.split("\n")
-    for line in response:
+    response_lines = response.split("\n")
+    for line in response_lines:
         l = line.strip()
         if str.startswith(l, "KUBERNETES_PORT_443_TCP_ADDR"):
             cluster_ip = l.split("=")[1]

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional
 
 import pytest
 from kubernetes import client
@@ -70,7 +70,7 @@ def new_om_s3_store(
 
 
 @fixture(scope="module")
-def s3_bucket(aws_s3_client: AwsS3Client, namespace: str, vault_namespace: str, vault_name: str) -> str:
+def s3_bucket(aws_s3_client: AwsS3Client, namespace: str, vault_namespace: str, vault_name: str) -> Iterator[str]:
     create_aws_secret(aws_s3_client, S3_SECRET_NAME, vault_namespace, vault_name, namespace)
     yield from create_s3_bucket(aws_s3_client, bucket_prefix="test-s3-bucket-")
 
@@ -240,8 +240,8 @@ def test_enable_kubernetes_auth(vault_name: str, vault_namespace: str):
 
     response = run_command_in_vault(vault_namespace, vault_name, cmd, expected_message=[])
 
-    response = response.split("\n")
-    for line in response:
+    response_lines = response.split("\n")
+    for line in response_lines:
         l = line.strip()
         if str.startswith(l, "KUBERNETES_PORT_443_TCP_ADDR"):
             cluster_ip = l.split("=")[1]

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
@@ -122,8 +122,8 @@ def test_enable_kubernetes_auth(vault_name: str, vault_namespace: str):
 
     response = run_command_in_vault(vault_namespace, vault_name, cmd, expected_message=[])
 
-    response = response.split("\n")
-    for line in response:
+    response_lines = response.split("\n")
+    for line in response_lines:
         l = line.strip()
         if str.startswith(l, "KUBERNETES_PORT_443_TCP_ADDR"):
             cluster_ip = l.split("=")[1]

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/vault_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/vault_tls.py
@@ -103,8 +103,8 @@ def test_enable_kubernetes_auth(vault_name: str, vault_namespace: str):
 
     response = run_command_in_vault(vault_namespace, vault_name, cmd, expected_message=[])
 
-    response = response.split("\n")
-    for line in response:
+    response_lines = response.split("\n")
+    for line in response_lines:
         l = line.strip()
         if str.startswith(l, "KUBERNETES_PORT_443_TCP_ADDR"):
             cluster_ip = l.split("=")[1]

--- a/docker/mongodb-kubernetes-tests/tests/webhooks/e2e_mongodb_roles_validation_webhook.py
+++ b/docker/mongodb-kubernetes-tests/tests/webhooks/e2e_mongodb_roles_validation_webhook.py
@@ -1,3 +1,4 @@
+import kubernetes.client.rest
 import pytest
 from kubernetes import client
 from kubernetes.client.rest import ApiException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ include = '\.pyi?$'
 [tool.isort]
 profile = "black"
 line_length = 120
+
+[tool.ty.analysis]
+allowed-unresolved-imports = ["kubernetes.**", "ldap.**", "boto3.**", "botocore.**", "jsonpatch.**", "pycognito.**"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ types-freezegun==1.1.10
 types-PyYAML==6.0.12.20260408
 types-pytz==2026.1.1.20260408
 types-python-dateutil==2.9.0.20260408
+types-requests==2.32.4.20250611
 pipupgrade==1.12.0
 pytest-cov==7.1.0
 pytest-socket==0.7.0


### PR DESCRIPTION
# Summary

Expand static Python type checking in `docker/mongodb-kubernetes-tests/` from the search tests to every `tests/` file. Before this PR the `ty` pre-commit hook only ran against `tests/search/` and `tests/common/search/`; everything else was unchecked.

## Proof of Work

Green [evg](https://spruce.mongodb.com/version/69e9a71e8b720100074d7b76)