### PR TITLE
fix(community): fix MongoDBCommunity scale-up deadlock when TLS/mTLS …

### DIFF
--- a/mongodb-community-operator/controllers/replica_set_controller.go
+++ b/mongodb-community-operator/controllers/replica_set_controller.go
@@ -397,19 +397,24 @@ func (r *ReplicaSetReconciler) deployAutomationConfig(ctx context.Context, mdb m
 
 // shouldRunInOrder returns true if the order of execution of the AutomationConfig & StatefulSet
 // functions should be sequential or not. A value of false indicates they will run in reversed order.
-func (r *ReplicaSetReconciler) shouldRunInOrder(ctx context.Context, mdb mdbv1.MongoDBCommunity) bool {
-	// The only case when we push the StatefulSet first is when we are ensuring TLS for the already existing ReplicaSet
-	sts, err := r.client.GetStatefulSet(ctx, mdb.NamespacedName())
-	if !statefulset.IsReady(sts, mdb.StatefulSetReplicasThisReconciliation()) && mdb.Spec.Security.TLS.Enabled {
-		r.log.Debug("Enabling TLS on a deployment with a StatefulSet that is not Ready, the Automation Config must be updated first")
-		return true
-	}
-	if err == nil && mdb.Spec.Security.TLS.Enabled {
-		r.log.Debug("Enabling TLS on an existing deployment, the StatefulSet must be updated first")
-		return false
-	}
+//
+// Ordering rules (evaluated in priority order):
+//  1. Scaling up                        → STS first (false)
+//     When TLS is being enabled simultaneously with scale-up, we scale
+//     all members first then apply TLS to all members at once via AC.
+//     This avoids mixed TLS/non-TLS state and cert-not-found errors that
+//     occur when AC enables TLS before STS has mounted cert volumes on pods.
+//  2. TLS enabled on stable deployment  → STS first (false)
+//     Only fires when scaling is fully complete to ensure TLS is applied
+//     to all members at once, not to an intermediate member count.
+//  3. TLS enabled but STS not ready     → AC first (true)
+//  4. Scaling down                      → AC first (true)
+//  5. Version change                    → STS first (false)
+//  6. Default                           → AC first (true)
 
-	// if we are scaling up, we need to make sure the StatefulSet is scaled up first.
+func (r *ReplicaSetReconciler) shouldRunInOrder(ctx context.Context, mdb mdbv1.MongoDBCommunity) bool {
+	sts, err := r.client.GetStatefulSet(ctx, mdb.NamespacedName())
+
 	if scale.IsScalingUp(&mdb) || mdb.CurrentArbiters() < mdb.DesiredArbiters() {
 		if scale.HasZeroReplicas(&mdb) {
 			r.log.Debug("Scaling up the ReplicaSet when there is no replicas, the Automation Config must be updated first")
@@ -419,13 +424,21 @@ func (r *ReplicaSetReconciler) shouldRunInOrder(ctx context.Context, mdb mdbv1.M
 		return false
 	}
 
+	if err == nil && mdb.Spec.Security.TLS.Enabled && !scale.IsScalingDown(&mdb) && !scale.IsStillScaling(&mdb) {
+		r.log.Debug("Enabling TLS on an existing deployment, the StatefulSet must be updated first")
+		return false
+	}
+
+	if !statefulset.IsReady(sts, mdb.StatefulSetReplicasThisReconciliation()) && mdb.Spec.Security.TLS.Enabled {
+		r.log.Debug("Enabling TLS on a deployment with a StatefulSet that is not Ready, the Automation Config must be updated first")
+		return true
+	}
+
 	if scale.IsScalingDown(&mdb) {
 		r.log.Debug("Scaling down the ReplicaSet, the Automation Config must be updated first")
 		return true
 	}
 
-	// when we change version, we need the StatefulSet images to be updated first, then the agent can get to goal
-	// state on the new version.
 	if mdb.IsChangingVersion() {
 		r.log.Debug("Version change in progress, the StatefulSet must be updated first")
 		return false


### PR DESCRIPTION
…is enabled

When MongoDBCommunity has TLS enabled and spec.members is increased, the reconciliation loop gets stuck indefinitely with the StatefulSet never scaling up.

Root cause: In shouldRunInOrder(), the TLS ordering check fires before the scale-up check. During scale-up the StatefulSet is not yet ready which causes the TLS not-ready check to return true (AC first) before the scale-up check is ever evaluated. The AutomationConfig is updated with the new member count while the StatefulSet still has the old pod count. The agent waits forever for pods that do not exist yet causing an infinite reconciliation loop.

Fix: Reorder checks so scale-up is always evaluated before TLS checks. ensure TLS is applied to all members at once after scaling completes, not at an intermediate member count. This also correctly handles the case where TLS is enabled simultaneously with a scale-up.

Tested on OpenShift with MongoDB Community Operator v1.7.0:
- Scale up 3->5 with mTLS already enabled (original bug) PASS
- Enable TLS + scale up 3->5 simultaneously PASS
- Scale down 5->3 with mTLS enabled PASS

# Summary

<!-- Enter your PR summary here. Try to emphasize on WHY this change is needed, followed by what's being done in the PR. -->

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
