### PR TITLE
CLOUDP-385917: Add installation method telemetry

### DIFF
--- a/changelog/20260430_feature_add_installation_telemetry.md
+++ b/changelog/20260430_feature_add_installation_telemetry.md
@@ -1,0 +1,6 @@
+---
+kind: feature
+date: 2026-04-30
+---
+
+* Add Installation Telemetry

--- a/changelog/20260430_feature_add_installation_telemetry.md
+++ b/changelog/20260430_feature_add_installation_telemetry.md
@@ -1,6 +1,0 @@
----
-kind: feature
-date: 2026-04-30
----
-
-* Add Installation Telemetry

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: mongodb-kubernetes-operator
         app.kubernetes.io/instance: mongodb-kubernetes-operator
+      annotations:
+        mongodb.com/installation-method: "helm"
     spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
@@ -102,6 +104,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MCK_INSTALLER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['mongodb.com/installation-method']
             - name: OPERATOR_NAME
               value: mongodb-kubernetes-operator
             # Community Env Vars Start

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: mongodb-kubernetes-operator
         app.kubernetes.io/instance: mongodb-kubernetes-operator
       annotations:
-        mongodb.com/installation-method: "olm"
+        mongodb.com/installation-method: "yaml"
     spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -372,4 +372,3 @@ spec:
       volumes:
         - name: webhook-server-dir
           emptyDir: {}
-

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: mongodb-kubernetes-operator
         app.kubernetes.io/instance: mongodb-kubernetes-operator
       annotations:
-        mongodb.com/installation-method: "helm"
+        mongodb.com/installation-method: "olm"
     spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
@@ -372,3 +372,4 @@ spec:
       volumes:
         - name: webhook-server-dir
           emptyDir: {}
+

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -19,9 +19,10 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: {{ .Values.operator.name }}
         app.kubernetes.io/instance: {{ .Values.operator.name }}
+      annotations:
+        mongodb.com/installation-method: {{ .Values.operator.installationMethod | default "helm" | quote }}
 {{- if .Values.operator.vaultSecretBackend }}
   {{- if .Values.operator.vaultSecretBackend.enabled }}
-      annotations:
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "mongodbenterprise"
         {{- if .Values.operator.vaultSecretBackend.tlsSecretRef }}
@@ -220,6 +221,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MCK_INSTALLER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['mongodb.com/installation-method']
             - name: OPERATOR_NAME
               value: {{ .Values.operator.name }}
             # Community Env Vars Start

--- a/main.go
+++ b/main.go
@@ -314,7 +314,8 @@ func run() error {
 
 	if telemetry.IsTelemetryActivated() {
 		log.Info("Running telemetry component!")
-		telemetryRunnable, err := telemetry.NewLeaderRunnable(mgr, memberClusterObjectsMap, currentNamespace, imageUrls[util.MongodbImageEnv], imageUrls[util.NonStaticDatabaseEnterpriseImage], getOperatorEnv())
+		installerMethod := envvar.GetEnvOrDefault(telemetry.InstallerEnvVar, "")
+		telemetryRunnable, err := telemetry.NewLeaderRunnable(mgr, memberClusterObjectsMap, currentNamespace, imageUrls[util.MongodbImageEnv], imageUrls[util.NonStaticDatabaseEnterpriseImage], installerMethod, getOperatorEnv())
 		if err != nil {
 			log.Errorf("Unable to enable telemetry; err: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func run() error {
 
 	if telemetry.IsTelemetryActivated() {
 		log.Info("Running telemetry component!")
-		installerMethod := envvar.GetEnvOrDefault(telemetry.InstallerEnvVar, "")
+		installerMethod := env.ReadOrDefault(telemetry.InstallerEnvVar, "")
 		telemetryRunnable, err := telemetry.NewLeaderRunnable(mgr, memberClusterObjectsMap, currentNamespace, imageUrls[util.MongodbImageEnv], imageUrls[util.NonStaticDatabaseEnterpriseImage], installerMethod, getOperatorEnv())
 		if err != nil {
 			log.Errorf("Unable to enable telemetry; err: %s", err)

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -175,6 +175,7 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 		uid := getKubernetesClusterUUID(ctx, uncachedClient)
 		kubeClusterUUIDList = append(kubeClusterUUIDList, uid)
 	}
+	installMethod := envvar.GetEnvOrDefault("MCK_INSTALLER", "")
 
 	slices.Sort(kubeClusterUUIDList)
 
@@ -186,6 +187,7 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 		OperatorType:         MEKO,
 		OperatorArchitecture: runtime.GOARCH,
 		OperatorOS:           runtime.GOOS,
+		OperatorInstaller:    installMethod,
 	}
 
 	event := createEvent(operatorEvent, time.Now(), Operators)

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -30,6 +30,10 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/versionutil"
 )
 
+const (
+	InstallerEnvVar = "MCK_INSTALLER"
+)
+
 // Logger should default to the global default from zap. Running into the main function of this package
 // should reconfigure zap.
 var Logger = zap.S()
@@ -175,7 +179,7 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 		uid := getKubernetesClusterUUID(ctx, uncachedClient)
 		kubeClusterUUIDList = append(kubeClusterUUIDList, uid)
 	}
-	installMethod := envvar.GetEnvOrDefault("MCK_INSTALLER", "")
+	installMethod := envvar.GetEnvOrDefault(InstallerEnvVar, "")
 
 	slices.Sort(kubeClusterUUIDList)
 

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -54,6 +54,7 @@ type LeaderRunnable struct {
 	currentNamespace        string
 	mongodbImage            string
 	databaseNonStaticImage  string
+	installerMethod         string
 	configuredOperatorEnv   util.OperatorEnvironment
 }
 
@@ -61,7 +62,7 @@ func (l *LeaderRunnable) NeedLeaderElection() bool {
 	return true
 }
 
-func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[string]cluster.Cluster, currentNamespace, mongodbImage, databaseNonStaticImage string, operatorEnv util.OperatorEnvironment) (*LeaderRunnable, error) {
+func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[string]cluster.Cluster, currentNamespace, mongodbImage, databaseNonStaticImage, installerMethod string, operatorEnv util.OperatorEnvironment) (*LeaderRunnable, error) {
 	atlasClient, err := NewClient(nil)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed creating atlas telemetry client: %w", err)
@@ -74,12 +75,13 @@ func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[
 		configuredOperatorEnv:   operatorEnv,
 		mongodbImage:            mongodbImage,
 		databaseNonStaticImage:  databaseNonStaticImage,
+		installerMethod:         installerMethod,
 	}, nil
 }
 
 func (l *LeaderRunnable) Start(ctx context.Context) error {
 	Logger.Debug("Starting leader-only telemetry goroutine")
-	RunTelemetry(ctx, l.mongodbImage, l.databaseNonStaticImage, l.currentNamespace, l.operatorMgr, l.memberClusterObjectsMap, l.atlasClient, l.configuredOperatorEnv)
+	RunTelemetry(ctx, l.mongodbImage, l.databaseNonStaticImage, l.currentNamespace, l.installerMethod, l.operatorMgr, l.memberClusterObjectsMap, l.atlasClient, l.configuredOperatorEnv)
 
 	return nil
 }
@@ -87,7 +89,7 @@ func (l *LeaderRunnable) Start(ctx context.Context) error {
 type snapshotCollector func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event
 
 // RunTelemetry lists the specified CRDs and sends them as events to Segment
-func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticImage, namespace string, operatorClusterMgr manager.Manager, clusterMap map[string]cluster.Cluster, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment) {
+func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticImage, namespace, installerMethod string, operatorClusterMgr manager.Manager, clusterMap map[string]cluster.Cluster, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment) {
 	Logger.Debug("Collecting telemetry!")
 	ctx, span := TRACER.Start(leaderTrace, "RunTelemetry")
 	span.SetAttributes(
@@ -112,7 +114,9 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 	// Mapping of snapshot types to their respective collector functions
 	// The functions are not 100% identical, this map takes care of that
 	snapshotCollectors := map[EventType]func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event{
-		Operators: collectOperatorSnapshot,
+		Operators: func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, _, _ string) []Event {
+			return collectOperatorSnapshot(ctx, memberClusterMap, operatorClusterMgr, operatorUUID, installerMethod)
+		},
 		Clusters: func(ctx context.Context, cc map[string]ConfigClient, operatorClusterMgr manager.Manager, _, _, _ string) []Event {
 			return collectClustersSnapshot(ctx, cc, operatorClusterMgr)
 		},
@@ -164,7 +168,7 @@ func collectAndSendSnapshot(ctx context.Context, eventType EventType, cf snapsho
 	handleEvents(ctx, atlasClient, events, eventType, namespace, operatorClusterMgr.GetClient())
 }
 
-func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, _, _ string) []Event {
+func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, installerMethod string) []Event {
 	var kubeClusterUUIDList []string
 	uncachedClient := operatorClusterMgr.GetAPIReader()
 	kubeClusterOperatorUUID := getKubernetesClusterUUID(ctx, uncachedClient)
@@ -179,7 +183,6 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 		uid := getKubernetesClusterUUID(ctx, uncachedClient)
 		kubeClusterUUIDList = append(kubeClusterUUIDList, uid)
 	}
-	installMethod := envvar.GetEnvOrDefault(InstallerEnvVar, "")
 
 	slices.Sort(kubeClusterUUIDList)
 
@@ -191,7 +194,7 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 		OperatorType:         MEKO,
 		OperatorArchitecture: runtime.GOARCH,
 		OperatorOS:           runtime.GOOS,
-		OperatorInstaller:    installMethod,
+		OperatorInstaller:    installerMethod,
 	}
 
 	event := createEvent(operatorEvent, time.Now(), Operators)

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"reflect"
 	"runtime"
 	"testing"
@@ -1454,6 +1455,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 				OperatorType:         MEKO,
 				OperatorArchitecture: runtime.GOARCH,
 				OperatorOS:           runtime.GOOS,
+				OperatorInstaller:    "yaml",
 			},
 		},
 		"multi cluster": {
@@ -1466,6 +1468,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 				OperatorType:         MEKO,
 				OperatorArchitecture: runtime.GOARCH,
 				OperatorOS:           runtime.GOOS,
+				OperatorInstaller:    "yaml",
 			},
 		},
 	}
@@ -1486,6 +1489,9 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 
 			ctx := context.Background()
 
+			err := os.Setenv(InstallerEnvVar, "yaml")
+			assert.NoError(t, err)
+
 			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, "", "")
 
 			require.Len(t, events, 1, "expected exactly one operator event")
@@ -1498,6 +1504,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 			assert.Equal(t, runtime.GOOS, event.Properties["operatorOS"])
 			assert.Equal(t, testOperatorUUID, event.Properties["operatorID"])
 			assert.Equal(t, string(MEKO), event.Properties["operatorType"])
+			assert.Equal(t, "yaml", event.Properties["operatorInstaller"])
 
 			assert.Contains(t, event.Properties, "kubernetesClusterID")
 			assert.Contains(t, event.Properties, "kubernetesClusterIDs")

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1447,7 +1447,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 		memberClusterMap map[string]ConfigClient
 		expectedProps    OperatorUsageSnapshotProperties
 	}{
-		"single cluster": {
+		"single cluster (yaml install)": {
 			memberClusterMap: map[string]ConfigClient{},
 			expectedProps: OperatorUsageSnapshotProperties{
 				OperatorID:           testOperatorUUID,
@@ -1457,7 +1457,26 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 				OperatorInstaller:    "yaml",
 			},
 		},
-		"multi cluster": {
+		"single cluster (helm install)": {
+			memberClusterMap: map[string]ConfigClient{},
+			expectedProps: OperatorUsageSnapshotProperties{
+				OperatorID:           testOperatorUUID,
+				OperatorType:         MEKO,
+				OperatorArchitecture: runtime.GOARCH,
+				OperatorOS:           runtime.GOOS,
+				OperatorInstaller:    "helm",
+			},
+		},
+		"single cluster (no installer)": {
+			memberClusterMap: map[string]ConfigClient{},
+			expectedProps: OperatorUsageSnapshotProperties{
+				OperatorID:           testOperatorUUID,
+				OperatorType:         MEKO,
+				OperatorArchitecture: runtime.GOARCH,
+				OperatorOS:           runtime.GOOS,
+			},
+		},
+		"multi cluster (olm install)": {
 			memberClusterMap: map[string]ConfigClient{
 				"cluster1": &mockConfigClient{clusterUUID: "cluster-uuid-1"},
 				"cluster2": &mockConfigClient{clusterUUID: "cluster-uuid-2"},
@@ -1467,7 +1486,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 				OperatorType:         MEKO,
 				OperatorArchitecture: runtime.GOARCH,
 				OperatorOS:           runtime.GOOS,
-				OperatorInstaller:    "yaml",
+				OperatorInstaller:    "olm",
 			},
 		},
 	}
@@ -1488,7 +1507,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 
 			ctx := context.Background()
 
-			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, "yaml")
+			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, test.expectedProps.OperatorInstaller)
 
 			require.Len(t, events, 1, "expected exactly one operator event")
 			event := events[0]
@@ -1500,7 +1519,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 			assert.Equal(t, runtime.GOOS, event.Properties["operatorOS"])
 			assert.Equal(t, testOperatorUUID, event.Properties["operatorID"])
 			assert.Equal(t, string(MEKO), event.Properties["operatorType"])
-			assert.Equal(t, "yaml", event.Properties["operatorInstaller"])
+			assert.Equal(t, test.expectedProps.OperatorInstaller, event.Properties["operatorInstaller"])
 
 			assert.Contains(t, event.Properties, "kubernetesClusterID")
 			assert.Contains(t, event.Properties, "kubernetesClusterIDs")

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"reflect"
 	"runtime"
 	"testing"
@@ -1489,10 +1488,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 
 			ctx := context.Background()
 
-			err := os.Setenv(InstallerEnvVar, "yaml")
-			assert.NoError(t, err)
-
-			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, "", "")
+			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, "yaml")
 
 			require.Len(t, events, 1, "expected exactly one operator event")
 			event := events[0]

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -22,6 +22,7 @@ type OperatorUsageSnapshotProperties struct {
 	OperatorType         OperatorType `json:"operatorType"`         // MEKO, MCK, MCO (here meko)
 	OperatorArchitecture string       `json:"operatorArchitecture"` // Architecture of the operator binary (amd64, arm64, s390x, ppc64le)
 	OperatorOS           string       `json:"operatorOS"`           // Operating system of the operator binary (linux, darwin, windows)
+	OperatorInstaller    string       `json:"operatorInstaller"`    // Installation method of the operator (helm, olm, yaml, unknown)
 }
 
 func (p OperatorUsageSnapshotProperties) ConvertToFlatMap() (map[string]any, error) {

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -325,6 +325,8 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: mongodb-kubernetes-operator-multi-cluster
         app.kubernetes.io/instance: mongodb-kubernetes-operator-multi-cluster
+      annotations:
+        mongodb.com/installation-method: "yaml"
     spec:
       serviceAccountName: mongodb-kubernetes-operator-multi-cluster
       securityContext:
@@ -411,6 +413,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MCK_INSTALLER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['mongodb.com/installation-method']
             - name: OPERATOR_NAME
               value: mongodb-kubernetes-operator-multi-cluster
             # Community Env Vars Start

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -325,6 +325,8 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: mongodb-kubernetes-operator
         app.kubernetes.io/instance: mongodb-kubernetes-operator
+      annotations:
+        mongodb.com/installation-method: "yaml"
     spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
@@ -407,6 +409,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MCK_INSTALLER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['mongodb.com/installation-method']
             - name: OPERATOR_NAME
               value: mongodb-kubernetes-operator
             # Community Env Vars Start

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -325,6 +325,8 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: mongodb-kubernetes-operator
         app.kubernetes.io/instance: mongodb-kubernetes-operator
+      annotations:
+        mongodb.com/installation-method: "yaml"
     spec:
       serviceAccountName: mongodb-kubernetes-operator
       securityContext:
@@ -408,6 +410,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MCK_INSTALLER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['mongodb.com/installation-method']
             - name: OPERATOR_NAME
               value: mongodb-kubernetes-operator
             # Community Env Vars Start

--- a/scripts/dev/generate_files.sh
+++ b/scripts/dev/generate_files.sh
@@ -38,13 +38,13 @@ generate_standalone_yaml() {
   )
 
   # generate normal public example
-  helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" "$@"
+  helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --set operator.installationMethod=yaml "$@"
   cat "${FILES[@]}" >public/mongodb-kubernetes.yaml
   cat "helm_chart/crds/"* >public/crds.yaml
 
   # generate openshift public example
   rm -rf "${charttmpdir:?}"/*
-  helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-openshift.yaml "$@"
+  helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-openshift.yaml --set operator.installationMethod=yaml "$@"
   cat "${FILES[@]}" >public/mongodb-kubernetes-openshift.yaml
 
   # generate openshift files for kustomize used for generating OLM bundle
@@ -62,7 +62,7 @@ generate_standalone_yaml() {
 
   # generate multi-cluster public example
   rm -rf "${charttmpdir:?}"/*
-  helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-multi-cluster.yaml "$@"
+  helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-multi-cluster.yaml --set operator.installationMethod=yaml "$@"
   cat "${FILES[@]}" >public/mongodb-kubernetes-multi-cluster.yaml
 }
 

--- a/scripts/dev/generate_files.sh
+++ b/scripts/dev/generate_files.sh
@@ -50,7 +50,7 @@ generate_standalone_yaml() {
   # generate openshift files for kustomize used for generating OLM bundle
   rm -rf "${charttmpdir:?}"/*
   helm template --namespace mongodb -f helm_chart/values.yaml helm_chart --output-dir "${charttmpdir}" --values helm_chart/values-openshift.yaml \
-    --set operator.webhook.registerConfiguration=false --set operator.webhook.installClusterRole=false "$@"
+    --set operator.webhook.registerConfiguration=false --set operator.webhook.installClusterRole=false --set operator.installationMethod=yaml "$@"
 
   # update kustomize files for OLM bundle with files generated for openshift
   cp "${charttmpdir}/mongodb-kubernetes/templates/operator.yaml" config/manager/manager.yaml

--- a/scripts/evergreen/operator-sdk/prepare-openshift-bundles.sh
+++ b/scripts/evergreen/operator-sdk/prepare-openshift-bundles.sh
@@ -27,6 +27,10 @@ echo "Aligning metadata.annotations.containerImage version with deployment's ima
 operator_deployment_image=$(yq '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' < "${bundle_csv_file}")
 yq e ".metadata.annotations.containerImage = \"${operator_deployment_image}\"" -i "${bundle_csv_file}"
 
+echo "Setting installation-method annotation to 'olm' in deployment pod template in ${bundle_csv_file}"
+yq e '.spec.install.spec.deployments[0].spec.template.metadata.annotations."mongodb.com/installation-method" = "olm"' \
+  -i "${bundle_csv_file}"
+
 echo "Edited CSV: ${bundle_csv_file}"
 cat "${bundle_csv_file}"
 

--- a/scripts/evergreen/operator-sdk/prepare-openshift-bundles.sh
+++ b/scripts/evergreen/operator-sdk/prepare-openshift-bundles.sh
@@ -24,11 +24,11 @@ bundle_dockerfile="bundle/${VERSION}/bundle.Dockerfile"
 bundle_csv_file="bundle/${VERSION}/manifests/mongodb-kubernetes.clusterserviceversion.yaml"
 
 echo "Aligning metadata.annotations.containerImage version with deployment's image in ${bundle_csv_file}"
-operator_deployment_image=$(yq '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' < "${bundle_csv_file}")
+operator_deployment_image=$(yq '.spec.install.spec.deployments[] | select(.name == "mongodb-kubernetes-operator") | .spec.template.spec.containers[0].image' < "${bundle_csv_file}")
 yq e ".metadata.annotations.containerImage = \"${operator_deployment_image}\"" -i "${bundle_csv_file}"
 
 echo "Setting installation-method annotation to 'olm' in deployment pod template in ${bundle_csv_file}"
-yq e '.spec.install.spec.deployments[0].spec.template.metadata.annotations."mongodb.com/installation-method" = "olm"' \
+yq e '(.spec.install.spec.deployments[] | select(.name == "mongodb-kubernetes-operator") | .spec.template.metadata.annotations."mongodb.com/installation-method") = "olm"' \
   -i "${bundle_csv_file}"
 
 echo "Edited CSV: ${bundle_csv_file}"
@@ -46,10 +46,10 @@ echo "Running digest pinning for certified bundle"
 # This can fail during the release because the latest image is not available yet and will be available the next day/next daily rebuild.
 # We decided to skip digest pinning during the as it is a post-processing step and it should be fine to skip it when testing OLM during the release.
 if [[ "${DIGEST_PINNING_ENABLED:-"true"}" == "true" ]]; then
-  operator_image=$(yq ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image" < ./bundle/"${VERSION}"/manifests/mongodb-kubernetes.clusterserviceversion.yaml)
+  operator_image=$(yq '.spec.install.spec.deployments[] | select(.name == "mongodb-kubernetes-operator") | .spec.template.spec.containers[0].image' < ./bundle/"${VERSION}"/manifests/mongodb-kubernetes.clusterserviceversion.yaml)
   operator_annotation_image=$(yq ".metadata.annotations.containerImage" < ./bundle/"${VERSION}"/manifests/mongodb-kubernetes.clusterserviceversion.yaml)
   if [[ "${operator_image}" != "${operator_annotation_image}" ]]; then
-    echo "Inconsistent operator images in CSV (.spec.install.spec.deployments[0].spec.template.spec.containers[0].image=${operator_image}, .metadata.annotations.containerImage=${operator_annotation_image})"
+    echo "Inconsistent operator images in CSV (.spec.install.spec.deployments[mongodb-kubernetes-operator].spec.template.spec.containers[0].image=${operator_image}, .metadata.annotations.containerImage=${operator_annotation_image})"
     cat ./bundle/"${VERSION}"/manifests/mongodb-kubernetes.clusterserviceversion.yaml
     exit 1
   fi


### PR DESCRIPTION
# Summary

Track the installation method of MCK (Helm, OLM, or YAML) and return that result alongside the existing telemetry we send.

Installation method is determined based on annotations we attach to the operator, which we then retrieve as environment variables via the downward API.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
