### PR TITLE
fix: correct logger.error format string in assert_data_got_restored

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -1843,7 +1843,7 @@ def assert_data_got_restored(test_data, collection1, collection2=None, timeout=3
             # We ignore Exception as there is usually a blip in connection (backup restore
             # results in reelection or whatever)
             # "Connection reset by peer" or "not master and slaveOk=false"
-            logger.error("Exception happened while waiting for db data restore: ", e)
+            logger.error("Exception happened while waiting for db data restore: %s", e)
             # this is definitely the sign of a problem - no need continuing as each connection times out
             # after many minutes
             if "Connection refused" in str(e):


### PR DESCRIPTION
# Summary

`assert_data_got_restored` in `tests/conftest.py` catches generic `Exception`s during the data-restore polling loop (e.g. SSL handshake failures, connection resets that happen while the replica set re-elects after a PIT restore) and logs them before retrying. The `logger.error()` call was passing the exception as a positional argument without a `%s` placeholder in the format string:

```python
logger.error("Exception happened while waiting for db data restore: ", e)
```

Python's `logging` module uses `%`-style formatting when extra args are supplied. With no `%s` in the message, formatting raises `TypeError: not all arguments converted during string formatting` — which propagates out of the `except` block and crashes the test with a confusing error instead of the actual assertion failure.

The fix adds `%s` to the format string so the exception is included in the log message as intended.

## Proof of Work

Caught via `[e2e_om_ops_manager_backup_restore_minio](https://parsley.corp.mongodb.com/evergreen/mongodb_kubernetes_e2e_static_om80_kind_ubi_e2e_om_ops_manager_backup_restore_minio_859f2ba384bf9f31b3f14a2fce1008b3e72020e0_26_03_31_10_38_11/1/task?bookmarks=0,8180&selectedLineRange=L4945)` on `e2e_static_om80_kind_ubi` — the test showed `FAILED ... TypeError: not all arguments converted during string formatting` at `logging/__init__.py:400`, traced back to this line.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed