### PR TITLE
Add API types for VM migration: ExternalMember, Conditions, MigrationStatus

### DIFF
--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -1352,7 +1353,7 @@ func (m *MongoDB) UpdateStatus(phase status.Phase, statusOptions ...status.Optio
 	if option, exists := status.GetOption(statusOptions, status.MigrationConditionOption{}); exists {
 		c := option.(status.MigrationConditionOption).Condition
 		c.ObservedGeneration = m.GetGeneration()
-		m.Status.Conditions = setCondition(m.Status.Conditions, c)
+		_ = meta.SetStatusCondition(&m.Status.Conditions, c)
 	}
 	switch m.Spec.ResourceType {
 	case ReplicaSet:
@@ -1382,25 +1383,6 @@ func (m *MongoDB) UpdateStatus(phase status.Phase, statusOptions ...status.Optio
 			m.Status.ShardCount = m.Spec.ShardCount
 		}
 	}
-}
-
-// setCondition sets or updates a condition by type (replaces existing with the same type).
-// Conditions are additive by nature per type, so NetworkConditions is one.
-func setCondition(conditions []metav1.Condition, c metav1.Condition) []metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type != c.Type {
-			continue
-		}
-		existing := conditions[i]
-		// LastTransitionTime is only updated when Status or Reason changes,
-		// c.LastTransitionTime is always now, that's why we overwrite this to not trigger a change
-		if existing.Status == c.Status && existing.Reason == c.Reason {
-			c.LastTransitionTime = existing.LastTransitionTime
-		}
-		conditions[i] = c
-		return conditions
-	}
-	return append(conditions, c)
 }
 
 func (m *MongoDB) SetWarnings(warnings []status.Warning, _ ...status.Option) {

--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -366,6 +366,9 @@ type MongoDbStatus struct {
 	Link                                   string                                     `json:"link,omitempty"`
 	FeatureCompatibilityVersion            string                                     `json:"featureCompatibilityVersion,omitempty"`
 	Warnings                               []status.Warning                           `json:"warnings,omitempty"`
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 type BackupMode string
@@ -1346,6 +1349,11 @@ func (m *MongoDB) UpdateStatus(phase status.Phase, statusOptions ...status.Optio
 	if option, exists := status.GetOption(statusOptions, status.BaseUrlOption{}); exists {
 		m.Status.Link = option.(status.BaseUrlOption).BaseUrl
 	}
+	if option, exists := status.GetOption(statusOptions, status.MigrationConditionOption{}); exists {
+		c := option.(status.MigrationConditionOption).Condition
+		c.ObservedGeneration = m.GetGeneration()
+		setCondition(&m.Status.Conditions, c)
+	}
 	switch m.Spec.ResourceType {
 	case ReplicaSet:
 		if option, exists := status.GetOption(statusOptions, status.ReplicaSetMembersOption{}); exists {
@@ -1374,6 +1382,26 @@ func (m *MongoDB) UpdateStatus(phase status.Phase, statusOptions ...status.Optio
 			m.Status.ShardCount = m.Spec.ShardCount
 		}
 	}
+}
+
+// setCondition sets or updates a condition by type (replaces existing with same type).
+// LastTransitionTime is only updated when Status or Reason changes.
+// Conditions are additive by nature per type so NetworkConditions is one.
+func setCondition(conditions *[]metav1.Condition, c metav1.Condition) {
+	if conditions == nil {
+		return
+	}
+	for i := range *conditions {
+		if (*conditions)[i].Type == c.Type {
+			existing := &(*conditions)[i]
+			if existing.Status == c.Status && existing.Reason == c.Reason {
+				c.LastTransitionTime = existing.LastTransitionTime
+			}
+			(*conditions)[i] = c
+			return
+		}
+	}
+	*conditions = append(*conditions, c)
 }
 
 func (m *MongoDB) SetWarnings(warnings []status.Warning, _ ...status.Option) {

--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -1352,7 +1352,7 @@ func (m *MongoDB) UpdateStatus(phase status.Phase, statusOptions ...status.Optio
 	if option, exists := status.GetOption(statusOptions, status.MigrationConditionOption{}); exists {
 		c := option.(status.MigrationConditionOption).Condition
 		c.ObservedGeneration = m.GetGeneration()
-		setCondition(&m.Status.Conditions, c)
+		m.Status.Conditions = setCondition(m.Status.Conditions, c)
 	}
 	switch m.Spec.ResourceType {
 	case ReplicaSet:
@@ -1384,24 +1384,23 @@ func (m *MongoDB) UpdateStatus(phase status.Phase, statusOptions ...status.Optio
 	}
 }
 
-// setCondition sets or updates a condition by type (replaces existing with same type).
-// LastTransitionTime is only updated when Status or Reason changes.
-// Conditions are additive by nature per type so NetworkConditions is one.
-func setCondition(conditions *[]metav1.Condition, c metav1.Condition) {
-	if conditions == nil {
-		return
-	}
-	for i := range *conditions {
-		if (*conditions)[i].Type == c.Type {
-			existing := &(*conditions)[i]
-			if existing.Status == c.Status && existing.Reason == c.Reason {
-				c.LastTransitionTime = existing.LastTransitionTime
-			}
-			(*conditions)[i] = c
-			return
+// setCondition sets or updates a condition by type (replaces existing with the same type).
+// Conditions are additive by nature per type, so NetworkConditions is one.
+func setCondition(conditions []metav1.Condition, c metav1.Condition) []metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type != c.Type {
+			continue
 		}
+		existing := conditions[i]
+		// LastTransitionTime is only updated when Status or Reason changes,
+		// c.LastTransitionTime is always now, that's why we overwrite this to not trigger a change
+		if existing.Status == c.Status && existing.Reason == c.Reason {
+			c.LastTransitionTime = existing.LastTransitionTime
+		}
+		conditions[i] = c
+		return conditions
 	}
-	*conditions = append(*conditions, c)
+	return append(conditions, c)
 }
 
 func (m *MongoDB) SetWarnings(warnings []status.Warning, _ ...status.Option) {

--- a/api/v1/mdb/mongodb_types_test.go
+++ b/api/v1/mdb/mongodb_types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/connectionstring"
@@ -464,4 +465,61 @@ func TestAdditionalMongodConfigMarshalJSON(t *testing.T) {
 	expected := mdb.Spec.GetAdditionalMongodConfig().ToMap()
 	actual := unmarshalledSpec.AdditionalMongodConfig.ToMap()
 	assert.Equal(t, expected, actual)
+}
+
+func TestUpdateStatus_AppliesMigrationCondition_WithObservedGeneration(t *testing.T) {
+	m := &MongoDB{}
+	m.Generation = 5
+	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
+		status.MigrationPhaseConnectivityCheckPassed, "NetworkValidationPassed", "All external members reachable",
+	)))
+	assert.Len(t, m.Status.Conditions, 1)
+	c := m.Status.Conditions[0]
+	assert.Equal(t, status.ConditionNetworkConnectivityVerification, c.Type)
+	assert.Equal(t, int64(5), c.ObservedGeneration)
+	assert.Equal(t, "NetworkValidationPassed", c.Reason)
+	assert.Equal(t, metav1.ConditionTrue, c.Status)
+}
+
+func TestUpdateStatus_MigrationConditionReplacesByType(t *testing.T) {
+	m := &MongoDB{}
+	m.Generation = 1
+	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
+		status.MigrationPhaseConnectivityCheckRunning, "Running", "first",
+	)))
+	assert.Len(t, m.Status.Conditions, 1)
+	assert.Equal(t, "first", m.Status.Conditions[0].Message)
+
+	m.Generation = 2
+	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
+		status.MigrationPhaseConnectivityCheckFailed, "NetworkFailed", "second",
+	)))
+	assert.Len(t, m.Status.Conditions, 1)
+	assert.Equal(t, "second", m.Status.Conditions[0].Message)
+	assert.Equal(t, int64(2), m.Status.Conditions[0].ObservedGeneration)
+}
+
+func TestUpdateStatus_MigrationCondition_LastTransitionTimeOnlyChangesOnStatusOrReasonChange(t *testing.T) {
+	m := &MongoDB{}
+	m.Generation = 1
+	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
+		status.MigrationPhaseConnectivityCheckRunning, "Running", "in progress",
+	)))
+	assert.Len(t, m.Status.Conditions, 1)
+	firstTransition := m.Status.Conditions[0].LastTransitionTime
+
+	// Same status and reason, only message differs: LastTransitionTime should be preserved
+	m.Generation = 2
+	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
+		status.MigrationPhaseConnectivityCheckRunning, "Running", "still in progress",
+	)))
+	assert.Len(t, m.Status.Conditions, 1)
+	assert.Equal(t, firstTransition, m.Status.Conditions[0].LastTransitionTime, "LastTransitionTime should not change when status and reason are unchanged")
+
+	// Status changes: LastTransitionTime should update
+	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
+		status.MigrationPhaseConnectivityCheckPassed, "NetworkValidationPassed", "done",
+	)))
+	assert.Len(t, m.Status.Conditions, 1)
+	assert.False(t, m.Status.Conditions[0].LastTransitionTime.Equal(&firstTransition), "LastTransitionTime should change when status changes")
 }

--- a/api/v1/mdb/mongodb_types_test.go
+++ b/api/v1/mdb/mongodb_types_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/connectionstring"
@@ -467,59 +466,3 @@ func TestAdditionalMongodConfigMarshalJSON(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestUpdateStatus_AppliesMigrationCondition_WithObservedGeneration(t *testing.T) {
-	m := &MongoDB{}
-	m.Generation = 5
-	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
-		status.MigrationPhaseConnectivityCheckPassed, "NetworkValidationPassed", "All external members reachable",
-	)))
-	assert.Len(t, m.Status.Conditions, 1)
-	c := m.Status.Conditions[0]
-	assert.Equal(t, status.ConditionNetworkConnectivityVerification, c.Type)
-	assert.Equal(t, int64(5), c.ObservedGeneration)
-	assert.Equal(t, "NetworkValidationPassed", c.Reason)
-	assert.Equal(t, metav1.ConditionTrue, c.Status)
-}
-
-func TestUpdateStatus_MigrationConditionReplacesByType(t *testing.T) {
-	m := &MongoDB{}
-	m.Generation = 1
-	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
-		status.MigrationPhaseConnectivityCheckRunning, "Running", "first",
-	)))
-	assert.Len(t, m.Status.Conditions, 1)
-	assert.Equal(t, "first", m.Status.Conditions[0].Message)
-
-	m.Generation = 2
-	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
-		status.MigrationPhaseConnectivityCheckFailed, "NetworkFailed", "second",
-	)))
-	assert.Len(t, m.Status.Conditions, 1)
-	assert.Equal(t, "second", m.Status.Conditions[0].Message)
-	assert.Equal(t, int64(2), m.Status.Conditions[0].ObservedGeneration)
-}
-
-func TestUpdateStatus_MigrationCondition_LastTransitionTimeOnlyChangesOnStatusOrReasonChange(t *testing.T) {
-	m := &MongoDB{}
-	m.Generation = 1
-	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
-		status.MigrationPhaseConnectivityCheckRunning, "Running", "in progress",
-	)))
-	assert.Len(t, m.Status.Conditions, 1)
-	firstTransition := m.Status.Conditions[0].LastTransitionTime
-
-	// Same status and reason, only message differs: LastTransitionTime should be preserved
-	m.Generation = 2
-	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
-		status.MigrationPhaseConnectivityCheckRunning, "Running", "still in progress",
-	)))
-	assert.Len(t, m.Status.Conditions, 1)
-	assert.Equal(t, firstTransition, m.Status.Conditions[0].LastTransitionTime, "LastTransitionTime should not change when status and reason are unchanged")
-
-	// Status changes: LastTransitionTime should update
-	m.UpdateStatus(status.PhasePending, status.NewMigrationConditionOption(status.MigrationCondition(
-		status.MigrationPhaseConnectivityCheckPassed, "NetworkValidationPassed", "done",
-	)))
-	assert.Len(t, m.Status.Conditions, 1)
-	assert.False(t, m.Status.Conditions[0].LastTransitionTime.Equal(&firstTransition), "LastTransitionTime should change when status changes")
-}

--- a/api/v1/mdb/zz_generated.deepcopy.go
+++ b/api/v1/mdb/zz_generated.deepcopy.go
@@ -22,10 +22,11 @@ package mdb
 
 import (
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
-	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1"
+	apiv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1/common"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/automationconfig"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -426,7 +427,7 @@ func (in *DbCommonSpec) DeepCopyInto(out *DbCommonSpec) {
 	}
 	if in.Prometheus != nil {
 		in, out := &in.Prometheus, &out.Prometheus
-		*out = new(v1.Prometheus)
+		*out = new(apiv1.Prometheus)
 		**out = **in
 	}
 	if in.StatefulSetConfiguration != nil {
@@ -928,6 +929,13 @@ func (in *MongoDbStatus) DeepCopyInto(out *MongoDbStatus) {
 		in, out := &in.Warnings, &out.Warnings
 		*out = make([]status.Warning, len(*in))
 		copy(*out, *in)
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/api/v1/status/migration_status.go
+++ b/api/v1/status/migration_status.go
@@ -19,8 +19,10 @@ const (
 // MigrationCondition returns a metav1.Condition for the migration connectivity check.
 // Passed -> True, Failed -> False, Running -> Unknown.
 //
-// Unknown when running follows standard Kubernetes condition semantics: True = condition
-// satisfied, False = not satisfied, Unknown = outcome not yet known (verification in progress).
+// Unknown when running follows standard Kubernetes condition semantics:
+//   - True = condition satisfied,
+//   - False = not satisfied,
+//   - Unknown = outcome not yet known (verification in progress).
 func MigrationCondition(phase MigrationPhase, reason, message string) metav1.Condition {
 	status := metav1.ConditionUnknown
 	switch phase {

--- a/api/v1/status/migration_status.go
+++ b/api/v1/status/migration_status.go
@@ -1,0 +1,39 @@
+package status
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionNetworkConnectivityVerification Condition type for migration (connectivity validation) dry run.
+const ConditionNetworkConnectivityVerification = "NetworkConnectivityVerification"
+
+// MigrationPhase describes the current phase of a connectivity validation dry run.
+type MigrationPhase string
+
+const (
+	MigrationPhaseConnectivityCheckRunning MigrationPhase = "ConnectivityCheckRunning"
+	MigrationPhaseConnectivityCheckPassed  MigrationPhase = "ConnectivityCheckPassed"
+	MigrationPhaseConnectivityCheckFailed  MigrationPhase = "ConnectivityCheckFailed"
+)
+
+// MigrationCondition returns a metav1.Condition for the migration connectivity check.
+// Passed -> True, Failed -> False, Running -> Unknown.
+//
+// Unknown when running follows standard Kubernetes condition semantics: True = condition
+// satisfied, False = not satisfied, Unknown = outcome not yet known (verification in progress).
+func MigrationCondition(phase MigrationPhase, reason, message string) metav1.Condition {
+	status := metav1.ConditionUnknown
+	switch phase {
+	case MigrationPhaseConnectivityCheckPassed:
+		status = metav1.ConditionTrue
+	case MigrationPhaseConnectivityCheckFailed:
+		status = metav1.ConditionFalse
+	}
+	return metav1.Condition{
+		Type:               ConditionNetworkConnectivityVerification,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+}

--- a/api/v1/status/migration_status_test.go
+++ b/api/v1/status/migration_status_test.go
@@ -1,0 +1,33 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMigrationCondition_PhaseToStatus(t *testing.T) {
+	t.Run("Passed maps to True", func(t *testing.T) {
+		c := MigrationCondition(MigrationPhaseConnectivityCheckPassed, "R", "M")
+		assert.Equal(t, metav1.ConditionTrue, c.Status)
+	})
+	t.Run("Failed maps to False", func(t *testing.T) {
+		c := MigrationCondition(MigrationPhaseConnectivityCheckFailed, "R", "M")
+		assert.Equal(t, metav1.ConditionFalse, c.Status)
+	})
+	t.Run("Running maps to Unknown", func(t *testing.T) {
+		c := MigrationCondition(MigrationPhaseConnectivityCheckRunning, "R", "M")
+		assert.Equal(t, metav1.ConditionUnknown, c.Status)
+	})
+}
+
+func TestMigrationCondition_FieldsSet(t *testing.T) {
+	reason, message := "SomeReason", "some message"
+	c := MigrationCondition(MigrationPhaseConnectivityCheckPassed, reason, message)
+
+	assert.Equal(t, ConditionNetworkConnectivityVerification, c.Type)
+	assert.Equal(t, reason, c.Reason)
+	assert.Equal(t, message, c.Message)
+	assert.False(t, c.LastTransitionTime.IsZero())
+}

--- a/api/v1/status/migration_status_test.go
+++ b/api/v1/status/migration_status_test.go
@@ -21,13 +21,3 @@ func TestMigrationCondition_PhaseToStatus(t *testing.T) {
 		assert.Equal(t, metav1.ConditionUnknown, c.Status)
 	})
 }
-
-func TestMigrationCondition_FieldsSet(t *testing.T) {
-	reason, message := "SomeReason", "some message"
-	c := MigrationCondition(MigrationPhaseConnectivityCheckPassed, reason, message)
-
-	assert.Equal(t, ConditionNetworkConnectivityVerification, c.Type)
-	assert.Equal(t, reason, c.Reason)
-	assert.Equal(t, message, c.Message)
-	assert.False(t, c.LastTransitionTime.IsZero())
-}

--- a/api/v1/status/option.go
+++ b/api/v1/status/option.go
@@ -2,6 +2,8 @@ package status
 
 import (
 	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Option interface {
@@ -120,4 +122,19 @@ func (o PVCStatusOption) Value() interface{} {
 // Otherwise, that field will forever be in the status field.
 func NewPVCsStatusOptionEmptyStatus() PVCStatusOption {
 	return PVCStatusOption{PVC: nil}
+}
+
+// MigrationConditionOption carries a NetworkConnectivityVerification-style metav1.Condition through the
+// same status.Option mechanism as phase/PVC options. We use Options so updateStatus can merge several
+// writers in one call; the condition is also written to status.conditions by type (not duplicated as arbitrary option data).
+type MigrationConditionOption struct {
+	Condition metav1.Condition
+}
+
+func NewMigrationConditionOption(condition metav1.Condition) MigrationConditionOption {
+	return MigrationConditionOption{Condition: condition}
+}
+
+func (o MigrationConditionOption) Value() interface{} {
+	return o.Condition
 }

--- a/api/v1/status/phase.go
+++ b/api/v1/status/phase.go
@@ -25,6 +25,9 @@ const (
 
 	// PhaseUnsupported means a resource is not supported by the current Operator version
 	PhaseUnsupported Phase = "Unsupported"
+
+	// PhaseConnectivityValidation means the resource is in migration dry-run: only connectivity to external members is being validated (no Ops Manager or StatefulSet changes).
+	PhaseConnectivityValidation Phase = "ConnectivityValidation"
 )
 
 type Updater interface {

--- a/api/v1/status/phase.go
+++ b/api/v1/status/phase.go
@@ -26,7 +26,7 @@ const (
 	// PhaseUnsupported means a resource is not supported by the current Operator version
 	PhaseUnsupported Phase = "Unsupported"
 
-	// PhaseConnectivityValidation means the resource is in migration dry-run: only connectivity to external members is being validated (no Ops Manager or StatefulSet changes).
+	// PhaseConnectivityValidation means the resource is in migration dry-run: only connectivity to external members is being validated.
 	PhaseConnectivityValidation Phase = "ConnectivityValidation"
 )
 

--- a/config/crd/bases/mongodb.com_mongodb.yaml
+++ b/config/crd/bases/mongodb.com_mongodb.yaml
@@ -2690,6 +2690,65 @@ spec:
                 required:
                 - statusName
                 type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configServerCount:
                 type: integer
               featureCompatibilityVersion:

--- a/config/crd/bases/mongodb.com_opsmanagers.yaml
+++ b/config/crd/bases/mongodb.com_opsmanagers.yaml
@@ -1815,6 +1815,66 @@ spec:
                           type: integer
                       type: object
                     type: array
+                  conditions:
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
                   configServerCount:
                     type: integer
                   featureCompatibilityVersion:

--- a/helm_chart/crds/mongodb.com_mongodb.yaml
+++ b/helm_chart/crds/mongodb.com_mongodb.yaml
@@ -2690,6 +2690,65 @@ spec:
                 required:
                 - statusName
                 type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configServerCount:
                 type: integer
               featureCompatibilityVersion:

--- a/helm_chart/crds/mongodb.com_opsmanagers.yaml
+++ b/helm_chart/crds/mongodb.com_opsmanagers.yaml
@@ -1815,6 +1815,66 @@ spec:
                           type: integer
                       type: object
                     type: array
+                  conditions:
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
                   configServerCount:
                     type: integer
                   featureCompatibilityVersion:

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -2798,6 +2798,65 @@ spec:
                 required:
                 - statusName
                 type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configServerCount:
                 type: integer
               featureCompatibilityVersion:
@@ -6504,6 +6563,66 @@ spec:
                           type: integer
                       type: object
                     type: array
+                  conditions:
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
                   configServerCount:
                     type: integer
                   featureCompatibilityVersion:


### PR DESCRIPTION
# Summary

**Part 1 of 4** in the VM-to-Kubernetes migration dry-run stack.

This PR adds the foundational API types needed for the VM migration feature. These types enable the operator to:

1. Report migration status via standard Kubernetes conditions

## Changes

### New Types

- **`MigrationStatus`** and **`MigrationPhase`**: Status reporting for migration operations
    - `ConnectivityCheckRunning/Passed/Failed` phases
    - Condition-based status updates

### Spec Additions

- `Conditions []metav1.Condition` on `MongoDbStatus`


## Proof of Work

- Unit tests added for new types and helpers
- CRDs regenerated and validated

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed