### PR TITLE
Add E2E tests and infrastructure for VM migration dry-run

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/tls/fixtures/vm_service.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/tls/fixtures/vm_service.yaml
@@ -6,8 +6,10 @@ metadata:
     app: vm-mongodb
 spec:
   type: ClusterIP
+  clusterIP: None  # headless: vm-mongodb-0.vm-mongodb.ns.svc.cluster.local resolves to pod IP
   selector:
     app: vm-mongodb
   ports:
     - port: 27017
+      targetPort: 27017
       name: mongodb

--- a/docker/mongodb-kubernetes-tests/tests/tls/fixtures/vm_statefulset.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/tls/fixtures/vm_statefulset.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: mongodb-agent
           image: quay.io/mongodb/mongodb-agent:13.48.0.10348-1
+          ports:
+            - containerPort: 27017
+              name: mongodb
           command:
             - /bin/sh
             - -c

--- a/docker/mongodb-kubernetes-tests/tests/tls/vm_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/vm_migration.py
@@ -15,9 +15,13 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
+# Annotation that triggers migration dry-run (connectivity validation only, no OM/StatefulSet changes).
+MIGRATION_DRY_RUN_ANNOTATION = "mongodb.com/migration-dry-run"
+CONDITION_NETWORK_CONNECTIVITY_VERIFIED = "NetworkConnectivityVerification"
+
 
 @fixture(scope="module")
-def om_tester(namespace: str) -> OMTester:
+def om_tester(namespace: str, operator) -> OMTester:
     config_map = KubernetesTester.read_configmap(namespace, "my-project")
     secret = KubernetesTester.read_secret(namespace, "my-credentials")
     tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
@@ -98,6 +102,15 @@ def test_update_vm_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, c
         # If there are already processes, it means the test is retried.
         return
 
+    # Pin the automation agent version to match the image in vm_statefulset.yaml.
+    # Without this, OM offers the latest available agent version; the running agent (older)
+    # downloads it, forks the new binary, then exits (PID 1 exits → container restarts).
+    # This creates an infinite upgrade loop that keeps the vm-mongodb pods in CrashLoopBackOff
+    # and makes the connectivity check fail with DNS/connection errors.
+    agent_image_tag = vm_sts["spec"]["template"]["spec"]["containers"][0]["image"].split(":")[-1]
+    if "agentVersion" in ac:
+        ac["agentVersion"]["name"] = agent_image_tag
+
     ac["processes"] = []
     ac["monitoringVersions"] = []
 
@@ -155,6 +168,42 @@ def test_update_vm_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, c
         )
 
     om_tester.api_put_automation_config(ac)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    """Run migration dry-run: operator only validates connectivity to externalMembers, then we clear the annotation."""
+
+    mdb_migration.load()
+    if "metadata" not in mdb_migration:
+        mdb_migration["metadata"] = {}
+    if "annotations" not in mdb_migration["metadata"]:
+        mdb_migration["metadata"]["annotations"] = {}
+    mdb_migration["metadata"]["annotations"][MIGRATION_DRY_RUN_ANNOTATION] = "true"
+    mdb_migration.update()
+
+    def migration_connectivity_passed(mdb: MongoDB) -> bool:
+        # MongoDB (CustomObject) supports [] but not .get(); status/conditions come from the API.
+        try:
+            status = mdb["status"]
+        except (KeyError, AttributeError, TypeError):
+            status = {}
+        conditions = status.get("conditions", []) if isinstance(status, dict) else []
+        for c in conditions:
+            if c.get("type") == CONDITION_NETWORK_CONNECTIVITY_VERIFIED and c.get("status") == "True":
+                return True
+        return False
+
+    mdb_migration.wait_for(migration_connectivity_passed, timeout=600)
+
+    # Remove dry-run annotation so later tests (test_mdb_reaches_running, test_promote_and_prune) reconcile normally.
+    # Use backing object so we mutate what update() will send. JSON merge patch only removes keys when set to null.
+    mdb_migration.load()
+    ann = mdb_migration.backing_obj.get("metadata").get("annotations")
+    if ann is not None and MIGRATION_DRY_RUN_ANNOTATION in ann:
+        ann[MIGRATION_DRY_RUN_ANNOTATION] = None
+        mdb_migration.update()
 
 
 @mark.e2e_vm_migration

--- a/docker/mongodb-kubernetes-tests/tests/tls/vm_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/vm_migration.py
@@ -15,9 +15,7 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
-# Annotation that triggers migration dry-run (connectivity validation only, no OM/StatefulSet changes).
-MIGRATION_DRY_RUN_ANNOTATION = "mongodb.com/migration-dry-run"
-CONDITION_NETWORK_CONNECTIVITY_VERIFIED = "NetworkConnectivityVerification"
+from tests.tls.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
 
 
 @fixture(scope="module")
@@ -165,36 +163,7 @@ def test_update_vm_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, c
 @mark.e2e_vm_migration
 def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
     """Run migration dry-run: operator only validates connectivity to externalMembers, then we clear the annotation."""
-
-    mdb_migration.load()
-    if "metadata" not in mdb_migration:
-        mdb_migration["metadata"] = {}
-    if "annotations" not in mdb_migration["metadata"]:
-        mdb_migration["metadata"]["annotations"] = {}
-    mdb_migration["metadata"]["annotations"][MIGRATION_DRY_RUN_ANNOTATION] = "true"
-    mdb_migration.update()
-
-    def migration_connectivity_passed(mdb: MongoDB) -> bool:
-        # MongoDB (CustomObject) supports [] but not .get(); status/conditions come from the API.
-        try:
-            status = mdb["status"]
-        except (KeyError, AttributeError, TypeError):
-            status = {}
-        conditions = status.get("conditions", []) if isinstance(status, dict) else []
-        for c in conditions:
-            if c.get("type") == CONDITION_NETWORK_CONNECTIVITY_VERIFIED and c.get("status") == "True":
-                return True
-        return False
-
-    mdb_migration.wait_for(migration_connectivity_passed, timeout=600)
-
-    # Remove dry-run annotation so later tests (test_mdb_reaches_running, test_promote_and_prune) reconcile normally.
-    # Use backing object so we mutate what update() will send. JSON merge patch only removes keys when set to null.
-    mdb_migration.load()
-    ann = mdb_migration.backing_obj.get("metadata").get("annotations")
-    if ann is not None and MIGRATION_DRY_RUN_ANNOTATION in ann:
-        ann[MIGRATION_DRY_RUN_ANNOTATION] = None
-        mdb_migration.update()
+    run_migration_dry_run_connectivity_passes(mdb_migration)
 
 
 @mark.e2e_vm_migration

--- a/docker/mongodb-kubernetes-tests/tests/tls/vm_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/vm_migration.py
@@ -102,15 +102,6 @@ def test_update_vm_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, c
         # If there are already processes, it means the test is retried.
         return
 
-    # Pin the automation agent version to match the image in vm_statefulset.yaml.
-    # Without this, OM offers the latest available agent version; the running agent (older)
-    # downloads it, forks the new binary, then exits (PID 1 exits → container restarts).
-    # This creates an infinite upgrade loop that keeps the vm-mongodb pods in CrashLoopBackOff
-    # and makes the connectivity check fail with DNS/connection errors.
-    agent_image_tag = vm_sts["spec"]["template"]["spec"]["containers"][0]["image"].split(":")[-1]
-    if "agentVersion" in ac:
-        ac["agentVersion"]["name"] = agent_image_tag
-
     ac["processes"] = []
     ac["monitoringVersions"] = []
 

--- a/docker/mongodb-kubernetes-tests/tests/tls/vm_migration_dry_run.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/vm_migration_dry_run.py
@@ -1,0 +1,43 @@
+"""Shared VM migration dry-run (connectivity-only) flow for plain-TLS and X509 E2E tests."""
+
+from kubetester.mongodb import MongoDB
+
+# Annotation that triggers migration dry-run (connectivity validation only, no OM/StatefulSet changes).
+MIGRATION_DRY_RUN_ANNOTATION = "mongodb.com/migration-dry-run"
+CONDITION_NETWORK_CONNECTIVITY_VERIFIED = "NetworkConnectivityVerification"
+
+
+def _migration_connectivity_passed(mdb: MongoDB) -> bool:
+    # MongoDB (CustomObject) supports [] but not .get(); status/conditions come from the API.
+    try:
+        status = mdb["status"]
+    except (KeyError, AttributeError, TypeError):
+        status = {}
+    conditions = status.get("conditions", []) if isinstance(status, dict) else []
+    for c in conditions:
+        if c.get("type") == CONDITION_NETWORK_CONNECTIVITY_VERIFIED and c.get("status") == "True":
+            return True
+    return False
+
+
+def run_migration_dry_run_connectivity_passes(mdb: MongoDB, *, timeout: int = 600) -> None:
+    """Set migration-dry-run annotation, wait for NetworkConnectivityVerification, then clear the annotation.
+
+    Removes the dry-run annotation so later tests reconcile normally. Uses backing_obj and JSON merge
+    patch (null) so the key is actually removed—merge patch only drops keys when set to null.
+    """
+    mdb.load()
+    if "metadata" not in mdb:
+        mdb["metadata"] = {}
+    if "annotations" not in mdb["metadata"]:
+        mdb["metadata"]["annotations"] = {}
+    mdb["metadata"]["annotations"][MIGRATION_DRY_RUN_ANNOTATION] = "true"
+    mdb.update()
+
+    mdb.wait_for(_migration_connectivity_passed, timeout=timeout)
+
+    mdb.load()
+    ann = mdb.backing_obj.get("metadata").get("annotations")
+    if ann is not None and MIGRATION_DRY_RUN_ANNOTATION in ann:
+        ann[MIGRATION_DRY_RUN_ANNOTATION] = None
+        mdb.update()

--- a/docker/mongodb-kubernetes-tests/tests/tls/vm_migration_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/vm_migration_x509.py
@@ -32,9 +32,7 @@ from kubetester.omtester import OMContext, OMTester
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
-# Annotation that triggers migration dry-run (connectivity validation only, no OM/StatefulSet changes).
-MIGRATION_DRY_RUN_ANNOTATION = "mongodb.com/migration-dry-run"
-CONDITION_NETWORK_CONNECTIVITY_VERIFIED = "NetworkConnectivityVerification"
+from tests.tls.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
 
 VM_STS_NAME = "vm-mongodb"
 VM_RS_NAME = "vm-mongodb-rs"
@@ -401,33 +399,7 @@ def test_vm_ac_x509_auth(
 @mark.e2e_vm_migration_x509
 def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
     """Run migration dry-run: operator only validates connectivity to externalMembers, then we clear the annotation."""
-    mdb_migration.load()
-    if "metadata" not in mdb_migration:
-        mdb_migration["metadata"] = {}
-    if "annotations" not in mdb_migration["metadata"]:
-        mdb_migration["metadata"]["annotations"] = {}
-    mdb_migration["metadata"]["annotations"][MIGRATION_DRY_RUN_ANNOTATION] = "true"
-    mdb_migration.update()
-
-    def migration_connectivity_passed(mdb: MongoDB) -> bool:
-        try:
-            status = mdb["status"]
-        except (KeyError, AttributeError, TypeError):
-            status = {}
-        conditions = status.get("conditions", []) if isinstance(status, dict) else []
-        for c in conditions:
-            if c.get("type") == CONDITION_NETWORK_CONNECTIVITY_VERIFIED and c.get("status") == "True":
-                return True
-        return False
-
-    mdb_migration.wait_for(migration_connectivity_passed, timeout=600)
-
-    # Remove dry-run annotation so later tests reconcile normally.
-    mdb_migration.load()
-    ann = mdb_migration.backing_obj.get("metadata").get("annotations")
-    if ann is not None and MIGRATION_DRY_RUN_ANNOTATION in ann:
-        ann[MIGRATION_DRY_RUN_ANNOTATION] = None
-        mdb_migration.update()
+    run_migration_dry_run_connectivity_passes(mdb_migration)
 
 
 @mark.e2e_vm_migration_x509

--- a/docker/mongodb-kubernetes-tests/tests/tls/vm_migration_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/vm_migration_x509.py
@@ -32,6 +32,10 @@ from kubetester.omtester import OMContext, OMTester
 from kubetester.phase import Phase
 from pytest import fixture, mark
 
+# Annotation that triggers migration dry-run (connectivity validation only, no OM/StatefulSet changes).
+MIGRATION_DRY_RUN_ANNOTATION = "mongodb.com/migration-dry-run"
+CONDITION_NETWORK_CONNECTIVITY_VERIFIED = "NetworkConnectivityVerification"
+
 VM_STS_NAME = "vm-mongodb"
 VM_RS_NAME = "vm-mongodb-rs"
 MDB_RESOURCE_NAME = "my-replica-set"
@@ -392,6 +396,38 @@ def test_vm_ac_x509_auth(
     }
     om_tester.api_put_automation_config(ac)
     om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_x509
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    """Run migration dry-run: operator only validates connectivity to externalMembers, then we clear the annotation."""
+    mdb_migration.load()
+    if "metadata" not in mdb_migration:
+        mdb_migration["metadata"] = {}
+    if "annotations" not in mdb_migration["metadata"]:
+        mdb_migration["metadata"]["annotations"] = {}
+    mdb_migration["metadata"]["annotations"][MIGRATION_DRY_RUN_ANNOTATION] = "true"
+    mdb_migration.update()
+
+    def migration_connectivity_passed(mdb: MongoDB) -> bool:
+        try:
+            status = mdb["status"]
+        except (KeyError, AttributeError, TypeError):
+            status = {}
+        conditions = status.get("conditions", []) if isinstance(status, dict) else []
+        for c in conditions:
+            if c.get("type") == CONDITION_NETWORK_CONNECTIVITY_VERIFIED and c.get("status") == "True":
+                return True
+        return False
+
+    mdb_migration.wait_for(migration_connectivity_passed, timeout=600)
+
+    # Remove dry-run annotation so later tests reconcile normally.
+    mdb_migration.load()
+    ann = mdb_migration.backing_obj.get("metadata").get("annotations")
+    if ann is not None and MIGRATION_DRY_RUN_ANNOTATION in ann:
+        ann[MIGRATION_DRY_RUN_ANNOTATION] = None
+        mdb_migration.update()
 
 
 @mark.e2e_vm_migration_x509

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
-github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
+github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.6.9 h1:MU/8wDLif2qCXZmzncUQ/BOfxWfthHi63KqpoNbWqVw=

--- a/pkg/migration/job.go
+++ b/pkg/migration/job.go
@@ -117,7 +117,11 @@ func BuildJobFromStatefulSet(rs *mdbv1.MongoDB, sts *appsv1.StatefulSet, operato
 	}
 
 	keyfilePath := util.InternalClusterAuthMountPath + "keyfile"
-	certPath := util.AgentCertMountPath + "/" + agentCertHash
+	// Use autoPEMKeyFilePath from spec if set (custom mount path for migration), else default path.
+	certPath := security.GetAgentAutoPEMKeyFilePath()
+	if certPath == "" {
+		certPath = util.AgentCertMountPath + "/" + agentCertHash
+	}
 
 	var caPath string
 	switch authMechanism {

--- a/scripts/dev/contexts/private-context-template
+++ b/scripts/dev/contexts/private-context-template
@@ -108,3 +108,7 @@ export PRERELEASE_PULLSECRET_DOCKERCONFIGJSON="<dockerconfigjson secret>"
 
 # uncomment to enable agent debug mode (which adds a delve sidecar to the pods)
 #export MDB_AGENT_DEBUG=true
+
+export USER="surname.lastname"
+# Version tag for locally built dev images (e.g. make operator-image). Override in private-context if needed.
+export DEV_VERSION="${DEV_VERSION:-${USER}-dev}"

--- a/scripts/dev/prepare_local_e2e_run.sh
+++ b/scripts/dev/prepare_local_e2e_run.sh
@@ -78,6 +78,20 @@ wait "${pid_install}" || exit $?
 wait "${pid_om}" || exit $?
 test -f "docker/mongodb-kubernetes-tests/.test_identifiers" && rm "docker/mongodb-kubernetes-tests/.test_identifiers"
 
+# Ensure database pod service accounts exist in each watched namespace
+# regardless of DEPLOY_OPERATOR setting (the Helm chart only creates them
+# when DEPLOY_OPERATOR=true, but they're required even for local operator runs).
+# Add Helm ownership metadata so that when Helm runs (in this script or in pytest)
+# it can adopt these resources instead of failing with "invalid ownership metadata".
+for sa in mongodb-kubernetes-database-pods mongodb-kubernetes-appdb; do
+  kubectl create serviceaccount "${sa}" -n "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl label serviceaccount "${sa}" -n "${NAMESPACE}" "app.kubernetes.io/managed-by=Helm" --overwrite
+  kubectl annotate serviceaccount "${sa}" -n "${NAMESPACE}" \
+    "meta.helm.sh/release-name=mongodb-kubernetes-operator" \
+    "meta.helm.sh/release-namespace=${NAMESPACE}" \
+    --overwrite
+done
+
 (
   if [[ "${DEPLOY_OPERATOR:-"false"}" == "true" ]]; then
     echo "installing operator helm chart to create the necessary sa and roles"

--- a/scripts/dev/prepare_local_e2e_run.sh
+++ b/scripts/dev/prepare_local_e2e_run.sh
@@ -78,20 +78,6 @@ wait "${pid_install}" || exit $?
 wait "${pid_om}" || exit $?
 test -f "docker/mongodb-kubernetes-tests/.test_identifiers" && rm "docker/mongodb-kubernetes-tests/.test_identifiers"
 
-# Ensure database pod service accounts exist in each watched namespace
-# regardless of DEPLOY_OPERATOR setting (the Helm chart only creates them
-# when DEPLOY_OPERATOR=true, but they're required even for local operator runs).
-# Add Helm ownership metadata so that when Helm runs (in this script or in pytest)
-# it can adopt these resources instead of failing with "invalid ownership metadata".
-for sa in mongodb-kubernetes-database-pods mongodb-kubernetes-appdb; do
-  kubectl create serviceaccount "${sa}" -n "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-  kubectl label serviceaccount "${sa}" -n "${NAMESPACE}" "app.kubernetes.io/managed-by=Helm" --overwrite
-  kubectl annotate serviceaccount "${sa}" -n "${NAMESPACE}" \
-    "meta.helm.sh/release-name=mongodb-kubernetes-operator" \
-    "meta.helm.sh/release-namespace=${NAMESPACE}" \
-    --overwrite
-done
-
 (
   if [[ "${DEPLOY_OPERATOR:-"false"}" == "true" ]]; then
     echo "installing operator helm chart to create the necessary sa and roles"

--- a/scripts/dev/print_operator_env.sh
+++ b/scripts/dev/print_operator_env.sh
@@ -8,8 +8,11 @@ set -Eeou pipefail
 UBI_IMAGE_SUFFIX="-ubi"
 
 # Convert context variables to variables required by the operator binary
+# MDB_OPERATOR_IMAGE must match what 'make operator-image' pushes (see build_info.json patch scenario and Makefile DEV_VERSION)
+# and what Helm uses (registry/name:version+build) so migration dry-run Jobs can use it.
 function print_operator_env() {
   echo "OPERATOR_ENV=\"${OPERATOR_ENV}\"
+MDB_OPERATOR_IMAGE=\"${OPERATOR_REGISTRY:-${REGISTRY}}/mongodb-kubernetes:${DEV_VERSION:-${OPERATOR_VERSION:-latest}}${OPERATOR_BUILD:-}\"
 WATCH_NAMESPACE=\"${WATCH_NAMESPACE}\"
 NAMESPACE=\"${NAMESPACE}\"
 IMAGE_PULL_POLICY=\"Always\"

--- a/scripts/evergreen/e2e/dump_diagnostic_information.sh
+++ b/scripts/evergreen/e2e/dump_diagnostic_information.sh
@@ -343,6 +343,41 @@ download_test_results() {
     fi
 }
 
+# dump_job_pod_logs finds all Jobs in the namespace and writes each Job's pod container logs
+# to logs/ so they are uploaded to S3. Output: logs/${prefix}job_pod_output.log
+dump_job_pod_logs() {
+    local context="${1}"
+    local namespace="${2}"
+    local prefix="${3}"
+
+    local out_file="logs/${prefix}job_pod_output.log"
+    local jobs
+    jobs=$(kubectl --context="${context}" get jobs -n "${namespace}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+    if [[ -z "${jobs}" ]]; then
+        return
+    fi
+
+    for job in ${jobs}; do
+        echo "=== Job: ${job} ===" >> "${out_file}"
+        local pods
+        pods=$(kubectl --context="${context}" get pods -n "${namespace}" -l job-name="${job}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+        if [[ -z "${pods}" ]]; then
+            echo "(no pods for this job)" >> "${out_file}"
+            echo "" >> "${out_file}"
+            continue
+        fi
+        for pod in ${pods}; do
+            echo "--- Pod: ${pod} ---" >> "${out_file}"
+            for container in $(kubectl --context="${context}" get pod -n "${namespace}" "${pod}" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null); do
+                echo "---- container: ${container} ----" >> "${out_file}"
+                kubectl --context="${context}" logs -n "${namespace}" "${pod}" -c "${container}" >> "${out_file}" 2>&1 || true
+                echo "" >> "${out_file}"
+            done
+        done
+        echo "" >> "${out_file}"
+    done
+}
+
 # dump_events gets all events from a namespace and saves them to a file
 dump_events() {
     local context="${1}"
@@ -385,6 +420,9 @@ dump_namespace() {
 
     # Download test results from the test pod in community
     download_test_results "${context}" "${namespace}" "e2e-test"
+
+    # Explicitly capture job/test runner pod logs
+    dump_job_pod_logs "${context}" "${namespace}" "${prefix}"
 
     dump_objects "${context}" jobs "Jobs" "${namespace}" "get -o yaml" "logs/${prefix}z_jobs.txt"
     dump_objects "${context}" pvc "Persistent Volume Claims" "${namespace}" "get -o yaml" "logs/${prefix}z_persistent_volume_claims.txt"


### PR DESCRIPTION
This pull request introduces several improvements and new features to support migration dry-run testing and enhance diagnostics for Kubernetes-based MongoDB deployments. The most significant changes add a migration dry-run annotation and test, improve diagnostics by capturing Kubernetes Job pod logs, and make minor enhancements to deployment manifests and scripts.

**Migration dry-run support:**

* Added a new annotation (`mongodb.com/migration-dry-run`) and test cases in both `vm_migration.py` and `vm_migration_x509.py` to trigger a migration dry-run, which only validates connectivity to external members without making changes to the Operator or StatefulSet. The test checks for the `NetworkConnectivityVerification` condition and ensures the annotation is cleared after validation. [[1]](diffhunk://#diff-76ccb4b6d4de391476c5d55fc422aa42027c8587f36e0168b09cf25ba419d96cR18-R24) [[2]](diffhunk://#diff-76ccb4b6d4de391476c5d55fc422aa42027c8587f36e0168b09cf25ba419d96cR162-R197) [[3]](diffhunk://#diff-12e73de31ef675b34fb249c902536a55eefc985b86985c29cf3a581fe8989e5aR35-R38) [[4]](diffhunk://#diff-12e73de31ef675b34fb249c902536a55eefc985b86985c29cf3a581fe8989e5aR401-R432)

**Diagnostics and logging improvements:**

* Introduced a new `dump_job_pod_logs` function in `dump_diagnostic_information.sh` to collect logs from all Job pods in the namespace, improving visibility into Job execution during CI runs. This function is now called as part of the namespace dump process. [[1]](diffhunk://#diff-b8a706a188778e851f92bd2396e2a6d09914913583cda8c08aa4a9970155da47R346-R380) [[2]](diffhunk://#diff-b8a706a188778e851f92bd2396e2a6d09914913583cda8c08aa4a9970155da47R424-R426)

**Deployment and test manifest enhancements:**

* Updated the VM MongoDB service to be headless (`clusterIP: None`) and explicitly set `targetPort` for the MongoDB port, improving service discovery and connectivity.
* Added the MongoDB container port to the StatefulSet manifest, ensuring proper port mapping for the agent.

**Operator and build environment updates:**

* Enhanced the operator environment script to ensure `MDB_OPERATOR_IMAGE` is set consistently for migration dry-run Jobs, aligning with the image used by Helm and local builds.
* Added user and version tagging variables to the private context template for easier local development and image versioning.



passing x509 and vm migration test: https://spruce.corp.mongodb.com/version/69d760639f9bbb0007524043/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC