### PR TITLE
Revert "Remove s390 builds for mongodb-agent (#906)"

### DIFF
--- a/build_info.json
+++ b/build_info.json
@@ -320,6 +320,7 @@
         "platforms": [
           "linux/arm64",
           "linux/amd64",
+          "linux/s390x",
           "linux/ppc64le"
         ]
       },
@@ -332,6 +333,7 @@
         "platforms": [
           "linux/arm64",
           "linux/amd64",
+          "linux/s390x",
           "linux/ppc64le"
         ]
       }

--- a/changelog/20260409_fix_restore_s390x_builds_for_mongodb_agent.md
+++ b/changelog/20260409_fix_restore_s390x_builds_for_mongodb_agent.md
@@ -1,6 +1,0 @@
----
-kind: fix
-date: 2026-04-09
----
-
-* **MongoDBAgent**: Restored `linux/s390x` (IBM Z) platform support for the MongoDB Agent image builds.

--- a/changelog/20260409_fix_restore_s390x_builds_for_mongodb_agent.md
+++ b/changelog/20260409_fix_restore_s390x_builds_for_mongodb_agent.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-04-09
+---
+
+* **MongoDBAgent**: Restored `linux/s390x` (IBM Z) platform support for the MongoDB Agent image builds.

--- a/scripts/release/tests/build_info_test.py
+++ b/scripts/release/tests/build_info_test.py
@@ -297,7 +297,7 @@ def test_load_build_info_staging():
             ),
             "agent": ImageInfo(
                 repository="268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-agent",
-                platforms=["linux/arm64", "linux/amd64", "linux/ppc64le"],
+                platforms=["linux/arm64", "linux/amd64", "linux/s390x", "linux/ppc64le"],
                 dockerfile_path="docker/mongodb-agent/Dockerfile",
                 sign=True,
                 skip_if_exists=True,
@@ -419,7 +419,7 @@ def test_load_build_info_release():
             "agent": ImageInfo(
                 repository="quay.io/mongodb/mongodb-agent",
                 secondary_repositories=["quay.io/mongodb/mongodb-agent-ubi"],
-                platforms=["linux/arm64", "linux/amd64", "linux/ppc64le"],
+                platforms=["linux/arm64", "linux/amd64", "linux/s390x", "linux/ppc64le"],
                 dockerfile_path="docker/mongodb-agent/Dockerfile",
                 skip_if_exists=True,
                 olm_tag=True,

--- a/scripts/release/tests/release_info_test.py
+++ b/scripts/release/tests/release_info_test.py
@@ -43,7 +43,7 @@ def test_create_release_info_json():
             },
             "agent": {
                 "repoURL": "quay.io/mongodb/mongodb-agent",
-                "platforms": ["linux/arm64", "linux/amd64", "linux/ppc64le"],
+                "platforms": ["linux/arm64", "linux/amd64", "linux/s390x", "linux/ppc64le"],
                 "tag": "108.0.16.8895-1",
                 "digest": "sha256:793ae31c0d328fb3df1d3aa526f94e466cc2ed3410dd865548ce38fa3859cbaa",
             },


### PR DESCRIPTION
# Summary

Reverts #906, which removed `linux/s390x` (IBM Z) platform support from the MongoDB Agent image builds. The formatting changes introduced in that PR are intentionally preserved — only the s390x platform removal is reverted.

## Proof of Work

Not needed, but will be tested with s390x 108.0.22.8983-1 agent image released. More info in the slack thread -> https://mongodb.slack.com/archives/C07BZ5X09LN/p1775461600996639?thread_ts=1774438815.858419&cid=C07BZ5X09LN

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details