### PR TITLE
CLOUDP-362014: Enable s390x agent test infrastructure with conditional OTel and libsodium support

### DIFF
--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -244,9 +244,6 @@ buildvariants:
     display_name: init_smoke_tests_ibm_z
     max_hosts: -1
     tags: [ "release", "e2e_smoke_release_test_suite" ]
-    # TODO: Re-enable when ibm_z series is stable
-    # https://jira.mongodb.org/browse/DEVPROD-23283
-    disable: true
     run_on:
       - release-rhel9-zseries-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
       - release-rhel9-zseries-large # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
@@ -335,9 +332,6 @@ buildvariants:
   - name: e2e_smoke_ibm_z_release
     display_name: e2e_smoke_ibm_z
     tags: [ "release", "e2e_smoke_release_test_suite" ]
-    # TODO: Re-enable when ibm_z series is stable
-    # https://jira.mongodb.org/browse/DEVPROD-23283
-    disable: true
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
@@ -353,9 +347,6 @@ buildvariants:
   - name: e2e_static_smoke_ibm_z_release
     display_name: e2e_static_smoke_ibm_z
     tags: [ "release", "e2e_smoke_release_test_suite", "static" ]
-    # TODO: Re-enable when ibm_z series is stable
-    # https://jira.mongodb.org/browse/DEVPROD-23283
-    disable: true
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1660,9 +1660,6 @@ buildvariants:
       - rhel9-zseries-small
       - rhel9-zseries-large
     allowed_requesters: [ "patch", "commit" ]
-    # TODO: Re-enable when ibm_z series is stable
-    # https://jira.mongodb.org/browse/DEVPROD-23283
-    disable: true
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
@@ -1680,9 +1677,6 @@ buildvariants:
   - name: e2e_static_smoke_ibm_z
     display_name: e2e_static_smoke_ibm_z
     tags: [ "staging", "e2e_smoke_test_suite", "static" ]
-    # TODO: Re-enable when ibm_z series is stable
-    # https://jira.mongodb.org/browse/DEVPROD-23283
-    disable: true
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
@@ -1951,9 +1945,6 @@ buildvariants:
     display_name: init_test_run_ibm_z
     max_hosts: -1
     tags: [ "staging" ]
-    # TODO: Re-enable when ibm_z series is stable
-    # https://jira.mongodb.org/browse/DEVPROD-23283
-    disable: true
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -14,6 +14,9 @@ if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false":
     # Exclude it from collection when OTel is disabled so pytest doesn't try to import it.
     # More info on collect_ignore pytest configuration https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-collect_ignore
     collect_ignore = ["otel_plugin.py"]
+else:
+    # Importing otel_plugin.pytest_configure and otel_plugin.pytest_sessionstart hook is enough to configure OTEL plugin
+    from tests.otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401
 
 
 def _load_env_from_local_file_for_development():
@@ -1781,7 +1784,3 @@ def read_deployment_state(
     )
     state = json.loads(deployment_state_cm["state"])
     return state
-
-
-if os.environ.get("PYTEST_OTEL_ENABLED", "true") != "false":
-    from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -14,9 +14,6 @@ if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false":
     # Exclude it from collection when OTel is disabled so pytest doesn't try to import it.
     # More info on collect_ignore pytest configuration https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-collect_ignore
     collect_ignore = ["otel_plugin.py"]
-else:
-    # Importing otel_plugin.pytest_configure and otel_plugin.pytest_sessionstart hook is enough to configure OTEL plugin
-    from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401
 
 
 def _load_env_from_local_file_for_development():
@@ -1784,3 +1781,7 @@ def read_deployment_state(
     )
     state = json.loads(deployment_state_cm["state"])
     return state
+
+
+if os.environ.get("PYTEST_OTEL_ENABLED", "true") != "false":
+    from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -9,6 +9,10 @@ from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
 
+# otel_plugin.py requires pytest-opentelemetry which is disabled via PYTEST_OTEL_DISABLED=true on s390x.
+# Exclude it from collection when OTel is disabled so pytest doesn't try to import it.
+collect_ignore = ["otel_plugin.py"] if os.environ.get("PYTEST_OTEL_DISABLED", "false") == "true" else []
+
 
 def _load_env_from_local_file_for_development():
     """Load environment variables from .generated/context.env for local development.
@@ -1587,105 +1591,9 @@ def coredns_config(tld: str, mappings: str, additional_rules: str = None):
 
 
 import pytest
-from _pytest.main import Session
-from _pytest.nodes import Node
-from _pytest.reports import TestReport
-from _pytest.runner import CallInfo
-from opentelemetry import trace
-from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
-from pytest_opentelemetry.instrumentation import OpenTelemetryPlugin
 
-
-class PrefixProcessor(SpanProcessor):
-    def on_start(self, span: trace.Span, parent_context=None):
-        # Create a new dictionary for updated attributes, span.attribute is immutable
-        prefixed_attributes = EnhancedOpenTelemetryPlugin._prefix_attributes(span.attributes)
-        span.set_attributes(prefixed_attributes)
-
-    def on_end(self, span: ReadableSpan):
-        pass
-
-
-#  We are using a custom OpenTelemetryPlugin to ensure we are able to add more
-#  important failure information, outcome etc.
-class EnhancedOpenTelemetryPlugin(OpenTelemetryPlugin):
-    # This ensures that our pytest finish runs first before the plugins and we can attach spans before
-    # they are getting flushed.
-    def pytest_sessionfinish(self, session: Session, exitstatus: int = None) -> None:
-        # Add the exit status as an attribute if available
-        self.session_span.set_attribute("mck.pytest.overall_exit_status", int(session.exitstatus))
-
-        # Call the parent implementation
-        super().pytest_sessionfinish(session)
-
-    @staticmethod
-    def pytest_exception_interact(
-        node: Node,
-        call: CallInfo[Any],
-        report: TestReport,
-    ) -> None:
-        current_span = trace.get_current_span()
-        if isinstance(current_span, NonRecordingSpan):
-            return
-        prefixed_attributes = EnhancedOpenTelemetryPlugin._prefix_attributes(current_span.attributes)
-        prefixed_attributes["mck.pytest.error_details"] = str(report.longrepr)
-        current_span.set_attributes(prefixed_attributes)
-
-        OpenTelemetryPlugin.pytest_exception_interact(node, call, report)
-
-    # Add this helper method
-    @staticmethod
-    def _prefix_attributes(attributes):
-        """Add 'mck.' prefix to attribute keys that don't already have it."""
-        prefixed_attributes = {}
-        for k, v in attributes.items():
-            if not k.startswith("mck."):
-                prefixed_attributes[f"mck.{k}"] = v
-            else:
-                prefixed_attributes[k] = v
-        return prefixed_attributes
-
-    @pytest.hookimpl(hookwrapper=True)
-    def pytest_runtest_makereport(self, item, call):
-        outcome = yield
-        report = outcome.get_result()
-        current_span = trace.get_current_span()
-        if not current_span:
-            return
-
-        attributes = self._attributes_from_item(item)
-        prefixed_attributes = self._prefix_attributes(attributes)
-        current_span.set_attributes(prefixed_attributes)
-        current_span.set_attribute(f"mck.pytest.outcome.{call.when}", report.outcome)
-
-
-def configure_telemetry():
-    # Get the existing tracer provider that was set up by pytest-opentelemetry
-    tracer_provider = trace.get_tracer_provider()
-
-    if isinstance(tracer_provider, TracerProvider):
-        prefix_processor = PrefixProcessor()
-        tracer_provider.add_span_processor(prefix_processor)
-
-
-# Remove the OpenTelemetryPlugin from the list and replace it with our custom generated one.
-# That's why we run our pytest last.
-@pytest.hookimpl(trylast=True)
-def pytest_configure(config):
-    # Suppress the OpenTelemetry SDK warnings caused by swapping these plugins
-    logging.getLogger("opentelemetry").setLevel(logging.ERROR)
-
-    # Remove the default plugin if already registered
-    for i, plugin_instance in enumerate(config.pluginmanager.get_plugins()):
-        if isinstance(plugin_instance, OpenTelemetryPlugin):
-            config.pluginmanager.unregister(plugin=plugin_instance)
-            break
-
-    config.pluginmanager.register(EnhancedOpenTelemetryPlugin())
-
-
-def pytest_sessionstart():
-    configure_telemetry()
+if os.environ.get("PYTEST_OTEL_DISABLED", "false") != "true":
+    from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -9,9 +9,14 @@ from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
 
-# otel_plugin.py requires pytest-opentelemetry which is disabled via PYTEST_OTEL_ENABLED=false on s390x.
-# Exclude it from collection when OTel is disabled so pytest doesn't try to import it.
-collect_ignore = ["otel_plugin.py"] if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false" else []
+if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false":
+    # otel_plugin.py requires pytest-opentelemetry which is disabled via PYTEST_OTEL_ENABLED=false on s390x.
+    # Exclude it from collection when OTel is disabled so pytest doesn't try to import it.
+    # More info on collect_ignore pytest configuration https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-collect_ignore
+    collect_ignore = ["otel_plugin.py"]
+else:
+    # Importing otel_plugin.pytest_configure and otel_plugin.pytest_sessionstart hook is enough to configure OTEL plugin
+    from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401
 
 
 def _load_env_from_local_file_for_development():
@@ -56,9 +61,8 @@ from kubetester.kubetester import running_locally
 from kubetester.multicluster_client import MultiClusterClient
 from kubetester.omtester import OMContext, OMTester
 from kubetester.operator import Operator
-from opentelemetry.trace import NonRecordingSpan
 from pymongo.errors import ServerSelectionTimeoutError
-from pytest import fixture
+from pytest import fixture, hookimpl
 from tests import test_logger
 from tests.constants import (
     CLUSTER_HOST_MAPPING,
@@ -1590,13 +1594,7 @@ def coredns_config(tld: str, mappings: str, additional_rules: str = None):
 """
 
 
-import pytest
-
-if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "true":
-    from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401
-
-
-@pytest.hookimpl(tryfirst=True)
+@hookimpl(tryfirst=True)
 def pytest_sessionfinish(session, exitstatus):
     project_id = os.environ.get("OM_PROJECT_ID", "")
     if project_id:

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -9,9 +9,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
 
-# otel_plugin.py requires pytest-opentelemetry which is disabled via PYTEST_OTEL_DISABLED=true on s390x.
+# otel_plugin.py requires pytest-opentelemetry which is disabled via PYTEST_OTEL_ENABLED=false on s390x.
 # Exclude it from collection when OTel is disabled so pytest doesn't try to import it.
-collect_ignore = ["otel_plugin.py"] if os.environ.get("PYTEST_OTEL_DISABLED", "false") == "true" else []
+collect_ignore = ["otel_plugin.py"] if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false" else []
 
 
 def _load_env_from_local_file_for_development():
@@ -1592,7 +1592,7 @@ def coredns_config(tld: str, mappings: str, additional_rules: str = None):
 
 import pytest
 
-if os.environ.get("PYTEST_OTEL_DISABLED", "false") != "true":
+if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "true":
     from otel_plugin import pytest_configure, pytest_sessionstart  # noqa: F401
 
 

--- a/docker/mongodb-kubernetes-tests/tests/otel_plugin.py
+++ b/docker/mongodb-kubernetes-tests/tests/otel_plugin.py
@@ -1,0 +1,103 @@
+import logging
+from typing import Any
+
+import pytest
+from _pytest.main import Session
+from _pytest.nodes import Node
+from _pytest.reports import TestReport
+from _pytest.runner import CallInfo
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
+from opentelemetry.trace import NonRecordingSpan
+from pytest_opentelemetry.instrumentation import OpenTelemetryPlugin
+
+
+class PrefixProcessor(SpanProcessor):
+    def on_start(self, span: trace.Span, parent_context=None):
+        # Create a new dictionary for updated attributes, span.attribute is immutable
+        prefixed_attributes = EnhancedOpenTelemetryPlugin._prefix_attributes(span.attributes)
+        span.set_attributes(prefixed_attributes)
+
+    def on_end(self, span: ReadableSpan):
+        pass
+
+
+#  We are using a custom OpenTelemetryPlugin to ensure we are able to add more
+#  important failure information, outcome etc.
+class EnhancedOpenTelemetryPlugin(OpenTelemetryPlugin):
+    # This ensures that our pytest finish runs first before the plugins and we can attach spans before
+    # they are getting flushed.
+    def pytest_sessionfinish(self, session: Session, exitstatus: int = None) -> None:
+        # Add the exit status as an attribute if available
+        self.session_span.set_attribute("mck.pytest.overall_exit_status", int(session.exitstatus))
+
+        # Call the parent implementation
+        super().pytest_sessionfinish(session)
+
+    @staticmethod
+    def pytest_exception_interact(
+        node: Node,
+        call: CallInfo[Any],
+        report: TestReport,
+    ) -> None:
+        current_span = trace.get_current_span()
+        if isinstance(current_span, NonRecordingSpan):
+            return
+        prefixed_attributes = EnhancedOpenTelemetryPlugin._prefix_attributes(current_span.attributes)
+        prefixed_attributes["mck.pytest.error_details"] = str(report.longrepr)
+        current_span.set_attributes(prefixed_attributes)
+
+        OpenTelemetryPlugin.pytest_exception_interact(node, call, report)
+
+    @staticmethod
+    def _prefix_attributes(attributes):
+        """Add 'mck.' prefix to attribute keys that don't already have it."""
+        prefixed_attributes = {}
+        for k, v in attributes.items():
+            if not k.startswith("mck."):
+                prefixed_attributes[f"mck.{k}"] = v
+            else:
+                prefixed_attributes[k] = v
+        return prefixed_attributes
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(self, item, call):
+        outcome = yield
+        report = outcome.get_result()
+        current_span = trace.get_current_span()
+        if not current_span:
+            return
+
+        attributes = self._attributes_from_item(item)
+        prefixed_attributes = self._prefix_attributes(attributes)
+        current_span.set_attributes(prefixed_attributes)
+        current_span.set_attribute(f"mck.pytest.outcome.{call.when}", report.outcome)
+
+
+def _configure_telemetry():
+    # Get the existing tracer provider that was set up by pytest-opentelemetry
+    tracer_provider = trace.get_tracer_provider()
+
+    if isinstance(tracer_provider, TracerProvider):
+        prefix_processor = PrefixProcessor()
+        tracer_provider.add_span_processor(prefix_processor)
+
+
+# Remove the OpenTelemetryPlugin from the list and replace it with our custom generated one.
+# That's why we run our pytest last.
+@pytest.hookimpl(trylast=True)
+def pytest_configure(config):
+    # Suppress the OpenTelemetry SDK warnings caused by swapping these plugins
+    logging.getLogger("opentelemetry").setLevel(logging.ERROR)
+
+    # Remove the default plugin if already registered
+    for i, plugin_instance in enumerate(config.pluginmanager.get_plugins()):
+        if isinstance(plugin_instance, OpenTelemetryPlugin):
+            config.pluginmanager.unregister(plugin=plugin_instance)
+            break
+
+    config.pluginmanager.register(EnhancedOpenTelemetryPlugin())
+
+
+def pytest_sessionstart():
+    _configure_telemetry()

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,9 @@ GitPython==3.1.46
 setuptools>=71.0.3 # not directly required, pinned by Snyk to avoid a vulnerability
 opentelemetry-api==1.40.0
 opentelemetry-sdk==1.40.0
-pytest-opentelemetry==1.1.0
+# grpcio segfaults at process exit on s390x + Python 3.13 and is pulled by pytest-opentelemetry
+pytest-opentelemetry==1.1.0 ; platform_machine != "s390x"
+grpcio==1.80.0 ; platform_machine != "s390x"
 black==26.3.1
 flake8==7.3.0
 isort==8.0.1

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -165,9 +165,9 @@ export KUBECTL_VERSION="v1.35.0"
 # PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: s390x requires pure Python protobuf implementation
 #   https://github.com/protocolbuffers/protobuf/issues/24103
 # SODIUM_INSTALL: pynacl must link against system libsodium (RHEL9 ships 1.0.18; bundled build broken on s390x+Python 3.13)
-# PYTEST_OTEL_DISABLED: grpcio segfaults at exit on s390x+Python 3.13; pytest-opentelemetry excluded from requirements
+# PYTEST_OTEL_ENABLED: grpcio segfaults at exit on s390x+Python 3.13; pytest-opentelemetry excluded from requirements
 if [[ "$(uname -m)" == "s390x" ]]; then
   export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="${PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION:-python}"
   export SODIUM_INSTALL="${SODIUM_INSTALL:-system}"
-  export PYTEST_OTEL_DISABLED="${PYTEST_OTEL_DISABLED:-true}"
+  export PYTEST_OTEL_ENABLED="${PYTEST_OTEL_ENABLED:-false}"
 fi

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -160,3 +160,14 @@ export OPERATOR_CLUSTER_SCOPED=false
 # for downloading helm and kubectl binaries
 export HELM_VERSION="v3.19.4"
 export KUBECTL_VERSION="v1.35.0"
+
+# s390x-specific feature flags — use ${VAR:-default} so they can be overridden before sourcing this context.
+# PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: s390x requires pure Python protobuf implementation
+#   https://github.com/protocolbuffers/protobuf/issues/24103
+# SODIUM_INSTALL: pynacl must link against system libsodium (RHEL9 ships 1.0.18; bundled build broken on s390x+Python 3.13)
+# PYTEST_OTEL_DISABLED: grpcio segfaults at exit on s390x+Python 3.13; pytest-opentelemetry excluded from requirements
+if [[ "$(uname -m)" == "s390x" ]]; then
+  export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="${PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION:-python}"
+  export SODIUM_INSTALL="${SODIUM_INSTALL:-system}"
+  export PYTEST_OTEL_DISABLED="${PYTEST_OTEL_DISABLED:-true}"
+fi

--- a/scripts/evergreen/deployments/test-app/templates/mongodb-enterprise-tests.yaml
+++ b/scripts/evergreen/deployments/test-app/templates/mongodb-enterprise-tests.yaml
@@ -80,6 +80,8 @@ spec:
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: "{{ .Values.otel_resource_attributes }}"
     {{ end }}
+    - name: PYTEST_OTEL_ENABLED
+      value: "{{ .Values.pytestOtelEnabled }}"
     # Set service name to identify this component in the trace
     - name: OTEL_SERVICE_NAME
       value: mongodb-e2e-tests
@@ -205,7 +207,7 @@ spec:
     image: "{{ .Values.mekoTestsRegistry }}/mongodb-kubernetes-tests:{{ .Values.mekoTestsVersion }}"
     # Options to pytest command should go in the pytest.ini file.
     command: ["pytest"]
-    {{ if .Values.otel_endpoint }}
+    {{ if and .Values.otel_endpoint .Values.pytestOtelEnabled }}
     # Use trace-parent to create the root span with specified trace ID and parent ID
     # Note: we create the root span here, and the operator will create child spans that connect to it
     args: ["-vv", "-m", "{{ .Values.taskName }}", "--trace-parent", "00-{{ .Values.otel_trace_id }}-{{ .Values.otel_parent_id }}-01", "--export-traces"]

--- a/scripts/evergreen/deployments/test-app/values.yaml
+++ b/scripts/evergreen/deployments/test-app/values.yaml
@@ -38,6 +38,7 @@ otel_trace_id:
 otel_parent_id:
 otel_endpoint:
 otel_resource_attributes:
+pytestOtelEnabled: true
 mdbDefaultArchitecture: "non-static"
 
 # set to "true" to set OM_DEBUG_HTTP=true for the operator

--- a/scripts/evergreen/e2e/single_e2e.sh
+++ b/scripts/evergreen/e2e/single_e2e.sh
@@ -109,7 +109,8 @@ deploy_test_app() {
     # As soon as we are having one OTEL expansion it means we want to trace and send everything to our trace provider.
     # otel_parent_id is a special case (hence lower cased) since it is directly coming from evergreen and not via our
     # make switch mechanism. We need the "freshest" parent_id otherwise we are attaching to the wrong parent span.
-    if [[ -n "${otel_parent_id:-}" ]]; then
+    # pytest-opentelemetry and grpcio are not available on s390x, so OTEL tracing is disabled there.
+    if [[ -n "${otel_parent_id:-}" ]] && [[ "${PYTEST_OTEL_DISABLED:-false}" != "true" ]]; then
         otel_resource_attributes="evergreen.version.id=${VERSION_ID:-},evergreen.version.requester=${requester:-},mck.git_branch=${branch_name:-},evergreen.version.pr_num=${github_pr_number:-},mck.git_commit=${github_commit:-},mck.revision=${revision:-},is_patch=${IS_PATCH},evergreen.task.name=${TASK_NAME},evergreen.task.execution=${EXECUTION},evergreen.build.id=${BUILD_ID},evergreen.build.name=${BUILD_VARIANT},evergreen.task.id=${task_id},evergreen.project.id=${project_identifier:-}"
         # shellcheck disable=SC2001
         escaped_otel_resource_attributes=$(echo "${otel_resource_attributes}" | sed 's/,/\\,/g')

--- a/scripts/evergreen/e2e/single_e2e.sh
+++ b/scripts/evergreen/e2e/single_e2e.sh
@@ -109,8 +109,7 @@ deploy_test_app() {
     # As soon as we are having one OTEL expansion it means we want to trace and send everything to our trace provider.
     # otel_parent_id is a special case (hence lower cased) since it is directly coming from evergreen and not via our
     # make switch mechanism. We need the "freshest" parent_id otherwise we are attaching to the wrong parent span.
-    # pytest-opentelemetry and grpcio are not available on s390x, so OTEL tracing is disabled there.
-    if [[ -n "${otel_parent_id:-}" ]] && [[ "${PYTEST_OTEL_DISABLED:-false}" != "true" ]]; then
+    if [[ -n "${otel_parent_id:-}" ]]; then
         otel_resource_attributes="evergreen.version.id=${VERSION_ID:-},evergreen.version.requester=${requester:-},mck.git_branch=${branch_name:-},evergreen.version.pr_num=${github_pr_number:-},mck.git_commit=${github_commit:-},mck.revision=${revision:-},is_patch=${IS_PATCH},evergreen.task.name=${TASK_NAME},evergreen.task.execution=${EXECUTION},evergreen.build.id=${BUILD_ID},evergreen.build.name=${BUILD_VARIANT},evergreen.task.id=${task_id},evergreen.project.id=${project_identifier:-}"
         # shellcheck disable=SC2001
         escaped_otel_resource_attributes=$(echo "${otel_resource_attributes}" | sed 's/,/\\,/g')

--- a/scripts/evergreen/e2e/single_e2e.sh
+++ b/scripts/evergreen/e2e/single_e2e.sh
@@ -109,6 +109,9 @@ deploy_test_app() {
     # As soon as we are having one OTEL expansion it means we want to trace and send everything to our trace provider.
     # otel_parent_id is a special case (hence lower cased) since it is directly coming from evergreen and not via our
     # make switch mechanism. We need the "freshest" parent_id otherwise we are attaching to the wrong parent span.
+    # PYTEST_OTEL_ENABLED is set to false on s390x (via root-context) where pytest-opentelemetry is unavailable.
+    helm_params+=("--set" "pytestOtelEnabled=${PYTEST_OTEL_ENABLED:-true}")
+
     if [[ -n "${otel_parent_id:-}" ]]; then
         otel_resource_attributes="evergreen.version.id=${VERSION_ID:-},evergreen.version.requester=${requester:-},mck.git_branch=${branch_name:-},evergreen.version.pr_num=${github_pr_number:-},mck.git_commit=${github_commit:-},mck.revision=${revision:-},is_patch=${IS_PATCH},evergreen.task.name=${TASK_NAME},evergreen.task.execution=${EXECUTION},evergreen.build.id=${BUILD_ID},evergreen.build.name=${BUILD_VARIANT},evergreen.task.id=${task_id},evergreen.project.id=${project_identifier:-}"
         # shellcheck disable=SC2001

--- a/scripts/evergreen/setup_minikube_host.sh
+++ b/scripts/evergreen/setup_minikube_host.sh
@@ -38,6 +38,28 @@ run_setup_step() {
     fi
 }
 
+# Install libsodium from source on s390x — RHEL9 ships 1.0.18 which is too old for pynacl>=1.6
+if [[ "$(uname -m)" == "s390x" ]]; then
+    echo ""
+    echo ">>> Running: libsodium installation (s390x only)"
+    LIBSODIUM_VERSION="1.0.20"
+    if pkg-config --exists libsodium 2>/dev/null && [[ "$(pkg-config --modversion libsodium)" == "${LIBSODIUM_VERSION}" ]]; then
+        echo "✅ libsodium ${LIBSODIUM_VERSION} already installed, skipping"
+    else
+        echo ">>> Building libsodium ${LIBSODIUM_VERSION} from source..."
+        tmp_dir=$(mktemp -d)
+        curl --fail --retry 3 -L -o "${tmp_dir}/libsodium.tar.gz" \
+            "https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz"
+        tar xzf "${tmp_dir}/libsodium.tar.gz" -C "${tmp_dir}"
+        (cd "${tmp_dir}/libsodium-${LIBSODIUM_VERSION}" && ./configure --prefix=/usr/local && make -j"$(nproc)" && sudo make install)
+        # Ensure /usr/local/lib is in ldconfig search paths (RHEL9 doesn't include it by default)
+        echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/local.conf
+        sudo ldconfig
+        rm -rf "${tmp_dir}"
+        echo "✅ libsodium ${LIBSODIUM_VERSION} installed successfully"
+    fi
+fi
+
 # Setup Python environment (needed for AWS CLI pip installation)
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 run_setup_step "Python Virtual Environment" "scripts/dev/recreate_python_venv.sh"

--- a/scripts/evergreen/setup_minikube_host.sh
+++ b/scripts/evergreen/setup_minikube_host.sh
@@ -44,7 +44,7 @@ if [[ "$(uname -m)" == "s390x" ]]; then
     echo ">>> Running: libsodium installation (s390x only)"
     LIBSODIUM_VERSION="1.0.20"
     if pkg-config --exists libsodium 2>/dev/null && [[ "$(pkg-config --modversion libsodium)" == "${LIBSODIUM_VERSION}" ]]; then
-        echo "✅ libsodium ${LIBSODIUM_VERSION} already installed, skipping"
+        echo "✅ libsodium ${LIBSODIUM_VERSION} already installed, skipping installation"
     else
         echo ">>> Building libsodium ${LIBSODIUM_VERSION} from source..."
         tmp_dir=$(mktemp -d)

--- a/scripts/release/build/image_build_process.py
+++ b/scripts/release/build/image_build_process.py
@@ -108,11 +108,12 @@ class DockerImageBuilder(ImageBuilder):
         try:
             docker_cmd.buildx.imagetools.inspect(image_tag)
         except DockerException as e:
-            decoded_stderr = e.stderr.lower()
+            decoded_stderr = e.stderr.lower() if e.stderr else ""
             if any(str(error) in decoded_stderr for error in ["no such image", "image not known", "not found"]):
                 return False
-            else:
-                raise e
+            raise RuntimeError(
+                f"Failed to check if image '{image_tag}' exists: {e.stderr.strip() if e.stderr else str(e)}"
+            )
         else:
             return True
 

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -4,7 +4,6 @@ from functools import partial
 from typing import Callable, Dict
 
 from opentelemetry import context, trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter as OTLPSpanGrpcExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SynchronousMultiSpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -172,12 +171,23 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
 
 
 def _setup_tracing():
+    if os.environ.get("PYTEST_OTEL_DISABLED", "false") == "true":
+        logger.info("tracing disabled (PYTEST_OTEL_DISABLED=true)")
+        return
+
     trace_id = os.environ.get("otel_trace_id")
     parent_id = os.environ.get("otel_parent_id")
     endpoint = os.environ.get("otel_collector_endpoint")
     if any(value is None for value in [trace_id, parent_id, endpoint]):
         logger.info("tracing environment variables are missing, not configuring tracing")
         return
+
+    # Import lazily to avoid loading grpcio C extension when tracing is not used.
+    # grpcio registers at exit handlers that segfault on s390x + Python 3.13.
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # noqa: PLC0415
+        OTLPSpanExporter as OTLPSpanGrpcExporter,
+    )
+
     logger.info(f"parent_id is {parent_id}")
     logger.info(f"trace_id is {trace_id}")
     logger.info(f"endpoint is {endpoint}")

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -172,7 +172,7 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
 
 def _setup_tracing():
     if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false":
-        logger.info("tracing disabled (PYTEST_OTEL_ENABLED=false)")
+        logger.info("PYTEST_OTEL_ENABLED is false, not setting up tracing")
         return
 
     trace_id = os.environ.get("otel_trace_id")

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -171,8 +171,8 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
 
 
 def _setup_tracing():
-    if os.environ.get("PYTEST_OTEL_DISABLED", "false") == "true":
-        logger.info("tracing disabled (PYTEST_OTEL_DISABLED=true)")
+    if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false":
+        logger.info("tracing disabled (PYTEST_OTEL_ENABLED=false)")
         return
 
     trace_id = os.environ.get("otel_trace_id")


### PR DESCRIPTION
# Summary

Related https://github.com/mongodb/mongodb-kubernetes/pull/979

s390x (IBM Z) Evergreen test variants were previously disabled pending resolution of infrastructure gaps. This PR re-enables those variants by addressing two root causes: missing `libsodium` native library on s390x hosts, and `pytest-opentelemetry`/`grpcio` packages being incompatible with s390x + Python 3.13.

| File | Responsibility |
|------|---------------|
| `.evergreen.yml` / `.evergreen-release.yml` | Remove `disable: true` from s390x variants |
| `scripts/evergreen/setup_minikube_host.sh` | Build and install `libsodium` from source on s390x hosts |
| `requirements.txt` | Add platform markers to skip `pytest-opentelemetry` and `grpcio` on s390x |
| `scripts/dev/contexts/root-context` | Centralise s390x feature flags (`PYTEST_OTEL_ENABLED`, `SODIUM_INSTALL`, `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION`) |
| `tests/conftest.py` + new `tests/otel_plugin.py` | Extract OTel hooks into a separate module; set `collect_ignore` when `PYTEST_OTEL_ENABLED=false` (s390x), import from `tests.otel_plugin` when enabled |
| `scripts/release/pipeline.py` | Skip OTel tracing when `PYTEST_OTEL_ENABLED=false` |

## Proof of Work

Patch run for staging will be created when the new agent is released with `s390x` support -> https://github.com/mongodb/mongodb-kubernetes/pull/979

[Run multi-arch smoke tests including IBM Z](https://spruce.corp.mongodb.com/version/69dcb0627033110007d320bd/tasks)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details