### PR TITLE
Remove unsupported RHEL7 agent binaries for s390x and ppc64le

### DIFF
--- a/build_info_agent.json
+++ b/build_info_agent.json
@@ -9,11 +9,11 @@
       "tools_suffixes": ["rhel93-aarch64-{TOOLS_VERSION}.tgz", "rhel90-aarch64-{TOOLS_VERSION}.tgz"]
     },
     "linux/s390x": {
-      "agent_suffixes": ["rhel7_s390x.tar.gz", "rhel8_s390x.tar.gz", "rhel9_s390x.tar.gz"],
+      "agent_suffixes": ["rhel8_s390x.tar.gz", "rhel9_s390x.tar.gz"],
       "tools_suffixes": ["rhel9-s390x-{TOOLS_VERSION}.tgz", "rhel83-s390x-{TOOLS_VERSION}.tgz"]
     },
     "linux/ppc64le": {
-      "agent_suffixes": ["rhel8_ppc64le.tar.gz", "rhel7_ppc64le.tar.gz", "rhel9_ppc64le.tar.gz"],
+      "agent_suffixes": ["rhel8_ppc64le.tar.gz", "rhel9_ppc64le.tar.gz"],
       "tools_suffixes": ["rhel9-ppc64le-{TOOLS_VERSION}.tgz", "rhel81-ppc64le-{TOOLS_VERSION}.tgz"]
     }
   },


### PR DESCRIPTION
# Summary

RHEL7 is no longer a supported platform for agent binaries on s390x and ppc64le architectures. This removes the stale `rhel7_s390x` and `rhel7_ppc64le` suffixes from `build_info_agent.json` so they are no longer built or published.

## Proof of Work

Not needed.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details