### PR TITLE
Add Evergreen task to rebuild specific agent version manually

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -520,6 +520,7 @@ functions:
           BUILD_SCENARIO_OVERRIDE: ${build_scenario}
           FLAGS: ${flags}
           AGENT_VERSION_OVERRIDE: ${agent_version}
+          AGENT_TOOLS_VERSION: ${tools_version}
 
   teardown_cloud_qa_all:
     - command: shell.exec

--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -520,7 +520,7 @@ functions:
           BUILD_SCENARIO_OVERRIDE: ${build_scenario}
           FLAGS: ${flags}
           AGENT_VERSION_OVERRIDE: ${agent_version}
-          AGENT_TOOLS_VERSION: ${tools_version}
+          AGENT_TOOLS_VERSION: ${agent_tools_version}
 
   teardown_cloud_qa_all:
     - command: shell.exec

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -207,8 +207,8 @@ patch_aliases:
   - alias: "periodic_teardowns"
     variant_tags: [ "periodic_teardown" ]
     task: ".*"
-  - alias: "release_agent"
-    variant_tags: [ "release_agent" ]
+  - alias: "release_specific_agent_manually"
+    variant_tags: [ "release_specific_agent_manually" ]
     task: ".*"
   - alias: "release_all_agents_manually"
     variant_tags: [ "release_all_agents_manually" ]
@@ -378,6 +378,22 @@ tasks:
           agent_version: current
           image_name: agent
           flags: "--parallel --skip-if-exists=false"
+
+  - name: rebuild_specific_agent
+    # this enables us to run this manually (patch) and rebuild specific agent versions to verify
+    # Dockerfile, script changes etc.
+    allowed_requesters: [ "patch" ]
+    commands:
+      - func: clone
+      - func: setup_building_host
+      - func: quay_login
+      - func: pipeline
+        include_expansions_in_env:
+          - agent_version # You need to specify agent version for this task via --param flag!
+          - tools_version # You need to specify tool version for this task --param flag!
+        vars:
+          image_name: agent
+          flags: "--skip-if-exists=false"
 
   - name: build_kubectl_mongodb_plugin
     commands:
@@ -2062,6 +2078,18 @@ buildvariants:
       - ubuntu2404-large
     tasks:
       - name: rebuild_currently_used_agents
+
+    # Only called manually. It's used for releasing or rebuilding specific agent image version.
+    # Example command:
+    # evergreen patch -p mongodb-kubernetes -a release_specific_agent_manually -d "Rebuild 13.49.0.10397-1 CM agent" -u --path .evergreen.yml --param agent_version=13.49.0.10397-1 --param tools_version=100.14.0
+    # To target staging or release repositories specify correct e.g. --param BUILD_SCENARIO=staging or --param BUILD_SCENARIO=release
+  - name: manual_release_specific_agent
+    display_name: manual_release_specific_agent
+    tags: [ "manual_patch", "release_specific_agent_manually" ]
+    run_on:
+      - ubuntu2404-large
+    tasks:
+      - name: rebuild_specific_agent
 
   ### Build variants for manual patch only
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -390,7 +390,7 @@ tasks:
       - func: pipeline
         include_expansions_in_env:
           - agent_version # You need to specify agent version for this task via --param flag!
-          - tools_version # You need to specify tool version for this task --param flag!
+          - agent_tools_version # You need to specify tool version for this task --param flag!
         vars:
           image_name: agent
           flags: "--skip-if-exists=false"
@@ -2081,7 +2081,7 @@ buildvariants:
 
     # Only called manually. It's used for releasing or rebuilding specific agent image version.
     # Example command:
-    # evergreen patch -p mongodb-kubernetes -a release_specific_agent_manually -d "Rebuild 13.49.0.10397-1 CM agent" -u --path .evergreen.yml --param agent_version=13.49.0.10397-1 --param tools_version=100.14.0
+    # evergreen patch -p mongodb-kubernetes -a release_specific_agent_manually -d "Rebuild 13.49.0.10397-1 CM agent" -u --path .evergreen.yml --param agent_version=13.49.0.10397-1 --param agent_tools_version=100.14.0
     # To target staging or release repositories specify correct e.g. --param BUILD_SCENARIO=staging or --param BUILD_SCENARIO=release
   - name: manual_release_specific_agent
     display_name: manual_release_specific_agent

--- a/scripts/release/pipeline.sh
+++ b/scripts/release/pipeline.sh
@@ -36,8 +36,8 @@ if [[ "${IMAGE_VERSION:-}" != "" ]]; then
 fi
 
 # For agent builds, pass tools version if explicitly provided
-if [[ "${IMAGE_NAME}" == "agent" && "${TOOLS_VERSION:-}" != "" ]]; then
-    args+=(--agent-tools-version "${TOOLS_VERSION}")
+if [[ "${IMAGE_NAME}" == "agent" && "${AGENT_TOOLS_VERSION:-}" != "" ]]; then
+    args+=(--agent-tools-version "${AGENT_TOOLS_VERSION}")
 fi
 
 if [[ "${FLAGS:-}" != "" ]]; then


### PR DESCRIPTION
# Summary

When agent Dockerfile or build scripts change, there is currently no easy way to rebuild a specific historical agent version to verify the change. This PR adds a new manual-only Evergreen task (`rebuild_specific_agent`) and build variant (`manual_release_specific_agent`) to fill that gap.

Usage:
```
evergreen patch -p mongodb-kubernetes -a release_specific_agent_manually \
  -d "Rebuild 13.49.0.10397-1 agent" -u --path .evergreen.yml \
  --param agent_version=13.49.0.10397-1 --param agent_tools_version=100.14.0
```

| File | Change |
|------|--------|
| `.evergreen.yml` | New `rebuild_specific_agent` task + `manual_release_specific_agent` variant; rename alias `release_agent` → `release_specific_agent_manually` |
| `.evergreen-functions.yml` | Pass `AGENT_TOOLS_VERSION` env var (from `${agent_tools_version}` expansion) to `pipeline` function |
| `scripts/release/pipeline.sh` | Rename `TOOLS_VERSION` → `AGENT_TOOLS_VERSION` for agent builds |

## Proof of Work

TODO: add CI link or test output

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details