### PR TITLE
Ubi micro initcontainers

### DIFF
--- a/changelog/20260414_other_use_ubi9_micro_images_for_the_readinessprobe_and.md
+++ b/changelog/20260414_other_use_ubi9_micro_images_for_the_readinessprobe_and.md
@@ -1,0 +1,6 @@
+---
+kind: other
+date: 2026-04-14
+---
+
+* **Container images**: Use ubi9-micro images for the readinessprobe and upgrade hook containers to reduce the attack surface. the ubi mirco images have a much smaller package list and, given that these images are only used to copy a binary into a temporary volume for the main container to use, the micro images are sufficient.

--- a/docker/mongodb-kubernetes-readinessprobe/Dockerfile
+++ b/docker/mongodb-kubernetes-readinessprobe/Dockerfile
@@ -12,6 +12,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /data/scripts/readinessprobe ./mongodb-community-operator/cmd/readiness/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-micro
 
 COPY --from=builder /data/scripts/readinessprobe /probes/readinessprobe

--- a/docker/mongodb-kubernetes-upgrade-hook/Dockerfile
+++ b/docker/mongodb-kubernetes-upgrade-hook/Dockerfile
@@ -12,6 +12,6 @@ ARG TARGETARCH
 ARG TARGETOS
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /data/scripts/version-upgrade-hook ./mongodb-community-operator/cmd/versionhook/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-micro
 
 COPY --from=builder /data/scripts/version-upgrade-hook /version-upgrade-hook


### PR DESCRIPTION
# Summary

The init containers used in the mongoDBCommunity stateful set are build using the ubi-minimal images. These images are fairly large and, as off writing this, contain around 300 vulnerabilities according to Trivy scans.
Given that these images are only used to copy a binary into the main containers via a temporary volume, most off the vulnerable package are obsolete anyway.
To reduce the amount off package in these images, a quick fix is to use the micro version of the ubi images.

## Proof of Work

I've build these images, they are available at `docker.io/rosemay/mongodb-kubernetes-readinessprobe` and `docker.io/rosemay/mongodb-kubernetes-upgrade-hook`, and used them in a test deployment.
Here's an ArgoCD screenshot off one of the containers showing the images in use a the pod status:
<img width="1631" height="706" alt="Screenshot 2026-04-14 143039" src="https://github.com/user-attachments/assets/609cbcf5-d95b-454e-9a50-40b06f55725c" />

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
