### PR TITLE
CLOUDP-390500: Enforce Go bump policy

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -716,6 +716,14 @@ functions:
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         script: scripts/evergreen/unit-tests-sbom.sh
 
+  test_go_bump_policy:
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        script: scripts/test-check-go-bump-policy-examples.sh
+
   generate_perf_tests_tasks:
     - command: shell.exec
       type: setup

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -298,6 +298,11 @@ tasks:
     commands:
       - func: lint_repo
 
+  - name: go_bump_policy_tests
+    tags: [ "unit_tests" ]
+    commands:
+      - func: "test_go_bump_policy"
+
   # Runs on every merge - detects release.json changes and releases appropriate images
   - name: release_om_and_agents
     allowed_requesters: [ "patch" , "commit"]
@@ -680,6 +685,7 @@ task_groups:
       - unit_tests_python
       - unit_tests_helm
       - sbom_tests
+      - go_bump_policy_tests
     teardown_task:
       - command: attach.xunit_results
         params:

--- a/.github/workflows/go-bump-policy.yml
+++ b/.github/workflows/go-bump-policy.yml
@@ -1,0 +1,36 @@
+name: Go Bump Policy
+
+on:
+  schedule:
+    # Runs on the 1st and 15th of each month at 08:00 UTC (~every 2 weeks).
+    - cron: '0 8 1,15 * *'
+  workflow_dispatch:
+
+jobs:
+  check-and-bump:
+    name: Check and bump Go version if due
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Token with write access so create-go-bump-pr.sh can push a branch.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Stable toolchain to run the policy script; bump-go.sh passes
+          # FULL_VERSION to update_go_version.sh so the target version's
+          # toolchain does not need to be installed.
+          go-version: 'stable'
+          cache: false
+
+      - name: Run Go bump policy check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/check-go-bump-policy.sh

--- a/.github/workflows/go-bump-policy.yml
+++ b/.github/workflows/go-bump-policy.yml
@@ -18,15 +18,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          # Token with write access so create-go-bump-pr.sh can push a branch.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          # Stable toolchain to run the policy script; bump-go.sh passes
-          # FULL_VERSION to update_go_version.sh so the target version's
-          # toolchain does not need to be installed.
           go-version: 'stable'
           cache: false
 

--- a/scripts/bump-go.sh
+++ b/scripts/bump-go.sh
@@ -21,23 +21,16 @@ GO_MOD="${ROOT_DIR}/go.mod"
 
 printf 'bump-go: bumping Go version to %s\n' "${version}"
 
-# TEST_BUMP_DRY_RUN=1 lets the test suite confirm the script is reached
-# without touching real files (check-go-bump-policy.sh uses an absolute path
-# to invoke this script so PATH-based stubbing cannot intercept it).
 if [[ "${TEST_BUMP_DRY_RUN:-}" == "1" ]]; then
   printf 'bump-go: dry-run, skipping file updates\n'
   exit 0
 fi
 
-# 1. Update root go.mod go directive.
-#    Use a temp-file swap for cross-platform compatibility (GNU vs BSD sed).
+# Temp-file swap for cross-platform sed (GNU vs BSD).
 tmpfile=$(mktemp)
 sed "s|^go [0-9][0-9.]*$|go ${version}|" "${GO_MOD}" > "${tmpfile}"
 mv "${tmpfile}" "${GO_MOD}"
 printf 'bump-go: updated %s\n' "${GO_MOD}"
 
-# 2. Propagate the new version to all other tracked files (Dockerfiles,
-#    .tool-versions, secondary go.mod files, pre-commit config, etc.).
-#    Pass FULL_VERSION so update_go_version.sh skips `go list`, which would
-#    require the exact new toolchain to be installed.
+# FULL_VERSION skips `go list` so the target toolchain need not be installed.
 FULL_VERSION="${version}" "${SCRIPT_DIR}/dev/update_go_version.sh"

--- a/scripts/bump-go.sh
+++ b/scripts/bump-go.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Executor for Go toolchain bump (not implemented). All policy and filtering
-# live in scripts/check-go-bump-policy.sh.
+# Executor for Go toolchain bump. All policy and filtering live in
+# scripts/check-go-bump-policy.sh.
 #
 # Usage: bump-go.sh <version>
 #   <version> is the exact go directive (e.g. 1.26.2), no "go" prefix.
@@ -15,6 +15,29 @@ fi
 
 version="${1#go}"
 
-# TODO: Implement bump logic here in next PRs.
-# will invoke leverage scripts/dev/update_go_version.sh
-printf '%s\n' "bump-go: target go version: ${version}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GO_MOD="${ROOT_DIR}/go.mod"
+
+printf 'bump-go: bumping Go version to %s\n' "${version}"
+
+# TEST_BUMP_DRY_RUN=1 lets the test suite confirm the script is reached
+# without touching real files (check-go-bump-policy.sh uses an absolute path
+# to invoke this script so PATH-based stubbing cannot intercept it).
+if [[ "${TEST_BUMP_DRY_RUN:-}" == "1" ]]; then
+  printf 'bump-go: dry-run, skipping file updates\n'
+  exit 0
+fi
+
+# 1. Update root go.mod go directive.
+#    Use a temp-file swap for cross-platform compatibility (GNU vs BSD sed).
+tmpfile=$(mktemp)
+sed "s|^go [0-9][0-9.]*$|go ${version}|" "${GO_MOD}" > "${tmpfile}"
+mv "${tmpfile}" "${GO_MOD}"
+printf 'bump-go: updated %s\n' "${GO_MOD}"
+
+# 2. Propagate the new version to all other tracked files (Dockerfiles,
+#    .tool-versions, secondary go.mod files, pre-commit config, etc.).
+#    Pass FULL_VERSION so update_go_version.sh skips `go list`, which would
+#    require the exact new toolchain to be installed.
+FULL_VERSION="${version}" "${SCRIPT_DIR}/dev/update_go_version.sh"

--- a/scripts/check-go-bump-policy.sh
+++ b/scripts/check-go-bump-policy.sh
@@ -49,9 +49,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 GO_MOD="${ROOT_DIR}/go.mod"
 BUMP_SCRIPT="${ROOT_DIR}/scripts/bump-go.sh"
+PR_SCRIPT="${ROOT_DIR}/scripts/create-go-bump-pr.sh"
 
 [[ -f "${BUMP_SCRIPT}" ]] || {
   echo "check-go-bump-policy: error: missing ${BUMP_SCRIPT}" >&2
+  exit 1
+}
+[[ -f "${PR_SCRIPT}" ]] || {
+  echo "check-go-bump-policy: error: missing ${PR_SCRIPT}" >&2
   exit 1
 }
 [[ -f "${GO_MOD}" ]] || {
@@ -251,7 +256,10 @@ else
 fi
 
 case "${_rc}" in
-  0) exec "${BUMP_SCRIPT}" "${latest}" ;;
+  0)
+    "${BUMP_SCRIPT}" "${latest}"
+    "${PR_SCRIPT}" "${latest}"
+    ;;
 10) exit 0 ;;
   *) exit 1 ;;
 esac

--- a/scripts/create-go-bump-pr.sh
+++ b/scripts/create-go-bump-pr.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Opens a pull request for a Go version bump after bump-go.sh has updated files.
+# Called by check-go-bump-policy.sh; can also be run standalone.
+#
+# Usage: create-go-bump-pr.sh <version>
+#   <version> is the exact go directive (e.g. 1.26.2), no "go" prefix.
+#
+# Environment:
+#   TEST_BUMP_DRY_RUN=1   Print what would happen without touching git or gh.
+#   GIT_AUTHOR_NAME       Override committer name  (default: github-actions[bot])
+#   GIT_AUTHOR_EMAIL      Override committer email (default: github-actions[bot] noreply)
+
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1}" ]]; then
+  echo "usage: create-go-bump-pr.sh <version>" >&2
+  echo "  example: create-go-bump-pr.sh 1.26.2" >&2
+  exit 1
+fi
+
+version="${1#go}"
+branch="auto/bump-go-${version}"
+title="Bump Go version to ${version}"
+
+if [[ "${TEST_BUMP_DRY_RUN:-}" == "1" ]]; then
+  printf 'create-go-bump-pr: dry-run: would open PR "%s" from branch %s\n' "${title}" "${branch}"
+  exit 0
+fi
+
+command -v gh >/dev/null 2>&1 || {
+  echo "create-go-bump-pr: error: gh is required" >&2
+  exit 1
+}
+
+git config user.name  "${GIT_AUTHOR_NAME:-github-actions[bot]}"
+git config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+
+git checkout -b "${branch}"
+git add -A
+git commit -m "${title}"
+git push origin "${branch}"
+
+gh pr create \
+  --title "${title}" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Automated Go version bump triggered by the go-bump-policy schedule.
+
+The policy (see `scripts/check-go-bump-policy.sh`) bumps when the current
+minor is within 90 days of its EOL **and** a newer stable release is
+available on go.dev.
+
+## Checklist
+
+- [ ] CI passes
+- [ ] Review propagated version in Dockerfiles, `.tool-versions`, and secondary `go.mod` files
+EOF
+  )" \
+  --base master \
+  --head "${branch}"

--- a/scripts/dev/update_go_version.sh
+++ b/scripts/dev/update_go_version.sh
@@ -66,8 +66,10 @@ update_files() {
     done
 }
 
-# Extract version from go.mod (source of truth)
-FULL_VERSION=$(go list -m -f '{{.GoVersion}}')
+# Extract version from go.mod (source of truth).
+# FULL_VERSION env override skips the go list call, which lets callers like
+# bump-go.sh pass the target version without needing the exact toolchain installed.
+FULL_VERSION="${FULL_VERSION:-$(go list -m -f '{{.GoVersion}}')}"
 if [[ -z "${FULL_VERSION}" ]]; then
     echo "Error: Could not extract Go version from go.mod"
     exit 1

--- a/scripts/dev/update_go_version.sh
+++ b/scripts/dev/update_go_version.sh
@@ -67,8 +67,7 @@ update_files() {
 }
 
 # Extract version from go.mod (source of truth).
-# FULL_VERSION env override skips the go list call, which lets callers like
-# bump-go.sh pass the target version without needing the exact toolchain installed.
+# FULL_VERSION override bypasses `go list` when the target toolchain is not installed.
 FULL_VERSION="${FULL_VERSION:-$(go list -m -f '{{.GoVersion}}')}"
 if [[ -z "${FULL_VERSION}" ]]; then
     echo "Error: Could not extract Go version from go.mod"

--- a/scripts/test-check-go-bump-policy-examples.sh
+++ b/scripts/test-check-go-bump-policy-examples.sh
@@ -76,7 +76,7 @@ expect_bump() {
     failures=$((failures + 1))
     return
   fi
-  if ! grep -qE 'bump-go: target go version:' <<<"${out}"; then
+  if ! grep -qE 'bump-go: bumping Go version to' <<<"${out}"; then
     echo "FAIL: expected bump-go.sh output"
     echo "${out}"
     failures=$((failures + 1))
@@ -99,7 +99,8 @@ expect_bump "2) May 31 2026 — 1.25 vs 1.26, within upgrade window before EOL" 
   TEST_OVERRIDE_TODAY=2026-05-31 \
   TEST_OVERRIDE_CURRENT_EOL_DATE=2026-08-01 \
   TEST_OVERRIDE_LATEST_GO=1.26.2 \
-  TEST_OVERRIDE_CURRENT_GO=1.25.9
+  TEST_OVERRIDE_CURRENT_GO=1.25.9 \
+  TEST_BUMP_DRY_RUN=1
 
 # EOL 2027-02-01: outside upgrade window on 2026-09-20, inside on 2026-11-15.
 expect_pause "3) Sep 2026 — 1.26 vs 1.27, defer" \
@@ -112,14 +113,16 @@ expect_bump "4) Nov 2026 — 1.26 vs 1.27, within bumping period" \
   TEST_OVERRIDE_TODAY=2026-11-15 \
   TEST_OVERRIDE_CURRENT_EOL_DATE=2027-02-01 \
   TEST_OVERRIDE_LATEST_GO=1.27.1 \
-  TEST_OVERRIDE_CURRENT_GO=1.26.2
+  TEST_OVERRIDE_CURRENT_GO=1.26.2 \
+  TEST_BUMP_DRY_RUN=1
 
 # Past EOL → bump if not latest.
 expect_bump "5) Mar 2027 — 1.26 vs 1.28, past current minor EOL, so bump" \
   TEST_OVERRIDE_TODAY=2027-03-18 \
   TEST_OVERRIDE_CURRENT_EOL_DATE=2027-02-01 \
   TEST_OVERRIDE_LATEST_GO=1.28.0 \
-  TEST_OVERRIDE_CURRENT_GO=1.26.5
+  TEST_OVERRIDE_CURRENT_GO=1.26.5 \
+  TEST_BUMP_DRY_RUN=1
 
 echo
 if [[ "${failures}" -eq 0 ]]; then


### PR DESCRIPTION
# Summary

This change would enforce the recently added support for a go bump policy.

## Proof of Work

✅ [Default policy code passes self tests](https://spruce.corp.mongodb.com/version/69e1e9e498a1dc00077d2c6a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
✅ [Injected failure is detected](https://spruce.corp.mongodb.com/version/69e1eb26c27ae30007a3c0b2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
