### PR TITLE
Revert "fix notification to run with commits"

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -2167,7 +2167,6 @@ buildvariants:
   - name: flaky_test_report
     display_name: "Flaky Test Weekly Report"
     cron: "0 9 * * 1"
-    allowed_requesters: [ "ad_hoc", "patch" ] # only run on cron jobs or manually via patches
     run_on:
       - ubuntu2404-small
     tasks:


### PR DESCRIPTION
Reverts mongodb/mongodb-kubernetes#845

due to

It seems like not having the commit requester somehow failed the cronjob...
https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Controlling-when-tasks-run#cron
"""
Cron activates build variants or tasks on existing mainline commits based on a specified schedule....
"""