### PR TITLE
fix(preflight): resolve empty --version arg in preflight_check_smoke

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -484,7 +484,7 @@ functions:
           - --image
           - ${image_name}
           - --version
-          - ${OPERATOR_VERSION}
+          - ${mongodbOperator}
           - --submit
           - ${preflight_submit}
 

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -54,6 +54,7 @@ tasks:
     commands:
       - func: clone
       - func: python_venv
+      - func: update_evergreen_expansions
       - func: setup_preflight
       - func: preflight_image
         vars:


### PR DESCRIPTION
# Summary

`preflight_check_smoke` was failing with `argument --version: expected one argument` immediately after the task started.

The `preflight_image` Evergreen function passes `--version ${OPERATOR_VERSION}` via the `args:` list. Evergreen resolves these at **task dispatch time**, but `OPERATOR_VERSION` is only set at **runtime** by `set_env_context.sh` — it is never registered as an Evergreen expansion for the `preflight_release_images_check_only` variant. Evergreen omits the empty arg, leaving `--version` as the last argument with nothing after it, which argparse rejects.

The fix adds `update_evergreen_expansions` to the task (which reads `mongodbOperator` from `release.json` and registers it via `expansions.update`) and changes the function to reference `${mongodbOperator}` instead of `${OPERATOR_VERSION}`. Both resolve to the same value. The smoke check now validates the preflight toolchain against the last public release image — the right behavior for a per-commit toolchain check.

## Proof of Work

Identified from mainline failure at `9dcd46794344687d548b4adb873ee2c16c7af97f`: task `preflight_check_smoke` on variant `preflight_release_images_check_only`.

works now: https://spruce.corp.mongodb.com/version/69e62f315194a500070e324d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed