### PR TITLE
fix(e2e): install otel-collector into per-task namespace to fix Helm conflicts

### DIFF
--- a/scripts/evergreen/e2e/performance/honeycomb/install-hc.sh
+++ b/scripts/evergreen/e2e/performance/honeycomb/install-hc.sh
@@ -36,12 +36,30 @@ EOF
 
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm repo update
-kubectl create secret generic honeycomb --from-literal=endpoint="${otel_collector_endpoint}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic namespace --from-literal=namespace="${NAMESPACE}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic build-variant --from-literal=build-variant="${BUILD_VARIANT}"  --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic version-id --from-literal=version-id="${version_id}"  --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic task-id --from-literal=task-id="${task_id}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic task-name --from-literal=task-name="${task_name}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic honeycomb --from-literal=endpoint="${otel_collector_endpoint}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic namespace --from-literal=namespace="${NAMESPACE}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic build-variant --from-literal=build-variant="${BUILD_VARIANT}"  --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic version-id --from-literal=version-id="${version_id}"  --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic task-id --from-literal=task-id="${task_id}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic task-name --from-literal=task-name="${task_name}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
 
-helm upgrade --install otel-collector-cluster open-telemetry/opentelemetry-collector --namespace "${NAMESPACE}" --values scripts/evergreen/e2e/performance/honeycomb/values-deployment.yaml
-helm upgrade --install otel-collector open-telemetry/opentelemetry-collector --namespace "${NAMESPACE}" --values scripts/evergreen/e2e/performance/honeycomb/values-daemonset.yaml
+# The otel-collector Helm charts create cluster-scoped resources (ClusterRoles) so they must be
+# installed into a stable shared namespace. With max_hosts>1 two tasks may run concurrently on the
+# same cluster, causing Helm lock conflicts. Recovery steps:
+#   1. Roll back any release stuck in a pending-* state (left by a previous failed task).
+#   2. Use || true so a concurrent install by another task does not fail this task — the collector
+#      will already be running or will be started by the other task.
+for _release in otel-collector-cluster otel-collector; do
+    _status=$(helm status "${_release}" --namespace honeycomb -o json 2>/dev/null \
+        | jq -r '.info.status // empty' 2>/dev/null || true)
+    if [[ "${_status}" == "pending-install" || "${_status}" == "pending-upgrade" || "${_status}" == "pending-rollback" ]]; then
+        echo "Recovering stuck Helm release ${_release} (status: ${_status})"
+        helm rollback "${_release}" --namespace honeycomb 2>/dev/null \
+            || helm uninstall "${_release}" --namespace honeycomb 2>/dev/null \
+            || true
+    fi
+done
+
+helm upgrade --install otel-collector-cluster open-telemetry/opentelemetry-collector --namespace honeycomb --values scripts/evergreen/e2e/performance/honeycomb/values-deployment.yaml || true
+helm upgrade --install otel-collector open-telemetry/opentelemetry-collector --namespace honeycomb --values scripts/evergreen/e2e/performance/honeycomb/values-daemonset.yaml || true

--- a/scripts/evergreen/e2e/performance/honeycomb/install-hc.sh
+++ b/scripts/evergreen/e2e/performance/honeycomb/install-hc.sh
@@ -44,22 +44,9 @@ kubectl create secret generic version-id --from-literal=version-id="${version_id
 kubectl create secret generic task-id --from-literal=task-id="${task_id}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
 kubectl create secret generic task-name --from-literal=task-name="${task_name}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
 
-# The otel-collector Helm charts create cluster-scoped resources (ClusterRoles) so they must be
-# installed into a stable shared namespace. With max_hosts>1 two tasks may run concurrently on the
-# same cluster, causing Helm lock conflicts. Recovery steps:
-#   1. Roll back any release stuck in a pending-* state (left by a previous failed task).
-#   2. Use || true so a concurrent install by another task does not fail this task — the collector
-#      will already be running or will be started by the other task.
-for _release in otel-collector-cluster otel-collector; do
-    _status=$(helm status "${_release}" --namespace honeycomb -o json 2>/dev/null \
-        | jq -r '.info.status // empty' 2>/dev/null || true)
-    if [[ "${_status}" == "pending-install" || "${_status}" == "pending-upgrade" || "${_status}" == "pending-rollback" ]]; then
-        echo "Recovering stuck Helm release ${_release} (status: ${_status})"
-        helm rollback "${_release}" --namespace honeycomb 2>/dev/null \
-            || helm uninstall "${_release}" --namespace honeycomb 2>/dev/null \
-            || true
-    fi
-done
-
+# The otel-collector charts create cluster-scoped ClusterRoles tied to the honeycomb namespace.
+# With max_hosts>1, two tasks may run concurrently and race to install the same releases.
+# || true prevents a concurrent install by another task from failing this task — the collector
+# will already be running or will be started by the other task.
 helm upgrade --install otel-collector-cluster open-telemetry/opentelemetry-collector --namespace honeycomb --values scripts/evergreen/e2e/performance/honeycomb/values-deployment.yaml || true
 helm upgrade --install otel-collector open-telemetry/opentelemetry-collector --namespace honeycomb --values scripts/evergreen/e2e/performance/honeycomb/values-daemonset.yaml || true

--- a/scripts/evergreen/e2e/performance/honeycomb/install-hc.sh
+++ b/scripts/evergreen/e2e/performance/honeycomb/install-hc.sh
@@ -36,13 +36,12 @@ EOF
 
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm repo update
-kubectl create namespace honeycomb --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic honeycomb --from-literal=endpoint="${otel_collector_endpoint}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic namespace --from-literal=namespace="${NAMESPACE}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic build-variant --from-literal=build-variant="${BUILD_VARIANT}"  --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic version-id --from-literal=version-id="${version_id}"  --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic task-id --from-literal=task-id="${task_id}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic task-name --from-literal=task-name="${task_name}" --namespace=honeycomb --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic honeycomb --from-literal=endpoint="${otel_collector_endpoint}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic namespace --from-literal=namespace="${NAMESPACE}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic build-variant --from-literal=build-variant="${BUILD_VARIANT}"  --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic version-id --from-literal=version-id="${version_id}"  --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic task-id --from-literal=task-id="${task_id}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic task-name --from-literal=task-name="${task_name}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
-helm upgrade --install otel-collector-cluster open-telemetry/opentelemetry-collector --namespace honeycomb --values scripts/evergreen/e2e/performance/honeycomb/values-deployment.yaml
-helm upgrade --install otel-collector open-telemetry/opentelemetry-collector --namespace honeycomb --values scripts/evergreen/e2e/performance/honeycomb/values-daemonset.yaml
+helm upgrade --install otel-collector-cluster open-telemetry/opentelemetry-collector --namespace "${NAMESPACE}" --values scripts/evergreen/e2e/performance/honeycomb/values-deployment.yaml
+helm upgrade --install otel-collector open-telemetry/opentelemetry-collector --namespace "${NAMESPACE}" --values scripts/evergreen/e2e/performance/honeycomb/values-daemonset.yaml


### PR DESCRIPTION
# Summary

- don't fail if we cannot install the hc helm chart, since its a static cluster it might be stuck in a different state. We shouldn't fail due to that. 

## Proof of Work

fix: https://spruce.corp.mongodb.com/version/69e64cd160211e00087703ee/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed