### PR TITLE
fix: use retry flakiness metric for accurate flaky test detection

### DIFF
--- a/scripts/evergreen/notify_flaky_tests.py
+++ b/scripts/evergreen/notify_flaky_tests.py
@@ -116,9 +116,7 @@ def get_flaky_tasks(headers: dict) -> list[FlakyTask]:
             {"column": "evergreen.version.requester", "op": "=", "value": "gitter_request"},
             {"column": "evergreen.project.id", "op": "=", "value": PROJECT_ID},
         ],
-        "havings": [
-            {"calculate_op": "AVG", "column": "mck.retry_flakiness_percent", "op": ">", "value": 0}
-        ],
+        "havings": [{"calculate_op": "AVG", "column": "mck.retry_flakiness_percent", "op": ">", "value": 0}],
         "orders": [{"column": "mck.retry_flakiness_percent", "op": "AVG", "order": "descending"}],
         "limit": 50,
     }

--- a/scripts/evergreen/notify_flaky_tests.py
+++ b/scripts/evergreen/notify_flaky_tests.py
@@ -2,8 +2,11 @@
 """
 Weekly flaky test notification script.
 
-Queries Honeycomb for tests that have both passed and failed in the past 7 days
+Queries Honeycomb for tasks that required retries to pass in the past 7 days
 (indicating flaky behavior) and sends a summary to Slack.
+
+Uses the same query as the Honeycomb board:
+https://ui.honeycomb.io/mongodb-4b/environments/production/board/EgX7rho7iH3/kubernetes-operator
 
 Environment variables:
     HONEYCOMB_API_KEY: Honeycomb API key for authentication
@@ -19,38 +22,24 @@ import sys
 import time
 from dataclasses import dataclass
 from pprint import pprint
-from typing import Any, NamedTuple
+from typing import Any
 
 import requests
 
-# Type alias for pytest node IDs (e.g., "tests/test_foo.py::TestClass::test_method")
-NodeId = str
-
 HONEYCOMB_API_BASE = "https://api.honeycomb.io/1"
-DATASET_E2E = "mongodb-e2e-tests"  # Specific dataset for higher limits (10000)
-PROJECT_ID = "mongodb-kubernetes"  # Filter to our project only
+DATASET = "evergreen-agent"  # Task-level data with retry flakiness
+PROJECT_ID = "mongodb-kubernetes"
 TIME_RANGE_SECONDS = 604800  # 7 days
 HONEYCOMB_BOARD_URL = "https://ui.honeycomb.io/mongodb-4b/environments/production/board/EgX7rho7iH3/kubernetes-operator"
 
 
-class TaskFailureInfo(NamedTuple):
-    """Info about a test's failures within a specific task."""
+@dataclass
+class FlakyTask:
+    """Represents a flaky task with its statistics."""
 
     task_name: str
-    fail_count: int
-
-
-@dataclass
-class FlakyTest:
-    """Represents a flaky test with its statistics."""
-
-    name: NodeId
-    task: str  # Evergreen task name
-    failure_count: int
-    total_runs: int
-    failure_rate: float
-    avg_duration_ms: float  # Average task duration in milliseconds (total task time / executions)
-    failing_variants: list[str] = None  # List of variant names with failures
+    variant: str
+    flakiness_percent: float  # Based on retry success rate
 
 
 def get_honeycomb_headers() -> dict[str, str]:
@@ -64,8 +53,19 @@ def get_honeycomb_headers() -> dict[str, str]:
     }
 
 
-def run_query(headers: dict, query_id: str, dataset: str = DATASET_E2E) -> str:
-    """Execute a Honeycomb query and return the result ID."""
+def create_and_run_query(headers: dict, query_spec: dict, dataset: str = DATASET) -> dict[str, Any]:
+    """Create a query, run it, and return the results."""
+    # Create query
+    response = requests.post(
+        f"{HONEYCOMB_API_BASE}/queries/{dataset}",
+        headers=headers,
+        json=query_spec,
+        timeout=30,
+    )
+    response.raise_for_status()
+    query_id = response.json()["id"]
+
+    # Run query
     response = requests.post(
         f"{HONEYCOMB_API_BASE}/query_results/{dataset}",
         headers=headers,
@@ -73,12 +73,10 @@ def run_query(headers: dict, query_id: str, dataset: str = DATASET_E2E) -> str:
         timeout=30,
     )
     response.raise_for_status()
-    return response.json()["id"]
+    result_id = response.json()["id"]
 
-
-def fetch_results(headers: dict, result_id: str, dataset: str = DATASET_E2E, max_retries: int = 10) -> dict[str, Any]:
-    """Fetch query results, polling until complete."""
-    for attempt in range(max_retries):
+    # Poll for results
+    for attempt in range(10):
         response = requests.get(
             f"{HONEYCOMB_API_BASE}/query_results/{dataset}/{result_id}",
             headers=headers,
@@ -90,281 +88,84 @@ def fetch_results(headers: dict, result_id: str, dataset: str = DATASET_E2E, max
         if data.get("complete", False):
             return data
 
-        print(f"Query not complete, waiting... (attempt {attempt + 1}/{max_retries})")
+        print(f"Query not complete, waiting... (attempt {attempt + 1}/10)")
         time.sleep(2)
 
     raise RuntimeError("Query did not complete in time")
 
 
-def create_and_run_query(headers: dict, query_spec: dict, dataset: str = DATASET_E2E) -> dict[str, Any]:
-    """Create a query, run it, and return the results."""
-    response = requests.post(
-        f"{HONEYCOMB_API_BASE}/queries/{dataset}",
-        headers=headers,
-        json=query_spec,
-        timeout=30,
-    )
-    response.raise_for_status()
-    query_id = response.json()["id"]
+def get_flaky_tasks(headers: dict) -> list[FlakyTask]:
+    """Query Honeycomb for flaky tasks using the same logic as the board.
 
-    result_id = run_query(headers, query_id, dataset)
-    return fetch_results(headers, result_id, dataset)
-
-
-def get_task_avg_duration_minutes(headers: dict, task_names: list[str]) -> dict[str, float]:
-    """Query Honeycomb for average task duration in minutes.
-
-    Returns {task_name: avg_duration_minutes}.
+    A task is flaky if it required retries to pass (mck.retry_flakiness_percent > 0).
+    This metric is calculated as:
+    - execution 0 (first attempt succeeded) → 0%
+    - execution 1 (second attempt succeeded) → 50%
+    - execution 2 (third attempt succeeded) → 67%
+    - etc.
     """
-    if not task_names:
-        return {}
+    print("Querying flaky tasks from evergreen-agent...")
 
     query_spec = {
         "time_range": TIME_RANGE_SECONDS,
         "granularity": 0,
-        "breakdowns": ["evergreen.task.name"],
-        "calculations": [
-            {"op": "SUM", "column": "duration_ms"},
-            {"op": "COUNT_DISTINCT", "column": "evergreen.task.id"},
-        ],
+        "breakdowns": ["evergreen.task.name", "evergreen.build.name"],
+        "calculations": [{"op": "AVG", "column": "mck.retry_flakiness_percent"}],
         "filters": [
+            {"column": "evergreen.task.status", "op": "exists"},
+            {"column": "evergreen.version.requester", "op": "=", "value": "gitter_request"},
             {"column": "evergreen.project.id", "op": "=", "value": PROJECT_ID},
-            {"column": "evergreen.task.name", "op": "in", "value": list(task_names)},
-            {"column": "evergreen.version.requester", "op": "=", "value": "commit"},
         ],
-        "orders": [{"column": "duration_ms", "op": "SUM", "order": "descending"}],
-        "limit": 1000,
-    }
-
-    try:
-        results = create_and_run_query(headers, query_spec)
-    except requests.RequestException as e:
-        print(f"Warning: Failed to query task durations: {e}")
-        return {}
-
-    durations: dict[str, float] = {}
-    for row in results.get("data", {}).get("results", []):
-        row_data = row.get("data", row)
-        task = row_data.get("evergreen.task.name")
-        sum_ms = row_data.get("SUM(duration_ms)", 0) or 0
-        count = row_data.get("COUNT_DISTINCT(evergreen.task.id)", 0) or 0
-        durations[task] = (sum_ms / count) / 60000  # Convert ms to minutes
-
-    return durations
-
-
-def get_failed_tests_with_tasks(headers: dict) -> dict[NodeId, TaskFailureInfo]:
-    """Query for failed tests/functions with task names.
-
-    Returns {nodeid: TaskFailureInfo(task_name, fail_count)}.
-    """
-    query_spec = {
-        "time_range": TIME_RANGE_SECONDS,
-        "granularity": 0,
-        "breakdowns": ["evergreen.task.name", "mck.pytest.nodeid"],
-        "calculations": [{"op": "COUNT"}],
-        "filters": [
-            {"column": "evergreen.project.id", "op": "=", "value": PROJECT_ID},
-            {"column": "mck.pytest.nodeid", "op": "exists"},
-            {
-                "column": "mck.pytest.outcome.call",
-                "op": "=",
-                "value": "failed",
-            },  # Everything related to 'mck.' is collected and sent by our automation
-            {"column": "evergreen.task.name", "op": "exists"},
-            {"column": "evergreen.version.requester", "op": "=", "value": "commit"},
-            {"column": "evergreen.task.execution", "op": "=", "value": 0},  # First attempt only
+        "havings": [
+            {"calculate_op": "AVG", "column": "mck.retry_flakiness_percent", "op": ">", "value": 0}
         ],
-        "orders": [{"op": "COUNT", "order": "descending"}],
-        "limit": 1000,
+        "orders": [{"column": "mck.retry_flakiness_percent", "op": "AVG", "order": "descending"}],
+        "limit": 50,
     }
 
     results = create_and_run_query(headers, query_spec)
 
-    failed_tests: dict[NodeId, TaskFailureInfo] = {}
+    flaky_tasks = []
     for row in results.get("data", {}).get("results", []):
         row_data = row.get("data", row)
-        nodeid = row_data.get("mck.pytest.nodeid")
-        task = row_data.get("evergreen.task.name", "unknown")
-        count = row_data.get("COUNT", 0)
-        if nodeid:
-            # Keep entry with highest failure count for each nodeid
-            if nodeid not in failed_tests or count > failed_tests[nodeid].fail_count:
-                failed_tests[nodeid] = TaskFailureInfo(task_name=task, fail_count=count)
-
-    return failed_tests
-
-
-def get_failing_variants_for_tests(headers: dict, nodeids: list[NodeId]) -> dict[NodeId, list[str]]:
-    """Query for which build variants have failures for each test.
-
-    Returns {nodeid: [variant1, variant2, ...]}.
-    """
-    if not nodeids:
-        return {}
-
-    query_spec = {
-        "time_range": TIME_RANGE_SECONDS,
-        "granularity": 0,
-        "breakdowns": ["mck.pytest.nodeid", "evergreen.build.name"],
-        "calculations": [{"op": "COUNT"}],
-        "filters": [
-            {"column": "evergreen.project.id", "op": "=", "value": PROJECT_ID},
-            {"column": "mck.pytest.nodeid", "op": "in", "value": list(nodeids)},
-            {"column": "mck.pytest.outcome.call", "op": "=", "value": "failed"},
-            {"column": "evergreen.version.requester", "op": "=", "value": "commit"},
-            {"column": "evergreen.task.execution", "op": "=", "value": 0},
-        ],
-        "orders": [{"op": "COUNT", "order": "descending"}],
-        "limit": 1000,
-    }
-
-    try:
-        results = create_and_run_query(headers, query_spec)
-    except requests.RequestException as e:
-        print(f"Warning: Failed to query failing variants: {e}")
-        return {}
-
-    # Group variants by nodeid
-    failing_variants: dict[NodeId, list[str]] = {}
-    for row in results.get("data", {}).get("results", []):
-        row_data = row.get("data", row)
-        nodeid = row_data.get("mck.pytest.nodeid")
+        task_name = row_data.get("evergreen.task.name")
         variant = row_data.get("evergreen.build.name")
-        failing_variants.setdefault(nodeid, []).append(variant)
-    return failing_variants
+        flakiness = row_data.get("AVG(mck.retry_flakiness_percent)", 0)
 
-
-def get_passed_tests_batch(headers: dict, failed_nodeids: set[NodeId]) -> dict[NodeId, int]:
-    """Query for passed/successful tests. Returns {nodeid: pass_count}.
-
-    Uses 'in' filter to query only the specific nodeids that have failures,
-    ensuring we get pass counts for all failed tests within the 1000 limit.
-    """
-    if not failed_nodeids:
-        return {}
-
-    query_spec = {
-        "time_range": TIME_RANGE_SECONDS,
-        "granularity": 0,
-        "breakdowns": ["mck.pytest.nodeid"],
-        "calculations": [{"op": "COUNT"}],
-        "filters": [
-            {"column": "evergreen.project.id", "op": "=", "value": PROJECT_ID},
-            {"column": "mck.pytest.nodeid", "op": "in", "value": list(failed_nodeids)},
-            {"column": "mck.pytest.outcome.call", "op": "=", "value": "passed"},
-            {"column": "evergreen.version.requester", "op": "=", "value": "commit"},
-            {"column": "evergreen.task.execution", "op": "=", "value": 0},  # First attempt only
-        ],
-        "orders": [{"op": "COUNT", "order": "descending"}],
-        "limit": 1000,
-    }
-
-    results = create_and_run_query(headers, query_spec, dataset=DATASET_E2E)
-
-    passed_tests: dict[NodeId, int] = {}
-    for row in results.get("data", {}).get("results", []):
-        row_data = row.get("data", row)
-        nodeid = row_data.get("mck.pytest.nodeid")
-        count = row_data.get("COUNT", 0)
-        if nodeid:
-            passed_tests[nodeid] = count
-
-    return passed_tests
-
-
-def get_flaky_tests(headers: dict) -> list[FlakyTest]:
-    """Query Honeycomb and return list of flaky tests above threshold."""
-    # Query 1: Get all failed tests with task names
-    print("Querying failed tests...")
-    failed_tests = get_failed_tests_with_tasks(headers)
-    print(f"  Found {len(failed_tests)} tests with failures")
-
-    if not failed_tests:
-        print("No failed tests found")
-        return []
-
-    # Query 2: Batch query for passed counts of those failed ones to identify flaky candidates
-    print("Querying passed tests...")
-    failed_nodeids = set(failed_tests.keys())
-    passed_tests = get_passed_tests_batch(headers, failed_nodeids)
-    print(f"  Found {len(passed_tests)} tests with passes")
-
-    # Find flaky tests (tests that both pass and fail)
-    print("Analyzing flaky tests...")
-    flaky_candidates = []
-    for nodeid, info in failed_tests.items():
-        pass_count = passed_tests.get(nodeid, 0)
-
-        # Skip if not flaky (no passes means always failing, not flaky)
-        if pass_count == 0:
+        # Skip aggregation rows
+        if task_name in ("OTHER", "TOTAL") or variant in ("OTHER", "TOTAL"):
             continue
 
-        # That's not accurate, since we are looking across multiple runs and not for the same run. But it should give us a good approximation.
-        total_runs = pass_count + info.fail_count
-        failure_rate = info.fail_count / total_runs
-
-        flaky_candidates.append((nodeid, info.task_name, info.fail_count, total_runs, failure_rate))
-
-    # Query Honeycomb for task durations and failing variants
-    unique_tasks = list(set(task for _, task, _, _, _ in flaky_candidates))
-    unique_nodeids = [nodeid for nodeid, _, _, _, _ in flaky_candidates]
-    print(f"Querying task metadata for {len(unique_tasks)} tasks...")
-    task_durations = get_task_avg_duration_minutes(headers, unique_tasks)
-    failing_variants = get_failing_variants_for_tests(headers, unique_nodeids)
-
-    # Build final flaky tests list
-    flaky_tests = []
-    for nodeid, task, fail_count, total_runs, failure_rate in flaky_candidates:
-        avg_duration_min = task_durations.get(task, 0.0)  # 0.0 if not found
-        test_failing_variants = failing_variants.get(nodeid, [])
-        flaky_tests.append(
-            FlakyTest(
-                name=nodeid,
-                task=task,
-                failure_count=fail_count,
-                total_runs=total_runs,
-                failure_rate=failure_rate,
-                avg_duration_ms=avg_duration_min * 60000,  # Store as ms for compatibility
-                failing_variants=test_failing_variants,
+        if task_name and variant and flakiness > 0:
+            flaky_tasks.append(
+                FlakyTask(
+                    task_name=task_name,
+                    variant=variant,
+                    flakiness_percent=flakiness,
+                )
             )
-        )
 
-    # Sort by failure rate descending
-    flaky_tests.sort(key=lambda t: t.failure_rate, reverse=True)
-    return flaky_tests
+    print(f"  Found {len(flaky_tasks)} flaky task/variant combinations")
+    return flaky_tasks
 
 
-def format_test_name(full_name: str, max_length: int = 60) -> str:
-    """Format test name for display, extracting just the test function name if too long."""
-    if len(full_name) <= max_length:
-        return full_name
-
-    # Extract just the test function name (last part after ::)
-    if "::" in full_name:
-        parts = full_name.split("::")
-        return parts[-1]
-
-    return full_name[:max_length] + "..."
-
-
-def format_slack_message(flaky_tests: list[FlakyTest]) -> dict:
-    """Format flaky test results as Slack Block Kit message."""
-    if not flaky_tests:
+def format_slack_message(flaky_tasks: list[FlakyTask]) -> dict:
+    """Format flaky task results as Slack Block Kit message."""
+    if not flaky_tasks:
         return {
             "blocks": [
                 {
                     "type": "header",
                     "text": {
                         "type": "plain_text",
-                        "text": "Weekly Flaky Test Report",
+                        "text": "Weekly Flaky Task Report",
                     },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "No flaky tests found in master merges (past 7 days).",
+                        "text": "No flaky tasks found in master merges (past 7 days).",
                     },
                 },
             ]
@@ -375,14 +176,14 @@ def format_slack_message(flaky_tests: list[FlakyTest]) -> dict:
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": "Weekly Flaky Test Report",
+                "text": "Weekly Flaky Task Report",
             },
         },
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Top 5 flaky tests in master merges (past 7 days):",
+                "text": "Top 5 flaky tasks in master merges (past 7 days):",
             },
         },
         {
@@ -390,36 +191,21 @@ def format_slack_message(flaky_tests: list[FlakyTest]) -> dict:
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": "_Cross-run flakiness: tests that both passed and failed across different commits. This is a 7-day snapshot—some tests may have been fixed since._",
+                    "text": "_Retry flakiness: % of runs that needed retries to pass. Higher = more flaky._",
                 }
             ],
         },
         {"type": "divider"},
     ]
 
-    # Group tests into sections (Slack has limits on block count)
-    max_tests_to_show = 5
-    tests_to_show = flaky_tests[:max_tests_to_show]
-
-    for test in tests_to_show:
-        test_display = format_test_name(test.name)
-        failure_pct = int(test.failure_rate * 100)
-        avg_duration_min = test.avg_duration_ms / 60000  # Convert ms to minutes
-
-        # Build variant info string
-        variant_str = ""
-        if test.failing_variants:
-            variant_str = f"\nFailing on: {', '.join(sorted(test.failing_variants))}"
-
-        # Build metadata string with duration
-        duration_str = f" · {avg_duration_min:.0f} min avg" if avg_duration_min > 0 else ""
-
+    # Show top 5 flaky tasks
+    for task in flaky_tasks[:5]:
         blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*{test.task}*\n`{test_display}`\nFailed {test.failure_count}/{test.total_runs} runs ({failure_pct}%){duration_str}{variant_str}",
+                    "text": f"*{task.task_name}*\n`{task.variant}`\nFlakiness: {task.flakiness_percent:.1f}%",
                 },
             }
         )
@@ -458,7 +244,7 @@ def send_slack_notification(message: dict) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Send weekly flaky test summary to Slack")
+    parser = argparse.ArgumentParser(description="Send weekly flaky task summary to Slack")
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -468,14 +254,21 @@ def main():
 
     try:
         headers = get_honeycomb_headers()
-        flaky_tests = get_flaky_tests(headers)
+        flaky_tasks = get_flaky_tasks(headers)
 
-        print(f"\nFound {len(flaky_tests)} flaky tests")
+        print(f"\nFound {len(flaky_tasks)} flaky tasks")
 
-        message = format_slack_message(flaky_tests)
+        # Print table for dry-run visibility
+        if flaky_tasks:
+            print("\n| Flakiness % | Variant | Task |")
+            print("|-------------|---------|------|")
+            for task in flaky_tasks[:5]:
+                print(f"| {task.flakiness_percent:.1f}% | {task.variant} | {task.task_name} |")
+
+        message = format_slack_message(flaky_tasks)
 
         if args.dry_run:
-            print("\n--- DRY RUN: Would send this message to Slack (without slack formatting) ---")
+            print("\n--- DRY RUN: Would send this message to Slack ---")
             pprint(message)
         else:
             send_slack_notification(message)

--- a/scripts/evergreen/tests/test_notify_flaky_tests.py
+++ b/scripts/evergreen/tests/test_notify_flaky_tests.py
@@ -5,61 +5,42 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scripts.evergreen.notify_flaky_tests import (
-    FlakyTest,
+    FlakyTask,
     format_slack_message,
-    format_test_name,
     get_honeycomb_headers,
 )
 
 
-def make_flaky_test(
-    name: str = "test_file.py::TestClass::test_method",
-    task: str = "e2e_task",
-    failure_count: int = 5,
-    total_runs: int = 20,
-    failure_rate: float = 0.25,
-    avg_duration_ms: float = 3600000.0,  # 60 minutes
-) -> FlakyTest:
-    """Create a FlakyTest for testing."""
-    return FlakyTest(
-        name=name,
-        task=task,
-        failure_count=failure_count,
-        total_runs=total_runs,
-        failure_rate=failure_rate,
-        avg_duration_ms=avg_duration_ms,
+def make_flaky_task(
+    task_name: str = "e2e_task",
+    variant: str = "e2e_variant",
+    flakiness_percent: float = 25.0,
+) -> FlakyTask:
+    """Create a FlakyTask for testing."""
+    return FlakyTask(
+        task_name=task_name,
+        variant=variant,
+        flakiness_percent=flakiness_percent,
     )
 
 
-class TestFormatTestName:
-    def test_short_name_unchanged(self):
-        name = "test_short.py::test_func"
-        assert format_test_name(name) == name
-
-    def test_long_name_extracts_function(self):
-        name = "very/long/path/to/test_file.py::TestVeryLongClassName::test_very_long_method_name"
-        result = format_test_name(name, max_length=40)
-        assert result == "test_very_long_method_name"
-
-
 class TestFormatSlackMessage:
-    def test_empty_list_shows_no_flaky_tests(self):
+    def test_empty_list_shows_no_flaky_tasks(self):
         message = format_slack_message([])
-        assert "No flaky tests found" in message["blocks"][1]["text"]["text"]
+        assert "No flaky tasks found" in message["blocks"][1]["text"]["text"]
 
     def test_header_present(self):
-        message = format_slack_message([make_flaky_test()])
+        message = format_slack_message([make_flaky_task()])
         assert message["blocks"][0]["type"] == "header"
-        assert "Weekly Flaky Test Report" in message["blocks"][0]["text"]["text"]
+        assert "Weekly Flaky Task Report" in message["blocks"][0]["text"]["text"]
 
     def test_shows_top_5_header(self):
-        tests = [make_flaky_test(name=f"test_{i}") for i in range(5)]
-        message = format_slack_message(tests)
+        tasks = [make_flaky_task(task_name=f"task_{i}") for i in range(5)]
+        message = format_slack_message(tasks)
         assert "Top 5" in message["blocks"][1]["text"]["text"]
 
     def test_shows_task_name(self):
-        message = format_slack_message([make_flaky_test(task="my_e2e_task")])
-        # Find the section block with the task name
+        message = format_slack_message([make_flaky_task(task_name="my_e2e_task")])
         found = False
         for block in message["blocks"]:
             if block.get("type") == "section":
@@ -69,41 +50,39 @@ class TestFormatSlackMessage:
                     break
         assert found
 
-    def test_shows_failure_rate(self):
-        message = format_slack_message([make_flaky_test(failure_count=5, total_runs=20)])
-        # Should show "5/20 runs (25%)"
+    def test_shows_variant(self):
+        message = format_slack_message([make_flaky_task(variant="my_variant")])
         found = False
         for block in message["blocks"]:
             if block.get("type") == "section":
                 text = block.get("text", {}).get("text", "")
-                if "5/20" in text and "25%" in text:
+                if "my_variant" in text:
                     found = True
                     break
         assert found
 
-    def test_shows_duration(self):
-        # 60 minutes = 3600000 ms
-        message = format_slack_message([make_flaky_test(avg_duration_ms=3600000)])
+    def test_shows_flakiness_percent(self):
+        message = format_slack_message([make_flaky_task(flakiness_percent=33.3)])
         found = False
         for block in message["blocks"]:
             if block.get("type") == "section":
                 text = block.get("text", {}).get("text", "")
-                if "60 min" in text:
+                if "33.3%" in text:
                     found = True
                     break
         assert found
 
     def test_shows_only_top_5(self):
-        tests = [make_flaky_test(name=f"test_{i}") for i in range(20)]
-        message = format_slack_message(tests)
-        # Count test sections (exclude header, summary, context, dividers, honeycomb link)
-        test_sections = [
-            b for b in message["blocks"] if b.get("type") == "section" and "test_" in b.get("text", {}).get("text", "")
+        tasks = [make_flaky_task(task_name=f"task_{i}") for i in range(20)]
+        message = format_slack_message(tasks)
+        # Count task sections (exclude header, summary, context, dividers, honeycomb link)
+        task_sections = [
+            b for b in message["blocks"] if b.get("type") == "section" and "task_" in b.get("text", {}).get("text", "")
         ]
-        assert len(test_sections) == 5
+        assert len(task_sections) == 5
 
     def test_includes_honeycomb_link(self):
-        message = format_slack_message([make_flaky_test()])
+        message = format_slack_message([make_flaky_task()])
         found = False
         for block in message["blocks"]:
             if block.get("type") == "context":
@@ -127,59 +106,12 @@ class TestGetHoneycombHeaders:
         assert headers["Content-Type"] == "application/json"
 
 
-class TestFlakyTestDataclass:
+class TestFlakyTaskDataclass:
     def test_creation(self):
-        test = make_flaky_test()
-        assert test.name == "test_file.py::TestClass::test_method"
-        assert test.task == "e2e_task"
-        assert test.failure_count == 5
-        assert test.total_runs == 20
-        assert test.failure_rate == 0.25
-        assert test.avg_duration_ms == 3600000.0
-
-
-class TestHoneycombQueries:
-    @patch("scripts.evergreen.notify_flaky_tests.create_and_run_query")
-    def test_get_task_avg_duration_minutes_handles_error(self, mock_query, monkeypatch):
-        from requests.exceptions import RequestException
-
-        from scripts.evergreen.notify_flaky_tests import get_task_avg_duration_minutes
-
-        mock_query.side_effect = RequestException("API error")
-        monkeypatch.setenv("HONEYCOMB_API_KEY", "test")
-
-        result = get_task_avg_duration_minutes({"X-Honeycomb-Team": "test"}, ["task1"])
-        assert result == {}
-
-    @patch("scripts.evergreen.notify_flaky_tests.create_and_run_query")
-    def test_get_task_avg_duration_minutes_calculates_correctly(self, mock_query):
-        from scripts.evergreen.notify_flaky_tests import get_task_avg_duration_minutes
-
-        # Mock response: task with 120000ms total over 2 executions = 60000ms avg = 1 minute
-        mock_query.return_value = {
-            "data": {
-                "results": [
-                    {
-                        "data": {
-                            "evergreen.task.name": "test_task",
-                            "SUM(duration_ms)": 120000,
-                            "COUNT_DISTINCT(evergreen.task.id)": 2,
-                        }
-                    }
-                ]
-            }
-        }
-
-        result = get_task_avg_duration_minutes({"X-Honeycomb-Team": "test"}, ["test_task"])
-        assert result == {"test_task": 1.0}  # 1 minute
-
-    @patch("scripts.evergreen.notify_flaky_tests.create_and_run_query")
-    def test_get_task_avg_duration_minutes_empty_for_no_tasks(self, mock_query):
-        from scripts.evergreen.notify_flaky_tests import get_task_avg_duration_minutes
-
-        result = get_task_avg_duration_minutes({"X-Honeycomb-Team": "test"}, [])
-        assert result == {}
-        mock_query.assert_not_called()
+        task = make_flaky_task()
+        assert task.task_name == "e2e_task"
+        assert task.variant == "e2e_variant"
+        assert task.flakiness_percent == 25.0
 
 
 class TestSlackNotification:

--- a/scripts/evergreen/tests/test_notify_flaky_tests.py
+++ b/scripts/evergreen/tests/test_notify_flaky_tests.py
@@ -4,11 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.evergreen.notify_flaky_tests import (
-    FlakyTask,
-    format_slack_message,
-    get_honeycomb_headers,
-)
+from scripts.evergreen.notify_flaky_tests import FlakyTask, format_slack_message, get_honeycomb_headers
 
 
 def make_flaky_task(


### PR DESCRIPTION
# Summary

The flaky test notification script was producing inaccurate results by using a cross-run pass/fail comparison approach. 

This PR replaces that approach with Honeycomb's `mck.retry_flakiness_percent` metric from the `evergreen-agent` dataset, which measures **true flakiness**: the same code passing on retry after an initial failure. This is the same metric used by the existing Honeycomb board.

**Why this approach is better:**
- Measures genuine flakiness (same commit, different outcome)
- Single query instead of 4+ queries
- Full coverage including OpenShift variants
- Aligns with the existing Honeycomb board query
- Reduces script from ~400 lines to ~200 lines

**Trade-off:** Loses per-test granularity (now reports at task level), but the previous per-test data was noisy and incomplete anyway.

## Proof of Work

Dry run output matches the Honeycomb board:
```
| Flakiness % | Variant | Task |
|-------------|---------|------|
| 40.0% | e2e_mdb_openshift_search_ubi_cloudqa | e2e_search_sharded_openshift_external |
| 25.0% | e2e_mdb_openshift_ubi_cloudqa | e2e_sharded_cluster_pv |
| 20.8% | e2e_static_multi_cluster_kind | e2e_multi_cluster_replica_set_deletion |
| 19.5% | e2e_mdb_openshift_ubi_cloudqa | e2e_replica_set_pv |
| 16.7% | e2e_mdb_kind_ubi_cloudqa | e2e_disable_tls_and_scale |
```

https://spruce.corp.mongodb.com/version/69e749859d4cf20007401082/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC


## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - Marking skip-changelog as this is an internal tooling change