### PR TITLE
CLOUDP-398902: Reduce mongot CPU request in e2e_search_sharded_openshift_external

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
@@ -219,8 +219,15 @@ def mdbs(namespace: str, mdb: MongoDB, helper: SearchDeploymentHelper) -> MongoD
     # mongod connects via Route hostnames instead.
     if _route_hostnames:
         resource["spec"]["loadBalancer"]["managed"]["externalHostname"] = derive_lb_endpoint_template(_route_hostnames)
+    # We run on a shared OpenShift cluster with only 2 schedulable workers (the other nodes are
+    # tainted for masters/infra), and this test starts 4 mongot pods.
+    # The operator default of 2 CPU per pod would ask for 8 CPU total, which doesn't fit, and the pods stay Pending.
+    # Real mongot CPU usage is well under 1 CPU, so we just ask for less. Other search tests run on Kind where
+    # scheduling isn't tight, so they keep the default.
+    # Memory stays at 2 Gi because mongot's JVM heap size (-Xmx) is derived from it in
+    # search_construction.go (jvmFlags), lowering it would shrink the heap.
     resource["spec"]["resourceRequirements"] = {
-        "requests": {"cpu": "1", "memory": "2Gi"},
+        "requests": {"cpu": "250m", "memory": "2Gi"},
     }
     return resource
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
@@ -224,8 +224,6 @@ def mdbs(namespace: str, mdb: MongoDB, helper: SearchDeploymentHelper) -> MongoD
     # The operator default of 2 CPU per pod would ask for 8 CPU total, which doesn't fit, and the pods stay Pending.
     # Real mongot CPU usage is well under 1 CPU, so we just ask for less. Other search tests run on Kind where
     # scheduling isn't tight, so they keep the default.
-    # Memory stays at 2 Gi because mongot's JVM heap size (-Xmx) is derived from it in
-    # search_construction.go (jvmFlags), lowering it would shrink the heap.
     resource["spec"]["resourceRequirements"] = {
         "requests": {"cpu": "250m", "memory": "2Gi"},
     }

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
@@ -219,11 +219,10 @@ def mdbs(namespace: str, mdb: MongoDB, helper: SearchDeploymentHelper) -> MongoD
     # mongod connects via Route hostnames instead.
     if _route_hostnames:
         resource["spec"]["loadBalancer"]["managed"]["externalHostname"] = derive_lb_endpoint_template(_route_hostnames)
-    # We run on a shared OpenShift cluster with only 2 schedulable workers (the other nodes are
-    # tainted for masters/infra), and this test starts 4 mongot pods.
-    # The operator default of 2 CPU per pod would ask for 8 CPU total, which doesn't fit, and the pods stay Pending.
-    # Real mongot CPU usage is well under 1 CPU, so we just ask for less. Other search tests run on Kind where
-    # scheduling isn't tight, so they keep the default.
+    # Shared OpenShift cluster: only 2 schedulable workers (other nodes are tainted master/infra), and this
+    # test runs 4 mongot pods. CPU requests must stay low enough that 4 pods fit alongside other concurrent
+    # tasks, otherwise pods go Pending with FailedScheduling. Memory drives mongot's JVM heap: -Xmx is set
+    # to half the memory request in search_construction.go (jvmFlags), so lowering memory shrinks the heap.
     resource["spec"]["resourceRequirements"] = {
         "requests": {"cpu": "250m", "memory": "2Gi"},
     }


### PR DESCRIPTION
# Summary

`e2e_search_sharded_openshift_external` has been failing most of the time on master since it was added. The test runs 4 mongot pods and reserves 1 CPU each, so it asks for 4 CPU. The shared OpenShift CloudQA cluster only has 2 schedulable workers (the other nodes are tainted master/infra), and with other tasks running concurrently there isn't enough room, so pods stay `Pending` with `FailedScheduling: Insufficient cpu`.

Observed mongot CPU usage during passing runs is well under 1 CPU per pod, so the reservation was much larger than the real demand. Dropping it to 250m leaves plenty of headroom for the JVM while freeing 3 CPU of phantom reservation across the cluster. Memory stays at 2 Gi because `search_construction.go` derives mongot's `-Xmx` from it.

## Proof of Work

The test was failing 100% of the time so a passing run won't prove anything. I'll monitor it this week.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
