### PR TITLE
fix: honor klog -stderrthreshold even when -logtostderr is true

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,11 @@ func run() error {
 	operator.OmUpdateChannel = make(chan event.GenericEvent)
 
 	klog.InitFlags(nil)
+	// Opt into the new klog behavior so that -stderrthreshold is honored even
+	// when -logtostderr=true (the default).
+	// Ref: kubernetes/klog#212, kubernetes/klog#432
+	flag.Set("legacy_stderr_threshold_behavior", "false") //nolint:errcheck
+	flag.Set("stderrthreshold", "INFO")                   //nolint:errcheck
 	initializeEnvironment()
 
 	imageUrls := images.LoadImageUrlsFromEnv()


### PR DESCRIPTION
## What changed

klog v2 defaults `-logtostderr` to `true`, which silently ignores `-stderrthreshold` — all log levels go to stderr unconditionally. This has been an [open issue since 2020](https://github.com/kubernetes/klog/issues/212).

klog **v2.140.0** introduced a fix behind an opt-in flag (`legacy_stderr_threshold_behavior`). This PR enables the fix in `main.go` so that `-stderrthreshold` is honored, while preserving the current default behavior (`stderrthreshold=INFO` means all logs still go to stderr unless the user explicitly overrides it on the command line).

### Why this matters

In production Kubernetes clusters, log-aggregation systems (Fluentd, Fluent Bit, Loki, Datadog, …) typically ingest from container stderr. When every severity goes there indiscriminately:

- **Log storage costs increase** — INFO noise stored alongside real errors
- **Alerting becomes unreliable** — stderr contains everything, so severity-based alerts don't work
- **Signal-to-noise ratio degrades** — finding real errors in a stream of INFO is a needle-in-a-haystack problem

The `-stderrthreshold` flag exists precisely to solve this, but it has never worked under the default klog v2 configuration — until now.

### What the fix does

```go
klog.InitFlags(nil)
flag.Set("legacy_stderr_threshold_behavior", "false") // enable the klog fix
flag.Set("stderrthreshold", "INFO")                   // preserve current default
```

- **Placement**: after `klog.InitFlags(nil)` (registers the flags) but before the flags are used
- **`stderrthreshold=INFO`**: keeps current behavior — all logs still go to stderr by default
- **User override**: users can now pass `-stderrthreshold=WARNING` or `-stderrthreshold=ERROR` and it will actually take effect

### References

- Upstream issue: https://github.com/kubernetes/klog/issues/212
- Upstream fix: https://github.com/kubernetes/klog/pull/432