### PR TITLE
Release MCK 1.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ scripts/code_snippets/tests/outputs/*
 
 .claude
 
+mck-ci

--- a/cmd/mck-ci/main.go
+++ b/cmd/mck-ci/main.go
@@ -1,0 +1,24 @@
+// mck-ci is the MongoDB Controllers for Kubernetes (MCK) CI/release helper.
+//
+// This is a thin entry point: it sets up signal handling and delegates to
+// internal/ci/cli. All runnable logic lives under internal/ci so it can be
+// imported from tests and so it never ends up linked into the operator binary.
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/mongodb/mongodb-kubernetes/internal/ci/cli"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := cli.NewRoot().ExecuteContext(ctx); err != nil {
+		os.Exit(1)
+	}
+}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.8.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -72,16 +72,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -118,12 +118,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.8.0
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.8.1
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.7.0
+  replaces: mongodb-kubernetes.v1.8.0
   version: 0.0.0

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.8.0
+version: 1.8.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.8.0
+  version: 1.8.1
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.8.0
+  version: 1.8.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -131,11 +131,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.8.0
+  version: 1.8.1
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.8.0
+  version: 1.8.1
 
 ## Ops Manager
 opsManager:
@@ -143,7 +143,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.8.0
+  version: 1.8.1
 
 agent:
   name: mongodb-agent

--- a/internal/ci/cli/open_release_pr.go
+++ b/internal/ci/cli/open_release_pr.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mongodb/mongodb-kubernetes/internal/ci/release"
+	"github.com/mongodb/mongodb-kubernetes/internal/ci/runner"
+)
+
+func newOpenReleasePRCmd() *cobra.Command {
+	var (
+		draft  bool
+		dryRun bool
+	)
+	cmd := &cobra.Command{
+		Use:   "open-release-pr <version>",
+		Short: "Open a release PR for the given MCK version",
+		Long: `Validates the current branch + worktree, regenerates release artifacts via
+'make precommit-full', commits any changes, pushes the branch, and opens a PR
+against master.
+
+Intended to be run after release.json has been bumped and copy_release_dockerfiles
+has been run on a feature branch.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOpenReleasePR(cmd.Context(), args[0], draft, dryRun)
+		},
+	}
+	cmd.Flags().BoolVar(&draft, "draft", false, "open the PR as draft")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print actions without executing them")
+	return cmd
+}
+
+func runOpenReleasePR(ctx context.Context, version string, draft, dryRun bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+	r := runner.New(dryRun, cwd)
+
+	branch, err := r.Capture(ctx, "git", "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return fmt.Errorf("get current branch: %w", err)
+	}
+
+	clean, err := isWorktreeClean(ctx, r)
+	if err != nil {
+		return fmt.Errorf("check worktree: %w", err)
+	}
+
+	releaseVer, err := release.ReadOperatorVersion("release.json")
+	if err != nil {
+		return err
+	}
+
+	if err := (release.PreflightInputs{
+		Branch:         branch,
+		WorktreeClean:  clean,
+		ReleaseJSONVer: releaseVer,
+		WantVersion:    version,
+	}).Validate(); err != nil {
+		return err
+	}
+
+	if err := r.Exec(ctx, "make", "precommit-full"); err != nil {
+		return fmt.Errorf("make precommit-full: %w", err)
+	}
+
+	if err := commitRegeneratedArtifacts(ctx, r, version, dryRun); err != nil {
+		return err
+	}
+
+	if err := r.Exec(ctx, "git", "push", "-u", "origin", branch); err != nil {
+		return fmt.Errorf("git push: %w", err)
+	}
+
+	body, err := release.RenderPRBody(version)
+	if err != nil {
+		return err
+	}
+	ghArgs := []string{
+		"pr", "create",
+		"--base", "master",
+		"--head", branch,
+		"--title", release.PRTitle(version),
+		"--body", body,
+	}
+	if draft {
+		ghArgs = append(ghArgs, "--draft")
+	}
+	if err := r.Exec(ctx, "gh", ghArgs...); err != nil {
+		return fmt.Errorf("gh pr create: %w", err)
+	}
+	return nil
+}
+
+func commitRegeneratedArtifacts(ctx context.Context, r *runner.Runner, version string, dryRun bool) error {
+	if dryRun {
+		fmt.Fprintln(r.LogOut, "[dry-run] would `git add -A` and commit if precommit-full produced changes")
+		return nil
+	}
+	clean, err := isWorktreeClean(ctx, r)
+	if err != nil {
+		return fmt.Errorf("check worktree post-precommit: %w", err)
+	}
+	if clean {
+		fmt.Fprintln(r.LogOut, "→ no files changed by precommit-full; skipping commit")
+		return nil
+	}
+	if err := r.Exec(ctx, "git", "add", "-A"); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	msg := fmt.Sprintf("Regenerate release artifacts for %s", version)
+	if err := r.Exec(ctx, "git", "commit", "-m", msg); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+	return nil
+}
+
+// isWorktreeClean returns true if both the working tree and the index are
+// clean. `git diff --quiet` exits 0 when clean, 1 when dirty; any other
+// non-zero is a real error.
+func isWorktreeClean(ctx context.Context, r *runner.Runner) (bool, error) {
+	for _, args := range [][]string{
+		{"diff", "--quiet"},
+		{"diff", "--cached", "--quiet"},
+	} {
+		err := r.CheckExitCode(ctx, "git", args...)
+		switch runner.ExitCode(err) {
+		case 0:
+			continue
+		case 1:
+			return false, nil
+		default:
+			return false, err
+		}
+	}
+	return true, nil
+}

--- a/internal/ci/cli/root.go
+++ b/internal/ci/cli/root.go
@@ -15,14 +15,19 @@ import (
 // without shared global cobra state.
 func NewRoot() *cobra.Command {
 	root := &cobra.Command{
-		Use:           "mck-ci",
-		Short:         "MCK CI and release automation helper",
-		Long:          "mck-ci centralizes CI automation logic, including release-automation logic so it can be invoked identically from local shells, GitHub Actions, and Evergreen.",
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:          "mck-ci",
+		Short:        "MCK CI and release automation helper",
+		Long:         "mck-ci centralizes CI automation logic, including release-automation logic so it can be invoked identically from local shells, GitHub Actions, and Evergreen.",
+		SilenceUsage: true,
+		// No subcommand selected: print help and succeed instead of returning
+		// flag.ErrHelp (which would otherwise propagate as exit 1 from main).
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
 	}
 
 	root.AddCommand(newVersionCmd())
+	root.AddCommand(newOpenReleasePRCmd())
 
 	return root
 }

--- a/internal/ci/cli/root.go
+++ b/internal/ci/cli/root.go
@@ -1,0 +1,28 @@
+// Package cli builds the cobra command tree for mck-ci.
+//
+// NewRoot is the single entry point: cmd/mck-ci/main.go calls it, and tests
+// instantiate fresh root commands per case. Subcommands register themselves
+// here in NewRoot; their implementations live in sibling files (one file per
+// subcommand) so they stay independently testable.
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewRoot constructs a fresh root command with all subcommands registered.
+// It returns a new instance on every call so tests can run in parallel
+// without shared global cobra state.
+func NewRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "mck-ci",
+		Short:         "MCK CI and release automation helper",
+		Long:          "mck-ci centralizes CI automation logic, including release-automation logic so it can be invoked identically from local shells, GitHub Actions, and Evergreen.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	root.AddCommand(newVersionCmd())
+
+	return root
+}

--- a/internal/ci/cli/root_test.go
+++ b/internal/ci/cli/root_test.go
@@ -9,7 +9,10 @@ import (
 func TestNewRoot_RegistersExpectedSubcommands(t *testing.T) {
 	root := NewRoot()
 
-	want := map[string]bool{"version": false}
+	want := map[string]bool{
+		"version":         false,
+		"open-release-pr": false,
+	}
 	for _, sub := range root.Commands() {
 		if _, ok := want[sub.Name()]; ok {
 			want[sub.Name()] = true

--- a/internal/ci/cli/root_test.go
+++ b/internal/ci/cli/root_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewRoot_RegistersExpectedSubcommands(t *testing.T) {
+	root := NewRoot()
+
+	want := map[string]bool{"version": false}
+	for _, sub := range root.Commands() {
+		if _, ok := want[sub.Name()]; ok {
+			want[sub.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("subcommand %q not registered on root", name)
+		}
+	}
+}
+
+func TestNewRoot_NoArgsPrintsHelp(t *testing.T) {
+	root := NewRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("executing root with no args returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "mck-ci") {
+		t.Errorf("expected help output to mention mck-ci, got: %q", out.String())
+	}
+}
+
+func TestVersionCmd_PrintsBuildInfo(t *testing.T) {
+	root := NewRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"version"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("version subcommand returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "mck-ci") {
+		t.Errorf("expected version output to mention mck-ci, got: %q", out.String())
+	}
+}

--- a/internal/ci/cli/version.go
+++ b/internal/ci/cli/version.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print mck-ci build information",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			info, ok := debug.ReadBuildInfo()
+			if !ok {
+				_, err := fmt.Fprintln(cmd.OutOrStdout(), "mck-ci: build info unavailable")
+				return err
+			}
+			rev, modified := vcsInfo(info)
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "mck-ci\n  go:       %s\n  module:   %s\n  revision: %s\n  modified: %t\n",
+				info.GoVersion, info.Main.Path, rev, modified)
+			return err
+		},
+	}
+}
+
+// vcsInfo extracts the VCS revision and dirty flag from build settings.
+// Returns ("", false) if the binary was built without VCS metadata
+// (e.g. `go run` from a non-git directory or `-buildvcs=false`).
+func vcsInfo(info *debug.BuildInfo) (revision string, modified bool) {
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	return revision, modified
+}

--- a/internal/ci/release/pr_body.go
+++ b/internal/ci/release/pr_body.go
@@ -1,0 +1,27 @@
+package release
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed pr_body.tpl.md
+var prBodyRaw string
+
+var prBodyTpl = template.Must(template.New("pr-body").Parse(prBodyRaw))
+
+// PRTitle returns the canonical title for an MCK release PR.
+func PRTitle(version string) string {
+	return fmt.Sprintf("Release MCK %s", version)
+}
+
+// RenderPRBody fills the embedded markdown template with the given version.
+func RenderPRBody(version string) (string, error) {
+	var buf bytes.Buffer
+	if err := prBodyTpl.Execute(&buf, struct{ Version string }{Version: version}); err != nil {
+		return "", fmt.Errorf("render PR body: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/internal/ci/release/pr_body.tpl.md
+++ b/internal/ci/release/pr_body.tpl.md
@@ -1,0 +1,17 @@
+## Summary
+
+Release PR for MCK {{.Version}}.
+
+Opened via `mck-ci open-release-pr`.
+
+## Included changes
+
+- Bump `mongodbOperator` to {{.Version}}
+- Copy release Dockerfiles to `public/dockerfiles/*/{{.Version}}/ubi/`
+- Regenerate release artifacts (Helm chart, manifests, CSV, licenses, RBAC)
+
+## Checklist
+
+- [ ] CI green
+- [ ] `release.json` `mongodbOperator` = {{.Version}}
+- [ ] Expected Dockerfiles present under `public/dockerfiles/*/{{.Version}}/`

--- a/internal/ci/release/pr_body_test.go
+++ b/internal/ci/release/pr_body_test.go
@@ -1,0 +1,41 @@
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPRTitle(t *testing.T) {
+	got := PRTitle("1.8.0")
+	want := "Release MCK 1.8.0"
+	if got != want {
+		t.Errorf("PRTitle: got %q, want %q", got, want)
+	}
+}
+
+func TestRenderPRBody_ContainsKeyMarkers(t *testing.T) {
+	body, err := RenderPRBody("1.8.0")
+	if err != nil {
+		t.Fatalf("RenderPRBody: %v", err)
+	}
+	for _, want := range []string{
+		"Release PR for MCK 1.8.0.",
+		"Bump `mongodbOperator` to 1.8.0",
+		"public/dockerfiles/*/1.8.0/ubi/",
+		"`release.json` `mongodbOperator` = 1.8.0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered body missing %q\n--body--\n%s", want, body)
+		}
+	}
+}
+
+func TestRenderPRBody_NoUnrenderedPlaceholders(t *testing.T) {
+	body, err := RenderPRBody("1.8.0")
+	if err != nil {
+		t.Fatalf("RenderPRBody: %v", err)
+	}
+	if strings.Contains(body, "{{") || strings.Contains(body, "}}") {
+		t.Errorf("body contains unrendered template markers:\n%s", body)
+	}
+}

--- a/internal/ci/release/precheck.go
+++ b/internal/ci/release/precheck.go
@@ -1,0 +1,47 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// protectedReleaseBranchPattern matches branches in the GitHub-protected
+// `release-*` namespace, which cannot be pushed to or merged from this tool.
+var protectedReleaseBranchPattern = regexp.MustCompile(`^release-`)
+
+// PreflightInputs are the conditions a release-PR command checks before
+// executing any side effects. They're collected by the orchestrator (current
+// branch from git, worktree state from git, version from release.json) and
+// validated here as a pure function.
+type PreflightInputs struct {
+	Branch         string
+	WorktreeClean  bool
+	ReleaseJSONVer string
+	WantVersion    string
+}
+
+// Validate returns the first violation encountered, or nil if all checks pass.
+// Errors are user-facing: they describe what went wrong and how to recover.
+func (p PreflightInputs) Validate() error {
+	if p.Branch == "" {
+		return errors.New("could not determine current branch")
+	}
+	if p.Branch == "master" {
+		return errors.New("cannot open a release PR from master; create a feature branch first")
+	}
+	if protectedReleaseBranchPattern.MatchString(p.Branch) {
+		return fmt.Errorf("branch %q matches protected pattern 'release-*'; rename the branch before re-running", p.Branch)
+	}
+	if !p.WorktreeClean {
+		return errors.New("working tree has uncommitted changes; commit or stash before running")
+	}
+	if p.WantVersion == "" {
+		return errors.New("target version must not be empty")
+	}
+	if p.ReleaseJSONVer != p.WantVersion {
+		return fmt.Errorf("release.json mongodbOperator is %q, expected %q; bump release.json + copy dockerfiles first, or pass the actual version",
+			p.ReleaseJSONVer, p.WantVersion)
+	}
+	return nil
+}

--- a/internal/ci/release/precheck_test.go
+++ b/internal/ci/release/precheck_test.go
@@ -1,0 +1,84 @@
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreflightInputs_Validate(t *testing.T) {
+	happy := PreflightInputs{
+		Branch:         "release/mck-1.8.0",
+		WorktreeClean:  true,
+		ReleaseJSONVer: "1.8.0",
+		WantVersion:    "1.8.0",
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*PreflightInputs)
+		wantErr string
+	}{
+		{
+			name:    "happy path",
+			mutate:  func(*PreflightInputs) {},
+			wantErr: "",
+		},
+		{
+			name:    "empty branch",
+			mutate:  func(p *PreflightInputs) { p.Branch = "" },
+			wantErr: "could not determine current branch",
+		},
+		{
+			name:    "branch is master",
+			mutate:  func(p *PreflightInputs) { p.Branch = "master" },
+			wantErr: "cannot open a release PR from master",
+		},
+		{
+			name:    "branch matches protected pattern",
+			mutate:  func(p *PreflightInputs) { p.Branch = "release-1.8.0" },
+			wantErr: "protected pattern 'release-*'",
+		},
+		{
+			name:    "release-foo also protected",
+			mutate:  func(p *PreflightInputs) { p.Branch = "release-foo" },
+			wantErr: "protected pattern",
+		},
+		{
+			name:    "worktree dirty",
+			mutate:  func(p *PreflightInputs) { p.WorktreeClean = false },
+			wantErr: "uncommitted changes",
+		},
+		{
+			name:    "empty want version",
+			mutate:  func(p *PreflightInputs) { p.WantVersion = "" },
+			wantErr: "target version must not be empty",
+		},
+		{
+			name: "release.json mismatch",
+			mutate: func(p *PreflightInputs) {
+				p.ReleaseJSONVer = "1.7.0"
+			},
+			wantErr: `release.json mongodbOperator is "1.7.0", expected "1.8.0"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := happy
+			tt.mutate(&p)
+			err := p.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/internal/ci/release/release_json.go
+++ b/internal/ci/release/release_json.go
@@ -1,0 +1,31 @@
+// Package release contains pure (non-I/O-orchestrating) logic for MCK
+// release automation: parsing release.json, validating release preconditions,
+// rendering PR bodies. Side-effecting code (git, gh, make) lives in the cli
+// orchestrators that consume this package.
+package release
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ReadOperatorVersion reads release.json at path and returns the
+// `mongodbOperator` field. Returns a typed error if the file is missing,
+// malformed, or the field is absent or empty.
+func ReadOperatorVersion(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc struct {
+		MongoDBOperator string `json:"mongodbOperator"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	if doc.MongoDBOperator == "" {
+		return "", fmt.Errorf("%s: mongodbOperator field is missing or empty", path)
+	}
+	return doc.MongoDBOperator, nil
+}

--- a/internal/ci/release/release_json_test.go
+++ b/internal/ci/release/release_json_test.go
@@ -1,0 +1,79 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTmp(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "release.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	return path
+}
+
+func TestReadOperatorVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "happy path",
+			content: `{"mongodbOperator": "1.8.0", "other": "value"}`,
+			want:    "1.8.0",
+		},
+		{
+			name:    "missing field",
+			content: `{"other": "value"}`,
+			wantErr: "mongodbOperator field is missing",
+		},
+		{
+			name:    "empty field",
+			content: `{"mongodbOperator": ""}`,
+			wantErr: "mongodbOperator field is missing",
+		},
+		{
+			name:    "malformed json",
+			content: `{not valid json`,
+			wantErr: "parse",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTmp(t, tt.content)
+			got, err := ReadOperatorVersion(path)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadOperatorVersion_FileMissing(t *testing.T) {
+	_, err := ReadOperatorVersion(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "read") {
+		t.Errorf("expected error mentioning 'read', got %v", err)
+	}
+}

--- a/internal/ci/runner/runner.go
+++ b/internal/ci/runner/runner.go
@@ -1,0 +1,88 @@
+// Package runner wraps os/exec with dry-run support and uniform logging
+// of side-effecting commands. Read-only commands (Capture, CheckExitCode)
+// always run, since their results drive control flow.
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Runner struct {
+	DryRun  bool
+	WorkDir string
+	Stdout  io.Writer
+	Stderr  io.Writer
+	LogOut  io.Writer
+}
+
+func New(dryRun bool, workDir string) *Runner {
+	return &Runner{
+		DryRun:  dryRun,
+		WorkDir: workDir,
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+		LogOut:  os.Stderr,
+	}
+}
+
+// Exec runs a command for its side effects, honoring DryRun.
+func (r *Runner) Exec(ctx context.Context, name string, args ...string) error {
+	if r.DryRun {
+		fmt.Fprintf(r.LogOut, "[dry-run] would run: %s\n", format(name, args))
+		return nil
+	}
+	fmt.Fprintf(r.LogOut, "→ %s\n", format(name, args))
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = r.WorkDir
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
+// Capture runs a command and returns trimmed stdout. Always runs, even
+// in dry-run mode, since callers use the output for control-flow decisions.
+func (r *Runner) Capture(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = r.WorkDir
+	cmd.Stderr = r.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\n"), nil
+}
+
+// CheckExitCode runs a command for its exit status only.
+// Returns the *exec.ExitError on non-zero exit; nil on success.
+// Always runs, regardless of DryRun.
+func (r *Runner) CheckExitCode(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = r.WorkDir
+	return cmd.Run()
+}
+
+// ExitCode returns the exit code from an error returned by CheckExitCode
+// (or any *exec.ExitError). Returns -1 if the error is not an *exec.ExitError.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func format(name string, args []string) string {
+	if len(args) == 0 {
+		return name
+	}
+	return name + " " + strings.Join(args, " ")
+}

--- a/internal/ci/runner/runner_test.go
+++ b/internal/ci/runner/runner_test.go
@@ -1,0 +1,67 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestExec_DryRunSkipsAndLogs(t *testing.T) {
+	var log bytes.Buffer
+	r := &Runner{DryRun: true, LogOut: &log, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+
+	if err := r.Exec(context.Background(), "false"); err != nil {
+		t.Fatalf("dry-run exec should not fail even on a normally-failing command: %v", err)
+	}
+	if !strings.Contains(log.String(), "[dry-run] would run: false") {
+		t.Errorf("expected dry-run log message, got %q", log.String())
+	}
+}
+
+func TestExec_RealRunPropagatesError(t *testing.T) {
+	r := &Runner{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, LogOut: &bytes.Buffer{}}
+	err := r.Exec(context.Background(), "false")
+	if err == nil {
+		t.Fatal("expected error from `false`, got nil")
+	}
+	if ExitCode(err) != 1 {
+		t.Errorf("expected exit code 1, got %d", ExitCode(err))
+	}
+}
+
+func TestCapture_TrimsTrailingNewline(t *testing.T) {
+	r := &Runner{Stderr: &bytes.Buffer{}}
+	out, err := r.Capture(context.Background(), "echo", "hello")
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if out != "hello" {
+		t.Errorf("expected %q, got %q", "hello", out)
+	}
+}
+
+func TestCapture_IgnoresDryRun(t *testing.T) {
+	r := &Runner{DryRun: true, Stderr: &bytes.Buffer{}}
+	out, err := r.Capture(context.Background(), "echo", "ok")
+	if err != nil {
+		t.Fatalf("Capture in dry-run should still run: %v", err)
+	}
+	if out != "ok" {
+		t.Errorf("expected %q, got %q", "ok", out)
+	}
+}
+
+func TestCheckExitCode(t *testing.T) {
+	r := &Runner{}
+	if err := r.CheckExitCode(context.Background(), "true"); err != nil {
+		t.Errorf("expected nil for `true`, got %v", err)
+	}
+	err := r.CheckExitCode(context.Background(), "false")
+	if err == nil {
+		t.Fatal("expected error for `false`, got nil")
+	}
+	if ExitCode(err) != 1 {
+		t.Errorf("expected exit code 1, got %d", ExitCode(err))
+	}
+}

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -332,7 +332,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.8.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -383,16 +383,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -329,7 +329,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.8.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -379,16 +379,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -423,12 +423,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -332,7 +332,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.8.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -380,16 +380,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: DATABASE_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.0"
+              value: "1.8.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/release.json
+++ b/release.json
@@ -3,9 +3,9 @@
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.15.0.tgz"
   },
   "mongodbOperator": "1.8.1",
-  "initDatabaseVersion": "1.8.0",
-  "initOpsManagerVersion": "1.8.0",
-  "databaseImageVersion": "1.8.0",
+  "initDatabaseVersion": "1.8.1",
+  "initOpsManagerVersion": "1.8.1",
+  "databaseImageVersion": "1.8.1",
   "agentVersion": "108.0.12.8846-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -91,7 +91,8 @@
         "1.6.0",
         "1.6.1",
         "1.7.0",
-        "1.8.0"
+        "1.8.0",
+        "1.8.1"
       ],
       "variants": [
         "ubi"
@@ -276,7 +277,8 @@
         "1.6.0",
         "1.6.1",
         "1.7.0",
-        "1.8.0"
+        "1.8.0",
+        "1.8.1"
       ],
       "variants": [
         "ubi"
@@ -295,7 +297,8 @@
         "1.6.0",
         "1.6.1",
         "1.7.0",
-        "1.8.0"
+        "1.8.0",
+        "1.8.1"
       ],
       "variants": [
         "ubi"
@@ -314,7 +317,8 @@
         "1.6.0",
         "1.6.1",
         "1.7.0",
-        "1.8.0"
+        "1.8.0",
+        "1.8.1"
       ],
       "variants": [
         "ubi"

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.15.0.tgz"
   },
-  "mongodbOperator": "1.8.0",
+  "mongodbOperator": "1.8.1",
   "initDatabaseVersion": "1.8.0",
   "initOpsManagerVersion": "1.8.0",
   "databaseImageVersion": "1.8.0",


### PR DESCRIPTION
## Summary

Release PR for MCK 1.8.1.

Opened via `mck-ci open-release-pr`.

## Included changes

- Bump `mongodbOperator` to 1.8.1
- Copy release Dockerfiles to `public/dockerfiles/*/1.8.1/ubi/`
- Regenerate release artifacts (Helm chart, manifests, CSV, licenses, RBAC)

## Checklist

- [ ] CI green
- [ ] `release.json` `mongodbOperator` = 1.8.1
- [ ] Expected Dockerfiles present under `public/dockerfiles/*/1.8.1/`
