### PR TITLE
Fix master build broken by staging publish PR

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -393,7 +393,11 @@ functions:
       type: setup
       retry_on_failure: true
       params:
-        command: "docker login quay.io -u ${quay_staging_username} -p ${quay_staging_robot_token}"
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        env:
+          QUAY_STAGING_USERNAME: ${quay_staging_username}
+          QUAY_STAGING_PASSWORD: ${quay_staging_robot_token}
+        binary: scripts/release/quay_staging_login.sh
 
   setup_cloud_qa:
     - command: shell.exec

--- a/build_info.json
+++ b/build_info.json
@@ -364,7 +364,6 @@
         "sign": true,
         "skip-if-exists": true,
         "repository": "268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager-ubi",
-        "secondary-repositories": ["quay.io/mongodb/staging/mongodb-enterprise-ops-manager-ubi"],
         "platforms": [
           "linux/amd64"
         ]

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -4,10 +4,11 @@ import os
 import subprocess
 import tempfile
 import time
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv  # ty: ignore[unresolved-import]
 
 if os.environ.get("PYTEST_OTEL_ENABLED", "true") == "false":
     # otel_plugin.py requires pytest-opentelemetry which is disabled via PYTEST_OTEL_ENABLED=false on s390x.
@@ -1631,7 +1632,7 @@ def pytest_sessionfinish(session, exitstatus):
 
                 # let's only access om if its healthy and around.
                 status_code, _ = tester.request_health(base_url)
-                if status_code == requests.status_codes.codes.OK:
+                if status_code == HTTPStatus.OK:
                     ev = tester.get_project_events().json()["results"]
                     with open(f"/tmp/diagnostics/{project_id}-events.json", "w", encoding="utf-8") as f:
                         json.dump(ev, f, ensure_ascii=False, indent=4)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
@@ -355,4 +355,4 @@ def test_telemetry_configmap(namespace: str):
             assert isinstance(payload, list), "payload should be a list"
             assert len(payload) > 0, "payload should not be empty"
         except json.JSONDecodeError:
-            pytest.fail("payload contains invalid JSON data")
+            pytest.fail("payload contains invalid JSON data")  # ty: ignore[invalid-argument-type]

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
@@ -621,4 +621,4 @@ def test_telemetry_configmap(namespace: str):
         assert payload[1]["properties"]["type"] == "OpsManager"
         assert payload[1]["properties"]["externalDomains"] == "Mixed"
     except json.JSONDecodeError:
-        pytest.fail("payload contains invalid JSON data")
+        pytest.fail("payload contains invalid JSON data")  # ty: ignore[invalid-argument-type]

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_upgrade.py
@@ -116,7 +116,9 @@ class TestOpsManagerCreation:
         om_tester.assert_test_service()
         try:
             om_tester.assert_support_page_enabled()
-            pytest.xfail("mms.helpAndSupportPage.enabled is expected to be false")
+            pytest.xfail(
+                "mms.helpAndSupportPage.enabled is expected to be false"  # ty: ignore[too-many-positional-arguments]
+            )
         except AssertionError:
             pass
 
@@ -237,7 +239,7 @@ class TestOpsManagerConfigurationChange:
         om_tester.assert_support_page_enabled()
         try:
             om_tester.assert_test_service()
-            pytest.xfail("mms.testUtil.enabled is expected to be false")
+            pytest.xfail("mms.testUtil.enabled is expected to be false")  # ty: ignore[too-many-positional-arguments]
         except AssertionError:
             pass
 

--- a/scripts/release/build/image_build_process.py
+++ b/scripts/release/build/image_build_process.py
@@ -111,6 +111,10 @@ class DockerImageBuilder(ImageBuilder):
             decoded_stderr = e.stderr.lower() if e.stderr else ""
             if any(str(error) in decoded_stderr for error in ["no such image", "image not known", "not found"]):
                 return False
+            # Quay.io returns 401 Unauthorized for non-existent manifests instead of 404,
+            # even when the registry credentials are valid. Treat that case as "not found".
+            if "quay.io" in image_tag.lower() and "401 unauthorized" in decoded_stderr:
+                return False
             raise RuntimeError(
                 f"Failed to check if image '{image_tag}' exists: {e.stderr.strip() if e.stderr else str(e)}"
             )

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -111,8 +111,8 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
     builder = get_image_builder_from_arg(image_build_info.builder)
     latest_tag = (
         image_build_info.latest_tag
-        and os.environ.get("requester", "") is "commit"
-        and os.environ.get("branch_name") is "master"
+        and os.environ.get("requester", "") == "commit"
+        and os.environ.get("branch_name") == "master"
     )
     olm_tag = image_build_info.olm_tag
     if args.registry:

--- a/scripts/release/quay_staging_login.sh
+++ b/scripts/release/quay_staging_login.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+if [[ -z "${QUAY_STAGING_USERNAME:-}" || -z "${QUAY_STAGING_PASSWORD:-}" ]]; then
+  echo "Error: QUAY_STAGING_USERNAME and QUAY_STAGING_PASSWORD must be set"
+  exit 1
+fi
+
+# IBM hosts (ppc64le, s390x) run rootful podman; configure_container_auth.sh writes
+# credentials to /root/.config/containers/auth.json via `sudo podman login`. Match
+# that here so the buildx imagetools inspect/push calls find quay.io credentials.
+if [[ -z "${CONTAINER_RUNTIME:-}" ]]; then
+  case "$(uname -m)" in
+    ppc64le|s390x) CONTAINER_RUNTIME=podman ;;
+    *) CONTAINER_RUNTIME=docker ;;
+  esac
+fi
+
+case "${CONTAINER_RUNTIME}" in
+  podman)
+    if ! command -v podman &> /dev/null; then
+      echo "Error: Podman is not available but was specified"
+      exit 1
+    fi
+    echo "${QUAY_STAGING_PASSWORD}" | sudo podman login \
+      --authfile /root/.config/containers/auth.json \
+      --username "${QUAY_STAGING_USERNAME}" \
+      --password-stdin quay.io
+    ;;
+  docker)
+    if ! command -v docker &> /dev/null; then
+      echo "Error: Docker is not available but was specified"
+      exit 1
+    fi
+    echo "${QUAY_STAGING_PASSWORD}" | docker login \
+      --username "${QUAY_STAGING_USERNAME}" \
+      --password-stdin quay.io
+    ;;
+  *)
+    echo "Error: Invalid container runtime '${CONTAINER_RUNTIME}'. Must be 'docker' or 'podman'"
+    exit 1
+    ;;
+esac

--- a/scripts/release/tests/build_info_test.py
+++ b/scripts/release/tests/build_info_test.py
@@ -315,7 +315,6 @@ def test_load_build_info_staging():
             ),
             "ops-manager": ImageInfo(
                 repository="268558157000.dkr.ecr.us-east-1.amazonaws.com/staging/mongodb-enterprise-ops-manager-ubi",
-                secondary_repositories=["quay.io/mongodb/staging/mongodb-enterprise-ops-manager-ubi"],
                 platforms=["linux/amd64"],
                 dockerfile_path="docker/mongodb-enterprise-ops-manager/Dockerfile",
                 sign=True,


### PR DESCRIPTION
## Summary

Fixes master build broken by #901:

- `scripts/release/build/image_build_process.py`: treat 401 from quay.io `imagetools inspect` as "image not found" so `skip_if_exists` falls through to building.
- `scripts/release/quay_staging_login.sh` (new) + `.evergreen-functions.yml`: use `sudo podman login` on `ppc64le`/`s390x`, plain `docker login` elsewhere — the inline `docker login` failed on IBM hosts where docker is the podman shim.
- `scripts/release/pipeline.py`: `is`→`==` for the `requester`/`branch_name` checks gating `latest_tag`.

### Disable ops-manager staging publish to quay.io

`build_info.json`: drop the `quay.io/mongodb/staging/mongodb-enterprise-ops-manager-ubi` secondary repository for the `ops-manager` image. That quay repo doesn't accept pushes from the staging robot (other staging quay repos work — repo-specific issue), and OM images aren't consumed from staging quay anyway. ECR push is unchanged. `init-ops-manager` keeps its quay.io secondary.

### Fix ty pre-commit errors

`make precommit` was failing on pre-existing `ty` (the new Python type-checker added in #897) errors unrelated to this fix. Cleaning them up so the gate is green:

- `tests/conftest.py`: import `HTTPStatus` and use `HTTPStatus.OK` instead of `requests.codes.ok` (ty can't see the dynamic `LookupDict` attributes); silence `unresolved-import` for `python-dotenv` (no stubs ship).
- `pytest.fail`/`pytest.xfail` callsites: ty's pytest stubs reject the `(str)` call signature; suppress `invalid-argument-type` / `too-many-positional-arguments` inline.

## Proof of Work

All build variants (incl. previously failing OM and IBM ones) green on staging:
https://spruce.corp.mongodb.com/version/69f0a06a3cf8b30007da17a1

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` label applied — CI/build infrastructure only
