### PR TITLE
Multi-cluster wiring foundation for MongoDBSearch (B1)

### DIFF
--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -9,13 +9,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
@@ -27,6 +29,7 @@ import (
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
+	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster/memberwatch"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
@@ -191,15 +194,52 @@ func AddMongoDBSearchController(
 
 	r := newMongoDBSearchReconciler(mgr.GetClient(), operatorSearchConfig, multicluster.ClustersMapToClientMap(memberClusterObjectsMap))
 
-	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo
-		For(&searchv1.MongoDBSearch{}).
-		Watches(&mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}).
-		Watches(&mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch}).
-		Watches(&corev1.Secret{}, &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch}).
-		Watches(&corev1.ConfigMap{}, &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch}).
-		Owns(&appsv1.StatefulSet{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{}).
-		Complete(r)
+	c, err := controller.New("mongodbsearch-controller", mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1), // nolint:forbidigo
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &searchv1.MongoDBSearch{}, &handler.EnqueueRequestForObject{})); err != nil {
+		return err
+	}
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch})); err != nil {
+		return err
+	}
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch})); err != nil {
+		return err
+	}
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.Secret{}, &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch})); err != nil {
+		return err
+	}
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.ConfigMap{}, &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch})); err != nil {
+		return err
+	}
+	ownerHandler := handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &searchv1.MongoDBSearch{}, handler.OnlyControllerOwner())
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &appsv1.StatefulSet{}, ownerHandler)); err != nil {
+		return err
+	}
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.Service{}, ownerHandler)); err != nil {
+		return err
+	}
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.Secret{}, ownerHandler)); err != nil {
+		return err
+	}
+
+	// Health-check goroutine fans out per-cluster reachability changes onto a
+	// GenericEvent channel that the controller watches. Empty memberClusterObjectsMap
+	// (single-cluster install) skips the goroutine entirely — there is nothing to watch.
+	if len(memberClusterObjectsMap) > 0 {
+		eventChannel := make(chan event.GenericEvent)
+		healthChecker := memberwatch.MemberClusterHealthChecker{Cache: make(map[string]*memberwatch.MemberHeathCheck)}
+		go healthChecker.WatchMemberClusterHealth(ctx, zap.S(), eventChannel, r.kubeClient, memberClusterObjectsMap)
+
+		if err := c.Watch(source.Channel[client.Object](eventChannel, &handler.EnqueueRequestForObject{})); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -7,8 +7,8 @@ import (
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	runtime_cluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -183,7 +183,7 @@ func AddMongoDBSearchController(
 	ctx context.Context,
 	mgr manager.Manager,
 	operatorSearchConfig searchcontroller.OperatorSearchConfig,
-	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+	memberClusterObjectsMap map[string]cluster.Cluster,
 ) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, mdbcSearchIndexBuilder); err != nil {
 		return err

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -18,6 +18,7 @@ import (
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/secrets"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
@@ -32,6 +33,12 @@ type MongoDBSearchReconciler struct {
 	kubeClient           kubernetesClient.Client
 	watch                *watch.ResourceWatcher
 	operatorSearchConfig searchcontroller.OperatorSearchConfig
+
+	// memberClusterClientsMap is keyed by the member cluster name and holds
+	// the per-cluster Kubernetes client. Empty in single-cluster installs;
+	// callers must fall back to kubeClient via selectClusterClient().
+	memberClusterClientsMap       map[string]kubernetesClient.Client
+	memberClusterSecretClientsMap map[string]secrets.SecretClient
 }
 
 func newMongoDBSearchReconciler(client client.Client, operatorSearchConfig searchcontroller.OperatorSearchConfig) *MongoDBSearchReconciler {

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -118,7 +118,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		r.watch.AddWatchedResourceIfNotAdded(mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name, mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
 	}
 
-	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(r.kubeClient), mdbSearch, searchSource, r.operatorSearchConfig)
+	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig)
 
 	return reconcileHelper.Reconcile(ctx, log).ReconcileResult()
 }
@@ -194,7 +194,7 @@ func AddMongoDBSearchController(
 
 	r := newMongoDBSearchReconciler(mgr.GetClient(), operatorSearchConfig, multicluster.ClustersMapToClientMap(memberClusterObjectsMap))
 
-	c, err := controller.New("mongodbsearch-controller", mgr, controller.Options{
+	c, err := controller.New(util.MongoDbSearchController, mgr, controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1), // nolint:forbidigo
 	})

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	runtime_cluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -25,6 +26,7 @@ import (
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
+	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
@@ -177,12 +179,17 @@ func mdbcSearchIndexBuilder(rawObj client.Object) []string {
 	return []string{resourceRef.Namespace + "/" + resourceRef.Name}
 }
 
-func AddMongoDBSearchController(ctx context.Context, mgr manager.Manager, operatorSearchConfig searchcontroller.OperatorSearchConfig) error {
+func AddMongoDBSearchController(
+	ctx context.Context,
+	mgr manager.Manager,
+	operatorSearchConfig searchcontroller.OperatorSearchConfig,
+	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, mdbcSearchIndexBuilder); err != nil {
 		return err
 	}
 
-	r := newMongoDBSearchReconciler(mgr.GetClient(), operatorSearchConfig, nil)
+	r := newMongoDBSearchReconciler(mgr.GetClient(), operatorSearchConfig, multicluster.ClustersMapToClientMap(memberClusterObjectsMap))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -182,7 +182,7 @@ func AddMongoDBSearchController(ctx context.Context, mgr manager.Manager, operat
 		return err
 	}
 
-	r := newMongoDBSearchReconciler(kubernetesClient.NewClient(mgr.GetClient()), operatorSearchConfig, nil)
+	r := newMongoDBSearchReconciler(mgr.GetClient(), operatorSearchConfig, nil)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -34,18 +34,32 @@ type MongoDBSearchReconciler struct {
 	watch                *watch.ResourceWatcher
 	operatorSearchConfig searchcontroller.OperatorSearchConfig
 
-	// memberClusterClientsMap is keyed by the member cluster name and holds
-	// the per-cluster Kubernetes client. Empty in single-cluster installs;
-	// callers must fall back to kubeClient via selectClusterClient().
-	memberClusterClientsMap       map[string]kubernetesClient.Client
-	memberClusterSecretClientsMap map[string]secrets.SecretClient
+	memberClusterClientsMap       map[string]kubernetesClient.Client // per-cluster Kubernetes client; empty in single-cluster installs
+	memberClusterSecretClientsMap map[string]secrets.SecretClient    // per-cluster secret client; empty in single-cluster installs
 }
 
-func newMongoDBSearchReconciler(client client.Client, operatorSearchConfig searchcontroller.OperatorSearchConfig) *MongoDBSearchReconciler {
+func newMongoDBSearchReconciler(
+	kubeClient client.Client,
+	operatorSearchConfig searchcontroller.OperatorSearchConfig,
+	memberClustersMap map[string]client.Client,
+) *MongoDBSearchReconciler {
+	clientsMap := make(map[string]kubernetesClient.Client, len(memberClustersMap))
+	secretClientsMap := make(map[string]secrets.SecretClient, len(memberClustersMap))
+
+	for k, v := range memberClustersMap {
+		clientsMap[k] = kubernetesClient.NewClient(v)
+		secretClientsMap[k] = secrets.SecretClient{
+			VaultClient: nil, // Vault is not supported on multicluster
+			KubeClient:  clientsMap[k],
+		}
+	}
+
 	return &MongoDBSearchReconciler{
-		kubeClient:           kubernetesClient.NewClient(client),
-		watch:                watch.NewResourceWatcher(),
-		operatorSearchConfig: operatorSearchConfig,
+		kubeClient:                    kubernetesClient.NewClient(kubeClient),
+		watch:                         watch.NewResourceWatcher(),
+		operatorSearchConfig:          operatorSearchConfig,
+		memberClusterClientsMap:       clientsMap,
+		memberClusterSecretClientsMap: secretClientsMap,
 	}
 }
 
@@ -168,7 +182,7 @@ func AddMongoDBSearchController(ctx context.Context, mgr manager.Manager, operat
 		return err
 	}
 
-	r := newMongoDBSearchReconciler(kubernetesClient.NewClient(mgr.GetClient()), operatorSearchConfig)
+	r := newMongoDBSearchReconciler(kubernetesClient.NewClient(mgr.GetClient()), operatorSearchConfig, nil)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -81,7 +83,7 @@ func newSearchReconcilerWithOperatorConfig(
 
 	fakeClient := builder.Build()
 
-	return newMongoDBSearchReconciler(fakeClient, operatorConfig), fakeClient
+	return newMongoDBSearchReconciler(fakeClient, operatorConfig, map[string]client.Client{}), fakeClient
 }
 
 func newSearchReconciler(
@@ -362,4 +364,41 @@ func TestMongoDBSearchReconcile_InvalidSearchImageVersion(t *testing.T) {
 			checkSearchReconcileFailed(ctx, t, reconciler, reconciler.kubeClient, search, expectedMsg)
 		})
 	}
+}
+
+func newFakeClientForTest(t *testing.T) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
+}
+
+func TestNewMongoDBSearchReconciler_SingleCluster(t *testing.T) {
+	central := newFakeClientForTest(t)
+	members := map[string]client.Client{} // empty -> single-cluster install
+
+	r := newMongoDBSearchReconciler(central, searchcontroller.OperatorSearchConfig{}, members)
+
+	assert.NotNil(t, r.kubeClient, "central kubeClient must be set")
+	assert.Empty(t, r.memberClusterClientsMap, "members map must be empty in single-cluster mode")
+	assert.Empty(t, r.memberClusterSecretClientsMap, "secret-clients map must be empty in single-cluster mode")
+}
+
+func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
+	central := newFakeClientForTest(t)
+	east := newFakeClientForTest(t)
+	west := newFakeClientForTest(t)
+	members := map[string]client.Client{
+		"us-east-k8s": east,
+		"eu-west-k8s": west,
+	}
+
+	r := newMongoDBSearchReconciler(central, searchcontroller.OperatorSearchConfig{}, members)
+
+	assert.Len(t, r.memberClusterClientsMap, 2)
+	assert.Len(t, r.memberClusterSecretClientsMap, 2)
+	assert.NotNil(t, r.memberClusterClientsMap["us-east-k8s"])
+	assert.NotNil(t, r.memberClusterClientsMap["eu-west-k8s"])
+	assert.NotNil(t, r.memberClusterSecretClientsMap["us-east-k8s"].KubeClient)
+	assert.NotNil(t, r.memberClusterSecretClientsMap["eu-west-k8s"].KubeClient)
 }

--- a/controllers/searchcontroller/cluster_clients.go
+++ b/controllers/searchcontroller/cluster_clients.go
@@ -1,0 +1,29 @@
+package searchcontroller
+
+import (
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
+)
+
+// SelectClusterClient returns the Kubernetes client to use for the given cluster name.
+//
+// Rules:
+//  1. If members is empty (single-cluster install where the operator was started without
+//     mongodbmulticluster as a watched CRD), return central — single-cluster fallback.
+//  2. If clusterName is empty (single-cluster spec.clusters[0] with no clusterName set),
+//     return central — degenerate single-cluster mode.
+//  3. If clusterName is present in members, return that client.
+//  4. If clusterName is set but missing from members, return (nil, false) — this is a
+//     configuration error and the caller must surface it as a status warning.
+func SelectClusterClient(
+	clusterName string,
+	central kubernetesClient.Client,
+	members map[string]kubernetesClient.Client,
+) (kubernetesClient.Client, bool) {
+	if len(members) == 0 || clusterName == "" {
+		return central, true
+	}
+	if c, ok := members[clusterName]; ok {
+		return c, true
+	}
+	return nil, false
+}

--- a/controllers/searchcontroller/cluster_clients_test.go
+++ b/controllers/searchcontroller/cluster_clients_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
 
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 )

--- a/controllers/searchcontroller/cluster_clients_test.go
+++ b/controllers/searchcontroller/cluster_clients_test.go
@@ -1,0 +1,63 @@
+package searchcontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
+)
+
+func newFakeKube(t *testing.T) kubernetesClient.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	return kubernetesClient.NewClient(fake.NewClientBuilder().WithScheme(scheme).Build())
+}
+
+func TestSelectClusterClient_FallbackWhenMembersEmpty(t *testing.T) {
+	central := newFakeKube(t)
+	var members map[string]kubernetesClient.Client
+
+	got, ok := SelectClusterClient("us-east-k8s", central, members)
+
+	assert.True(t, ok, "fallback to central should always succeed when members is empty")
+	assert.Equal(t, central, got)
+}
+
+func TestSelectClusterClient_FallbackWhenClusterNameEmpty(t *testing.T) {
+	central := newFakeKube(t)
+	members := map[string]kubernetesClient.Client{"us-east-k8s": newFakeKube(t)}
+
+	got, ok := SelectClusterClient("", central, members)
+
+	assert.True(t, ok)
+	assert.Equal(t, central, got, "empty clusterName means single-cluster spec.clusters[0]; fall back to central")
+}
+
+func TestSelectClusterClient_HitInMemberMap(t *testing.T) {
+	central := newFakeKube(t)
+	east := newFakeKube(t)
+	members := map[string]kubernetesClient.Client{"us-east-k8s": east}
+
+	got, ok := SelectClusterClient("us-east-k8s", central, members)
+
+	assert.True(t, ok)
+	assert.Equal(t, east, got)
+}
+
+func TestSelectClusterClient_MissInMemberMap(t *testing.T) {
+	central := newFakeKube(t)
+	east := newFakeKube(t)
+	members := map[string]kubernetesClient.Client{"us-east-k8s": east}
+
+	got, ok := SelectClusterClient("eu-west-k8s", central, members)
+
+	assert.False(t, ok, "explicit clusterName not in member map is a configuration error, not a fallback case")
+	assert.Nil(t, got)
+}

--- a/main.go
+++ b/main.go
@@ -288,7 +288,7 @@ func run() error {
 		}
 	}
 	if slices.Contains(crds, mongoDBSearchCRDPlural) {
-		if err := setupMongoDBSearchCRD(ctx, mgr); err != nil {
+		if err := setupMongoDBSearchCRD(ctx, mgr, memberClusterObjectsMap); err != nil {
 			return err
 		}
 	}
@@ -406,12 +406,16 @@ func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, image
 		Complete()
 }
 
-func setupMongoDBSearchCRD(ctx context.Context, mgr manager.Manager) error {
+func setupMongoDBSearchCRD(
+	ctx context.Context,
+	mgr manager.Manager,
+	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+) error {
 	if err := operator.AddMongoDBSearchController(ctx, mgr, searchcontroller.OperatorSearchConfig{
 		SearchRepo:    env.ReadOrPanic(util.SearchRepoURLEnv),
 		SearchName:    env.ReadOrPanic(util.SearchNameEnv),
 		SearchVersion: env.ReadOrPanic(util.SearchVersionEnv),
-	}); err != nil {
+	}, memberClusterObjectsMap); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

This PR is **B1 of the multi-cluster MongoDBSearch implementation plan** — pure internal scaffolding that plumbs per-cluster Kubernetes clients into `MongoDBSearchReconciler`. All subsequent B-section tickets (B2 admission, B4 hostnames, B5 secret presence checks, B8 cross-cluster watches, B9 status, B14 distribution CRD, B16 Envoy MC) build on top of this foundation.

**No user-visible behaviour changes.** Existing single-cluster `MongoDBSearch` deployments are unaffected — `memberClusterClientsMap` is empty in single-cluster installs and all per-cluster lookups transparently fall back to the central manager client (see `SelectClusterClient`).

| File | Responsibility |
| --- | --- |
| `controllers/operator/mongodbsearch_controller.go` | New `memberClusterClientsMap` + `memberClusterSecretClientsMap` fields on the reconciler; constructor takes `map[string]client.Client` and populates both; `AddMongoDBSearchController` accepts `map[string]cluster.Cluster` and converts via `multicluster.ClustersMapToClientMap`; switched from controller-builder to `controller.New + c.Watch` to attach a member-cluster health-check `source.Channel` watch (gated on `len(memberClusterObjectsMap) > 0`). |
| `main.go` | `setupMongoDBSearchCRD` now takes `memberClusterObjectsMap` and forwards it; the existing `mongodbmulticluster`-gated `memberClusterObjectsMap` (already plumbed into MongoDB / OpsManager / User / MultiCluster CRDs) is now also plumbed into Search. |
| `controllers/searchcontroller/cluster_clients.go` | New `SelectClusterClient` helper — single source of truth for the central-fallback rule. Four cases: empty members → central; empty clusterName → central; clusterName hit → that client; clusterName miss → `(nil, false)` config error. |
| `controllers/operator/mongodbsearch_controller_test.go` | New `TestNewMongoDBSearchReconciler_SingleCluster` and `TestNewMongoDBSearchReconciler_MultiCluster` covering both map population paths. |
| `controllers/searchcontroller/cluster_clients_test.go` | New `TestSelectClusterClient_*` (4 cases) covering all four fallback rules. |

The pattern mirrors the established `ReconcileMongoDbMultiReplicaSet` + `AddMultiReplicaSetController` pair (see [`controllers/operator/mongodbmultireplicaset_controller.go:78-122,1123-1185`](https://github.com/mongodb/mongodb-kubernetes/blob/master/controllers/operator/mongodbmultireplicaset_controller.go)).

### What's NOT in this PR (intentional)

- `MongoDBSearchEnvoyController` cluster-awareness — B16
- `spec.clusters[]` CRD field, `clusterName`, `syncSourceSelector.matchTags`, `shardOverrides[]` — B14
- Admission rejection of non-Q2 multi-cluster shapes — B13
- `readPreferenceTags` mongot-config rendering — B2 (the load-bearing Q2-MC behaviour)
- Cross-cluster watches on member-cluster resources — B8
- Per-cluster status surface — B9
- Member-cluster secret presence checks — B5

These all build on B1 and land as separate PRs once B1 is in.

## Proof of Work

- Unit tests added & passing:
  - `controllers/operator/mongodbsearch_controller_test.go::TestNewMongoDBSearchReconciler_SingleCluster`
  - `controllers/operator/mongodbsearch_controller_test.go::TestNewMongoDBSearchReconciler_MultiCluster`
  - `controllers/searchcontroller/cluster_clients_test.go::TestSelectClusterClient_FallbackWhenMembersEmpty`
  - `controllers/searchcontroller/cluster_clients_test.go::TestSelectClusterClient_FallbackWhenClusterNameEmpty`
  - `controllers/searchcontroller/cluster_clients_test.go::TestSelectClusterClient_HitInMemberMap`
  - `controllers/searchcontroller/cluster_clients_test.go::TestSelectClusterClient_MissInMemberMap`
- Local regression sweep: `go test ./controllers/operator/... ./controllers/searchcontroller/... ./pkg/multicluster/... -count=1` — all green, no regressions.
- `go vet` clean on `./controllers/operator/...` and `./controllers/searchcontroller/...`.
- `go build ./...` clean.
- Evergreen patch with full search e2e coverage submitted at https://evergreen.mongodb.com/version/69f1ca5328e4ad00075df463 (`unit_tests` + `e2e_mdb_kind_ubi_cloudqa_large` covering `e2e_mdb_kind_search_task_group` + `e2e_mdb_kind_search_large_task_group`). PR will be marked ready for review once that lands green.

## Why this PR is marked draft

Evergreen e2e coverage is in flight (link above). Will mark ready-for-review once it lands green and any findings are addressed.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
    - No JIRA ticket assigned yet — happy to add it once one is created.
- [ ] Have you checked whether your jira ticket required DOCSP changes?
    - N/A; no user-visible behaviour change in this PR. Documentation lands with B14 (when `spec.clusters[]` becomes user-visible).
- [x] Have you added changelog file?
    - `skip-changelog` label applied — B1 is internal scaffolding with no user-visible behaviour change.