### PR TITLE
B8: Per-member-cluster watches for MongoDBSearch resources

### DIFF
--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -39,11 +39,8 @@ type MongoDBSearchReconciler struct {
 	watch                *watch.ResourceWatcher
 	operatorSearchConfig searchcontroller.OperatorSearchConfig
 
-	// memberClusterClientsMap is keyed by the member cluster name and holds
-	// the per-cluster Kubernetes client. Empty in single-cluster installs;
-	// callers must fall back to kubeClient via selectClusterClient().
-	memberClusterClientsMap       map[string]kubernetesClient.Client
-	memberClusterSecretClientsMap map[string]secrets.SecretClient
+	memberClusterClientsMap       map[string]kubernetesClient.Client // per-cluster Kubernetes client; empty in single-cluster installs
+	memberClusterSecretClientsMap map[string]secrets.SecretClient    // per-cluster secret client; empty in single-cluster installs
 }
 
 func newMongoDBSearchReconciler(

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster/memberwatch"
@@ -238,6 +239,31 @@ func AddMongoDBSearchController(
 
 		if err := c.Watch(source.Channel[client.Object](eventChannel, &handler.EnqueueRequestForObject{})); err != nil {
 			return err
+		}
+
+		// Per-member-cluster watches for resources the search controller manages there.
+		// Owner references do not cross cluster boundaries, so the
+		// EnqueueRequestForSearchOwnerMultiCluster handler reads the
+		// MongoDBSearchResourceAnnotation off the watched object instead.
+		// PredicatesForMultiClusterSearchResource filters out unrelated churn.
+		// Backoff on unreachable member API is handled by controller-runtime's
+		// informer cache and surfaced via the health-check goroutine above.
+		searchOwnerHandler := &khandler.EnqueueRequestForSearchOwnerMultiCluster{}
+		searchOwnerPredicate := watch.PredicatesForMultiClusterSearchResource()
+		watchedTypes := []client.Object{
+			&appsv1.StatefulSet{},
+			&corev1.Service{},
+			&appsv1.Deployment{},
+			&corev1.ConfigMap{},
+			&corev1.Secret{},
+		}
+		for k, v := range memberClusterObjectsMap {
+			memberCluster := v
+			for _, gvk := range watchedTypes {
+				if err := c.Watch(source.Kind[client.Object](memberCluster.GetCache(), gvk, searchOwnerHandler, searchOwnerPredicate)); err != nil {
+					return xerrors.Errorf("failed to set MongoDBSearch member-cluster watch on %s for %T: %w", k, gvk, err)
+				}
+			}
 		}
 	}
 

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -39,8 +39,11 @@ type MongoDBSearchReconciler struct {
 	watch                *watch.ResourceWatcher
 	operatorSearchConfig searchcontroller.OperatorSearchConfig
 
-	memberClusterClientsMap       map[string]kubernetesClient.Client // per-cluster Kubernetes client; empty in single-cluster installs
-	memberClusterSecretClientsMap map[string]secrets.SecretClient    // per-cluster secret client; empty in single-cluster installs
+	// memberClusterClientsMap is keyed by the member cluster name and holds
+	// the per-cluster Kubernetes client. Empty in single-cluster installs;
+	// callers must fall back to kubeClient via selectClusterClient().
+	memberClusterClientsMap       map[string]kubernetesClient.Client
+	memberClusterSecretClientsMap map[string]secrets.SecretClient
 }
 
 func newMongoDBSearchReconciler(

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -258,9 +258,8 @@ func AddMongoDBSearchController(
 			&corev1.Secret{},
 		}
 		for k, v := range memberClusterObjectsMap {
-			memberCluster := v
 			for _, gvk := range watchedTypes {
-				if err := c.Watch(source.Kind[client.Object](memberCluster.GetCache(), gvk, searchOwnerHandler, searchOwnerPredicate)); err != nil {
+				if err := c.Watch(source.Kind[client.Object](v.GetCache(), gvk, searchOwnerHandler, searchOwnerPredicate)); err != nil {
 					return xerrors.Errorf("failed to set MongoDBSearch member-cluster watch on %s for %T: %w", k, gvk, err)
 				}
 			}

--- a/controllers/operator/watch/predicates.go
+++ b/controllers/operator/watch/predicates.go
@@ -151,6 +151,30 @@ func PredicatesForStatefulSet() predicate.Funcs {
 	}
 }
 
+// PredicatesForMultiClusterSearchResource filters watch events for resources
+// the MongoDBSearch controller places in member clusters. Owner references do
+// not cross cluster boundaries, so identification is by annotation
+// (handler.MongoDBSearchResourceAnnotation) rather than ownerRef.
+//
+// Create / Delete: pass through only when the annotation is present.
+// Update:          pass through if either side carries the annotation
+//
+//	(so annotation add/remove transitions also reconcile).
+//
+// Generic:         drop — informer-resync events are noise here.
+func PredicatesForMultiClusterSearchResource() predicate.Funcs {
+	hasAnn := func(obj interface{ GetAnnotations() map[string]string }) bool {
+		_, ok := obj.GetAnnotations()[handler.MongoDBSearchResourceAnnotation]
+		return ok
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return hasAnn(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasAnn(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return hasAnn(e.ObjectOld) || hasAnn(e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}
+
 // PredicatesForMultiStatefulSet is the predicate functions for the custom Statefulset Event
 // handler used for Multicluster reconciler
 func PredicatesForMultiStatefulSet() predicate.Funcs {

--- a/controllers/operator/watch/predicates.go
+++ b/controllers/operator/watch/predicates.go
@@ -156,12 +156,9 @@ func PredicatesForStatefulSet() predicate.Funcs {
 // not cross cluster boundaries, so identification is by annotation
 // (handler.MongoDBSearchResourceAnnotation) rather than ownerRef.
 //
-// Create / Delete: pass through only when the annotation is present.
-// Update:          pass through if either side carries the annotation
-//
-//	(so annotation add/remove transitions also reconcile).
-//
-// Generic:         drop — informer-resync events are noise here.
+// Create and Delete pass through only when the annotation is present. Update
+// passes if either side carries the annotation, so annotation add/remove
+// transitions also reconcile. Generic drops everything (informer-resync noise).
 func PredicatesForMultiClusterSearchResource() predicate.Funcs {
 	hasAnn := func(obj interface{ GetAnnotations() map[string]string }) bool {
 		_, ok := obj.GetAnnotations()[handler.MongoDBSearchResourceAnnotation]

--- a/controllers/operator/watch/predicates_test.go
+++ b/controllers/operator/watch/predicates_test.go
@@ -6,10 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/v1/om"
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/api/v1/user"
+	"github.com/mongodb/mongodb-kubernetes/pkg/handler"
 )
 
 func TestPredicatesForUser(t *testing.T) {
@@ -88,4 +92,41 @@ func TestPredicatesForMongoDB(t *testing.T) {
 			event.UpdateEvent{ObjectOld: oldMdb, ObjectNew: newMdb}),
 		)
 	})
+}
+
+func annotatedSearchObj(ann map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns", Annotations: ann}}
+}
+
+func TestPredicatesForMultiClusterSearchResource_Create(t *testing.T) {
+	p := PredicatesForMultiClusterSearchResource()
+
+	assert.True(t, p.CreateFunc(event.CreateEvent{Object: annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})}))
+	assert.False(t, p.CreateFunc(event.CreateEvent{Object: annotatedSearchObj(nil)}))
+	assert.False(t, p.CreateFunc(event.CreateEvent{Object: annotatedSearchObj(map[string]string{"unrelated": "x"})}))
+}
+
+func TestPredicatesForMultiClusterSearchResource_Update(t *testing.T) {
+	p := PredicatesForMultiClusterSearchResource()
+
+	annotatedNew := annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})
+	annotatedOld := annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})
+	plain := annotatedSearchObj(nil)
+
+	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: annotatedOld, ObjectNew: annotatedNew}))
+	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: annotatedNew}), "newly annotated must enqueue")
+	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: annotatedOld, ObjectNew: plain}), "annotation removal must enqueue")
+	assert.False(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: plain}))
+}
+
+func TestPredicatesForMultiClusterSearchResource_Delete(t *testing.T) {
+	p := PredicatesForMultiClusterSearchResource()
+
+	assert.True(t, p.DeleteFunc(event.DeleteEvent{Object: annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})}))
+	assert.False(t, p.DeleteFunc(event.DeleteEvent{Object: annotatedSearchObj(nil)}))
+}
+
+func TestPredicatesForMultiClusterSearchResource_Generic_AlwaysFalse(t *testing.T) {
+	p := PredicatesForMultiClusterSearchResource()
+	assert.False(t, p.GenericFunc(event.GenericEvent{Object: annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})}))
 }

--- a/controllers/searchcontroller/cluster_clients_test.go
+++ b/controllers/searchcontroller/cluster_clients_test.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 )
 

--- a/controllers/searchcontroller/cluster_clients_test.go
+++ b/controllers/searchcontroller/cluster_clients_test.go
@@ -8,7 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
-
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 )
 

--- a/controllers/searchcontroller/cluster_clients_test.go
+++ b/controllers/searchcontroller/cluster_clients_test.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 )
 

--- a/pkg/handler/enqueue_owner_multi_search.go
+++ b/pkg/handler/enqueue_owner_multi_search.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// MongoDBSearchResourceAnnotation is set on resources the MongoDBSearch
+// controller writes into a member cluster. It carries the name of the owning
+// MongoDBSearch CR in the central cluster. The owner namespace equals the
+// annotated object's own namespace — search resources never cross namespaces.
+//
+// This is a separate annotation from MongoDBMultiResourceAnnotation:
+// MongoDBMultiCluster and MongoDBSearch may coexist in the same namespace,
+// and event routing must not collide.
+const MongoDBSearchResourceAnnotation = "mongodb.com/v1.MongoDBSearchResource"
+
+var _ handler.EventHandler = &EnqueueRequestForSearchOwnerMultiCluster{}
+
+// EnqueueRequestForSearchOwnerMultiCluster enqueues reconcile requests for the
+// MongoDBSearch CR identified by MongoDBSearchResourceAnnotation on the watched
+// resource. Owner references do not cross clusters, so we use this annotation
+// pattern (mirrors EnqueueRequestForOwnerMultiCluster).
+type EnqueueRequestForSearchOwnerMultiCluster struct{}
+
+func (e *EnqueueRequestForSearchOwnerMultiCluster) Create(_ context.Context, evt event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	if req := getOwnerSearchCRD(evt.Object.GetAnnotations(), evt.Object.GetNamespace()); req != (reconcile.Request{}) {
+		q.Add(req)
+	}
+}
+
+func (e *EnqueueRequestForSearchOwnerMultiCluster) Update(_ context.Context, evt event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	for _, req := range []reconcile.Request{
+		getOwnerSearchCRD(evt.ObjectOld.GetAnnotations(), evt.ObjectOld.GetNamespace()),
+		getOwnerSearchCRD(evt.ObjectNew.GetAnnotations(), evt.ObjectNew.GetNamespace()),
+	} {
+		if req != (reconcile.Request{}) {
+			q.Add(req)
+		}
+	}
+}
+
+func (e *EnqueueRequestForSearchOwnerMultiCluster) Delete(_ context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	if req := getOwnerSearchCRD(evt.Object.GetAnnotations(), evt.Object.GetNamespace()); req != (reconcile.Request{}) {
+		q.Add(req)
+	}
+}
+
+func (e *EnqueueRequestForSearchOwnerMultiCluster) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func getOwnerSearchCRD(annotations map[string]string, namespace string) reconcile.Request {
+	val, ok := annotations[MongoDBSearchResourceAnnotation]
+	if !ok {
+		return reconcile.Request{}
+	}
+	return reconcile.Request{NamespacedName: types.NamespacedName{Name: val, Namespace: namespace}}
+}

--- a/pkg/handler/enqueue_owner_multi_search_test.go
+++ b/pkg/handler/enqueue_owner_multi_search_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newQueue() workqueue.TypedRateLimitingInterface[reconcile.Request] {
+	return workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+}
+
+func newAnnotatedConfigMap(ns, name string, ann map[string]string) client.Object {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Annotations: ann},
+	}
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Create_AnnotationPresent_Enqueues(t *testing.T) {
+	q := newQueue()
+	defer q.ShutDown()
+
+	obj := newAnnotatedConfigMap("ns1", "mongot-cm", map[string]string{
+		MongoDBSearchResourceAnnotation: "my-search",
+	})
+	h := &EnqueueRequestForSearchOwnerMultiCluster{}
+	h.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: obj}, q)
+
+	assert.Equal(t, 1, q.Len())
+	got, _ := q.Get()
+	assert.Equal(t, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "my-search"}}, got)
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Create_AnnotationMissing_NoEnqueue(t *testing.T) {
+	q := newQueue()
+	defer q.ShutDown()
+
+	obj := newAnnotatedConfigMap("ns1", "unrelated", nil)
+	h := &EnqueueRequestForSearchOwnerMultiCluster{}
+	h.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: obj}, q)
+
+	assert.Equal(t, 0, q.Len())
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Update_BothAnnotated_EnqueuesBoth(t *testing.T) {
+	q := newQueue()
+	defer q.ShutDown()
+
+	oldObj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "old-owner"})
+	newObj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "new-owner"})
+
+	h := &EnqueueRequestForSearchOwnerMultiCluster{}
+	h.Update(context.Background(), event.TypedUpdateEvent[client.Object]{ObjectOld: oldObj, ObjectNew: newObj}, q)
+
+	assert.Equal(t, 2, q.Len(), "both old and new owners must be enqueued so the leaving CR can clean up")
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Delete_AnnotationPresent_Enqueues(t *testing.T) {
+	q := newQueue()
+	defer q.ShutDown()
+
+	obj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "my-search"})
+	h := &EnqueueRequestForSearchOwnerMultiCluster{}
+	h.Delete(context.Background(), event.TypedDeleteEvent[client.Object]{Object: obj}, q)
+
+	assert.Equal(t, 1, q.Len())
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Generic_NoEnqueue(t *testing.T) {
+	q := newQueue()
+	defer q.ShutDown()
+
+	obj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "my-search"})
+	h := &EnqueueRequestForSearchOwnerMultiCluster{}
+	h.Generic(context.Background(), event.TypedGenericEvent[client.Object]{Object: obj}, q)
+
+	assert.Equal(t, 0, q.Len(), "generic events do not trigger reconciles for owner-tracking handlers")
+}


### PR DESCRIPTION
## Summary
B8 for the multi-cluster MongoDBSearch MVP — adds per-member-cluster informer-cache watches for resources owned (by annotation) by a central-cluster `MongoDBSearch`. Owner refs do not cross cluster boundaries, so identification is annotation-driven.

## Changes
- `pkg/handler/enqueue_owner_multi_search.go` — `EnqueueRequestForSearchOwnerMultiCluster` handler reads the search resource annotation in member-cluster events and enqueues a reconcile.Request for the central CR.
- `controllers/operator/watch/predicates.go` — `PredicatesForMultiClusterSearchResource()` filters Create/Update/Delete events to only those carrying the search owner annotation; drops Generic noise.
- `controllers/operator/mongodbsearch_controller.go` — `AddMongoDBSearchController` iterates `memberClusterObjectsMap` and registers per-cluster watches on `{StatefulSet, Service, Deployment, ConfigMap, Secret}` using the new handler + predicate.

## Stack
- Base: [#1027](https://github.com/mongodb/mongodb-kubernetes/pull/1027) (B1 foundation — cluster client plumbing)

## Out of scope
- Reconcile-loop consumption of these events (already wired through `reconcile.Request`)
- Per-cluster status surface (B9)
- Backoff state machine for unreachable member API (relies on B1's `MemberClusterHealthChecker` + controller-runtime's manager-level retry)

## Testing
- Unit: `go test ./controllers/operator/watch/... ./pkg/handler/... ./controllers/operator/...` passes
- e2e: deferred to integration milestone (no MC search e2e variants exist yet)

## Implementation notes
Pattern mirrors `controllers/operator/mongodbmultireplicaset_controller.go:1170-1175` (per-cluster `c.Watch` registration) and the `EnqueueRequestForOwnerMultiCluster` handler. Annotation key is intentionally distinct from the multi-RS handler to keep cross-CRD event routing clean.