### PR TITLE
B5: Per-cluster customer-replicated secrets presence checks

### DIFF
--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -138,7 +138,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	}
 	gaps := searchcontroller.CheckSecretsPresence(ctx, mdbSearch, r.kubeClient, memberClients)
 	if len(gaps) > 0 {
-		r.surfaceMissingSecrets(mdbSearch, gaps, log)
+		r.surfaceMissingSecrets(gaps, log)
 		if result.RequeueAfter == 0 {
 			result.RequeueAfter = secretsCheckRequeueAfter
 		}
@@ -146,13 +146,10 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	return result, nil
 }
 
-// surfaceMissingSecrets logs the missing-secret list per cluster. The customer
-// must replicate the missing secrets before reconcile can complete; the
-// reconcile loop returns RequeueAfter so we don't backoff exponentially while
-// waiting. Per-cluster status warnings will be added in B9 when the per-cluster
-// status surface lands.
+// surfaceMissingSecrets logs one entry per cluster that has gaps. The reconcile
+// loop returns RequeueAfter so the controller waits without exponential backoff
+// while the customer replicates the missing secrets.
 func (r *MongoDBSearchReconciler) surfaceMissingSecrets(
-	_ *searchv1.MongoDBSearch,
 	gaps []searchcontroller.SecretCheckResult,
 	log *zap.SugaredLogger,
 ) {

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
@@ -33,6 +34,12 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
+
+// secretsCheckRequeueAfter is the requeue interval used when CheckSecretsPresence
+// reports any per-cluster customer-replicated secret missing. Reconcile returns
+// (Result{RequeueAfter: secretsCheckRequeueAfter}, nil) so we don't trigger
+// exponential backoff while the customer is fixing the gap.
+const secretsCheckRequeueAfter = 30 * time.Second
 
 type MongoDBSearchReconciler struct {
 	kubeClient           kubernetesClient.Client
@@ -120,7 +127,45 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 
 	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig)
 
-	return reconcileHelper.Reconcile(ctx, log).ReconcileResult()
+	result, err := reconcileHelper.Reconcile(ctx, log).ReconcileResult()
+	if err != nil {
+		return result, err
+	}
+
+	memberClients := make(map[string]client.Client, len(r.memberClusterClientsMap))
+	for name, kc := range r.memberClusterClientsMap {
+		memberClients[name] = kc
+	}
+	gaps := searchcontroller.CheckSecretsPresence(ctx, mdbSearch, r.kubeClient, memberClients)
+	if len(gaps) > 0 {
+		r.surfaceMissingSecrets(mdbSearch, gaps, log)
+		if result.RequeueAfter == 0 {
+			result.RequeueAfter = secretsCheckRequeueAfter
+		}
+	}
+	return result, nil
+}
+
+// surfaceMissingSecrets logs the missing-secret list per cluster. The customer
+// must replicate the missing secrets before reconcile can complete; the
+// reconcile loop returns RequeueAfter so we don't backoff exponentially while
+// waiting. Per-cluster status warnings will be added in B9 when the per-cluster
+// status surface lands.
+func (r *MongoDBSearchReconciler) surfaceMissingSecrets(
+	_ *searchv1.MongoDBSearch,
+	gaps []searchcontroller.SecretCheckResult,
+	log *zap.SugaredLogger,
+) {
+	for _, g := range gaps {
+		clusterLabel := g.Cluster
+		if clusterLabel == "" {
+			clusterLabel = "central"
+		}
+		log.Infow("MongoDBSearch missing customer-replicated secrets",
+			"cluster", clusterLabel,
+			"missing", g.Missing,
+		)
+	}
 }
 
 func (r *MongoDBSearchReconciler) getSourceMongoDBForSearch(ctx context.Context, kubeClient client.Client, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
@@ -192,7 +237,11 @@ func AddMongoDBSearchController(
 		return err
 	}
 
-	r := newMongoDBSearchReconciler(mgr.GetClient(), operatorSearchConfig, multicluster.ClustersMapToClientMap(memberClusterObjectsMap))
+	r := newMongoDBSearchReconciler(
+		mgr.GetClient(),
+		operatorSearchConfig,
+		multicluster.ClustersMapToClientMap(memberClusterObjectsMap),
+	)
 
 	c, err := controller.New(util.MongoDbSearchController, mgr, controller.Options{
 		Reconciler:              r,

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -402,3 +402,19 @@ func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
 	assert.NotNil(t, r.memberClusterSecretClientsMap["us-east-k8s"].KubeClient)
 	assert.NotNil(t, r.memberClusterSecretClientsMap["eu-west-k8s"].KubeClient)
 }
+
+func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+
+	reconciler, _ := newSearchReconciler(mdbc, search)
+
+	res, err := reconciler.Reconcile(
+		ctx,
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}},
+	)
+
+	require.NoError(t, err, "missing secret must surface as RequeueAfter, not an error")
+	require.True(t, res.RequeueAfter > 0, "must requeue when a customer-replicated secret is missing")
+}

--- a/controllers/searchcontroller/secrets_presence.go
+++ b/controllers/searchcontroller/secrets_presence.go
@@ -2,12 +2,12 @@ package searchcontroller
 
 import (
 	"context"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
 )
@@ -103,11 +103,9 @@ func expectedSecretNames(search *searchv1.MongoDBSearch) []string {
 	return names
 }
 
-// missingSecretsIn does a Get on each name and returns names that are NotFound.
-// Other errors (RBAC, transport) are conservatively treated as "missing" because
-// from the reconciler's POV the secret is not usable. This is a deliberate simplification
-// for the MVP — B9 will distinguish between NotFound and operational errors when it adds
-// the per-cluster status surface.
+// missingSecretsIn does a Get on each name and returns names that are not accessible.
+// RBAC and transport errors are treated the same as NotFound: the secret is not
+// usable from the reconciler's perspective regardless of the root cause.
 func missingSecretsIn(ctx context.Context, c client.Client, namespace string, names []string) []string {
 	if c == nil {
 		return nil
@@ -116,22 +114,15 @@ func missingSecretsIn(ctx context.Context, c client.Client, namespace string, na
 	for _, name := range names {
 		var s corev1.Secret
 		if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &s); err != nil {
-			if apierrors.IsNotFound(err) {
-				missing = append(missing, name)
-			} else {
-				// Treat operational errors as missing for MVP. B9 will refine.
-				missing = append(missing, name)
-			}
+			missing = append(missing, name)
 		}
 	}
 	return missing
 }
 
 func appendUnique(in []string, name string) []string {
-	for _, existing := range in {
-		if existing == name {
-			return in
-		}
+	if slices.Contains(in, name) {
+		return in
 	}
 	return append(in, name)
 }

--- a/controllers/searchcontroller/secrets_presence.go
+++ b/controllers/searchcontroller/secrets_presence.go
@@ -1,0 +1,137 @@
+package searchcontroller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
+)
+
+// SecretCheckResult records the customer-replicated secrets that are missing in a
+// single member cluster. Empty Missing is filtered out by CheckSecretsPresence;
+// callers receive only entries that have at least one gap.
+//
+// Cluster is the cluster name as it appears in the operator's member-cluster map,
+// or the empty string for the central / single-cluster case.
+type SecretCheckResult struct {
+	Cluster string
+	Missing []string
+}
+
+// CheckSecretsPresence iterates the central cluster (always) plus every member cluster
+// and verifies that the customer-replicated secrets derived from search.Spec are
+// present. It only does Get; it never mutates any secret in any cluster.
+//
+// Returns one SecretCheckResult per cluster that has at least one missing secret;
+// clusters with no gaps are omitted. The returned slice is empty (or nil) if every
+// expected secret is present everywhere.
+//
+// members may be nil or empty for single-cluster installs; in that case only
+// central is checked.
+func CheckSecretsPresence(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	central client.Client,
+	members map[string]client.Client,
+) []SecretCheckResult {
+	expected := expectedSecretNames(search)
+	if len(expected) == 0 {
+		return nil
+	}
+
+	results := make([]SecretCheckResult, 0, len(members)+1)
+
+	if missing := missingSecretsIn(ctx, central, search.Namespace, expected); len(missing) > 0 {
+		results = append(results, SecretCheckResult{Cluster: "", Missing: missing})
+	}
+
+	for clusterName, c := range members {
+		if missing := missingSecretsIn(ctx, c, search.Namespace, expected); len(missing) > 0 {
+			results = append(results, SecretCheckResult{Cluster: clusterName, Missing: missing})
+		}
+	}
+
+	return results
+}
+
+// expectedSecretNames returns the deduplicated list of secret names the customer is
+// expected to replicate into every member cluster's namespace, derived from the CR.
+// Order is stable so logs and test assertions are deterministic.
+func expectedSecretNames(search *searchv1.MongoDBSearch) []string {
+	var names []string
+
+	// Sync-source password — always required when a password ref is configured.
+	if ref := search.SourceUserPasswordSecretRef(); ref != nil && ref.Name != "" {
+		names = appendUnique(names, ref.Name)
+	}
+
+	// External CA bundle — Q2-MC only.
+	if search.IsExternalMongoDBSource() {
+		ext := search.Spec.Source.ExternalMongoDBSource
+		if ext.TLS != nil && ext.TLS.CA != nil && ext.TLS.CA.Name != "" {
+			names = appendUnique(names, ext.TLS.CA.Name)
+		}
+		// Keyfile — sharded only.
+		if search.IsExternalSourceSharded() && ext.KeyFileSecretKeyRef != nil && ext.KeyFileSecretKeyRef.Name != "" {
+			names = appendUnique(names, ext.KeyFileSecretKeyRef.Name)
+		}
+	}
+
+	// mongot server TLS cert per unit (single RS or per shard) + Envoy server TLS cert.
+	// Both share the same `<prefix>-...-cert` family so listing the mongot cert covers
+	// the Envoy expectation in Q2-MC where Envoy reuses the per-shard cert.
+	if search.Spec.Security.TLS != nil {
+		if search.IsExternalSourceSharded() {
+			for _, shard := range search.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards {
+				names = appendUnique(names, search.TLSSecretForShard(shard.ShardName).Name)
+			}
+		} else {
+			names = appendUnique(names, search.TLSSecretNamespacedName().Name)
+		}
+	}
+
+	// x509 client cert — only when x509 auth is configured.
+	if search.IsX509Auth() {
+		names = appendUnique(names, search.X509ClientCertSecret().Name)
+	}
+
+	return names
+}
+
+// missingSecretsIn does a Get on each name and returns names that are NotFound.
+// Other errors (RBAC, transport) are conservatively treated as "missing" because
+// from the reconciler's POV the secret is not usable. This is a deliberate simplification
+// for the MVP — B9 will distinguish between NotFound and operational errors when it adds
+// the per-cluster status surface.
+func missingSecretsIn(ctx context.Context, c client.Client, namespace string, names []string) []string {
+	if c == nil {
+		return nil
+	}
+	var missing []string
+	for _, name := range names {
+		var s corev1.Secret
+		if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &s); err != nil {
+			if apierrors.IsNotFound(err) {
+				missing = append(missing, name)
+			} else {
+				// Treat operational errors as missing for MVP. B9 will refine.
+				missing = append(missing, name)
+			}
+		}
+	}
+	return missing
+}
+
+func appendUnique(in []string, name string) []string {
+	for _, existing := range in {
+		if existing == name {
+			return in
+		}
+	}
+	return append(in, name)
+}

--- a/controllers/searchcontroller/secrets_presence_test.go
+++ b/controllers/searchcontroller/secrets_presence_test.go
@@ -1,0 +1,204 @@
+package searchcontroller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
+	userv1 "github.com/mongodb/mongodb-kubernetes/api/v1/user"
+)
+
+func newSecretsPresenceScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := searchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	return scheme
+}
+
+func newSecretObj(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func newClientWithSecrets(t *testing.T, secrets ...*corev1.Secret) client.Client {
+	t.Helper()
+	objs := make([]client.Object, 0, len(secrets))
+	for _, s := range secrets {
+		objs = append(objs, s)
+	}
+	return fake.NewClientBuilder().WithScheme(newSecretsPresenceScheme(t)).WithObjects(objs...).Build()
+}
+
+func newSearchWithExternalSource(name, namespace string) *searchv1.MongoDBSearch {
+	return &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+					HostAndPorts: []string{"mongo-0:27017"},
+				},
+				PasswordSecretRef: &userv1.SecretKeyRef{Name: "search-sync-password"},
+			},
+		},
+	}
+}
+
+func TestCheckSecretsPresence_AllPresent_NoResults(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+
+	assert.Empty(t, got, "all secrets present in central → no SecretCheckResult entries")
+}
+
+func TestCheckSecretsPresence_TLSPrefix_SingleRS(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	search.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "lt"}
+
+	// Only the password is present; the TLS cert is missing → expect it in Missing.
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "", got[0].Cluster)
+	assert.Contains(t, got[0].Missing, search.TLSSecretNamespacedName().Name)
+}
+
+func TestCheckSecretsPresence_MissingPasswordInOneMember(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+
+	// Central + east have the password; west does not.
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+	east := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+	west := newClientWithSecrets(t)
+	members := map[string]client.Client{"east": east, "west": west}
+
+	got := CheckSecretsPresence(context.Background(), search, central, members)
+
+	// Only `west` should appear; `central` and `east` are silent.
+	assert.Len(t, got, 1)
+	assert.Equal(t, "west", got[0].Cluster)
+	assert.Equal(t, []string{"search-sync-password"}, got[0].Missing)
+}
+
+func TestCheckSecretsPresence_TLSPrefix_PerShard(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	search.Spec.Source.ExternalMongoDBSource.HostAndPorts = nil
+	search.Spec.Source.ExternalMongoDBSource.ShardedCluster = &searchv1.ExternalShardedClusterConfig{
+		Router: searchv1.ExternalRouterConfig{Hosts: []string{"router:27017"}},
+		Shards: []searchv1.ExternalShardConfig{
+			{ShardName: "shard-0", Hosts: []string{"shard-0-mongo:27017"}},
+			{ShardName: "shard-1", Hosts: []string{"shard-1-mongo:27017"}},
+		},
+	}
+	search.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "lt"}
+
+	// Provide all secrets except shard-1's TLS cert.
+	central := newClientWithSecrets(t,
+		newSecretObj("search-sync-password", "ns"),
+		newSecretObj(search.TLSSecretForShard("shard-0").Name, "ns"),
+	)
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, []string{search.TLSSecretForShard("shard-1").Name}, got[0].Missing)
+}
+
+func TestCheckSecretsPresence_KeyfileSharded_RequiredOnlyWhenSet(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	search.Spec.Source.ExternalMongoDBSource.HostAndPorts = nil
+	search.Spec.Source.ExternalMongoDBSource.ShardedCluster = &searchv1.ExternalShardedClusterConfig{
+		Router: searchv1.ExternalRouterConfig{Hosts: []string{"router:27017"}},
+		Shards: []searchv1.ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
+	}
+	// No KeyFileSecretKeyRef set — must not be checked.
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Empty(t, got, "keyfile must not be required when KeyFileSecretKeyRef is unset")
+}
+
+func TestCheckSecretsPresence_KeyfileSharded_MissingWhenSet(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	search.Spec.Source.ExternalMongoDBSource.HostAndPorts = nil
+	search.Spec.Source.ExternalMongoDBSource.ShardedCluster = &searchv1.ExternalShardedClusterConfig{
+		Router: searchv1.ExternalRouterConfig{Hosts: []string{"router:27017"}},
+		Shards: []searchv1.ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
+	}
+	search.Spec.Source.ExternalMongoDBSource.KeyFileSecretKeyRef = &userv1.SecretKeyRef{Name: "mongod-keyfile"}
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Len(t, got, 1)
+	assert.Contains(t, got[0].Missing, "mongod-keyfile")
+}
+
+func TestCheckSecretsPresence_KeyfileNotRequiredForRS(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	// RS source with KeyFileSecretKeyRef set on the spec → should still NOT be checked
+	// because the secret is sharded-only per spec §3.1 B5 row.
+	search.Spec.Source.ExternalMongoDBSource.KeyFileSecretKeyRef = &userv1.SecretKeyRef{Name: "should-not-check"}
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Empty(t, got, "keyfile is sharded-only; do not check it for RS sources")
+}
+
+func TestCheckSecretsPresence_X509_NotRequired_WhenAbsent(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Empty(t, got)
+}
+
+func TestCheckSecretsPresence_X509_Required_WhenConfigured(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	search.Spec.Source.X509 = &searchv1.X509Auth{
+		ClientCertificateSecret: corev1.LocalObjectReference{Name: "x509-client"},
+	}
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Len(t, got, 1)
+	assert.Contains(t, got[0].Missing, "x509-client")
+}
+
+func TestCheckSecretsPresence_SingleClusterFallback(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	central := newClientWithSecrets(t) // empty — password is missing
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "", got[0].Cluster, "single-cluster gap must surface as empty cluster name (central)")
+	assert.Equal(t, []string{"search-sync-password"}, got[0].Missing)
+}
+
+func TestCheckSecretsPresence_ExternalCA_RequiredWhenSet(t *testing.T) {
+	search := newSearchWithExternalSource("s", "ns")
+	search.Spec.Source.ExternalMongoDBSource.TLS = &searchv1.ExternalMongodTLS{
+		CA: &corev1.LocalObjectReference{Name: "external-ca"},
+	}
+	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
+
+	got := CheckSecretsPresence(context.Background(), search, central, nil)
+	assert.Len(t, got, 1)
+	assert.Contains(t, got[0].Missing, "external-ca")
+}


### PR DESCRIPTION
## Summary
B5 for the multi-cluster MongoDBSearch MVP — operator verifies per-cluster customer-replicated secrets presence; never replicates them. Missing secrets surface via structured logs and a non-erroring `RequeueAfter` so reconcile retries until the customer fixes the gap.

## Changes
- `controllers/searchcontroller/secrets_presence.go` — pure `CheckSecretsPresence(ctx, search, central, members) []SecretCheckResult` returns missing-secret gaps per cluster.
- Reconcile call site logs gaps and sets `RequeueAfter = 30s` (no error, no exponential backoff).

## Stack
- Base: [#1027](https://github.com/mongodb/mongodb-kubernetes/pull/1027) (B1 foundation)

## Testing
- Unit tests: `go test ./controllers/operator/... ./controllers/searchcontroller/...` passes
- Lint: `golangci-lint run ./...` passes (no new findings)

## Out of scope (deferred)
- Per-cluster status warnings — **B9** will consume `[]SecretCheckResult` and write per-cluster `phase: Pending` + warnings.
- Kubernetes Events emission — would require adding `events: [create, patch]` to the operator Role across helm + config + public/* manifests; deferred to keep RBAC scope unchanged for the MVP.
- Secret rotation handling — Phase 2.
- Replication of secrets — NOT operator's job; customer-owned per design (B-doc §B5 *Resolved*).

## Notes
The function does not call Create/Update/Delete on any Secret in any cluster — only `Get`. Customer-replicated secrets list driven by `MongoDBSearch.spec`:
| Source field | Secret |
| ------------ | ------ |
| `spec.source.passwordSecretRef.name` | sync-source password |
| `spec.source.external.tls.ca.name` | external CA bundle (Q2 only) |
| `spec.source.external.keyfileSecretRef.name` | keyfile (sharded only) |
| `<spec.security.tls.certsSecretPrefix>-<unit>-cert` | mongot/Envoy server TLS |
| `spec.security.authentication.x509.certsSecretPrefix-…` | x509 client cert (optional) |