### PR TITLE
B4: clusterName/clusterIndex placeholder resolution + admission

### DIFF
--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -807,6 +807,18 @@ func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
 	return out
 }
 
+// GetManagedLBEndpointForClusterShard returns the externalHostname template with
+// {clusterName}, {clusterIndex}, and {shardName} all resolved for the
+// (spec.clusters[i], shardName) pair. Used for sharded multi-cluster
+// MongoDBSearch deployments. Returns "" when managed LB is not configured.
+func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(i int, shardName string) string {
+	out := s.GetManagedLBEndpointForCluster(i)
+	if out == "" {
+		return ""
+	}
+	return strings.ReplaceAll(out, ShardNamePlaceholder, shardName)
+}
+
 // IsLoadBalancerReady returns true if managed LB is not configured,
 // or if it is configured and its status phase is Running.
 func (s *MongoDBSearch) IsLoadBalancerReady() bool {

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -19,6 +20,17 @@ import (
 
 // ShardNamePlaceholder is the placeholder used in endpoint templates for sharded clusters
 const ShardNamePlaceholder = "{shardName}"
+
+// ClusterNamePlaceholder is substituted with spec.clusters[i].ClusterName when
+// resolving spec.loadBalancer.managed.externalHostname for cluster i in
+// multi-cluster MongoDBSearch deployments.
+const ClusterNamePlaceholder = "{clusterName}"
+
+// ClusterIndexPlaceholder is substituted with the slice index i of spec.clusters[i].
+// TODO(B3): switch to the stable cluster-index annotation
+// (mongodb.com/v1.last-cluster-num-mapping) after B3 lands so adds/removes don't
+// shuffle indices on existing entries.
+const ClusterIndexPlaceholder = "{clusterIndex}"
 
 const (
 	MongotDefaultWireprotoPort      int32 = 27027
@@ -763,6 +775,36 @@ func (s *MongoDBSearch) GetManagedLBEndpointForShard(shardName string) string {
 		return ""
 	}
 	return strings.ReplaceAll(s.Spec.LoadBalancer.Managed.ExternalHostname, ShardNamePlaceholder, shardName)
+}
+
+// GetManagedLBEndpointForCluster returns the externalHostname template with
+// {clusterName} and {clusterIndex} resolved for spec.clusters[i]. Returns "" when
+// managed LB is not configured. Use GetManagedLBEndpointForClusterShard for
+// sharded sources where {shardName} also needs resolving.
+//
+// Behaviour:
+//   - Legacy single-cluster (spec.clusters nil): placeholders are left untouched.
+//     Admission rejects MC specs missing the required placeholders, so reaching
+//     this path with a placeholder-bearing legacy template is malformed.
+//   - Out-of-range i: placeholders are left untouched (defensive — call sites
+//     iterate over len(*spec.clusters)).
+func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
+	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+		return ""
+	}
+	out := s.Spec.LoadBalancer.Managed.ExternalHostname
+	if s.Spec.Clusters == nil {
+		return out
+	}
+	clusters := *s.Spec.Clusters
+	if i < 0 || i >= len(clusters) {
+		return out
+	}
+	out = strings.ReplaceAll(out, ClusterNamePlaceholder, clusters[i].ClusterName)
+	// TODO(B3): replace strconv.Itoa(i) with the cluster's stable annotation index
+	// (mongodb.com/v1.last-cluster-num-mapping) once B3 lands.
+	out = strings.ReplaceAll(out, ClusterIndexPlaceholder, strconv.Itoa(i))
+	return out
 }
 
 // IsLoadBalancerReady returns true if managed LB is not configured,

--- a/api/v1/search/mongodbsearch_types_test.go
+++ b/api/v1/search/mongodbsearch_types_test.go
@@ -205,3 +205,45 @@ func TestGetManagedLBEndpointForCluster_NotManaged(t *testing.T) {
 	s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: ""}}
 	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
 }
+
+func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
+	template := "{clusterName}.{shardName}.lb.example.com:443"
+	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
+	shards := []string{"shard-0", "shard-1"}
+	s := &MongoDBSearch{
+		Spec: MongoDBSearchSpec{
+			LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			Clusters:     &clusters,
+		},
+	}
+
+	got := make(map[string]struct{})
+	for i := range clusters {
+		for _, sh := range shards {
+			got[s.GetManagedLBEndpointForClusterShard(i, sh)] = struct{}{}
+		}
+	}
+	assert.Len(t, got, 4, "2x2 cross-product should yield 4 distinct hostnames")
+	assert.Contains(t, got, "us-east-k8s.shard-0.lb.example.com:443")
+	assert.Contains(t, got, "us-east-k8s.shard-1.lb.example.com:443")
+	assert.Contains(t, got, "eu-west-k8s.shard-0.lb.example.com:443")
+	assert.Contains(t, got, "eu-west-k8s.shard-1.lb.example.com:443")
+}
+
+func TestGetManagedLBEndpointForClusterShard_ClusterIndex(t *testing.T) {
+	template := "search-{clusterIndex}.{shardName}.lb.example.com:443"
+	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
+	s := &MongoDBSearch{
+		Spec: MongoDBSearchSpec{
+			LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			Clusters:     &clusters,
+		},
+	}
+	assert.Equal(t, "search-0.shard-a.lb.example.com:443", s.GetManagedLBEndpointForClusterShard(0, "shard-a"))
+	assert.Equal(t, "search-1.shard-b.lb.example.com:443", s.GetManagedLBEndpointForClusterShard(1, "shard-b"))
+}
+
+func TestGetManagedLBEndpointForClusterShard_NotManaged(t *testing.T) {
+	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard(0, "shard-0"))
+}

--- a/api/v1/search/mongodbsearch_types_test.go
+++ b/api/v1/search/mongodbsearch_types_test.go
@@ -130,3 +130,78 @@ func TestIsLoadBalancerReady(t *testing.T) {
 		})
 	}
 }
+
+func TestGetManagedLBEndpointForCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		clusters []ClusterSpec
+		index    int
+		want     string
+	}{
+		{
+			name:     "clusterName substitution first cluster",
+			template: "{clusterName}.search-lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			index:    0,
+			want:     "us-east-k8s.search-lb.example.com:443",
+		},
+		{
+			name:     "clusterIndex substitution second cluster",
+			template: "search-{clusterIndex}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			index:    1,
+			want:     "search-1.lb.example.com:443",
+		},
+		{
+			name:     "both placeholders present",
+			template: "{clusterName}-{clusterIndex}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			index:    1,
+			want:     "eu-west-k8s-1.lb.example.com:443",
+		},
+		{
+			name:     "no placeholders left untouched",
+			template: "static.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			index:    0,
+			want:     "static.lb.example.com:443",
+		},
+		{
+			name:     "legacy spec.clusters nil leaves placeholders literal",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: nil,
+			index:    0,
+			want:     "{clusterName}.lb.example.com:443",
+		},
+		{
+			name:     "out-of-range index leaves placeholders literal",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			index:    5,
+			want:     "{clusterName}.lb.example.com:443",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &MongoDBSearch{
+				Spec: MongoDBSearchSpec{
+					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tc.template}},
+				},
+			}
+			if tc.clusters != nil {
+				cs := tc.clusters
+				s.Spec.Clusters = &cs
+			}
+			assert.Equal(t, tc.want, s.GetManagedLBEndpointForCluster(tc.index))
+		})
+	}
+}
+
+func TestGetManagedLBEndpointForCluster_NotManaged(t *testing.T) {
+	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
+
+	s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: ""}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
+}

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -50,6 +50,7 @@ func (s *MongoDBSearch) RunValidations() []v1.ValidationResult {
 		validateClustersUniqueClusterName,
 		validateClustersSyncSourceSelector,
 		validateClustersShardOverrides,
+		validateMCExternalHostnamePlaceholders,
 	}
 
 	var results []v1.ValidationResult
@@ -380,4 +381,37 @@ func ValidateShardNameRFC1123(shardName string) error {
 	}
 
 	return nil
+}
+
+// validateMCExternalHostnamePlaceholders enforces:
+//   - When len(spec.clusters) > 1 and managed LB is in use, externalHostname
+//     must contain {clusterName} or {clusterIndex} so each cluster's resolved
+//     hostname is distinct.
+//   - When the source is external sharded AND len(spec.clusters) > 1,
+//     externalHostname must additionally contain {shardName}.
+//
+// Single-cluster (len <= 1) and legacy specs (clusters nil) fall through —
+// the existing single-cluster behaviour is preserved.
+func validateMCExternalHostnamePlaceholders(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+		return v1.ValidationSuccess()
+	}
+	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {
+		return v1.ValidationSuccess()
+	}
+	tmpl := s.Spec.LoadBalancer.Managed.ExternalHostname
+	hasCluster := strings.Contains(tmpl, ClusterNamePlaceholder) || strings.Contains(tmpl, ClusterIndexPlaceholder)
+	if !hasCluster {
+		return v1.ValidationError(
+			"spec.loadBalancer.managed.externalHostname must contain %s or %s when len(spec.clusters) > 1",
+			ClusterNamePlaceholder, ClusterIndexPlaceholder,
+		)
+	}
+	if s.IsExternalSourceSharded() && !strings.Contains(tmpl, ShardNamePlaceholder) {
+		return v1.ValidationError(
+			"spec.loadBalancer.managed.externalHostname must contain %s for multi-cluster sharded deployments",
+			ShardNamePlaceholder,
+		)
+	}
+	return v1.ValidationSuccess()
 }

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -51,6 +51,7 @@ func (s *MongoDBSearch) RunValidations() []v1.ValidationResult {
 		validateClustersSyncSourceSelector,
 		validateClustersShardOverrides,
 		validateMCExternalHostnamePlaceholders,
+		validateExternalHostnameDNSLength,
 	}
 
 	var results []v1.ValidationResult
@@ -412,6 +413,92 @@ func validateMCExternalHostnamePlaceholders(s *MongoDBSearch) v1.ValidationResul
 			"spec.loadBalancer.managed.externalHostname must contain %s for multi-cluster sharded deployments",
 			ShardNamePlaceholder,
 		)
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateExternalHostnameDNSLength validates that every resolved
+// (cluster, shard) cross-product hostname is a valid RFC 1123 subdomain
+// (FQDN <= 253 chars, each label <= 63 chars). The host portion is the
+// substring before the last ":" (port stripped); if no ":" is present the
+// entire string is the host. Iterates spec.clusters[] x
+// spec.source.external.shardedCluster.shards[] (either may be empty).
+func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+		return v1.ValidationSuccess()
+	}
+
+	var clusterCount int
+	if s.Spec.Clusters != nil {
+		clusterCount = len(*s.Spec.Clusters)
+	}
+
+	var shardNames []string
+	if s.IsExternalSourceSharded() {
+		for _, sh := range s.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards {
+			shardNames = append(shardNames, sh.ShardName)
+		}
+	}
+
+	check := func(host string) v1.ValidationResult {
+		h := host
+		if idx := strings.LastIndex(h, ":"); idx >= 0 {
+			h = h[:idx]
+		}
+		if len(h) == 0 {
+			return v1.ValidationError(
+				"spec.loadBalancer.managed.externalHostname resolves to an empty host: %q",
+				host,
+			)
+		}
+		// IsDNS1123Subdomain caps the FQDN at 253 chars and enforces the
+		// overall regex, but does *not* enforce the per-label 63-char limit.
+		// Walk the labels separately so a single oversized cluster/shard label trips here.
+		if errs := validation.IsDNS1123Subdomain(h); len(errs) > 0 {
+			return v1.ValidationError(
+				"spec.loadBalancer.managed.externalHostname resolves to an invalid DNS subdomain %q: %s",
+				h, strings.Join(errs, ", "),
+			)
+		}
+		for _, label := range strings.Split(h, ".") {
+			if errs := validation.IsDNS1123Label(label); len(errs) > 0 {
+				return v1.ValidationError(
+					"spec.loadBalancer.managed.externalHostname resolves to an invalid DNS subdomain %q: label %q: %s",
+					h, label, strings.Join(errs, ", "),
+				)
+			}
+		}
+		return v1.ValidationSuccess()
+	}
+
+	// Legacy / single-cluster (no spec.clusters): no cluster substitution.
+	if clusterCount == 0 {
+		base := s.Spec.LoadBalancer.Managed.ExternalHostname
+		if len(shardNames) == 0 {
+			return check(base)
+		}
+		for _, sn := range shardNames {
+			if res := check(strings.ReplaceAll(base, ShardNamePlaceholder, sn)); res.Level == v1.ErrorLevel {
+				return res
+			}
+		}
+		return v1.ValidationSuccess()
+	}
+
+	// Multi-cluster (clusterCount >= 1): substitute per cluster, then per shard.
+	for i := 0; i < clusterCount; i++ {
+		base := s.GetManagedLBEndpointForCluster(i)
+		if len(shardNames) == 0 {
+			if res := check(base); res.Level == v1.ErrorLevel {
+				return res
+			}
+			continue
+		}
+		for _, sn := range shardNames {
+			if res := check(strings.ReplaceAll(base, ShardNamePlaceholder, sn)); res.Level == v1.ErrorLevel {
+				return res
+			}
+		}
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -471,23 +471,18 @@ func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
 		return v1.ValidationSuccess()
 	}
 
-	// Legacy / single-cluster (no spec.clusters): no cluster substitution.
-	if clusterCount == 0 {
-		base := s.Spec.LoadBalancer.Managed.ExternalHostname
-		if len(shardNames) == 0 {
-			return check(base)
-		}
-		for _, sn := range shardNames {
-			if res := check(strings.ReplaceAll(base, ShardNamePlaceholder, sn)); res.Level == v1.ErrorLevel {
-				return res
-			}
-		}
-		return v1.ValidationSuccess()
+	// Iterate the cross-product. clusterCount == 0 (legacy / no spec.clusters)
+	// runs a single pass with no cluster substitution; len(shardNames) == 0
+	// runs a single pass with no shard substitution.
+	clusterIters := clusterCount
+	if clusterIters == 0 {
+		clusterIters = 1
 	}
-
-	// Multi-cluster (clusterCount >= 1): substitute per cluster, then per shard.
-	for i := 0; i < clusterCount; i++ {
-		base := s.GetManagedLBEndpointForCluster(i)
+	for i := 0; i < clusterIters; i++ {
+		base := s.Spec.LoadBalancer.Managed.ExternalHostname
+		if clusterCount > 0 {
+			base = s.GetManagedLBEndpointForCluster(i)
+		}
 		if len(shardNames) == 0 {
 			if res := check(base); res.Level == v1.ErrorLevel {
 				return res

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -395,6 +395,126 @@ func TestValidateMCExternalHostnamePlaceholders(t *testing.T) {
 	}
 }
 
+func TestValidateExternalHostnameDNSLength(t *testing.T) {
+	mkSearch := func(template string, clusters []ClusterSpec, shardNames []string) *MongoDBSearch {
+		s := &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+			Spec: MongoDBSearchSpec{
+				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			},
+		}
+		if clusters != nil {
+			cs := clusters
+			s.Spec.Clusters = &cs
+		}
+		if shardNames != nil {
+			shards := make([]ExternalShardConfig, 0, len(shardNames))
+			for _, sn := range shardNames {
+				shards = append(shards, ExternalShardConfig{ShardName: sn, Hosts: []string{"h:27017"}})
+			}
+			s.Spec.Source = &MongoDBSource{
+				ExternalMongoDBSource: &ExternalMongoDBSource{
+					ShardedCluster: &ExternalShardedClusterConfig{
+						Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
+						Shards: shards,
+					},
+				},
+			}
+		}
+		return s
+	}
+
+	// Build a > 63-char label.
+	longLabel := strings.Repeat("a", 64)
+
+	// Build a > 253-char total host: 4 labels of 60 chars each separated by dots = 4*60 + 3 = 243 (<253),
+	// so use longer labels to overflow. 5 labels of 60 chars: 5*60 + 4 = 304 > 253.
+	longClusterLabel := strings.Repeat("c", 60)
+
+	tests := []struct {
+		name          string
+		template      string
+		clusters      []ClusterSpec
+		shardNames    []string
+		errorContains string
+	}{
+		{
+			name:     "short hostname RS legacy passes",
+			template: "search.lb.example.com:443",
+		},
+		{
+			name:     "short hostname MC RS passes",
+			template: "{clusterName}.search-lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:       "short hostname MC sharded passes",
+			template:   "{clusterName}.{shardName}.lb.example.com:443",
+			clusters:   []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			shardNames: []string{"shard-0", "shard-1"},
+		},
+		{
+			name:          "DNS label > 63 after substitution rejected",
+			template:      "{clusterName}.lb.example.com:443",
+			clusters:      []ClusterSpec{{ClusterName: longLabel}, {ClusterName: "ok"}},
+			errorContains: "invalid DNS subdomain",
+		},
+		{
+			// Each label fits 63, but the FQDN exceeds 253 after substitution.
+			// 4 x 60-char labels + 4 dots = 244; plus "{clusterName}." (60+1=61) and tail (suffix) bring it well over 253.
+			name:     "FQDN > 253 after cross-product rejected",
+			template: "{clusterName}." + strings.Repeat("a", 60) + "." + strings.Repeat("b", 60) + "." + strings.Repeat("c", 60) + "." + strings.Repeat("d", 60) + ".lb.example.com:443",
+			clusters: []ClusterSpec{
+				{ClusterName: longClusterLabel},
+				{ClusterName: "ok"},
+			},
+			errorContains: "invalid DNS subdomain",
+		},
+		{
+			name:     "single-cluster legacy with literal hostname passes",
+			template: "search.lb.example.com:443",
+			clusters: nil,
+		},
+		{
+			name:     "single-entry clusters substitutes and validates",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+		},
+		{
+			name:     "no managed LB returns success",
+			template: "",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:          "empty host after port-stripping rejected",
+			template:      ":443",
+			clusters:      nil,
+			errorContains: "empty host",
+		},
+		{
+			name:     "no port present validates whole string as host",
+			template: "{clusterName}.lb.example.com",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := mkSearch(tt.template, tt.clusters, tt.shardNames)
+			if tt.template == "" {
+				s.Spec.LoadBalancer = nil
+			}
+			res := validateExternalHostnameDNSLength(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
+			}
+		})
+	}
+}
+
 func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTLS, isLBManaged bool) *MongoDBSearch {
 	search := &MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-namespace"},

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -300,6 +300,101 @@ func TestValidateClustersUniqueClusterName(t *testing.T) {
 	}
 }
 
+func TestValidateMCExternalHostnamePlaceholders(t *testing.T) {
+	mkSearch := func(template string, clusters []ClusterSpec, sharded bool) *MongoDBSearch {
+		s := &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+			Spec: MongoDBSearchSpec{
+				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			},
+		}
+		if clusters != nil {
+			cs := clusters
+			s.Spec.Clusters = &cs
+		}
+		if sharded {
+			s.Spec.Source = &MongoDBSource{
+				ExternalMongoDBSource: &ExternalMongoDBSource{
+					ShardedCluster: &ExternalShardedClusterConfig{
+						Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
+						Shards: []ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
+					},
+				},
+			}
+		}
+		return s
+	}
+
+	tests := []struct {
+		name          string
+		template      string
+		clusters      []ClusterSpec
+		sharded       bool
+		errorContains string
+	}{
+		{
+			name:     "single-cluster legacy no placeholder",
+			template: "static.lb.example.com:443",
+			clusters: nil,
+		},
+		{
+			name:     "single-entry clusters does not require placeholder",
+			template: "static.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+		},
+		{
+			name:     "MC RS with clusterName placeholder",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:     "MC RS with clusterIndex placeholder",
+			template: "search-{clusterIndex}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:          "MC RS missing both cluster placeholders",
+			template:      "static.lb.example.com:443",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			errorContains: "{clusterName}",
+		},
+		{
+			name:     "MC sharded with all three placeholders",
+			template: "{clusterName}.{shardName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			sharded:  true,
+		},
+		{
+			name:          "MC sharded missing shardName",
+			template:      "{clusterName}.lb.example.com:443",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			sharded:       true,
+			errorContains: "{shardName}",
+		},
+		{
+			name:     "no managed LB returns success",
+			template: "",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := mkSearch(tt.template, tt.clusters, tt.sharded)
+			if tt.template == "" {
+				s.Spec.LoadBalancer = nil
+			}
+			res := validateMCExternalHostnamePlaceholders(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
+			}
+		})
+	}
+}
+
 func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTLS, isLBManaged bool) *MongoDBSearch {
 	search := &MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-namespace"},


### PR DESCRIPTION
## Summary
B4 for MC MongoDBSearch MVP — adds `{clusterName}` and `{clusterIndex}` placeholders to `loadBalancer.managed.externalHostname` with cross-product (cluster x shard) resolution and admission validation.

## Changes
- New constants `ClusterNamePlaceholder` and `ClusterIndexPlaceholder` next to existing `ShardNamePlaceholder`
- `MongoDBSearch.GetManagedLBEndpointForCluster(i int) string` resolves `{clusterName}` and `{clusterIndex}` for `spec.clusters[i]`
- `MongoDBSearch.GetManagedLBEndpointForClusterShard(i int, shardName string) string` adds `{shardName}` for the sharded cross-product
- Admission `validateMCExternalHostnamePlaceholders`: when `len(spec.clusters) > 1`, `externalHostname` must contain `{clusterName}` or `{clusterIndex}`; sharded MC additionally requires `{shardName}`
- Admission `validateExternalHostnameDNSLength`: every resolved (cluster, shard) hostname (port stripped on the last `:`) must be a valid RFC 1123 subdomain (FQDN <= 253, each label <= 63)
- Single-cluster legacy behaviour preserved (placeholders left literal when `spec.clusters` is nil; admission does not require placeholders for `len <= 1`)

## Stack
- Base: [#1030](https://github.com/mongodb/mongodb-kubernetes/pull/1030) (B14)
- Bottom: [#1027](https://github.com/mongodb/mongodb-kubernetes/pull/1027) (B1)

## Out of scope
- `{clusterIndex}` uses the slice index for now; switches to B3's stable annotation index in a follow-up after B3 lands. TODO marker is at the substitution call site.
- B13 admission CEL XValidation extensions (separate PR).
- No reconcile-loop call-site changes (consumers in B5/B16/readPrefTags).
- No CRD/deepcopy regen — Go-level admission only.

## Testing
- Unit: `go test ./api/v1/search/... ./controllers/searchcontroller/...` passes
- Lint: `golangci-lint run ./api/v1/search/...` 0 issues