### PR TITLE
B3+B4+B13: cluster index, placeholders, MC admission validators

### DIFF
--- a/api/v1/search/cluster_index.go
+++ b/api/v1/search/cluster_index.go
@@ -1,0 +1,66 @@
+package search
+
+import (
+	"encoding/json"
+)
+
+// AssignClusterIndices returns a new clusterName -> clusterIndex mapping that:
+//   - preserves every entry in existing (never deletes a name, even if it is
+//     not present in currentClusterNames — that's how indices are not reused
+//     on remove/re-add);
+//   - appends every name in currentClusterNames that is not already in the
+//     mapping, assigning indices monotonically starting at max(existing)+1 (or
+//     0 when existing is empty).
+//
+// existing is not mutated; callers may safely pass in the result of unmarshalling
+// the persisted annotation. The returned map is always non-nil.
+func AssignClusterIndices(existing map[string]int, currentClusterNames []string) map[string]int {
+	result := make(map[string]int, len(existing)+len(currentClusterNames))
+	next := 0
+	for k, v := range existing {
+		result[k] = v
+		if v >= next {
+			next = v + 1
+		}
+	}
+	for _, name := range currentClusterNames {
+		if _, ok := result[name]; ok {
+			continue
+		}
+		result[name] = next
+		next++
+	}
+	return result
+}
+
+// ClusterIndex returns the persisted clusterIndex for the given clusterName by
+// consulting the LastClusterNumMapping annotation on the MongoDBSearch CR. The
+// second return value is false when the annotation is missing, empty, malformed,
+// or does not contain the name.
+//
+// ClusterIndex is the read API used by downstream consumers (B4 placeholder
+// resolution, B16 SNI ordering, B9 status). It deliberately reads only the
+// persisted mapping — not spec.clusters — so a name that has been removed from
+// the spec but is still recorded in the mapping continues to resolve.
+func ClusterIndex(search *MongoDBSearch, clusterName string) (int, bool) {
+	if search == nil {
+		return 0, false
+	}
+	mapping := parseClusterMapping(search.Annotations[LastClusterNumMapping])
+	idx, ok := mapping[clusterName]
+	return idx, ok
+}
+
+// parseClusterMapping unmarshals the LastClusterNumMapping annotation value into
+// a clusterName -> clusterIndex map. Returns nil when the value is empty or
+// malformed (callers should treat both as "no mapping yet").
+func parseClusterMapping(value string) map[string]int {
+	if value == "" {
+		return nil
+	}
+	m := make(map[string]int)
+	if err := json.Unmarshal([]byte(value), &m); err != nil {
+		return nil
+	}
+	return m
+}

--- a/api/v1/search/cluster_index_test.go
+++ b/api/v1/search/cluster_index_test.go
@@ -1,0 +1,112 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAssignClusterIndices(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]int
+		current  []string
+		want     map[string]int
+	}{
+		{
+			name:     "empty existing, empty current",
+			existing: map[string]int{},
+			current:  nil,
+			want:     map[string]int{},
+		},
+		{
+			name:     "first assignment starts at 0",
+			existing: map[string]int{},
+			current:  []string{"us-east", "us-west"},
+			want:     map[string]int{"us-east": 0, "us-west": 1},
+		},
+		{
+			name:     "preserve existing on no-op",
+			existing: map[string]int{"us-east": 0, "us-west": 1},
+			current:  []string{"us-east", "us-west"},
+			want:     map[string]int{"us-east": 0, "us-west": 1},
+		},
+		{
+			name:     "append new monotonically from max+1",
+			existing: map[string]int{"us-east": 0, "us-west": 1},
+			current:  []string{"us-east", "us-west", "eu-central"},
+			want:     map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2},
+		},
+		{
+			name:     "non-contiguous existing — next index is max+1, not gap",
+			existing: map[string]int{"us-east": 0, "us-west": 5},
+			current:  []string{"us-east", "us-west", "eu-central"},
+			want:     map[string]int{"us-east": 0, "us-west": 5, "eu-central": 6},
+		},
+		{
+			name:     "removed cluster stays in map (no reuse)",
+			existing: map[string]int{"us-east": 0, "us-west": 1},
+			current:  []string{"us-east"},
+			want:     map[string]int{"us-east": 0, "us-west": 1},
+		},
+		{
+			name:     "remove and re-add reuses the original index",
+			existing: map[string]int{"us-east": 0, "us-west": 1},
+			current:  []string{"us-east", "us-west"},
+			want:     map[string]int{"us-east": 0, "us-west": 1},
+		},
+		{
+			name:     "remove then add a different name uses next-after-max",
+			existing: map[string]int{"us-east": 0, "us-west": 1},
+			current:  []string{"us-east", "eu-central"},
+			want:     map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AssignClusterIndices(tt.existing, tt.current)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAssignClusterIndicesDoesNotMutateExisting(t *testing.T) {
+	existing := map[string]int{"a": 0, "b": 1}
+	AssignClusterIndices(existing, []string{"a", "b", "c"})
+	assert.Equal(t, map[string]int{"a": 0, "b": 1}, existing, "existing must not be mutated")
+}
+
+func TestClusterIndex(t *testing.T) {
+	withAnnotation := func(value string) *MongoDBSearch {
+		return &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns", Annotations: map[string]string{LastClusterNumMapping: value}},
+		}
+	}
+	tests := []struct {
+		name        string
+		search      *MongoDBSearch
+		clusterName string
+		wantIdx     int
+		wantOK      bool
+	}{
+		{name: "nil search", search: nil, clusterName: "us-east", wantOK: false},
+		{name: "no annotations", search: &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s"}}, clusterName: "us-east", wantOK: false},
+		{name: "annotation missing", search: &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s", Annotations: map[string]string{}}}, clusterName: "us-east", wantOK: false},
+		{name: "annotation empty string", search: withAnnotation(""), clusterName: "us-east", wantOK: false},
+		{name: "annotation malformed JSON", search: withAnnotation("{not-json"), clusterName: "us-east", wantOK: false},
+		{name: "name present", search: withAnnotation(`{"us-east":0,"us-west":1}`), clusterName: "us-east", wantIdx: 0, wantOK: true},
+		{name: "name missing in valid mapping", search: withAnnotation(`{"us-east":0,"us-west":1}`), clusterName: "eu-central", wantOK: false},
+		{name: "removed-but-still-mapped name returns persisted idx", search: withAnnotation(`{"us-east":0,"us-west":1}`), clusterName: "us-west", wantIdx: 1, wantOK: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIdx, gotOK := ClusterIndex(tt.search, tt.clusterName)
+			assert.Equal(t, tt.wantOK, gotOK)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantIdx, gotIdx)
+			}
+		})
+	}
+}

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -20,10 +21,16 @@ import (
 // ShardNamePlaceholder is the placeholder used in endpoint templates for sharded clusters
 const ShardNamePlaceholder = "{shardName}"
 
-// ClusterNamePlaceholder is the placeholder used in managed-LB externalHostname
-// templates for multi-cluster deployments. The Envoy reconciler substitutes the
+// ClusterNamePlaceholder is substituted with spec.clusters[i].ClusterName when
+// resolving spec.loadBalancer.managed.externalHostname for cluster i in
+// multi-cluster MongoDBSearch deployments. The Envoy reconciler substitutes the
 // member cluster name so per-cluster SNI hostnames stay distinct.
 const ClusterNamePlaceholder = "{clusterName}"
+
+// ClusterIndexPlaceholder is substituted with the stable cluster-index assigned
+// by the LastClusterNumMapping annotation for spec.clusters[i]. The index is
+// monotonic and never reused on remove/re-add (see api/v1/search/cluster_index.go).
+const ClusterIndexPlaceholder = "{clusterIndex}"
 
 const (
 	MongotDefaultWireprotoPort      int32 = 27027
@@ -34,6 +41,13 @@ const (
 	MongotDefaultSyncSourceUsername       = "search-sync-source"
 
 	ForceWireprotoAnnotation = "mongodb.com/v1.force-search-wireproto"
+
+	// LastClusterNumMapping holds the JSON-encoded clusterName -> clusterIndex
+	// mapping for spec.clusters[]. Mirrors mdbmulti.LastClusterNumMapping; the
+	// string value is intentionally identical so a future shared util can collapse
+	// the two without breaking existing CR annotations. Index never reused on
+	// remove/re-add (see api/v1/search/cluster_index.go).
+	LastClusterNumMapping = "mongodb.com/v1.lastClusterNumMapping"
 
 	MongoDBSearchIndexFieldName = "mdbsearch-for-mongodbresourceref-index"
 
@@ -841,6 +855,54 @@ func (s *MongoDBSearch) GetManagedLBEndpointForShard(shardName string) string {
 		return ""
 	}
 	return strings.ReplaceAll(s.Spec.LoadBalancer.Managed.ExternalHostname, ShardNamePlaceholder, shardName)
+}
+
+// GetManagedLBEndpointForCluster returns the externalHostname template with
+// {clusterName} and {clusterIndex} resolved for spec.clusters[i]. Returns "" when
+// managed LB is not configured. Use GetManagedLBEndpointForClusterShard for
+// sharded sources where {shardName} also needs resolving.
+//
+// Behaviour:
+//   - Legacy single-cluster (spec.clusters nil): placeholders are left untouched.
+//     Admission rejects MC specs missing the required placeholders, so reaching
+//     this path with a placeholder-bearing legacy template is malformed.
+//   - Out-of-range i: placeholders are left untouched (defensive — call sites
+//     iterate over len(*spec.clusters)).
+func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
+	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+		return ""
+	}
+	out := s.Spec.LoadBalancer.Managed.ExternalHostname
+	if s.Spec.Clusters == nil {
+		return out
+	}
+	clusters := *s.Spec.Clusters
+	if i < 0 || i >= len(clusters) {
+		return out
+	}
+	out = strings.ReplaceAll(out, ClusterNamePlaceholder, clusters[i].ClusterName)
+	// {clusterIndex} resolves to the persisted monotonic index from the
+	// LastClusterNumMapping annotation when available; otherwise it falls back
+	// to the slice index. The fallback covers legacy specs that have not yet
+	// been re-reconciled to populate the annotation.
+	idx := i
+	if persisted, ok := ClusterIndex(s, clusters[i].ClusterName); ok {
+		idx = persisted
+	}
+	out = strings.ReplaceAll(out, ClusterIndexPlaceholder, strconv.Itoa(idx))
+	return out
+}
+
+// GetManagedLBEndpointForClusterShard returns the externalHostname template with
+// {clusterName}, {clusterIndex}, and {shardName} all resolved for the
+// (spec.clusters[i], shardName) pair. Used for sharded multi-cluster
+// MongoDBSearch deployments. Returns "" when managed LB is not configured.
+func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(i int, shardName string) string {
+	out := s.GetManagedLBEndpointForCluster(i)
+	if out == "" {
+		return ""
+	}
+	return strings.ReplaceAll(out, ShardNamePlaceholder, shardName)
 }
 
 // IsLoadBalancerReady returns true if managed LB is not configured,

--- a/api/v1/search/mongodbsearch_types_test.go
+++ b/api/v1/search/mongodbsearch_types_test.go
@@ -217,3 +217,120 @@ func TestIsLoadBalancerReady(t *testing.T) {
 		})
 	}
 }
+
+func TestGetManagedLBEndpointForCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		clusters []ClusterSpec
+		index    int
+		want     string
+	}{
+		{
+			name:     "clusterName substitution first cluster",
+			template: "{clusterName}.search-lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			index:    0,
+			want:     "us-east-k8s.search-lb.example.com:443",
+		},
+		{
+			name:     "clusterIndex substitution second cluster",
+			template: "search-{clusterIndex}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			index:    1,
+			want:     "search-1.lb.example.com:443",
+		},
+		{
+			name:     "both placeholders present",
+			template: "{clusterName}-{clusterIndex}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			index:    1,
+			want:     "eu-west-k8s-1.lb.example.com:443",
+		},
+		{
+			name:     "no placeholders left untouched",
+			template: "static.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			index:    0,
+			want:     "static.lb.example.com:443",
+		},
+		{
+			name:     "legacy spec.clusters nil leaves placeholders literal",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: nil,
+			index:    0,
+			want:     "{clusterName}.lb.example.com:443",
+		},
+		{
+			name:     "out-of-range index leaves placeholders literal",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			index:    5,
+			want:     "{clusterName}.lb.example.com:443",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &MongoDBSearch{
+				Spec: MongoDBSearchSpec{
+					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tc.template}},
+				},
+			}
+			if tc.clusters != nil {
+				cs := tc.clusters
+				s.Spec.Clusters = &cs
+			}
+			assert.Equal(t, tc.want, s.GetManagedLBEndpointForCluster(tc.index))
+		})
+	}
+}
+
+func TestGetManagedLBEndpointForCluster_NotManaged(t *testing.T) {
+	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
+
+	s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: ""}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
+}
+
+func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
+	template := "{clusterName}.{shardName}.lb.example.com:443"
+	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
+	shards := []string{"shard-0", "shard-1"}
+	s := &MongoDBSearch{
+		Spec: MongoDBSearchSpec{
+			LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			Clusters:     &clusters,
+		},
+	}
+
+	got := make(map[string]struct{})
+	for i := range clusters {
+		for _, sh := range shards {
+			got[s.GetManagedLBEndpointForClusterShard(i, sh)] = struct{}{}
+		}
+	}
+	assert.Len(t, got, 4, "2x2 cross-product should yield 4 distinct hostnames")
+	assert.Contains(t, got, "us-east-k8s.shard-0.lb.example.com:443")
+	assert.Contains(t, got, "us-east-k8s.shard-1.lb.example.com:443")
+	assert.Contains(t, got, "eu-west-k8s.shard-0.lb.example.com:443")
+	assert.Contains(t, got, "eu-west-k8s.shard-1.lb.example.com:443")
+}
+
+func TestGetManagedLBEndpointForClusterShard_ClusterIndex(t *testing.T) {
+	template := "search-{clusterIndex}.{shardName}.lb.example.com:443"
+	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
+	s := &MongoDBSearch{
+		Spec: MongoDBSearchSpec{
+			LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			Clusters:     &clusters,
+		},
+	}
+	assert.Equal(t, "search-0.shard-a.lb.example.com:443", s.GetManagedLBEndpointForClusterShard(0, "shard-a"))
+	assert.Equal(t, "search-1.shard-b.lb.example.com:443", s.GetManagedLBEndpointForClusterShard(1, "shard-b"))
+}
+
+func TestGetManagedLBEndpointForClusterShard_NotManaged(t *testing.T) {
+	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard(0, "shard-0"))
+}

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -47,11 +47,18 @@ func (s *MongoDBSearch) RunValidations() []v1.ValidationResult {
 		validateShardNames,
 		validateJVMFlags,
 		validateX509AuthConfig,
+		validateClustersClusterNameNonEmpty,
 		validateClustersUniqueClusterName,
 		validateClustersSyncSourceSelector,
 		validateClustersShardOverrides,
 		validateClustersAndTopLevelFieldsMutuallyExclusive,
 		validateClustersEnvoyResourceNames,
+		validateClustersNoRename,
+		validateMCExternalHostnamePlaceholders,
+		validateExternalHostnameDNSLength,
+		validateMCRejectsUnmanagedLB,
+		validateMCRequiresLoadBalancerManaged,
+		validateMCMatchTagsNonEmpty,
 	}
 
 	var results []v1.ValidationResult
@@ -311,6 +318,26 @@ func validateX509AuthConfig(s *MongoDBSearch) v1.ValidationResult {
 	return v1.ValidationSuccess()
 }
 
+// validateClustersClusterNameNonEmpty rejects an empty spec.clusters[i].clusterName
+// when len(spec.clusters) > 1. The single-cluster degenerate case (len <= 1) keeps
+// allowing an empty clusterName. Uniqueness is the next validator's job; the dedicated
+// "is required" message fires here so a two-empty-names spec surfaces the actionable
+// hint instead of "duplicate".
+func validateClustersClusterNameNonEmpty(s *MongoDBSearch) v1.ValidationResult {
+	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {
+		return v1.ValidationSuccess()
+	}
+	for i, c := range *s.Spec.Clusters {
+		if c.ClusterName == "" {
+			return v1.ValidationError(
+				"spec.clusters[%d].clusterName is required when len(spec.clusters) > 1",
+				i,
+			)
+		}
+	}
+	return v1.ValidationSuccess()
+}
+
 // validateClustersUniqueClusterName enforces clusterName uniqueness inside spec.clusters.
 // ClusterName presence and immutability when len(clusters) > 1 are B13 scope.
 func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
@@ -441,6 +468,55 @@ func validateClustersAndTopLevelFieldsMutuallyExclusive(s *MongoDBSearch) v1.Val
 	return v1.ValidationSuccess()
 }
 
+// validateClustersNoRename rejects an Update where a clusterName has been removed
+// from spec.clusters AND a different clusterName has been added in the same update.
+// Pure rename (one removed, one added) is the operation we forbid; pure remove or
+// pure add is allowed (the index mapping handles both safely — removed indices are
+// preserved, added clusters get the next monotonic index).
+//
+// This is a soft, single-update rule: a remove-then-readd in two separate updates
+// is indistinguishable from a real rename. We accept that — the index is preserved
+// in both cases, so the worst case is that a real rename slips through across two
+// updates and the user sees no observable difference. There is no admission webhook
+// for MongoDBSearch today; all the more reason to keep the rule tight enough to
+// catch the obvious mistake but loose enough not to false-positive on benign edits.
+func validateClustersNoRename(s *MongoDBSearch) v1.ValidationResult {
+	raw, ok := s.Annotations[LastClusterNumMapping]
+	if !ok || raw == "" {
+		return v1.ValidationSuccess()
+	}
+	previous := parseClusterMapping(raw)
+	if len(previous) == 0 {
+		return v1.ValidationSuccess()
+	}
+	if s.Spec.Clusters == nil {
+		return v1.ValidationSuccess()
+	}
+	currentSet := make(map[string]struct{}, len(*s.Spec.Clusters))
+	for _, c := range *s.Spec.Clusters {
+		currentSet[c.ClusterName] = struct{}{}
+	}
+	var removed []string
+	for name := range previous {
+		if _, ok := currentSet[name]; !ok {
+			removed = append(removed, name)
+		}
+	}
+	var added []string
+	for name := range currentSet {
+		if _, ok := previous[name]; !ok {
+			added = append(added, name)
+		}
+	}
+	if len(removed) > 0 && len(added) > 0 {
+		return v1.ValidationError(
+			"clusterName changes are not allowed: removed=%v added=%v. To rename a cluster, recreate the MongoDBSearch resource",
+			removed, added,
+		)
+	}
+	return v1.ValidationSuccess()
+}
+
 func ValidateShardNameRFC1123(shardName string) error {
 	if shardName == "" {
 		return fmt.Errorf("shardName is required")
@@ -451,4 +527,177 @@ func ValidateShardNameRFC1123(shardName string) error {
 	}
 
 	return nil
+}
+
+// validateMCExternalHostnamePlaceholders enforces:
+//   - When len(spec.clusters) > 1 and managed LB is in use, externalHostname
+//     must contain {clusterName} or {clusterIndex} so each cluster's resolved
+//     hostname is distinct.
+//   - When the source is external sharded AND len(spec.clusters) > 1,
+//     externalHostname must additionally contain {shardName}.
+//
+// Single-cluster (len <= 1) and legacy specs (clusters nil) fall through —
+// the existing single-cluster behaviour is preserved.
+func validateMCExternalHostnamePlaceholders(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+		return v1.ValidationSuccess()
+	}
+	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {
+		return v1.ValidationSuccess()
+	}
+	tmpl := s.Spec.LoadBalancer.Managed.ExternalHostname
+	hasCluster := strings.Contains(tmpl, ClusterNamePlaceholder) || strings.Contains(tmpl, ClusterIndexPlaceholder)
+	if !hasCluster {
+		return v1.ValidationError(
+			"spec.loadBalancer.managed.externalHostname must contain %s or %s when len(spec.clusters) > 1",
+			ClusterNamePlaceholder, ClusterIndexPlaceholder,
+		)
+	}
+	if s.IsExternalSourceSharded() && !strings.Contains(tmpl, ShardNamePlaceholder) {
+		return v1.ValidationError(
+			"spec.loadBalancer.managed.externalHostname must contain %s for multi-cluster sharded deployments",
+			ShardNamePlaceholder,
+		)
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateExternalHostnameDNSLength validates that every resolved
+// (cluster, shard) cross-product hostname is a valid RFC 1123 subdomain
+// (FQDN <= 253 chars, each label <= 63 chars). The host portion is the
+// substring before the last ":" (port stripped); if no ":" is present the
+// entire string is the host. Iterates spec.clusters[] x
+// spec.source.external.shardedCluster.shards[] (either may be empty).
+func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+		return v1.ValidationSuccess()
+	}
+
+	var clusterCount int
+	if s.Spec.Clusters != nil {
+		clusterCount = len(*s.Spec.Clusters)
+	}
+
+	var shardNames []string
+	if s.IsExternalSourceSharded() {
+		for _, sh := range s.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards {
+			shardNames = append(shardNames, sh.ShardName)
+		}
+	}
+
+	check := func(host string) v1.ValidationResult {
+		h := host
+		if idx := strings.LastIndex(h, ":"); idx >= 0 {
+			h = h[:idx]
+		}
+		if len(h) == 0 {
+			return v1.ValidationError(
+				"spec.loadBalancer.managed.externalHostname resolves to an empty host: %q",
+				host,
+			)
+		}
+		// IsDNS1123Subdomain caps the FQDN at 253 chars and enforces the
+		// overall regex, but does *not* enforce the per-label 63-char limit.
+		// Walk the labels separately so a single oversized cluster/shard label trips here.
+		if errs := validation.IsDNS1123Subdomain(h); len(errs) > 0 {
+			return v1.ValidationError(
+				"spec.loadBalancer.managed.externalHostname resolves to an invalid DNS subdomain %q: %s",
+				h, strings.Join(errs, ", "),
+			)
+		}
+		for _, label := range strings.Split(h, ".") {
+			if errs := validation.IsDNS1123Label(label); len(errs) > 0 {
+				return v1.ValidationError(
+					"spec.loadBalancer.managed.externalHostname resolves to an invalid DNS subdomain %q: label %q: %s",
+					h, label, strings.Join(errs, ", "),
+				)
+			}
+		}
+		return v1.ValidationSuccess()
+	}
+
+	// Iterate the cross-product. clusterCount == 0 (legacy / no spec.clusters)
+	// runs a single pass with no cluster substitution; len(shardNames) == 0
+	// runs a single pass with no shard substitution.
+	clusterIters := clusterCount
+	if clusterIters == 0 {
+		clusterIters = 1
+	}
+	for i := 0; i < clusterIters; i++ {
+		base := s.Spec.LoadBalancer.Managed.ExternalHostname
+		if clusterCount > 0 {
+			base = s.GetManagedLBEndpointForCluster(i)
+		}
+		if len(shardNames) == 0 {
+			if res := check(base); res.Level == v1.ErrorLevel {
+				return res
+			}
+			continue
+		}
+		for _, sn := range shardNames {
+			if res := check(strings.ReplaceAll(base, ShardNamePlaceholder, sn)); res.Level == v1.ErrorLevel {
+				return res
+			}
+		}
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateMCRejectsUnmanagedLB rejects multi-cluster MongoDBSearch with
+// spec.loadBalancer.unmanaged set. Q3-MC / Q4-MC topologies are deferred
+// post-GA per spec §4.4 and §B0.2; multi-cluster at GA requires managed LB.
+// Single-cluster (and the degenerate single-entry spec.clusters case) keep
+// using unmanaged LB without change.
+func validateMCRejectsUnmanagedLB(s *MongoDBSearch) v1.ValidationResult {
+	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {
+		return v1.ValidationSuccess()
+	}
+	if s.Spec.LoadBalancer == nil || s.Spec.LoadBalancer.Unmanaged == nil {
+		return v1.ValidationSuccess()
+	}
+	return v1.ValidationError(
+		"Q3/Q4-MC topologies are deferred — multi-cluster MongoDBSearch requires spec.loadBalancer.managed; spec.loadBalancer.unmanaged is single-cluster only at GA",
+	)
+}
+
+// validateMCRequiresLoadBalancerManaged rejects multi-cluster MongoDBSearch
+// without spec.loadBalancer set at all. Q5-MC / Q6-MC ("no LB" + MC) are
+// permanently rejected per spec §4.4 / §B0.2 — multi-cluster requires Envoy.
+// Combined with validateMCRejectsUnmanagedLB above, this enforces the
+// "MC at GA = Q1 or Q2 = managed LB" rule symbolically without inspecting
+// per-cluster replicas.
+func validateMCRequiresLoadBalancerManaged(s *MongoDBSearch) v1.ValidationResult {
+	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {
+		return v1.ValidationSuccess()
+	}
+	if s.Spec.LoadBalancer != nil {
+		return v1.ValidationSuccess()
+	}
+	return v1.ValidationError(
+		"multi-cluster MongoDBSearch requires spec.loadBalancer.managed; no-LB MC topologies (Q5/Q6) are not supported",
+	)
+}
+
+// validateMCMatchTagsNonEmpty rejects an explicitly-set-but-empty
+// syncSourceSelector.matchTags in spec.clusters[] when len(spec.clusters) > 1.
+// An empty map is meaningless: the operator cannot peek at the external
+// replSetConfig to autodetect tags. Nil (omitted) is fine — inherits.
+// validateClustersSyncSourceSelector covers the matchTags-vs-hosts mutual
+// exclusion; this rule covers the non-nil-but-empty case.
+func validateMCMatchTagsNonEmpty(s *MongoDBSearch) v1.ValidationResult {
+	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {
+		return v1.ValidationSuccess()
+	}
+	for i, c := range *s.Spec.Clusters {
+		if c.SyncSourceSelector == nil {
+			continue
+		}
+		if c.SyncSourceSelector.MatchTags != nil && len(c.SyncSourceSelector.MatchTags) == 0 {
+			return v1.ValidationError(
+				"spec.clusters[%d].syncSourceSelector.matchTags cannot be empty when set; remove the field to inherit, or specify at least one tag — operator cannot autodetect tags from external mongod replSetConfig",
+				i,
+			)
+		}
+	}
+	return v1.ValidationSuccess()
 }

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -354,6 +355,432 @@ func TestValidateClustersAndTopLevelFieldsMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestValidateMCExternalHostnamePlaceholders(t *testing.T) {
+	mkSearch := func(template string, clusters []ClusterSpec, sharded bool) *MongoDBSearch {
+		s := &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+			Spec: MongoDBSearchSpec{
+				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			},
+		}
+		if clusters != nil {
+			cs := clusters
+			s.Spec.Clusters = &cs
+		}
+		if sharded {
+			s.Spec.Source = &MongoDBSource{
+				ExternalMongoDBSource: &ExternalMongoDBSource{
+					ShardedCluster: &ExternalShardedClusterConfig{
+						Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
+						Shards: []ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
+					},
+				},
+			}
+		}
+		return s
+	}
+
+	tests := []struct {
+		name          string
+		template      string
+		clusters      []ClusterSpec
+		sharded       bool
+		errorContains string
+	}{
+		{
+			name:     "single-cluster legacy no placeholder",
+			template: "static.lb.example.com:443",
+			clusters: nil,
+		},
+		{
+			name:     "single-entry clusters does not require placeholder",
+			template: "static.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+		},
+		{
+			name:     "MC RS with clusterName placeholder",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:     "MC RS with clusterIndex placeholder",
+			template: "search-{clusterIndex}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:          "MC RS missing both cluster placeholders",
+			template:      "static.lb.example.com:443",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			errorContains: "{clusterName}",
+		},
+		{
+			name:     "MC sharded with all three placeholders",
+			template: "{clusterName}.{shardName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			sharded:  true,
+		},
+		{
+			name:          "MC sharded missing shardName",
+			template:      "{clusterName}.lb.example.com:443",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			sharded:       true,
+			errorContains: "{shardName}",
+		},
+		{
+			name:     "no managed LB returns success",
+			template: "",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := mkSearch(tt.template, tt.clusters, tt.sharded)
+			if tt.template == "" {
+				s.Spec.LoadBalancer = nil
+			}
+			res := validateMCExternalHostnamePlaceholders(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
+			}
+		})
+	}
+}
+
+func TestValidateExternalHostnameDNSLength(t *testing.T) {
+	mkSearch := func(template string, clusters []ClusterSpec, shardNames []string) *MongoDBSearch {
+		s := &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+			Spec: MongoDBSearchSpec{
+				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
+			},
+		}
+		if clusters != nil {
+			cs := clusters
+			s.Spec.Clusters = &cs
+		}
+		if shardNames != nil {
+			shards := make([]ExternalShardConfig, 0, len(shardNames))
+			for _, sn := range shardNames {
+				shards = append(shards, ExternalShardConfig{ShardName: sn, Hosts: []string{"h:27017"}})
+			}
+			s.Spec.Source = &MongoDBSource{
+				ExternalMongoDBSource: &ExternalMongoDBSource{
+					ShardedCluster: &ExternalShardedClusterConfig{
+						Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
+						Shards: shards,
+					},
+				},
+			}
+		}
+		return s
+	}
+
+	// Build a > 63-char label.
+	longLabel := strings.Repeat("a", 64)
+
+	// Build a > 253-char total host: 4 labels of 60 chars each separated by dots = 4*60 + 3 = 243 (<253),
+	// so use longer labels to overflow. 5 labels of 60 chars: 5*60 + 4 = 304 > 253.
+	longClusterLabel := strings.Repeat("c", 60)
+
+	tests := []struct {
+		name          string
+		template      string
+		clusters      []ClusterSpec
+		shardNames    []string
+		errorContains string
+	}{
+		{
+			name:     "short hostname RS legacy passes",
+			template: "search.lb.example.com:443",
+		},
+		{
+			name:     "short hostname MC RS passes",
+			template: "{clusterName}.search-lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:       "short hostname MC sharded passes",
+			template:   "{clusterName}.{shardName}.lb.example.com:443",
+			clusters:   []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			shardNames: []string{"shard-0", "shard-1"},
+		},
+		{
+			name:          "DNS label > 63 after substitution rejected",
+			template:      "{clusterName}.lb.example.com:443",
+			clusters:      []ClusterSpec{{ClusterName: longLabel}, {ClusterName: "ok"}},
+			errorContains: "invalid DNS subdomain",
+		},
+		{
+			// Each label fits 63, but the FQDN exceeds 253 after substitution.
+			// 4 x 60-char labels + 4 dots = 244; plus "{clusterName}." (60+1=61) and tail (suffix) bring it well over 253.
+			name:     "FQDN > 253 after cross-product rejected",
+			template: "{clusterName}." + strings.Repeat("a", 60) + "." + strings.Repeat("b", 60) + "." + strings.Repeat("c", 60) + "." + strings.Repeat("d", 60) + ".lb.example.com:443",
+			clusters: []ClusterSpec{
+				{ClusterName: longClusterLabel},
+				{ClusterName: "ok"},
+			},
+			errorContains: "invalid DNS subdomain",
+		},
+		{
+			name:     "single-cluster legacy with literal hostname passes",
+			template: "search.lb.example.com:443",
+			clusters: nil,
+		},
+		{
+			name:     "single-entry clusters substitutes and validates",
+			template: "{clusterName}.lb.example.com:443",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+		},
+		{
+			name:     "no managed LB returns success",
+			template: "",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:          "empty host after port-stripping rejected",
+			template:      ":443",
+			clusters:      nil,
+			errorContains: "empty host",
+		},
+		{
+			name:     "no port present validates whole string as host",
+			template: "{clusterName}.lb.example.com",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := mkSearch(tt.template, tt.clusters, tt.shardNames)
+			if tt.template == "" {
+				s.Spec.LoadBalancer = nil
+			}
+			res := validateExternalHostnameDNSLength(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
+			}
+		})
+	}
+}
+
+func TestValidateMCRejectsUnmanagedLB(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusters      []ClusterSpec
+		lb            *LoadBalancerConfig
+		errorContains string
+	}{
+		{
+			name:     "single-cluster + unmanaged LB allowed (legacy)",
+			clusters: nil,
+			lb:       &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: "lb.example.com:443"}},
+		},
+		{
+			name:     "single-entry clusters + unmanaged LB allowed",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			lb:       &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: "lb.example.com:443"}},
+		},
+		{
+			name:     "MC + managed LB allowed",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			lb:       &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{clusterName}.lb.example.com:443"}},
+		},
+		{
+			name:     "MC + no LB passes here (other validator rejects)",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			lb:       nil,
+		},
+		{
+			name:          "MC + unmanaged LB rejected",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			lb:            &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: "lb.example.com:443"}},
+			errorContains: "Q3/Q4-MC",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{LoadBalancer: tt.lb},
+			}
+			if tt.clusters != nil {
+				cs := tt.clusters
+				s.Spec.Clusters = &cs
+			}
+			res := validateMCRejectsUnmanagedLB(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level)
+			}
+		})
+	}
+}
+
+func TestValidateMCRequiresLoadBalancerManaged(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusters      []ClusterSpec
+		lb            *LoadBalancerConfig
+		errorContains string
+	}{
+		{
+			name:     "single-cluster + no LB allowed (legacy Q5/Q6)",
+			clusters: nil,
+			lb:       nil,
+		},
+		{
+			name:     "single-entry clusters + no LB allowed",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			lb:       nil,
+		},
+		{
+			name:     "MC + managed LB allowed",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			lb:       &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{clusterName}.lb.example.com:443"}},
+		},
+		{
+			name:     "MC + unmanaged LB passes here (other validator rejects)",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			lb:       &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: "lb.example.com:443"}},
+		},
+		{
+			name:          "MC + no LB rejected",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			lb:            nil,
+			errorContains: "Q5/Q6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{LoadBalancer: tt.lb},
+			}
+			if tt.clusters != nil {
+				cs := tt.clusters
+				s.Spec.Clusters = &cs
+			}
+			res := validateMCRequiresLoadBalancerManaged(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level)
+			}
+		})
+	}
+}
+
+func TestValidateClustersClusterNameNonEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusters      []ClusterSpec
+		errorContains string
+	}{
+		{
+			name:     "single empty clusterName legacy",
+			clusters: []ClusterSpec{{}},
+		},
+		{
+			name:     "MC all non-empty",
+			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+		},
+		{
+			name:          "MC with empty clusterName at index 1",
+			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: ""}},
+			errorContains: "spec.clusters[1].clusterName is required",
+		},
+		{
+			name:          "MC with empty clusterName at index 0",
+			clusters:      []ClusterSpec{{ClusterName: ""}, {ClusterName: "eu-west-k8s"}},
+			errorContains: "spec.clusters[0].clusterName is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusters := tt.clusters
+			s := &MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &clusters},
+			}
+			res := validateClustersClusterNameNonEmpty(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level)
+			}
+		})
+	}
+}
+
+func TestValidateMCMatchTagsNonEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusters      []ClusterSpec
+		errorContains string
+	}{
+		{
+			name:     "single-cluster with empty matchTags allowed (legacy)",
+			clusters: []ClusterSpec{{SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{}}}},
+		},
+		{
+			name: "MC nil syncSourceSelector",
+			clusters: []ClusterSpec{
+				{ClusterName: "us-east-k8s"},
+				{ClusterName: "eu-west-k8s"},
+			},
+		},
+		{
+			name: "MC nil matchTags inherits",
+			clusters: []ClusterSpec{
+				{ClusterName: "us-east-k8s", SyncSourceSelector: &SyncSourceSelector{Hosts: []string{"h:27017"}}},
+				{ClusterName: "eu-west-k8s", SyncSourceSelector: &SyncSourceSelector{Hosts: []string{"h:27017"}}},
+			},
+		},
+		{
+			name: "MC populated matchTags",
+			clusters: []ClusterSpec{
+				{ClusterName: "us-east-k8s", SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "us-east"}}},
+				{ClusterName: "eu-west-k8s", SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "eu-west"}}},
+			},
+		},
+		{
+			name: "MC empty matchTags rejected",
+			clusters: []ClusterSpec{
+				{ClusterName: "us-east-k8s", SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "us-east"}}},
+				{ClusterName: "eu-west-k8s", SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{}}},
+			},
+			errorContains: "spec.clusters[1].syncSourceSelector.matchTags cannot be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusters := tt.clusters
+			s := &MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &clusters},
+			}
+			res := validateMCMatchTagsNonEmpty(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level)
+			}
+		})
+	}
+}
+
 func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTLS, isLBManaged bool) *MongoDBSearch {
 	search := &MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-namespace"},
@@ -375,6 +802,86 @@ func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTL
 		search.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{}}
 	}
 	return search
+}
+
+func TestValidateClustersNoRename(t *testing.T) {
+	withMapping := func(s *MongoDBSearch, m map[string]int) *MongoDBSearch {
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
+		}
+		b, _ := json.Marshal(m)
+		s.Annotations[LastClusterNumMapping] = string(b)
+		return s
+	}
+	tests := []struct {
+		name          string
+		search        *MongoDBSearch
+		errorContains string
+	}{
+		{
+			name: "no annotation: nothing to compare against",
+			search: &MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}}},
+			},
+		},
+		{
+			name: "first-time set: persisted mapping is empty",
+			search: withMapping(&MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}},
+			}, map[string]int{}),
+		},
+		{
+			name: "names unchanged",
+			search: withMapping(&MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}},
+			}, map[string]int{"us-east": 0, "us-west": 1}),
+		},
+		{
+			name: "pure remove: us-west missing from spec but no new name added — allowed",
+			search: withMapping(&MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}}},
+			}, map[string]int{"us-east": 0, "us-west": 1}),
+		},
+		{
+			name: "pure add: eu-central new but no name removed — allowed",
+			search: withMapping(&MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec: MongoDBSearchSpec{Clusters: &[]ClusterSpec{
+					{ClusterName: "us-east"}, {ClusterName: "us-west"}, {ClusterName: "eu-central"},
+				}},
+			}, map[string]int{"us-east": 0, "us-west": 1}),
+		},
+		{
+			name: "rename: us-west removed and eu-central added — rejected",
+			search: withMapping(&MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "eu-central"}}},
+			}, map[string]int{"us-east": 0, "us-west": 1}),
+			errorContains: "clusterName changes are not allowed",
+		},
+		{
+			name: "remove-then-readd via two separate updates is allowed",
+			search: withMapping(&MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}},
+			}, map[string]int{"us-east": 0, "us-west": 1}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := validateClustersNoRename(tt.search)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level)
+			}
+		})
+	}
 }
 
 // TestManagedLBConfig_Replicas_FieldExists is a B16 smoke test: the Replicas
@@ -412,8 +919,8 @@ func TestLoadBalancerStatus_ClustersFieldExists(t *testing.T) {
 
 // TestValidateClustersEnvoyResourceNames is the B16 admission check for the
 // per-cluster Envoy Deployment + ConfigMap resource names. The Deployment name
-// follows DNS-1123 label rules (≤63 chars); the ConfigMap follows DNS-1123
-// subdomain rules (≤253). When the search resource name + cluster suffix push
+// follows DNS-1123 label rules (<=63 chars); the ConfigMap follows DNS-1123
+// subdomain rules (<=253). When the search resource name + cluster suffix push
 // the result over the limit, validation must reject the spec.
 func TestValidateClustersEnvoyResourceNames(t *testing.T) {
 	tests := []struct {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,11 +23,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/automationconfig"
+	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/annotations"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/podtemplatespec"
@@ -116,10 +117,10 @@ type reconcileUnit struct {
 // topology-wide knobs and hooks that surround the loop. Everything sharded-specific lives
 // here in hook closures so the reconcile body stays a straight, unbranched sequence.
 type reconcilePlan struct {
-	units        []reconcileUnit
-	manageProxySvc bool                                                              // topology-wide: true when the operator owns the proxy Service lifecycle (i.e. the LB is not user-managed)
-	preflight    func(context.Context, *zap.SugaredLogger) workflow.Status           // runs before the loop; must return workflow.OK() to proceed
-	cleanup      func(context.Context, *zap.SugaredLogger)                           // runs after the loop; best-effort, errors logged
+	units          []reconcileUnit
+	manageProxySvc bool                                                      // topology-wide: true when the operator owns the proxy Service lifecycle (i.e. the LB is not user-managed)
+	preflight      func(context.Context, *zap.SugaredLogger) workflow.Status // runs before the loop; must return workflow.OK() to proceed
+	cleanup        func(context.Context, *zap.SugaredLogger)                 // runs after the loop; best-effort, errors logged
 }
 
 // buildReconcilePlan returns the full reconcile plan for the current topology.
@@ -162,8 +163,8 @@ func (r *MongoDBSearchReconcileHelper) buildReplicaSetPlan() (reconcilePlan, err
 			mongotConfigFn:     mongot.Apply(baseMongotConfig(r.mdbSearch, hostSeeds), wireprotoMongotMod(r.mdbSearch)),
 		}},
 		manageProxySvc: !r.mdbSearch.IsReplicaSetUnmanagedLB(),
-		preflight:    func(context.Context, *zap.SugaredLogger) workflow.Status { return workflow.OK() },
-		cleanup:      func(context.Context, *zap.SugaredLogger) {},
+		preflight:      func(context.Context, *zap.SugaredLogger) workflow.Status { return workflow.OK() },
+		cleanup:        func(context.Context, *zap.SugaredLogger) {},
 	}, nil
 }
 
@@ -193,7 +194,7 @@ func (r *MongoDBSearchReconcileHelper) buildShardedPlan(shardedSource SearchSour
 	}
 
 	return reconcilePlan{
-		units:        units,
+		units:          units,
 		manageProxySvc: !r.mdbSearch.IsShardedUnmanagedLB(),
 		preflight: func(ctx context.Context, log *zap.SugaredLogger) workflow.Status {
 			return r.validatePerShardTLSSecrets(ctx, log, shardNames)
@@ -220,6 +221,10 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 
 	if err := r.mdbSearch.ValidateSpec(); err != nil {
 		return workflow.Invalid("%s", err.Error())
+	}
+
+	if err := r.ensureClusterIndexAnnotation(ctx, log); err != nil {
+		return workflow.Failed(err)
 	}
 
 	if err := r.db.Validate(); err != nil {
@@ -356,6 +361,51 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 			WithAdditionalOptions(searchv1.NewMongoDBSearchVersionOption(imageVersion))
 	}
 	return workflow.OK().WithAdditionalOptions(searchv1.NewMongoDBSearchVersionOption(imageVersion))
+}
+
+// ensureClusterIndexAnnotation persists the MongoDBSearch CR's clusterName -> clusterIndex
+// mapping into the LastClusterNumMapping annotation. It preserves every previously-assigned
+// index and appends new clusters monotonically (see search.AssignClusterIndices); a removed
+// cluster's index is never reused. The annotation is the single source of truth for the
+// ClusterIndex read API consumed by B4 (placeholder resolution) and B16 (SNI route ordering).
+//
+// No-ops when spec.clusters is nil or empty (single-cluster path) and when the new mapping
+// matches the current annotation byte-for-byte.
+func (r *MongoDBSearchReconcileHelper) ensureClusterIndexAnnotation(ctx context.Context, log *zap.SugaredLogger) error {
+	if r.mdbSearch.Spec.Clusters == nil || len(*r.mdbSearch.Spec.Clusters) == 0 {
+		return nil
+	}
+
+	currentNames := make([]string, 0, len(*r.mdbSearch.Spec.Clusters))
+	for _, c := range *r.mdbSearch.Spec.Clusters {
+		currentNames = append(currentNames, c.ClusterName)
+	}
+
+	rawExisting := r.mdbSearch.Annotations[searchv1.LastClusterNumMapping]
+	existing := map[string]int{}
+	if rawExisting != "" {
+		if err := json.Unmarshal([]byte(rawExisting), &existing); err != nil {
+			// Malformed annotation is recoverable — start from scratch and let
+			// AssignClusterIndices rebuild a sane mapping. Log because this should
+			// never happen except via direct hand-edit.
+			log.Warnf("LastClusterNumMapping annotation is malformed (%v); rebuilding from spec.clusters", err)
+			existing = map[string]int{}
+		}
+	}
+
+	newMapping := searchv1.AssignClusterIndices(existing, currentNames)
+	newBytes, err := json.Marshal(newMapping)
+	if err != nil {
+		return xerrors.Errorf("marshalling cluster index mapping: %w", err)
+	}
+
+	if rawExisting == string(newBytes) {
+		return nil
+	}
+
+	return annotations.SetAnnotations(ctx, r.mdbSearch, map[string]string{
+		searchv1.LastClusterNumMapping: string(newBytes),
+	}, r.client)
 }
 
 // isOwnedBy returns true if the object has an owner reference pointing to the given owner.
@@ -748,7 +798,6 @@ func buildProxyService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev
 
 	return serviceBuilder.Build()
 }
-
 
 // EnsureEmbeddingAPIKeySecret makes sure that the scret that is provided in MDBSearch resource
 // for embedding model's keys is present and has expected keys.

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -2,15 +2,16 @@ package searchcontroller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
-	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/v1/user"
@@ -464,26 +466,28 @@ func TestMongoDBSearchReconcileHelper_ServiceCreation(t *testing.T) {
 	}
 }
 
-var testApiKeySecretName = "api-key-secret"
-var embeddingWriterTrue = true
-var mode = int32(400)
-var expectedVolumes = []corev1.Volume{
-	{
-		Name: embeddingKeyVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName:  testApiKeySecretName,
-				DefaultMode: &mode,
+var (
+	testApiKeySecretName = "api-key-secret"
+	embeddingWriterTrue  = true
+	mode                 = int32(400)
+	expectedVolumes      = []corev1.Volume{
+		{
+			Name: embeddingKeyVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  testApiKeySecretName,
+					DefaultMode: &mode,
+				},
 			},
 		},
-	},
-	{
-		Name: apiKeysTempVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		{
+			Name: apiKeysTempVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
 		},
-	},
-}
+	}
+)
 var expectedVolumeMount = []corev1.VolumeMount{
 	{
 		Name:      apiKeysTempVolumeName,
@@ -2523,4 +2527,104 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 
 	assert.Equal(t, "test-search-search-config", cm.Name)
 	assert.Contains(t, cm.Data, MongotConfigFilename)
+}
+
+func TestEnsureClusterIndexAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	buildHelper := func(t *testing.T, search *searchv1.MongoDBSearch) (*MongoDBSearchReconcileHelper, kubernetesClient.Client) {
+		t.Helper()
+		c := newTestFakeClient(search)
+		h := &MongoDBSearchReconcileHelper{
+			client:    c,
+			mdbSearch: search,
+		}
+		return h, c
+	}
+
+	readMapping := func(t *testing.T, c kubernetesClient.Client, name, namespace string) map[string]int {
+		t.Helper()
+		got := &searchv1.MongoDBSearch{}
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, got))
+		val, ok := got.Annotations[searchv1.LastClusterNumMapping]
+		if !ok {
+			return nil
+		}
+		out := map[string]int{}
+		require.NoError(t, json.Unmarshal([]byte(val), &out))
+		return out
+	}
+
+	withClusters := func(names ...string) func(*searchv1.MongoDBSearch) {
+		return func(s *searchv1.MongoDBSearch) {
+			entries := make([]searchv1.ClusterSpec, 0, len(names))
+			for _, n := range names {
+				entries = append(entries, searchv1.ClusterSpec{ClusterName: n})
+			}
+			s.Spec.Clusters = &entries
+		}
+	}
+
+	t.Run("nil clusters: no annotation written", func(t *testing.T) {
+		search := newTestMongoDBSearch("s1", "ns")
+		h, c := buildHelper(t, search)
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		assert.Nil(t, readMapping(t, c, "s1", "ns"))
+	})
+
+	t.Run("empty clusters: no annotation written", func(t *testing.T) {
+		empty := []searchv1.ClusterSpec{}
+		search := newTestMongoDBSearch("s2", "ns", func(s *searchv1.MongoDBSearch) { s.Spec.Clusters = &empty })
+		h, c := buildHelper(t, search)
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		assert.Nil(t, readMapping(t, c, "s2", "ns"))
+	})
+
+	t.Run("first reconcile writes mapping", func(t *testing.T) {
+		search := newTestMongoDBSearch("s3", "ns", withClusters("us-east", "us-west"))
+		h, c := buildHelper(t, search)
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, readMapping(t, c, "s3", "ns"))
+	})
+
+	t.Run("second reconcile is a no-op", func(t *testing.T) {
+		search := newTestMongoDBSearch("s4", "ns", withClusters("us-east", "us-west"))
+		h, c := buildHelper(t, search)
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		before := &searchv1.MongoDBSearch{}
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "s4", Namespace: "ns"}, before))
+		rvBefore := before.GetResourceVersion()
+
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		after := &searchv1.MongoDBSearch{}
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "s4", Namespace: "ns"}, after))
+		assert.Equal(t, rvBefore, after.GetResourceVersion(), "no-op reconcile must not bump resourceVersion")
+	})
+
+	t.Run("adding a cluster extends the mapping monotonically", func(t *testing.T) {
+		search := newTestMongoDBSearch("s5", "ns", withClusters("us-east", "us-west"))
+		h, c := buildHelper(t, search)
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+
+		extended := []searchv1.ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}, {ClusterName: "eu-central"}}
+		search.Spec.Clusters = &extended
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2}, readMapping(t, c, "s5", "ns"))
+	})
+
+	t.Run("removing then re-adding a cluster keeps the original index", func(t *testing.T) {
+		search := newTestMongoDBSearch("s6", "ns", withClusters("us-east", "us-west"))
+		h, c := buildHelper(t, search)
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+
+		shrunk := []searchv1.ClusterSpec{{ClusterName: "us-east"}}
+		search.Spec.Clusters = &shrunk
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, readMapping(t, c, "s6", "ns"), "removed cluster must remain in mapping")
+
+		regrown := []searchv1.ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}
+		search.Spec.Clusters = &regrown
+		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
+		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, readMapping(t, c, "s6", "ns"), "re-added cluster keeps original idx")
+	})
 }


### PR DESCRIPTION
## Summary
Consolidates **B3** (per-cluster index annotation), **B4** (`{clusterName}`/`{clusterIndex}` placeholder resolution), and **B13** (residual MC admission validators) into one PR — they're all CRD-level admission/validation work for the multi-cluster MongoDBSearch MVP, and reviewing them together catches inter-rule overlap.

## Changes

**B3 — cluster index annotation**
- `AssignClusterIndices(existing, currentClusterNames) map[string]int` — preserves existing assignments, monotonic-only, never reuses on remove/re-add
- `ClusterIndex(search, clusterName)` accessor for downstream consumers
- Annotation `mongodb.com/v1.last-cluster-num-mapping` persisted on the MongoDBSearch CR at reconcile entry
- Admission rule: rejects `clusterName` rename in a single Update (rename = recreate)

**B4 — placeholder resolution**
- `{clusterName}` and `{clusterIndex}` resolvers in `loadBalancer.managed.externalHostname`
- Cross-product (cluster × shard) hostname resolver for sharded MC
- Admission requires `{clusterName}` or `{clusterIndex}` when `len(spec.clusters) > 1`
- Sharded MC additionally requires `{shardName}`
- Cross-product DNS-length validation (RFC 1123 label ≤ 63, FQDN ≤ 253)

**B13 — MC admission residuals (4 new validators)**
- `validateMCRejectsUnmanagedLB` — Q3/Q4-MC reject (`len(clusters) > 1` + unmanaged LB)
- `validateMCRequiresLoadBalancerManaged` — Q5/Q6-MC reject (`len(clusters) > 1` + no LB)
- `validateClustersClusterNameNonEmpty` — explicit empty-string rejection with clear error
- `validateMCMatchTagsNonEmpty` — empty MatchTags map rejected (operator can't autodetect from external `replSetConfig`)

(MongoDBCommunity-source MC rejection is already covered by B2's `validateMCRequiresExternalSource`.)

## Stack
- Base: [#1030](https://github.com/mongodb/mongodb-kubernetes/pull/1030) (B14+B18 — `spec.clusters[]` types + defaulting)
- Bottom: [#1027](https://github.com/mongodb/mongodb-kubernetes/pull/1027) (B1 — cluster client plumbing)

## Replaces
- [#1031](https://github.com/mongodb/mongodb-kubernetes/pull/1031) — closed in favour of this consolidated PR

## Out of scope
- Per-cluster status surface (B9 / [#1033](https://github.com/mongodb/mongodb-kubernetes/pull/1033))
- Reconcile loop consumption of placeholder resolution (B16 / readPrefTags)

## Testing
- Unit: `go test ./api/v1/search/... ./controllers/searchcontroller/... ./controllers/operator/...` passes
- Lint: `golangci-lint run ./api/v1/search/...` clean