### PR TITLE
KUBE-47: Apply per-cluster statefulSet override in multi-cluster AppDB

### DIFF
--- a/changelog/20260429_fix_apply_per_cluster_statefulset_override_in_multi.md
+++ b/changelog/20260429_fix_apply_per_cluster_statefulset_override_in_multi.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-04-29
+---
+
+* **MongoDBOpsManager**, **AppDB**: In multi-cluster AppDB topology, fixed a bug where the per-cluster `spec.applicationDatabase.clusterSpecList[i].statefulSet` override was silently ignored.

--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -454,6 +454,19 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 	if podSpec != nil {
 		sts.Spec = merge.StatefulSetSpecs(sts.Spec, appsv1.StatefulSetSpec{Template: *podSpec})
 	}
+
+	// In multi-cluster topology, also apply the per-cluster statefulSet override
+	// from clusterSpecList[i].statefulSet to that cluster's STS.
+	// Quick fix. The proper pattern, used by OpsManager, MongoDBMultiCluster and
+	// Sharded, is to resolve the override in the controller and pass it via
+	// DatabaseStatefulSetOptions.StatefulSetSpecOverride, instead of reading the
+	// spec from inside the construct function.
+	if appDb.IsMultiCluster() {
+		clusterSpecItem := appDb.GetMemberClusterSpecByName(scaler.MemberClusterName())
+		if clusterSpecItem.StatefulSetConfiguration != nil {
+			sts.Spec = merge.StatefulSetSpecs(sts.Spec, clusterSpecItem.StatefulSetConfiguration.SpecWrapper.Spec)
+		}
+	}
 	return sts, nil
 }
 

--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -455,12 +455,8 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 		sts.Spec = merge.StatefulSetSpecs(sts.Spec, appsv1.StatefulSetSpec{Template: *podSpec})
 	}
 
-	// In multi-cluster topology, also apply the per-cluster statefulSet override
-	// from clusterSpecList[i].statefulSet to that cluster's STS.
-	// Quick fix. The proper pattern, used by OpsManager, MongoDBMultiCluster and
-	// Sharded, is to resolve the override in the controller and pass it via
-	// DatabaseStatefulSetOptions.StatefulSetSpecOverride, instead of reading the
-	// spec from inside the construct function.
+	// Apply per-cluster clusterSpecList[i].statefulSet override (KUBE-47).
+	// Anti-pattern: should be resolved in the controller and passed via StatefulSetSpecOverride (cf. OpsManager, Sharded).
 	if appDb.IsMultiCluster() {
 		clusterSpecItem := appDb.GetMemberClusterSpecByName(scaler.MemberClusterName())
 		if clusterSpecItem.StatefulSetConfiguration != nil {

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -37,6 +37,69 @@ func TestAppDBAgentFlags(t *testing.T) {
 	assert.Contains(t, command[len(command)-1], "-Key1=Value1", "-Key2=Value2")
 }
 
+// TestAppDBMultiClusterPerClusterStatefulSetOverride verifies that a
+// per-cluster StatefulSetConfiguration set on
+// spec.applicationDatabase.clusterSpecList[i].statefulSet is merged into the
+// generated StatefulSet. Specifically asserts hostAliases, since each pod in
+// a multi-cluster AppDB needs to bind its own external FQDN to localhost.
+func TestAppDBMultiClusterPerClusterStatefulSetOverride(t *testing.T) {
+	hostAliasesA := []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"appdb-a.example.com"}}}
+	hostAliasesB := []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"appdb-b.example.com"}}}
+
+	clusterSpecList := mdbv1.ClusterSpecList{
+		{
+			ClusterName: "cluster-a",
+			Members:     2,
+			StatefulSetConfiguration: &common.StatefulSetConfiguration{
+				SpecWrapper: common.StatefulSetSpecWrapper{
+					Spec: v1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{HostAliases: hostAliasesA},
+						},
+					},
+				},
+			},
+		},
+		{
+			ClusterName: "cluster-b",
+			Members:     1,
+			StatefulSetConfiguration: &common.StatefulSetConfiguration{
+				SpecWrapper: common.StatefulSetSpecWrapper{
+					Spec: v1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{HostAliases: hostAliasesB},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	om := omv1.NewOpsManagerBuilderDefault().
+		SetAppDBTopology(omv1.ClusterTopologyMultiCluster).
+		SetAppDBClusterSpecList(clusterSpecList).
+		Build()
+
+	stsA, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "cluster-a", 0, nil), v1.OnDeleteStatefulSetStrategyType, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, hostAliasesA, stsA.Spec.Template.Spec.HostAliases)
+
+	stsB, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "cluster-b", 1, nil), v1.OnDeleteStatefulSetStrategyType, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, hostAliasesB, stsB.Spec.Template.Spec.HostAliases)
+
+	// The per-cluster override only sets hostAliases, so fields set by the base
+	// construction (Replicas, ServiceName) must not be overwritten by the merge.
+	assert.NotNil(t, stsA.Spec.Replicas)
+	assert.Equal(t, int32(2), *stsA.Spec.Replicas)
+	assert.NotEmpty(t, stsA.Spec.ServiceName)
+	assert.NotNil(t, stsB.Spec.Replicas)
+	assert.Equal(t, int32(1), *stsB.Spec.Replicas)
+	assert.NotEmpty(t, stsB.Spec.ServiceName)
+}
+
 func TestResourceRequirements(t *testing.T) {
 	om := omv1.NewOpsManagerBuilderDefault().Build()
 	agentResourceRequirements := corev1.ResourceRequirements{

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -37,11 +37,6 @@ func TestAppDBAgentFlags(t *testing.T) {
 	assert.Contains(t, command[len(command)-1], "-Key1=Value1", "-Key2=Value2")
 }
 
-// TestAppDBMultiClusterPerClusterStatefulSetOverride verifies that a
-// per-cluster StatefulSetConfiguration set on
-// spec.applicationDatabase.clusterSpecList[i].statefulSet is merged into the
-// generated StatefulSet. Specifically asserts hostAliases, since each pod in
-// a multi-cluster AppDB needs to bind its own external FQDN to localhost.
 func TestAppDBMultiClusterPerClusterStatefulSetOverride(t *testing.T) {
 	hostAliasesA := []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"appdb-a.example.com"}}}
 	hostAliasesB := []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"appdb-b.example.com"}}}

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
@@ -46,11 +46,7 @@ def ops_manager_unmarshalled(
         item["statefulSet"] = {
             "spec": {
                 "template": {
-                    "spec": {
-                        "hostAliases": [
-                            {"ip": "127.0.0.1", "hostnames": [f"appdb-{item['clusterName']}.local"]}
-                        ]
-                    }
+                    "spec": {"hostAliases": [{"ip": "127.0.0.1", "hostnames": [f"appdb-{item['clusterName']}.local"]}]}
                 }
             }
         }

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
@@ -11,6 +11,21 @@ from tests.multicluster.conftest import cluster_spec_list
 CERT_PREFIX = "prefix"
 
 
+def appdb_cluster_spec_list_with_overrides(cluster_names: list[str], members: list[int]) -> list[dict]:
+    """Wraps cluster_spec_list and re-applies the per-cluster hostAliases override
+    so it is preserved across reconciliations (KUBE-47)."""
+    spec_list = cluster_spec_list(cluster_names, members)
+    for item in spec_list:
+        item["statefulSet"] = {
+            "spec": {
+                "template": {
+                    "spec": {"hostAliases": [{"ip": "127.0.0.1", "hostnames": [f"appdb-{item['clusterName']}.local"]}]}
+                }
+            }
+        }
+    return spec_list
+
+
 @fixture(scope="module")
 def appdb_member_cluster_names() -> list[str]:
     return ["kind-e2e-cluster-2", "kind-e2e-cluster-3"]
@@ -37,22 +52,9 @@ def ops_manager_unmarshalled(
     resource.create_admin_secret(api_client=central_cluster_client)
 
     resource["spec"]["backup"] = {"enabled": False}
-    appdb_cluster_spec_list = cluster_spec_list(appdb_member_cluster_names, [2, 3])
-    # Per-cluster statefulSet override (hostAliases). Verifies that
-    # clusterSpecList[i].statefulSet is merged into the AppDB STS of that cluster.
-    # Only verified at initial create. Later tests rebuild clusterSpecList via
-    # cluster_spec_list(...) and drop this override.
-    for item in appdb_cluster_spec_list:
-        item["statefulSet"] = {
-            "spec": {
-                "template": {
-                    "spec": {"hostAliases": [{"ip": "127.0.0.1", "hostnames": [f"appdb-{item['clusterName']}.local"]}]}
-                }
-            }
-        }
     resource["spec"]["applicationDatabase"] = {
         "topology": "MultiCluster",
-        "clusterSpecList": appdb_cluster_spec_list,
+        "clusterSpecList": appdb_cluster_spec_list_with_overrides(appdb_member_cluster_names, [2, 3]),
         "version": custom_appdb_version,
         "agent": {"logLevel": "DEBUG"},
         "security": {
@@ -118,7 +120,7 @@ def test_create_om(ops_manager: MongoDBOpsManager, appdb_member_cluster_names: l
 @mark.e2e_multi_cluster_appdb
 def test_scale_up_one_cluster(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
         appdb_member_cluster_names, [4, 3]
     )
     ops_manager.update()
@@ -130,7 +132,7 @@ def test_scale_up_one_cluster(ops_manager: MongoDBOpsManager, appdb_member_clust
 @mark.e2e_multi_cluster_appdb
 def test_scale_down_one_cluster(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
         appdb_member_cluster_names, [4, 1]
     )
     ops_manager.update()
@@ -146,7 +148,7 @@ def test_hosts_removed_after_scale_down_one_cluster(ops_manager: MongoDBOpsManag
 @mark.e2e_multi_cluster_appdb
 def test_scale_up_two_clusters(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
         appdb_member_cluster_names, [5, 2]
     )
     ops_manager.update()
@@ -156,7 +158,7 @@ def test_scale_up_two_clusters(ops_manager: MongoDBOpsManager, appdb_member_clus
 @mark.e2e_multi_cluster_appdb
 def test_scale_down_two_clusters(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
         appdb_member_cluster_names, [2, 1]
     )
     ops_manager.update()
@@ -167,7 +169,7 @@ def test_scale_down_two_clusters(ops_manager: MongoDBOpsManager, appdb_member_cl
 def test_add_cluster_to_cluster_spec(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(cluster_names, [2, 2, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 2, 1])
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
 
@@ -177,14 +179,14 @@ def test_remove_cluster_from_cluster_spec(ops_manager: MongoDBOpsManager, appdb_
     # Before removing, we need to scale down the cluster to zero
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(cluster_names, [2, 0, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 0, 1])
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
 
     # Now we can remove the cluster from the spec
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names[1:]
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(cluster_names, [2, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 1])
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
 
@@ -193,6 +195,6 @@ def test_remove_cluster_from_cluster_spec(ops_manager: MongoDBOpsManager, appdb_
 def test_read_cluster_to_cluster_spec(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(cluster_names, [2, 2, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 2, 1])
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
@@ -37,9 +37,26 @@ def ops_manager_unmarshalled(
     resource.create_admin_secret(api_client=central_cluster_client)
 
     resource["spec"]["backup"] = {"enabled": False}
+    appdb_cluster_spec_list = cluster_spec_list(appdb_member_cluster_names, [2, 3])
+    # Per-cluster statefulSet override (hostAliases). Verifies that
+    # clusterSpecList[i].statefulSet is merged into the AppDB STS of that cluster.
+    # Only verified at initial create. Later tests rebuild clusterSpecList via
+    # cluster_spec_list(...) and drop this override.
+    for item in appdb_cluster_spec_list:
+        item["statefulSet"] = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "hostAliases": [
+                            {"ip": "127.0.0.1", "hostnames": [f"appdb-{item['clusterName']}.local"]}
+                        ]
+                    }
+                }
+            }
+        }
     resource["spec"]["applicationDatabase"] = {
         "topology": "MultiCluster",
-        "clusterSpecList": cluster_spec_list(appdb_member_cluster_names, [2, 3]),
+        "clusterSpecList": appdb_cluster_spec_list,
         "version": custom_appdb_version,
         "agent": {"logLevel": "DEBUG"},
         "security": {
@@ -85,11 +102,21 @@ def test_patch_central_namespace(namespace: str, central_cluster_client: kuberne
 
 @mark.usefixtures("multi_cluster_operator")
 @mark.e2e_multi_cluster_appdb
-def test_create_om(ops_manager: MongoDBOpsManager):
+def test_create_om(ops_manager: MongoDBOpsManager, appdb_member_cluster_names: list[str]):
     ops_manager.load()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
     ops_manager.assert_appdb_preferred_hostnames_are_added()
     ops_manager.assert_appdb_hostnames_are_correct()
+
+    # Verify the per-cluster statefulSet override (hostAliases) set in the fixture
+    # was merged into each cluster's AppDB StatefulSet.
+    for cluster_name in appdb_member_cluster_names:
+        sts = ops_manager.read_appdb_statefulset(member_cluster_name=cluster_name)
+        host_aliases = sts.spec.template.spec.host_aliases or []
+        hostnames = [h for alias in host_aliases for h in (alias.hostnames or [])]
+        assert (
+            f"appdb-{cluster_name}.local" in hostnames
+        ), f"per-cluster hostAlias missing on AppDB STS in {cluster_name}: got {hostnames}"
 
 
 @mark.e2e_multi_cluster_appdb

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
@@ -11,7 +11,7 @@ from tests.multicluster.conftest import cluster_spec_list
 CERT_PREFIX = "prefix"
 
 
-def appdb_cluster_spec_list_with_overrides(cluster_names: list[str], members: list[int]) -> list[dict]:
+def appdb_cluster_spec_list_with_overrides(cluster_names: list[str], members: list[int | None]) -> list[dict]:
     """Wraps cluster_spec_list and re-applies the per-cluster hostAliases override
     so it is preserved across reconciliations (KUBE-47)."""
     spec_list = cluster_spec_list(cluster_names, members)
@@ -169,7 +169,9 @@ def test_scale_down_two_clusters(ops_manager: MongoDBOpsManager, appdb_member_cl
 def test_add_cluster_to_cluster_spec(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 2, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
+        cluster_names, [2, 2, 1]
+    )
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
 
@@ -179,14 +181,18 @@ def test_remove_cluster_from_cluster_spec(ops_manager: MongoDBOpsManager, appdb_
     # Before removing, we need to scale down the cluster to zero
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 0, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
+        cluster_names, [2, 0, 1]
+    )
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
 
     # Now we can remove the cluster from the spec
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names[1:]
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
+        cluster_names, [2, 1]
+    )
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)
 
@@ -195,6 +201,8 @@ def test_remove_cluster_from_cluster_spec(ops_manager: MongoDBOpsManager, appdb_
 def test_read_cluster_to_cluster_spec(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
     cluster_names = ["kind-e2e-cluster-1"] + appdb_member_cluster_names
-    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(cluster_names, [2, 2, 1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(
+        cluster_names, [2, 2, 1]
+    )
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running)


### PR DESCRIPTION
# Summary

In multi-cluster AppDB topology, `spec.applicationDatabase.clusterSpecList[i].statefulSet` was silently dropped: only the global `spec.applicationDatabase.podSpec` was merged into the generated StatefulSet. Any per-member-cluster override (hostAliases, tolerations, nodeSelector, affinity, env, volumes) never reached the pods of that cluster.

The fix is a few lines in `AppDbStatefulSet`: after the existing global `podSpec` merge, also merge the per-cluster `StatefulSetConfiguration` when the topology is multi-cluster.

This is a quick, localized fix. The proper pattern, already used in other controllers like Sharded, is to resolve the override in the controller and pass it via `DatabaseStatefulSetOptions.StatefulSetSpecOverride` rather than reading the spec from inside the construct function. A follow-up to align AppDB with that pattern is worth filing separately.

## Proof of Work

- Unit test in `appdb_construction_test.go` builds an AppDB with two clusters, each with a different `hostAliases` block, and asserts each cluster's STS gets only its own. Also asserts the merge does not clobber `Replicas` and `ServiceName` from the base construction.
- e2e: `multicluster_appdb.py` fixture now sets a per-cluster `hostAliases` on each cluster spec item and `test_create_om` reads back each member cluster's AppDB STS to confirm the alias landed. Note: only verified at initial create; the later scale tests rebuild `clusterSpecList` from `cluster_spec_list(...)` and drop the override (called out in a comment).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details