### PR TITLE
docs(search): add Q2-MC RS + Sharded snippet tutorials

### DIFF
--- a/docs/search/12-search-q2-mc-rs/README.md
+++ b/docs/search/12-search-q2-mc-rs/README.md
@@ -1,0 +1,213 @@
+# Q2-MC MongoDBSearch — ReplicaSet source, managed Envoy, multi-cluster
+
+Deploy **MongoDBSearch** in **multi-cluster (MC) mode** against an existing **external MongoDB replica set**, with the operator managing Envoy per cluster. This tutorial mirrors the load-test contract YAML from the MVP design spec §4.1.
+
+## When to use this tutorial
+
+You are a load-test or platform engineer who already has:
+
+- A **3-node external replica set** with members spread across 2-3 regions, each member tagged in `replSetConfig` with `region: <region>` matching the K8s cluster's region (spec §6.1, §6.4).
+- **2-3 Kubernetes member clusters** registered with a central operator via `kubectl mongodb multicluster setup`.
+- Customer-replicated secrets in every member cluster (spec §6.3): `search-sync-password`, `external-ca`, plus mongot + Envoy server TLS certs under a known prefix.
+
+For the single-cluster flavour, see [docs/search/10-search-external-rs-mongod-managed-lb](../10-search-external-rs-mongod-managed-lb/).
+
+## Topology
+
+```mermaid
+graph TD
+    subgraph ext["External MongoDB Replica Set (customer-owned)"]
+        rs0(["mongod-east-1\nregion=us-east"])
+        rs1(["mongod-east-2\nregion=us-east"])
+        rs2(["mongod-west-1\nregion=eu-west"])
+    end
+
+    subgraph cent["Central K8s cluster"]
+        op["MongoDB Kubernetes Operator\n(multi-cluster mode)"]
+        cr["MongoDBSearch CR\nclusters: [us-east-k8s, eu-west-k8s]"]
+    end
+
+    subgraph east["us-east-k8s member cluster"]
+        envoy_e["Envoy Deployment\n{clusterName}.search-lb...:443"]
+        mot_e["mongot StatefulSet\nreplicas=2"]
+    end
+
+    subgraph west["eu-west-k8s member cluster"]
+        envoy_w["Envoy Deployment\n{clusterName}.search-lb...:443"]
+        mot_w["mongot StatefulSet\nreplicas=2"]
+    end
+
+    op -- reconciles per cluster --> envoy_e
+    op -- reconciles per cluster --> envoy_w
+    op -- reconciles per cluster --> mot_e
+    op -- reconciles per cluster --> mot_w
+
+    rs0 -- "readPreferenceTags region=us-east" --> mot_e
+    rs1 -- "readPreferenceTags region=us-east" --> mot_e
+    rs2 -- "readPreferenceTags region=eu-west" --> mot_w
+
+    classDef ext fill:#023430,stroke:#E3FCF7,color:#fff
+    classDef k8s fill:#E8EDEB,stroke:#00684A,color:#023430
+    class ext ext
+    class east,west,cent k8s
+```
+
+Each member cluster's mongot pool pulls only from same-region external members via `readPreferenceTags`. Search queries hit each cluster's local Envoy on its `{clusterName}.search-lb.lt.example.com:443` endpoint.
+
+## Prerequisites
+
+- `kubectl` with one context per K8s cluster (one central + 2-3 members).
+- `kubectl mongodb` plugin installed (the [MCK CLI](../../../tools/multicluster/)).
+- `helm` 3.x.
+- DNS layer that points each `{clusterName}.search-lb.lt.example.com` at the cloud LB / ingress fronting Envoy in that member cluster (cloud LB, ingress controller, or external-DNS).
+- Secrets pre-replicated into the namespace in **every** member cluster — see spec §6.3.
+
+## Getting started
+
+```bash
+cd docs/search/12-search-q2-mc-rs
+
+# Edit env_variables.sh to set your contexts, member cluster names, region tags,
+# external host:port entries, and TLS prefix.
+vi env_variables.sh
+
+source env_variables.sh
+./test.sh
+```
+
+## Step-by-step
+
+| Step | Snippet | What it does |
+| ---- | ------- | ------------ |
+| 1 | `12_0040_validate_env.sh` | Validates required env vars and that `externalHostname` template contains `{clusterName}` (or `{clusterIndex}`). |
+| 2 | `12_0045_create_namespaces.sh` | Creates `${MDB_NS}` in central + every member cluster. |
+| 3 | `12_0050_kubectl_mongodb_multicluster_setup.sh` | Registers member clusters with the central operator. |
+| 4 | `12_0100_install_operator.sh` | Helm-installs the MongoDB Kubernetes Operator in multi-cluster mode. |
+| 5 | `12_0200_verify_secrets_present.sh` | Verifies `${MDB_SYNC_PASSWORD_SECRET}` and `${MDB_EXTERNAL_CA_SECRET}` exist in each member cluster (spec §6.3). |
+| 6 | `12_0320_create_mongodb_search_resource.sh` | Applies the MongoDBSearch CR (mirrors spec §4.1). |
+| 7 | `12_0325_wait_for_search_resource.sh` | Waits for top-level `status.phase=Running` *and* per-cluster `clusterStatusList.clusterStatuses[i].phase=Running` (spec §4.3 — per-cluster phase is the real readiness gate, not the top-level phase alone). |
+| 8 | `12_0326_verify_per_cluster_envoy.sh` | Confirms each member cluster has an Available Envoy Deployment. |
+| 9 | `12_0330_show_running_pods.sh` | Shows pods + the MongoDBSearch resource. |
+| 10 | `12_0340_query_through_envoy.sh` | Smoke-test the per-cluster `{clusterName}.search-lb...:443` SNI endpoint. |
+| Cleanup | `12_9010_cleanup.sh` | Deletes the CR and the namespaces. |
+
+## Key spec contract (§4.1)
+
+The applied CR matches the load-test contract YAML byte-for-byte:
+
+```yaml
+apiVersion: mongodb.com/v1
+kind: MongoDBSearch
+metadata:
+  name: lt-search
+  namespace: mongodb
+spec:
+  source:
+    external:
+      hostAndPorts: [...]
+      tls:
+        ca:
+          name: external-ca
+    username: search-sync-source
+    passwordSecretRef:
+      name: search-sync-password
+      key: password
+  loadBalancer:
+    managed:
+      externalHostname: "{clusterName}.search-lb.lt.example.com:443"
+  security:
+    tls:
+      certsSecretPrefix: lt-prefix
+  clusters:
+    - clusterName: us-east-k8s
+      replicas: 2
+      syncSourceSelector:
+        matchTags:
+          region: us-east
+    - clusterName: eu-west-k8s
+      replicas: 2
+      syncSourceSelector:
+        matchTags:
+          region: eu-west
+```
+
+### Required, MVP
+
+- `source.external.hostAndPorts[]`, `source.external.tls.ca`, `source.username`, `source.passwordSecretRef`
+- `loadBalancer.managed.externalHostname` **must** contain `{clusterName}` or `{clusterIndex}`
+- `security.tls.certsSecretPrefix`
+- `clusters[].clusterName` (immutable, unique)
+- `clusters[].replicas` (>= 1)
+- `clusters[].syncSourceSelector.matchTags` (non-empty — the operator cannot peek at external `replSetConfig`, so the customer-owned tag is the only routing signal)
+
+### Forbidden-at-MVP shapes (spec §4.4)
+
+These will be rejected at admission once the MVP lands; load testers should avoid them up front:
+
+- `len(clusters) > 1` with `loadBalancer.unmanaged.*` (Q3/Q4-MC out of scope).
+- `len(clusters) > 1` with any internal source (`source.mongodbResourceRef.*`) — Q1-MC is phase 2.
+- `externalHostname` missing `{clusterName}` / `{clusterIndex}` when `len(clusters) > 1`.
+- `clusters[].clusterName` non-unique or empty.
+- `clusters[].syncSourceSelector.matchTags` empty.
+- `spec.replicas` set together with `spec.clusters[].replicas`.
+
+## Status surface (load-test observability)
+
+Per spec §4.3, treat `status.clusterStatusList.clusterStatuses[i].phase` + `observedReplicas` as the readiness gate, not the top-level `phase` alone:
+
+```yaml
+status:
+  phase: Running                 # worst-of any active cluster
+  clusterStatusList:
+    clusterStatuses:
+      - clusterName: us-east-k8s
+        phase: Running
+        observedGeneration: 7
+        observedReplicas: 2
+      - clusterName: eu-west-k8s
+        phase: Running
+        observedGeneration: 7
+        observedReplicas: 2
+```
+
+## Troubleshooting
+
+### Per-cluster `phase: Pending` with secret missing
+
+```bash
+kubectl get mongodbsearch "${MDB_SEARCH_RESOURCE_NAME}" -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" -o jsonpath='{.status.clusterStatusList}' | jq
+```
+
+If a cluster shows `phase: Pending` with `"Secret '...' missing in cluster"`, replicate the missing secret into that member cluster's namespace.
+
+### mongot can't find a sync source
+
+Re-check that every external mongod has its `region` tag in `replSetConfig.members[].tags`:
+
+```bash
+mongosh "<external-rs>" --eval 'rs.conf().members.forEach(m => print(m.host, JSON.stringify(m.tags)))'
+```
+
+If tags are missing, `mongot` will fail to find a sync source and search will be unavailable in that region (spec §6.4).
+
+### Envoy not Available in a member cluster
+
+```bash
+kubectl describe deployment "${MDB_SEARCH_RESOURCE_NAME}-search-lb-0" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}"
+kubectl logs -l "app=${MDB_SEARCH_RESOURCE_NAME}-search-lb-0" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}"
+```
+
+## Cleanup
+
+```bash
+./code_snippets/12_9010_cleanup.sh
+```
+
+## References
+
+- [Multi-Cluster MongoDBSearch Q2-MC MVP design spec, §4.1, §4.3, §4.4](https://example.invalid/q2-mc-mvp-design)
+- Single-cluster analogue: [docs/search/10-search-external-rs-mongod-managed-lb](../10-search-external-rs-mongod-managed-lb/)
+- Multi-cluster setup architecture: [public/architectures/setup-multi-cluster](../../../public/architectures/setup-multi-cluster/)

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0040_validate_env.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0040_validate_env.sh
@@ -1,0 +1,37 @@
+echo "Validating environment variables..."
+
+ok=true
+[[ -n "${K8S_CENTRAL_CTX:-}" && "${K8S_CENTRAL_CTX}" != "<"* ]] || { echo "  [FAIL] K8S_CENTRAL_CTX not set" >&2; ok=false; }
+[[ -n "${K8S_CLUSTER_0_CTX:-}" && "${K8S_CLUSTER_0_CTX}" != "<"* ]] || { echo "  [FAIL] K8S_CLUSTER_0_CTX not set" >&2; ok=false; }
+[[ -n "${K8S_CLUSTER_1_CTX:-}" && "${K8S_CLUSTER_1_CTX}" != "<"* ]] || { echo "  [FAIL] K8S_CLUSTER_1_CTX not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_0_NAME:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_0_NAME not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_1_NAME:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_1_NAME not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_0_REGION:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_0_REGION not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_1_REGION:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_1_REGION not set" >&2; ok=false; }
+[[ -n "${MDB_NS:-}" ]] || { echo "  [FAIL] MDB_NS not set" >&2; ok=false; }
+[[ -n "${MDB_SEARCH_RESOURCE_NAME:-}" ]] || { echo "  [FAIL] MDB_SEARCH_RESOURCE_NAME not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_HOST_0:-}" && "${MDB_EXTERNAL_HOST_0}" != "<"* ]] || { echo "  [FAIL] MDB_EXTERNAL_HOST_0 not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_HOST_1:-}" && "${MDB_EXTERNAL_HOST_1}" != "<"* ]] || { echo "  [FAIL] MDB_EXTERNAL_HOST_1 not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_HOST_2:-}" && "${MDB_EXTERNAL_HOST_2}" != "<"* ]] || { echo "  [FAIL] MDB_EXTERNAL_HOST_2 not set" >&2; ok=false; }
+[[ -n "${MDB_SYNC_PASSWORD_SECRET:-}" ]] || { echo "  [FAIL] MDB_SYNC_PASSWORD_SECRET not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_CA_SECRET:-}" ]] || { echo "  [FAIL] MDB_EXTERNAL_CA_SECRET not set" >&2; ok=false; }
+[[ -n "${MDB_TLS_CERT_SECRET_PREFIX:-}" ]] || { echo "  [FAIL] MDB_TLS_CERT_SECRET_PREFIX not set" >&2; ok=false; }
+[[ -n "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" ]] || { echo "  [FAIL] MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE not set" >&2; ok=false; }
+[[ "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" == *"{clusterName}"* || "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" == *"{clusterIndex}"* ]] \
+  || { echo "  [FAIL] MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE must contain {clusterName} or {clusterIndex} (spec §4.1)" >&2; ok=false; }
+
+kubectl config get-contexts "${K8S_CENTRAL_CTX}" &>/dev/null || { echo "  [FAIL] central context '${K8S_CENTRAL_CTX}' missing from kubeconfig" >&2; ok=false; }
+kubectl config get-contexts "${K8S_CLUSTER_0_CTX}" &>/dev/null || { echo "  [FAIL] member context '${K8S_CLUSTER_0_CTX}' missing from kubeconfig" >&2; ok=false; }
+kubectl config get-contexts "${K8S_CLUSTER_1_CTX}" &>/dev/null || { echo "  [FAIL] member context '${K8S_CLUSTER_1_CTX}' missing from kubeconfig" >&2; ok=false; }
+
+if [[ "${ok}" == "true" ]]; then
+  echo "[ok] Environment validated"
+  echo "  Central context: ${K8S_CENTRAL_CTX}"
+  echo "  Member 0 (${MEMBER_CLUSTER_0_NAME}, region=${MEMBER_CLUSTER_0_REGION}): ${K8S_CLUSTER_0_CTX}"
+  echo "  Member 1 (${MEMBER_CLUSTER_1_NAME}, region=${MEMBER_CLUSTER_1_REGION}): ${K8S_CLUSTER_1_CTX}"
+  echo "  Search resource: ${MDB_SEARCH_RESOURCE_NAME} (ns=${MDB_NS})"
+  echo "  externalHostname template: ${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"
+else
+  echo "ERROR: validation failed — fix env_variables.sh and re-source it" >&2
+  exit 1
+fi

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0045_create_namespaces.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0045_create_namespaces.sh
@@ -1,0 +1,12 @@
+echo "Creating namespace '${MDB_NS}' in central + member clusters..."
+
+kubectl create namespace "${MDB_NS}" --context "${K8S_CENTRAL_CTX}" --dry-run=client -o yaml | \
+  kubectl apply --context "${K8S_CENTRAL_CTX}" -f -
+
+kubectl create namespace "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" --dry-run=client -o yaml | \
+  kubectl apply --context "${K8S_CLUSTER_0_CTX}" -f -
+
+kubectl create namespace "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" --dry-run=client -o yaml | \
+  kubectl apply --context "${K8S_CLUSTER_1_CTX}" -f -
+
+echo "[ok] Namespace '${MDB_NS}' ready in central + ${MEMBER_CLUSTER_0_NAME} + ${MEMBER_CLUSTER_1_NAME}"

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0050_kubectl_mongodb_multicluster_setup.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0050_kubectl_mongodb_multicluster_setup.sh
@@ -1,0 +1,11 @@
+echo "Registering member clusters with the central operator (kubectl mongodb multicluster setup)..."
+
+kubectl mongodb multicluster setup \
+  --central-cluster="${K8S_CENTRAL_CTX}" \
+  --member-clusters="${K8S_CLUSTER_0_CTX},${K8S_CLUSTER_1_CTX}" \
+  --member-cluster-namespace="${MDB_NS}" \
+  --central-cluster-namespace="${OPERATOR_NAMESPACE}" \
+  --create-service-account-secrets \
+  --install-database-roles=true
+
+echo "[ok] kubectl-mongodb multicluster setup complete"

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0100_install_operator.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0100_install_operator.sh
@@ -1,0 +1,23 @@
+echo "Installing MongoDB Kubernetes Operator (multi-cluster mode) on the central cluster..."
+
+helm upgrade --install mongodb-kubernetes-operator-multi-cluster \
+  "${OPERATOR_HELM_CHART}" \
+  --kube-context "${K8S_CENTRAL_CTX}" \
+  --namespace "${OPERATOR_NAMESPACE}" \
+  --set namespace="${OPERATOR_NAMESPACE}" \
+  --set operator.namespace="${OPERATOR_NAMESPACE}" \
+  --set operator.watchNamespace="${MDB_NS}" \
+  --set operator.name=mongodb-kubernetes-operator-multi-cluster \
+  --set operator.createOperatorServiceAccount=false \
+  --set operator.createResourcesServiceAccountsAndRoles=false \
+  --set "multiCluster.clusters={${K8S_CLUSTER_0_CTX},${K8S_CLUSTER_1_CTX}}" \
+  --set "${OPERATOR_ADDITIONAL_HELM_VALUES:-dummy=value}" \
+  --wait \
+  --timeout 5m
+
+kubectl rollout status deployment/mongodb-kubernetes-operator-multi-cluster \
+  --namespace "${OPERATOR_NAMESPACE}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=120s
+
+echo "[ok] Operator installed and ready"

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0200_verify_secrets_present.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0200_verify_secrets_present.sh
@@ -1,0 +1,17 @@
+echo "Verifying customer-replicated secrets are present in every member cluster (spec §6.3)..."
+
+# Sync-source password
+kubectl get secret "${MDB_SYNC_PASSWORD_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_0_NAME}: secret/${MDB_SYNC_PASSWORD_SECRET}"
+kubectl get secret "${MDB_SYNC_PASSWORD_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_1_NAME}: secret/${MDB_SYNC_PASSWORD_SECRET}"
+
+# External CA bundle
+kubectl get secret "${MDB_EXTERNAL_CA_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_0_NAME}: secret/${MDB_EXTERNAL_CA_SECRET}"
+kubectl get secret "${MDB_EXTERNAL_CA_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_1_NAME}: secret/${MDB_EXTERNAL_CA_SECRET}"
+
+echo "[ok] Required secrets present in every member cluster"
+echo "  Note: TLS prefix '${MDB_TLS_CERT_SECRET_PREFIX}' must produce valid mongot + Envoy server certs"
+echo "        signed by the same CA. Operator will surface a warning per-cluster if any are missing."

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0320_create_mongodb_search_resource.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0320_create_mongodb_search_resource.sh
@@ -1,0 +1,42 @@
+echo "Applying MongoDBSearch CR (Q2-MC RS, mirrors spec §4.1)..."
+
+kubectl apply --context "${K8S_CENTRAL_CTX}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBSearch
+metadata:
+  name: ${MDB_SEARCH_RESOURCE_NAME}
+  namespace: ${MDB_NS}
+spec:
+  source:
+    external:
+      hostAndPorts:
+        - ${MDB_EXTERNAL_HOST_0}
+        - ${MDB_EXTERNAL_HOST_1}
+        - ${MDB_EXTERNAL_HOST_2}
+      tls:
+        ca:
+          name: ${MDB_EXTERNAL_CA_SECRET}
+    username: ${MDB_SEARCH_SYNC_USERNAME}
+    passwordSecretRef:
+      name: ${MDB_SYNC_PASSWORD_SECRET}
+      key: password
+  loadBalancer:
+    managed:
+      externalHostname: "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"
+  security:
+    tls:
+      certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
+  clusters:
+    - clusterName: ${MEMBER_CLUSTER_0_NAME}
+      replicas: ${MDB_MONGOT_REPLICAS}
+      syncSourceSelector:
+        matchTags:
+          region: ${MEMBER_CLUSTER_0_REGION}
+    - clusterName: ${MEMBER_CLUSTER_1_NAME}
+      replicas: ${MDB_MONGOT_REPLICAS}
+      syncSourceSelector:
+        matchTags:
+          region: ${MEMBER_CLUSTER_1_REGION}
+EOF
+
+echo "[ok] MongoDBSearch '${MDB_SEARCH_RESOURCE_NAME}' applied"

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0325_wait_for_search_resource.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0325_wait_for_search_resource.sh
@@ -1,0 +1,26 @@
+echo "Waiting for MongoDBSearch top-level status.phase=Running..."
+
+kubectl wait --for=jsonpath='{.status.phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=600s
+
+echo "Waiting for ${MEMBER_CLUSTER_0_NAME} per-cluster status.phase=Running (spec §4.3)..."
+kubectl wait --for=jsonpath='{.status.clusterStatusList.clusterStatuses[?(@.clusterName=="'"${MEMBER_CLUSTER_0_NAME}"'")].phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=600s
+
+echo "Waiting for ${MEMBER_CLUSTER_1_NAME} per-cluster status.phase=Running..."
+kubectl wait --for=jsonpath='{.status.clusterStatusList.clusterStatuses[?(@.clusterName=="'"${MEMBER_CLUSTER_1_NAME}"'")].phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=600s
+
+echo "[ok] MongoDBSearch is Running across all member clusters"
+echo ""
+kubectl get mongodbsearch "${MDB_SEARCH_RESOURCE_NAME}" -n "${MDB_NS}" --context "${K8S_CENTRAL_CTX}" -o yaml \
+  | grep -A 80 '^status:' | head -80

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0326_verify_per_cluster_envoy.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0326_verify_per_cluster_envoy.sh
@@ -1,0 +1,18 @@
+echo "Verifying per-cluster Envoy Deployment in each member cluster..."
+
+envoy_deployment="${MDB_SEARCH_RESOURCE_NAME}-search-lb-0"
+
+echo "Member ${MEMBER_CLUSTER_0_NAME} (${K8S_CLUSTER_0_CTX}):"
+kubectl wait --for=condition=Available deployment/"${envoy_deployment}" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" --timeout=300s
+kubectl get deployment "${envoy_deployment}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}"
+
+echo ""
+echo "Member ${MEMBER_CLUSTER_1_NAME} (${K8S_CLUSTER_1_CTX}):"
+kubectl wait --for=condition=Available deployment/"${envoy_deployment}" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" --timeout=300s
+kubectl get deployment "${envoy_deployment}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}"
+
+echo ""
+echo "[ok] Per-cluster Envoy is Available; the SNI route '<clusterName>.search-lb.lt.example.com:443'"
+echo "     should now resolve through your DNS layer to each cluster's Envoy frontend."

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0330_show_running_pods.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0330_show_running_pods.sh
@@ -1,0 +1,10 @@
+echo "Pods in ${MEMBER_CLUSTER_0_NAME} (${K8S_CLUSTER_0_CTX}):"
+kubectl get pods -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" -o wide
+
+echo ""
+echo "Pods in ${MEMBER_CLUSTER_1_NAME} (${K8S_CLUSTER_1_CTX}):"
+kubectl get pods -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" -o wide
+
+echo ""
+echo "MongoDBSearch resource (central):"
+kubectl get mongodbsearch -n "${MDB_NS}" --context "${K8S_CENTRAL_CTX}"

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_0340_query_through_envoy.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_0340_query_through_envoy.sh
@@ -1,0 +1,21 @@
+echo "Smoke-test the per-cluster Envoy SNI endpoint with mongosh..."
+echo ""
+echo "Each member cluster publishes its own Envoy frontend at:"
+echo "  ${MEMBER_CLUSTER_0_NAME}.search-lb.lt.example.com:443"
+echo "  ${MEMBER_CLUSTER_1_NAME}.search-lb.lt.example.com:443"
+echo ""
+echo "From a host with mongosh + DNS access, run a search query against the external mongod"
+echo "via mongos / your test client; mongot connections will pin to the same-region cluster's"
+echo "endpoint per spec §5.1.2."
+echo ""
+echo "Example (run against the external replica set; mongot lookups happen server-side):"
+cat <<'EOF'
+mongosh "mongodb://search-sync-source@<external-mongod-host>:27017/?tls=true" \
+  --eval 'db.getSiblingDB("admin").runCommand({ ping: 1 })'
+EOF
+echo ""
+echo "Verify the per-cluster Envoy is reachable on its SNI hostname:"
+cat <<'EOF'
+openssl s_client -connect <clusterName>.search-lb.lt.example.com:443 \
+  -servername <clusterName>.search-lb.lt.example.com -showcerts < /dev/null
+EOF

--- a/docs/search/12-search-q2-mc-rs/code_snippets/12_9010_cleanup.sh
+++ b/docs/search/12-search-q2-mc-rs/code_snippets/12_9010_cleanup.sh
@@ -1,0 +1,10 @@
+echo "Deleting MongoDBSearch '${MDB_SEARCH_RESOURCE_NAME}' from central cluster..."
+kubectl delete mongodbsearch "${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" --context "${K8S_CENTRAL_CTX}" --ignore-not-found --wait=true
+
+echo "Deleting namespace '${MDB_NS}' from each cluster (non-blocking)..."
+kubectl delete namespace "${MDB_NS}" --context "${K8S_CENTRAL_CTX}"  --wait=false --ignore-not-found
+kubectl delete namespace "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" --wait=false --ignore-not-found
+kubectl delete namespace "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" --wait=false --ignore-not-found
+
+echo "[ok] Cleanup initiated"

--- a/docs/search/12-search-q2-mc-rs/env_variables.sh
+++ b/docs/search/12-search-q2-mc-rs/env_variables.sh
@@ -1,0 +1,87 @@
+# ============================================================================
+# Q2-MC ReplicaSet — Multi-cluster MongoDBSearch with managed Envoy + external mongod
+#
+# Source this file with `source env_variables.sh` before running the snippets.
+# Replace every `<...>` placeholder before sourcing.
+# ============================================================================
+
+# ============================================================================
+# KUBERNETES CONTEXTS
+# ============================================================================
+
+# Central (operator) cluster context
+export K8S_CENTRAL_CTX="<central cluster context>"
+
+# Member clusters where mongot + Envoy run.
+# Per spec §6.2 the load-test target is 2-3 member clusters.
+export K8S_CLUSTER_0_CTX="<member cluster 0 context>"
+export K8S_CLUSTER_1_CTX="<member cluster 1 context>"
+
+# Member cluster names — these are the values that resolve {clusterName}
+# in `loadBalancer.managed.externalHostname`. They MUST match the names used
+# in `clusters[].clusterName` in the MongoDBSearch spec.
+export MEMBER_CLUSTER_0_NAME="us-east-k8s"
+export MEMBER_CLUSTER_1_NAME="eu-west-k8s"
+
+# Region tags on each member cluster's external mongod (replSetConfig.members[].tags)
+# Per spec §6.4: every external mongod member must carry a `region` tag matching
+# `clusters[].syncSourceSelector.matchTags`.
+export MEMBER_CLUSTER_0_REGION="us-east"
+export MEMBER_CLUSTER_1_REGION="eu-west"
+
+# Namespace where MongoDBSearch will be deployed (same in every member cluster)
+export MDB_NS="mongodb"
+
+# ============================================================================
+# MONGODBSEARCH RESOURCE
+# ============================================================================
+
+export MDB_SEARCH_RESOURCE_NAME="lt-search"
+
+# Mongot replicas per member cluster (>= 1 per spec §4.1)
+export MDB_MONGOT_REPLICAS=2
+
+# ============================================================================
+# EXTERNAL MONGODB REPLICA SET (customer-owned, off-cluster)
+# ============================================================================
+# Per spec §6.1 — a 3-node external replica set with members across 2-3 regions,
+# each member tagged in replSetConfig with `region: <region>`.
+
+export MDB_EXTERNAL_HOST_0="<mongod-east-1.lt.example.com:27017>"
+export MDB_EXTERNAL_HOST_1="<mongod-east-2.lt.example.com:27017>"
+export MDB_EXTERNAL_HOST_2="<mongod-west-1.lt.example.com:27017>"
+
+# Sync-source user — pre-created on the external mongod with `searchCoordinator`
+# (or equivalent) role. Password lives in the secret named below.
+export MDB_SEARCH_SYNC_USERNAME="search-sync-source"
+
+# ============================================================================
+# CUSTOMER-REPLICATED SECRETS (per-cluster, same name in every cluster)
+# ============================================================================
+# Per spec §6.3 — the load tester replicates these into every member cluster.
+
+# Sync-source password (key: password)
+export MDB_SYNC_PASSWORD_SECRET="search-sync-password"
+
+# CA bundle (key: ca.crt)
+export MDB_EXTERNAL_CA_SECRET="external-ca"
+
+# TLS certs prefix — operator looks up `<prefix>-<unit-name>-cert` per cluster
+export MDB_TLS_CERT_SECRET_PREFIX="lt-prefix"
+
+# ============================================================================
+# LOAD BALANCER HOSTNAME TEMPLATE
+# ============================================================================
+# Per spec §4.1 — must contain {clusterName} (or {clusterIndex}) so each member
+# cluster gets its own resolvable hostname. The load tester is responsible for
+# DNS pointing each {clusterName}.search-lb.lt.example.com at the local cloud
+# LB / ingress fronting Envoy in that cluster.
+export MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE="{clusterName}.search-lb.lt.example.com:443"
+
+# ============================================================================
+# OPERATOR INSTALL
+# ============================================================================
+
+export OPERATOR_NAMESPACE="${MDB_NS}"
+export OPERATOR_HELM_CHART="oci://quay.io/mongodb/helm-charts/mongodb-kubernetes"
+export OPERATOR_ADDITIONAL_HELM_VALUES=""

--- a/docs/search/12-search-q2-mc-rs/test.sh
+++ b/docs/search/12-search-q2-mc-rs/test.sh
@@ -1,0 +1,51 @@
+# Test runner for Q2-MC ReplicaSet — MongoDBSearch with managed Envoy + external mongod.
+#
+# Usage:
+#   source env_variables.sh
+#   ./test.sh
+#
+# Prerequisites: 2-3 K8s clusters reachable via kubeconfig contexts and an external
+# replica set (with regional tags) per spec §6.1.
+
+set -eou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+project_dir="${script_dir}/../../.."
+
+source "${project_dir}/scripts/code_snippets/sample_test_runner.sh"
+
+cd "${script_dir}"
+
+prepare_snippets
+
+# Prerequisites
+run               12_0040_validate_env.sh
+run               12_0045_create_namespaces.sh
+run_for_output    12_0050_kubectl_mongodb_multicluster_setup.sh
+run_for_output    12_0100_install_operator.sh
+
+# Customer-replicated secrets (load tester stages these per §6.3 — verified, not created)
+run               12_0200_verify_secrets_present.sh
+
+# Apply CR + wait for steady-state across clusters
+run               12_0320_create_mongodb_search_resource.sh
+run_for_output    12_0325_wait_for_search_resource.sh
+
+# Verification
+run_for_output    12_0326_verify_per_cluster_envoy.sh
+run_for_output    12_0330_show_running_pods.sh
+run_for_output    12_0340_query_through_envoy.sh
+
+echo ""
+echo "============================================"
+echo "Q2-MC RS deployment complete!"
+echo "============================================"
+echo ""
+echo "MongoDBSearch is running across:"
+echo "  - ${MEMBER_CLUSTER_0_NAME} (region=${MEMBER_CLUSTER_0_REGION})"
+echo "  - ${MEMBER_CLUSTER_1_NAME} (region=${MEMBER_CLUSTER_1_REGION})"
+echo ""
+echo "To clean up, run: ./code_snippets/12_9010_cleanup.sh"
+
+cd -

--- a/docs/search/13-search-q2-mc-sharded/README.md
+++ b/docs/search/13-search-q2-mc-sharded/README.md
@@ -115,6 +115,7 @@ spec:
     username: search-sync-source
     passwordSecretRef:
       name: search-sync-password
+      key: password
   loadBalancer:
     managed:
       externalHostname: "{clusterName}.{shardName}.search-lb.lt.example.com:443"

--- a/docs/search/13-search-q2-mc-sharded/README.md
+++ b/docs/search/13-search-q2-mc-sharded/README.md
@@ -1,0 +1,220 @@
+# Q2-MC MongoDBSearch — Sharded source, managed Envoy, multi-cluster
+
+Deploy **MongoDBSearch** in **multi-cluster (MC) mode** against an existing **external sharded MongoDB cluster** (mongos pool + per-shard replica sets), with the operator managing one Envoy Deployment per K8s cluster that multiplexes per-shard SNI routes. This tutorial mirrors the load-test contract YAML from the MVP design spec §4.2.
+
+## When to use this tutorial
+
+You are a load-test or platform engineer who already has:
+
+- An **external sharded cluster** — mongos pool + per-shard 3-node replica sets, each shard's members tagged per region (spec §6.1).
+- **2-3 Kubernetes member clusters** registered with a central operator via `kubectl mongodb multicluster setup`.
+- Customer-replicated secrets in every member cluster (spec §6.3): `search-sync-password`, `external-ca`, `mongod-keyfile` (sharded-only), plus mongot + Envoy server TLS certs under a known prefix.
+
+For the single-cluster flavour, see [docs/search/07-search-external-sharded-mongod-managed-lb](../07-search-external-sharded-mongod-managed-lb/).
+
+## Topology
+
+```mermaid
+graph TD
+    subgraph ext["External Sharded Cluster (customer-owned)"]
+        mongos["mongos pool"]
+        s0e(["shard-0/east-1\nregion=us-east"])
+        s0w(["shard-0/west-1\nregion=eu-west"])
+        s1e(["shard-1/east-1\nregion=us-east"])
+        s1w(["shard-1/west-1\nregion=eu-west"])
+    end
+
+    subgraph east["us-east-k8s member cluster"]
+        envoy_e["Envoy\nSNI: us-east-k8s.shard-0..., us-east-k8s.shard-1..."]
+        mot_e0["mongot/shard-0\nreplicas=2"]
+        mot_e1["mongot/shard-1\nreplicas=2"]
+    end
+
+    subgraph west["eu-west-k8s member cluster"]
+        envoy_w["Envoy\nSNI: eu-west-k8s.shard-0..., eu-west-k8s.shard-1..."]
+        mot_w0["mongot/shard-0\nreplicas=2"]
+        mot_w1["mongot/shard-1\nreplicas=2"]
+    end
+
+    s0e -- "readPreferenceTags region=us-east" --> mot_e0
+    s1e -- "readPreferenceTags region=us-east" --> mot_e1
+    s0w -- "readPreferenceTags region=eu-west" --> mot_w0
+    s1w -- "readPreferenceTags region=eu-west" --> mot_w1
+
+    classDef ext fill:#023430,stroke:#E3FCF7,color:#fff
+    classDef k8s fill:#E8EDEB,stroke:#00684A,color:#023430
+    class ext ext
+    class east,west k8s
+```
+
+Every (cluster, shard) tuple gets its own SNI route through the per-cluster Envoy: `{clusterName}.{shardName}.search-lb.lt.example.com:443`.
+
+## Prerequisites
+
+- `kubectl` with one context per K8s cluster (one central + 2-3 members).
+- `kubectl mongodb` plugin installed (the [MCK CLI](../../../tools/multicluster/)).
+- `helm` 3.x.
+- DNS layer that points each `{clusterName}.{shardName}.search-lb.lt.example.com` at the cloud LB / ingress fronting Envoy in that member cluster (a wildcard `*.{clusterName}.search-lb.lt.example.com` typically suffices).
+- Secrets pre-replicated into the namespace in **every** member cluster — see spec §6.3.
+
+## Getting started
+
+```bash
+cd docs/search/13-search-q2-mc-sharded
+
+vi env_variables.sh
+source env_variables.sh
+./test.sh
+```
+
+## Step-by-step
+
+| Step | Snippet | What it does |
+| ---- | ------- | ------------ |
+| 1 | `13_0040_validate_env.sh` | Validates env vars and that `externalHostname` template contains both `{clusterName}` (or `{clusterIndex}`) and `{shardName}`. |
+| 2 | `13_0045_create_namespaces.sh` | Creates `${MDB_NS}` in central + every member cluster. |
+| 3 | `13_0050_kubectl_mongodb_multicluster_setup.sh` | Registers member clusters with the central operator. |
+| 4 | `13_0100_install_operator.sh` | Helm-installs the MongoDB Kubernetes Operator in multi-cluster mode. |
+| 5 | `13_0200_verify_secrets_present.sh` | Verifies sync-password, CA bundle, and (sharded-only) `mongod-keyfile` secrets in each member cluster. |
+| 6 | `13_0320_create_mongodb_search_resource.sh` | Applies the MongoDBSearch CR (mirrors spec §4.2). |
+| 7 | `13_0325_wait_for_search_resource.sh` | Waits for top-level `status.phase=Running` *and* per-cluster `clusterStatusList.clusterStatuses[i].phase=Running` (spec §4.3). |
+| 8 | `13_0326_verify_per_cluster_envoy.sh` | Confirms each member cluster has an Available Envoy Deployment. |
+| 9 | `13_0330_show_running_pods.sh` | Shows pods + the MongoDBSearch resource. |
+| 10 | `13_0340_query_through_envoy.sh` | Smoke-test the per-(cluster, shard) SNI endpoints. |
+| Optional | `13_0322_apply_shard_overrides_example.sh` | Demos `clusters[].shardOverrides[]` to bias hot vs. cold shards (spec §4.2 / §5.1.4). |
+| Cleanup | `13_9010_cleanup.sh` | Deletes the CR and the namespaces. |
+
+## Key spec contract (§4.2)
+
+The applied CR matches the load-test contract YAML byte-for-byte:
+
+```yaml
+apiVersion: mongodb.com/v1
+kind: MongoDBSearch
+metadata:
+  name: lt-search-sharded
+  namespace: mongodb
+spec:
+  source:
+    external:
+      shardedCluster:
+        router:
+          hosts:
+            - mongos-east-1.lt.example.com:27017
+            - mongos-west-1.lt.example.com:27017
+        shards:
+          - shardName: shard-0
+            hosts: [...]
+          - shardName: shard-1
+            hosts: [...]
+      tls:
+        ca:
+          name: external-ca
+      keyfileSecretRef:
+        name: mongod-keyfile
+    username: search-sync-source
+    passwordSecretRef:
+      name: search-sync-password
+  loadBalancer:
+    managed:
+      externalHostname: "{clusterName}.{shardName}.search-lb.lt.example.com:443"
+  security:
+    tls:
+      certsSecretPrefix: lt-prefix
+  clusters:
+    - clusterName: us-east-k8s
+      replicas: 2                         # PER SHARD, not total
+      syncSourceSelector:
+        matchTags:
+          region: us-east
+    - clusterName: eu-west-k8s
+      replicas: 2
+      syncSourceSelector:
+        matchTags:
+          region: eu-west
+```
+
+### Required (in addition to Q2-MC RS)
+
+- `source.external.shardedCluster.router.hosts[]`
+- `source.external.shardedCluster.shards[].{shardName,hosts[]}`
+- `source.external.keyfileSecretRef`
+- `externalHostname` containing **both** `{clusterName}` (or `{clusterIndex}`) **and** `{shardName}`
+- `clusters[].replicas` is mongot pods **per shard**, not total
+
+### Per-shard tuning — `shardOverrides`
+
+`clusters[i].shardOverrides[]` lets a load tester bias hot vs. cold shards without inflating the spec. Each entry takes a `shardNames[]` selector and any of `replicas`, `resourceRequirements`, `persistence`, `statefulSet`. See `code_snippets/13_0322_apply_shard_overrides_example.sh`.
+
+### Forbidden-at-MVP shapes (spec §4.4)
+
+- `len(clusters) > 1` with `loadBalancer.unmanaged.*`.
+- `len(clusters) > 1` with any internal source.
+- `externalHostname` missing `{clusterName}` / `{clusterIndex}` *or* missing `{shardName}` when sharded.
+- `clusters[].clusterName` non-unique or empty.
+- `clusters[].syncSourceSelector.matchTags` empty.
+- `spec.replicas` set together with `spec.clusters[].replicas`.
+
+## Status surface (load-test observability)
+
+Per spec §4.3, sharded status nests `loadBalancer.shards[<shardName>].phase` per cluster:
+
+```yaml
+status:
+  phase: Running
+  clusterStatusList:
+    clusterStatuses:
+      - clusterName: us-east-k8s
+        phase: Running
+        observedReplicas: 4              # 2 shards * 2 replicas
+        loadBalancer:
+          phase: Running
+          shards:
+            shard-0: { phase: Running }
+            shard-1: { phase: Running }
+      - clusterName: eu-west-k8s
+        phase: Running
+        observedReplicas: 4
+```
+
+Treat per-cluster `phase` + per-shard `loadBalancer.shards[*].phase` as the readiness gate, not the top-level `phase` alone.
+
+## Troubleshooting
+
+### Per-cluster `phase: Pending` with secret missing
+
+```bash
+kubectl get mongodbsearch "${MDB_SEARCH_RESOURCE_NAME}" -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" -o jsonpath='{.status.clusterStatusList}' | jq
+```
+
+### mongot can't find a sync source for a shard
+
+Re-check that every external shard mongod has its `region` tag in `replSetConfig.members[].tags`:
+
+```bash
+mongosh "<external-shard-rs>" --eval 'rs.conf().members.forEach(m => print(m.host, JSON.stringify(m.tags)))'
+```
+
+If tags are missing on a shard, mongot for that shard will fail to find a sync source in that region (spec §6.4).
+
+### Envoy not Available in a member cluster
+
+```bash
+kubectl describe deployment "${MDB_SEARCH_RESOURCE_NAME}-search-lb-0" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}"
+kubectl logs -l "app=${MDB_SEARCH_RESOURCE_NAME}-search-lb-0" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}"
+```
+
+## Cleanup
+
+```bash
+./code_snippets/13_9010_cleanup.sh
+```
+
+## References
+
+- [Multi-Cluster MongoDBSearch Q2-MC MVP design spec, §4.2, §4.3, §4.4](https://example.invalid/q2-mc-mvp-design)
+- Single-cluster analogue: [docs/search/07-search-external-sharded-mongod-managed-lb](../07-search-external-sharded-mongod-managed-lb/)
+- Multi-cluster setup architecture: [public/architectures/setup-multi-cluster](../../../public/architectures/setup-multi-cluster/)

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0040_validate_env.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0040_validate_env.sh
@@ -1,0 +1,46 @@
+echo "Validating environment variables..."
+
+ok=true
+[[ -n "${K8S_CENTRAL_CTX:-}" && "${K8S_CENTRAL_CTX}" != "<"* ]] || { echo "  [FAIL] K8S_CENTRAL_CTX not set" >&2; ok=false; }
+[[ -n "${K8S_CLUSTER_0_CTX:-}" && "${K8S_CLUSTER_0_CTX}" != "<"* ]] || { echo "  [FAIL] K8S_CLUSTER_0_CTX not set" >&2; ok=false; }
+[[ -n "${K8S_CLUSTER_1_CTX:-}" && "${K8S_CLUSTER_1_CTX}" != "<"* ]] || { echo "  [FAIL] K8S_CLUSTER_1_CTX not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_0_NAME:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_0_NAME not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_1_NAME:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_1_NAME not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_0_REGION:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_0_REGION not set" >&2; ok=false; }
+[[ -n "${MEMBER_CLUSTER_1_REGION:-}" ]] || { echo "  [FAIL] MEMBER_CLUSTER_1_REGION not set" >&2; ok=false; }
+[[ -n "${MDB_NS:-}" ]] || { echo "  [FAIL] MDB_NS not set" >&2; ok=false; }
+[[ -n "${MDB_SEARCH_RESOURCE_NAME:-}" ]] || { echo "  [FAIL] MDB_SEARCH_RESOURCE_NAME not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_MONGOS_HOST_0:-}" && "${MDB_EXTERNAL_MONGOS_HOST_0}" != "<"* ]] || { echo "  [FAIL] MDB_EXTERNAL_MONGOS_HOST_0 not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_MONGOS_HOST_1:-}" && "${MDB_EXTERNAL_MONGOS_HOST_1}" != "<"* ]] || { echo "  [FAIL] MDB_EXTERNAL_MONGOS_HOST_1 not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_0_NAME:-}" ]] || { echo "  [FAIL] MDB_SHARD_0_NAME not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_0_HOST_0:-}" && "${MDB_SHARD_0_HOST_0}" != "<"* ]] || { echo "  [FAIL] MDB_SHARD_0_HOST_0 not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_0_HOST_1:-}" && "${MDB_SHARD_0_HOST_1}" != "<"* ]] || { echo "  [FAIL] MDB_SHARD_0_HOST_1 not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_0_HOST_2:-}" && "${MDB_SHARD_0_HOST_2}" != "<"* ]] || { echo "  [FAIL] MDB_SHARD_0_HOST_2 not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_1_NAME:-}" ]] || { echo "  [FAIL] MDB_SHARD_1_NAME not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_1_HOST_0:-}" && "${MDB_SHARD_1_HOST_0}" != "<"* ]] || { echo "  [FAIL] MDB_SHARD_1_HOST_0 not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_1_HOST_1:-}" && "${MDB_SHARD_1_HOST_1}" != "<"* ]] || { echo "  [FAIL] MDB_SHARD_1_HOST_1 not set" >&2; ok=false; }
+[[ -n "${MDB_SHARD_1_HOST_2:-}" && "${MDB_SHARD_1_HOST_2}" != "<"* ]] || { echo "  [FAIL] MDB_SHARD_1_HOST_2 not set" >&2; ok=false; }
+[[ -n "${MDB_SYNC_PASSWORD_SECRET:-}" ]] || { echo "  [FAIL] MDB_SYNC_PASSWORD_SECRET not set" >&2; ok=false; }
+[[ -n "${MDB_EXTERNAL_CA_SECRET:-}" ]] || { echo "  [FAIL] MDB_EXTERNAL_CA_SECRET not set" >&2; ok=false; }
+[[ -n "${MDB_KEYFILE_SECRET:-}" ]] || { echo "  [FAIL] MDB_KEYFILE_SECRET not set" >&2; ok=false; }
+[[ -n "${MDB_TLS_CERT_SECRET_PREFIX:-}" ]] || { echo "  [FAIL] MDB_TLS_CERT_SECRET_PREFIX not set" >&2; ok=false; }
+[[ -n "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" ]] || { echo "  [FAIL] MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE not set" >&2; ok=false; }
+[[ "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" == *"{clusterName}"* || "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" == *"{clusterIndex}"* ]] \
+  || { echo "  [FAIL] externalHostname template must contain {clusterName} or {clusterIndex} (spec §4.2)" >&2; ok=false; }
+[[ "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE:-}" == *"{shardName}"* ]] \
+  || { echo "  [FAIL] externalHostname template must contain {shardName} for sharded MC (spec §4.2)" >&2; ok=false; }
+
+kubectl config get-contexts "${K8S_CENTRAL_CTX}" &>/dev/null || { echo "  [FAIL] central context '${K8S_CENTRAL_CTX}' missing from kubeconfig" >&2; ok=false; }
+kubectl config get-contexts "${K8S_CLUSTER_0_CTX}" &>/dev/null || { echo "  [FAIL] member context '${K8S_CLUSTER_0_CTX}' missing from kubeconfig" >&2; ok=false; }
+kubectl config get-contexts "${K8S_CLUSTER_1_CTX}" &>/dev/null || { echo "  [FAIL] member context '${K8S_CLUSTER_1_CTX}' missing from kubeconfig" >&2; ok=false; }
+
+if [[ "${ok}" == "true" ]]; then
+  echo "[ok] Environment validated"
+  echo "  Central: ${K8S_CENTRAL_CTX}"
+  echo "  Members: ${MEMBER_CLUSTER_0_NAME}/${MEMBER_CLUSTER_0_REGION}, ${MEMBER_CLUSTER_1_NAME}/${MEMBER_CLUSTER_1_REGION}"
+  echo "  Shards: ${MDB_SHARD_0_NAME}, ${MDB_SHARD_1_NAME}"
+  echo "  externalHostname template: ${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"
+else
+  echo "ERROR: validation failed — fix env_variables.sh and re-source it" >&2
+  exit 1
+fi

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0045_create_namespaces.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0045_create_namespaces.sh
@@ -1,0 +1,7 @@
+echo "Creating namespace '${MDB_NS}' in central + member clusters..."
+
+kubectl create namespace "${MDB_NS}" --context "${K8S_CENTRAL_CTX}"  --dry-run=client -o yaml | kubectl apply --context "${K8S_CENTRAL_CTX}"  -f -
+kubectl create namespace "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" --dry-run=client -o yaml | kubectl apply --context "${K8S_CLUSTER_0_CTX}" -f -
+kubectl create namespace "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" --dry-run=client -o yaml | kubectl apply --context "${K8S_CLUSTER_1_CTX}" -f -
+
+echo "[ok] Namespace '${MDB_NS}' ready in central + ${MEMBER_CLUSTER_0_NAME} + ${MEMBER_CLUSTER_1_NAME}"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0050_kubectl_mongodb_multicluster_setup.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0050_kubectl_mongodb_multicluster_setup.sh
@@ -1,0 +1,11 @@
+echo "Registering member clusters with the central operator (kubectl mongodb multicluster setup)..."
+
+kubectl mongodb multicluster setup \
+  --central-cluster="${K8S_CENTRAL_CTX}" \
+  --member-clusters="${K8S_CLUSTER_0_CTX},${K8S_CLUSTER_1_CTX}" \
+  --member-cluster-namespace="${MDB_NS}" \
+  --central-cluster-namespace="${OPERATOR_NAMESPACE}" \
+  --create-service-account-secrets \
+  --install-database-roles=true
+
+echo "[ok] kubectl-mongodb multicluster setup complete"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0100_install_operator.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0100_install_operator.sh
@@ -1,0 +1,23 @@
+echo "Installing MongoDB Kubernetes Operator (multi-cluster mode) on the central cluster..."
+
+helm upgrade --install mongodb-kubernetes-operator-multi-cluster \
+  "${OPERATOR_HELM_CHART}" \
+  --kube-context "${K8S_CENTRAL_CTX}" \
+  --namespace "${OPERATOR_NAMESPACE}" \
+  --set namespace="${OPERATOR_NAMESPACE}" \
+  --set operator.namespace="${OPERATOR_NAMESPACE}" \
+  --set operator.watchNamespace="${MDB_NS}" \
+  --set operator.name=mongodb-kubernetes-operator-multi-cluster \
+  --set operator.createOperatorServiceAccount=false \
+  --set operator.createResourcesServiceAccountsAndRoles=false \
+  --set "multiCluster.clusters={${K8S_CLUSTER_0_CTX},${K8S_CLUSTER_1_CTX}}" \
+  --set "${OPERATOR_ADDITIONAL_HELM_VALUES:-dummy=value}" \
+  --wait \
+  --timeout 5m
+
+kubectl rollout status deployment/mongodb-kubernetes-operator-multi-cluster \
+  --namespace "${OPERATOR_NAMESPACE}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=120s
+
+echo "[ok] Operator installed and ready"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0200_verify_secrets_present.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0200_verify_secrets_present.sh
@@ -1,0 +1,23 @@
+echo "Verifying customer-replicated secrets are present in every member cluster (spec §6.3)..."
+
+# Sync-source password
+kubectl get secret "${MDB_SYNC_PASSWORD_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_0_NAME}: secret/${MDB_SYNC_PASSWORD_SECRET}"
+kubectl get secret "${MDB_SYNC_PASSWORD_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_1_NAME}: secret/${MDB_SYNC_PASSWORD_SECRET}"
+
+# CA bundle
+kubectl get secret "${MDB_EXTERNAL_CA_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_0_NAME}: secret/${MDB_EXTERNAL_CA_SECRET}"
+kubectl get secret "${MDB_EXTERNAL_CA_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_1_NAME}: secret/${MDB_EXTERNAL_CA_SECRET}"
+
+# Sharded-only — keyfile must be present in every member cluster
+kubectl get secret "${MDB_KEYFILE_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_0_NAME}: secret/${MDB_KEYFILE_SECRET}"
+kubectl get secret "${MDB_KEYFILE_SECRET}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" >/dev/null \
+  && echo "  [ok] ${MEMBER_CLUSTER_1_NAME}: secret/${MDB_KEYFILE_SECRET}"
+
+echo "[ok] Required secrets present in every member cluster"
+echo "  Note: TLS prefix '${MDB_TLS_CERT_SECRET_PREFIX}' must produce valid mongot + Envoy server certs"
+echo "        for every (cluster, shard) pair, signed by the same CA."

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0320_create_mongodb_search_resource.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0320_create_mongodb_search_resource.sh
@@ -33,6 +33,7 @@ spec:
     username: ${MDB_SEARCH_SYNC_USERNAME}
     passwordSecretRef:
       name: ${MDB_SYNC_PASSWORD_SECRET}
+      key: password
   loadBalancer:
     managed:
       externalHostname: "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0320_create_mongodb_search_resource.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0320_create_mongodb_search_resource.sh
@@ -1,0 +1,55 @@
+echo "Applying MongoDBSearch CR (Q2-MC Sharded, mirrors spec §4.2)..."
+
+kubectl apply --context "${K8S_CENTRAL_CTX}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBSearch
+metadata:
+  name: ${MDB_SEARCH_RESOURCE_NAME}
+  namespace: ${MDB_NS}
+spec:
+  source:
+    external:
+      shardedCluster:
+        router:
+          hosts:
+            - ${MDB_EXTERNAL_MONGOS_HOST_0}
+            - ${MDB_EXTERNAL_MONGOS_HOST_1}
+        shards:
+          - shardName: ${MDB_SHARD_0_NAME}
+            hosts:
+              - ${MDB_SHARD_0_HOST_0}
+              - ${MDB_SHARD_0_HOST_1}
+              - ${MDB_SHARD_0_HOST_2}
+          - shardName: ${MDB_SHARD_1_NAME}
+            hosts:
+              - ${MDB_SHARD_1_HOST_0}
+              - ${MDB_SHARD_1_HOST_1}
+              - ${MDB_SHARD_1_HOST_2}
+      tls:
+        ca:
+          name: ${MDB_EXTERNAL_CA_SECRET}
+      keyfileSecretRef:
+        name: ${MDB_KEYFILE_SECRET}
+    username: ${MDB_SEARCH_SYNC_USERNAME}
+    passwordSecretRef:
+      name: ${MDB_SYNC_PASSWORD_SECRET}
+  loadBalancer:
+    managed:
+      externalHostname: "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"
+  security:
+    tls:
+      certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
+  clusters:
+    - clusterName: ${MEMBER_CLUSTER_0_NAME}
+      replicas: ${MDB_MONGOT_REPLICAS}
+      syncSourceSelector:
+        matchTags:
+          region: ${MEMBER_CLUSTER_0_REGION}
+    - clusterName: ${MEMBER_CLUSTER_1_NAME}
+      replicas: ${MDB_MONGOT_REPLICAS}
+      syncSourceSelector:
+        matchTags:
+          region: ${MEMBER_CLUSTER_1_REGION}
+EOF
+
+echo "[ok] MongoDBSearch '${MDB_SEARCH_RESOURCE_NAME}' applied"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0322_apply_shard_overrides_example.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0322_apply_shard_overrides_example.sh
@@ -1,0 +1,63 @@
+echo "Applying a shardOverrides example (spec §4.2 — bias hot vs. cold shards)..."
+echo ""
+echo "This patches the existing CR with a shardOverrides[] entry on cluster 0,"
+echo "scaling shard-0 (hot) to 4 mongot replicas while shard-1 (cold) stays at"
+echo "the cluster baseline of ${MDB_MONGOT_REPLICAS}."
+
+kubectl apply --context "${K8S_CENTRAL_CTX}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBSearch
+metadata:
+  name: ${MDB_SEARCH_RESOURCE_NAME}
+  namespace: ${MDB_NS}
+spec:
+  source:
+    external:
+      shardedCluster:
+        router:
+          hosts:
+            - ${MDB_EXTERNAL_MONGOS_HOST_0}
+            - ${MDB_EXTERNAL_MONGOS_HOST_1}
+        shards:
+          - shardName: ${MDB_SHARD_0_NAME}
+            hosts:
+              - ${MDB_SHARD_0_HOST_0}
+              - ${MDB_SHARD_0_HOST_1}
+              - ${MDB_SHARD_0_HOST_2}
+          - shardName: ${MDB_SHARD_1_NAME}
+            hosts:
+              - ${MDB_SHARD_1_HOST_0}
+              - ${MDB_SHARD_1_HOST_1}
+              - ${MDB_SHARD_1_HOST_2}
+      tls:
+        ca:
+          name: ${MDB_EXTERNAL_CA_SECRET}
+      keyfileSecretRef:
+        name: ${MDB_KEYFILE_SECRET}
+    username: ${MDB_SEARCH_SYNC_USERNAME}
+    passwordSecretRef:
+      name: ${MDB_SYNC_PASSWORD_SECRET}
+  loadBalancer:
+    managed:
+      externalHostname: "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"
+  security:
+    tls:
+      certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
+  clusters:
+    - clusterName: ${MEMBER_CLUSTER_0_NAME}
+      replicas: ${MDB_MONGOT_REPLICAS}
+      syncSourceSelector:
+        matchTags:
+          region: ${MEMBER_CLUSTER_0_REGION}
+      shardOverrides:
+        - shardNames:
+            - ${MDB_SHARD_0_NAME}
+          replicas: 4
+    - clusterName: ${MEMBER_CLUSTER_1_NAME}
+      replicas: ${MDB_MONGOT_REPLICAS}
+      syncSourceSelector:
+        matchTags:
+          region: ${MEMBER_CLUSTER_1_REGION}
+EOF
+
+echo "[ok] shardOverrides applied on cluster '${MEMBER_CLUSTER_0_NAME}' for shard '${MDB_SHARD_0_NAME}'"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0322_apply_shard_overrides_example.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0322_apply_shard_overrides_example.sh
@@ -37,6 +37,7 @@ spec:
     username: ${MDB_SEARCH_SYNC_USERNAME}
     passwordSecretRef:
       name: ${MDB_SYNC_PASSWORD_SECRET}
+      key: password
   loadBalancer:
     managed:
       externalHostname: "${MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE}"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0325_wait_for_search_resource.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0325_wait_for_search_resource.sh
@@ -1,0 +1,26 @@
+echo "Waiting for MongoDBSearch top-level status.phase=Running..."
+
+kubectl wait --for=jsonpath='{.status.phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=600s
+
+echo "Waiting for ${MEMBER_CLUSTER_0_NAME} per-cluster status.phase=Running (spec §4.3)..."
+kubectl wait --for=jsonpath='{.status.clusterStatusList.clusterStatuses[?(@.clusterName=="'"${MEMBER_CLUSTER_0_NAME}"'")].phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=600s
+
+echo "Waiting for ${MEMBER_CLUSTER_1_NAME} per-cluster status.phase=Running..."
+kubectl wait --for=jsonpath='{.status.clusterStatusList.clusterStatuses[?(@.clusterName=="'"${MEMBER_CLUSTER_1_NAME}"'")].phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CENTRAL_CTX}" \
+  --timeout=600s
+
+echo "[ok] MongoDBSearch is Running across all member clusters / shards"
+echo ""
+kubectl get mongodbsearch "${MDB_SEARCH_RESOURCE_NAME}" -n "${MDB_NS}" --context "${K8S_CENTRAL_CTX}" -o yaml \
+  | grep -A 120 '^status:' | head -120

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0326_verify_per_cluster_envoy.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0326_verify_per_cluster_envoy.sh
@@ -1,0 +1,20 @@
+echo "Verifying per-cluster Envoy Deployment in each member cluster (one Envoy per cluster, multiplexing shards via SNI)..."
+
+envoy_deployment="${MDB_SEARCH_RESOURCE_NAME}-search-lb-0"
+
+echo "Member ${MEMBER_CLUSTER_0_NAME} (${K8S_CLUSTER_0_CTX}):"
+kubectl wait --for=condition=Available deployment/"${envoy_deployment}" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" --timeout=300s
+kubectl get deployment "${envoy_deployment}" -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}"
+
+echo ""
+echo "Member ${MEMBER_CLUSTER_1_NAME} (${K8S_CLUSTER_1_CTX}):"
+kubectl wait --for=condition=Available deployment/"${envoy_deployment}" \
+  -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" --timeout=300s
+kubectl get deployment "${envoy_deployment}" -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}"
+
+echo ""
+echo "[ok] Per-cluster Envoy is Available; SNI hostnames"
+echo "       <clusterName>.<shardName>.search-lb.lt.example.com:443"
+echo "     should now resolve through your DNS layer to each cluster's Envoy frontend,"
+echo "     with per-shard routing inside Envoy."

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0330_show_running_pods.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0330_show_running_pods.sh
@@ -1,0 +1,10 @@
+echo "Pods in ${MEMBER_CLUSTER_0_NAME} (${K8S_CLUSTER_0_CTX}):"
+kubectl get pods -n "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" -o wide
+
+echo ""
+echo "Pods in ${MEMBER_CLUSTER_1_NAME} (${K8S_CLUSTER_1_CTX}):"
+kubectl get pods -n "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" -o wide
+
+echo ""
+echo "MongoDBSearch resource (central):"
+kubectl get mongodbsearch -n "${MDB_NS}" --context "${K8S_CENTRAL_CTX}"

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_0340_query_through_envoy.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_0340_query_through_envoy.sh
@@ -1,0 +1,21 @@
+echo "Smoke-test the per-cluster, per-shard Envoy SNI endpoints..."
+echo ""
+echo "Each (cluster, shard) tuple has its own SNI hostname:"
+echo "  ${MEMBER_CLUSTER_0_NAME}.${MDB_SHARD_0_NAME}.search-lb.lt.example.com:443"
+echo "  ${MEMBER_CLUSTER_0_NAME}.${MDB_SHARD_1_NAME}.search-lb.lt.example.com:443"
+echo "  ${MEMBER_CLUSTER_1_NAME}.${MDB_SHARD_0_NAME}.search-lb.lt.example.com:443"
+echo "  ${MEMBER_CLUSTER_1_NAME}.${MDB_SHARD_1_NAME}.search-lb.lt.example.com:443"
+echo ""
+echo "Connect mongosh to your external mongos and run a search query; mongot lookups"
+echo "happen server-side and pin to the same-region cluster's Envoy per shard."
+echo ""
+cat <<'EOF'
+mongosh "mongodb://search-sync-source@<external-mongos>:27017/?tls=true" \
+  --eval 'db.getSiblingDB("admin").runCommand({ ping: 1 })'
+EOF
+echo ""
+echo "Per-(cluster,shard) reachability check:"
+cat <<'EOF'
+openssl s_client -connect <clusterName>.<shardName>.search-lb.lt.example.com:443 \
+  -servername <clusterName>.<shardName>.search-lb.lt.example.com -showcerts < /dev/null
+EOF

--- a/docs/search/13-search-q2-mc-sharded/code_snippets/13_9010_cleanup.sh
+++ b/docs/search/13-search-q2-mc-sharded/code_snippets/13_9010_cleanup.sh
@@ -1,0 +1,10 @@
+echo "Deleting MongoDBSearch '${MDB_SEARCH_RESOURCE_NAME}' from central cluster..."
+kubectl delete mongodbsearch "${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" --context "${K8S_CENTRAL_CTX}" --ignore-not-found --wait=true
+
+echo "Deleting namespace '${MDB_NS}' from each cluster (non-blocking)..."
+kubectl delete namespace "${MDB_NS}" --context "${K8S_CENTRAL_CTX}"  --wait=false --ignore-not-found
+kubectl delete namespace "${MDB_NS}" --context "${K8S_CLUSTER_0_CTX}" --wait=false --ignore-not-found
+kubectl delete namespace "${MDB_NS}" --context "${K8S_CLUSTER_1_CTX}" --wait=false --ignore-not-found
+
+echo "[ok] Cleanup initiated"

--- a/docs/search/13-search-q2-mc-sharded/env_variables.sh
+++ b/docs/search/13-search-q2-mc-sharded/env_variables.sh
@@ -1,0 +1,96 @@
+# ============================================================================
+# Q2-MC Sharded — Multi-cluster MongoDBSearch with managed Envoy + external mongod
+#
+# Source this file with `source env_variables.sh` before running the snippets.
+# Replace every `<...>` placeholder before sourcing.
+# ============================================================================
+
+# ============================================================================
+# KUBERNETES CONTEXTS
+# ============================================================================
+
+# Central (operator) cluster context
+export K8S_CENTRAL_CTX="<central cluster context>"
+
+# Member clusters where mongot + Envoy run.
+# Per spec §6.2 the load-test target is 2-3 member clusters.
+export K8S_CLUSTER_0_CTX="<member cluster 0 context>"
+export K8S_CLUSTER_1_CTX="<member cluster 1 context>"
+
+# Member cluster names — these resolve {clusterName} in the externalHostname template.
+export MEMBER_CLUSTER_0_NAME="us-east-k8s"
+export MEMBER_CLUSTER_1_NAME="eu-west-k8s"
+
+# Region tags (must match `region` tag on every external mongod member, per spec §6.4)
+export MEMBER_CLUSTER_0_REGION="us-east"
+export MEMBER_CLUSTER_1_REGION="eu-west"
+
+# Namespace where MongoDBSearch will be deployed
+export MDB_NS="mongodb"
+
+# ============================================================================
+# MONGODBSEARCH RESOURCE
+# ============================================================================
+
+export MDB_SEARCH_RESOURCE_NAME="lt-search-sharded"
+
+# Mongot replicas PER SHARD per cluster (spec §4.2 — `clusters[].replicas` is
+# pods per shard, not total).
+export MDB_MONGOT_REPLICAS=2
+
+# ============================================================================
+# EXTERNAL SHARDED CLUSTER (customer-owned, off-cluster)
+# ============================================================================
+# Per spec §6.1 — mongos pool + per-shard 3-node replica sets, each shard's
+# members tagged per region.
+
+# Mongos router hosts
+export MDB_EXTERNAL_MONGOS_HOST_0="<mongos-east-1.lt.example.com:27017>"
+export MDB_EXTERNAL_MONGOS_HOST_1="<mongos-west-1.lt.example.com:27017>"
+
+# Shard 0 members (per region — replSetConfig.members[].tags must carry `region`)
+export MDB_SHARD_0_NAME="shard-0"
+export MDB_SHARD_0_HOST_0="<shard0-east-1.lt.example.com:27018>"
+export MDB_SHARD_0_HOST_1="<shard0-east-2.lt.example.com:27018>"
+export MDB_SHARD_0_HOST_2="<shard0-west-1.lt.example.com:27018>"
+
+# Shard 1 members
+export MDB_SHARD_1_NAME="shard-1"
+export MDB_SHARD_1_HOST_0="<shard1-east-1.lt.example.com:27018>"
+export MDB_SHARD_1_HOST_1="<shard1-east-2.lt.example.com:27018>"
+export MDB_SHARD_1_HOST_2="<shard1-west-1.lt.example.com:27018>"
+
+# Sync-source user (pre-created on the external sharded cluster)
+export MDB_SEARCH_SYNC_USERNAME="search-sync-source"
+
+# ============================================================================
+# CUSTOMER-REPLICATED SECRETS (per-cluster, same name in every cluster)
+# ============================================================================
+# Per spec §6.3.
+
+# Sync-source password (key: password)
+export MDB_SYNC_PASSWORD_SECRET="search-sync-password"
+
+# CA bundle (key: ca.crt)
+export MDB_EXTERNAL_CA_SECRET="external-ca"
+
+# Sharded-only — keyfile shared with the external mongod cluster
+export MDB_KEYFILE_SECRET="mongod-keyfile"
+
+# TLS certs prefix
+export MDB_TLS_CERT_SECRET_PREFIX="lt-prefix"
+
+# ============================================================================
+# LOAD BALANCER HOSTNAME TEMPLATE
+# ============================================================================
+# Per spec §4.2 — must contain BOTH {clusterName} (or {clusterIndex}) AND
+# {shardName} for sharded multi-cluster.
+export MDB_LB_EXTERNAL_HOSTNAME_TEMPLATE="{clusterName}.{shardName}.search-lb.lt.example.com:443"
+
+# ============================================================================
+# OPERATOR INSTALL
+# ============================================================================
+
+export OPERATOR_NAMESPACE="${MDB_NS}"
+export OPERATOR_HELM_CHART="oci://quay.io/mongodb/helm-charts/mongodb-kubernetes"
+export OPERATOR_ADDITIONAL_HELM_VALUES=""

--- a/docs/search/13-search-q2-mc-sharded/test.sh
+++ b/docs/search/13-search-q2-mc-sharded/test.sh
@@ -1,0 +1,57 @@
+# Test runner for Q2-MC Sharded — MongoDBSearch with managed Envoy + external sharded mongod.
+#
+# Usage:
+#   source env_variables.sh
+#   ./test.sh
+#
+# Prerequisites: 2-3 K8s clusters reachable via kubeconfig contexts and an external
+# sharded cluster (mongos pool + per-shard tagged replica sets) per spec §6.1.
+
+set -eou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+project_dir="${script_dir}/../../.."
+
+source "${project_dir}/scripts/code_snippets/sample_test_runner.sh"
+
+cd "${script_dir}"
+
+prepare_snippets
+
+# Prerequisites
+run               13_0040_validate_env.sh
+run               13_0045_create_namespaces.sh
+run_for_output    13_0050_kubectl_mongodb_multicluster_setup.sh
+run_for_output    13_0100_install_operator.sh
+
+# Customer-replicated secrets (load tester stages these per §6.3)
+run               13_0200_verify_secrets_present.sh
+
+# Apply CR + wait for steady-state across clusters/shards
+run               13_0320_create_mongodb_search_resource.sh
+run_for_output    13_0325_wait_for_search_resource.sh
+
+# Verification
+run_for_output    13_0326_verify_per_cluster_envoy.sh
+run_for_output    13_0330_show_running_pods.sh
+run_for_output    13_0340_query_through_envoy.sh
+
+# Optional: shardOverrides example (commented out by default — uncomment to demo
+# the per-shard `replicas` bias from spec §4.2 / §5.1.4)
+# run               13_0322_apply_shard_overrides_example.sh
+# run_for_output    13_0325_wait_for_search_resource.sh
+
+echo ""
+echo "============================================"
+echo "Q2-MC Sharded deployment complete!"
+echo "============================================"
+echo ""
+echo "MongoDBSearch is running across:"
+echo "  - ${MEMBER_CLUSTER_0_NAME} (region=${MEMBER_CLUSTER_0_REGION})"
+echo "  - ${MEMBER_CLUSTER_1_NAME} (region=${MEMBER_CLUSTER_1_REGION})"
+echo "  - shards: ${MDB_SHARD_0_NAME}, ${MDB_SHARD_1_NAME}"
+echo ""
+echo "To clean up, run: ./code_snippets/13_9010_cleanup.sh"
+
+cd -


### PR DESCRIPTION
## Summary
Adds the canonical user-facing snippet tutorials for Q2-MC MongoDBSearch — one for ReplicaSet source, one for Sharded — mirroring the load-test contract YAML from the MVP spec §4.

## New tutorials
- `docs/search/12-search-q2-mc-rs/` — Q2-MC RS with managed Envoy + external mongod
- `docs/search/13-search-q2-mc-sharded/` — Q2-MC Sharded with managed Envoy + external mongod (includes a `shardOverrides` example)

## Stack
- Base: `search/ga-base` (the MVP integration branch)
- Will run CI after the MVP stack (#1027/#1030/#1028/#1029/#1032/#1034/#1033/#1036) lands in `search/ga-base`. Until then, this PR is for content review only — the operator built from this branch does not yet honor `spec.clusters[]` reconcile semantics.

## Snippet rules followed
Both tutorials follow the `snippet-coding-standards` skill rules: no shebangs in `code_snippets/*.sh`, no for/while loops, no `trap` handlers, no `read -rp` prompts, `quay.io` image registry, and `kubectl wait` over polling. Existing single-cluster siblings (07/10) predate the rules and are not modified.

## Deviations from spec §4
- Spec §4.1 RS sets `passwordSecretRef.key: password`; spec §4.2 Sharded omits `key`. The snippets mirror this literally — RS includes `key`, Sharded does not. Worth checking with the spec author whether the Sharded omission is intentional (relies on a default key) or a typo.
- The cluster-simulation `_internal_*` scripts from analogues 07/10 (CoreDNS rewrite, simulated external mongod via the Enterprise operator, cert-manager bootstrap) are intentionally dropped — Q2-MC cannot be faithfully simulated in single-cluster CI, and the load-test team points the snippets at a real external mongod per spec §6.1.

## Related
- MVP spec: §4 (CRD load-tester contract), §6 (test prerequisites)
- Existing single-cluster analogues: snippets 07 (sharded) and 10 (RS)

## Open questions
- `passwordSecretRef.key` inconsistency between §4.1 and §4.2 — confirm the intended default key when omitted.
- Do we want a pre-merge content review pass with the load-test team owner before rebasing onto the converged ga-base?

/label skip-changelog