### PR TITLE
simplify: cleanup pass over B-train on search/ga-base

### DIFF
--- a/api/v1/search/cluster_index.go
+++ b/api/v1/search/cluster_index.go
@@ -38,10 +38,9 @@ func AssignClusterIndices(existing map[string]int, currentClusterNames []string)
 // second return value is false when the annotation is missing, empty, malformed,
 // or does not contain the name.
 //
-// ClusterIndex is the read API used by downstream consumers (B4 placeholder
-// resolution, B16 SNI ordering, B9 status). It deliberately reads only the
-// persisted mapping — not spec.clusters — so a name that has been removed from
-// the spec but is still recorded in the mapping continues to resolve.
+// It deliberately reads only the persisted mapping — not spec.clusters — so a
+// name that has been removed from the spec but is still recorded in the mapping
+// continues to resolve.
 func ClusterIndex(search *MongoDBSearch, clusterName string) (int, bool) {
 	if search == nil {
 		return 0, false

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -139,8 +139,8 @@ type MongoDBSearchSpec struct {
 	JVMFlags []string `json:"jvmFlags,omitempty"`
 	// Clusters is the per-cluster distribution shape. Required for multi-cluster
 	// deployments (len > 1); when omitted, the reconciler defaults it to a single
-	// entry built from the top-level fields (B18 — not yet implemented). Pointer-of-slice
-	// so omitted vs. empty is distinguishable.
+	// entry built from the top-level fields. Pointer-of-slice so omitted vs.
+	// empty is distinguishable.
 	// MaxItems is set so the apiserver can bound the cost of the clusterName
 	// uniqueness CEL rule below; 50 is well above any realistic multi-cluster
 	// deployment.
@@ -151,8 +151,7 @@ type MongoDBSearchSpec struct {
 }
 
 // SyncSourceSelector picks which mongods this cluster's mongot fleet syncs from.
-// At-most-one of MatchTags or Hosts may be set; the cross-field rule that
-// requires exactly one when len(spec.clusters) > 1 lives in B13.
+// At-most-one of MatchTags or Hosts may be set.
 // MaxProperties / MaxItems / MaxLength on the children are required so the
 // apiserver can bound the schema-cost contribution that the XValidation rule
 // reads via has().
@@ -180,8 +179,7 @@ type PerClusterLoadBalancerConfig struct {
 }
 
 // ShardOverride lets sharded MongoDBSearch deployments tune one or more shards
-// beyond the per-cluster defaults. Only valid for sharded sources (the source-aware
-// admission rule lives in B13).
+// beyond the per-cluster defaults. Only valid for sharded sources.
 type ShardOverride struct {
 	// ShardNames is the set of shard names this override applies to.
 	// +kubebuilder:validation:Required
@@ -199,7 +197,7 @@ type ShardOverride struct {
 }
 
 // ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-// when len(spec.clusters) > 1 (B13); optional in the single-cluster degenerate case.
+// when len(spec.clusters) > 1; optional in the single-cluster degenerate case.
 // All other fields override the corresponding top-level value when set; nil/omitted inherits.
 type ClusterSpec struct {
 	// ClusterName is the Kubernetes cluster name. Required and immutable
@@ -391,14 +389,11 @@ type LoadBalancerStatus struct {
 	Message string       `json:"message,omitempty"`
 	// Clusters is the per-cluster managed-LB phase. Only populated when
 	// len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-	// B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-	// observedGeneration, etc.).
 	// +optional
 	Clusters []ClusterLoadBalancerStatus `json:"clusters,omitempty"`
 }
 
 // ClusterLoadBalancerStatus reports per-cluster managed LB state.
-// Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
 type ClusterLoadBalancerStatus struct {
 	// ClusterName is the member cluster this status entry belongs to.
 	ClusterName string `json:"clusterName"`
@@ -437,8 +432,7 @@ type SearchClusterStatusItem struct {
 	// +optional
 	ObservedReplicas int32 `json:"observedReplicas,omitempty"`
 	// Warnings is the per-cluster warnings list (e.g. customer-replicated
-	// secret missing in this cluster). Populated by the per-cluster presence
-	// check in B5; nil until that integration lands.
+	// secret missing in this cluster).
 	// +optional
 	Warnings []status.Warning `json:"warnings,omitempty"`
 	// LoadBalancer reports the per-cluster managed-LB phase for ReplicaSet
@@ -984,7 +978,7 @@ func (s *MongoDBSearch) LoadBalancerConfigMapName() string {
 }
 
 // LoadBalancerDeploymentNameForCluster returns the name of the managed Envoy
-// Deployment for one member cluster (B16). When clusterName is empty the result
+// Deployment for one member cluster. When clusterName is empty the result
 // matches LoadBalancerDeploymentName for back-compat with single-cluster installs.
 // In multi-cluster, the cluster identifier is appended so per-cluster Deployments
 // in the same namespace stay distinct (resource-name length is checked at
@@ -997,7 +991,7 @@ func (s *MongoDBSearch) LoadBalancerDeploymentNameForCluster(clusterName string)
 }
 
 // LoadBalancerConfigMapNameForCluster returns the name of the managed Envoy
-// ConfigMap for one member cluster (B16). See LoadBalancerDeploymentNameForCluster.
+// ConfigMap for one member cluster. See LoadBalancerDeploymentNameForCluster.
 func (s *MongoDBSearch) LoadBalancerConfigMapNameForCluster(clusterName string) string {
 	if clusterName == "" {
 		return s.LoadBalancerConfigMapName()

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -356,7 +356,6 @@ func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
 	return v1.ValidationSuccess()
 }
 
-
 // validateClustersSyncSourceSelector enforces the at-most-one matchTags/hosts rule
 // for every entry in spec.clusters.
 func validateClustersSyncSourceSelector(s *MongoDBSearch) v1.ValidationResult {

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -339,7 +339,6 @@ func validateClustersClusterNameNonEmpty(s *MongoDBSearch) v1.ValidationResult {
 }
 
 // validateClustersUniqueClusterName enforces clusterName uniqueness inside spec.clusters.
-// ClusterName presence and immutability when len(clusters) > 1 are B13 scope.
 func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
 	if s.Spec.Clusters == nil {
 		return v1.ValidationSuccess()
@@ -359,8 +358,7 @@ func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
 
 
 // validateClustersSyncSourceSelector enforces the at-most-one matchTags/hosts rule
-// for every entry in spec.clusters. The "exactly one when len(clusters) > 1" rule
-// lives in B13 (it depends on cluster-count semantics that aren't B14's scope).
+// for every entry in spec.clusters.
 func validateClustersSyncSourceSelector(s *MongoDBSearch) v1.ValidationResult {
 	if s.Spec.Clusters == nil {
 		return v1.ValidationSuccess()
@@ -381,11 +379,11 @@ func validateClustersSyncSourceSelector(s *MongoDBSearch) v1.ValidationResult {
 }
 
 // validateClustersEnvoyResourceNames enforces DNS-1123 length and label/subdomain
-// rules on the per-cluster Envoy Deployment + ConfigMap names that the B16
+// rules on the per-cluster Envoy Deployment + ConfigMap names that the
 // Envoy reconciler will create. Without this admission check, an over-long
 // clusterName would fail at runtime with a kube API error during reconcile.
 //
-// Mirrors the B14 sharded-resource-name pattern in generateShardResourceNames /
+// Mirrors the sharded-resource-name pattern in generateShardResourceNames /
 // validateResourceName.
 func validateClustersEnvoyResourceNames(s *MongoDBSearch) v1.ValidationResult {
 	if s.Spec.Clusters == nil {
@@ -417,8 +415,6 @@ func validateClustersEnvoyResourceNames(s *MongoDBSearch) v1.ValidationResult {
 }
 
 // validateClustersShardOverrides enforces shardNames non-empty per ShardOverride.
-// Whether shardOverrides[] is allowed at all (only sharded sources) is a B13
-// source-aware rule and lives outside B14.
 func validateClustersShardOverrides(s *MongoDBSearch) v1.ValidationResult {
 	if s.Spec.Clusters == nil {
 		return v1.ValidationSuccess()
@@ -436,7 +432,7 @@ func validateClustersShardOverrides(s *MongoDBSearch) v1.ValidationResult {
 	return v1.ValidationSuccess()
 }
 
-// validateClustersAndTopLevelFieldsMutuallyExclusive enforces B18's mutual-exclusion
+// validateClustersAndTopLevelFieldsMutuallyExclusive enforces the mutual-exclusion
 // rule: when spec.clusters is set, none of the auto-promotion-eligible top-level
 // distribution fields (spec.replicas, spec.resourceRequirements, spec.persistence,
 // spec.statefulSet) may also be set. This keeps the migration path unambiguous —

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -884,7 +884,7 @@ func TestValidateClustersNoRename(t *testing.T) {
 	}
 }
 
-// TestManagedLBConfig_Replicas_FieldExists is a B16 smoke test: the Replicas
+// TestManagedLBConfig_Replicas_FieldExists is a smoke test: the Replicas
 // field on ManagedLBConfig is wired so per-cluster managed LB can specify a
 // replica count and the Envoy reconciler can default it to 1 when unset.
 func TestManagedLBConfig_Replicas_FieldExists(t *testing.T) {
@@ -900,9 +900,9 @@ func TestManagedLBConfig_Replicas_FieldExists(t *testing.T) {
 	assert.Equal(t, int32(1), *s.Spec.LoadBalancer.Managed.Replicas)
 }
 
-// TestLoadBalancerStatus_ClustersFieldExists is a B16 smoke test: the per-cluster
-// placeholder slice exists on LoadBalancerStatus so the Envoy reconciler can write
-// per-cluster phases. B9 will formalize the schema.
+// TestLoadBalancerStatus_ClustersFieldExists is a smoke test: the per-cluster
+// slice exists on LoadBalancerStatus so the Envoy reconciler can write
+// per-cluster phases.
 func TestLoadBalancerStatus_ClustersFieldExists(t *testing.T) {
 	s := &MongoDBSearch{
 		Status: MongoDBSearchStatus{
@@ -917,7 +917,7 @@ func TestLoadBalancerStatus_ClustersFieldExists(t *testing.T) {
 	assert.Equal(t, "us-east-k8s", s.Status.LoadBalancer.Clusters[0].ClusterName)
 }
 
-// TestValidateClustersEnvoyResourceNames is the B16 admission check for the
+// TestValidateClustersEnvoyResourceNames is the admission check for the
 // per-cluster Envoy Deployment + ConfigMap resource names. The Deployment name
 // follows DNS-1123 label rules (<=63 chars); the ConfigMap follows DNS-1123
 // subdomain rules (<=253). When the search resource name + cluster suffix push

--- a/api/v1/search/status_aggregation_test.go
+++ b/api/v1/search/status_aggregation_test.go
@@ -82,12 +82,12 @@ func TestAggregateClusterStatuses_WarningsAndLoadBalancerCarry(t *testing.T) {
 			ClusterName:      "us-east-k8s",
 			Common:           status.Common{Phase: status.PhaseRunning},
 			ObservedReplicas: 2,
-			Warnings:         []status.Warning{"B5: secret 'search-sync-password' missing"},
+			Warnings:         []status.Warning{"secret 'search-sync-password' missing"},
 			LoadBalancer:     &LoadBalancerStatus{Phase: status.PhaseRunning},
 		},
 	}
 	s.AggregateClusterStatuses(items)
 	require.Len(t, s.Status.ClusterStatusList.ClusterStatuses, 1)
-	assert.Equal(t, []status.Warning{"B5: secret 'search-sync-password' missing"}, s.Status.ClusterStatusList.ClusterStatuses[0].Warnings)
+	assert.Equal(t, []status.Warning{"secret 'search-sync-password' missing"}, s.Status.ClusterStatusList.ClusterStatuses[0].Warnings)
 	assert.NotNil(t, s.Status.ClusterStatusList.ClusterStatuses[0].LoadBalancer)
 }

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -86,15 +86,15 @@ spec:
                 description: |-
                   Clusters is the per-cluster distribution shape. Required for multi-cluster
                   deployments (len > 1); when omitted, the reconciler defaults it to a single
-                  entry built from the top-level fields (B18 — not yet implemented). Pointer-of-slice
-                  so omitted vs. empty is distinguishable.
+                  entry built from the top-level fields. Pointer-of-slice so omitted vs.
+                  empty is distinguishable.
                   MaxItems is set so the apiserver can bound the cost of the clusterName
                   uniqueness CEL rule below; 50 is well above any realistic multi-cluster
                   deployment.
                 items:
                   description: |-
                     ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-                    when len(spec.clusters) > 1 (B13); optional in the single-cluster degenerate case.
+                    when len(spec.clusters) > 1; optional in the single-cluster degenerate case.
                     All other fields override the corresponding top-level value when set; nil/omitted inherits.
                   properties:
                     clusterName:
@@ -344,8 +344,7 @@ spec:
                       items:
                         description: |-
                           ShardOverride lets sharded MongoDBSearch deployments tune one or more shards
-                          beyond the per-cluster defaults. Only valid for sharded sources (the source-aware
-                          admission rule lives in B13).
+                          beyond the per-cluster defaults. Only valid for sharded sources.
                         properties:
                           persistence:
                             properties:
@@ -520,8 +519,7 @@ spec:
                     syncSourceSelector:
                       description: |-
                         SyncSourceSelector picks which mongods this cluster's mongot fleet syncs from.
-                        At-most-one of MatchTags or Hosts may be set; the cross-field rule that
-                        requires exactly one when len(spec.clusters) > 1 lives in B13.
+                        At-most-one of MatchTags or Hosts may be set.
                         MaxProperties / MaxItems / MaxLength on the children are required so the
                         apiserver can bound the schema-cost contribution that the XValidation rule
                         reads via has().
@@ -1082,12 +1080,9 @@ spec:
                               description: |-
                                 Clusters is the per-cluster managed-LB phase. Only populated when
                                 len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-                                B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-                                observedGeneration, etc.).
                               items:
-                                description: |-
-                                  ClusterLoadBalancerStatus reports per-cluster managed LB state.
-                                  Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
+                                description: ClusterLoadBalancerStatus reports per-cluster
+                                  managed LB state.
                                 properties:
                                   clusterName:
                                     description: ClusterName is the member cluster
@@ -1168,8 +1163,7 @@ spec:
                         warnings:
                           description: |-
                             Warnings is the per-cluster warnings list (e.g. customer-replicated
-                            secret missing in this cluster). Populated by the per-cluster presence
-                            check in B5; nil until that integration lands.
+                            secret missing in this cluster).
                           items:
                             type: string
                           type: array
@@ -1192,12 +1186,9 @@ spec:
                     description: |-
                       Clusters is the per-cluster managed-LB phase. Only populated when
                       len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-                      B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-                      observedGeneration, etc.).
                     items:
-                      description: |-
-                        ClusterLoadBalancerStatus reports per-cluster managed LB state.
-                        Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
+                      description: ClusterLoadBalancerStatus reports per-cluster managed
+                        LB state.
                       properties:
                         clusterName:
                           description: ClusterName is the member cluster this status

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -160,14 +160,14 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 			perClusterStatuses = append(perClusterStatuses, searchv1.ClusterLoadBalancerStatus{
 				ClusterName: w.ClusterName,
 				Phase:       st.Phase(),
-				Message:     extractWorkflowMsg(st),
+				Message:     searchcontroller.MessageFromStatus(st),
 			})
 		}
 		if isWorsePhase(st.Phase(), worstPhase) {
 			worstPhase = st.Phase()
 		}
 		if !st.IsOK() && firstFailure == nil {
-			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, extractWorkflowMsg(st))
+			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st))
 		}
 	}
 
@@ -270,16 +270,6 @@ func isWorsePhase(a, b status.Phase) bool {
 		}
 	}
 	return rank(a) > rank(b)
-}
-
-// extractWorkflowMsg pulls the message from a workflow.Status's StatusOptions.
-// The workflow.Status interface does not expose Msg() directly; the message
-// rides on a status.MessageOption populated by workflow.{Pending,Failed,Invalid}.
-func extractWorkflowMsg(st workflow.Status) string {
-	if opt, ok := status.GetOption(st.StatusOptions(), status.MessageOption{}); ok {
-		return opt.(status.MessageOption).Message
-	}
-	return ""
 }
 
 // updateLBStatus patches the loadBalancer sub-status on the MongoDBSearch CR

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -61,7 +61,7 @@ const (
 
 	labelName = "search-proxy"
 
-	// Cross-cluster enqueue labels (B16). Cross-cluster owner refs do not GC,
+	// Cross-cluster enqueue labels. Cross-cluster owner refs do not GC,
 	// so a label-based mapper is the only path back to the parent MongoDBSearch
 	// for member-cluster Deployment/ConfigMap watches.
 	envoyOwnerSearchNameLabel      = "mongodb.com/search-name"
@@ -202,7 +202,7 @@ type clusterWorkItem struct {
 // buildClusterWorkList expands spec.clusters[] into the per-cluster work units
 // the reconciler will iterate over. Membership rules:
 //   - len(memberClusterClientsMap) == 0 → single-cluster install; one work item with "".
-//   - len(spec.clusters) == 0 → single-cluster degenerate; one work item with "" until B18 lands.
+//   - len(spec.clusters) == 0 → single-cluster degenerate; one work item with "".
 //   - otherwise → one work item per spec.clusters[i]. Member clusters in the
 //     reconciler's map but absent from spec.clusters[] are intentionally ignored
 //     (the CR drives, not the operator's membership).
@@ -305,10 +305,10 @@ func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search
 // created when managed LB was active. This is called exactly once per LB removal,
 // gated by Status.LoadBalancer != nil (cleared immediately after).
 //
-// B16 scope: this still walks only the central cluster. Member-cluster
-// Deployments + ConfigMaps will leak on managed→unmanaged transitions and on
-// CR delete because cross-cluster owner refs do not GC. B12 (graceful drain
-// on cluster removal) extends this to all member clusters in memberClusterClientsMap.
+// This still walks only the central cluster. Member-cluster Deployments +
+// ConfigMaps will leak on managed→unmanaged transitions and on CR delete because
+// cross-cluster owner refs do not GC; graceful drain on cluster removal will
+// extend this to all member clusters in memberClusterClientsMap.
 func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) {
 	ns := search.Namespace
 
@@ -392,7 +392,7 @@ func buildReplicaSetRoute(search *searchv1.MongoDBSearch) envoyRoute {
 	}
 }
 
-// buildRoutesForCluster returns the Envoy routes for one member cluster (B16).
+// buildRoutesForCluster returns the Envoy routes for one member cluster.
 // When clusterName is empty, this is the single-cluster install path and
 // behaves identically to buildRoutes (back-compat).
 //
@@ -445,8 +445,8 @@ func applyClusterIDToSNI(sni, clusterName string, templated bool) string {
 	}
 	if templated {
 		// User supplied an externalHostname template without {clusterName}; honour
-		// it as-is. Multi-cluster users are expected (per B4) to include the
-		// placeholder; a missing-placeholder admission rule lives in B13/B4.
+		// it as-is. Multi-cluster users are expected to include the placeholder;
+		// admission rejects multi-cluster specs that omit it.
 		return sni
 	}
 	// Default service-FQDN base: <name>.<ns>.svc.cluster.local — append cluster
@@ -696,10 +696,10 @@ func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) map
 }
 
 // selectEnvoyClient picks the right Kubernetes client for one member cluster.
-// Mirrors B1's selectClusterClient: empty clusterName means single-cluster
-// (return central); known member name returns the member client; unknown name
-// silently falls back to central. The reconcile loop is responsible for
-// surfacing unknown ClusterNames as Pending in per-cluster status.
+// Mirrors searchcontroller.SelectClusterClient: empty clusterName means
+// single-cluster (return central); known member name returns the member client;
+// unknown name silently falls back to central. The reconcile loop is responsible
+// for surfacing unknown ClusterNames as Pending in per-cluster status.
 func selectEnvoyClient(clusterName string, central kubernetesClient.Client, members map[string]kubernetesClient.Client) kubernetesClient.Client {
 	if clusterName == "" {
 		return central

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -667,7 +667,7 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 	}
 	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, "missing-cluster", zap.S())
 	assert.Equal(t, status.PhasePending, st.Phase())
-	assert.Contains(t, extractWorkflowMsg(st), "missing-cluster")
+	assert.Contains(t, searchcontroller.MessageFromStatus(st), "missing-cluster")
 }
 
 func TestMapEnvoyObjectToSearch(t *testing.T) {
@@ -720,7 +720,7 @@ func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 	}
 
 	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, "a", zap.S())
-	require.True(t, st.IsOK(), "expected OK, got %s: %s", st.Phase(), extractWorkflowMsg(st))
+	require.True(t, st.IsOK(), "expected OK, got %s: %s", st.Phase(), searchcontroller.MessageFromStatus(st))
 
 	// Member cluster has Deployment + ConfigMap; central does not.
 	dep := &appsv1.Deployment{}

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -269,7 +269,7 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	assert.Equal(t, resource.MustParse("500m"), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
 }
 
-// --- B16 per-cluster route renderer tests -------------------------------------
+// --- per-cluster route renderer tests -----------------------------------------
 
 func TestBuildRoutesForCluster_RS_TemplateSubstitutesClusterName(t *testing.T) {
 	one := int32(1)
@@ -330,7 +330,7 @@ func TestBuildRoutesForCluster_SingleClusterUnchanged(t *testing.T) {
 	assert.Equal(t, sc[0].UpstreamHost, mc[0].UpstreamHost)
 }
 
-// mockShardedSourceForEnvoy is a minimal SearchSourceShardedDeployment double for B16 tests.
+// mockShardedSourceForEnvoy is a minimal SearchSourceShardedDeployment double for these tests.
 type mockShardedSourceForEnvoy struct {
 	shardNames []string
 }
@@ -387,7 +387,7 @@ func TestBuildRoutesForCluster_Sharded_PerClusterShardSNI(t *testing.T) {
 	assert.Len(t, seen, 4, "per-(cluster, shard) SNIs must all be distinct")
 }
 
-// --- B16 reconciler constructor with member-cluster client maps ---------------
+// --- reconciler constructor with member-cluster client maps -------------------
 
 func TestNewMongoDBSearchEnvoyReconciler_AcceptsMemberClusters(t *testing.T) {
 	central := fake.NewClientBuilder().Build()
@@ -414,7 +414,7 @@ func TestNewMongoDBSearchEnvoyReconciler_NilMembersMap(t *testing.T) {
 	assert.Empty(t, r.memberClusterSecretClientsMap)
 }
 
-// --- B16 selectEnvoyClient ----------------------------------------------------
+// --- selectEnvoyClient --------------------------------------------------------
 
 func TestSelectEnvoyClient(t *testing.T) {
 	central := kubernetesClient.NewClient(fake.NewClientBuilder().Build())
@@ -425,11 +425,11 @@ func TestSelectEnvoyClient(t *testing.T) {
 	assert.Equal(t, central, selectEnvoyClient("", central, members))
 	// Known member name → that member
 	assert.Equal(t, memberA, selectEnvoyClient("a", central, members))
-	// Unknown member name → silent fallback to central (mirrors B1 selectClusterClient)
+	// Unknown member name → silent fallback to central (mirrors searchcontroller.SelectClusterClient)
 	assert.Equal(t, central, selectEnvoyClient("zzz", central, members))
 }
 
-// --- B16 per-cluster name helpers + cross-cluster enqueue labels --------------
+// --- per-cluster name helpers + cross-cluster enqueue labels ------------------
 
 func TestLoadBalancerNamesForCluster_SingleClusterUnchanged(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
@@ -463,7 +463,7 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 	assert.Equal(t, "us-east-k8s", mc[envoyClusterNameLabel])
 }
 
-// --- B16 per-cluster replicas defaulting -------------------------------------
+// --- per-cluster replicas defaulting ------------------------------------------
 
 func TestEnvoyReplicasForCluster_SingleCluster_DefaultsTo1(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
@@ -604,7 +604,7 @@ func TestEnsureDeployment_PerClusterReplicas_FromClustersSpec(t *testing.T) {
 	assert.Equal(t, int32(5), *dep.Spec.Replicas)
 }
 
-// --- B16 reconcile loop + per-cluster status -----------------------------------
+// --- reconcile loop + per-cluster status --------------------------------------
 
 func TestBuildClusterWorkList_SingleClusterDegenerate(t *testing.T) {
 	r := newMongoDBSearchEnvoyReconciler(fake.NewClientBuilder().Build(), "envoy:latest", nil)
@@ -782,7 +782,7 @@ func TestEnvoyReplicasForCluster_PerClusterOverride(t *testing.T) {
 	assert.Equal(t, int32(2), envoyReplicasForCluster(search, "eu-west-k8s"))
 }
 
-// --- B16 end-to-end Reconcile + status aggregation ---------------------------
+// --- end-to-end Reconcile + status aggregation -------------------------------
 
 // TestReconcile_PerClusterStatus_Aggregated exercises the full Reconcile path:
 // two clusters in spec.clusters[]; one is a member registered with the operator

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -211,9 +211,9 @@ func (r *MongoDBSearchReconcileHelper) buildShardedPlan(shardedSource SearchSour
 func (r *MongoDBSearchReconcileHelper) Reconcile(ctx context.Context, log *zap.SugaredLogger) workflow.Status {
 	workflowStatus := r.reconcile(ctx, log)
 
-	// B9: populate the per-cluster status surface from spec.clusters[i] before
-	// the patch goes out. No-op when spec.clusters is nil/empty (legacy
-	// single-cluster install) — top-level fields keep their existing semantics.
+	// Populate the per-cluster status surface from spec.clusters[i] before the
+	// patch goes out. No-op when spec.clusters is nil/empty (legacy single-cluster
+	// install) — top-level fields keep their existing semantics.
 	r.mdbSearch.AggregateClusterStatuses(buildPerClusterStatusItems(r.mdbSearch, workflowStatus))
 
 	if _, err := commoncontroller.UpdateStatus(ctx, r.client, r.mdbSearch, workflowStatus, log); err != nil {
@@ -223,10 +223,8 @@ func (r *MongoDBSearchReconcileHelper) Reconcile(ctx context.Context, log *zap.S
 }
 
 // buildPerClusterStatusItems returns one SearchClusterStatusItem per
-// spec.clusters[i]. For B9 minimal, every entry copies the workflow outcome's
-// phase + message into its inlined status.Common. Per-cluster phase divergence
-// (e.g. one cluster Pending because its presence-checked secret is missing)
-// lands in B5/B14 follow-ups. Returns nil when spec.clusters is nil or empty
+// spec.clusters[i]. Every entry copies the workflow outcome's phase + message
+// into its inlined status.Common. Returns nil when spec.clusters is nil or empty
 // (legacy single-cluster); the top-level Phase keeps its existing semantics.
 func buildPerClusterStatusItems(mdb *searchv1.MongoDBSearch, st workflow.Status) []searchv1.SearchClusterStatusItem {
 	if mdb.Spec.Clusters == nil || len(*mdb.Spec.Clusters) == 0 {
@@ -411,7 +409,7 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 // mapping into the LastClusterNumMapping annotation. It preserves every previously-assigned
 // index and appends new clusters monotonically (see search.AssignClusterIndices); a removed
 // cluster's index is never reused. The annotation is the single source of truth for the
-// ClusterIndex read API consumed by B4 (placeholder resolution) and B16 (SNI route ordering).
+// ClusterIndex read API used by placeholder resolution and SNI route ordering.
 //
 // No-ops when spec.clusters is nil or empty (single-cluster path) and when the new mapping
 // matches the current annotation byte-for-byte.

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -230,7 +230,7 @@ func buildPerClusterStatusItems(mdb *searchv1.MongoDBSearch, st workflow.Status)
 	if mdb.Spec.Clusters == nil || len(*mdb.Spec.Clusters) == 0 {
 		return nil
 	}
-	message := messageFromStatus(st)
+	message := MessageFromStatus(st)
 	items := make([]searchv1.SearchClusterStatusItem, 0, len(*mdb.Spec.Clusters))
 	for _, c := range *mdb.Spec.Clusters {
 		items = append(items, searchv1.SearchClusterStatusItem{
@@ -244,10 +244,10 @@ func buildPerClusterStatusItems(mdb *searchv1.MongoDBSearch, st workflow.Status)
 	return items
 }
 
-// messageFromStatus extracts the user-visible message from a workflow.Status.
+// MessageFromStatus extracts the user-visible message from a workflow.Status.
 // workflow.Status does not expose Message() directly; the message is carried
 // in StatusOptions() as a MessageOption.
-func messageFromStatus(st workflow.Status) string {
+func MessageFromStatus(st workflow.Status) string {
 	if st == nil {
 		return ""
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -821,7 +821,7 @@ func TestEnsureMongotConfig_PerPodModes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			search := newTestMongoDBSearch("test-search", "test-ns")
-			//nolint:staticcheck // SA1019: exercising the legacy single-cluster path under B18 auto-promotion.
+			//nolint:staticcheck // SA1019: exercising the legacy single-cluster auto-promotion path.
 			search.Spec.Replicas = ptr.To(tc.replicas)
 			if tc.hasAutoEmbedding {
 				search.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{}
@@ -860,7 +860,7 @@ func TestEnsureMongotConfig_PerPodModes(t *testing.T) {
 
 func TestEnsureMongotConfig_TransitionBetweenModes(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
-	//nolint:staticcheck // SA1019: exercising the legacy single-cluster path under B18 auto-promotion.
+	//nolint:staticcheck // SA1019: exercising the legacy single-cluster auto-promotion path.
 	search.Spec.Replicas = ptr.To(int32(1))
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig())

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -488,6 +488,7 @@ var (
 		},
 	}
 )
+
 var expectedVolumeMount = []corev1.VolumeMount{
 	{
 		Name:      apiKeysTempVolumeName,

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -94,9 +94,10 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, stsName, nam
 		mongotConfigVolumeMount = statefulset.CreateVolumeMount(mongotConfigVolumeName, MongotConfigPath, statefulset.WithReadOnly(true), statefulset.WithSubPath(MongotConfigFilename))
 	}
 
-	// Single-cluster MVP: B18 auto-promotion guarantees len==1 unless the user
-	// posted spec.clusters: []. Guard against the empty-slice corner case so we
-	// degrade to "no override" rather than panic.
+	// EffectiveClusters auto-promotes the legacy top-level fields when spec.clusters
+	// is unset, so this normally returns one entry. Guard against the empty-slice
+	// corner case (user posted spec.clusters: []) so we degrade to "no override"
+	// rather than panic.
 	effective := searchv1.EffectiveClusters(mdbSearch)
 	var perCluster searchv1.ClusterSpec
 	if len(effective) > 0 {

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -99,7 +99,7 @@ func TestCreateSearchStatefulSetFunc_JVMFlags(t *testing.T) {
 			search := newTestMongoDBSearch("test-search", "default", func(s *searchv1.MongoDBSearch) {
 				s.Spec.JVMFlags = tc.userProvidedJVMFlags
 				if tc.userProvidedMemory != "" {
-					//nolint:staticcheck // SA1019: exercising the legacy single-cluster path under B18 auto-promotion.
+					//nolint:staticcheck // SA1019: exercising the legacy single-cluster auto-promotion path.
 					s.Spec.ResourceRequirements = &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse(tc.userProvidedMemory),

--- a/controllers/searchcontroller/secrets_presence.go
+++ b/controllers/searchcontroller/secrets_presence.go
@@ -70,7 +70,7 @@ func expectedSecretNames(search *searchv1.MongoDBSearch) []string {
 		names = appendUnique(names, ref.Name)
 	}
 
-	// External CA bundle — Q2-MC only.
+	// External CA bundle — only required for external MongoDB sources.
 	if search.IsExternalMongoDBSource() {
 		ext := search.Spec.Source.ExternalMongoDBSource
 		if ext.TLS != nil && ext.TLS.CA != nil && ext.TLS.CA.Name != "" {
@@ -84,7 +84,7 @@ func expectedSecretNames(search *searchv1.MongoDBSearch) []string {
 
 	// mongot server TLS cert per unit (single RS or per shard) + Envoy server TLS cert.
 	// Both share the same `<prefix>-...-cert` family so listing the mongot cert covers
-	// the Envoy expectation in Q2-MC where Envoy reuses the per-shard cert.
+	// the Envoy expectation where Envoy reuses the per-shard cert.
 	if search.Spec.Security.TLS != nil {
 		if search.IsExternalSourceSharded() {
 			for _, shard := range search.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards {

--- a/controllers/searchcontroller/secrets_presence_test.go
+++ b/controllers/searchcontroller/secrets_presence_test.go
@@ -153,7 +153,7 @@ func TestCheckSecretsPresence_KeyfileSharded_MissingWhenSet(t *testing.T) {
 func TestCheckSecretsPresence_KeyfileNotRequiredForRS(t *testing.T) {
 	search := newSearchWithExternalSource("s", "ns")
 	// RS source with KeyFileSecretKeyRef set on the spec → should still NOT be checked
-	// because the secret is sharded-only per spec §3.1 B5 row.
+	// because the keyfile secret is sharded-only.
 	search.Spec.Source.ExternalMongoDBSource.KeyFileSecretKeyRef = &userv1.SecretKeyRef{Name: "should-not-check"}
 	central := newClientWithSecrets(t, newSecretObj("search-sync-password", "ns"))
 

--- a/docker/mongodb-kubernetes-tests/tests/common/multicluster_search/mc_search_deployment_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/multicluster_search/mc_search_deployment_helper.py
@@ -6,7 +6,7 @@ clusters, replicate Secrets, and surface per-cluster naming
 
 The cluster-index ordering is the registration order in `member_cluster_clients`
 — that mirrors the operator's `clusterSpecList[].clusterName` ordering, which
-is what B3's stable cluster-index annotation pins.
+is what the stable cluster-index annotation pins.
 """
 
 from typing import Mapping

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -86,15 +86,15 @@ spec:
                 description: |-
                   Clusters is the per-cluster distribution shape. Required for multi-cluster
                   deployments (len > 1); when omitted, the reconciler defaults it to a single
-                  entry built from the top-level fields (B18 — not yet implemented). Pointer-of-slice
-                  so omitted vs. empty is distinguishable.
+                  entry built from the top-level fields. Pointer-of-slice so omitted vs.
+                  empty is distinguishable.
                   MaxItems is set so the apiserver can bound the cost of the clusterName
                   uniqueness CEL rule below; 50 is well above any realistic multi-cluster
                   deployment.
                 items:
                   description: |-
                     ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-                    when len(spec.clusters) > 1 (B13); optional in the single-cluster degenerate case.
+                    when len(spec.clusters) > 1; optional in the single-cluster degenerate case.
                     All other fields override the corresponding top-level value when set; nil/omitted inherits.
                   properties:
                     clusterName:
@@ -344,8 +344,7 @@ spec:
                       items:
                         description: |-
                           ShardOverride lets sharded MongoDBSearch deployments tune one or more shards
-                          beyond the per-cluster defaults. Only valid for sharded sources (the source-aware
-                          admission rule lives in B13).
+                          beyond the per-cluster defaults. Only valid for sharded sources.
                         properties:
                           persistence:
                             properties:
@@ -520,8 +519,7 @@ spec:
                     syncSourceSelector:
                       description: |-
                         SyncSourceSelector picks which mongods this cluster's mongot fleet syncs from.
-                        At-most-one of MatchTags or Hosts may be set; the cross-field rule that
-                        requires exactly one when len(spec.clusters) > 1 lives in B13.
+                        At-most-one of MatchTags or Hosts may be set.
                         MaxProperties / MaxItems / MaxLength on the children are required so the
                         apiserver can bound the schema-cost contribution that the XValidation rule
                         reads via has().
@@ -1082,12 +1080,9 @@ spec:
                               description: |-
                                 Clusters is the per-cluster managed-LB phase. Only populated when
                                 len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-                                B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-                                observedGeneration, etc.).
                               items:
-                                description: |-
-                                  ClusterLoadBalancerStatus reports per-cluster managed LB state.
-                                  Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
+                                description: ClusterLoadBalancerStatus reports per-cluster
+                                  managed LB state.
                                 properties:
                                   clusterName:
                                     description: ClusterName is the member cluster
@@ -1168,8 +1163,7 @@ spec:
                         warnings:
                           description: |-
                             Warnings is the per-cluster warnings list (e.g. customer-replicated
-                            secret missing in this cluster). Populated by the per-cluster presence
-                            check in B5; nil until that integration lands.
+                            secret missing in this cluster).
                           items:
                             type: string
                           type: array
@@ -1192,12 +1186,9 @@ spec:
                     description: |-
                       Clusters is the per-cluster managed-LB phase. Only populated when
                       len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-                      B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-                      observedGeneration, etc.).
                     items:
-                      description: |-
-                        ClusterLoadBalancerStatus reports per-cluster managed LB state.
-                        Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
+                      description: ClusterLoadBalancerStatus reports per-cluster managed
+                        LB state.
                       properties:
                         clusterName:
                           description: ClusterName is the member cluster this status

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4108,15 +4108,15 @@ spec:
                 description: |-
                   Clusters is the per-cluster distribution shape. Required for multi-cluster
                   deployments (len > 1); when omitted, the reconciler defaults it to a single
-                  entry built from the top-level fields (B18 — not yet implemented). Pointer-of-slice
-                  so omitted vs. empty is distinguishable.
+                  entry built from the top-level fields. Pointer-of-slice so omitted vs.
+                  empty is distinguishable.
                   MaxItems is set so the apiserver can bound the cost of the clusterName
                   uniqueness CEL rule below; 50 is well above any realistic multi-cluster
                   deployment.
                 items:
                   description: |-
                     ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-                    when len(spec.clusters) > 1 (B13); optional in the single-cluster degenerate case.
+                    when len(spec.clusters) > 1; optional in the single-cluster degenerate case.
                     All other fields override the corresponding top-level value when set; nil/omitted inherits.
                   properties:
                     clusterName:
@@ -4366,8 +4366,7 @@ spec:
                       items:
                         description: |-
                           ShardOverride lets sharded MongoDBSearch deployments tune one or more shards
-                          beyond the per-cluster defaults. Only valid for sharded sources (the source-aware
-                          admission rule lives in B13).
+                          beyond the per-cluster defaults. Only valid for sharded sources.
                         properties:
                           persistence:
                             properties:
@@ -4542,8 +4541,7 @@ spec:
                     syncSourceSelector:
                       description: |-
                         SyncSourceSelector picks which mongods this cluster's mongot fleet syncs from.
-                        At-most-one of MatchTags or Hosts may be set; the cross-field rule that
-                        requires exactly one when len(spec.clusters) > 1 lives in B13.
+                        At-most-one of MatchTags or Hosts may be set.
                         MaxProperties / MaxItems / MaxLength on the children are required so the
                         apiserver can bound the schema-cost contribution that the XValidation rule
                         reads via has().
@@ -5104,12 +5102,9 @@ spec:
                               description: |-
                                 Clusters is the per-cluster managed-LB phase. Only populated when
                                 len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-                                B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-                                observedGeneration, etc.).
                               items:
-                                description: |-
-                                  ClusterLoadBalancerStatus reports per-cluster managed LB state.
-                                  Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
+                                description: ClusterLoadBalancerStatus reports per-cluster
+                                  managed LB state.
                                 properties:
                                   clusterName:
                                     description: ClusterName is the member cluster
@@ -5190,8 +5185,7 @@ spec:
                         warnings:
                           description: |-
                             Warnings is the per-cluster warnings list (e.g. customer-replicated
-                            secret missing in this cluster). Populated by the per-cluster presence
-                            check in B5; nil until that integration lands.
+                            secret missing in this cluster).
                           items:
                             type: string
                           type: array
@@ -5214,12 +5208,9 @@ spec:
                     description: |-
                       Clusters is the per-cluster managed-LB phase. Only populated when
                       len(spec.clusters) > 0 — single-cluster keeps the existing top-level Phase.
-                      B16 writes a placeholder schema; B9 will formalize it (sharded sub-statuses,
-                      observedGeneration, etc.).
                     items:
-                      description: |-
-                        ClusterLoadBalancerStatus reports per-cluster managed LB state.
-                        Placeholder schema written by B16; B9 formalizes the per-cluster status surface.
+                      description: ClusterLoadBalancerStatus reports per-cluster managed
+                        LB state.
                       properties:
                         clusterName:
                           description: ClusterName is the member cluster this status


### PR DESCRIPTION
## Summary

Mechanical /simplify pass over the full B-train diff (`origin/master..origin/search/ga-base`). Four logical commits:

1. **Drop stale B-task references** — strip `(B16)`, `B5/B14 follow-ups`, `until B18 lands` etc. from comments. The B-train PRs have all landed; their task numbering isn't visible to readers of merged code. Substantive context (the *why*) is preserved.
2. **Consolidate workflow message extractor** — `messageFromStatus` (searchcontroller) and `extractWorkflowMsg` (operator) were byte-equivalent. Promote to a single exported `searchcontroller.MessageFromStatus`; the envoy controller already imports `searchcontroller` so this adds no new dependency edge.
3. **Fix formatting drift** — gofumpt complaint, stray double blank line.
4. **Regenerate CRDs** — `make manifests` propagates the comment cleanup through `config/crd/bases/`, `helm_chart/crds/`, and `public/crds.yaml`.

No behavior changes. No new features. No removed features.

## What I deliberately did not change

- `isWorsePhase` (envoy controller, 3 phases) vs `phaseRank`/`WorstOfPhase` (api/v1/search, 6 phases) — different rankings, unifying would change semantics.
- `searchcontroller.SelectClusterClient` — currently has only test callers, but it's the documented public API for the cluster-selection pattern that Phase 2 consumes.
- `memberClusterSecretClientsMap` field — populated but not yet read at runtime; Phase 2 wires it.
- `clusterWorkItem` single-field struct — kept for readability of `wl[i].ClusterName` over `wl[i]`.
- `Q3/Q4-MC` / `§B0.2` references in error strings and comments — tested error text and spec-section identifiers, not stale task tags.

## Test plan

- [x] `go test ./api/v1/search/... ./controllers/searchcontroller/... ./controllers/operator/... ./pkg/handler/... -count=1` — all green
- [x] `golangci-lint run ./... --timeout=5m --new-from-rev=origin/master` — 0 new issues (17 pre-existing issues unchanged; not introduced by this PR)
- [x] `make manifests` clean (drift committed in 797fb4aeb)
- [x] `make generate` clean (no diff)
- [ ] Evergreen patch on this branch — relevant search e2es green