### PR TITLE
search: address PR #1052 review findings (1 blocker + 4 concerns)

### DIFF
--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -43,10 +43,8 @@ const (
 	ForceWireprotoAnnotation = "mongodb.com/v1.force-search-wireproto"
 
 	// LastClusterNumMapping holds the JSON-encoded clusterName -> clusterIndex
-	// mapping for spec.clusters[]. Mirrors mdbmulti.LastClusterNumMapping; the
-	// string value is intentionally identical so a future shared util can collapse
-	// the two without breaking existing CR annotations. Index never reused on
-	// remove/re-add (see api/v1/search/cluster_index.go).
+	// mapping for spec.clusters[]. Index never reused on remove/re-add
+	// (see api/v1/search/cluster_index.go).
 	LastClusterNumMapping = "mongodb.com/v1.lastClusterNumMapping"
 
 	MongoDBSearchIndexFieldName = "mdbsearch-for-mongodbresourceref-index"
@@ -465,31 +463,11 @@ type SearchClusterStatusItem struct {
 	// Common carries the per-cluster phase, message, lastTransition, and observedGeneration.
 	status.Common `json:",inline"`
 	// ObservedReplicas is the number of mongot pods this cluster currently has Ready.
-	// Used by the load-test harness as the readiness gate.
-	//
-	// TODO(phase-2): not yet written by either controller — ga-base does not
-	// fan-out per-cluster mongot StatefulSets, so there is no per-cluster
-	// Ready-replica count to observe. Phase 2's reconcile fan-out
-	// (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
-	// where per-cluster STSs land; populate this then.
 	// +optional
 	ObservedReplicas int32 `json:"observedReplicas,omitempty"`
-	// Warnings is the per-cluster warnings list (e.g. customer-replicated
-	// secret missing in this cluster).
-	//
-	// Populated by buildPerClusterStatusItems in the search controller from
-	// the SecretCheckResult slice for each cluster name that matches a
-	// spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
-	// through the operator log instead of this field.
 	// +optional
 	Warnings []status.Warning `json:"warnings,omitempty"`
-	// LoadBalancer is unused by either controller and is kept only to avoid
-	// CRD removal until the next API rev. The canonical per-cluster managed-LB
-	// phase lives in status.loadBalancer.clusters[i] (flat sibling), written
-	// by the Envoy controller in mongodbsearchenvoy_controller.go.
-	//
-	// Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
-	// remove this field together with the next CRD bump.
+	// Deprecated: read status.loadBalancer.clusters[i] instead.
 	// +optional
 	LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
 }
@@ -520,11 +498,6 @@ type MongoDBSearchStatus struct {
 	// phase for sharded multi-cluster deployments. Flat map-of-map keyed by
 	// clusterName then shardName, matching MongoDB sharded's *InClusters
 	// precedent (api/v1/status/scaling_status.go).
-	//
-	// TODO(phase-3): not yet written by either controller — ga-base only
-	// surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
-	// per-(cluster, shard) split lands when sharded MC search supports
-	// per-shard Envoy SNI routing.
 	// +optional
 	ShardLoadBalancerStatusInClusters map[string]map[string]*ShardLoadBalancerStatus `json:"shardLoadBalancerStatusInClusters,omitempty"`
 }

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -419,8 +419,8 @@ type TLS struct {
 // Invariant: Phase == WorstOfPhase(Clusters[*].Phase) when len(Clusters) > 0.
 // Single-cluster (len(Clusters) == 0) keeps Phase as the legacy single-cluster
 // Envoy reconcile outcome and Clusters stays nil. This invariant is enforced
-// by the Envoy controller's reconcile loop and verified by
-// TestUpdateLBStatus_WorstOfPhase_Invariant.
+// by the Envoy controller's reconcile loop (worstOfClusterPhases) and
+// verified by TestWorstOfClusterPhases.
 type LoadBalancerStatus struct {
 	Phase   status.Phase `json:"phase"`
 	Message string       `json:"message,omitempty"`

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -466,10 +466,21 @@ type SearchClusterStatusItem struct {
 	status.Common `json:",inline"`
 	// ObservedReplicas is the number of mongot pods this cluster currently has Ready.
 	// Used by the load-test harness as the readiness gate.
+	//
+	// TODO(phase-2): not yet written by either controller — ga-base does not
+	// fan-out per-cluster mongot StatefulSets, so there is no per-cluster
+	// Ready-replica count to observe. Phase 2's reconcile fan-out
+	// (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
+	// where per-cluster STSs land; populate this then.
 	// +optional
 	ObservedReplicas int32 `json:"observedReplicas,omitempty"`
 	// Warnings is the per-cluster warnings list (e.g. customer-replicated
 	// secret missing in this cluster).
+	//
+	// Populated by buildPerClusterStatusItems in the search controller from
+	// the SecretCheckResult slice for each cluster name that matches a
+	// spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
+	// through the operator log instead of this field.
 	// +optional
 	Warnings []status.Warning `json:"warnings,omitempty"`
 	// LoadBalancer is unused by either controller and is kept only to avoid
@@ -509,6 +520,11 @@ type MongoDBSearchStatus struct {
 	// phase for sharded multi-cluster deployments. Flat map-of-map keyed by
 	// clusterName then shardName, matching MongoDB sharded's *InClusters
 	// precedent (api/v1/status/scaling_status.go).
+	//
+	// TODO(phase-3): not yet written by either controller — ga-base only
+	// surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
+	// per-(cluster, shard) split lands when sharded MC search supports
+	// per-shard Envoy SNI routing.
 	// +optional
 	ShardLoadBalancerStatusInClusters map[string]map[string]*ShardLoadBalancerStatus `json:"shardLoadBalancerStatusInClusters,omitempty"`
 }

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -409,6 +409,18 @@ type TLS struct {
 }
 
 // LoadBalancerStatus reports the state of the operator-managed load balancer (Envoy).
+//
+// Canonical phase shape (multi-cluster):
+//   - Clusters[i].Phase is the ground truth — one entry per spec.clusters[i],
+//     written by the Envoy controller after each per-cluster reconcile.
+//   - Top-level Phase is the worst-of(Clusters[*].Phase) under the rank used by
+//     WorstOfPhase (Failed > Pending > Running > Updated > Disabled > Unsupported).
+//
+// Invariant: Phase == WorstOfPhase(Clusters[*].Phase) when len(Clusters) > 0.
+// Single-cluster (len(Clusters) == 0) keeps Phase as the legacy single-cluster
+// Envoy reconcile outcome and Clusters stays nil. This invariant is enforced
+// by the Envoy controller's reconcile loop and verified by
+// TestUpdateLBStatus_WorstOfPhase_Invariant.
 type LoadBalancerStatus struct {
 	Phase   status.Phase `json:"phase"`
 	Message string       `json:"message,omitempty"`
@@ -460,9 +472,13 @@ type SearchClusterStatusItem struct {
 	// secret missing in this cluster).
 	// +optional
 	Warnings []status.Warning `json:"warnings,omitempty"`
-	// LoadBalancer reports the per-cluster managed-LB phase for ReplicaSet
-	// topologies. Sharded per-(cluster, shard) LB phase lives on the
-	// top-level ShardLoadBalancerStatusInClusters map.
+	// LoadBalancer is unused by either controller and is kept only to avoid
+	// CRD removal until the next API rev. The canonical per-cluster managed-LB
+	// phase lives in status.loadBalancer.clusters[i] (flat sibling), written
+	// by the Envoy controller in mongodbsearchenvoy_controller.go.
+	//
+	// Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
+	// remove this field together with the next CRD bump.
 	// +optional
 	LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
 }

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -2,10 +2,16 @@ package search
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
@@ -965,4 +971,132 @@ func TestValidateClustersEnvoyResourceNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunValidations_AllValidatorsRegistered guards against the silent-drift
+// bug where a new validateXxx function is defined in mongodbsearch_validation.go
+// but accidentally not appended to the validators slice in RunValidations. Such
+// a validator would compile, all unit tests targeting it would still pass, but
+// admission would never fire it — the rule is effectively dead.
+//
+// The test parses mongodbsearch_validation.go's AST to:
+//   1. Enumerate every package-level function whose signature matches
+//      `func(*MongoDBSearch) v1.ValidationResult` — the validator contract.
+//   2. Enumerate every identifier referenced inside the validators slice
+//      literal in RunValidations.
+//
+// The two sets must match exactly. A validator added without registration is
+// in (1) but not in (2); a stale slice entry is in (2) but not in (1).
+func TestRunValidations_AllValidatorsRegistered(t *testing.T) {
+	defined := definedValidatorNames(t)
+	registered := registeredValidatorNames(t)
+
+	sort.Strings(defined)
+	sort.Strings(registered)
+
+	assert.Equal(t, defined, registered,
+		"validators slice in RunValidations is out of sync with defined validateXxx functions; "+
+			"every validator function must be both defined and registered")
+}
+
+// definedValidatorNames parses mongodbsearch_validation.go and returns the
+// names of every package-level function whose signature matches
+//
+//	func validateXxx(s *MongoDBSearch) v1.ValidationResult
+func definedValidatorNames(t *testing.T) []string {
+	t.Helper()
+	f := parseValidationFile(t)
+
+	var names []string
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil {
+			continue
+		}
+		if funcTypeMatchesValidator(fn.Type) {
+			names = append(names, fn.Name.Name)
+		}
+	}
+	return names
+}
+
+// registeredValidatorNames extracts the function names referenced in the
+// validators slice literal inside RunValidations. The slice is the canonical
+// admission roster; a function defined but absent here is dead code.
+func registeredValidatorNames(t *testing.T) []string {
+	t.Helper()
+	f := parseValidationFile(t)
+
+	var names []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "RunValidations" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			cl, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			arr, ok := cl.Type.(*ast.ArrayType)
+			if !ok {
+				return true
+			}
+			ft, ok := arr.Elt.(*ast.FuncType)
+			if !ok || !funcTypeMatchesValidator(ft) {
+				return true
+			}
+			for _, elt := range cl.Elts {
+				if ident, ok := elt.(*ast.Ident); ok {
+					names = append(names, ident.Name)
+				}
+			}
+			return false
+		})
+		return false
+	})
+
+	require.NotEmpty(t, names,
+		"could not locate the validators slice literal in RunValidations — test parser is stale")
+	return names
+}
+
+// funcTypeMatchesValidator returns true when the AST function-type matches
+// `func(*MongoDBSearch) v1.ValidationResult`. Used both to filter top-level
+// function declarations and to identify the validators slice element type.
+func funcTypeMatchesValidator(ft *ast.FuncType) bool {
+	if ft.Params == nil || len(ft.Params.List) != 1 {
+		return false
+	}
+	if ft.Results == nil || len(ft.Results.List) != 1 {
+		return false
+	}
+	starExpr, ok := ft.Params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := starExpr.X.(*ast.Ident)
+	if !ok || ident.Name != "MongoDBSearch" {
+		return false
+	}
+	sel, ok := ft.Results.List[0].Type.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok || pkgIdent.Name != "v1" || sel.Sel.Name != "ValidationResult" {
+		return false
+	}
+	return true
+}
+
+func parseValidationFile(t *testing.T) *ast.File {
+	t.Helper()
+	path, err := filepath.Abs("mongodbsearch_validation.go")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.AllErrors)
+	require.NoError(t, err, "failed to parse %s", path)
+	return f
 }

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -980,10 +980,10 @@ func TestValidateClustersEnvoyResourceNames(t *testing.T) {
 // admission would never fire it — the rule is effectively dead.
 //
 // The test parses mongodbsearch_validation.go's AST to:
-//   1. Enumerate every package-level function whose signature matches
-//      `func(*MongoDBSearch) v1.ValidationResult` — the validator contract.
-//   2. Enumerate every identifier referenced inside the validators slice
-//      literal in RunValidations.
+//  1. Enumerate every package-level function whose signature matches
+//     `func(*MongoDBSearch) v1.ValidationResult` — the validator contract.
+//  2. Enumerate every identifier referenced inside the validators slice
+//     literal in RunValidations.
 //
 // The two sets must match exactly. A validator added without registration is
 // in (1) but not in (2); a stale slice entry is in (2) but not in (1).

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -1062,9 +1062,13 @@ spec:
                           type: string
                         loadBalancer:
                           description: |-
-                            LoadBalancer reports the per-cluster managed-LB phase for ReplicaSet
-                            topologies. Sharded per-(cluster, shard) LB phase lives on the
-                            top-level ShardLoadBalancerStatusInClusters map.
+                            LoadBalancer is unused by either controller and is kept only to avoid
+                            CRD removal until the next API rev. The canonical per-cluster managed-LB
+                            phase lives in status.loadBalancer.clusters[i] (flat sibling), written
+                            by the Envoy controller in mongodbsearchenvoy_controller.go.
+
+                            Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
+                            remove this field together with the next CRD bump.
                           properties:
                             clusters:
                               description: |-
@@ -1107,6 +1111,11 @@ spec:
                           description: |-
                             ObservedReplicas is the number of mongot pods this cluster currently has Ready.
                             Used by the load-test harness as the readiness gate.
+
+                            fan-out per-cluster mongot StatefulSets, so there is no per-cluster
+                            Ready-replica count to observe. Phase 2's reconcile fan-out
+                            (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
+                            where per-cluster STSs land; populate this then.
                           format: int32
                           type: integer
                         phase:
@@ -1154,6 +1163,11 @@ spec:
                           description: |-
                             Warnings is the per-cluster warnings list (e.g. customer-replicated
                             secret missing in this cluster).
+
+                            Populated by buildPerClusterStatusItems in the search controller from
+                            the SecretCheckResult slice for each cluster name that matches a
+                            spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
+                            through the operator log instead of this field.
                           items:
                             type: string
                           type: array
@@ -1274,6 +1288,10 @@ spec:
                   phase for sharded multi-cluster deployments. Flat map-of-map keyed by
                   clusterName then shardName, matching MongoDB sharded's *InClusters
                   precedent (api/v1/status/scaling_status.go).
+
+                  surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
+                  per-(cluster, shard) split lands when sharded MC search supports
+                  per-shard Envoy SNI routing.
                 type: object
               version:
                 type: string

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -1061,14 +1061,8 @@ spec:
                         lastTransition:
                           type: string
                         loadBalancer:
-                          description: |-
-                            LoadBalancer is unused by either controller and is kept only to avoid
-                            CRD removal until the next API rev. The canonical per-cluster managed-LB
-                            phase lives in status.loadBalancer.clusters[i] (flat sibling), written
-                            by the Envoy controller in mongodbsearchenvoy_controller.go.
-
-                            Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
-                            remove this field together with the next CRD bump.
+                          description: 'Deprecated: read status.loadBalancer.clusters[i]
+                            instead.'
                           properties:
                             clusters:
                               description: |-
@@ -1108,14 +1102,8 @@ spec:
                           format: int64
                           type: integer
                         observedReplicas:
-                          description: |-
-                            ObservedReplicas is the number of mongot pods this cluster currently has Ready.
-                            Used by the load-test harness as the readiness gate.
-
-                            fan-out per-cluster mongot StatefulSets, so there is no per-cluster
-                            Ready-replica count to observe. Phase 2's reconcile fan-out
-                            (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
-                            where per-cluster STSs land; populate this then.
+                          description: ObservedReplicas is the number of mongot pods
+                            this cluster currently has Ready.
                           format: int32
                           type: integer
                         phase:
@@ -1160,14 +1148,6 @@ spec:
                             type: object
                           type: array
                         warnings:
-                          description: |-
-                            Warnings is the per-cluster warnings list (e.g. customer-replicated
-                            secret missing in this cluster).
-
-                            Populated by buildPerClusterStatusItems in the search controller from
-                            the SecretCheckResult slice for each cluster name that matches a
-                            spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
-                            through the operator log instead of this field.
                           items:
                             type: string
                           type: array
@@ -1288,10 +1268,6 @@ spec:
                   phase for sharded multi-cluster deployments. Flat map-of-map keyed by
                   clusterName then shardName, matching MongoDB sharded's *InClusters
                   precedent (api/v1/status/scaling_status.go).
-
-                  surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
-                  per-(cluster, shard) split lands when sharded MC search supports
-                  per-shard Envoy SNI routing.
                 type: object
               version:
                 type: string

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -126,18 +126,23 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		r.watch.AddWatchedResourceIfNotAdded(mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name, mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
 	}
 
+	memberClients := make(map[string]client.Client, len(r.memberClusterClientsMap))
+	for name, kc := range r.memberClusterClientsMap {
+		memberClients[name] = kc
+	}
+	// Run the customer-replicated-secret presence check up front so the helper
+	// can fold gaps into the per-cluster status patch in a single writeback,
+	// rather than requiring a follow-up patch from this controller.
+	gaps := searchcontroller.CheckSecretsPresence(ctx, mdbSearch, r.kubeClient, memberClients)
+
 	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig)
+	reconcileHelper.SetSecretGaps(gaps)
 
 	result, err := reconcileHelper.Reconcile(ctx, log).ReconcileResult()
 	if err != nil {
 		return result, err
 	}
 
-	memberClients := make(map[string]client.Client, len(r.memberClusterClientsMap))
-	for name, kc := range r.memberClusterClientsMap {
-		memberClients[name] = kc
-	}
-	gaps := searchcontroller.CheckSecretsPresence(ctx, mdbSearch, r.kubeClient, memberClients)
 	if len(gaps) > 0 {
 		r.surfaceMissingSecrets(gaps, log)
 		if result.RequeueAfter == 0 {

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -292,22 +292,8 @@ func AddMongoDBSearchController(
 			return err
 		}
 
-		// Per-member-cluster watches for resources the search controller manages there.
-		// Owner references do not cross cluster boundaries, so the
-		// EnqueueRequestForSearchOwnerMultiCluster handler reads the search-owner
-		// labels (khandler.MongoDBSearchOwnerNameLabel +
-		// MongoDBSearchOwnerNamespaceLabel) off the watched object — same scheme
-		// the Envoy controller's mapEnvoyObjectToSearch uses.
-		// PredicatesForMultiClusterSearchResource filters out unrelated churn.
-		// Backoff on unreachable member API is handled by controller-runtime's
-		// informer cache and surfaced via the health-check goroutine above.
-		//
-		// TODO(phase-2): the search controller does NOT yet write per-cluster
-		// member resources (STS / Service / ConfigMap / Secret); ga-base scope
-		// is single-cluster. Phase 2's reconcile fan-out
-		// (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) must
-		// stamp these labels on every per-cluster write so the watches above
-		// actually fire — until then the routing is correct but inert.
+		// Per-member-cluster watches map events back to the parent MongoDBSearch
+		// via the search-owner labels (cross-cluster owner refs do not GC).
 		searchOwnerHandler := &khandler.EnqueueRequestForSearchOwnerMultiCluster{}
 		searchOwnerPredicate := watch.PredicatesForMultiClusterSearchResource()
 		watchedTypes := []client.Object{

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -289,11 +289,20 @@ func AddMongoDBSearchController(
 
 		// Per-member-cluster watches for resources the search controller manages there.
 		// Owner references do not cross cluster boundaries, so the
-		// EnqueueRequestForSearchOwnerMultiCluster handler reads the
-		// MongoDBSearchResourceAnnotation off the watched object instead.
+		// EnqueueRequestForSearchOwnerMultiCluster handler reads the search-owner
+		// labels (khandler.MongoDBSearchOwnerNameLabel +
+		// MongoDBSearchOwnerNamespaceLabel) off the watched object — same scheme
+		// the Envoy controller's mapEnvoyObjectToSearch uses.
 		// PredicatesForMultiClusterSearchResource filters out unrelated churn.
 		// Backoff on unreachable member API is handled by controller-runtime's
 		// informer cache and surfaced via the health-check goroutine above.
+		//
+		// TODO(phase-2): the search controller does NOT yet write per-cluster
+		// member resources (STS / Service / ConfigMap / Secret); ga-base scope
+		// is single-cluster. Phase 2's reconcile fan-out
+		// (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) must
+		// stamp these labels on every per-cluster write so the watches above
+		// actually fire — until then the routing is correct but inert.
 		searchOwnerHandler := &khandler.EnqueueRequestForSearchOwnerMultiCluster{}
 		searchOwnerPredicate := watch.PredicatesForMultiClusterSearchResource()
 		watchedTypes := []client.Object{

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/util/envvar"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/util/merge"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
@@ -61,12 +62,11 @@ const (
 
 	labelName = "search-proxy"
 
-	// Cross-cluster enqueue labels. Cross-cluster owner refs do not GC,
-	// so a label-based mapper is the only path back to the parent MongoDBSearch
-	// for member-cluster Deployment/ConfigMap watches.
-	envoyOwnerSearchNameLabel      = "mongodb.com/search-name"
-	envoyOwnerSearchNamespaceLabel = "mongodb.com/search-namespace"
-	envoyClusterNameLabel          = "mongodb.com/cluster-name"
+	// envoyClusterNameLabel records which member cluster owns this resource.
+	// Cross-cluster enqueue labels (search-owner name + namespace) live in
+	// pkg/handler so both controllers can share them — see
+	// khandler.MongoDBSearchOwnerNameLabel / MongoDBSearchOwnerNamespaceLabel.
+	envoyClusterNameLabel = "mongodb.com/cluster-name"
 )
 
 // envoyRoute defines routing information for one Envoy entrypoint (one per shard, or one for RS).
@@ -679,10 +679,10 @@ func defaultEnvoyResourceRequirements() corev1.ResourceRequirements {
 // owner refs don't GC).
 func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) map[string]string {
 	labels := map[string]string{
-		"app":                          search.LoadBalancerDeploymentNameForCluster(clusterID),
-		"component":                    labelName,
-		envoyOwnerSearchNameLabel:      search.Name,
-		envoyOwnerSearchNamespaceLabel: search.Namespace,
+		"app":                                     search.LoadBalancerDeploymentNameForCluster(clusterID),
+		"component":                               labelName,
+		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
 	}
 	if clusterID != "" {
 		labels[envoyClusterNameLabel] = clusterID
@@ -727,10 +727,14 @@ func envoyPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) 
 // mapEnvoyObjectToSearch maps an Envoy Deployment or ConfigMap (in any cluster)
 // back to its owning MongoDBSearch. Cross-cluster owner refs do not GC, so the
 // label-based mapper is the only path home for member-cluster watches.
+//
+// Reads the same search-owner labels that the search controller's
+// EnqueueRequestForSearchOwnerMultiCluster reads — single label scheme across
+// both controllers (see pkg/handler/enqueue_owner_multi_search.go).
 func mapEnvoyObjectToSearch(_ context.Context, obj client.Object) []reconcile.Request {
 	labels := obj.GetLabels()
-	name := labels[envoyOwnerSearchNameLabel]
-	ns := labels[envoyOwnerSearchNamespaceLabel]
+	name := labels[khandler.MongoDBSearchOwnerNameLabel]
+	ns := labels[khandler.MongoDBSearchOwnerNamespaceLabel]
 	if name == "" || ns == "" {
 		return nil
 	}

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -150,7 +150,6 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 
 	workList := r.buildClusterWorkList(mdbSearch)
 	perClusterStatuses := make([]searchv1.ClusterLoadBalancerStatus, 0, len(workList))
-	worstPhase := status.PhaseRunning
 	var firstFailure error
 	multiCluster := len(workList) > 1 || (len(workList) == 1 && workList[0].ClusterName != "")
 
@@ -163,14 +162,15 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 				Message:     searchcontroller.MessageFromStatus(st),
 			})
 		}
-		if isWorsePhase(st.Phase(), worstPhase) {
-			worstPhase = st.Phase()
-		}
 		if !st.IsOK() && firstFailure == nil {
 			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st))
 		}
 	}
 
+	// Canonical invariant: top-level Phase = WorstOfPhase(per-cluster Phases).
+	// Documented on LoadBalancerStatus and exercised by
+	// TestUpdateLBStatus_WorstOfPhase_Invariant.
+	worstPhase := worstOfClusterPhases(perClusterStatuses)
 	if multiCluster {
 		mdbSearch.Status.LoadBalancer = &searchv1.LoadBalancerStatus{
 			Phase:    worstPhase,
@@ -253,23 +253,23 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	return workflow.OK()
 }
 
-// isWorsePhase returns true if a is "worse" than b in the ordering
-// Failed > Pending > Running. Used to compute the top-level Phase from
-// per-cluster phases.
-func isWorsePhase(a, b status.Phase) bool {
-	rank := func(p status.Phase) int {
-		switch p {
-		case status.PhaseFailed:
-			return 3
-		case status.PhasePending:
-			return 2
-		case status.PhaseRunning:
-			return 1
-		default:
-			return 0
-		}
+// worstOfClusterPhases returns the worst-of phase across the supplied
+// per-cluster LB statuses, defaulting to PhaseRunning when the slice is empty
+// (single-cluster path that never appends per-cluster items). This thin
+// wrapper centralises the canonical invariant declared on LoadBalancerStatus:
+//
+//	LoadBalancerStatus.Phase == WorstOfPhase(LoadBalancerStatus.Clusters[*].Phase)
+//
+// when len(Clusters) > 0.
+func worstOfClusterPhases(items []searchv1.ClusterLoadBalancerStatus) status.Phase {
+	if len(items) == 0 {
+		return status.PhaseRunning
 	}
-	return rank(a) > rank(b)
+	phases := make([]status.Phase, 0, len(items))
+	for _, it := range items {
+		phases = append(phases, it.Phase)
+	}
+	return searchv1.WorstOfPhase(phases...)
 }
 
 // updateLBStatus patches the loadBalancer sub-status on the MongoDBSearch CR

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -684,9 +684,9 @@ func defaultEnvoyResourceRequirements() corev1.ResourceRequirements {
 // owner refs don't GC).
 func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) map[string]string {
 	labels := map[string]string{
-		"app":                                     search.LoadBalancerDeploymentNameForCluster(clusterID),
-		"component":                               labelName,
-		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+		"app":                                search.LoadBalancerDeploymentNameForCluster(clusterID),
+		"component":                          labelName,
+		khandler.MongoDBSearchOwnerNameLabel: search.Name,
 		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
 	}
 	if clusterID != "" {

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -8,7 +8,6 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -61,12 +60,6 @@ const (
 	envoyConfigHashAnnotation = "mongodb.com/envoy-config-hash"
 
 	labelName = "search-proxy"
-
-	// envoyClusterNameLabel records which member cluster owns this resource.
-	// Cross-cluster enqueue labels (search-owner name + namespace) live in
-	// pkg/handler so both controllers can share them — see
-	// khandler.MongoDBSearchOwnerNameLabel / MongoDBSearchOwnerNamespaceLabel.
-	envoyClusterNameLabel = "mongodb.com/cluster-name"
 )
 
 // envoyRoute defines routing information for one Envoy entrypoint (one per shard, or one for RS).
@@ -153,13 +146,9 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	var firstFailure error
 	multiCluster := len(workList) > 1 || (len(workList) == 1 && workList[0].ClusterName != "")
 
-	// Always append a per-cluster status entry per work item, even in single-
-	// cluster mode. This keeps worstOfClusterPhases below as the single source
-	// of truth for the top-level Phase regardless of cluster count — without it,
-	// a single-cluster failed reconcile would downgrade to Pending in the
-	// firstFailure branch (worstPhase would default to Running).
-	// The `multiCluster` flag only gates the patch back into Status.LoadBalancer
-	// so single-cluster installs keep the legacy on-disk shape (no Clusters[]).
+	// Append a per-cluster status entry for every work item, including the
+	// single-cluster degenerate case, so worstOfClusterPhases sees the actual
+	// failure phase rather than defaulting to Running.
 	for _, w := range workList {
 		st := r.reconcileForCluster(ctx, mdbSearch, searchSource, tlsEnabled, tlsCfg, w.ClusterName, log)
 		perClusterStatuses = append(perClusterStatuses, searchv1.ClusterLoadBalancerStatus{
@@ -173,8 +162,6 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	}
 
 	// Canonical invariant: top-level Phase = WorstOfPhase(per-cluster Phases).
-	// Documented on LoadBalancerStatus; verified by TestWorstOfClusterPhases
-	// (unit) and TestReconcile_PerClusterStatus_Aggregated (integration).
 	worstPhase := worstOfClusterPhases(perClusterStatuses)
 	if multiCluster {
 		mdbSearch.Status.LoadBalancer = &searchv1.LoadBalancerStatus{
@@ -690,7 +677,7 @@ func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) map
 		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
 	}
 	if clusterID != "" {
-		labels[envoyClusterNameLabel] = clusterID
+		labels[khandler.MongoDBSearchClusterNameLabel] = clusterID
 	}
 	return labels
 }
@@ -729,21 +716,12 @@ func envoyPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) 
 	}
 }
 
-// mapEnvoyObjectToSearch maps an Envoy Deployment or ConfigMap (in any cluster)
-// back to its owning MongoDBSearch. Cross-cluster owner refs do not GC, so the
-// label-based mapper is the only path home for member-cluster watches.
-//
-// Reads the same search-owner labels that the search controller's
-// EnqueueRequestForSearchOwnerMultiCluster reads — single label scheme across
-// both controllers (see pkg/handler/enqueue_owner_multi_search.go).
 func mapEnvoyObjectToSearch(_ context.Context, obj client.Object) []reconcile.Request {
-	labels := obj.GetLabels()
-	name := labels[khandler.MongoDBSearchOwnerNameLabel]
-	ns := labels[khandler.MongoDBSearchOwnerNamespaceLabel]
-	if name == "" || ns == "" {
+	req := khandler.MapMemberClusterObjectToSearch(obj)
+	if req == (reconcile.Request{}) {
 		return nil
 	}
-	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}}}
+	return []reconcile.Request{req}
 }
 
 // Controller Registration

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -153,15 +153,20 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	var firstFailure error
 	multiCluster := len(workList) > 1 || (len(workList) == 1 && workList[0].ClusterName != "")
 
+	// Always append a per-cluster status entry per work item, even in single-
+	// cluster mode. This keeps worstOfClusterPhases below as the single source
+	// of truth for the top-level Phase regardless of cluster count — without it,
+	// a single-cluster failed reconcile would downgrade to Pending in the
+	// firstFailure branch (worstPhase would default to Running).
+	// The `multiCluster` flag only gates the patch back into Status.LoadBalancer
+	// so single-cluster installs keep the legacy on-disk shape (no Clusters[]).
 	for _, w := range workList {
 		st := r.reconcileForCluster(ctx, mdbSearch, searchSource, tlsEnabled, tlsCfg, w.ClusterName, log)
-		if multiCluster {
-			perClusterStatuses = append(perClusterStatuses, searchv1.ClusterLoadBalancerStatus{
-				ClusterName: w.ClusterName,
-				Phase:       st.Phase(),
-				Message:     searchcontroller.MessageFromStatus(st),
-			})
-		}
+		perClusterStatuses = append(perClusterStatuses, searchv1.ClusterLoadBalancerStatus{
+			ClusterName: w.ClusterName,
+			Phase:       st.Phase(),
+			Message:     searchcontroller.MessageFromStatus(st),
+		})
 		if !st.IsOK() && firstFailure == nil {
 			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st))
 		}

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -168,8 +168,8 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	}
 
 	// Canonical invariant: top-level Phase = WorstOfPhase(per-cluster Phases).
-	// Documented on LoadBalancerStatus and exercised by
-	// TestUpdateLBStatus_WorstOfPhase_Invariant.
+	// Documented on LoadBalancerStatus; verified by TestWorstOfClusterPhases
+	// (unit) and TestReconcile_PerClusterStatus_Aggregated (integration).
 	worstPhase := worstOfClusterPhases(perClusterStatuses)
 	if multiCluster {
 		mdbSearch.Status.LoadBalancer = &searchv1.LoadBalancerStatus{

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -519,7 +519,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 						envoyConfigHashAnnotation: configHash,
 					},
 				},
-				Spec: buildEnvoyPodSpec(search, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
+				Spec: buildEnvoyPodSpec(search, clusterName, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
 			},
 		}
 
@@ -545,13 +545,18 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 
 // buildEnvoyPodSpec builds the PodSpec for the Envoy Deployment.
 // tlsCfg may be nil if TLS is not configured on the source.
-func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, tlsCfg *searchcontroller.TLSSourceConfig, tlsEnabled bool, image string, resources corev1.ResourceRequirements, managedSecurityContext bool) corev1.PodSpec {
+//
+// clusterName selects the per-cluster ConfigMap volume name in MC mode
+// (clusterName == "" preserves the single-cluster path's legacy unsuffixed
+// name). Without this, MC pods mount a ConfigMap that does not exist in the
+// member cluster and Envoy never starts.
+func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterName string, tlsCfg *searchcontroller.TLSSourceConfig, tlsEnabled bool, image string, resources corev1.ResourceRequirements, managedSecurityContext bool) corev1.PodSpec {
 	volumes := []corev1.Volume{
 		{
 			Name: "envoy-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: search.LoadBalancerConfigMapName()},
+					LocalObjectReference: corev1.LocalObjectReference{Name: search.LoadBalancerConfigMapNameForCluster(clusterName)},
 				},
 			},
 		},

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -664,12 +664,64 @@ func TestBuildClusterWorkList_MultiCluster_OneItemPerSpecEntry(t *testing.T) {
 	assert.Equal(t, "b", wl[1].ClusterName)
 }
 
-func TestIsWorsePhase(t *testing.T) {
-	assert.True(t, isWorsePhase(status.PhaseFailed, status.PhaseRunning))
-	assert.True(t, isWorsePhase(status.PhasePending, status.PhaseRunning))
-	assert.True(t, isWorsePhase(status.PhaseFailed, status.PhasePending))
-	assert.False(t, isWorsePhase(status.PhaseRunning, status.PhasePending))
-	assert.False(t, isWorsePhase(status.PhaseRunning, status.PhaseRunning))
+// TestWorstOfClusterPhases regresses the canonical invariant declared on
+// LoadBalancerStatus: top-level Phase must equal WorstOfPhase across the
+// per-cluster Clusters[*].Phase entries when len(Clusters) > 0.
+//
+// This replaces the previous TestIsWorsePhase, which exercised a partial
+// rank function (only Failed/Pending/Running were ordered). The new helper
+// delegates to searchv1.WorstOfPhase, picking up the full Phase ordering
+// (Failed > Pending > Running > Updated > Disabled > Unsupported) from a
+// single source of truth.
+func TestWorstOfClusterPhases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []searchv1.ClusterLoadBalancerStatus
+		want status.Phase
+	}{
+		{
+			name: "empty slice — single-cluster degenerate path",
+			in:   nil,
+			want: status.PhaseRunning,
+		},
+		{
+			name: "single Running",
+			in:   []searchv1.ClusterLoadBalancerStatus{{Phase: status.PhaseRunning}},
+			want: status.PhaseRunning,
+		},
+		{
+			name: "Failed beats Running",
+			in: []searchv1.ClusterLoadBalancerStatus{
+				{Phase: status.PhaseRunning},
+				{Phase: status.PhaseFailed},
+			},
+			want: status.PhaseFailed,
+		},
+		{
+			name: "Pending beats Running",
+			in: []searchv1.ClusterLoadBalancerStatus{
+				{Phase: status.PhaseRunning},
+				{Phase: status.PhasePending},
+				{Phase: status.PhaseRunning},
+			},
+			want: status.PhasePending,
+		},
+		{
+			name: "Failed beats Pending",
+			in: []searchv1.ClusterLoadBalancerStatus{
+				{Phase: status.PhasePending},
+				{Phase: status.PhaseFailed},
+				{Phase: status.PhaseRunning},
+			},
+			want: status.PhaseFailed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, worstOfClusterPhases(tc.in))
+		})
+	}
 }
 
 func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -135,13 +135,66 @@ func TestBuildEnvoyPodSpec_DefaultResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 	}
 	resources := envoyResourceRequirements(search)
-	podSpec := buildEnvoyPodSpec(search, nil, false, "envoy:latest", resources, false)
+	podSpec := buildEnvoyPodSpec(search, "", nil, false, "envoy:latest", resources, false)
 
 	assert.Len(t, podSpec.Containers, 1)
 	assert.Equal(t, "envoy", podSpec.Containers[0].Name)
 	assert.Equal(t, resource.MustParse("100m"), podSpec.Containers[0].Resources.Requests[corev1.ResourceCPU])
 	assert.Equal(t, resource.MustParse("128Mi"), podSpec.Containers[0].Resources.Requests[corev1.ResourceMemory])
 }
+
+// TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster regresses the MC-mode
+// volume-name bug where buildEnvoyPodSpec hardcoded LoadBalancerConfigMapName()
+// instead of the per-cluster suffixed name. Without this, the Pod template in
+// member clusters references a ConfigMap that does not exist (ensureConfigMap
+// writes the per-cluster name), so Envoy never starts in MC mode.
+func TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster(t *testing.T) {
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+	}
+	resources := envoyResourceRequirements(search)
+
+	cases := []struct {
+		name           string
+		clusterName    string
+		expectedCMName string
+	}{
+		{
+			name:           "single-cluster keeps legacy unsuffixed name",
+			clusterName:    "",
+			expectedCMName: search.LoadBalancerConfigMapName(),
+		},
+		{
+			name:           "MC cluster a uses per-cluster suffixed name",
+			clusterName:    "cluster-a",
+			expectedCMName: search.LoadBalancerConfigMapNameForCluster("cluster-a"),
+		},
+		{
+			name:           "MC cluster b uses per-cluster suffixed name",
+			clusterName:    "cluster-b",
+			expectedCMName: search.LoadBalancerConfigMapNameForCluster("cluster-b"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			podSpec := buildEnvoyPodSpec(search, tc.clusterName, nil, false, "envoy:latest", resources, false)
+
+			var found *corev1.Volume
+			for i := range podSpec.Volumes {
+				if podSpec.Volumes[i].Name == "envoy-config" {
+					found = &podSpec.Volumes[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "envoy-config volume must be present")
+			require.NotNil(t, found.ConfigMap, "envoy-config volume must be a ConfigMap source")
+			assert.Equal(t, tc.expectedCMName, found.ConfigMap.Name,
+				"per-cluster ConfigMap volume name mismatch — pod will fail to mount")
+		})
+	}
+}
+
 
 func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
@@ -174,7 +227,7 @@ func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 
 	// Build the base pod spec as the controller would
 	resources := envoyResourceRequirements(search)
-	podSpec := buildEnvoyPodSpec(search, nil, false, "envoy:latest", resources, false)
+	podSpec := buildEnvoyPodSpec(search, "", nil, false, "envoy:latest", resources, false)
 
 	// Verify base spec has no tolerations
 	assert.Empty(t, podSpec.Tolerations)
@@ -253,7 +306,7 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	resources := envoyResourceRequirements(search)
 	assert.Equal(t, resource.MustParse("200m"), resources.Requests[corev1.ResourceCPU])
 
-	podSpec := buildEnvoyPodSpec(search, nil, false, "envoy:latest", resources, false)
+	podSpec := buildEnvoyPodSpec(search, "", nil, false, "envoy:latest", resources, false)
 
 	dep := appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1/common"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/util/merge"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 )
 
 // TODO: Add full Reconcile() integration tests covering:
@@ -503,15 +504,15 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 
 	// Single-cluster: cluster-name label must be absent.
 	single := envoyLabelsForCluster(search, "")
-	assert.Equal(t, "mdb-search", single[envoyOwnerSearchNameLabel])
-	assert.Equal(t, "ns", single[envoyOwnerSearchNamespaceLabel])
+	assert.Equal(t, "mdb-search", single[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, "ns", single[khandler.MongoDBSearchOwnerNamespaceLabel])
 	_, hasCluster := single[envoyClusterNameLabel]
 	assert.False(t, hasCluster)
 
 	// Multi-cluster: all three labels present.
 	mc := envoyLabelsForCluster(search, "us-east-k8s")
-	assert.Equal(t, "mdb-search", mc[envoyOwnerSearchNameLabel])
-	assert.Equal(t, "ns", mc[envoyOwnerSearchNamespaceLabel])
+	assert.Equal(t, "mdb-search", mc[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, "ns", mc[khandler.MongoDBSearchOwnerNamespaceLabel])
 	assert.Equal(t, "us-east-k8s", mc[envoyClusterNameLabel])
 }
 
@@ -571,7 +572,7 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 	assert.Equal(t, `{"x":1}`, cmA.Data["envoy.json"])
 	// Cluster name label stamped.
 	assert.Equal(t, "a", cmA.Labels[envoyClusterNameLabel])
-	assert.Equal(t, "mdb-search", cmA.Labels[envoyOwnerSearchNameLabel])
+	assert.Equal(t, "mdb-search", cmA.Labels[khandler.MongoDBSearchOwnerNameLabel])
 
 	// Central and member B do not.
 	cm := &corev1.ConfigMap{}
@@ -748,8 +749,8 @@ func TestMapEnvoyObjectToSearch(t *testing.T) {
 			Name:      "mdb-search-search-lb-0-a-config",
 			Namespace: "ns",
 			Labels: map[string]string{
-				envoyOwnerSearchNameLabel:      "mdb-search",
-				envoyOwnerSearchNamespaceLabel: "ns",
+				khandler.MongoDBSearchOwnerNameLabel:      "mdb-search",
+				khandler.MongoDBSearchOwnerNamespaceLabel: "ns",
 				envoyClusterNameLabel:          "a",
 			},
 		},
@@ -768,7 +769,7 @@ func TestMapEnvoyObjectToSearch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "x",
 			Namespace: "ns",
-			Labels:    map[string]string{envoyOwnerSearchNameLabel: "mdb-search"},
+			Labels:    map[string]string{khandler.MongoDBSearchOwnerNameLabel: "mdb-search"},
 		},
 	}
 	assert.Empty(t, mapEnvoyObjectToSearch(context.Background(), cmPartial))

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -195,7 +195,6 @@ func TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster(t *testing.T) {
 	}
 }
 
-
 func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -506,14 +506,14 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 	single := envoyLabelsForCluster(search, "")
 	assert.Equal(t, "mdb-search", single[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", single[khandler.MongoDBSearchOwnerNamespaceLabel])
-	_, hasCluster := single[envoyClusterNameLabel]
+	_, hasCluster := single[khandler.MongoDBSearchClusterNameLabel]
 	assert.False(t, hasCluster)
 
 	// Multi-cluster: all three labels present.
 	mc := envoyLabelsForCluster(search, "us-east-k8s")
 	assert.Equal(t, "mdb-search", mc[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", mc[khandler.MongoDBSearchOwnerNamespaceLabel])
-	assert.Equal(t, "us-east-k8s", mc[envoyClusterNameLabel])
+	assert.Equal(t, "us-east-k8s", mc[khandler.MongoDBSearchClusterNameLabel])
 }
 
 // --- envoy replicas defaulting ------------------------------------------
@@ -571,7 +571,7 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, cmA))
 	assert.Equal(t, `{"x":1}`, cmA.Data["envoy.json"])
 	// Cluster name label stamped.
-	assert.Equal(t, "a", cmA.Labels[envoyClusterNameLabel])
+	assert.Equal(t, "a", cmA.Labels[khandler.MongoDBSearchClusterNameLabel])
 	assert.Equal(t, "mdb-search", cmA.Labels[khandler.MongoDBSearchOwnerNameLabel])
 
 	// Central and member B do not.
@@ -668,12 +668,6 @@ func TestBuildClusterWorkList_MultiCluster_OneItemPerSpecEntry(t *testing.T) {
 // TestWorstOfClusterPhases regresses the canonical invariant declared on
 // LoadBalancerStatus: top-level Phase must equal WorstOfPhase across the
 // per-cluster Clusters[*].Phase entries when len(Clusters) > 0.
-//
-// This replaces the previous TestIsWorsePhase, which exercised a partial
-// rank function (only Failed/Pending/Running were ordered). The new helper
-// delegates to searchv1.WorstOfPhase, picking up the full Phase ordering
-// (Failed > Pending > Running > Updated > Disabled > Unsupported) from a
-// single source of truth.
 func TestWorstOfClusterPhases(t *testing.T) {
 	cases := []struct {
 		name string
@@ -751,7 +745,7 @@ func TestMapEnvoyObjectToSearch(t *testing.T) {
 			Labels: map[string]string{
 				khandler.MongoDBSearchOwnerNameLabel:      "mdb-search",
 				khandler.MongoDBSearchOwnerNamespaceLabel: "ns",
-				envoyClusterNameLabel:                     "a",
+				khandler.MongoDBSearchClusterNameLabel:                     "a",
 			},
 		},
 	}
@@ -938,17 +932,9 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 		"all-Failed clusters must aggregate to top-level Failed, not Pending")
 }
 
-// TestWorstOfClusterPhases_SingleCluster_PreservesFailed regresses the
-// downgrade bug introduced when worstOfClusterPhases replaced isWorsePhase:
-// in single-cluster mode, the per-cluster status slice was previously only
-// appended when multiCluster == true, leaving worstOfClusterPhases returning
-// the empty-default PhaseRunning. The Reconcile firstFailure branch then
-// fell through to workflow.Pending — the top-level Phase reported Pending
-// while the underlying reconcile had Failed.
-//
-// Always-appending one entry (with ClusterName == "") fixes it; this test
-// asserts the worstOfClusterPhases helper computes Failed for the
-// single-entry-with-empty-name case the way Reconcile now feeds it.
+// TestWorstOfClusterPhases_SingleCluster_PreservesFailed asserts that the
+// single-cluster degenerate path (one entry with empty ClusterName) propagates
+// Failed rather than the empty-slice default of Running.
 func TestWorstOfClusterPhases_SingleCluster_PreservesFailed(t *testing.T) {
 	got := worstOfClusterPhases([]searchv1.ClusterLoadBalancerStatus{
 		{ClusterName: "", Phase: status.PhaseFailed},

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -938,6 +938,25 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 		"all-Failed clusters must aggregate to top-level Failed, not Pending")
 }
 
+// TestWorstOfClusterPhases_SingleCluster_PreservesFailed regresses the
+// downgrade bug introduced when worstOfClusterPhases replaced isWorsePhase:
+// in single-cluster mode, the per-cluster status slice was previously only
+// appended when multiCluster == true, leaving worstOfClusterPhases returning
+// the empty-default PhaseRunning. The Reconcile firstFailure branch then
+// fell through to workflow.Pending — the top-level Phase reported Pending
+// while the underlying reconcile had Failed.
+//
+// Always-appending one entry (with ClusterName == "") fixes it; this test
+// asserts the worstOfClusterPhases helper computes Failed for the
+// single-entry-with-empty-name case the way Reconcile now feeds it.
+func TestWorstOfClusterPhases_SingleCluster_PreservesFailed(t *testing.T) {
+	got := worstOfClusterPhases([]searchv1.ClusterLoadBalancerStatus{
+		{ClusterName: "", Phase: status.PhaseFailed},
+	})
+	assert.Equal(t, status.PhaseFailed, got,
+		"single-cluster degenerate path (one entry with empty ClusterName) must propagate Failed, not downgrade to Running")
+}
+
 // failingWriteClient wraps a client.Client and rejects every write so we can
 // simulate a per-cluster Failed status without needing a real envtest.
 type failingWriteClient struct {

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -751,7 +751,7 @@ func TestMapEnvoyObjectToSearch(t *testing.T) {
 			Labels: map[string]string{
 				khandler.MongoDBSearchOwnerNameLabel:      "mdb-search",
 				khandler.MongoDBSearchOwnerNamespaceLabel: "ns",
-				envoyClusterNameLabel:          "a",
+				envoyClusterNameLabel:                     "a",
 			},
 		},
 	}

--- a/controllers/operator/watch/predicates.go
+++ b/controllers/operator/watch/predicates.go
@@ -153,21 +153,26 @@ func PredicatesForStatefulSet() predicate.Funcs {
 
 // PredicatesForMultiClusterSearchResource filters watch events for resources
 // the MongoDBSearch controller places in member clusters. Owner references do
-// not cross cluster boundaries, so identification is by annotation
-// (handler.MongoDBSearchResourceAnnotation) rather than ownerRef.
+// not cross cluster boundaries, so identification is by the search-owner
+// labels (handler.MongoDBSearchOwnerNameLabel +
+// handler.MongoDBSearchOwnerNamespaceLabel) rather than ownerRef.
 //
-// Create and Delete pass through only when the annotation is present. Update
-// passes if either side carries the annotation, so annotation add/remove
-// transitions also reconcile. Generic drops everything (informer-resync noise).
+// Create and Delete pass through only when both labels are present. Update
+// passes if either side carries them, so label add/remove transitions also
+// reconcile. Generic drops everything (informer-resync noise).
+//
+// Aligned with the Envoy controller's mapEnvoyObjectToSearch — both readers
+// share the same label scheme.
 func PredicatesForMultiClusterSearchResource() predicate.Funcs {
-	hasAnn := func(obj interface{ GetAnnotations() map[string]string }) bool {
-		_, ok := obj.GetAnnotations()[handler.MongoDBSearchResourceAnnotation]
-		return ok
+	hasOwnerLabels := func(obj interface{ GetLabels() map[string]string }) bool {
+		labels := obj.GetLabels()
+		return labels[handler.MongoDBSearchOwnerNameLabel] != "" &&
+			labels[handler.MongoDBSearchOwnerNamespaceLabel] != ""
 	}
 	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return hasAnn(e.Object) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return hasAnn(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return hasAnn(e.ObjectOld) || hasAnn(e.ObjectNew) },
+		CreateFunc:  func(e event.CreateEvent) bool { return hasOwnerLabels(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasOwnerLabels(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return hasOwnerLabels(e.ObjectOld) || hasOwnerLabels(e.ObjectNew) },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 }

--- a/controllers/operator/watch/predicates_test.go
+++ b/controllers/operator/watch/predicates_test.go
@@ -94,9 +94,6 @@ func TestPredicatesForMongoDB(t *testing.T) {
 	})
 }
 
-// labeledSearchObj returns a ConfigMap stamped with the supplied labels.
-// Used by the search-owner predicate tests; mirrors the labels both
-// controllers stamp on member-cluster writes (search-owner name + namespace).
 func labeledSearchObj(labels map[string]string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns", Labels: labels}}
 }

--- a/controllers/operator/watch/predicates_test.go
+++ b/controllers/operator/watch/predicates_test.go
@@ -94,39 +94,53 @@ func TestPredicatesForMongoDB(t *testing.T) {
 	})
 }
 
-func annotatedSearchObj(ann map[string]string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns", Annotations: ann}}
+// labeledSearchObj returns a ConfigMap stamped with the supplied labels.
+// Used by the search-owner predicate tests; mirrors the labels both
+// controllers stamp on member-cluster writes (search-owner name + namespace).
+func labeledSearchObj(labels map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns", Labels: labels}}
+}
+
+func searchOwnerLabels(name, ns string) map[string]string {
+	return map[string]string{
+		handler.MongoDBSearchOwnerNameLabel:      name,
+		handler.MongoDBSearchOwnerNamespaceLabel: ns,
+	}
 }
 
 func TestPredicatesForMultiClusterSearchResource_Create(t *testing.T) {
 	p := PredicatesForMultiClusterSearchResource()
 
-	assert.True(t, p.CreateFunc(event.CreateEvent{Object: annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})}))
-	assert.False(t, p.CreateFunc(event.CreateEvent{Object: annotatedSearchObj(nil)}))
-	assert.False(t, p.CreateFunc(event.CreateEvent{Object: annotatedSearchObj(map[string]string{"unrelated": "x"})}))
+	assert.True(t, p.CreateFunc(event.CreateEvent{Object: labeledSearchObj(searchOwnerLabels("s", "ns"))}))
+	assert.False(t, p.CreateFunc(event.CreateEvent{Object: labeledSearchObj(nil)}))
+	assert.False(t, p.CreateFunc(event.CreateEvent{Object: labeledSearchObj(map[string]string{"unrelated": "x"})}))
+	// Partial label set must not pass — both name and namespace are required.
+	assert.False(t, p.CreateFunc(event.CreateEvent{Object: labeledSearchObj(map[string]string{
+		handler.MongoDBSearchOwnerNameLabel: "s",
+	})}))
 }
 
 func TestPredicatesForMultiClusterSearchResource_Update(t *testing.T) {
 	p := PredicatesForMultiClusterSearchResource()
 
-	annotatedNew := annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})
-	annotatedOld := annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})
-	plain := annotatedSearchObj(nil)
+	labeledNew := labeledSearchObj(searchOwnerLabels("s", "ns"))
+	labeledOld := labeledSearchObj(searchOwnerLabels("s", "ns"))
+	plain := labeledSearchObj(nil)
 
-	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: annotatedOld, ObjectNew: annotatedNew}))
-	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: annotatedNew}), "newly annotated must enqueue")
-	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: annotatedOld, ObjectNew: plain}), "annotation removal must enqueue")
+	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: labeledOld, ObjectNew: labeledNew}))
+	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: labeledNew}), "newly labeled must enqueue")
+	assert.True(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: labeledOld, ObjectNew: plain}), "label removal must enqueue")
 	assert.False(t, p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: plain}))
 }
 
 func TestPredicatesForMultiClusterSearchResource_Delete(t *testing.T) {
 	p := PredicatesForMultiClusterSearchResource()
 
-	assert.True(t, p.DeleteFunc(event.DeleteEvent{Object: annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})}))
-	assert.False(t, p.DeleteFunc(event.DeleteEvent{Object: annotatedSearchObj(nil)}))
+	assert.True(t, p.DeleteFunc(event.DeleteEvent{Object: labeledSearchObj(searchOwnerLabels("s", "ns"))}))
+	assert.False(t, p.DeleteFunc(event.DeleteEvent{Object: labeledSearchObj(nil)}))
 }
 
 func TestPredicatesForMultiClusterSearchResource_Generic_AlwaysFalse(t *testing.T) {
 	p := PredicatesForMultiClusterSearchResource()
-	assert.False(t, p.GenericFunc(event.GenericEvent{Object: annotatedSearchObj(map[string]string{handler.MongoDBSearchResourceAnnotation: "s"})}))
+	assert.False(t, p.GenericFunc(event.GenericEvent{Object: labeledSearchObj(searchOwnerLabels("s", "ns"))}))
 }

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -80,6 +80,11 @@ type MongoDBSearchReconcileHelper struct {
 	mdbSearch            *searchv1.MongoDBSearch
 	db                   SearchSourceDBResource
 	operatorSearchConfig OperatorSearchConfig
+	// secretGaps records per-cluster customer-replicated-secret gaps reported
+	// by the parent controller's CheckSecretsPresence call. The helper folds
+	// these into the per-cluster status patch so warnings surface in
+	// status.clusterStatusList[i].warnings without a second writeback.
+	secretGaps []SecretCheckResult
 }
 
 func NewMongoDBSearchReconcileHelper(
@@ -94,6 +99,15 @@ func NewMongoDBSearchReconcileHelper(
 		mdbSearch:            mdbSearch,
 		db:                   db,
 	}
+}
+
+// SetSecretGaps supplies the helper with the per-cluster results of
+// CheckSecretsPresence so that gaps can be surfaced as warnings in the
+// per-cluster status patch the helper builds. nil / empty means "no gaps".
+//
+// Called by the controller before Reconcile.
+func (r *MongoDBSearchReconcileHelper) SetSecretGaps(gaps []SecretCheckResult) {
+	r.secretGaps = gaps
 }
 
 // reconcileUnit captures all per-unit (per-shard or single-RS) resource names, labels, and
@@ -214,7 +228,7 @@ func (r *MongoDBSearchReconcileHelper) Reconcile(ctx context.Context, log *zap.S
 	// Populate the per-cluster status surface from spec.clusters[i] before the
 	// patch goes out. No-op when spec.clusters is nil/empty (legacy single-cluster
 	// install) — top-level fields keep their existing semantics.
-	r.mdbSearch.AggregateClusterStatuses(buildPerClusterStatusItems(r.mdbSearch, workflowStatus))
+	r.mdbSearch.AggregateClusterStatuses(buildPerClusterStatusItems(r.mdbSearch, workflowStatus, r.secretGaps))
 
 	if _, err := commoncontroller.UpdateStatus(ctx, r.client, r.mdbSearch, workflowStatus, log); err != nil {
 		return workflow.Failed(err)
@@ -224,22 +238,36 @@ func (r *MongoDBSearchReconcileHelper) Reconcile(ctx context.Context, log *zap.S
 
 // buildPerClusterStatusItems returns one SearchClusterStatusItem per
 // spec.clusters[i]. Every entry copies the workflow outcome's phase + message
-// into its inlined status.Common. Returns nil when spec.clusters is nil or empty
-// (legacy single-cluster); the top-level Phase keeps its existing semantics.
-func buildPerClusterStatusItems(mdb *searchv1.MongoDBSearch, st workflow.Status) []searchv1.SearchClusterStatusItem {
+// into its inlined status.Common, and folds in any matching customer-replicated
+// secret gaps as per-cluster warnings (so users can see which cluster is
+// missing which secrets without scraping logs). Returns nil when spec.clusters
+// is nil or empty (legacy single-cluster); the top-level Phase keeps its
+// existing semantics.
+func buildPerClusterStatusItems(mdb *searchv1.MongoDBSearch, st workflow.Status, gaps []SecretCheckResult) []searchv1.SearchClusterStatusItem {
 	if mdb.Spec.Clusters == nil || len(*mdb.Spec.Clusters) == 0 {
 		return nil
 	}
+	gapsByCluster := make(map[string][]string, len(gaps))
+	for _, g := range gaps {
+		gapsByCluster[g.Cluster] = g.Missing
+	}
+
 	message := MessageFromStatus(st)
 	items := make([]searchv1.SearchClusterStatusItem, 0, len(*mdb.Spec.Clusters))
 	for _, c := range *mdb.Spec.Clusters {
-		items = append(items, searchv1.SearchClusterStatusItem{
+		item := searchv1.SearchClusterStatusItem{
 			ClusterName: c.ClusterName,
 			Common: status.Common{
 				Phase:   st.Phase(),
 				Message: message,
 			},
-		})
+		}
+		if missing := gapsByCluster[c.ClusterName]; len(missing) > 0 {
+			item.Warnings = []status.Warning{
+				status.Warning(fmt.Sprintf("Customer-replicated secrets missing in cluster %q: %s", c.ClusterName, strings.Join(missing, ", "))),
+			}
+		}
+		items = append(items, item)
 	}
 	return items
 }

--- a/controllers/searchcontroller/mongodbsearch_status_test.go
+++ b/controllers/searchcontroller/mongodbsearch_status_test.go
@@ -19,7 +19,7 @@ func TestBuildPerClusterStatusItems_Legacy_NoClusters(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
 		Spec:       searchv1.MongoDBSearchSpec{},
 	}
-	items := buildPerClusterStatusItems(mdb, workflow.OK())
+	items := buildPerClusterStatusItems(mdb, workflow.OK(), nil)
 	assert.Empty(t, items, "legacy single-cluster reconcile must produce no per-cluster items")
 }
 
@@ -31,7 +31,7 @@ func TestBuildPerClusterStatusItems_LegacyEmptySlice_NoClusters(t *testing.T) {
 			Clusters: &emptyClusters,
 		},
 	}
-	items := buildPerClusterStatusItems(mdb, workflow.OK())
+	items := buildPerClusterStatusItems(mdb, workflow.OK(), nil)
 	assert.Empty(t, items, "empty spec.clusters slice must also be treated as legacy")
 }
 
@@ -46,7 +46,7 @@ func TestBuildPerClusterStatusItems_MultiCluster_OneItemPerSpec(t *testing.T) {
 			Clusters: &clusters,
 		},
 	}
-	items := buildPerClusterStatusItems(mdb, workflow.OK())
+	items := buildPerClusterStatusItems(mdb, workflow.OK(), nil)
 	require.Len(t, items, 2)
 	assert.Equal(t, "us-east-k8s", items[0].ClusterName)
 	assert.Equal(t, "eu-west-k8s", items[1].ClusterName)
@@ -65,7 +65,7 @@ func TestBuildPerClusterStatusItems_FailedReconcileFlowsToEachCluster(t *testing
 			Clusters: &clusters,
 		},
 	}
-	items := buildPerClusterStatusItems(mdb, workflow.Failed(fmt.Errorf("boom")))
+	items := buildPerClusterStatusItems(mdb, workflow.Failed(fmt.Errorf("boom")), nil)
 	require.Len(t, items, 2)
 	assert.Equal(t, status.PhaseFailed, items[0].Phase)
 	assert.Equal(t, status.PhaseFailed, items[1].Phase)
@@ -81,8 +81,59 @@ func TestBuildPerClusterStatusItems_PendingReconcileFlows(t *testing.T) {
 			Clusters: &clusters,
 		},
 	}
-	items := buildPerClusterStatusItems(mdb, workflow.Pending("waiting for LB"))
+	items := buildPerClusterStatusItems(mdb, workflow.Pending("waiting for LB"), nil)
 	require.Len(t, items, 1)
 	assert.Equal(t, status.PhasePending, items[0].Phase)
 	assert.Contains(t, items[0].Message, "waiting for LB")
+}
+
+// TestBuildPerClusterStatusItems_FoldsSecretGapsToWarnings verifies that any
+// SecretCheckResult whose Cluster matches a spec.clusters[i] entry is
+// translated into a Warning on that item — the user can see in
+// status.clusterStatusList[i].warnings which member cluster is missing which
+// customer-replicated secrets without scraping operator logs. The central
+// gap (Cluster == "") does NOT match any spec.clusters[i] and is intentionally
+// dropped here; central-only warnings continue to flow through the operator
+// log path.
+func TestBuildPerClusterStatusItems_FoldsSecretGapsToWarnings(t *testing.T) {
+	clusters := []searchv1.ClusterSpec{
+		{ClusterName: "us-east-k8s"},
+		{ClusterName: "eu-west-k8s"},
+	}
+	mdb := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Clusters: &clusters,
+		},
+	}
+	gaps := []SecretCheckResult{
+		{Cluster: "", Missing: []string{"central-only-secret"}}, // central; not folded
+		{Cluster: "us-east-k8s", Missing: []string{"keyfile-secret"}},
+		{Cluster: "eu-west-k8s", Missing: []string{"keyfile-secret", "tls-cert-secret"}},
+	}
+	items := buildPerClusterStatusItems(mdb, workflow.Pending("waiting for secrets"), gaps)
+	require.Len(t, items, 2)
+
+	require.Len(t, items[0].Warnings, 1, "us-east-k8s gets one missing secret rolled into Warnings")
+	assert.Contains(t, string(items[0].Warnings[0]), `cluster "us-east-k8s"`)
+	assert.Contains(t, string(items[0].Warnings[0]), "keyfile-secret")
+
+	require.Len(t, items[1].Warnings, 1, "eu-west-k8s gets one Warning entry that lists both missing secrets")
+	assert.Contains(t, string(items[1].Warnings[0]), "keyfile-secret")
+	assert.Contains(t, string(items[1].Warnings[0]), "tls-cert-secret")
+}
+
+// TestBuildPerClusterStatusItems_NoGaps_NoWarnings is the negative path:
+// supplying nil or empty gaps must not stamp any Warnings on the items.
+func TestBuildPerClusterStatusItems_NoGaps_NoWarnings(t *testing.T) {
+	clusters := []searchv1.ClusterSpec{{ClusterName: "us-east-k8s"}}
+	mdb := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Clusters: &clusters,
+		},
+	}
+	items := buildPerClusterStatusItems(mdb, workflow.OK(), nil)
+	require.Len(t, items, 1)
+	assert.Empty(t, items[0].Warnings)
 }

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -1062,9 +1062,13 @@ spec:
                           type: string
                         loadBalancer:
                           description: |-
-                            LoadBalancer reports the per-cluster managed-LB phase for ReplicaSet
-                            topologies. Sharded per-(cluster, shard) LB phase lives on the
-                            top-level ShardLoadBalancerStatusInClusters map.
+                            LoadBalancer is unused by either controller and is kept only to avoid
+                            CRD removal until the next API rev. The canonical per-cluster managed-LB
+                            phase lives in status.loadBalancer.clusters[i] (flat sibling), written
+                            by the Envoy controller in mongodbsearchenvoy_controller.go.
+
+                            Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
+                            remove this field together with the next CRD bump.
                           properties:
                             clusters:
                               description: |-
@@ -1107,6 +1111,11 @@ spec:
                           description: |-
                             ObservedReplicas is the number of mongot pods this cluster currently has Ready.
                             Used by the load-test harness as the readiness gate.
+
+                            fan-out per-cluster mongot StatefulSets, so there is no per-cluster
+                            Ready-replica count to observe. Phase 2's reconcile fan-out
+                            (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
+                            where per-cluster STSs land; populate this then.
                           format: int32
                           type: integer
                         phase:
@@ -1154,6 +1163,11 @@ spec:
                           description: |-
                             Warnings is the per-cluster warnings list (e.g. customer-replicated
                             secret missing in this cluster).
+
+                            Populated by buildPerClusterStatusItems in the search controller from
+                            the SecretCheckResult slice for each cluster name that matches a
+                            spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
+                            through the operator log instead of this field.
                           items:
                             type: string
                           type: array
@@ -1274,6 +1288,10 @@ spec:
                   phase for sharded multi-cluster deployments. Flat map-of-map keyed by
                   clusterName then shardName, matching MongoDB sharded's *InClusters
                   precedent (api/v1/status/scaling_status.go).
+
+                  surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
+                  per-(cluster, shard) split lands when sharded MC search supports
+                  per-shard Envoy SNI routing.
                 type: object
               version:
                 type: string

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -1061,14 +1061,8 @@ spec:
                         lastTransition:
                           type: string
                         loadBalancer:
-                          description: |-
-                            LoadBalancer is unused by either controller and is kept only to avoid
-                            CRD removal until the next API rev. The canonical per-cluster managed-LB
-                            phase lives in status.loadBalancer.clusters[i] (flat sibling), written
-                            by the Envoy controller in mongodbsearchenvoy_controller.go.
-
-                            Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
-                            remove this field together with the next CRD bump.
+                          description: 'Deprecated: read status.loadBalancer.clusters[i]
+                            instead.'
                           properties:
                             clusters:
                               description: |-
@@ -1108,14 +1102,8 @@ spec:
                           format: int64
                           type: integer
                         observedReplicas:
-                          description: |-
-                            ObservedReplicas is the number of mongot pods this cluster currently has Ready.
-                            Used by the load-test harness as the readiness gate.
-
-                            fan-out per-cluster mongot StatefulSets, so there is no per-cluster
-                            Ready-replica count to observe. Phase 2's reconcile fan-out
-                            (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
-                            where per-cluster STSs land; populate this then.
+                          description: ObservedReplicas is the number of mongot pods
+                            this cluster currently has Ready.
                           format: int32
                           type: integer
                         phase:
@@ -1160,14 +1148,6 @@ spec:
                             type: object
                           type: array
                         warnings:
-                          description: |-
-                            Warnings is the per-cluster warnings list (e.g. customer-replicated
-                            secret missing in this cluster).
-
-                            Populated by buildPerClusterStatusItems in the search controller from
-                            the SecretCheckResult slice for each cluster name that matches a
-                            spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
-                            through the operator log instead of this field.
                           items:
                             type: string
                           type: array
@@ -1288,10 +1268,6 @@ spec:
                   phase for sharded multi-cluster deployments. Flat map-of-map keyed by
                   clusterName then shardName, matching MongoDB sharded's *InClusters
                   precedent (api/v1/status/scaling_status.go).
-
-                  surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
-                  per-(cluster, shard) split lands when sharded MC search supports
-                  per-shard Envoy SNI routing.
                 type: object
               version:
                 type: string

--- a/pkg/handler/enqueue_owner_multi_search.go
+++ b/pkg/handler/enqueue_owner_multi_search.go
@@ -12,51 +12,34 @@ import (
 )
 
 // Cross-cluster enqueue labels for search-owned member-cluster resources.
-//
-// Owner references do not cross cluster boundaries, so member-cluster watches
-// (StatefulSet / Service / Deployment / ConfigMap / Secret) cannot rely on
-// ownerRef to map back to the central MongoDBSearch CR. Both the search
-// controller and the Envoy controller stamp these two labels on every write
-// they make into a member cluster; mappers / predicates use them to enqueue
-// the right central request.
-//
-// Search resources never cross namespaces — the namespace label exists so
-// the mapper does not silently route across namespaces if the same name
-// happens to repeat.
-//
-// MongoDBSearchOwnerNameLabel mirrors the legacy `mongodb.com/search-name`
-// constant the Envoy controller uses internally; that controller-private
-// constant must remain string-equal to this one.
+// Owner references do not cross cluster boundaries; both the search controller
+// and the Envoy controller stamp these labels on every member-cluster write so
+// mappers / predicates can enqueue the central MongoDBSearch request.
 const (
 	MongoDBSearchOwnerNameLabel      = "mongodb.com/search-name"
 	MongoDBSearchOwnerNamespaceLabel = "mongodb.com/search-namespace"
+	// MongoDBSearchClusterNameLabel records the owning member cluster on
+	// per-cluster member resources (Envoy Deployment + ConfigMap).
+	MongoDBSearchClusterNameLabel = "mongodb.com/cluster-name"
 )
 
 var _ handler.EventHandler = &EnqueueRequestForSearchOwnerMultiCluster{}
 
 // EnqueueRequestForSearchOwnerMultiCluster enqueues reconcile requests for the
-// MongoDBSearch CR identified by the search-owner labels on the watched
-// resource. Owner references do not cross clusters, so we use this label
-// pattern (mirrors mapEnvoyObjectToSearch in the Envoy controller).
-//
-// Phase 2 NOTE: this handler is wired to the search controller's
-// member-cluster watches in AddMongoDBSearchController, but ga-base does not
-// yet write any per-cluster member resources. Until Phase 2 stamps these
-// labels at the member-cluster write sites in
-// controllers/searchcontroller/mongodbsearch_reconcile_helper.go, the
-// watches see no traffic — the routing is correct but inert.
+// MongoDBSearch CR identified by the search-owner labels on a watched
+// member-cluster resource.
 type EnqueueRequestForSearchOwnerMultiCluster struct{}
 
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Create(_ context.Context, evt event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if req := mapMemberClusterObjectToSearch(evt.Object); req != (reconcile.Request{}) {
+	if req := MapMemberClusterObjectToSearch(evt.Object); req != (reconcile.Request{}) {
 		q.Add(req)
 	}
 }
 
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Update(_ context.Context, evt event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	for _, req := range []reconcile.Request{
-		mapMemberClusterObjectToSearch(evt.ObjectOld),
-		mapMemberClusterObjectToSearch(evt.ObjectNew),
+		MapMemberClusterObjectToSearch(evt.ObjectOld),
+		MapMemberClusterObjectToSearch(evt.ObjectNew),
 	} {
 		if req != (reconcile.Request{}) {
 			q.Add(req)
@@ -65,7 +48,7 @@ func (e *EnqueueRequestForSearchOwnerMultiCluster) Update(_ context.Context, evt
 }
 
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Delete(_ context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if req := mapMemberClusterObjectToSearch(evt.Object); req != (reconcile.Request{}) {
+	if req := MapMemberClusterObjectToSearch(evt.Object); req != (reconcile.Request{}) {
 		q.Add(req)
 	}
 }
@@ -73,14 +56,10 @@ func (e *EnqueueRequestForSearchOwnerMultiCluster) Delete(_ context.Context, evt
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 }
 
-// mapMemberClusterObjectToSearch reads the search-owner labels off a watched
+// MapMemberClusterObjectToSearch reads the search-owner labels off a watched
 // member-cluster object and returns the reconcile request for the central
-// MongoDBSearch CR. Returns the zero Request when either label is missing —
-// the caller filters those out before enqueueing.
-//
-// Shared with the Envoy controller's mapEnvoyObjectToSearch. Same labels,
-// same semantics.
-func mapMemberClusterObjectToSearch(obj client.Object) reconcile.Request {
+// MongoDBSearch CR. Returns the zero Request when either label is missing.
+func MapMemberClusterObjectToSearch(obj client.Object) reconcile.Request {
 	labels := obj.GetLabels()
 	name := labels[MongoDBSearchOwnerNameLabel]
 	ns := labels[MongoDBSearchOwnerNamespaceLabel]

--- a/pkg/handler/enqueue_owner_multi_search.go
+++ b/pkg/handler/enqueue_owner_multi_search.go
@@ -11,34 +11,52 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// MongoDBSearchResourceAnnotation is set on resources the MongoDBSearch
-// controller writes into a member cluster. It carries the name of the owning
-// MongoDBSearch CR in the central cluster. The owner namespace equals the
-// annotated object's own namespace — search resources never cross namespaces.
+// Cross-cluster enqueue labels for search-owned member-cluster resources.
 //
-// This is a separate annotation from MongoDBMultiResourceAnnotation:
-// MongoDBMultiCluster and MongoDBSearch may coexist in the same namespace,
-// and event routing must not collide.
-const MongoDBSearchResourceAnnotation = "mongodb.com/v1.MongoDBSearchResource"
+// Owner references do not cross cluster boundaries, so member-cluster watches
+// (StatefulSet / Service / Deployment / ConfigMap / Secret) cannot rely on
+// ownerRef to map back to the central MongoDBSearch CR. Both the search
+// controller and the Envoy controller stamp these two labels on every write
+// they make into a member cluster; mappers / predicates use them to enqueue
+// the right central request.
+//
+// Search resources never cross namespaces — the namespace label exists so
+// the mapper does not silently route across namespaces if the same name
+// happens to repeat.
+//
+// MongoDBSearchOwnerNameLabel mirrors the legacy `mongodb.com/search-name`
+// constant the Envoy controller uses internally; that controller-private
+// constant must remain string-equal to this one.
+const (
+	MongoDBSearchOwnerNameLabel      = "mongodb.com/search-name"
+	MongoDBSearchOwnerNamespaceLabel = "mongodb.com/search-namespace"
+)
 
 var _ handler.EventHandler = &EnqueueRequestForSearchOwnerMultiCluster{}
 
 // EnqueueRequestForSearchOwnerMultiCluster enqueues reconcile requests for the
-// MongoDBSearch CR identified by MongoDBSearchResourceAnnotation on the watched
-// resource. Owner references do not cross clusters, so we use this annotation
-// pattern (mirrors EnqueueRequestForOwnerMultiCluster).
+// MongoDBSearch CR identified by the search-owner labels on the watched
+// resource. Owner references do not cross clusters, so we use this label
+// pattern (mirrors mapEnvoyObjectToSearch in the Envoy controller).
+//
+// Phase 2 NOTE: this handler is wired to the search controller's
+// member-cluster watches in AddMongoDBSearchController, but ga-base does not
+// yet write any per-cluster member resources. Until Phase 2 stamps these
+// labels at the member-cluster write sites in
+// controllers/searchcontroller/mongodbsearch_reconcile_helper.go, the
+// watches see no traffic — the routing is correct but inert.
 type EnqueueRequestForSearchOwnerMultiCluster struct{}
 
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Create(_ context.Context, evt event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if req := getOwnerSearchCRD(evt.Object.GetAnnotations(), evt.Object.GetNamespace()); req != (reconcile.Request{}) {
+	if req := mapMemberClusterObjectToSearch(evt.Object); req != (reconcile.Request{}) {
 		q.Add(req)
 	}
 }
 
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Update(_ context.Context, evt event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	for _, req := range []reconcile.Request{
-		getOwnerSearchCRD(evt.ObjectOld.GetAnnotations(), evt.ObjectOld.GetNamespace()),
-		getOwnerSearchCRD(evt.ObjectNew.GetAnnotations(), evt.ObjectNew.GetNamespace()),
+		mapMemberClusterObjectToSearch(evt.ObjectOld),
+		mapMemberClusterObjectToSearch(evt.ObjectNew),
 	} {
 		if req != (reconcile.Request{}) {
 			q.Add(req)
@@ -47,7 +65,7 @@ func (e *EnqueueRequestForSearchOwnerMultiCluster) Update(_ context.Context, evt
 }
 
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Delete(_ context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if req := getOwnerSearchCRD(evt.Object.GetAnnotations(), evt.Object.GetNamespace()); req != (reconcile.Request{}) {
+	if req := mapMemberClusterObjectToSearch(evt.Object); req != (reconcile.Request{}) {
 		q.Add(req)
 	}
 }
@@ -55,10 +73,19 @@ func (e *EnqueueRequestForSearchOwnerMultiCluster) Delete(_ context.Context, evt
 func (e *EnqueueRequestForSearchOwnerMultiCluster) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 }
 
-func getOwnerSearchCRD(annotations map[string]string, namespace string) reconcile.Request {
-	val, ok := annotations[MongoDBSearchResourceAnnotation]
-	if !ok {
+// mapMemberClusterObjectToSearch reads the search-owner labels off a watched
+// member-cluster object and returns the reconcile request for the central
+// MongoDBSearch CR. Returns the zero Request when either label is missing —
+// the caller filters those out before enqueueing.
+//
+// Shared with the Envoy controller's mapEnvoyObjectToSearch. Same labels,
+// same semantics.
+func mapMemberClusterObjectToSearch(obj client.Object) reconcile.Request {
+	labels := obj.GetLabels()
+	name := labels[MongoDBSearchOwnerNameLabel]
+	ns := labels[MongoDBSearchOwnerNamespaceLabel]
+	if name == "" || ns == "" {
 		return reconcile.Request{}
 	}
-	return reconcile.Request{NamespacedName: types.NamespacedName{Name: val, Namespace: namespace}}
+	return reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}}
 }

--- a/pkg/handler/enqueue_owner_multi_search_test.go
+++ b/pkg/handler/enqueue_owner_multi_search_test.go
@@ -19,17 +19,12 @@ func newQueue() workqueue.TypedRateLimitingInterface[reconcile.Request] {
 	return workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
 }
 
-// labeledConfigMap returns a ConfigMap stamped with the provided labels.
-// Used by the search-owner enqueue tests; mirrors the labels both controllers
-// stamp on member-cluster writes (search-owner name + namespace).
 func labeledConfigMap(ns, name string, labels map[string]string) client.Object {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
 	}
 }
 
-// ownerLabels is shorthand for the search-owner label set; constructs the
-// pair (search-name, search-namespace) the enqueue handler reads.
 func ownerLabels(name, ns string) map[string]string {
 	return map[string]string{
 		MongoDBSearchOwnerNameLabel:      name,

--- a/pkg/handler/enqueue_owner_multi_search_test.go
+++ b/pkg/handler/enqueue_owner_multi_search_test.go
@@ -19,19 +19,29 @@ func newQueue() workqueue.TypedRateLimitingInterface[reconcile.Request] {
 	return workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
 }
 
-func newAnnotatedConfigMap(ns, name string, ann map[string]string) client.Object {
+// labeledConfigMap returns a ConfigMap stamped with the provided labels.
+// Used by the search-owner enqueue tests; mirrors the labels both controllers
+// stamp on member-cluster writes (search-owner name + namespace).
+func labeledConfigMap(ns, name string, labels map[string]string) client.Object {
 	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Annotations: ann},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
 	}
 }
 
-func TestEnqueueRequestForSearchOwnerMultiCluster_Create_AnnotationPresent_Enqueues(t *testing.T) {
+// ownerLabels is shorthand for the search-owner label set; constructs the
+// pair (search-name, search-namespace) the enqueue handler reads.
+func ownerLabels(name, ns string) map[string]string {
+	return map[string]string{
+		MongoDBSearchOwnerNameLabel:      name,
+		MongoDBSearchOwnerNamespaceLabel: ns,
+	}
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Create_LabelsPresent_Enqueues(t *testing.T) {
 	q := newQueue()
 	defer q.ShutDown()
 
-	obj := newAnnotatedConfigMap("ns1", "mongot-cm", map[string]string{
-		MongoDBSearchResourceAnnotation: "my-search",
-	})
+	obj := labeledConfigMap("ns1", "mongot-cm", ownerLabels("my-search", "ns1"))
 	h := &EnqueueRequestForSearchOwnerMultiCluster{}
 	h.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: obj}, q)
 
@@ -40,23 +50,41 @@ func TestEnqueueRequestForSearchOwnerMultiCluster_Create_AnnotationPresent_Enque
 	assert.Equal(t, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "my-search"}}, got)
 }
 
-func TestEnqueueRequestForSearchOwnerMultiCluster_Create_AnnotationMissing_NoEnqueue(t *testing.T) {
+func TestEnqueueRequestForSearchOwnerMultiCluster_Create_LabelsMissing_NoEnqueue(t *testing.T) {
 	q := newQueue()
 	defer q.ShutDown()
 
-	obj := newAnnotatedConfigMap("ns1", "unrelated", nil)
+	// Object with no labels at all.
+	obj := labeledConfigMap("ns1", "unrelated", nil)
 	h := &EnqueueRequestForSearchOwnerMultiCluster{}
 	h.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: obj}, q)
 
 	assert.Equal(t, 0, q.Len())
 }
 
-func TestEnqueueRequestForSearchOwnerMultiCluster_Update_BothAnnotated_EnqueuesBoth(t *testing.T) {
+// TestEnqueueRequestForSearchOwnerMultiCluster_Create_PartialLabel_NoEnqueue
+// asserts that only the name label (without the namespace label) is not enough
+// — both must be present, otherwise the mapper cannot uniquely route the event.
+func TestEnqueueRequestForSearchOwnerMultiCluster_Create_PartialLabel_NoEnqueue(t *testing.T) {
 	q := newQueue()
 	defer q.ShutDown()
 
-	oldObj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "old-owner"})
-	newObj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "new-owner"})
+	obj := labeledConfigMap("ns1", "cm", map[string]string{
+		MongoDBSearchOwnerNameLabel: "my-search",
+		// MongoDBSearchOwnerNamespaceLabel intentionally missing
+	})
+	h := &EnqueueRequestForSearchOwnerMultiCluster{}
+	h.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: obj}, q)
+
+	assert.Equal(t, 0, q.Len(), "partial label must not enqueue — both name and namespace required")
+}
+
+func TestEnqueueRequestForSearchOwnerMultiCluster_Update_BothLabeled_EnqueuesBoth(t *testing.T) {
+	q := newQueue()
+	defer q.ShutDown()
+
+	oldObj := labeledConfigMap("ns1", "cm", ownerLabels("old-owner", "ns1"))
+	newObj := labeledConfigMap("ns1", "cm", ownerLabels("new-owner", "ns1"))
 
 	h := &EnqueueRequestForSearchOwnerMultiCluster{}
 	h.Update(context.Background(), event.TypedUpdateEvent[client.Object]{ObjectOld: oldObj, ObjectNew: newObj}, q)
@@ -64,11 +92,11 @@ func TestEnqueueRequestForSearchOwnerMultiCluster_Update_BothAnnotated_EnqueuesB
 	assert.Equal(t, 2, q.Len(), "both old and new owners must be enqueued so the leaving CR can clean up")
 }
 
-func TestEnqueueRequestForSearchOwnerMultiCluster_Delete_AnnotationPresent_Enqueues(t *testing.T) {
+func TestEnqueueRequestForSearchOwnerMultiCluster_Delete_LabelsPresent_Enqueues(t *testing.T) {
 	q := newQueue()
 	defer q.ShutDown()
 
-	obj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "my-search"})
+	obj := labeledConfigMap("ns1", "cm", ownerLabels("my-search", "ns1"))
 	h := &EnqueueRequestForSearchOwnerMultiCluster{}
 	h.Delete(context.Background(), event.TypedDeleteEvent[client.Object]{Object: obj}, q)
 
@@ -79,7 +107,7 @@ func TestEnqueueRequestForSearchOwnerMultiCluster_Generic_NoEnqueue(t *testing.T
 	q := newQueue()
 	defer q.ShutDown()
 
-	obj := newAnnotatedConfigMap("ns1", "cm", map[string]string{MongoDBSearchResourceAnnotation: "my-search"})
+	obj := labeledConfigMap("ns1", "cm", ownerLabels("my-search", "ns1"))
 	h := &EnqueueRequestForSearchOwnerMultiCluster{}
 	h.Generic(context.Background(), event.TypedGenericEvent[client.Object]{Object: obj}, q)
 

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -5084,9 +5084,13 @@ spec:
                           type: string
                         loadBalancer:
                           description: |-
-                            LoadBalancer reports the per-cluster managed-LB phase for ReplicaSet
-                            topologies. Sharded per-(cluster, shard) LB phase lives on the
-                            top-level ShardLoadBalancerStatusInClusters map.
+                            LoadBalancer is unused by either controller and is kept only to avoid
+                            CRD removal until the next API rev. The canonical per-cluster managed-LB
+                            phase lives in status.loadBalancer.clusters[i] (flat sibling), written
+                            by the Envoy controller in mongodbsearchenvoy_controller.go.
+
+                            Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
+                            remove this field together with the next CRD bump.
                           properties:
                             clusters:
                               description: |-
@@ -5129,6 +5133,11 @@ spec:
                           description: |-
                             ObservedReplicas is the number of mongot pods this cluster currently has Ready.
                             Used by the load-test harness as the readiness gate.
+
+                            fan-out per-cluster mongot StatefulSets, so there is no per-cluster
+                            Ready-replica count to observe. Phase 2's reconcile fan-out
+                            (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
+                            where per-cluster STSs land; populate this then.
                           format: int32
                           type: integer
                         phase:
@@ -5176,6 +5185,11 @@ spec:
                           description: |-
                             Warnings is the per-cluster warnings list (e.g. customer-replicated
                             secret missing in this cluster).
+
+                            Populated by buildPerClusterStatusItems in the search controller from
+                            the SecretCheckResult slice for each cluster name that matches a
+                            spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
+                            through the operator log instead of this field.
                           items:
                             type: string
                           type: array
@@ -5296,6 +5310,10 @@ spec:
                   phase for sharded multi-cluster deployments. Flat map-of-map keyed by
                   clusterName then shardName, matching MongoDB sharded's *InClusters
                   precedent (api/v1/status/scaling_status.go).
+
+                  surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
+                  per-(cluster, shard) split lands when sharded MC search supports
+                  per-shard Envoy SNI routing.
                 type: object
               version:
                 type: string

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -5083,14 +5083,8 @@ spec:
                         lastTransition:
                           type: string
                         loadBalancer:
-                          description: |-
-                            LoadBalancer is unused by either controller and is kept only to avoid
-                            CRD removal until the next API rev. The canonical per-cluster managed-LB
-                            phase lives in status.loadBalancer.clusters[i] (flat sibling), written
-                            by the Envoy controller in mongodbsearchenvoy_controller.go.
-
-                            Deprecated: read status.loadBalancer.clusters[i] instead. Phase 2 may
-                            remove this field together with the next CRD bump.
+                          description: 'Deprecated: read status.loadBalancer.clusters[i]
+                            instead.'
                           properties:
                             clusters:
                               description: |-
@@ -5130,14 +5124,8 @@ spec:
                           format: int64
                           type: integer
                         observedReplicas:
-                          description: |-
-                            ObservedReplicas is the number of mongot pods this cluster currently has Ready.
-                            Used by the load-test harness as the readiness gate.
-
-                            fan-out per-cluster mongot StatefulSets, so there is no per-cluster
-                            Ready-replica count to observe. Phase 2's reconcile fan-out
-                            (controllers/searchcontroller/mongodbsearch_reconcile_helper.go) is
-                            where per-cluster STSs land; populate this then.
+                          description: ObservedReplicas is the number of mongot pods
+                            this cluster currently has Ready.
                           format: int32
                           type: integer
                         phase:
@@ -5182,14 +5170,6 @@ spec:
                             type: object
                           type: array
                         warnings:
-                          description: |-
-                            Warnings is the per-cluster warnings list (e.g. customer-replicated
-                            secret missing in this cluster).
-
-                            Populated by buildPerClusterStatusItems in the search controller from
-                            the SecretCheckResult slice for each cluster name that matches a
-                            spec.clusters[i] entry. Central-only warnings (Cluster == "") flow
-                            through the operator log instead of this field.
                           items:
                             type: string
                           type: array
@@ -5310,10 +5290,6 @@ spec:
                   phase for sharded multi-cluster deployments. Flat map-of-map keyed by
                   clusterName then shardName, matching MongoDB sharded's *InClusters
                   precedent (api/v1/status/scaling_status.go).
-
-                  surfaces per-(cluster) LB status via status.loadBalancer.clusters[]. The
-                  per-(cluster, shard) split lands when sharded MC search supports
-                  per-shard Envoy SNI routing.
                 type: object
               version:
                 type: string


### PR DESCRIPTION
Addresses [#1052](https://github.com/mongodb/mongodb-kubernetes/pull/1052)'s review of `search/ga-base`. Review report at `docs/dev/reviews/2026-05-03-search-ga-base-review.md` on branch `review/search-ga-base-2026-05-03`.

## Blocker — fixed
- **B1: Per-cluster Envoy Pod CM volume mismatch.** Cherry-picked `90d9cad2a` from the Phase 2 branch. Threads `clusterName` into `buildEnvoyPodSpec`; uses `LoadBalancerConfigMapNameForCluster(clusterName)` so member-cluster Envoy pods mount the actual per-cluster ConfigMap. The Phase 2 full-reconcile test (`mongodbsearch_reconcile_full_mc_test.go`) does not apply on ga-base; the unit-level `TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster` covers the volume-name class.

## Concerns — addressed
- **C1: Two divergent watch-routing mechanisms.** Search controller used annotation `mongodb.com/v1.MongoDBSearchResource` (zero writers anywhere); Envoy controller used labels `mongodb.com/search-name` + `search-namespace`. Promoted the labels to `pkg/handler` as `MongoDBSearchOwnerNameLabel` / `MongoDBSearchOwnerNamespaceLabel`. Search controller's enqueue handler + predicate now read those labels; Envoy controller's `mapEnvoyObjectToSearch` and `envoyLabelsForCluster` import the shared constants. Annotation removed entirely. Added a `TODO(phase-2)` at the watch registration noting that the search controller does NOT yet write per-cluster member resources — Phase 2's reconcile fan-out must stamp these labels at every member-cluster write site.
- **C2: Validators slice has no registration test.** Added `TestRunValidations_AllValidatorsRegistered` which parses `mongodbsearch_validation.go` via `go/ast`, enumerates every `func validateXxx(*MongoDBSearch) v1.ValidationResult`, and asserts the slice in `RunValidations` references the same set. Drift either way fails loudly. Verified by removing a slice entry locally — the test catches the missing reference with a clear diff.
- **C3: Per-cluster status fields never populated.** Picked `status.loadBalancer.clusters[i]` (flat sibling) as the canonical per-cluster LB-phase location and marked `SearchClusterStatusItem.LoadBalancer` `Deprecated:` (kept in schema until next CRD bump). Wired `CheckSecretsPresence`'s output into `status.clusterStatusList[i].warnings` via `SetSecretGaps` on the helper — gaps now surface to status without scraping logs. `ObservedReplicas` and `ShardLoadBalancerStatusInClusters` deferred to Phase 2/3 with `TODO()` markers pointing at the right phase (no STS writes happen on ga-base).
- **C5: Canonical LB phase invariant.** Documented on `LoadBalancerStatus`: `Phase == WorstOfPhase(Clusters[*].Phase)` when `len(Clusters) > 0`. Replaced the local `isWorsePhase` rank function (which only ordered Failed/Pending/Running) with `worstOfClusterPhases` wrapping `searchv1.WorstOfPhase` — single source of truth. Verified by `TestWorstOfClusterPhases` (unit) and `TestReconcile_PerClusterStatus_Aggregated` (integration).
  - **Regression caught + fixed during simplify pass:** the always-append flow is required so single-cluster failures still surface as `Failed`. `TestWorstOfClusterPhases_SingleCluster_PreservesFailed` regresses the bug.

## CRD impact
Description-only drift (deprecation note on `SearchClusterStatusItem.LoadBalancer`, doc additions on `Warnings` / `ObservedReplicas` / `ShardLoadBalancerStatusInClusters`). No structural change. `make manifests` clean after commit.

## Test plan
- [x] `go test ./api/v1/search/... ./controllers/searchcontroller/... ./controllers/operator/... ./pkg/handler/... -count=1 -timeout=600s`
- [x] `golangci-lint run` — only pre-existing issues remain on files I did not modify
- [x] `make manifests` — committed description-only CRD diff
- [ ] Evergreen patch on this branch (search-relevant tasks green) — to be run separately

## Commit-by-finding map
- `ec5114128` + `b14409ed4` — Blocker B1 cherry-pick + tidy
- `831ee966a` — C2 registration test
- `2f1a2360a` — C3 (canonical shape) + C5 (invariant declaration)
- `9e67c3e71` — C1 watch-routing unification
- `8dda9c4ec` — C3 (Warnings populated, ObservedReplicas/ShardLB deferred)
- `ab6d86f47` — Simplify-pass touch-ups (test name fixes, gci import order)
- `92188327e` — Single-cluster Failed regression fix