### PR TITLE
fix(test): pin q2_mc_rs_steady source mongod to 8.2.0-ent

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/fixtures/search-q2-mc-rs.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/fixtures/search-q2-mc-rs.yaml
@@ -10,6 +10,9 @@ metadata:
   name: mdb-mc-rs-ext-lb
 spec:
   type: ReplicaSet
+  # Search-aware mongod required for additionalMongodConfig.setParameter.searchIndexManagementHostAndPort
+  # (the test sets that in q2_mc_rs_steady.py). 6.x mongods reject it at startup.
+  version: 8.2.0-ent
   duplicateServiceObjects: false
   credentials: my-credentials
   opsManager:

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -45,7 +45,6 @@ from kubernetes.client import CoreV1Api
 from kubetester import create_or_update_configmap, create_or_update_secret, try_load
 from kubetester.certs import create_tls_certs
 from kubetester.certs_mongodb_multi import create_multi_cluster_mongodb_tls_certs
-from kubetester.kubetester import ensure_ent_version
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb_multi import MongoDBMulti
 from kubetester.mongodb_search import MongoDBSearch
@@ -134,10 +133,13 @@ def mdb(
     namespace: str,
     central_cluster_client: kubernetes.client.ApiClient,
     member_cluster_names: List[str],
-    custom_mdb_version: str,
     ca_configmap: str,
 ) -> MongoDBMulti:
     """2-cluster MongoDBMulti RS source with TLS+SCRAM.
+
+    Version is pinned in the fixture YAML to a search-aware mongod —
+    the setParameter keys below only exist on 8.x; see the YAML for
+    the exact constraint.
 
     `mongotHost` is set top-level to cluster-0's proxy-svc FQDN to keep
     every mongod's startup-time validation happy (the source RS can't
@@ -152,7 +154,6 @@ def mdb(
         name=MDB_RESOURCE_NAME,
         namespace=namespace,
     )
-    resource.set_version(ensure_ent_version(custom_mdb_version))
     resource["spec"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, MEMBERS_PER_CLUSTER)
 
     # Top-level mongotHost points at cluster-0's per-cluster proxy Service.


### PR DESCRIPTION
## Summary

Fixes the deterministic 1500s timeout failure of `e2e_search_q2_mc_rs_steady` on the v2 G2 patch (executions 0 and 1, https://evergreen.mongodb.com/version/69f83680dd956c000756f522).

The `mdb` fixture writes search-aware `--setParameter` keys (`searchIndexManagementHostAndPort`, `mongotHost`, `useGrpcForSearch`, etc.) into `spec.additionalMongodConfig.setParameter`, but the resource was being pinned to a 6.x mongod (CI's `CUSTOM_MDB_VERSION=6.0.5` flowed through `set_version(ensure_ent_version(custom_mdb_version))`). The 6.x mongod rejected the search parameter at startup ("BadValue: Unknown --setParameter 'searchIndexManagementHostAndPort'"), the StatefulSet never reached Ready, and the MongoDBMulti stayed at `Phase.Pending` until the test wait expired.

This change mirrors the established pattern from every passing SC search e2e (`enterprise-replicaset-sample-mflix.yaml`, `enterprise-sharded-cluster-sample-mflix.yaml`, `community-replicaset-sample-mflix.yaml`): pin `version: 8.2.0-ent` in the fixture YAML and drop the `set_version` override in the test code.

Full root-cause writeup, with file:line citations and artifact paths, is in #1054 (`docs/superpowers/reports/2026-05-04-v2-e2e-search-q2-mc-rs-steady-execution-0-failure.md`).

## Test plan

- [x] Confirmed the agent log smoking gun (`Unknown --setParameter 'searchIndexManagementHostAndPort'`) on both executions of the failing task
- [x] Confirmed `MongoDB(Multi).from_yaml` will not clobber a fixture version >= `CUSTOM_MDB_VERSION` (`docker/mongodb-kubernetes-tests/kubetester/mongodb.py:54-60`), so `8.2.0-ent` in the fixture sticks even with CI's `CUSTOM_MDB_VERSION=6.0.5`
- [x] Confirmed `ensure_ent_version` and `custom_mdb_version` no longer referenced in the file after the edit
- [x] Python AST + YAML parse OK
- [ ] Followup (user): re-run the v2 patch's failing tasks (or submit a fresh patch) once this lands on `mc-search-phase2-q2-rs`