### PR TITLE
KUBE-69 Cloud Manager binary is not available for linux/s390x platform

### DIFF
--- a/scripts/release/agent/validation.py
+++ b/scripts/release/agent/validation.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from typing import Callable, Dict, List
 
 import requests
@@ -35,23 +34,25 @@ class PlatformConfiguration:
 
         Returns:
             Dictionary of build arguments for docker build (tools only)
+
+        Raises:
+            RuntimeError: if a requested platform is unknown or no working tools
+                filename can be resolved for it.
         """
         build_args = {}
 
         for platform in platforms:
             if platform not in self.agent_info["platforms"]:
-                logger.error(f"Platform {platform} not found in agent mappings, skipping")
-                continue
+                raise RuntimeError(f"Platform {platform} not found in agent mappings")
 
             arch = platform.split("/")[-1]
 
-            # Use the same logic as validation to get the working tools filename
             tools_filename = get_working_tools_filename(tools_version, platform)
-            if tools_filename:
-                build_args[f"mongodb_tools_version_{arch}"] = tools_filename
-            else:
-                logger.error(f"No working tools filename found for platform {platform}")
-                continue
+            if not tools_filename:
+                raise RuntimeError(
+                    f"No working tools filename found for platform {platform} (tools version {tools_version})"
+                )
+            build_args[f"mongodb_tools_version_{arch}"] = tools_filename
 
         return build_args
 
@@ -66,30 +67,35 @@ class PlatformConfiguration:
 
         Returns:
             Dictionary of build arguments for docker build
+
+        Raises:
+            RuntimeError: if a requested platform is unknown or no working agent
+                or tools filename can be resolved for it.
         """
         build_args = {}
 
         for platform in platforms:
             if platform not in self.agent_info["platforms"]:
-                logger.warning(f"Platform {platform} not found in agent mappings, skipping")
-                continue
+                raise RuntimeError(f"Platform {platform} not found in agent mappings")
 
             arch = platform.split("/")[-1]
 
             agent_filename = get_working_agent_filename(agent_version, platform)
-            tools_filename = get_working_tools_filename(tools_version, platform)
-
-            # Only add build args if we have valid filenames
-            if agent_filename and tools_filename:
-                build_args[f"mongodb_agent_version_{arch}"] = agent_filename
-                build_args[f"mongodb_tools_version_{arch}"] = tools_filename
-                logger.debug(
-                    f"Validated agent and tools versions for {platform}: agent={agent_filename}, tools={tools_filename}"
+            if not agent_filename:
+                raise RuntimeError(
+                    f"No working agent filename found for platform {platform} (agent version {agent_version})"
                 )
-            else:
-                logger.warning(f"Skipping build args for {platform} - missing agent or tools filename")
-                logger.debug(f"  agent_filename: {agent_filename}")
-                logger.debug(f"  tools_filename: {tools_filename}")
+            tools_filename = get_working_tools_filename(tools_version, platform)
+            if not tools_filename:
+                raise RuntimeError(
+                    f"No working tools filename found for platform {platform} (tools version {tools_version})"
+                )
+
+            build_args[f"mongodb_agent_version_{arch}"] = agent_filename
+            build_args[f"mongodb_tools_version_{arch}"] = tools_filename
+            logger.debug(
+                f"Validated agent and tools versions for {platform}: agent={agent_filename}, tools={tools_filename}"
+            )
 
         return build_args
 
@@ -173,42 +179,8 @@ def _find_working_filename(
         else:
             logger.debug(f"{version_type.title()} version {version} not found for platform {platform} at {url}")
 
-    logger.warning(f"No working {version_type} filename found for {platform}, platform will be skipped")
+    logger.warning(f"No working {version_type} filename found for {platform}")
     return ""
-
-
-def _get_available_platforms(
-    version: str,
-    platforms: List[str],
-    base_url: str,
-    filenames_builder: Callable[[dict, str, str], List[str]],
-    version_type: str,
-) -> List[str]:
-    """
-    Generic function to get the list of platforms where a version is actually available,
-    trying multiple filename possibilities for each platform.
-
-    Args:
-        version: Version to check
-        platforms: List of platforms to check
-        base_url: Base URL for downloads
-        filenames_builder: Function that builds list of filenames from (agent_info, version, platform)
-        version_type: Type of version being validated (for logging)
-
-    Returns:
-        List of platforms where the version exists
-    """
-    available_platforms = []
-
-    for platform in platforms:
-        working_filename = _find_working_filename(version, platform, base_url, filenames_builder, version_type)
-        if working_filename:
-            available_platforms.append(platform)
-            logger.debug(
-                f"{version_type.title()} version {version} available for platform {platform} using {working_filename}"
-            )
-
-    return available_platforms
 
 
 def get_working_agent_filename(agent_version: str, platform: str) -> str:

--- a/scripts/release/agent/validation.py
+++ b/scripts/release/agent/validation.py
@@ -34,10 +34,6 @@ class PlatformConfiguration:
 
         Returns:
             Dictionary of build arguments for docker build (tools only)
-
-        Raises:
-            RuntimeError: if a requested platform is unknown or no working tools
-                filename can be resolved for it.
         """
         build_args = {}
 
@@ -47,12 +43,13 @@ class PlatformConfiguration:
 
             arch = platform.split("/")[-1]
 
+            # Use the same logic as validation to get the working tools filename
             tools_filename = get_working_tools_filename(tools_version, platform)
-            if not tools_filename:
-                raise RuntimeError(
-                    f"No working tools filename found for platform {platform} (tools version {tools_version})"
-                )
-            build_args[f"mongodb_tools_version_{arch}"] = tools_filename
+            if tools_filename:
+                build_args[f"mongodb_tools_version_{arch}"] = tools_filename
+            else:
+                logger.error(f"No working tools filename found for platform {platform}")
+                continue
 
         return build_args
 
@@ -67,10 +64,6 @@ class PlatformConfiguration:
 
         Returns:
             Dictionary of build arguments for docker build
-
-        Raises:
-            RuntimeError: if a requested platform is unknown or no working agent
-                or tools filename can be resolved for it.
         """
         build_args = {}
 
@@ -81,21 +74,19 @@ class PlatformConfiguration:
             arch = platform.split("/")[-1]
 
             agent_filename = get_working_agent_filename(agent_version, platform)
-            if not agent_filename:
-                raise RuntimeError(
-                    f"No working agent filename found for platform {platform} (agent version {agent_version})"
-                )
             tools_filename = get_working_tools_filename(tools_version, platform)
-            if not tools_filename:
-                raise RuntimeError(
-                    f"No working tools filename found for platform {platform} (tools version {tools_version})"
-                )
 
-            build_args[f"mongodb_agent_version_{arch}"] = agent_filename
-            build_args[f"mongodb_tools_version_{arch}"] = tools_filename
-            logger.debug(
-                f"Validated agent and tools versions for {platform}: agent={agent_filename}, tools={tools_filename}"
-            )
+            # Only add build args if we have valid filenames
+            if agent_filename and tools_filename:
+                build_args[f"mongodb_agent_version_{arch}"] = agent_filename
+                build_args[f"mongodb_tools_version_{arch}"] = tools_filename
+                logger.debug(
+                    f"Validated agent and tools versions for {platform}: agent={agent_filename}, tools={tools_filename}"
+                )
+            else:
+                logger.warning(f"Skipping build args for {platform} - missing agent or tools filename")
+                logger.debug(f"  agent_filename: {agent_filename}")
+                logger.debug(f"  tools_filename: {tools_filename}")
 
         return build_args
 
@@ -179,7 +170,7 @@ def _find_working_filename(
         else:
             logger.debug(f"{version_type.title()} version {version} not found for platform {platform} at {url}")
 
-    logger.warning(f"No working {version_type} filename found for {platform}")
+    logger.warning(f"No working {version_type} filename found for {platform}, platform will be skipped")
     return ""
 
 

--- a/scripts/release/argparse_utils.py
+++ b/scripts/release/argparse_utils.py
@@ -17,7 +17,7 @@ def str2bool(v):
         raise argparse.ArgumentTypeError("Boolean value expected.")
 
 
-def get_scenario_from_arg(args_scenario: str) -> BuildScenario | None:
+def get_scenario_from_arg(args_scenario: str) -> BuildScenario:
     try:
         return BuildScenario(args_scenario)
     except ValueError as e:

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -8,7 +8,7 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from copy import copy
 from queue import Queue
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from opentelemetry import trace
@@ -333,12 +333,14 @@ def build_agent_pipeline(
 ):
     build_configuration_copy = copy(build_configuration)
     build_configuration_copy.version = agent_version
+    build_configuration_copy.platforms = resolve_agent_platforms(agent_version, build_configuration.platforms)
+
     print(
         f"======== Building agent pipeline for version {agent_version}, build configuration version: {build_configuration.version}"
     )
 
     platform_build_args = generate_agent_build_args(
-        platforms=build_configuration.platforms, agent_version=agent_version, tools_version=tools_version
+        platforms=build_configuration_copy.platforms, agent_version=agent_version, tools_version=tools_version
     )
 
     agent_base_url = (
@@ -358,6 +360,15 @@ def build_agent_pipeline(
         build_configuration=build_configuration_copy,
         build_args=args,
     )
+
+
+def resolve_agent_platforms(agent_version: str, available_platforms: List[str]) -> List[str]:
+    # Cloud Manager (agent version 13.x) does not ship a linux/s390x build.
+    # Tracking ticket: https://jira.mongodb.org/browse/KUBE-69
+    if agent_version.startswith("13."):
+        return [p for p in available_platforms if p != "linux/s390x"]
+
+    return available_platforms
 
 
 def queue_exception_handling(tasks_queue):

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -5,11 +5,10 @@ and where to fetch and calculate parameters."""
 import datetime
 import json
 import os
-import shutil
 from concurrent.futures import ProcessPoolExecutor
 from copy import copy
 from queue import Queue
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import requests
 from opentelemetry import trace
@@ -239,9 +238,6 @@ def build_init_database_image(build_configuration: ImageBuildConfiguration):
     platform_build_args = generate_tools_build_args(
         platforms=build_configuration.platforms, tools_version=tools_version
     )
-    if not platform_build_args:
-        logger.warning(f"Skipping build for init-database - tools version {tools_version} not found in repository")
-        return
 
     args = {
         "version": build_configuration.version,
@@ -311,7 +307,6 @@ def build_agent(build_configuration: ImageBuildConfiguration):
             _build_agent(
                 agent_tools_version,
                 build_configuration,
-                build_configuration.platforms,
                 executor,
                 tasks_queue,
             )
@@ -322,33 +317,28 @@ def build_agent(build_configuration: ImageBuildConfiguration):
 def _build_agent(
     agent_tools_version: Tuple[str, str],
     build_configuration: ImageBuildConfiguration,
-    available_platforms: List[str],
     executor: ProcessPoolExecutor,
     tasks_queue: Queue,
 ):
     agent_version = agent_tools_version[0]
     tools_version = agent_tools_version[1]
 
-    tasks_queue.put(
-        executor.submit(build_agent_pipeline, build_configuration, agent_version, tools_version, available_platforms)
-    )
+    tasks_queue.put(executor.submit(build_agent_pipeline, build_configuration, agent_version, tools_version))
 
 
 def build_agent_pipeline(
     build_configuration: ImageBuildConfiguration,
     agent_version: str,
     tools_version: str,
-    available_platforms: List[str],
 ):
     build_configuration_copy = copy(build_configuration)
     build_configuration_copy.version = agent_version
-    build_configuration_copy.platforms = available_platforms  # Use only available platforms
     print(
         f"======== Building agent pipeline for version {agent_version}, build configuration version: {build_configuration.version}"
     )
 
     platform_build_args = generate_agent_build_args(
-        platforms=available_platforms, agent_version=agent_version, tools_version=tools_version
+        platforms=build_configuration.platforms, agent_version=agent_version, tools_version=tools_version
     )
 
     agent_base_url = (

--- a/scripts/release/build/image_build_configuration.py
+++ b/scripts/release/build/image_build_configuration.py
@@ -16,7 +16,7 @@ class ImageBuildConfiguration:
     registries: List[str]
     dockerfile_path: str
     builder: ImageBuilder
-    platforms: Optional[List[str]] = None
+    platforms: List[str] = None
     sign: bool = False
     skip_if_exists: bool = False
 

--- a/scripts/release/tests/atomic_pipeline_test.py
+++ b/scripts/release/tests/atomic_pipeline_test.py
@@ -65,6 +65,56 @@ class TestValidationFunctions(unittest.TestCase):
         self.agent_version = "13.5.2.7785"
 
 
+class TestBuildArgumentFailFast(unittest.TestCase):
+    """Build-arg generation must fail fast when a requested platform cannot be satisfied."""
+
+    def setUp(self):
+        self.platforms = ["linux/amd64", "linux/s390x"]
+        self.tools_version = "100.9.5"
+        self.agent_version = "13.5.2.7785"
+
+    @patch("scripts.release.agent.validation._validate_url_exists")
+    def test_generate_tools_build_args_raises_when_platform_unresolvable(self, mock_validate):
+        # Tools available for amd64 but not s390x.
+        mock_validate.side_effect = lambda url, timeout=30: "s390x" not in url
+
+        with self.assertRaisesRegex(RuntimeError, r"linux/s390x"):
+            generate_tools_build_args(self.platforms, self.tools_version)
+
+    @patch("scripts.release.agent.validation._validate_url_exists")
+    def test_generate_agent_build_args_raises_when_agent_missing_for_platform(self, mock_validate):
+        # Agent missing for s390x (matches the cloud_manager 13.51.0.10584-1 regression).
+        def side_effect(url, timeout=30):
+            if "automation-agent" in url and "s390x" in url:
+                return False
+            return True
+
+        mock_validate.side_effect = side_effect
+
+        with self.assertRaisesRegex(RuntimeError, r"agent.*linux/s390x"):
+            generate_agent_build_args(self.platforms, self.agent_version, self.tools_version)
+
+    @patch("scripts.release.agent.validation._validate_url_exists")
+    def test_generate_agent_build_args_raises_when_tools_missing_for_platform(self, mock_validate):
+        def side_effect(url, timeout=30):
+            if "database-tools" in url and "s390x" in url:
+                return False
+            return True
+
+        mock_validate.side_effect = side_effect
+
+        with self.assertRaisesRegex(RuntimeError, r"tools.*linux/s390x"):
+            generate_agent_build_args(self.platforms, self.agent_version, self.tools_version)
+
+    def test_generate_tools_build_args_raises_for_unknown_platform(self):
+        with self.assertRaisesRegex(RuntimeError, r"unknown/arch"):
+            generate_tools_build_args(["unknown/arch"], self.tools_version)
+
+    def test_generate_agent_build_args_raises_for_unknown_platform(self):
+        with self.assertRaisesRegex(RuntimeError, r"unknown/arch"):
+            generate_agent_build_args(["unknown/arch"], self.agent_version, self.tools_version)
+
+
 class TestPlatformAvailability(unittest.TestCase):
     """Test cases for platform availability functions."""
 

--- a/scripts/release/tests/atomic_pipeline_test.py
+++ b/scripts/release/tests/atomic_pipeline_test.py
@@ -12,6 +12,7 @@ from scripts.release.agent.validation import (
     get_working_agent_filename,
     get_working_tools_filename,
 )
+from scripts.release.atomic_pipeline import resolve_agent_platforms
 
 
 class TestBuildArgumentGeneration(unittest.TestCase):
@@ -113,6 +114,31 @@ class TestBuildArgumentFailFast(unittest.TestCase):
     def test_generate_agent_build_args_raises_for_unknown_platform(self):
         with self.assertRaisesRegex(RuntimeError, r"unknown/arch"):
             generate_agent_build_args(["unknown/arch"], self.agent_version, self.tools_version)
+
+
+class TestResolveAgentPlatforms(unittest.TestCase):
+    """resolve_agent_platforms drops linux/s390x for Cloud Manager (13.x) agents only."""
+
+    def test_strips_s390x_for_cloud_manager(self):
+        result = resolve_agent_platforms(
+            "13.51.0.10584-1", ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+        )
+
+        self.assertEqual(result, ["linux/amd64", "linux/arm64", "linux/ppc64le"])
+
+    def test_keeps_all_for_non_cloud_manager(self):
+        platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+
+        result = resolve_agent_platforms("14.0.0.7785", platforms)
+
+        self.assertEqual(result, platforms)
+
+    def test_cloud_manager_without_s390x_is_unchanged(self):
+        platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+
+        result = resolve_agent_platforms("13.51.0.10584-1", platforms)
+
+        self.assertEqual(result, platforms)
 
 
 class TestPlatformAvailability(unittest.TestCase):

--- a/scripts/release/tests/atomic_pipeline_test.py
+++ b/scripts/release/tests/atomic_pipeline_test.py
@@ -66,8 +66,9 @@ class TestValidationFunctions(unittest.TestCase):
         self.agent_version = "13.5.2.7785"
 
 
-class TestBuildArgumentFailFast(unittest.TestCase):
-    """Build-arg generation must fail fast when a requested platform cannot be satisfied."""
+class TestBuildArgumentSkipsUnresolvable(unittest.TestCase):
+    """Build-arg generation skips platforms whose agent or tools tarball cannot be resolved
+    (e.g. when an old agent's S3 artifact has aged out). Callers handle the consequences."""
 
     def setUp(self):
         self.platforms = ["linux/amd64", "linux/s390x"]
@@ -75,16 +76,16 @@ class TestBuildArgumentFailFast(unittest.TestCase):
         self.agent_version = "13.5.2.7785"
 
     @patch("scripts.release.agent.validation._validate_url_exists")
-    def test_generate_tools_build_args_raises_when_platform_unresolvable(self, mock_validate):
-        # Tools available for amd64 but not s390x.
+    def test_generate_tools_build_args_skips_unresolvable_platform(self, mock_validate):
         mock_validate.side_effect = lambda url, timeout=30: "s390x" not in url
 
-        with self.assertRaisesRegex(RuntimeError, r"linux/s390x"):
-            generate_tools_build_args(self.platforms, self.tools_version)
+        build_args = generate_tools_build_args(self.platforms, self.tools_version)
+
+        self.assertIn("mongodb_tools_version_amd64", build_args)
+        self.assertNotIn("mongodb_tools_version_s390x", build_args)
 
     @patch("scripts.release.agent.validation._validate_url_exists")
-    def test_generate_agent_build_args_raises_when_agent_missing_for_platform(self, mock_validate):
-        # Agent missing for s390x (matches the cloud_manager 13.51.0.10584-1 regression).
+    def test_generate_agent_build_args_skips_when_agent_missing_for_platform(self, mock_validate):
         def side_effect(url, timeout=30):
             if "automation-agent" in url and "s390x" in url:
                 return False
@@ -92,11 +93,15 @@ class TestBuildArgumentFailFast(unittest.TestCase):
 
         mock_validate.side_effect = side_effect
 
-        with self.assertRaisesRegex(RuntimeError, r"agent.*linux/s390x"):
-            generate_agent_build_args(self.platforms, self.agent_version, self.tools_version)
+        build_args = generate_agent_build_args(self.platforms, self.agent_version, self.tools_version)
+
+        self.assertIn("mongodb_agent_version_amd64", build_args)
+        self.assertIn("mongodb_tools_version_amd64", build_args)
+        self.assertNotIn("mongodb_agent_version_s390x", build_args)
+        self.assertNotIn("mongodb_tools_version_s390x", build_args)
 
     @patch("scripts.release.agent.validation._validate_url_exists")
-    def test_generate_agent_build_args_raises_when_tools_missing_for_platform(self, mock_validate):
+    def test_generate_agent_build_args_skips_when_tools_missing_for_platform(self, mock_validate):
         def side_effect(url, timeout=30):
             if "database-tools" in url and "s390x" in url:
                 return False
@@ -104,8 +109,11 @@ class TestBuildArgumentFailFast(unittest.TestCase):
 
         mock_validate.side_effect = side_effect
 
-        with self.assertRaisesRegex(RuntimeError, r"tools.*linux/s390x"):
-            generate_agent_build_args(self.platforms, self.agent_version, self.tools_version)
+        build_args = generate_agent_build_args(self.platforms, self.agent_version, self.tools_version)
+
+        self.assertIn("mongodb_agent_version_amd64", build_args)
+        self.assertNotIn("mongodb_agent_version_s390x", build_args)
+        self.assertNotIn("mongodb_tools_version_s390x", build_args)
 
     def test_generate_tools_build_args_raises_for_unknown_platform(self):
         with self.assertRaisesRegex(RuntimeError, r"unknown/arch"):


### PR DESCRIPTION
# Summary

The cloud_manager agent release on 2026-05-04 failed during `docker buildx` with `gzip: stdin: not in gzip format` in the `linux/s390x` stage. Cloud Manager (agent versions starting `13.`) does not ship a `linux/s390x` build, so when the release pipeline asked buildx to build for all four platforms the s390x agent_downloader stage downloaded an HTML error page from S3 and `tar` choked.

This PR adds `resolve_agent_platforms` in `atomic_pipeline.py`: for `13.x` agent versions it drops `linux/s390x` from the platform list before both `--platform` and `generate_agent_build_args` see it. Other agent versions are unaffected. Tracking ticket: KUBE-69.

While in the area, this PR also:
- Removes the misleading `available_platforms` parameter in `build_agent` / `_build_agent` / `build_agent_pipeline` that always equalled `build_configuration.platforms`.
- Drops the silent-skip in `build_init_database_image` so a missing tools version raises naturally rather than disappearing into a `return`.
- Makes `generate_tools_build_args` and `generate_agent_build_args` raise `RuntimeError` when a requested platform is not present in the agent mappings (programmer/config error). Unresolvable agent or tools URLs still warn-and-skip as before.
- Tightens `ImageBuildConfiguration.platforms` and `get_scenario_from_arg` return type to non-`Optional`.
- Removes the orphan `_get_available_platforms` helper and unused `import sys` / `import shutil`.

## Proof of Work

- `scripts/release/tests/atomic_pipeline_test.py` — added `TestBuildArgumentSkipsUnresolvable` (5 tests covering skip behavior for missing agent/tools URLs, plus `RuntimeError` for unknown platforms) and `TestResolveAgentPlatforms` (3 tests: strips `linux/s390x` for 13.x, keeps all platforms for non-13.x, no-op when 13.x input has no s390x).

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details