### PR TITLE
KUBE-69: re-added Cloud Manager rhel7 s390x support

### DIFF
--- a/build_info_agent.json
+++ b/build_info_agent.json
@@ -9,7 +9,7 @@
       "tools_suffixes": ["rhel93-aarch64-{TOOLS_VERSION}.tgz", "rhel90-aarch64-{TOOLS_VERSION}.tgz"]
     },
     "linux/s390x": {
-      "agent_suffixes": ["rhel8_s390x.tar.gz", "rhel9_s390x.tar.gz"],
+      "agent_suffixes": ["rhel7_s390x.tar.gz", "rhel8_s390x.tar.gz", "rhel9_s390x.tar.gz"],
       "tools_suffixes": ["rhel9-s390x-{TOOLS_VERSION}.tgz", "rhel83-s390x-{TOOLS_VERSION}.tgz"]
     },
     "linux/ppc64le": {

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -8,7 +8,7 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from copy import copy
 from queue import Queue
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import requests
 from opentelemetry import trace
@@ -333,14 +333,13 @@ def build_agent_pipeline(
 ):
     build_configuration_copy = copy(build_configuration)
     build_configuration_copy.version = agent_version
-    build_configuration_copy.platforms = resolve_agent_platforms(agent_version, build_configuration.platforms)
 
     print(
         f"======== Building agent pipeline for version {agent_version}, build configuration version: {build_configuration.version}"
     )
 
     platform_build_args = generate_agent_build_args(
-        platforms=build_configuration_copy.platforms, agent_version=agent_version, tools_version=tools_version
+        platforms=build_configuration.platforms, agent_version=agent_version, tools_version=tools_version
     )
 
     agent_base_url = (
@@ -360,15 +359,6 @@ def build_agent_pipeline(
         build_configuration=build_configuration_copy,
         build_args=args,
     )
-
-
-def resolve_agent_platforms(agent_version: str, available_platforms: List[str]) -> List[str]:
-    # Cloud Manager (agent version 13.x) does not ship a linux/s390x build.
-    # Tracking ticket: https://jira.mongodb.org/browse/KUBE-69
-    if agent_version.startswith("13."):
-        return [p for p in available_platforms if p != "linux/s390x"]
-
-    return available_platforms
 
 
 def queue_exception_handling(tasks_queue):

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -339,7 +339,7 @@ def build_agent_pipeline(
     )
 
     platform_build_args = generate_agent_build_args(
-        platforms=build_configuration.platforms, agent_version=agent_version, tools_version=tools_version
+        platforms=build_configuration_copy.platforms, agent_version=agent_version, tools_version=tools_version
     )
 
     agent_base_url = (

--- a/scripts/release/tests/atomic_pipeline_test.py
+++ b/scripts/release/tests/atomic_pipeline_test.py
@@ -12,7 +12,6 @@ from scripts.release.agent.validation import (
     get_working_agent_filename,
     get_working_tools_filename,
 )
-from scripts.release.atomic_pipeline import resolve_agent_platforms
 
 
 class TestBuildArgumentGeneration(unittest.TestCase):
@@ -122,31 +121,6 @@ class TestBuildArgumentSkipsUnresolvable(unittest.TestCase):
     def test_generate_agent_build_args_raises_for_unknown_platform(self):
         with self.assertRaisesRegex(RuntimeError, r"unknown/arch"):
             generate_agent_build_args(["unknown/arch"], self.agent_version, self.tools_version)
-
-
-class TestResolveAgentPlatforms(unittest.TestCase):
-    """resolve_agent_platforms drops linux/s390x for Cloud Manager (13.x) agents only."""
-
-    def test_strips_s390x_for_cloud_manager(self):
-        result = resolve_agent_platforms(
-            "13.51.0.10584-1", ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
-        )
-
-        self.assertEqual(result, ["linux/amd64", "linux/arm64", "linux/ppc64le"])
-
-    def test_keeps_all_for_non_cloud_manager(self):
-        platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
-
-        result = resolve_agent_platforms("14.0.0.7785", platforms)
-
-        self.assertEqual(result, platforms)
-
-    def test_cloud_manager_without_s390x_is_unchanged(self):
-        platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
-
-        result = resolve_agent_platforms("13.51.0.10584-1", platforms)
-
-        self.assertEqual(result, platforms)
 
 
 class TestPlatformAvailability(unittest.TestCase):


### PR DESCRIPTION
# Summary

Re-add `rhel7_s390x.tar.gz` to the `linux/s390x.agent_suffixes` list so the validation in `generate_agent_build_args` can resolve it.

Net effect: cloud_manager agent images now build for all four platforms (`linux/amd64`, `linux/arm64`, `linux/s390x`, `linux/ppc64le`) using the rhel7 s390x tarball.

## Proof of Work

- `scripts/release/tests/atomic_pipeline_test.py` — 11/11 tests pass after dropping `TestResolveAgentPlatforms`.

## Cloud Manager image rebuild

[Release 13.50.0.10511-1 CM agent](https://spruce.corp.mongodb.com/task/mongodb_kubernetes_manual_release_specific_agent_rebuild_specific_agent_patch_1a5c63cd80dd1bd59b330bc9dff97a4832006be7_69f9aead01d6040007f940a9_26_05_05_08_47_43/logs?execution=0)

```
[2026/05/05 10:50:44.610] DEBUG    2026-05-05 08:50:44,609 [validation]  Validated agent and tools versions for linux/arm64: agent=mongodb-mms-automation-agent-13.50.0.10511-1.amzn2_aarch64.tar.gz, tools=mongodb-database-tools-rhel93-aarch64-100.15.0.tgz
[2026/05/05 10:50:44.659] DEBUG    2026-05-05 08:50:44,659 [validation]  Validated agent and tools versions for linux/amd64: agent=mongodb-mms-automation-agent-13.50.0.10511-1.linux_x86_64.tar.gz, tools=mongodb-database-tools-rhel93-x86_64-100.15.0.tgz
[2026/05/05 10:50:44.712] DEBUG    2026-05-05 08:50:44,712 [validation]  Validated agent and tools versions for linux/s390x: agent=mongodb-mms-automation-agent-13.50.0.10511-1.rhel7_s390x.tar.gz, tools=mongodb-database-tools-rhel9-s390x-100.15.0.tgz
[2026/05/05 10:50:44.758] DEBUG    2026-05-05 08:50:44,758 [validation]  Validated agent and tools versions for linux/ppc64le: agent=mongodb-mms-automation-agent-13.50.0.10511-1.rhel8_ppc64le.tar.gz, tools=mongodb-database-tools-rhel9-ppc64le-100.15.0.tgz
```

[Release 13.51.0.10584-1 CM agent](https://spruce.corp.mongodb.com/task/mongodb_kubernetes_manual_release_specific_agent_rebuild_specific_agent_patch_1a5c63cd80dd1bd59b330bc9dff97a4832006be7_69f9b10e01d6040007f946b4_26_05_05_08_57_51/logs?execution=0)

```
[2026/05/05 11:00:29.058] DEBUG    2026-05-05 09:00:29,058 [validation]  Validated agent and tools versions for linux/arm64: agent=mongodb-mms-automation-agent-13.51.0.10584-1.amzn2_aarch64.tar.gz, tools=mongodb-database-tools-rhel93-aarch64-100.15.0.tgz
[2026/05/05 11:00:29.109] DEBUG    2026-05-05 09:00:29,109 [validation]  Validated agent and tools versions for linux/amd64: agent=mongodb-mms-automation-agent-13.51.0.10584-1.linux_x86_64.tar.gz, tools=mongodb-database-tools-rhel93-x86_64-100.15.0.tgz
[2026/05/05 11:00:29.165] DEBUG    2026-05-05 09:00:29,164 [validation]  Validated agent and tools versions for linux/s390x: agent=mongodb-mms-automation-agent-13.51.0.10584-1.rhel7_s390x.tar.gz, tools=mongodb-database-tools-rhel9-s390x-100.15.0.tgz
[2026/05/05 11:00:29.215] DEBUG    2026-05-05 09:00:29,214 [validation]  Validated agent and tools versions for linux/ppc64le: agent=mongodb-mms-automation-agent-13.51.0.10584-1.rhel8_ppc64le.tar.gz, tools=mongodb-database-tools-rhel9-ppc64le-100.15.0.tgz
```

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details