### PR TITLE
Store State in a config map, use cluster indexes for resource names

### DIFF
--- a/api/v1/search/cluster_index.go
+++ b/api/v1/search/cluster_index.go
@@ -1,9 +1,5 @@
 package search
 
-import (
-	"encoding/json"
-)
-
 // AssignClusterIndices returns a new clusterName -> clusterIndex mapping that:
 //   - preserves every entry in existing (never deletes a name, even if it is
 //     not present in currentClusterNames — that's how indices are not reused
@@ -12,8 +8,8 @@ import (
 //     mapping, assigning indices monotonically starting at max(existing)+1 (or
 //     0 when existing is empty).
 //
-// existing is not mutated; callers may safely pass in the result of unmarshalling
-// the persisted annotation. The returned map is always non-nil.
+// existing is not mutated; callers may safely pass in a map from any persistence
+// layer. The returned map is always non-nil.
 func AssignClusterIndices(existing map[string]int, currentClusterNames []string) map[string]int {
 	result := make(map[string]int, len(existing)+len(currentClusterNames))
 	next := 0
@@ -31,35 +27,4 @@ func AssignClusterIndices(existing map[string]int, currentClusterNames []string)
 		next++
 	}
 	return result
-}
-
-// ClusterIndex returns the persisted clusterIndex for the given clusterName by
-// consulting the LastClusterNumMapping annotation on the MongoDBSearch CR. The
-// second return value is false when the annotation is missing, empty, malformed,
-// or does not contain the name.
-//
-// It deliberately reads only the persisted mapping — not spec.clusters — so a
-// name that has been removed from the spec but is still recorded in the mapping
-// continues to resolve.
-func ClusterIndex(search *MongoDBSearch, clusterName string) (int, bool) {
-	if search == nil {
-		return 0, false
-	}
-	mapping := parseClusterMapping(search.Annotations[LastClusterNumMapping])
-	idx, ok := mapping[clusterName]
-	return idx, ok
-}
-
-// parseClusterMapping unmarshals the LastClusterNumMapping annotation value into
-// a clusterName -> clusterIndex map. Returns nil when the value is empty or
-// malformed (callers should treat both as "no mapping yet").
-func parseClusterMapping(value string) map[string]int {
-	if value == "" {
-		return nil
-	}
-	m := make(map[string]int)
-	if err := json.Unmarshal([]byte(value), &m); err != nil {
-		return nil
-	}
-	return m
 }

--- a/api/v1/search/cluster_index_test.go
+++ b/api/v1/search/cluster_index_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAssignClusterIndices(t *testing.T) {
@@ -78,35 +76,3 @@ func TestAssignClusterIndicesDoesNotMutateExisting(t *testing.T) {
 	assert.Equal(t, map[string]int{"a": 0, "b": 1}, existing, "existing must not be mutated")
 }
 
-func TestClusterIndex(t *testing.T) {
-	withAnnotation := func(value string) *MongoDBSearch {
-		return &MongoDBSearch{
-			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns", Annotations: map[string]string{LastClusterNumMapping: value}},
-		}
-	}
-	tests := []struct {
-		name        string
-		search      *MongoDBSearch
-		clusterName string
-		wantIdx     int
-		wantOK      bool
-	}{
-		{name: "nil search", search: nil, clusterName: "us-east", wantOK: false},
-		{name: "no annotations", search: &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s"}}, clusterName: "us-east", wantOK: false},
-		{name: "annotation missing", search: &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s", Annotations: map[string]string{}}}, clusterName: "us-east", wantOK: false},
-		{name: "annotation empty string", search: withAnnotation(""), clusterName: "us-east", wantOK: false},
-		{name: "annotation malformed JSON", search: withAnnotation("{not-json"), clusterName: "us-east", wantOK: false},
-		{name: "name present", search: withAnnotation(`{"us-east":0,"us-west":1}`), clusterName: "us-east", wantIdx: 0, wantOK: true},
-		{name: "name missing in valid mapping", search: withAnnotation(`{"us-east":0,"us-west":1}`), clusterName: "eu-central", wantOK: false},
-		{name: "removed-but-still-mapped name returns persisted idx", search: withAnnotation(`{"us-east":0,"us-west":1}`), clusterName: "us-west", wantIdx: 1, wantOK: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotIdx, gotOK := ClusterIndex(tt.search, tt.clusterName)
-			assert.Equal(t, tt.wantOK, gotOK)
-			if tt.wantOK {
-				assert.Equal(t, tt.wantIdx, gotIdx)
-			}
-		})
-	}
-}

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,8 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/v1/user"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1/common"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 // ShardNamePlaceholder is the placeholder used in endpoint templates for sharded clusters
@@ -27,10 +30,14 @@ const ShardNamePlaceholder = "{shardName}"
 // member cluster name so per-cluster SNI hostnames stay distinct.
 const ClusterNamePlaceholder = "{clusterName}"
 
-// ClusterIndexPlaceholder is substituted with the stable cluster-index assigned
-// by the LastClusterNumMapping annotation for spec.clusters[i]. The index is
-// monotonic and never reused on remove/re-add (see api/v1/search/cluster_index.go).
+// ClusterIndexPlaceholder is substituted with the stable cluster-index for
+// spec.clusters[i]. The index is monotonic and never reused on remove/re-add
+// (see api/v1/search/cluster_index.go).
 const ClusterIndexPlaceholder = "{clusterIndex}"
+
+// LabelResourceOwner is the label key used to identify the MongoDBSearch CR that
+// owns a resource. Used as part of GetOwnerLabels for StateStore ConfigMap selection.
+const LabelResourceOwner = "mongodb.com/v1.mongodbSearchResourceOwner"
 
 const (
 	MongotDefaultWireprotoPort      int32 = 27027
@@ -41,11 +48,6 @@ const (
 	MongotDefaultSyncSourceUsername       = "search-sync-source"
 
 	ForceWireprotoAnnotation = "mongodb.com/v1.force-search-wireproto"
-
-	// LastClusterNumMapping holds the JSON-encoded clusterName -> clusterIndex
-	// mapping for spec.clusters[]. Index never reused on remove/re-add
-	// (see api/v1/search/cluster_index.go).
-	LastClusterNumMapping = "mongodb.com/v1.lastClusterNumMapping"
 
 	MongoDBSearchIndexFieldName = "mdbsearch-for-mongodbresourceref-index"
 
@@ -951,6 +953,8 @@ func (s *MongoDBSearch) GetManagedLBEndpointForShard(shardName string) string {
 //     this path with a placeholder-bearing legacy template is malformed.
 //   - Out-of-range i: placeholders are left untouched (defensive — call sites
 //     iterate over len(*spec.clusters)).
+//
+// {clusterIndex} is resolved using the slice index i directly.
 func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
 	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
 		return ""
@@ -964,15 +968,7 @@ func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
 		return out
 	}
 	out = strings.ReplaceAll(out, ClusterNamePlaceholder, clusters[i].ClusterName)
-	// {clusterIndex} resolves to the persisted monotonic index from the
-	// LastClusterNumMapping annotation when available; otherwise it falls back
-	// to the slice index. The fallback covers legacy specs that have not yet
-	// been re-reconciled to populate the annotation.
-	idx := i
-	if persisted, ok := ClusterIndex(s, clusters[i].ClusterName); ok {
-		idx = persisted
-	}
-	out = strings.ReplaceAll(out, ClusterIndexPlaceholder, strconv.Itoa(idx))
+	out = strings.ReplaceAll(out, ClusterIndexPlaceholder, strconv.Itoa(i))
 	return out
 }
 
@@ -1069,4 +1065,23 @@ func (s *MongoDBSearch) LoadBalancerClientCert() types.NamespacedName {
 		}
 	}
 	return types.NamespacedName{Name: fmt.Sprintf("%s-search-lb-0-client-cert", s.Name), Namespace: s.Namespace}
+}
+
+// ObjectKey implements v1.ResourceOwner.
+func (s *MongoDBSearch) ObjectKey() client.ObjectKey {
+	return kube.ObjectKey(s.Namespace, s.Name)
+}
+
+// GetOwnerLabels implements v1.ResourceOwner. Returns labels used to identify
+// the state ConfigMap owned by this MongoDBSearch.
+func (s *MongoDBSearch) GetOwnerLabels() map[string]string {
+	return map[string]string{
+		util.OperatorLabelName: util.OperatorLabelValue,
+		LabelResourceOwner:     s.Name,
+	}
+}
+
+// GetKind implements v1.ObjectOwner.
+func (s *MongoDBSearch) GetKind() string {
+	return "MongoDBSearch"
 }

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -1004,25 +1004,19 @@ func (s *MongoDBSearch) LoadBalancerConfigMapName() string {
 }
 
 // LoadBalancerDeploymentNameForCluster returns the name of the managed Envoy
-// Deployment for one member cluster. When clusterName is empty the result
-// matches LoadBalancerDeploymentName for back-compat with single-cluster installs.
-// In multi-cluster, the cluster identifier is appended so per-cluster Deployments
-// in the same namespace stay distinct (resource-name length is checked at
-// admission via validateClustersEnvoyResourceNames).
-func (s *MongoDBSearch) LoadBalancerDeploymentNameForCluster(clusterName string) string {
-	if clusterName == "" {
-		return s.LoadBalancerDeploymentName()
-	}
-	return s.LoadBalancerDeploymentName() + "-" + clusterName
+// Deployment for one member cluster. The cluster index (from the persisted
+// StateStore mapping) is appended so per-cluster Deployments in the same
+// namespace stay distinct without encoding user-supplied cluster names into
+// resource names (name length is checked at admission via
+// validateClustersEnvoyResourceNames).
+func (s *MongoDBSearch) LoadBalancerDeploymentNameForCluster(clusterIndex int) string {
+	return fmt.Sprintf("%s-%d", s.LoadBalancerDeploymentName(), clusterIndex)
 }
 
 // LoadBalancerConfigMapNameForCluster returns the name of the managed Envoy
 // ConfigMap for one member cluster. See LoadBalancerDeploymentNameForCluster.
-func (s *MongoDBSearch) LoadBalancerConfigMapNameForCluster(clusterName string) string {
-	if clusterName == "" {
-		return s.LoadBalancerConfigMapName()
-	}
-	return s.Name + "-search-lb-0-" + clusterName + "-config"
+func (s *MongoDBSearch) LoadBalancerConfigMapNameForCluster(clusterIndex int) string {
+	return fmt.Sprintf("%s-search-lb-0-%d-config", s.Name, clusterIndex)
 }
 
 // LoadBalancerServerCert returns the namespaced name of the TLS server certificate secret for the

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -387,19 +387,19 @@ func validateClustersEnvoyResourceNames(s *MongoDBSearch) v1.ValidationResult {
 	if s.Spec.Clusters == nil {
 		return v1.ValidationSuccess()
 	}
-	for _, c := range *s.Spec.Clusters {
+	for i, c := range *s.Spec.Clusters {
 		if c.ClusterName == "" {
 			continue
 		}
 		resources := []shardResourceName{
 			{
 				ResourceType: "Envoy Deployment (per cluster)",
-				Name:         s.LoadBalancerDeploymentNameForCluster(c.ClusterName),
+				Name:         s.LoadBalancerDeploymentNameForCluster(i),
 				Standard:     dnsLabel,
 			},
 			{
 				ResourceType: "Envoy ConfigMap (per cluster)",
-				Name:         s.LoadBalancerConfigMapNameForCluster(c.ClusterName),
+				Name:         s.LoadBalancerConfigMapNameForCluster(i),
 				Standard:     dnsSubdomain,
 			},
 		}
@@ -464,7 +464,6 @@ func validateClustersAndTopLevelFieldsMutuallyExclusive(s *MongoDBSearch) v1.Val
 	}
 	return v1.ValidationSuccess()
 }
-
 
 func ValidateShardNameRFC1123(shardName string) error {
 	if shardName == "" {

--- a/api/v1/search/mongodbsearch_validation.go
+++ b/api/v1/search/mongodbsearch_validation.go
@@ -53,7 +53,6 @@ func (s *MongoDBSearch) RunValidations() []v1.ValidationResult {
 		validateClustersShardOverrides,
 		validateClustersAndTopLevelFieldsMutuallyExclusive,
 		validateClustersEnvoyResourceNames,
-		validateClustersNoRename,
 		validateMCExternalHostnamePlaceholders,
 		validateExternalHostnameDNSLength,
 		validateMCRejectsUnmanagedLB,
@@ -466,54 +465,6 @@ func validateClustersAndTopLevelFieldsMutuallyExclusive(s *MongoDBSearch) v1.Val
 	return v1.ValidationSuccess()
 }
 
-// validateClustersNoRename rejects an Update where a clusterName has been removed
-// from spec.clusters AND a different clusterName has been added in the same update.
-// Pure rename (one removed, one added) is the operation we forbid; pure remove or
-// pure add is allowed (the index mapping handles both safely — removed indices are
-// preserved, added clusters get the next monotonic index).
-//
-// This is a soft, single-update rule: a remove-then-readd in two separate updates
-// is indistinguishable from a real rename. We accept that — the index is preserved
-// in both cases, so the worst case is that a real rename slips through across two
-// updates and the user sees no observable difference. There is no admission webhook
-// for MongoDBSearch today; all the more reason to keep the rule tight enough to
-// catch the obvious mistake but loose enough not to false-positive on benign edits.
-func validateClustersNoRename(s *MongoDBSearch) v1.ValidationResult {
-	raw, ok := s.Annotations[LastClusterNumMapping]
-	if !ok || raw == "" {
-		return v1.ValidationSuccess()
-	}
-	previous := parseClusterMapping(raw)
-	if len(previous) == 0 {
-		return v1.ValidationSuccess()
-	}
-	if s.Spec.Clusters == nil {
-		return v1.ValidationSuccess()
-	}
-	currentSet := make(map[string]struct{}, len(*s.Spec.Clusters))
-	for _, c := range *s.Spec.Clusters {
-		currentSet[c.ClusterName] = struct{}{}
-	}
-	var removed []string
-	for name := range previous {
-		if _, ok := currentSet[name]; !ok {
-			removed = append(removed, name)
-		}
-	}
-	var added []string
-	for name := range currentSet {
-		if _, ok := previous[name]; !ok {
-			added = append(added, name)
-		}
-	}
-	if len(removed) > 0 && len(added) > 0 {
-		return v1.ValidationError(
-			"clusterName changes are not allowed: removed=%v added=%v. To rename a cluster, recreate the MongoDBSearch resource",
-			removed, added,
-		)
-	}
-	return v1.ValidationSuccess()
-}
 
 func ValidateShardNameRFC1123(shardName string) error {
 	if shardName == "" {

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"encoding/json"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -810,85 +809,6 @@ func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTL
 	return search
 }
 
-func TestValidateClustersNoRename(t *testing.T) {
-	withMapping := func(s *MongoDBSearch, m map[string]int) *MongoDBSearch {
-		if s.Annotations == nil {
-			s.Annotations = map[string]string{}
-		}
-		b, _ := json.Marshal(m)
-		s.Annotations[LastClusterNumMapping] = string(b)
-		return s
-	}
-	tests := []struct {
-		name          string
-		search        *MongoDBSearch
-		errorContains string
-	}{
-		{
-			name: "no annotation: nothing to compare against",
-			search: &MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}}},
-			},
-		},
-		{
-			name: "first-time set: persisted mapping is empty",
-			search: withMapping(&MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}},
-			}, map[string]int{}),
-		},
-		{
-			name: "names unchanged",
-			search: withMapping(&MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}},
-			}, map[string]int{"us-east": 0, "us-west": 1}),
-		},
-		{
-			name: "pure remove: us-west missing from spec but no new name added — allowed",
-			search: withMapping(&MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}}},
-			}, map[string]int{"us-east": 0, "us-west": 1}),
-		},
-		{
-			name: "pure add: eu-central new but no name removed — allowed",
-			search: withMapping(&MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec: MongoDBSearchSpec{Clusters: &[]ClusterSpec{
-					{ClusterName: "us-east"}, {ClusterName: "us-west"}, {ClusterName: "eu-central"},
-				}},
-			}, map[string]int{"us-east": 0, "us-west": 1}),
-		},
-		{
-			name: "rename: us-west removed and eu-central added — rejected",
-			search: withMapping(&MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "eu-central"}}},
-			}, map[string]int{"us-east": 0, "us-west": 1}),
-			errorContains: "clusterName changes are not allowed",
-		},
-		{
-			name: "remove-then-readd via two separate updates is allowed",
-			search: withMapping(&MongoDBSearch{
-				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: &[]ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}},
-			}, map[string]int{"us-east": 0, "us-west": 1}),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			res := validateClustersNoRename(tt.search)
-			if tt.errorContains != "" {
-				assert.Equal(t, v1.ErrorLevel, res.Level)
-				assert.Contains(t, res.Msg, tt.errorContains)
-			} else {
-				assert.Equal(t, v1.SuccessLevel, res.Level)
-			}
-		})
-	}
-}
 
 // TestManagedLBConfig_Replicas_FieldExists is a smoke test: the Replicas
 // field on ManagedLBConfig is wired so per-cluster managed LB can specify a

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -866,9 +866,11 @@ func TestValidateClustersEnvoyResourceNames(t *testing.T) {
 			clusterNames: nil,
 		},
 		{
+			// Deployment name: <name>-search-lb-0-<index>
+			// suffix "-search-lb-0-0" is 14 chars; need len(name) > 49 to exceed 63.
 			name:          "Deployment name >63 chars rejected",
-			searchName:    strings.Repeat("a", 40),
-			clusterNames:  []string{strings.Repeat("c", 30)},
+			searchName:    strings.Repeat("a", 50),
+			clusterNames:  []string{"us-east-k8s"},
 			errorContains: "exceeds",
 		},
 	}

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"go.uber.org/zap"
@@ -29,6 +30,7 @@ import (
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster/memberwatch"
@@ -41,6 +43,37 @@ import (
 // (Result{RequeueAfter: secretsCheckRequeueAfter}, nil) so we don't trigger
 // exponential backoff while the customer is fixing the gap.
 const secretsCheckRequeueAfter = 30 * time.Second
+
+type SearchDeploymentState struct {
+	CommonDeploymentState `json:",inline"`
+}
+
+func NewSearchDeploymentState() *SearchDeploymentState {
+	return &SearchDeploymentState{
+		CommonDeploymentState: CommonDeploymentState{ClusterMapping: map[string]int{}},
+	}
+}
+
+// loadOrInitSearchState reads the per-CR state ConfigMap, treating NotFound as
+// fresh state. Returns the state plus the bound store so callers can WriteState.
+func loadOrInitSearchState(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+) (*SearchDeploymentState, *StateStore[SearchDeploymentState], error) {
+	store := NewStateStore[SearchDeploymentState](search, kube.BaseOwnerReference(search), c)
+	state, err := store.ReadState(ctx)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return NewSearchDeploymentState(), store, nil
+		}
+		return nil, nil, err
+	}
+	if state.ClusterMapping == nil {
+		state.ClusterMapping = map[string]int{}
+	}
+	return state, store, nil
+}
 
 type MongoDBSearchReconciler struct {
 	kubeClient           kubernetesClient.Client
@@ -134,6 +167,24 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	// can fold gaps into the per-cluster status patch in a single writeback,
 	// rather than requiring a follow-up patch from this controller.
 	gaps := searchcontroller.CheckSecretsPresence(ctx, mdbSearch, r.kubeClient, memberClients)
+
+	state, stateStore, err := loadOrInitSearchState(ctx, r.kubeClient, mdbSearch)
+	if err != nil {
+		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(err), log)
+	}
+	var currentNames []string
+	if mdbSearch.Spec.Clusters != nil {
+		for _, c := range *mdbSearch.Spec.Clusters {
+			currentNames = append(currentNames, c.ClusterName)
+		}
+	}
+	newMapping := searchv1.AssignClusterIndices(state.ClusterMapping, currentNames)
+	if !reflect.DeepEqual(newMapping, state.ClusterMapping) {
+		state.ClusterMapping = newMapping
+		if err := stateStore.WriteState(ctx, state, log); err != nil {
+			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(err), log)
+		}
+	}
 
 	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig)
 	reconcileHelper.SetSecretGaps(gaps)

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -420,6 +420,9 @@ func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
 	require.True(t, res.RequeueAfter > 0, "must requeue when a customer-replicated secret is missing")
 }
 
+// TODO(@anandsyncs PR #1064): refactor StateConfigMap reconcile-loop tests
+// (this one + _NoOpOnStableMapping, _OperatorRestart, _ReAddCluster) into a
+// single table-driven test.
 func TestMongoDBSearchControllerReconcile_StateConfigMap(t *testing.T) {
 	ctx := context.Background()
 

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
@@ -417,4 +418,188 @@ func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
 
 	require.NoError(t, err, "missing secret must surface as RequeueAfter, not an error")
 	require.True(t, res.RequeueAfter > 0, "must requeue when a customer-replicated secret is missing")
+}
+
+func TestMongoDBSearchControllerReconcile_StateConfigMap(t *testing.T) {
+	ctx := context.Background()
+
+	withClusters := func(names ...string) func(*searchv1.MongoDBSearch) {
+		return func(s *searchv1.MongoDBSearch) {
+			entries := make([]searchv1.ClusterSpec, 0, len(names))
+			for _, n := range names {
+				entries = append(entries, searchv1.ClusterSpec{ClusterName: n})
+			}
+			s.Spec.Clusters = &entries
+		}
+	}
+
+	search := newMongoDBSearch("mysearch", mock.TestNamespace, "mdb")
+	withClusters("us-east", "us-west")(search)
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+	reconciler, c := newSearchReconciler(mdbc, search)
+
+	// First reconcile — state ConfigMap must be created.
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+
+	stateCM := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM))
+
+	var gotState SearchDeploymentState
+	require.NoError(t, decodeStateJSON(stateCM, &gotState))
+	assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, gotState.ClusterMapping)
+
+	// Owner reference must point to the MongoDBSearch.
+	latestSearch := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, latestSearch))
+	require.Len(t, stateCM.OwnerReferences, 1)
+	assert.Equal(t, latestSearch.UID, stateCM.OwnerReferences[0].UID)
+
+	// Second reconcile — add a third cluster.
+	withClusters("us-east", "us-west", "eu-central")(latestSearch)
+	require.NoError(t, c.Update(ctx, latestSearch))
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM))
+	require.NoError(t, decodeStateJSON(stateCM, &gotState))
+	assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2}, gotState.ClusterMapping)
+
+	// Third reconcile — remove us-west; mapping must retain it.
+	latestSearch = &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, latestSearch))
+	withClusters("us-east", "eu-central")(latestSearch)
+	require.NoError(t, c.Update(ctx, latestSearch))
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM))
+	require.NoError(t, decodeStateJSON(stateCM, &gotState))
+	assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2}, gotState.ClusterMapping, "removed cluster must be retained")
+}
+
+// decodeStateJSON parses the "state" key of a state ConfigMap into dst.
+func decodeStateJSON(cm *corev1.ConfigMap, dst interface{}) error {
+	raw, ok := cm.Data["state"]
+	if !ok {
+		return fmt.Errorf("state key missing from ConfigMap %s", cm.Name)
+	}
+	return json.Unmarshal([]byte(raw), dst)
+}
+
+// TestMongoDBSearchControllerReconcile_StateConfigMap_NoOpOnStableMapping verifies that a second reconcile
+// with an unchanged cluster list does not bump the state ConfigMap's resourceVersion.
+func TestMongoDBSearchControllerReconcile_StateConfigMap_NoOpOnStableMapping(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("mysearch", mock.TestNamespace, "mdb")
+	clusters := []searchv1.ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}
+	search.Spec.Clusters = &clusters
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+	reconciler, c := newSearchReconciler(mdbc, search)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	stateCM := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM))
+	rvAfterFirst := stateCM.ResourceVersion
+
+	// Second reconcile with identical spec — mapping is stable; state CM must not be rewritten.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	stateCM2 := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM2))
+	assert.Equal(t, rvAfterFirst, stateCM2.ResourceVersion, "state CM must not be rewritten when mapping is unchanged")
+}
+
+// TestMongoDBSearchControllerReconcile_StateConfigMap_OperatorRestart simulates an operator restart by
+// pre-seeding a state CM in the fake client before constructing the reconciler.  The reconcile must
+// preserve the existing mapping rather than initialising a fresh one.
+func TestMongoDBSearchControllerReconcile_StateConfigMap_OperatorRestart(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("mysearch", mock.TestNamespace, "mdb")
+	clusters := []searchv1.ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}
+	search.Spec.Clusters = &clusters
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+
+	// Build reconciler and client, then manually seed a state CM that already contains
+	// a non-trivial mapping — as if a previous operator instance had written it.
+	reconciler, c := newSearchReconciler(mdbc, search)
+
+	existingState := SearchDeploymentState{
+		CommonDeploymentState: CommonDeploymentState{
+			ClusterMapping: map[string]int{"us-east": 0, "us-west": 1},
+		},
+	}
+	stateJSON, err := json.Marshal(existingState)
+	require.NoError(t, err)
+	seedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mysearch-state",
+			Namespace: mock.TestNamespace,
+		},
+		Data: map[string]string{stateKey: string(stateJSON)},
+	}
+	require.NoError(t, c.Create(ctx, seedCM))
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+
+	stateCM := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM))
+	var gotState SearchDeploymentState
+	require.NoError(t, decodeStateJSON(stateCM, &gotState))
+	assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, gotState.ClusterMapping, "existing mapping must be preserved across operator restart")
+}
+
+// TestMongoDBSearchControllerReconcile_StateConfigMap_ReAddCluster verifies that a cluster that was previously
+// removed and then re-added gets back its original index (monotonic, stable index assignment).
+func TestMongoDBSearchControllerReconcile_StateConfigMap_ReAddCluster(t *testing.T) {
+	ctx := context.Background()
+
+	withClusters := func(s *searchv1.MongoDBSearch, names ...string) {
+		entries := make([]searchv1.ClusterSpec, 0, len(names))
+		for _, n := range names {
+			entries = append(entries, searchv1.ClusterSpec{ClusterName: n})
+		}
+		s.Spec.Clusters = &entries
+	}
+
+	search := newMongoDBSearch("mysearch", mock.TestNamespace, "mdb")
+	withClusters(search, "us-east", "us-west", "eu-central")
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+	reconciler, c := newSearchReconciler(mdbc, search)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
+
+	// Initial reconcile: assign indices 0, 1, 2.
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Remove us-west (index 1).
+	latestSearch := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, latestSearch))
+	withClusters(latestSearch, "us-east", "eu-central")
+	require.NoError(t, c.Update(ctx, latestSearch))
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Re-add us-west — it must reclaim index 1.
+	latestSearch = &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, latestSearch))
+	withClusters(latestSearch, "us-east", "eu-central", "us-west")
+	require.NoError(t, c.Update(ctx, latestSearch))
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	stateCM := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mysearch-state", Namespace: mock.TestNamespace}, stateCM))
+	var gotState SearchDeploymentState
+	require.NoError(t, decodeStateJSON(stateCM, &gotState))
+	assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2}, gotState.ClusterMapping,
+		"re-added cluster must reclaim its original index")
 }

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -138,10 +138,16 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 		return r.updateLBStatus(ctx, mdbSearch, workflow.Pending("Waiting for search source: %s", err), log)
 	}
 
+	// Load the per-CR state to get the stable clusterName → clusterIndex mapping.
+	state, _, err := loadOrInitSearchState(ctx, r.kubeClient, mdbSearch)
+	if err != nil {
+		return r.updateLBStatus(ctx, mdbSearch, workflow.Pending("Waiting for search state: %s", err), log)
+	}
+
 	tlsCfg := searchSource.TLSConfig()
 	tlsEnabled := mdbSearch.IsTLSConfigured()
 
-	workList := r.buildClusterWorkList(mdbSearch)
+	workList := r.buildClusterWorkList(mdbSearch, state.ClusterMapping)
 	perClusterStatuses := make([]searchv1.ClusterLoadBalancerStatus, 0, len(workList))
 	var firstFailure error
 	multiCluster := len(workList) > 1 || (len(workList) == 1 && workList[0].ClusterName != "")
@@ -150,7 +156,14 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	// single-cluster degenerate case, so worstOfClusterPhases sees the actual
 	// failure phase rather than defaulting to Running.
 	for _, w := range workList {
-		st := r.reconcileForCluster(ctx, mdbSearch, searchSource, tlsEnabled, tlsCfg, w.ClusterName, log)
+		var st workflow.Status
+		if w.ClusterIndex == -1 {
+			// Cluster not yet registered in state mapping; Envoy controller
+			// reconciles after the main search controller writes the mapping.
+			st = workflow.Pending("Waiting for cluster %q to be registered in search state", w.ClusterName)
+		} else {
+			st = r.reconcileForCluster(ctx, mdbSearch, searchSource, tlsEnabled, tlsCfg, w.ClusterName, w.ClusterIndex, log)
+		}
 		perClusterStatuses = append(perClusterStatuses, searchv1.ClusterLoadBalancerStatus{
 			ClusterName: w.ClusterName,
 			Phase:       st.Phase(),
@@ -184,32 +197,40 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	return r.updateLBStatus(ctx, mdbSearch, workflow.OK(), log)
 }
 
-// clusterWorkItem represents one (clusterName) unit the reconciler must process.
+// clusterWorkItem represents one (clusterName, clusterIndex) unit the reconciler must process.
 // In single-cluster (no spec.clusters or empty memberClusterClientsMap) the slice
-// has one entry with ClusterName == "" and writes go to the central cluster.
+// has one entry with ClusterName == "" and ClusterIndex == 0.
+// ClusterIndex == -1 is a sentinel meaning the cluster has not yet been registered
+// in the state mapping; the reconciler surfaces a per-cluster Pending for those.
 type clusterWorkItem struct {
-	ClusterName string
+	ClusterName  string
+	ClusterIndex int
 }
 
 // buildClusterWorkList expands spec.clusters[] into the per-cluster work units
 // the reconciler will iterate over. Membership rules:
-//   - len(memberClusterClientsMap) == 0 → single-cluster install; one work item with "".
-//   - len(spec.clusters) == 0 → single-cluster degenerate; one work item with "".
-//   - otherwise → one work item per spec.clusters[i]. Member clusters in the
-//     reconciler's map but absent from spec.clusters[] are intentionally ignored
-//     (the CR drives, not the operator's membership).
-func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.MongoDBSearch) []clusterWorkItem {
+//   - len(memberClusterClientsMap) == 0 → single-cluster install; one work item with ClusterName="" and ClusterIndex=0.
+//   - len(spec.clusters) == 0 → single-cluster degenerate; one work item with ClusterName="" and ClusterIndex=0.
+//   - otherwise → one work item per spec.clusters[i]. ClusterIndex is resolved from
+//     mapping; -1 if the cluster is not yet in the mapping (first reconcile race).
+func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.MongoDBSearch, mapping map[string]int) []clusterWorkItem {
 	if len(r.memberClusterClientsMap) == 0 || search.Spec.Clusters == nil || len(*search.Spec.Clusters) == 0 {
-		return []clusterWorkItem{{ClusterName: ""}}
+		return []clusterWorkItem{{ClusterName: "", ClusterIndex: 0}}
 	}
 	work := make([]clusterWorkItem, 0, len(*search.Spec.Clusters))
 	for _, c := range *search.Spec.Clusters {
-		work = append(work, clusterWorkItem{ClusterName: c.ClusterName})
+		idx, ok := mapping[c.ClusterName]
+		if !ok {
+			idx = -1
+		}
+		work = append(work, clusterWorkItem{ClusterName: c.ClusterName, ClusterIndex: idx})
 	}
 	return work
 }
 
 // reconcileForCluster runs the ConfigMap + Deployment ensure for one cluster.
+// clusterName is used for client lookup and log context; clusterIndex is used
+// for resource naming.
 // Returns a workflow.Status describing the per-cluster outcome.
 func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	ctx context.Context,
@@ -218,6 +239,7 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	tlsEnabled bool,
 	tlsCfg *searchcontroller.TLSSourceConfig,
 	clusterName string,
+	clusterIndex int,
 	log *zap.SugaredLogger,
 ) workflow.Status {
 	if clusterName != "" {
@@ -236,10 +258,10 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	if err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
-	if err := r.ensureConfigMap(ctx, search, envoyJSON, clusterName, log); err != nil {
+	if err := r.ensureConfigMap(ctx, search, envoyJSON, clusterName, clusterIndex, log); err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
-	if err := r.ensureDeployment(ctx, search, envoyJSON, clusterName, tlsCfg, log); err != nil {
+	if err := r.ensureDeployment(ctx, search, envoyJSON, clusterName, clusterIndex, tlsCfg, log); err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 	return workflow.OK()
@@ -287,6 +309,9 @@ func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search
 // created when managed LB was active. This is called exactly once per LB removal,
 // gated by Status.LoadBalancer != nil (cleared immediately after).
 //
+// Single-cluster installs use index 0, matching the index assigned by
+// buildClusterWorkList for the single-cluster degenerate path.
+//
 // This still walks only the central cluster. Member-cluster Deployments +
 // ConfigMaps will leak on managed→unmanaged transitions and on CR delete because
 // cross-cluster owner refs do not GC; graceful drain on cluster removal will
@@ -294,14 +319,14 @@ func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search
 func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) {
 	ns := search.Namespace
 
-	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentName(), Namespace: ns}}
+	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: ns}}
 	if err := r.kubeClient.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
 		log.Warnf("Failed to delete Envoy Deployment %s: %s", dep.Name, err)
 	} else if err == nil {
 		log.Infof("Deleted Envoy Deployment %s", dep.Name)
 	}
 
-	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapName(), Namespace: ns}}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: ns}}
 	if err := r.kubeClient.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
 		log.Warnf("Failed to delete Envoy ConfigMap %s: %s", cm.Name, err)
 	} else if err == nil {
@@ -442,22 +467,24 @@ func applyClusterIDToSNI(sni, clusterName string, templated bool) string {
 
 // ensureConfigMap creates or updates the Envoy ConfigMap in the cluster
 // indicated by clusterName ("" = central cluster, single-cluster path).
+// clusterIndex is used for resource naming; clusterName is used for client
+// lookup and labels.
 //
 // Cross-cluster ownership note: Kubernetes garbage collection does not span
 // clusters, so we only set an OwnerReference when writing into the central
 // cluster (clusterName == ""). Cleanup of member-cluster objects is handled
 // explicitly in deleteEnvoyResources.
-func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, envoyJSON, clusterName string, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, envoyJSON, clusterName string, clusterIndex int, log *zap.SugaredLogger) error {
 	c := selectEnvoyClient(clusterName, r.kubeClient, r.memberClusterClientsMap)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.LoadBalancerConfigMapNameForCluster(clusterName),
+			Name:      search.LoadBalancerConfigMapNameForCluster(clusterIndex),
 			Namespace: search.Namespace,
 		},
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
-		cm.Labels = envoyLabelsForCluster(search, clusterName)
+		cm.Labels = envoyLabelsForCluster(search, clusterName, clusterIndex)
 		cm.Data = map[string]string{"envoy.json": envoyJSON}
 		if clusterName == "" {
 			return controllerutil.SetOwnerReference(search, cm, c.Scheme())
@@ -474,13 +501,15 @@ func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, sear
 
 // ensureDeployment creates or updates the Envoy Deployment in the cluster
 // indicated by clusterName ("" = central cluster, single-cluster path).
+// clusterIndex is used for resource naming; clusterName is used for client
+// lookup and labels.
 // See ensureConfigMap for the cross-cluster ownership rule.
-func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, envoyJSON, clusterName string, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, envoyJSON, clusterName string, clusterIndex int, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
 	c := selectEnvoyClient(clusterName, r.kubeClient, r.memberClusterClientsMap)
 	configHash := fmt.Sprintf("%x", sha256.Sum256([]byte(envoyJSON)))
 	replicas := envoyReplicas(search)
-	labels := envoyLabelsForCluster(search, clusterName)
-	podLabels := envoyPodLabelsForCluster(search, clusterName)
+	labels := envoyLabelsForCluster(search, clusterName, clusterIndex)
+	podLabels := envoyPodLabelsForCluster(search, clusterIndex)
 	tlsEnabled := search.IsTLSConfigured()
 	image, err := r.envoyContainerImage()
 	if err != nil {
@@ -491,7 +520,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.LoadBalancerDeploymentNameForCluster(clusterName),
+			Name:      search.LoadBalancerDeploymentNameForCluster(clusterIndex),
 			Namespace: search.Namespace,
 		},
 	}
@@ -511,7 +540,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 						envoyConfigHashAnnotation: configHash,
 					},
 				},
-				Spec: buildEnvoyPodSpec(search, clusterName, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
+				Spec: buildEnvoyPodSpec(search, clusterIndex, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
 			},
 		}
 
@@ -538,17 +567,16 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 // buildEnvoyPodSpec builds the PodSpec for the Envoy Deployment.
 // tlsCfg may be nil if TLS is not configured on the source.
 //
-// clusterName selects the per-cluster ConfigMap volume name in MC mode
-// (clusterName == "" preserves the single-cluster path's legacy unsuffixed
-// name). Without this, MC pods mount a ConfigMap that does not exist in the
-// member cluster and Envoy never starts.
-func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterName string, tlsCfg *searchcontroller.TLSSourceConfig, tlsEnabled bool, image string, resources corev1.ResourceRequirements, managedSecurityContext bool) corev1.PodSpec {
+// clusterIndex selects the per-cluster ConfigMap volume name. Without this,
+// MC pods mount a ConfigMap that does not exist in the member cluster and
+// Envoy never starts.
+func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg *searchcontroller.TLSSourceConfig, tlsEnabled bool, image string, resources corev1.ResourceRequirements, managedSecurityContext bool) corev1.PodSpec {
 	volumes := []corev1.Volume{
 		{
 			Name: "envoy-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: search.LoadBalancerConfigMapNameForCluster(clusterName)},
+					LocalObjectReference: corev1.LocalObjectReference{Name: search.LoadBalancerConfigMapNameForCluster(clusterIndex)},
 				},
 			},
 		},
@@ -664,20 +692,22 @@ func defaultEnvoyResourceRequirements() corev1.ResourceRequirements {
 }
 
 // envoyLabelsForCluster returns Envoy resource labels including the cross-cluster
-// enqueue labels and an optional cluster-name label. In single-cluster (clusterID
+// enqueue labels and an optional cluster-name label. In single-cluster (clusterName
 // == "") the cluster-name label is omitted. Both stamp the cross-cluster enqueue
 // labels so the label-based mapper can route Deployment/ConfigMap events back
 // to the owning MongoDBSearch even when objects live in a member cluster (where
 // owner refs don't GC).
-func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) map[string]string {
+// clusterIndex is used for the "app" label (resource name); clusterName is used
+// for the cluster-name label so label selectors remain name-keyed.
+func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
 	labels := map[string]string{
-		"app":                                search.LoadBalancerDeploymentNameForCluster(clusterID),
+		"app":                                search.LoadBalancerDeploymentNameForCluster(clusterIndex),
 		"component":                          labelName,
 		khandler.MongoDBSearchOwnerNameLabel: search.Name,
 		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
 	}
-	if clusterID != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterID
+	if clusterName != "" {
+		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
 	}
 	return labels
 }
@@ -710,9 +740,9 @@ func envoyReplicas(search *searchv1.MongoDBSearch) int32 {
 // envoyPodLabelsForCluster returns Envoy pod-selection labels for one cluster.
 // The "app" label uses the per-cluster Deployment name so Pods stay distinct
 // per (cluster, namespace) — Pod names already carry the Deployment prefix.
-func envoyPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterID string) map[string]string {
+func envoyPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterIndex int) map[string]string {
 	return map[string]string{
-		"app": search.LoadBalancerDeploymentNameForCluster(clusterID),
+		"app": search.LoadBalancerDeploymentNameForCluster(clusterIndex),
 	}
 }
 

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -36,6 +37,28 @@ import (
 //   - Envoy Deployment/ConfigMap lifecycle (create, update, cleanup)
 //   - Error paths (missing envoy image, unreachable source)
 //   - Status updates for the loadBalancer sub-status
+
+// seedSearchStateCM writes a <searchName>-state ConfigMap carrying the given
+// clusterName→clusterIndex mapping into c, simulating a previous write by the
+// main search controller. Tests that exercise the Envoy reconcile loop must
+// seed this CM before constructing the reconciler so the Envoy controller can
+// resolve indices without needing the full main-controller reconcile path.
+func seedSearchStateCM(t *testing.T, ctx context.Context, c client.Client, searchName, ns string, mapping map[string]int) {
+	t.Helper()
+	state := SearchDeploymentState{
+		CommonDeploymentState: CommonDeploymentState{ClusterMapping: mapping},
+	}
+	raw, err := json.Marshal(state)
+	require.NoError(t, err)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      searchName + "-state",
+			Namespace: ns,
+		},
+		Data: map[string]string{stateKey: string(raw)},
+	}
+	require.NoError(t, c.Create(ctx, cm))
+}
 
 func TestBuildReplicaSetRoute(t *testing.T) {
 	tests := []struct {
@@ -136,7 +159,7 @@ func TestBuildEnvoyPodSpec_DefaultResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 	}
 	resources := envoyResourceRequirements(search)
-	podSpec := buildEnvoyPodSpec(search, "", nil, false, "envoy:latest", resources, false)
+	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	assert.Len(t, podSpec.Containers, 1)
 	assert.Equal(t, "envoy", podSpec.Containers[0].Name)
@@ -157,29 +180,29 @@ func TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster(t *testing.T) {
 
 	cases := []struct {
 		name           string
-		clusterName    string
+		clusterIndex   int
 		expectedCMName string
 	}{
 		{
-			name:           "single-cluster keeps legacy unsuffixed name",
-			clusterName:    "",
-			expectedCMName: search.LoadBalancerConfigMapName(),
+			name:           "single-cluster uses index 0",
+			clusterIndex:   0,
+			expectedCMName: search.LoadBalancerConfigMapNameForCluster(0),
 		},
 		{
-			name:           "MC cluster a uses per-cluster suffixed name",
-			clusterName:    "cluster-a",
-			expectedCMName: search.LoadBalancerConfigMapNameForCluster("cluster-a"),
+			name:           "MC first cluster uses index 0",
+			clusterIndex:   0,
+			expectedCMName: search.LoadBalancerConfigMapNameForCluster(0),
 		},
 		{
-			name:           "MC cluster b uses per-cluster suffixed name",
-			clusterName:    "cluster-b",
-			expectedCMName: search.LoadBalancerConfigMapNameForCluster("cluster-b"),
+			name:           "MC second cluster uses index 1",
+			clusterIndex:   1,
+			expectedCMName: search.LoadBalancerConfigMapNameForCluster(1),
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			podSpec := buildEnvoyPodSpec(search, tc.clusterName, nil, false, "envoy:latest", resources, false)
+			podSpec := buildEnvoyPodSpec(search, tc.clusterIndex, nil, false, "envoy:latest", resources, false)
 
 			var found *corev1.Volume
 			for i := range podSpec.Volumes {
@@ -227,7 +250,7 @@ func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 
 	// Build the base pod spec as the controller would
 	resources := envoyResourceRequirements(search)
-	podSpec := buildEnvoyPodSpec(search, "", nil, false, "envoy:latest", resources, false)
+	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	// Verify base spec has no tolerations
 	assert.Empty(t, podSpec.Tolerations)
@@ -306,7 +329,7 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	resources := envoyResourceRequirements(search)
 	assert.Equal(t, resource.MustParse("200m"), resources.Requests[corev1.ResourceCPU])
 
-	podSpec := buildEnvoyPodSpec(search, "", nil, false, "envoy:latest", resources, false)
+	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	dep := appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
@@ -484,36 +507,39 @@ func TestSelectEnvoyClient(t *testing.T) {
 
 // --- per-cluster name helpers + cross-cluster enqueue labels ------------------
 
-func TestLoadBalancerNamesForCluster_SingleClusterUnchanged(t *testing.T) {
+func TestLoadBalancerNamesForCluster_IndexBased(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-	assert.Equal(t, search.LoadBalancerDeploymentName(), search.LoadBalancerDeploymentNameForCluster(""))
-	assert.Equal(t, search.LoadBalancerConfigMapName(), search.LoadBalancerConfigMapNameForCluster(""))
-}
 
-func TestLoadBalancerNamesForCluster_MultiClusterAppendsClusterID(t *testing.T) {
-	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-	dep := search.LoadBalancerDeploymentNameForCluster("us-east-k8s")
-	cm := search.LoadBalancerConfigMapNameForCluster("us-east-k8s")
-	assert.Contains(t, dep, "us-east-k8s")
-	assert.Contains(t, cm, "us-east-k8s")
-	assert.NotEqual(t, search.LoadBalancerDeploymentName(), dep)
+	// Index 0 (single-cluster degenerate path).
+	assert.Equal(t, "mdb-search-search-lb-0-0", search.LoadBalancerDeploymentNameForCluster(0))
+	assert.Equal(t, "mdb-search-search-lb-0-0-config", search.LoadBalancerConfigMapNameForCluster(0))
+
+	// Index 2 (higher MC index).
+	assert.Equal(t, "mdb-search-search-lb-0-2", search.LoadBalancerDeploymentNameForCluster(2))
+	assert.Equal(t, "mdb-search-search-lb-0-2-config", search.LoadBalancerConfigMapNameForCluster(2))
+
+	// Different indices produce different names.
+	assert.NotEqual(t, search.LoadBalancerDeploymentNameForCluster(0), search.LoadBalancerDeploymentNameForCluster(1))
+	assert.NotEqual(t, search.LoadBalancerConfigMapNameForCluster(0), search.LoadBalancerConfigMapNameForCluster(1))
 }
 
 func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
 
-	// Single-cluster: cluster-name label must be absent.
-	single := envoyLabelsForCluster(search, "")
+	// Single-cluster: cluster-name label must be absent; app label uses index 0.
+	single := envoyLabelsForCluster(search, "", 0)
 	assert.Equal(t, "mdb-search", single[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", single[khandler.MongoDBSearchOwnerNamespaceLabel])
 	_, hasCluster := single[khandler.MongoDBSearchClusterNameLabel]
 	assert.False(t, hasCluster)
+	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(0), single["app"])
 
-	// Multi-cluster: all three labels present.
-	mc := envoyLabelsForCluster(search, "us-east-k8s")
+	// Multi-cluster: all three labels present; app label uses the provided index.
+	mc := envoyLabelsForCluster(search, "us-east-k8s", 3)
 	assert.Equal(t, "mdb-search", mc[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", mc[khandler.MongoDBSearchOwnerNamespaceLabel])
 	assert.Equal(t, "us-east-k8s", mc[khandler.MongoDBSearchClusterNameLabel])
+	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(3), mc["app"])
 }
 
 // --- envoy replicas defaulting ------------------------------------------
@@ -563,24 +589,25 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 	})
 
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "a", zap.S()))
+	// cluster "a" is at index 0 in the mapping.
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "a", 0, zap.S()))
 
-	// Member A has it.
+	// Member A has the ConfigMap named with index 0.
 	cmA := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, cmA))
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cmA))
 	assert.Equal(t, `{"x":1}`, cmA.Data["envoy.json"])
-	// Cluster name label stamped.
+	// Cluster name label stamped (name-keyed for cross-cluster enqueue).
 	assert.Equal(t, "a", cmA.Labels[khandler.MongoDBSearchClusterNameLabel])
 	assert.Equal(t, "mdb-search", cmA.Labels[khandler.MongoDBSearchOwnerNameLabel])
 
 	// Central and member B do not.
 	cm := &corev1.ConfigMap{}
 	err := central.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, cm)
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm)
 	assert.True(t, apierrors.IsNotFound(err))
 	err = memberB.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, cm)
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm)
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
@@ -593,13 +620,14 @@ func TestEnsureConfigMap_SingleCluster_WritesToCentralWithOwnerRef(t *testing.T)
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
 	}
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "", zap.S()))
+	// Single-cluster uses index 0.
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "", 0, zap.S()))
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, central.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapName(), Namespace: "ns"}, cm))
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
 
-	// Owner ref present in single-cluster path (back-compat).
+	// Owner ref present in single-cluster path (central cluster).
 	require.Len(t, cm.OwnerReferences, 1)
 	assert.Equal(t, "mdb-search", cm.OwnerReferences[0].Name)
 }
@@ -614,11 +642,12 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
 	}
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "a", zap.S()))
+	// cluster "a" is at index 0.
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "a", 0, zap.S()))
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, cm))
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
 
 	// Cross-cluster: no owner ref (k8s GC does not span clusters).
 	assert.Empty(t, cm.OwnerReferences)
@@ -629,9 +658,10 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 func TestBuildClusterWorkList_SingleClusterDegenerate(t *testing.T) {
 	r := newMongoDBSearchEnvoyReconciler(fake.NewClientBuilder().Build(), "envoy:latest", nil)
 	search := &searchv1.MongoDBSearch{}
-	wl := r.buildClusterWorkList(search)
+	wl := r.buildClusterWorkList(search, nil)
 	require.Len(t, wl, 1)
 	assert.Equal(t, "", wl[0].ClusterName)
+	assert.Equal(t, 0, wl[0].ClusterIndex)
 }
 
 func TestBuildClusterWorkList_EmptySpecClusters_TreatedAsSingle(t *testing.T) {
@@ -640,9 +670,10 @@ func TestBuildClusterWorkList_EmptySpecClusters_TreatedAsSingle(t *testing.T) {
 		"a": fake.NewClientBuilder().Build(),
 	})
 	search := &searchv1.MongoDBSearch{}
-	wl := r.buildClusterWorkList(search)
+	wl := r.buildClusterWorkList(search, nil)
 	require.Len(t, wl, 1)
 	assert.Equal(t, "", wl[0].ClusterName)
+	assert.Equal(t, 0, wl[0].ClusterIndex)
 }
 
 func TestBuildClusterWorkList_MultiCluster_OneItemPerSpecEntry(t *testing.T) {
@@ -659,10 +690,30 @@ func TestBuildClusterWorkList_MultiCluster_OneItemPerSpecEntry(t *testing.T) {
 			},
 		},
 	}
-	wl := r.buildClusterWorkList(search)
+	mapping := map[string]int{"a": 0, "b": 1}
+	wl := r.buildClusterWorkList(search, mapping)
 	require.Len(t, wl, 2)
 	assert.Equal(t, "a", wl[0].ClusterName)
+	assert.Equal(t, 0, wl[0].ClusterIndex)
 	assert.Equal(t, "b", wl[1].ClusterName)
+	assert.Equal(t, 1, wl[1].ClusterIndex)
+}
+
+func TestBuildClusterWorkList_MissingFromMapping_SentinelIndex(t *testing.T) {
+	central := fake.NewClientBuilder().Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{
+		"a": fake.NewClientBuilder().Build(),
+	})
+	search := &searchv1.MongoDBSearch{
+		Spec: searchv1.MongoDBSearchSpec{
+			Clusters: &[]searchv1.ClusterSpec{{ClusterName: "a"}},
+		},
+	}
+	// Empty mapping simulates first reconcile before main controller writes state.
+	wl := r.buildClusterWorkList(search, map[string]int{})
+	require.Len(t, wl, 1)
+	assert.Equal(t, "a", wl[0].ClusterName)
+	assert.Equal(t, -1, wl[0].ClusterIndex, "missing cluster must use sentinel -1")
 }
 
 // TestWorstOfClusterPhases regresses the canonical invariant declared on
@@ -731,7 +782,7 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 			Clusters: &[]searchv1.ClusterSpec{{ClusterName: "missing-cluster"}},
 		},
 	}
-	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, "missing-cluster", zap.S())
+	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, "missing-cluster", 0, zap.S())
 	assert.Equal(t, status.PhasePending, st.Phase())
 	assert.Contains(t, searchcontroller.MessageFromStatus(st), "missing-cluster")
 }
@@ -785,19 +836,20 @@ func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 		},
 	}
 
-	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, "a", zap.S())
+	// cluster "a" is at index 0 in the mapping.
+	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, "a", 0, zap.S())
 	require.True(t, st.IsOK(), "expected OK, got %s: %s", st.Phase(), searchcontroller.MessageFromStatus(st))
 
 	// Member cluster has Deployment + ConfigMap; central does not.
 	dep := &appsv1.Deployment{}
 	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster("a"), Namespace: "ns"}, dep))
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, dep))
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, cm))
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
 
 	err := central.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster("a"), Namespace: "ns"}, &appsv1.Deployment{})
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, &appsv1.Deployment{})
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
@@ -815,11 +867,12 @@ func TestEnsureDeployment_Replicas_DefaultsTo1(t *testing.T) {
 			Clusters:     &[]searchv1.ClusterSpec{{ClusterName: "a"}},
 		},
 	}
-	require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, "a", nil, zap.S()))
+	// cluster "a" is at index 0.
+	require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, "a", 0, nil, zap.S()))
 
 	dep := &appsv1.Deployment{}
 	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster("a"), Namespace: "ns"}, dep))
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, dep))
 	require.NotNil(t, dep.Spec.Replicas)
 	assert.Equal(t, int32(1), *dep.Spec.Replicas, "envoy replicas must default to 1 when unset")
 }
@@ -832,6 +885,7 @@ func TestEnsureDeployment_Replicas_DefaultsTo1(t *testing.T) {
 // must hold one entry per cluster, and the aggregated top-level Phase must be
 // the worst-of (Pending here).
 func TestReconcile_PerClusterStatus_Aggregated(t *testing.T) {
+	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
 
@@ -860,9 +914,12 @@ func TestReconcile_PerClusterStatus_Aggregated(t *testing.T) {
 	}
 
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	// Seed state CM so the Envoy controller can resolve indices: "a"→0, "missing"→1.
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"a": 0, "missing": 1})
+
 	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA})
 
-	res, err := r.Reconcile(context.Background(), reconcile.Request{
+	res, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"},
 	})
 	require.NoError(t, err)
@@ -870,7 +927,7 @@ func TestReconcile_PerClusterStatus_Aggregated(t *testing.T) {
 
 	// Re-fetch to see the patched status.
 	patched := &searchv1.MongoDBSearch{}
-	require.NoError(t, central.Get(context.Background(),
+	require.NoError(t, central.Get(ctx,
 		types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
 	require.NotNil(t, patched.Status.LoadBalancer, "status.loadBalancer must be populated")
 	assert.Equal(t, status.PhasePending, patched.Status.LoadBalancer.Phase, "worst-of (Running, Pending) is Pending")
@@ -883,11 +940,11 @@ func TestReconcile_PerClusterStatus_Aggregated(t *testing.T) {
 	assert.Equal(t, status.PhaseRunning, byName["a"].Phase)
 	assert.Equal(t, status.PhasePending, byName["missing"].Phase)
 
-	// And cluster "a" actually got its Deployment + ConfigMap in the member-cluster client.
-	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster("a"), Namespace: "ns"}, &appsv1.Deployment{}))
-	require.NoError(t, memberA.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster("a"), Namespace: "ns"}, &corev1.ConfigMap{}))
+	// Cluster "a" (index 0) got its Deployment + ConfigMap in the member-cluster client.
+	require.NoError(t, memberA.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, &appsv1.Deployment{}))
+	require.NoError(t, memberA.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, &corev1.ConfigMap{}))
 }
 
 // TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed asserts that when a
@@ -895,6 +952,7 @@ func TestReconcile_PerClusterStatus_Aggregated(t *testing.T) {
 // phase patched onto status.loadBalancer is Failed (not Pending). Without
 // this guard, all errors would be downgraded to Pending in the final write.
 func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
+	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
 	search := &searchv1.MongoDBSearch{
@@ -914,18 +972,21 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 		},
 	}
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	// Seed state CM so the Envoy controller can resolve "a"→0.
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"a": 0})
+
 	// Member client is a fake that fails every write — drives Failed.
 	memberA := failingWriteClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
 
 	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA})
 
-	_, err := r.Reconcile(context.Background(), reconcile.Request{
+	_, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"},
 	})
 	require.NoError(t, err)
 
 	patched := &searchv1.MongoDBSearch{}
-	require.NoError(t, central.Get(context.Background(),
+	require.NoError(t, central.Get(ctx,
 		types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
 	require.NotNil(t, patched.Status.LoadBalancer)
 	assert.Equal(t, status.PhaseFailed, patched.Status.LoadBalancer.Phase,
@@ -941,6 +1002,197 @@ func TestWorstOfClusterPhases_SingleCluster_PreservesFailed(t *testing.T) {
 	})
 	assert.Equal(t, status.PhaseFailed, got,
 		"single-cluster degenerate path (one entry with empty ClusterName) must propagate Failed, not downgrade to Running")
+}
+
+// --- index-based naming reconcile loop tests ----------------------------------
+
+// TestReconcile_NoStateCM_ClustersPending asserts that when no <name>-state
+// ConfigMap exists (first reconcile before main controller runs), every
+// per-cluster status is Pending and no Envoy resources are created.
+func TestReconcile_NoStateCM_ClustersPending(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+					HostAndPorts: []string{"mongo-0:27017"},
+				},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{
+					ExternalHostname: "mongot-{clusterName}.example.com",
+				},
+			},
+			Clusters: &[]searchv1.ClusterSpec{
+				{ClusterName: "cluster-a"},
+				{ClusterName: "cluster-b"},
+			},
+		},
+	}
+
+	// No state CM seeded — first reconcile race.
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"cluster-a": memberA})
+
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	require.NotNil(t, patched.Status.LoadBalancer)
+	assert.Equal(t, status.PhasePending, patched.Status.LoadBalancer.Phase, "no state CM must produce Pending")
+	for _, cs := range patched.Status.LoadBalancer.Clusters {
+		assert.Equal(t, status.PhasePending, cs.Phase, "each cluster must be Pending when not in state mapping")
+	}
+
+	// No Envoy Deployments should have been created.
+	depList := &appsv1.DeploymentList{}
+	require.NoError(t, memberA.List(ctx, depList))
+	assert.Empty(t, depList.Items, "no Envoy Deployment must be created when clusters are not yet in state mapping")
+}
+
+// TestReconcile_UsesIndicesFromStateMapping asserts that Envoy resources are
+// named with the indices stored in the state ConfigMap, not the cluster names.
+func TestReconcile_UsesIndicesFromStateMapping(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
+	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+					HostAndPorts: []string{"mongo-0:27017"},
+				},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{
+					ExternalHostname: "mongot-{clusterName}.example.com",
+				},
+			},
+			Clusters: &[]searchv1.ClusterSpec{
+				{ClusterName: "cluster-a"},
+				{ClusterName: "cluster-b"},
+			},
+		},
+	}
+
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	// Seed non-trivial indices: cluster-a→5, cluster-b→7.
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"cluster-a": 5, "cluster-b": 7})
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{
+		"cluster-a": memberA,
+		"cluster-b": memberB,
+	})
+
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	// cluster-a (index 5) — resources must use index 5.
+	require.NoError(t, memberA.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(5), Namespace: "ns"}, &appsv1.Deployment{}),
+		"Envoy Deployment for cluster-a must use index 5")
+	require.NoError(t, memberA.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(5), Namespace: "ns"}, &corev1.ConfigMap{}),
+		"Envoy ConfigMap for cluster-a must use index 5")
+
+	// cluster-b (index 7) — resources must use index 7.
+	require.NoError(t, memberB.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(7), Namespace: "ns"}, &appsv1.Deployment{}),
+		"Envoy Deployment for cluster-b must use index 7")
+	require.NoError(t, memberB.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(7), Namespace: "ns"}, &corev1.ConfigMap{}),
+		"Envoy ConfigMap for cluster-b must use index 7")
+
+	// Cluster names must not appear in any resource name.
+	for _, name := range []string{
+		search.LoadBalancerDeploymentNameForCluster(5),
+		search.LoadBalancerDeploymentNameForCluster(7),
+		search.LoadBalancerConfigMapNameForCluster(5),
+		search.LoadBalancerConfigMapNameForCluster(7),
+	} {
+		assert.NotContains(t, name, "cluster-a", "resource names must not encode cluster names")
+		assert.NotContains(t, name, "cluster-b", "resource names must not encode cluster names")
+	}
+}
+
+// TestReconcile_StableIndexAcrossClusterRemovals asserts that removing a
+// cluster from spec.clusters does not shift the indices of remaining clusters.
+// "b" at index 1 must still be index 1 after "a" is removed.
+func TestReconcile_StableIndexAcrossClusterRemovals(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mkSearch := func(clusterNames ...string) *searchv1.MongoDBSearch {
+		clusters := make([]searchv1.ClusterSpec, 0, len(clusterNames))
+		for _, n := range clusterNames {
+			clusters = append(clusters, searchv1.ClusterSpec{ClusterName: n})
+		}
+		return &searchv1.MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+			Spec: searchv1.MongoDBSearchSpec{
+				Source: &searchv1.MongoDBSource{
+					ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+						HostAndPorts: []string{"mongo-0:27017"},
+					},
+				},
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{
+						ExternalHostname: "mongot-{clusterName}.example.com",
+					},
+				},
+				Clusters: &clusters,
+			},
+		}
+	}
+
+	// Start with both clusters; "a"→0, "b"→1.
+	search := mkSearch("a", "b")
+	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"a": 0, "b": 1})
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{
+		"a": memberA,
+		"b": memberB,
+	})
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	// First reconcile: "b" Deployment is at index 1.
+	require.NoError(t, memberB.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}, &appsv1.Deployment{}),
+		"b Deployment must be at index 1 on first reconcile")
+
+	// Remove "a" from spec.clusters; state CM still holds "a"→0, "b"→1.
+	latest := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, latest))
+	updated := mkSearch("b")
+	updated.ResourceVersion = latest.ResourceVersion
+	updated.UID = latest.UID
+	require.NoError(t, central.Update(ctx, updated))
+
+	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	// "b" must still use index 1 — index must not shift to 0 after "a" is removed.
+	require.NoError(t, memberB.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}, &appsv1.Deployment{}),
+		"b Deployment must retain index 1 after a is removed from spec.clusters")
 }
 
 // failingWriteClient wraps a client.Client and rejects every write so we can

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/automationconfig"
-	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/annotations"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/pkg/kube/podtemplatespec"
@@ -293,10 +292,6 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 		return workflow.Invalid("%s", err.Error())
 	}
 
-	if err := r.ensureClusterIndexAnnotation(ctx, log); err != nil {
-		return workflow.Failed(err)
-	}
-
 	if err := r.db.Validate(); err != nil {
 		return workflow.Failed(err)
 	}
@@ -433,50 +428,6 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 	return workflow.OK().WithAdditionalOptions(searchv1.NewMongoDBSearchVersionOption(imageVersion))
 }
 
-// ensureClusterIndexAnnotation persists the MongoDBSearch CR's clusterName -> clusterIndex
-// mapping into the LastClusterNumMapping annotation. It preserves every previously-assigned
-// index and appends new clusters monotonically (see search.AssignClusterIndices); a removed
-// cluster's index is never reused. The annotation is the single source of truth for the
-// ClusterIndex read API used by placeholder resolution and SNI route ordering.
-//
-// No-ops when spec.clusters is nil or empty (single-cluster path) and when the new mapping
-// matches the current annotation byte-for-byte.
-func (r *MongoDBSearchReconcileHelper) ensureClusterIndexAnnotation(ctx context.Context, log *zap.SugaredLogger) error {
-	if r.mdbSearch.Spec.Clusters == nil || len(*r.mdbSearch.Spec.Clusters) == 0 {
-		return nil
-	}
-
-	currentNames := make([]string, 0, len(*r.mdbSearch.Spec.Clusters))
-	for _, c := range *r.mdbSearch.Spec.Clusters {
-		currentNames = append(currentNames, c.ClusterName)
-	}
-
-	rawExisting := r.mdbSearch.Annotations[searchv1.LastClusterNumMapping]
-	existing := map[string]int{}
-	if rawExisting != "" {
-		if err := json.Unmarshal([]byte(rawExisting), &existing); err != nil {
-			// Malformed annotation is recoverable — start from scratch and let
-			// AssignClusterIndices rebuild a sane mapping. Log because this should
-			// never happen except via direct hand-edit.
-			log.Warnf("LastClusterNumMapping annotation is malformed (%v); rebuilding from spec.clusters", err)
-			existing = map[string]int{}
-		}
-	}
-
-	newMapping := searchv1.AssignClusterIndices(existing, currentNames)
-	newBytes, err := json.Marshal(newMapping)
-	if err != nil {
-		return xerrors.Errorf("marshalling cluster index mapping: %w", err)
-	}
-
-	if rawExisting == string(newBytes) {
-		return nil
-	}
-
-	return annotations.SetAnnotations(ctx, r.mdbSearch, map[string]string{
-		searchv1.LastClusterNumMapping: string(newBytes),
-	}, r.client)
-}
 
 // isOwnedBy returns true if the object has an owner reference pointing to the given owner.
 // Unlike metav1.IsControlledBy, this does not require the controller: true field,

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -787,7 +787,7 @@ func buildHeadlessService(search *searchv1.MongoDBSearch, unit reconcileUnit) co
 func buildProxyService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev1.Service {
 	var selector map[string]string
 	if search.IsLBModeManaged() && search.IsLoadBalancerReady() {
-		selector = map[string]string{appLabelKey: search.LoadBalancerDeploymentName()}
+		selector = map[string]string{appLabelKey: search.LoadBalancerDeploymentNameForCluster(0)}
 	} else {
 		selector = map[string]string{appLabelKey: unit.podLabels[appLabelKey]}
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -2,7 +2,6 @@ package searchcontroller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -2530,102 +2528,3 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Contains(t, cm.Data, MongotConfigFilename)
 }
 
-func TestEnsureClusterIndexAnnotation(t *testing.T) {
-	ctx := context.Background()
-
-	buildHelper := func(t *testing.T, search *searchv1.MongoDBSearch) (*MongoDBSearchReconcileHelper, kubernetesClient.Client) {
-		t.Helper()
-		c := newTestFakeClient(search)
-		h := &MongoDBSearchReconcileHelper{
-			client:    c,
-			mdbSearch: search,
-		}
-		return h, c
-	}
-
-	readMapping := func(t *testing.T, c kubernetesClient.Client, name, namespace string) map[string]int {
-		t.Helper()
-		got := &searchv1.MongoDBSearch{}
-		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, got))
-		val, ok := got.Annotations[searchv1.LastClusterNumMapping]
-		if !ok {
-			return nil
-		}
-		out := map[string]int{}
-		require.NoError(t, json.Unmarshal([]byte(val), &out))
-		return out
-	}
-
-	withClusters := func(names ...string) func(*searchv1.MongoDBSearch) {
-		return func(s *searchv1.MongoDBSearch) {
-			entries := make([]searchv1.ClusterSpec, 0, len(names))
-			for _, n := range names {
-				entries = append(entries, searchv1.ClusterSpec{ClusterName: n})
-			}
-			s.Spec.Clusters = &entries
-		}
-	}
-
-	t.Run("nil clusters: no annotation written", func(t *testing.T) {
-		search := newTestMongoDBSearch("s1", "ns")
-		h, c := buildHelper(t, search)
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		assert.Nil(t, readMapping(t, c, "s1", "ns"))
-	})
-
-	t.Run("empty clusters: no annotation written", func(t *testing.T) {
-		empty := []searchv1.ClusterSpec{}
-		search := newTestMongoDBSearch("s2", "ns", func(s *searchv1.MongoDBSearch) { s.Spec.Clusters = &empty })
-		h, c := buildHelper(t, search)
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		assert.Nil(t, readMapping(t, c, "s2", "ns"))
-	})
-
-	t.Run("first reconcile writes mapping", func(t *testing.T) {
-		search := newTestMongoDBSearch("s3", "ns", withClusters("us-east", "us-west"))
-		h, c := buildHelper(t, search)
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, readMapping(t, c, "s3", "ns"))
-	})
-
-	t.Run("second reconcile is a no-op", func(t *testing.T) {
-		search := newTestMongoDBSearch("s4", "ns", withClusters("us-east", "us-west"))
-		h, c := buildHelper(t, search)
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		before := &searchv1.MongoDBSearch{}
-		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "s4", Namespace: "ns"}, before))
-		rvBefore := before.GetResourceVersion()
-
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		after := &searchv1.MongoDBSearch{}
-		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "s4", Namespace: "ns"}, after))
-		assert.Equal(t, rvBefore, after.GetResourceVersion(), "no-op reconcile must not bump resourceVersion")
-	})
-
-	t.Run("adding a cluster extends the mapping monotonically", func(t *testing.T) {
-		search := newTestMongoDBSearch("s5", "ns", withClusters("us-east", "us-west"))
-		h, c := buildHelper(t, search)
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-
-		extended := []searchv1.ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}, {ClusterName: "eu-central"}}
-		search.Spec.Clusters = &extended
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1, "eu-central": 2}, readMapping(t, c, "s5", "ns"))
-	})
-
-	t.Run("removing then re-adding a cluster keeps the original index", func(t *testing.T) {
-		search := newTestMongoDBSearch("s6", "ns", withClusters("us-east", "us-west"))
-		h, c := buildHelper(t, search)
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-
-		shrunk := []searchv1.ClusterSpec{{ClusterName: "us-east"}}
-		search.Spec.Clusters = &shrunk
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, readMapping(t, c, "s6", "ns"), "removed cluster must remain in mapping")
-
-		regrown := []searchv1.ClusterSpec{{ClusterName: "us-east"}, {ClusterName: "us-west"}}
-		search.Spec.Clusters = &regrown
-		require.NoError(t, h.ensureClusterIndexAnnotation(ctx, zap.S()))
-		assert.Equal(t, map[string]int{"us-east": 0, "us-west": 1}, readMapping(t, c, "s6", "ns"), "re-added cluster keeps original idx")
-	})
-}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -347,8 +347,9 @@ func TestBuildProxyService_ManagedLB_Ready(t *testing.T) {
 	unit := newTestRSUnit(search)
 	svc := buildProxyService(search, unit)
 
-	// Selector flips to Envoy pods when LB is ready
-	assert.Equal(t, map[string]string{"app": "test-search-lb-0"}, svc.Spec.Selector)
+	// Selector flips to Envoy pods when LB is ready; must match the index-0 Deployment label
+	// so that traffic is not black-holed after the Commit-2 app-label rename.
+	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(0), svc.Spec.Selector["app"])
 	assert.Equal(t, int32(27028), svc.Spec.Ports[0].TargetPort.IntVal)
 }
 
@@ -379,7 +380,7 @@ func TestBuildProxyServiceForShard_ManagedLB_Ready(t *testing.T) {
 	unit := newTestShardUnit(search, "shard-0")
 	svc := buildProxyService(search, unit)
 
-	assert.Equal(t, map[string]string{"app": "test-search-lb-0"}, svc.Spec.Selector)
+	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(0), svc.Spec.Selector["app"])
 }
 
 func assertServiceBasicProperties(t *testing.T, svc corev1.Service, mdbSearch *searchv1.MongoDBSearch) {

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -115,14 +115,22 @@ def shard_proxy_service_host(search_name: str, shard_name: str, namespace: str, 
 # ============================================================================
 
 
-def lb_deployment_name(search_name: str) -> str:
-    """Managed LB Deployment name. Mirrors LoadBalancerDeploymentName()."""
-    return f"{search_name}-search-lb-0"
+def lb_deployment_name(search_name: str, cluster_index: int = 0) -> str:
+    """Managed LB Deployment name. Mirrors LoadBalancerDeploymentNameForCluster().
+
+    cluster_index defaults to 0 for single-cluster callers; pass the cluster
+    position explicitly for multi-cluster tests.
+    """
+    return f"{search_name}-search-lb-0-{cluster_index}"
 
 
-def lb_configmap_name(search_name: str) -> str:
-    """Managed LB ConfigMap name. Mirrors LoadBalancerConfigMapName()."""
-    return f"{search_name}-search-lb-0-config"
+def lb_configmap_name(search_name: str, cluster_index: int = 0) -> str:
+    """Managed LB ConfigMap name. Mirrors LoadBalancerConfigMapNameForCluster().
+
+    cluster_index defaults to 0 for single-cluster callers; pass the cluster
+    position explicitly for multi-cluster tests.
+    """
+    return f"{search_name}-search-lb-0-{cluster_index}-config"
 
 
 def lb_server_cert_name(search_name: str, certs_secret_prefix: str = "") -> str:


### PR DESCRIPTION
## Summary

Two focused fixes on top of `search/ga-base`:

### 1. Replace cluster-index annotation with `StateStore[SearchDeploymentState]` (`9f8bf66`)
The `clusterName -> clusterIndex` mapping for `MongoDBSearch` was persisted in the `mongodb.com/v1.lastClusterNumMapping` annotation on the CR. Annotations conflate user intent with operator bookkeeping and are visible/strippable. Switch to a per-CR `<name>-state` ConfigMap managed via `StateStore[SearchDeploymentState]`, matching the pattern used by `ShardedClusterDeploymentState` and `AppDBDeploymentState`.

The reconciler runs `AssignClusterIndices` against current `spec.clusters` and writes the merged mapping back via `stateStore.WriteState` before the helper runs. Steady-state reconciles are no-ops (`reflect.DeepEqual` guard).

`validateClustersNoRename` is dropped — it relied on reading the annotation at admission time, the StateStore is not visible there, and the index machinery already handles remove+add safely.

### 2. Envoy resource names use `clusterIndex`, not `clusterName` (`3551187`)
`clusterName` is a user-supplied Kubernetes cluster identifier that can be long (e.g. `gke-us-east1-prod-main`) and routinely overruns the 63-char DNS label limit when appended to the LB name base. Switch the per-cluster Envoy `Deployment` and `ConfigMap` to the stable cluster index from the StateStore mapping:

- `LoadBalancerDeploymentNameForCluster(int)` -> `<name>-search-lb-0-<i>`
- `LoadBalancerConfigMapNameForCluster(int)` -> `<name>-search-lb-0-<i>-config`

Single-cluster installs use index `0` uniformly. The empty-string back-compat branch is dropped (pre-GA).

The Envoy controller reads `state.ClusterMapping` via `loadOrInitSearchState` (read-only); clusters not yet registered in the mapping surface a per-cluster `Pending` and skip `reconcileForCluster` until the main controller writes the state CM.

Adjacent fix: `buildProxyService` selector now references the suffixed Envoy Deployment name (`LoadBalancerDeploymentNameForCluster(0)`) — the legacy unsuffixed name no longer matches the Envoy pods' `app` label, so leaving the selector unchanged would have broken the managed-LB Ready flip.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./api/... ./controllers/... ./pkg/...` (47 packages) — all pass
- [x] Full reconcile-loop unit tests exercise the state CM behaviour: initial create, no-op on stable mapping, operator-restart with pre-seeded CM, monotonic extension on cluster add, and index preservation on remove + re-add
- [x] Three Envoy reconcile-loop tests exercise: (1) no state CM -> per-cluster Pending, (2) reconcile uses indices from the seeded mapping verbatim, (3) stable index across cluster removals
- [x] Local kind smoke (`tests/search/search_replicaset_external_mongodb_proxy_service.py`): 12 passed, 1 skipped, 1 failed (the failure is a known local-dev DNS limitation — pymongo connecting to in-cluster DNS from the host process — not a code regression). Envoy index-suffixed naming verified end-to-end.
- [x] Evergreen patch [69fa0f2e](https://evergreen.mongodb.com/version/69fa0f2e8e31db0007047e4d) — all 32 tasks succeeded across 6 managed-LB e2e tasks x 5 variants

## Follow-ups

- [ ] Refactor the four `StateConfigMap` reconcile-loop tests (`TestMongoDBSearchControllerReconcile_StateConfigMap{,_NoOpOnStableMapping,_OperatorRestart,_ReAddCluster}`) into a single table-driven test (per @anandsyncs review). Tracked with a `// TODO(@anandsyncs PR #1064)` marker in `mongodbsearch_controller_test.go`.
- [ ] Add multi-cluster search e2e tests covering: state CM GC on CR deletion (owner ref), operator pod restart preserves mapping, monotonic-index invariant under random add/remove. The python helpers in `docker/mongodb-kubernetes-tests/tests/common/multicluster_search/` are already in place; the test files are not yet written.