### PR TITLE
feat: make keyfile path track downloadBase in automation config

### DIFF
--- a/api/v1/mdb/mongodb_types.go
+++ b/api/v1/mdb/mongodb_types.go
@@ -1013,6 +1013,13 @@ type Authentication struct {
 	RequiresClientTLSAuthentication bool `json:"requireClientTLSAuthentication,omitempty"`
 }
 
+// GetKeyfile returns the keyfile path derived from downloadBase, matching how
+// Ops Manager builds the path so that changing spec.downloadBase moves the
+// keyfile with it.
+func (a *Authentication) GetKeyfile(downloadBase string) string {
+	return downloadBase + "/keyfile"
+}
+
 // +kubebuilder:validation:Enum=X509;SCRAM;SCRAM-SHA-1;MONGODB-CR;SCRAM-SHA-256;LDAP;OIDC
 type AuthMode string
 

--- a/api/v1/mdb/mongodb_types_test.go
+++ b/api/v1/mdb/mongodb_types_test.go
@@ -448,6 +448,73 @@ func TestGetTransportSecurity(t *testing.T) {
 	}
 }
 
+func TestGetDownloadBase(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     DbCommonSpec
+		expected string
+	}{
+		{
+			name:     "unset falls back to default mount path",
+			spec:     DbCommonSpec{},
+			expected: util.DefaultPvcMmsMountPath,
+		},
+		{
+			name:     "explicit value is returned as-is",
+			spec:     DbCommonSpec{DownloadBase: "/var/lib/mongodb-mms-automation-custom"},
+			expected: "/var/lib/mongodb-mms-automation-custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.spec.GetDownloadBase())
+		})
+	}
+}
+
+func TestAuthentication_GetKeyfile(t *testing.T) {
+	const customDownloadBase = "/var/lib/mongodb-mms-automation-custom"
+
+	tests := []struct {
+		name         string
+		auth         *Authentication
+		downloadBase string
+		expected     string
+	}{
+		{
+			name:         "nil receiver returns <downloadBase>/keyfile",
+			auth:         nil,
+			downloadBase: customDownloadBase,
+			expected:     customDownloadBase + "/keyfile",
+		},
+		{
+			name:         "returns <downloadBase>/keyfile",
+			auth:         &Authentication{},
+			downloadBase: customDownloadBase,
+			expected:     customDownloadBase + "/keyfile",
+		},
+		{
+			name:         "default downloadBase produces historical path",
+			auth:         &Authentication{},
+			downloadBase: util.DefaultPvcMmsMountPath,
+			expected:     util.AutomationAgentKeyFilePathInContainer,
+		},
+		{
+			name:         "brand new custom downloadBase on top of existing custom one uses the new path",
+			auth:         &Authentication{},
+			downloadBase: "/var/lib/mongodb-mms-automation-new-custom",
+			expected:     "/var/lib/mongodb-mms-automation-new-custom/keyfile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.auth.GetKeyfile(tt.downloadBase))
+		})
+	}
+}
+
 func TestAdditionalMongodConfigMarshalJSON(t *testing.T) {
 	mdb := MongoDB{Spec: MongoDbSpec{DbCommonSpec: DbCommonSpec{Version: "4.2.1"}}}
 	mdb.InitDefaults()

--- a/controllers/om/deployment.go
+++ b/controllers/om/deployment.go
@@ -659,18 +659,8 @@ func (d Deployment) Debug(l *zap.SugaredLogger) {
 	l.Debugf(">> Deployment: \n %s \n", string(b))
 }
 
-func (d Deployment) GetDownloadBase() string {
-	if opts, ok := d["options"].(map[string]interface{}); ok {
-		if v, ok := opts["downloadBase"].(string); ok {
-			return v
-		}
-	}
-	return ""
-}
-
 func (d Deployment) SetDownloadBase(downloadBase string) {
-	opts := util.ReadOrCreateMap(d, "options")
-	opts["downloadBase"] = downloadBase
+	d["options"] = map[string]string{"downloadBase": downloadBase}
 }
 
 // ProcessesCopy returns the COPY of processes in the deployment.

--- a/controllers/operator/authentication/configure_authentication_test.go
+++ b/controllers/operator/authentication/configure_authentication_test.go
@@ -32,6 +32,7 @@ func TestConfigureScramSha256(t *testing.T) {
 		ProcessNames:     []string{"process-1", "process-2", "process-3"},
 		Mechanisms:       []string{"SCRAM"},
 		AgentMechanism:   "SCRAM",
+		KeyfilePath:      util.AutomationAgentKeyFilePathInContainer,
 		MongoDBResource:  mongoDBResource,
 	}
 
@@ -62,6 +63,7 @@ func TestConfigureX509(t *testing.T) {
 		Mechanisms:         []string{"X509"},
 		AgentMechanism:     "X509",
 		ClientCertificates: util.RequireClientCertificates,
+		KeyfilePath:        util.AutomationAgentKeyFilePathInContainer,
 		UserOptions: UserOptions{
 			AutomationSubject: validSubject("automation"),
 		},
@@ -94,6 +96,7 @@ func TestConfigureScramSha1(t *testing.T) {
 		ProcessNames:     []string{"process-1", "process-2", "process-3"},
 		Mechanisms:       []string{"SCRAM-SHA-1"},
 		AgentMechanism:   "SCRAM-SHA-1",
+		KeyfilePath:      util.AutomationAgentKeyFilePathInContainer,
 		MongoDBResource:  mongoDBResource,
 	}
 
@@ -121,6 +124,7 @@ func TestConfigureMultipleAuthenticationMechanisms(t *testing.T) {
 		ProcessNames:     []string{"process-1", "process-2", "process-3"},
 		Mechanisms:       []string{"X509", "SCRAM"},
 		AgentMechanism:   "SCRAM",
+		KeyfilePath:      util.AutomationAgentKeyFilePathInContainer,
 		UserOptions: UserOptions{
 			AutomationSubject: validSubject("automation"),
 		},
@@ -312,6 +316,9 @@ func assertAgentAuthenticationDisabled(t *testing.T, authMechanism Mechanism, co
 	kubeClient, _ := mock.NewDefaultFakeClient()
 	mongoDBResource := types.NamespacedName{Namespace: "test", Name: "test"}
 	opts.MongoDBResource = mongoDBResource
+	if opts.KeyfilePath == "" {
+		opts.KeyfilePath = util.AutomationAgentKeyFilePathInContainer
+	}
 
 	err := authMechanism.EnableAgentAuthentication(ctx, kubeClient, conn, opts, zap.S())
 	require.NoError(t, err)

--- a/controllers/operator/authentication/ldap.go
+++ b/controllers/operator/authentication/ldap.go
@@ -102,7 +102,7 @@ func (l *ldapAuthMechanism) DisableDeploymentAuthentication(conn om.Connection, 
 	}, log)
 }
 
-func (l *ldapAuthMechanism) IsAgentAuthenticationConfigured(ac *om.AutomationConfig, _ Options) bool {
+func (l *ldapAuthMechanism) IsAgentAuthenticationConfigured(ac *om.AutomationConfig, opts Options) bool {
 	if ac.Auth.Disabled {
 		return false
 	}
@@ -112,6 +112,10 @@ func (l *ldapAuthMechanism) IsAgentAuthenticationConfigured(ac *om.AutomationCon
 	}
 
 	if ac.Auth.AutoUser == "" || ac.Auth.AutoPwd == "" {
+		return false
+	}
+
+	if opts.KeyfilePath != "" && ac.Auth.KeyFile != opts.KeyfilePath {
 		return false
 	}
 

--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -71,7 +71,7 @@ func (s *automationConfigScramSha) EnableDeploymentAuthentication(conn om.Connec
 	}, log)
 }
 
-func (s *automationConfigScramSha) IsAgentAuthenticationConfigured(ac *om.AutomationConfig, _ Options) bool {
+func (s *automationConfigScramSha) IsAgentAuthenticationConfigured(ac *om.AutomationConfig, opts Options) bool {
 	if ac.Auth.Disabled {
 		return false
 	}
@@ -85,6 +85,10 @@ func (s *automationConfigScramSha) IsAgentAuthenticationConfigured(ac *om.Automa
 	}
 
 	if ac.Auth.Key == "" || ac.Auth.KeyFile == "" || ac.Auth.KeyFileWindows == "" {
+		return false
+	}
+
+	if opts.KeyfilePath != "" && ac.Auth.KeyFile != opts.KeyfilePath {
 		return false
 	}
 

--- a/controllers/operator/authentication/scramsha_test.go
+++ b/controllers/operator/authentication/scramsha_test.go
@@ -48,6 +48,7 @@ func TestAgentsAuthentication(t *testing.T) {
 			opts := Options{
 				AuthoritativeSet: true,
 				CAFilePath:       util.CAFilePathInContainer,
+				KeyfilePath:      util.AutomationAgentKeyFilePathInContainer,
 				MongoDBResource:  mongoDBResource,
 			}
 

--- a/controllers/operator/authentication/x509.go
+++ b/controllers/operator/authentication/x509.go
@@ -135,6 +135,10 @@ func (x *connectionX509) IsAgentAuthenticationConfigured(ac *om.AutomationConfig
 		return false
 	}
 
+	if opts.KeyfilePath != "" && ac.Auth.KeyFile != opts.KeyfilePath {
+		return false
+	}
+
 	if ac.AgentSSL != nil && ac.AgentSSL.AutoPEMKeyFilePath != opts.AutoPEMKeyFilePath {
 		return false
 	}

--- a/controllers/operator/authentication/x509_test.go
+++ b/controllers/operator/authentication/x509_test.go
@@ -27,6 +27,7 @@ func TestX509EnableAgentAuthentication(t *testing.T) {
 	options := Options{
 		AgentMechanism:     "X509",
 		ClientCertificates: util.RequireClientCertificates,
+		KeyfilePath:        util.AutomationAgentKeyFilePathInContainer,
 		UserOptions: UserOptions{
 			AutomationSubject: validSubject("automation"),
 		},
@@ -59,6 +60,7 @@ func TestX509_DisableAgentAuthentication(t *testing.T) {
 	conn := om.NewMockedOmConnection(om.NewDeployment())
 
 	opts := Options{
+		KeyfilePath: util.AutomationAgentKeyFilePathInContainer,
 		UserOptions: UserOptions{
 			AutomationSubject: validSubject("automation"),
 		},

--- a/controllers/operator/authentication_test.go
+++ b/controllers/operator/authentication_test.go
@@ -91,7 +91,7 @@ func TestUpdateOmAuthentication_NoAuthenticationEnabled(t *testing.T) {
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
-	r.updateOmAuthentication(ctx, conn, processNames, rs, "", "", "", "", false, zap.S())
+	r.updateOmAuthentication(ctx, conn, processNames, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 
 	ac, _ := conn.ReadAutomationConfig()
 
@@ -112,7 +112,7 @@ func TestUpdateOmAuthentication_EnableX509_TlsNotEnabled(t *testing.T) {
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, conn, []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, conn, []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 
 	assert.True(t, status.IsOK(), "configuring both options at once should not result in a failed status")
 	assert.True(t, isMultiStageReconciliation, "configuring both tls and x509 at once should result in a multi stage reconciliation")
@@ -124,7 +124,7 @@ func TestUpdateOmAuthentication_EnableX509_WithTlsAlreadyEnabled(t *testing.T) {
 	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)))
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 
 	assert.True(t, status.IsOK(), "configuring x509 when tls has already been enabled should not result in a failed status")
 	assert.False(t, isMultiStageReconciliation, "if tls is already enabled, we should be able to configure x509 is a single reconciliation")
@@ -140,7 +140,7 @@ func TestUpdateOmAuthentication_AuthenticationIsNotConfigured_IfAuthIsNotSet(t *
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
 	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", omConnectionFactory.GetConnectionFunc)
 
-	status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", "", false, zap.S())
+	status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 	assert.True(t, status.IsOK(), "no authentication should have been configured")
 
 	ac, _ := omConnectionFactory.GetConnection().ReadAutomationConfig()
@@ -212,7 +212,7 @@ func TestUpdateOmAuthentication_EnableX509_FromEmptyDeployment(t *testing.T) {
 	secretName := util.AgentSecretName
 	createAgentCSRs(t, ctx, r.client, secretName, certsv1.CertificateApproved)
 
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", util.DefaultPvcMmsMountPath, false, zap.S())
 	assert.True(t, status.IsOK(), "configuring x509 and tls when there are no processes should not result in a failed status")
 	assert.False(t, isMultiStageReconciliation, "if we are enabling tls and x509 at once, this should be done in a single reconciliation")
 }

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -562,7 +562,7 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 		CAFilePath:         caFilepath,
 		MongoDBResource:    types.NamespacedName{Namespace: ar.GetNamespace(), Name: ar.GetName()},
 		DownloadBase:       downloadBase,
-		KeyfilePath:        util.AutomationAgentKeyFilePathInContainer,
+		KeyfilePath:        ar.GetSecurity().Authentication.GetKeyfile(downloadBase),
 	}
 	var databaseSecretPath string
 	if r.VaultClient != nil {
@@ -1007,7 +1007,6 @@ func publishAutomationConfigFirst(ctx context.Context, getter kubernetesClient.C
 	currentSts, err := getter.GetStatefulSet(ctx, namespacedName)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
-			// No need to publish state as this is a new StatefulSet
 			log.Debugf("New StatefulSet %s", namespacedName)
 			return false
 		}
@@ -1105,8 +1104,8 @@ func ReconcileReplicaSetAC(ctx context.Context, d om.Deployment, spec mdbv1.DbCo
 		_ = UpdatePrometheus(ctx, &d, pc.conn, pc.prometheus, pc.secretsClient, pc.namespace, pc.prometheusCertHash, log)
 	}
 
-	if newBase := spec.GetDownloadBase(); newBase != d.GetDownloadBase() {
-		d.SetDownloadBase(newBase)
+	if db := spec.GetDownloadBase(); db != util.DefaultPvcMmsMountPath {
+		d.SetDownloadBase(db)
 	}
 
 	return nil

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -2044,8 +2044,8 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 
 			_ = UpdatePrometheus(ctx, &d, conn, sc.GetPrometheus(), r.commonController.SecretClient, sc.GetNamespace(), opts.prometheusCertHash, log)
 
-			if newBase := sc.Spec.GetDownloadBase(); newBase != d.GetDownloadBase() {
-				d.SetDownloadBase(newBase)
+			if db := sc.Spec.GetDownloadBase(); db != util.DefaultPvcMmsMountPath {
+				d.SetDownloadBase(db)
 			}
 
 			finalProcesses = d.GetProcessNames(om.ShardedCluster{}, sc.Name)

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_agent_flags.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_agent_flags.py
@@ -171,6 +171,25 @@ def test_custom_download_base_in_automation_config(replica_set: MongoDB):
     assert options.get("downloadBase") == custom_download_base
 
 
+@mark.e2e_replica_set_agent_flags_and_readinessProbe
+def test_enable_scram_auth(replica_set: MongoDB):
+    replica_set.load()
+    replica_set["spec"]["security"] = replica_set["spec"].get("security", {})
+    replica_set["spec"]["security"]["authentication"] = {
+        "enabled": True,
+        "modes": ["SCRAM"],
+    }
+    replica_set.update()
+    replica_set.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_replica_set_agent_flags_and_readinessProbe
+def test_custom_download_base_keyfile_in_automation_config(replica_set: MongoDB):
+    expected_keyfile = f"{custom_download_base}/keyfile"
+    auth = replica_set.get_automation_config_tester().automation_config.get("auth", {})
+    assert auth.get("keyfile") == expected_keyfile
+
+
 def assert_pod_log_types(replica_set: MongoDB, expected_log_types: Optional[set[str]]):
     for i in range(3):
         assert_log_types_in_structured_json_pod_log(

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_agent_flags.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_agent_flags.py
@@ -131,6 +131,25 @@ def test_custom_download_base_in_automation_config(sc: MongoDB):
     assert options.get("downloadBase") == custom_download_base
 
 
+@mark.e2e_sharded_cluster_agent_flags
+def test_enable_scram_auth(sc: MongoDB):
+    sc.load()
+    sc["spec"]["security"] = sc["spec"].get("security", {})
+    sc["spec"]["security"]["authentication"] = {
+        "enabled": True,
+        "modes": ["SCRAM"],
+    }
+    sc.update()
+    sc.assert_reaches_phase(Phase.Running, timeout=2500)
+
+
+@mark.e2e_sharded_cluster_agent_flags
+def test_custom_download_base_keyfile_in_automation_config(sc: MongoDB):
+    expected_keyfile = f"{custom_download_base}/keyfile"
+    auth = sc.get_automation_config_tester().automation_config.get("auth", {})
+    assert auth.get("keyfile") == expected_keyfile
+
+
 def _assert_log_types_in_pods(sc: MongoDB, expected_log_types: set[str]):
     for cluster_member_client in get_member_cluster_clients_using_cluster_mapping(sc.name, sc.namespace):
         cluster_idx = cluster_member_client.cluster_index


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1067

## Chain of upstream PRs as of 2026-06-03

* PR #800:
  `master` ← `vm-migration-feature-branch`

  * PR #837:
    `vm-migration-feature-branch` ← `vm-migration-feature-branch-downloadbase`

    * PR #1067:
      `vm-migration-feature-branch-downloadbase` ← `make-downloadbase-path-configurable-improvements`

      * **PR #1068 (THIS ONE)**:
        `make-downloadbase-path-configurable-improvements` ← `make-keyfile-path-configurable`

<!-- end git-machete generated -->

Previously the operator hardcoded the value for options.downloadBase and auth.keyfilePath.

- /var/lib/mongodb-mms-automation
- /var/lib/mongodb-mms-automation/keyfile

The hard-coded values are also the default values for non-mck deployments. It is important to note that there is a relationship between downloadBase and keyfilePath. When changing downloadBase in the UI, keyfilePath also gets updated to downloadBase + “/keyfile”. Note that this relationship does not exist when setting downloadBase via the API.

Solution:

- New optional CRD field:
    - spec.downloadBase
- Setting downloadBase also sets keyfilePath to downloadBase + “/keyfile”
- This field MUST only be used on new deployments, prefferably only for migrations. The deployemnts will not return back to running is the field is changed on a runnin deployment.

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in [CONTRIBUTING.md](http://CONTRIBUTING.md) for more details