### PR TITLE
Fixes #952: MongoDB images fail to pull from custom/private registrie…

### DIFF
--- a/mongodb-community-operator/controllers/construct/mongodbstatefulset.go
+++ b/mongodb-community-operator/controllers/construct/mongodbstatefulset.go
@@ -57,6 +57,7 @@ const (
 	agentHealthStatusFilePathValue    = "/var/log/mongodb-mms-automation/healthstatus/agent-health-status.json"
 
 	OfficialMongodbEnterpriseServerImageName = "mongodb-enterprise-server"
+	OfficialMongodbCommunityServerImageName  = "mongodb-community-server"
 
 	headlessAgentEnv           = "HEADLESS_AGENT"
 	podNamespaceEnv            = "POD_NAMESPACE"

--- a/mongodb-community-operator/controllers/replica_set_controller.go
+++ b/mongodb-community-operator/controllers/replica_set_controller.go
@@ -838,12 +838,12 @@ func getMongoDBImage(repoUrl, mongodbImage, mongodbImageType, version string) st
 		repoUrl = strings.TrimRight(repoUrl, "/")
 	}
 	mongoImageName := mongodbImage
-	for _, officialUrl := range construct.OfficialMongodbRepoUrls {
-		if repoUrl == officialUrl {
-			return fmt.Sprintf("%s/%s:%s-%s", repoUrl, mongoImageName, version, mongodbImageType)
-		}
+
+	// If the version doesn't have a hyphen, we assume it's a bare version and append the image type.
+	// This allows custom registries to mirror the official image tagging format.
+	if mongodbImageType != "" && !strings.Contains(version, "-") {
+		version = fmt.Sprintf("%s-%s", version, mongodbImageType)
 	}
 
-	// This is the old images backwards compatibility code path.
 	return fmt.Sprintf("%s/%s:%s", repoUrl, mongoImageName, version)
 }

--- a/pkg/images/Imageurls.go
+++ b/pkg/images/Imageurls.go
@@ -138,7 +138,7 @@ func GetOfficialImage(imageUrls ImageUrls, version string, annotations map[strin
 	}
 
 	assumeOldFormat := envvar.ReadBool(util.MdbAppdbAssumeOldFormat) // nolint:forbidigo
-	if IsEnterpriseImage(imageURL) && !assumeOldFormat {
+	if (IsEnterpriseImage(imageURL) || IsCommunityImage(imageURL)) && !assumeOldFormat {
 		// 5.0.6-ent -> 5.0.6-ubi8
 		if strings.HasSuffix(version, "-ent") {
 			version = fmt.Sprintf("%s%s", strings.TrimSuffix(version, "ent"), imageType)
@@ -165,4 +165,8 @@ func GetOfficialImage(imageUrls ImageUrls, version string, annotations map[strin
 
 func IsEnterpriseImage(mongodbImage string) bool {
 	return strings.Contains(mongodbImage, util.OfficialEnterpriseServerImageUrl)
+}
+
+func IsCommunityImage(mongodbImage string) bool {
+	return strings.Contains(mongodbImage, construct.OfficialMongodbCommunityServerImageName)
 }


### PR DESCRIPTION
Fixes #952
Problem
The operator previously used a hardcoded whitelist (OfficialMongodbRepoUrls) to determine whether to append the image type suffix to the version tag. If a user configured a custom registry (like Harbor) to mirror official images, the operator would omit the suffix, resulting in image tags like 8.2.6 instead of 8.2.6-ubi8. This caused pull failures in environments where the private registry mirrors the official tagging format.

Solution
This PR unifies the image tagging logic to be registry-agnostic:

Registry Flexibility: Updated getMongoDBImage in the Community controller to automatically append the image type suffix to "bare" version tags for ALL registries, not just official ones.
Unified Logic: Updated the shared GetOfficialImage helper in pkg/images to treat Community images the same as Enterprise images, ensuring consistent tagging when using the Unified operator.
Standardization: Added OfficialMongodbCommunityServerImageName constant to clarify image identification across the codebase.
Proof of Work
Verified the image URL construction logic for custom registries:

Legacy Behavior: my-harbor.com/mongodb/mongodb-community-server:8.2.6 (Failed)
New Behavior: my-harbor.com/mongodb/mongodb-community-server:8.2.6-ubi8 (Success)