### PR TITLE
KUBE-70: clean up lint debt on search/lb-improvements parent

### DIFF
--- a/api/v1/search/cluster_index_test.go
+++ b/api/v1/search/cluster_index_test.go
@@ -75,4 +75,3 @@ func TestAssignClusterIndicesDoesNotMutateExisting(t *testing.T) {
 	AssignClusterIndices(existing, []string{"a", "b", "c"})
 	assert.Equal(t, map[string]int{"a": 0, "b": 1}, existing, "existing must not be mutated")
 }
-

--- a/api/v1/search/mongodbsearch_validation_test.go
+++ b/api/v1/search/mongodbsearch_validation_test.go
@@ -809,7 +809,6 @@ func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTL
 	return search
 }
 
-
 // TestManagedLBConfig_Replicas_FieldExists is a smoke test: the Replicas field
 // on ManagedLBConfig is wired so per-cluster managed LB can specify a replica
 // count and the Envoy reconciler can default it to 1 when unset.

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -60,13 +60,6 @@ const (
 	envoyConfigHashAnnotation = "mongodb.com/envoy-config-hash"
 
 	labelName = "search-proxy"
-
-	// Cross-cluster enqueue labels. Cross-cluster owner refs do not GC,
-	// so a label-based mapper is the only path back to the parent MongoDBSearch
-	// for member-cluster Deployment/ConfigMap watches.
-	envoyOwnerSearchNameLabel      = "mongodb.com/search-name"
-	envoyOwnerSearchNamespaceLabel = "mongodb.com/search-namespace"
-	envoyClusterNameLabel          = "mongodb.com/cluster-name"
 )
 
 // envoyRoute defines routing information for one Envoy entrypoint (one per shard, or one for RS).
@@ -474,7 +467,7 @@ func buildReplicaSetRouteForCluster(search *searchv1.MongoDBSearch, clusterIndex
 
 // buildShardRoutesForCluster builds per-shard routes for one cluster. SNI naming
 // for sharded topologies still flows through ProxyServiceNameForShard +
-// applyClusterIDToSNI for now (no per-(cluster, shard) Service helper exists);
+// applyShardClusterIDToSNI for now (no per-(cluster, shard) Service helper exists);
 // the {clusterName}/{shardName} externalHostname template is the supported MC
 // path.
 func buildShardRoutesForCluster(search *searchv1.MongoDBSearch, shardNames []string, clusterName string) []envoyRoute {
@@ -485,20 +478,6 @@ func buildShardRoutesForCluster(search *searchv1.MongoDBSearch, shardNames []str
 		base[i].SNIHostname = applyShardClusterIDToSNI(base[i].SNIHostname, clusterName, templated)
 	}
 	return base
-}
-
-// applyClusterIDToSNI substitutes the {clusterName} placeholder when present.
-// Used for the externalHostname-template path (RS mode); the default
-// service-FQDN path is now produced directly by ProxyServiceNamespacedNameForCluster
-// and does not flow through this helper.
-func applyClusterIDToSNI(sni, clusterName string) string {
-	if strings.Contains(sni, searchv1.ClusterNamePlaceholder) {
-		return strings.ReplaceAll(sni, searchv1.ClusterNamePlaceholder, clusterName)
-	}
-	// User supplied an externalHostname template without {clusterName}; honour
-	// it as-is. Multi-cluster users are expected to include the placeholder;
-	// admission rejects multi-cluster specs that omit it.
-	return sni
 }
 
 // applyShardClusterIDToSNI handles the sharded SNI rewrite. Until a

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -949,7 +949,7 @@ func TestMapEnvoyObjectToSearch(t *testing.T) {
 			Labels: map[string]string{
 				khandler.MongoDBSearchOwnerNameLabel:      "mdb-search",
 				khandler.MongoDBSearchOwnerNamespaceLabel: "ns",
-				khandler.MongoDBSearchClusterNameLabel:                     "a",
+				khandler.MongoDBSearchClusterNameLabel:    "a",
 			},
 		},
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -633,7 +633,6 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 	return mutatedSts, nil
 }
 
-
 // isOwnedBy returns true if the object has an owner reference pointing to the given owner.
 // Unlike metav1.IsControlledBy, this does not require the controller: true field,
 // which is not set by controllerutil.SetOwnerReference.

--- a/controllers/searchcontroller/mongodbsearch_validation_test.go
+++ b/controllers/searchcontroller/mongodbsearch_validation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	corev1 "k8s.io/api/core/v1"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"

--- a/pkg/multicluster/memberwatch/clusterhealth.go
+++ b/pkg/multicluster/memberwatch/clusterhealth.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -61,7 +60,7 @@ func NewMemberHealthCheck(server string, ca []byte, token string, log *zap.Sugar
 			MinVersion: tls.VersionTLS12,
 		},
 	}
-	if proxyEnv := os.Getenv("MULTI_CLUSTER_HEALTHCHECK_PROXY"); proxyEnv != "" {
+	if proxyEnv := env.ReadOrDefault("MULTI_CLUSTER_HEALTHCHECK_PROXY", ""); proxyEnv != "" { // nolint:forbidigo
 		if proxyURL, perr := url.Parse(proxyEnv); perr == nil && proxyURL.Host != "" {
 			transport.Proxy = http.ProxyURL(proxyURL)
 		}


### PR DESCRIPTION
[skip-ci] KUBE-70

# Pre-existing lint + formatter debt on `search/lb-improvements`

The parent feature branch was first pushed to origin earlier today; CI
(golangci-lint, pre-commit) flagged accumulated debt that landed via
earlier feature-branch commits (B16, Phase-2, Devcontainers). Fix it in
one isolated precursor PR so child PRs can rebase onto a clean parent.

## Lint failures (5)

| File:Line | Failure | Fix |
|-----------|---------|-----|
| `pkg/multicluster/memberwatch/clusterhealth.go:64` | `forbidigo`: `os.Getenv` is forbidden outside `pkg/util/env` and `main.go` | Switch to `env.ReadOrDefault("MULTI_CLUSTER_HEALTHCHECK_PROXY", "")` with `// nolint:forbidigo`, matching the pattern already used at line 73 of the same file (`env.ReadIntOrDefault(...) // nolint:forbidigo`). Drop the now-unused `"os"` import. |
| `controllers/operator/mongodbsearchenvoy_controller.go:67` | `unused`: `envoyOwnerSearchNameLabel` | Delete. Repo-wide `grep -rn 'envoyOwnerSearchNameLabel' --include='*.go'` confirms declaration-only. |
| `controllers/operator/mongodbsearchenvoy_controller.go:68` | `unused`: `envoyOwnerSearchNamespaceLabel` | Delete (same grep — declaration-only). |
| `controllers/operator/mongodbsearchenvoy_controller.go:69` | `unused`: `envoyClusterNameLabel` | Delete (same grep — declaration-only). |
| `controllers/operator/mongodbsearchenvoy_controller.go:494` | `unused`: `applyClusterIDToSNI` | Delete the function. Grep shows the only remaining mentions are comments. The live SNI helper is `applyShardClusterIDToSNI`, which is unaffected; the `buildShardRoutesForCluster` doc comment that referenced the deleted helper is updated to point at the live one. |

The deleted symbols look like leftovers from an early cross-cluster
enqueue design that never landed — the actual cross-cluster enqueue path
in this controller goes through `khandler.EnqueueRequestsFromMapFunc` over
the parent `MongoDBSearch`, not label-based mapping.

## Formatter fixes (5 files, mechanical pre-commit auto-apply)

These are pure whitespace / struct-alignment / import-section fixes from
running `golangci-lint fmt` (gci + gofmt + gofumpt). No semantic change.

| File | Change |
|------|--------|
| `api/v1/search/cluster_index_test.go` | Drop trailing blank line at EOF. |
| `api/v1/search/mongodbsearch_validation_test.go` | Drop duplicate blank line between `newSearch` and `TestManagedLBConfig_Replicas_FieldExists`. |
| `controllers/operator/mongodbsearchenvoy_controller_test.go` | Re-align struct field padding in `TestMapEnvoyObjectToSearch` label literal (`gofumpt`). |
| `controllers/searchcontroller/mongodbsearch_reconcile_helper.go` | Collapse a duplicate blank line between two functions. |
| `controllers/searchcontroller/mongodbsearch_validation_test.go` | Insert a blank line between the `default` and `corev1` import groups (`gci` section ordering). |

## Proof of Work

- `make precommit` (full pre-commit run, all hooks except `shellcheck` —
  Docker-in-Docker required — and `govulncheck` — see "Known unrelated
  failures" below) — **passes** locally inside the devcontainer.
- `go build ./...` — clean.
- `go test ./controllers/searchcontroller/... ./controllers/operator/... ./api/v1/search/... ./pkg/multicluster/memberwatch/...` —
  **all pass** (every touched package's unit tests).
- e2e: N/A — no runtime behaviour change. The `os.Getenv` swap is a 1:1
  helper substitution; the deleted symbols had no callers; the formatter
  fixes are purely cosmetic.

## Known unrelated failures

- `lint_repo / govulncheck` is failing on this branch with 4 stdlib CVEs in Go 1.25.9 (fixed in 1.25.10). Master mainline (commit `449d6fd6`) is failing on the same task with the same CVEs — independent of this PR. Tracked separately as KUBE-71.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` applies — pure lint / formatter cleanup, no user-visible change.
