### PR TITLE
Stop running prepare_aws inside publish_helm_chart task

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -551,7 +551,6 @@ tasks:
       - func: python_venv
       - func: setup_kubectl
       - func: setup_aws
-      - func: prepare_aws
       - func: helm_registry_login_staging
       - func: publish_helm_chart
 

--- a/scripts/evergreen/prepare_aws.sh
+++ b/scripts/evergreen/prepare_aws.sh
@@ -15,6 +15,31 @@ calculate_hours_since_creation() {
   echo $(( (current_timestamp - creation_timestamp) / 3600 ))
 }
 
+# Deletes a bucket, including all object versions and delete markers when
+# versioning is enabled. `aws s3 rb --force` only removes current versions
+# and silently leaves versioned buckets undeletable (BucketNotEmpty), so
+# every patch retries the same zombies forever. This drains versions in
+# 1000-key batches before calling rb.
+delete_bucket_with_versions() {
+  bucket=$1
+
+  while :; do
+    payload=$(aws s3api list-object-versions \
+                --bucket "${bucket}" \
+                --max-items 1000 \
+                --output json 2>/dev/null \
+              | jq -c '{Objects: [(.Versions // []), (.DeleteMarkers // [])
+                                  | .[] | {Key, VersionId}], Quiet: true}')
+    count=$(echo "${payload}" | jq '.Objects | length')
+    if [[ -z "${count}" || "${count}" == "0" ]]; then
+      break
+    fi
+    aws s3api delete-objects --bucket "${bucket}" --delete "${payload}" >/dev/null 2>&1 || break
+  done
+
+  aws s3 rb "s3://${bucket}" --force || true
+}
+
 delete_buckets_from_file() {
   list_file=$1
 
@@ -32,7 +57,7 @@ delete_buckets_from_file() {
       hours_since_creation=$(calculate_hours_since_creation "${bucket_creation_date}")
 
       if [[ ${hours_since_creation} -ge 2 ]]; then
-        aws_cmd="aws s3 rb s3://${bucket_name} --force"
+        aws_cmd="delete_bucket_with_versions ${bucket_name}"
         echo "[${list_file}/${bucket_name}] Deleting e2e bucket: ${bucket_name}/${bucket_creation_date}; age in hours: ${hours_since_creation}; (${aws_cmd}), tags: Tags: $(echo "${tags}" | jq -cr .)"
         ${aws_cmd} || true
       else
@@ -43,7 +68,7 @@ delete_buckets_from_file() {
       hours_since_creation=$(calculate_hours_since_creation "${bucket_creation_date}")
       operatorOwnedTagExists=$(echo "${tags}" |  jq -r 'select(.TagSet | map({(.Key): .Value}) | add | .environment == "mongodb-enterprise-operator-tests")')
       if [[ ${hours_since_creation} -ge 24 && -n "${operatorOwnedTagExists}" ]]; then
-        aws_cmd="aws s3 rb s3://${bucket_name} --force"
+        aws_cmd="delete_bucket_with_versions ${bucket_name}"
         echo "[${list_file}/${bucket_name}] Deleting manual bucket: ${bucket_name}/${bucket_creation_date}; age in hours: ${hours_since_creation}; (${aws_cmd}), tags: Tags: $(echo "${tags}" | jq -cr .)"
         ${aws_cmd} || true
       else


### PR DESCRIPTION
## Summary

Publish helm chart task runs before any patch (even manually triggered), and now takes up to 15 min : https://spruce.corp.mongodb.com/task/mongodb_kubernetes_init_test_run_publish_helm_chart_7534cfd97bad046ccd43aecfdb3f87b84af2445d_26_05_11_08_15_10/logs?execution=0

Two changes:

1. **Stop running `prepare_aws` inside `publish_helm_chart`.** `setup_aws` is enough for the ECR login the chart publish needs. Bucket cleanup already runs in the standalone `prepare_aws` task and in the dedicated `periodic_teardown` build variant. Removing it lets e2e dispatch as soon as image builds finish (~3-4 min).

2. **Fix `prepare_aws.sh` so versioned buckets actually get deleted.** `aws s3 rb --force` only removes current versions; historical versions + delete markers stay, so versioned buckets (notably Ops Manager backup `oplog`/`blockstore`) fail with `BucketNotEmpty` on every run. The script now drains versions via `list-object-versions` + batch `delete-objects` before `rb`. I found out that there were 1,310 `test-*` buckets in the account, ~95% of them overdue that the old script could never delete.

## Proof of Work

Patch must pass.

Buckets are being deleted in the patch running from the PR: https://spruce.corp.mongodb.com/task/mongodb_kubernetes_init_test_run_prepare_aws_patch_7534cfd97bad046ccd43aecfdb3f87b84af2445d_6a020876d0ca8300077369f8_26_05_11_16_48_58/logs?execution=0 

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details