### PR TITLE
[AI] PR #1059 review fixes: comment trim + test cleanup + helper refactor

### DIFF
--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -793,25 +793,23 @@ func EffectiveClusters(s *MongoDBSearch) []ClusterSpec {
 	return out
 }
 
-// EffectiveClusterFor returns the cascaded ClusterSpec for a specific cluster
-// name. Returns the auto-promoted single-cluster spec when clusterName is empty
-// (legacy/single-cluster path). Returns a zero ClusterSpec if the named cluster
-// is not in spec.clusters[] (defensive — shouldn't happen in healthy reconcile
-// state but avoids panic).
-func (s *MongoDBSearch) EffectiveClusterFor(clusterName string) ClusterSpec {
+// EffectiveClusterFor returns the cascaded ClusterSpec for the named cluster.
+// Empty clusterName returns the auto-promoted single-cluster entry (legacy path).
+// Returns an error if the named cluster is not found in spec.clusters[].
+func (s *MongoDBSearch) EffectiveClusterFor(clusterName string) (ClusterSpec, error) {
 	effective := EffectiveClusters(s)
 	if clusterName == "" {
 		if len(effective) > 0 {
-			return effective[0]
+			return effective[0], nil
 		}
-		return ClusterSpec{}
+		return ClusterSpec{}, fmt.Errorf("cluster %q not found in spec.clusters", clusterName)
 	}
 	for _, c := range effective {
 		if c.ClusterName == clusterName {
-			return c
+			return c, nil
 		}
 	}
-	return ClusterSpec{}
+	return ClusterSpec{}, fmt.Errorf("cluster %q not found in spec.clusters", clusterName)
 }
 
 func (s *MongoDBSearch) GetReplicas() int {
@@ -831,7 +829,11 @@ func (s *MongoDBSearch) GetReplicas() int {
 // default, "1" if neither is set). clusterName="" returns the single-cluster
 // auto-promoted value (equivalent to GetReplicas).
 func (s *MongoDBSearch) GetReplicasForCluster(clusterName string) int {
-	if r := s.EffectiveClusterFor(clusterName).Replicas; r != nil && *r > 0 {
+	c, err := s.EffectiveClusterFor(clusterName)
+	if err != nil {
+		return 1
+	}
+	if r := c.Replicas; r != nil && *r > 0 {
 		return int(*r)
 	}
 	return 1

--- a/api/v1/search/mongodbsearch_types.go
+++ b/api/v1/search/mongodbsearch_types.go
@@ -450,9 +450,7 @@ func (s *MongoDBSearch) ProxyServiceNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Name: s.Name + "-search-0-" + ProxyServiceSuffix, Namespace: s.Namespace}
 }
 
-// ProxyServiceNamespacedNameForCluster returns the index-suffixed proxy Service
-// name for one member cluster. mongod's per-cluster mongotHost FQDN resolves to
-// this name.
+// ProxyServiceNamespacedNameForCluster returns the index-suffixed proxy Service name for one member cluster.
 func (s *MongoDBSearch) ProxyServiceNamespacedNameForCluster(clusterIndex int) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      fmt.Sprintf("%s-search-%d-%s", s.Name, clusterIndex, ProxyServiceSuffix),
@@ -480,9 +478,7 @@ func (s *MongoDBSearch) MongotConfigConfigMapNameForCluster(clusterIndex int) ty
 	}
 }
 
-// StatefulSetNamespacedNameForCluster returns the index-suffixed StatefulSet
-// name (`<name>-search-<idx>`). The unindexed name from
-// StatefulSetNamespacedName is reserved for the single-cluster path.
+// StatefulSetNamespacedNameForCluster returns the index-suffixed StatefulSet name for one member cluster.
 func (s *MongoDBSearch) StatefulSetNamespacedNameForCluster(clusterIndex int) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      fmt.Sprintf("%s-search-%d", s.Name, clusterIndex),

--- a/api/v1/search/mongodbsearch_types_test.go
+++ b/api/v1/search/mongodbsearch_types_test.go
@@ -168,33 +168,6 @@ func TestEffectiveClustersCascade(t *testing.T) {
 	assert.Empty(t, (*spec.Clusters)[2].JVMFlags)
 }
 
-// TestGetReplicasForCluster verifies the cascade-aware per-cluster replica accessor.
-func TestGetReplicasForCluster(t *testing.T) {
-	t.Run("empty clusterName + top-level set", func(t *testing.T) {
-		s := &MongoDBSearch{Spec: MongoDBSearchSpec{Replicas: ptr.To(int32(4))}}
-		assert.Equal(t, 4, s.GetReplicasForCluster(""))
-	})
-	t.Run("empty clusterName + nothing set defaults to 1", func(t *testing.T) {
-		s := &MongoDBSearch{}
-		assert.Equal(t, 1, s.GetReplicasForCluster(""))
-	})
-	t.Run("cluster-set wins over top-level default", func(t *testing.T) {
-		s := &MongoDBSearch{Spec: MongoDBSearchSpec{
-			Replicas: ptr.To(int32(2)),
-			Clusters: &[]ClusterSpec{
-				{ClusterName: "cluster-a"},                             // inherits top-level => 2
-				{ClusterName: "cluster-b", Replicas: ptr.To(int32(5))}, // override => 5
-			},
-		}}
-		assert.Equal(t, 2, s.GetReplicasForCluster("cluster-a"))
-		assert.Equal(t, 5, s.GetReplicasForCluster("cluster-b"))
-	})
-	t.Run("unknown clusterName defaults to 1", func(t *testing.T) {
-		s := &MongoDBSearch{Spec: MongoDBSearchSpec{Replicas: ptr.To(int32(7))}}
-		assert.Equal(t, 1, s.GetReplicasForCluster("missing"))
-	})
-}
-
 func TestEffectiveClusterFor(t *testing.T) {
 	topResources := &corev1.ResourceRequirements{}
 	clusterBResources := &corev1.ResourceRequirements{}
@@ -486,9 +459,6 @@ func TestProxyServiceNamespacedNameForCluster(t *testing.T) {
 
 	got1 := s.ProxyServiceNamespacedNameForCluster(1)
 	assert.Equal(t, "mdb-search-search-1-proxy-svc", got1.Name)
-
-	got2 := s.ProxyServiceNamespacedNameForCluster(2)
-	assert.Equal(t, "mdb-search-search-2-proxy-svc", got2.Name)
 }
 
 func TestMongotConfigConfigMapNameForCluster(t *testing.T) {

--- a/api/v1/search/mongodbsearch_types_test.go
+++ b/api/v1/search/mongodbsearch_types_test.go
@@ -174,7 +174,8 @@ func TestEffectiveClusterFor(t *testing.T) {
 
 	t.Run("empty clusterName returns first auto-promoted entry", func(t *testing.T) {
 		s := &MongoDBSearch{Spec: MongoDBSearchSpec{ResourceRequirements: topResources}}
-		got := s.EffectiveClusterFor("")
+		got, err := s.EffectiveClusterFor("")
+		require.NoError(t, err)
 		assert.Same(t, topResources, got.ResourceRequirements)
 	})
 
@@ -186,15 +187,20 @@ func TestEffectiveClusterFor(t *testing.T) {
 				{ClusterName: "cluster-b", ResourceRequirements: clusterBResources},
 			},
 		}}
-		assert.Same(t, topResources, s.EffectiveClusterFor("cluster-a").ResourceRequirements)
-		assert.Same(t, clusterBResources, s.EffectiveClusterFor("cluster-b").ResourceRequirements)
+		gotA, err := s.EffectiveClusterFor("cluster-a")
+		require.NoError(t, err)
+		assert.Same(t, topResources, gotA.ResourceRequirements)
+		gotB, err := s.EffectiveClusterFor("cluster-b")
+		require.NoError(t, err)
+		assert.Same(t, clusterBResources, gotB.ResourceRequirements)
 	})
 
-	t.Run("unknown clusterName returns zero spec", func(t *testing.T) {
+	t.Run("unknown clusterName returns error", func(t *testing.T) {
 		s := &MongoDBSearch{Spec: MongoDBSearchSpec{
 			Clusters: &[]ClusterSpec{{ClusterName: "only"}},
 		}}
-		got := s.EffectiveClusterFor("missing")
+		got, err := s.EffectiveClusterFor("missing")
+		require.Error(t, err)
 		assert.Equal(t, ClusterSpec{}, got)
 	})
 }

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -186,7 +186,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		}
 	}
 
-	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelperWithMembers(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig, r.memberClusterClientsMap, state.ClusterMapping)
+	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig, r.memberClusterClientsMap, state.ClusterMapping)
 
 	result, err := reconcileHelper.Reconcile(ctx, log).ReconcileResult()
 	if err != nil {

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,7 +22,6 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	apiv1 "github.com/mongodb/mongodb-kubernetes/api/v1"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/api/v1/status"
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/v1/user"
@@ -407,35 +405,6 @@ func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
 	assert.NotNil(t, r.memberClusterSecretClientsMap["eu-west-k8s"].KubeClient)
 }
 
-// Regression: per-cluster Service writes failed with "no kind is registered
-// for type search.MongoDBSearch in scheme" when member-cluster clients used a
-// scheme without searchv1; apiv1.AddToScheme must register MongoDBSearch.
-func TestOperatorSchemeKnowsMongoDBSearch(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, apiv1.AddToScheme(scheme))
-
-	gvks, _, err := scheme.ObjectKinds(&searchv1.MongoDBSearch{})
-	require.NoError(t, err, "scheme must resolve MongoDBSearch after apiv1.AddToScheme")
-	require.NotEmpty(t, gvks, "no GVK registered for searchv1.MongoDBSearch")
-
-	gvk := gvks[0]
-	assert.Equal(t, "mongodb.com", gvk.Group)
-	assert.Equal(t, "v1", gvk.Version)
-	assert.Equal(t, "MongoDBSearch", gvk.Kind)
-
-	mdbs := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "00000000-0000-0000-0000-000000000001"},
-	}
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search-search-0-svc", Namespace: "ns"},
-	}
-	require.NoError(t, controllerutil.SetOwnerReference(mdbs, svc, scheme))
-	require.Len(t, svc.OwnerReferences, 1)
-	assert.Equal(t, "MongoDBSearch", svc.OwnerReferences[0].Kind)
-	assert.Equal(t, "mongodb.com/v1", svc.OwnerReferences[0].APIVersion)
-}
-
 func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
 	ctx := context.Background()
 	search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
@@ -741,25 +710,6 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 				assert.Equal(t, search.Name, labels[khandler.MongoDBSearchOwnerNameLabel], "owner-name label on %T", obj)
 				assert.Equal(t, search.Namespace, labels[khandler.MongoDBSearchOwnerNamespaceLabel], "owner-namespace label on %T", obj)
 				assert.Equal(t, tc.clusterName, labels[khandler.MongoDBSearchClusterNameLabel], "cluster-name label on %T", obj)
-			}
-
-			// Per-cluster resources do NOT leak onto the other member client or
-			// onto the central client. Cross-cluster owner refs don't GC, so a
-			// stray write here would silently leak forever.
-			leaks := []struct {
-				name types.NamespacedName
-				obj  client.Object
-			}{
-				{stsName, &appsv1.StatefulSet{}},
-				{headlessName, &corev1.Service{}},
-				{proxyName, &corev1.Service{}},
-				{cmName, &corev1.ConfigMap{}},
-			}
-			for _, l := range leaks {
-				assert.True(t, apiErrors.IsNotFound(tc.otherMC.Get(ctx, l.name, l.obj)),
-					"%s must NOT be on the other member client", l.name)
-				assert.True(t, apiErrors.IsNotFound(centralClient.Get(ctx, l.name, l.obj)),
-					"%s must NOT be on the central client", l.name)
 			}
 		})
 	}

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -639,13 +639,6 @@ func TestMongoDBSearchControllerReconcile_StateConfigMap_ReAddCluster(t *testing
 		"re-added cluster must reclaim its original index")
 }
 
-// TestMongoDBSearchReconcile_Success_MultiCluster drives Reconcile() end-to-end
-// in MC mode with two member-cluster clients. It verifies the full fan-out:
-// each cluster gets its index-suffixed STS / headless Service / proxy Service /
-// mongot ConfigMap on its own member client (never on the central client or the
-// wrong member client), the owner-labels are stamped on every per-cluster write
-// so member-cluster watch routing + cross-cluster GC can find them, and the
-// top-level CR reaches PhaseRunning after STSes are marked ready.
 func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 	ctx := context.Background()
 
@@ -674,7 +667,6 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 		"us-west": westClient,
 	}
 
-	// External source — no MongoDBCommunity required on the central client.
 	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
@@ -742,9 +734,8 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 			cm := &corev1.ConfigMap{}
 			require.NoError(t, tc.mc.Get(ctx, cmName, cm), "mongot ConfigMap must exist on owning member client")
 
-			// Owner-labels at every member-cluster write site so cross-cluster
-			// watch routing (MapMemberClusterObjectToSearch) + cleanup-by-label
-			// can find the resource — owner refs do not cross cluster boundaries.
+			// Owner labels stamp cross-cluster identity — owner refs do not
+			// carry between clusters, so labels are the link back to the CR.
 			for _, obj := range []client.Object{sts, headlessSvc, proxySvc, cm} {
 				labels := obj.GetLabels()
 				assert.Equal(t, search.Name, labels[khandler.MongoDBSearchOwnerNameLabel], "owner-name label on %T", obj)

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -363,9 +363,7 @@ func buildReplicaSetRoute(search *searchv1.MongoDBSearch) envoyRoute {
 }
 
 // buildRoutesForCluster returns the Envoy routes for one member cluster.
-// clusterName == "" is the single-cluster path (delegates to buildRoutes).
-// For MC, the user-supplied externalHostname template wins; otherwise the
-// default SNI is the index-suffixed proxy-svc FQDN.
+// Empty clusterName is the single-cluster path.
 func buildRoutesForCluster(search *searchv1.MongoDBSearch, source searchcontroller.SearchSourceDBResource, clusterIndex int, clusterName string) []envoyRoute {
 	if clusterName == "" {
 		return buildRoutes(search, source)
@@ -378,9 +376,8 @@ func buildRoutesForCluster(search *searchv1.MongoDBSearch, source searchcontroll
 }
 
 // buildReplicaSetRouteForCluster builds the RS-mode route for one cluster.
-// Upstream MUST be the index-suffixed mongot Service for this cluster: the
-// legacy unindexed name would NXDOMAIN under STRICT_DNS and fast-fail mongod's
-// gRPC with code 125 ("Error connecting to Search Index Management service").
+// Upstream is the index-suffixed mongot Service — the unindexed name NXDOMAINs
+// under STRICT_DNS and fails mongod's gRPC with code 125.
 func buildReplicaSetRouteForCluster(search *searchv1.MongoDBSearch, clusterIndex int, clusterName string) envoyRoute {
 	mongotServiceName := search.SearchServiceNamespacedNameForCluster(clusterIndex).Name
 	namespace := search.Namespace

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -102,8 +102,6 @@ func TestBuildReplicaSetRoute(t *testing.T) {
 	}
 }
 
-// Regression: externalHostname template must substitute both {clusterName}
-// and {clusterIndex}; an earlier path left {clusterIndex} literal in SNI.
 func TestBuildReplicaSetRouteForCluster_PerClusterPlaceholders(t *testing.T) {
 	clusters := []searchv1.ClusterSpec{
 		{ClusterName: "kind-e2e-cluster-1"},

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -212,11 +212,8 @@ func (r *MongoDBSearchReconcileHelper) buildReconcilePlan(log *zap.SugaredLogger
 	return r.buildReplicaSetPlan(r.db)
 }
 
-// buildReplicaSetPlan returns one reconcileUnit per cluster. Single-cluster is
-// represented as a 1-element work list with clusterName "" and unindexed names;
-// MC fans out one unit per spec.clusters entry, with names indexed via the
-// persisted state.ClusterMapping (resilient to spec.clusters[] reorder). The
-// same external.hostAndPorts seed list is rendered into every cluster's mongot config.
+// buildReplicaSetPlan returns one reconcileUnit per cluster. Single-cluster is a
+// 1-element work list with unindexed names; MC indexes via state.ClusterMapping.
 func (r *MongoDBSearchReconcileHelper) buildReplicaSetPlan(rsSource SearchSourceReplicaSet) (reconcilePlan, error) {
 	hostSeeds, err := rsSource.HostSeeds("")
 	if err != nil {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -91,19 +91,9 @@ type MongoDBSearchReconcileHelper struct {
 	clusterMapping map[string]int
 }
 
+// NewMongoDBSearchReconcileHelper constructs a reconcile helper. Pass nil/nil for memberClusterClients
+// and clusterMapping on single-cluster installs.
 func NewMongoDBSearchReconcileHelper(
-	client kubernetesClient.Client,
-	mdbSearch *searchv1.MongoDBSearch,
-	db SearchSourceDBResource,
-	operatorSearchConfig OperatorSearchConfig,
-) *MongoDBSearchReconcileHelper {
-	return NewMongoDBSearchReconcileHelperWithMembers(client, mdbSearch, db, operatorSearchConfig, nil, nil)
-}
-
-// NewMongoDBSearchReconcileHelperWithMembers constructs a helper with the
-// per-member-cluster client map and persisted clusterMapping populated.
-// Pass nil/empty for single-cluster.
-func NewMongoDBSearchReconcileHelperWithMembers(
 	client kubernetesClient.Client,
 	mdbSearch *searchv1.MongoDBSearch,
 	db SearchSourceDBResource,
@@ -563,11 +553,15 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		},
 	))
 
+	stsFunc, err := CreateSearchStatefulSetFunc(r.mdbSearch, unit.clusterName, unit.stsName.Name, r.mdbSearch.Namespace, unit.headlessSvc.Name, unit.configMapName.Name, unit.podLabels, mods.searchImage, mods.usePerPodConfig)
+	if err != nil {
+		return nil, nil, err
+	}
 	mutatedSts, err := r.createOrUpdateStatefulSet(ctx,
 		log,
 		unitClient,
 		unit.stsName,
-		CreateSearchStatefulSetFunc(r.mdbSearch, unit.clusterName, unit.stsName.Name, r.mdbSearch.Namespace, unit.headlessSvc.Name, unit.configMapName.Name, unit.podLabels, mods.searchImage, mods.usePerPodConfig),
+		stsFunc,
 		withSearchOwnerLabels(r.mdbSearch, unit.clusterName),
 		mods.passwordAuthSts,
 		configHashModification,

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -99,6 +99,7 @@ func reconcileMongoDBSearch(ctx context.Context, fakeClient kubernetesClient.Cli
 		mdbSearch,
 		NewCommunityResourceSearchSource(mdbc),
 		operatorConfig,
+		nil, nil,
 	)
 
 	return helper.Reconcile(ctx, zap.S())
@@ -171,7 +172,7 @@ func TestMongoDBSearchReconcileHelper_ValidateSingleMongoDBSearchForSearchSource
 				clientBuilder.WithObjects(v)
 			}
 
-			helper := NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(clientBuilder.Build()), mdbSearch, NewCommunityResourceSearchSource(mdbc), OperatorSearchConfig{})
+			helper := NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(clientBuilder.Build()), mdbSearch, NewCommunityResourceSearchSource(mdbc), OperatorSearchConfig{}, nil, nil)
 			err := helper.ValidateSingleMongoDBSearchForSearchSource(t.Context())
 			if c.expectedError == "" {
 				assert.NoError(t, err)
@@ -602,7 +603,7 @@ func TestEnsureEmbeddingConfig_APIKeySecretAndProviderEndpont(t *testing.T) {
 	fakeClient := newTestFakeClient(search, apiKeySecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 		SearchVersion: "0.60.0",
-	})
+	}, nil, nil)
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	assert.Nil(t, err)
 
@@ -633,7 +634,7 @@ syncSource:
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 		SearchVersion: "0.58.0",
-	})
+	}, nil, nil)
 	ctx := context.TODO()
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	assert.Nil(t, err)
@@ -682,7 +683,7 @@ func TestEnsureEmbeddingConfig_JustAPIKeys(t *testing.T) {
 	fakeClient := newTestFakeClient(search, apiKeySecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 		SearchVersion: "0.60.0",
-	})
+	}, nil, nil)
 	ctx := context.TODO()
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	assert.Nil(t, err)
@@ -823,7 +824,7 @@ func TestValidateSearchResource(t *testing.T) {
 		fakeClient := newTestFakeClient(search, tc.apiKeySecret)
 		helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 			SearchVersion: tc.searchVersion,
-		})
+		}, nil, nil)
 		_, _, err := helper.ensureEmbeddingConfig(ctx, nil)
 		tc.errAssertion(t, err)
 		if tc.errMsg != "" {
@@ -872,7 +873,7 @@ func TestEnsureMongotConfig_PerPodModes(t *testing.T) {
 				search.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{}
 			}
 			fakeClient := newTestFakeClient(search)
-			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig())
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 			cmName := search.MongotConfigConfigMapNamespacedName()
 			stsName := search.StatefulSetNamespacedName().Name
 
@@ -908,7 +909,7 @@ func TestEnsureMongotConfig_TransitionBetweenModes(t *testing.T) {
 	//nolint:staticcheck // SA1019: exercising the legacy single-cluster auto-promotion path.
 	search.Spec.Replicas = ptr.To(int32(1))
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig())
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 	cmName := search.MongotConfigConfigMapNamespacedName()
 	stsName := search.StatefulSetNamespacedName().Name
 
@@ -948,12 +949,16 @@ func TestCreateSearchStatefulSetFunc_ConfigMounting(t *testing.T) {
 
 	// Single config mode
 	sts := &appsv1.StatefulSet{}
-	CreateSearchStatefulSetFunc(search, "", "sts", "ns", "svc", "cm", labels, "img:v1", false)(sts)
+	stsFunc, err := CreateSearchStatefulSetFunc(search, "", "sts", "ns", "svc", "cm", labels, "img:v1", false)
+	require.NoError(t, err)
+	stsFunc(sts)
 	assert.Contains(t, sts.Spec.Template.Spec.Containers[0].Args[1], MongotConfigPath)
 
 	// Per-pod config mode
 	sts = &appsv1.StatefulSet{}
-	CreateSearchStatefulSetFunc(search, "", "sts", "ns", "svc", "cm", labels, "img:v1", true)(sts)
+	stsFunc, err = CreateSearchStatefulSetFunc(search, "", "sts", "ns", "svc", "cm", labels, "img:v1", true)
+	require.NoError(t, err)
+	stsFunc(sts)
 	startupCmd := sts.Spec.Template.Spec.Containers[0].Args[1]
 	assert.Contains(t, startupCmd, MongotPerPodConfigDirPath)
 	assert.Contains(t, startupCmd, "ROLE=$(cat")
@@ -1320,6 +1325,7 @@ func TestValidateMultipleReplicasConfig(t *testing.T) {
 				tc.search,
 				NewCommunityResourceSearchSource(mdbc),
 				OperatorSearchConfig{},
+				nil, nil,
 			)
 
 			err := helper.ValidateMultipleReplicasConfig()
@@ -1396,6 +1402,7 @@ func TestValidateManagedLBShardedTLS(t *testing.T) {
 				tc.search,
 				tc.source,
 				OperatorSearchConfig{},
+				nil, nil,
 			)
 
 			err := helper.ValidateManagedLBShardedTLS()
@@ -1985,6 +1992,7 @@ func TestReconcileSharded_CertificateKeySecretRefRejected(t *testing.T) {
 		search,
 		shardedSource,
 		newTestOperatorSearchConfig(),
+		nil, nil,
 	)
 
 	result := helper.reconcile(t.Context(), zap.S())
@@ -2105,6 +2113,7 @@ func TestValidatePerShardTLSSecrets(t *testing.T) {
 				search,
 				shardedSource,
 				newTestOperatorSearchConfig(),
+				nil, nil,
 			)
 
 			status := helper.validatePerShardTLSSecrets(t.Context(), zap.S(), tc.shardNames)
@@ -2159,6 +2168,7 @@ func TestValidatePerShardTLSSecretsAllExist(t *testing.T) {
 		search,
 		shardedSource,
 		newTestOperatorSearchConfig(),
+		nil, nil,
 	)
 
 	status := helper.validatePerShardTLSSecrets(t.Context(), zap.S(), shardNames)
@@ -2169,7 +2179,7 @@ func TestEnsureX509ClientCertConfig_NoopWhenNotConfigured(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
 
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig())
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 
 	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context())
 	require.NoError(t, err)
@@ -2208,7 +2218,7 @@ func TestEnsureX509ClientCertConfig_ErrorWhenTLSNotConfigured(t *testing.T) {
 	dbSource := &mockShardedSource{tlsConfig: nil} // No TLS on source
 
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig())
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
 	_, _, err := helper.ensureX509ClientCertConfig(t.Context())
 	require.Error(t, err)
@@ -2233,7 +2243,7 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	}
 
 	fakeClient := newTestFakeClient(search, x509Secret)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig())
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
 	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context())
 	require.NoError(t, err)
@@ -2326,7 +2336,7 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	}
 
 	fakeClient := newTestFakeClient(search, x509Secret)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig())
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
 	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context())
 	require.NoError(t, err)
@@ -2415,6 +2425,7 @@ func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 		search,
 		shardedSource,
 		newTestOperatorSearchConfig(),
+		nil, nil,
 	)
 
 	// Pass 1: creates shard-0 resources, returns Pending (StatefulSet not ready)
@@ -2501,7 +2512,7 @@ func TestCleanupStaleShardResources(t *testing.T) {
 		proxySvc("shard-2", true),  // stale, owned
 		proxySvc("shard-x", false), // different owner
 	)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig())
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 	require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), []string{"shard-0", "shard-1"}))
 
 	_, err := fakeClient.GetService(t.Context(), search.ProxyServiceNameForShard("shard-0"))
@@ -2524,6 +2535,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 		search,
 		NewCommunityResourceSearchSource(mdbc),
 		newTestOperatorSearchConfig(),
+		nil, nil,
 	)
 
 	// Pass 1: creates resources, returns Pending (StatefulSet not ready)

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -80,7 +80,7 @@ type TLSSourceConfig struct {
 // clusterName selects which entry of EffectiveClusters() is read for the per-cluster
 // Persistence / ResourceRequirements / StatefulSetConfiguration fields. Empty string
 // = legacy single-cluster path (uses the auto-promoted top-level fields).
-func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, clusterName, stsName, namespace, svcName, configMapName string, labels map[string]string, searchImage string, usePerPodConfig bool) statefulset.Modification {
+func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, clusterName, stsName, namespace, svcName, configMapName string, labels map[string]string, searchImage string, usePerPodConfig bool) (statefulset.Modification, error) {
 	tmpVolume := statefulset.CreateVolumeFromEmptyDir("tmp")
 	tmpVolumeMount := statefulset.CreateVolumeMount(tmpVolume.Name, tempVolumePath, statefulset.WithReadOnly(false))
 
@@ -101,7 +101,10 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, clusterName,
 	// Per-cluster spec for THIS cluster, cascaded over the top-level defaults
 	// (REPLACE-if-nil for Persistence / ResourceRequirements /
 	// StatefulSetConfiguration). Empty clusterName == single-cluster path.
-	perCluster := mdbSearch.EffectiveClusterFor(clusterName)
+	perCluster, err := mdbSearch.EffectiveClusterFor(clusterName)
+	if err != nil {
+		return nil, err
+	}
 
 	var persistenceConfig *common.PersistenceConfig
 	if perCluster.Persistence != nil && perCluster.Persistence.SingleConfig != nil {
@@ -140,7 +143,7 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, clusterName,
 				podtemplatespec.WithPodLabels(labels),
 				podtemplatespec.WithVolumes(volumes),
 				podtemplatespec.WithServiceAccount(util.MongoDBServiceAccount),
-				podtemplatespec.WithContainer(MongotContainerName, mongodbSearchContainer(mdbSearch, clusterName, volumeMounts, searchImage, usePerPodConfig)),
+				podtemplatespec.WithContainer(MongotContainerName, mongodbSearchContainer(mdbSearch, perCluster, volumeMounts, searchImage, usePerPodConfig)),
 			),
 		),
 	}
@@ -153,7 +156,7 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, clusterName,
 		))
 	}
 
-	return statefulset.Apply(stsModifications...)
+	return statefulset.Apply(stsModifications...), nil
 }
 
 // PasswordAuthModification returns a statefulset.Modification that mounts the password secret
@@ -224,9 +227,8 @@ func jvmFlags(userJVMFlags []string, resourceRequirements corev1.ResourceRequire
 	return fmt.Sprintf(`--jvm-flags "%s"`, flagsValue)
 }
 
-func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, clusterName string, volumeMounts []corev1.VolumeMount, searchImage string, usePerPodConfig bool) container.Modification {
+func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster searchv1.ClusterSpec, volumeMounts []corev1.VolumeMount, searchImage string, usePerPodConfig bool) container.Modification {
 	_, containerSecurityContext := podtemplatespec.WithDefaultSecurityContextsModifications()
-	perCluster := mdbSearch.EffectiveClusterFor(clusterName)
 	resourceRequirements := createSearchResourceRequirements(perCluster.ResourceRequirements)
 	jvmFlags := jvmFlags(perCluster.JVMFlags, resourceRequirements)
 

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -109,7 +109,8 @@ func TestCreateSearchStatefulSetFunc_JVMFlags(t *testing.T) {
 				}
 			})
 
-			stsModification := CreateSearchStatefulSetFunc(search, "", "", "", "", "", nil, "mongot:latest", false)
+			stsModification, err := CreateSearchStatefulSetFunc(search, "", "", "", "", "", nil, "mongot:latest", false)
+			require.NoError(t, err)
 			sts := statefulset.New(stsModification)
 
 			// Find the mongot container


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1059

## Chain of upstream PRs as of 2026-05-12

* PR #1048:
  `master` ← `search/ga-base`

  * PR #1059:
    `search/ga-base` ← `mc-search-phase2-q2-rs-mongothost-fix`

    * **PR #1101 (THIS ONE)**:
      `mc-search-phase2-q2-rs-mongothost-fix` ← `mc-search-multi-rs-fixes`

<!-- end git-machete generated -->

Addresses review comments on #1059. Stacked branch off `mc-search-phase2-q2-rs-mongothost-fix`.

## Summary

Three thematic commits:

1. **Comment trim** — collapse multi-line docstrings on per-cluster name helpers and on `buildRoutes` / `buildReplicaSetPlan`; strip test preambles and intra-test commentary that test names and assertion messages already convey.
2. **Test cleanup** — delete the scheme-registration test (operator startup already fails loudly without `MongoDBSearch` in the scheme), trim a redundant per-cluster `Replicas` sub-test and a third proxy-svc name case, and drop the cross-cluster leak assertions from the MC reconcile test.
3. **Helper refactor** — collapse the two `MongoDBSearchReconcileHelper` constructors into one (call sites pass `nil` for member-cluster wiring on single-cluster paths). `EffectiveClusterFor` now returns `(ClusterSpec, error)`; the container builder takes the resolved per-cluster spec directly, eliminating the redundant lookup.

## Out of scope

- Cross-cluster finalizer / GC — deferred per the parent PR's MVP scope; will land in a follow-up.
- Single-cluster `-0` naming alignment — breaking-change scope, not part of this batch.
- Anand's earlier comments that were already resolved at the parent PR's current HEAD — no code change here; closed with a pointer to the relevant file:line.

## Test plan

- [ ] `go test ./api/v1/search/... ./controllers/searchcontroller/... ./controllers/operator/...` green
- [ ] No changes outside the targeted files (no .idea/, no vendor reflow)
- [ ] Targeted Evergreen patch (search e2e subset) before merging