### PR TITLE
[KUBE-11] Don't set PublishNotReady field for headless svc to default it to false

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -165,7 +165,6 @@ type reconcileUnit struct {
 	configMapName       types.NamespacedName
 	podLabels           map[string]string    // applied identically as STS metadata labels, matchLabels, and pod-template labels
 	additionalSvcLabels map[string]string    // merged into both headless and proxy Service metadata labels (e.g. {"shard": name})
-	publishNotReady     bool                 // headless Service PublishNotReadyAddresses
 	extraHeadlessPorts  []corev1.ServicePort // additional ports on the headless Service (e.g. wireproto for RS)
 	logFields           []any                // k/v fields attached to the per-unit logger (nil for single-unit topologies)
 	tlsResource         tls.TLSConfigurableResource
@@ -300,7 +299,6 @@ func (r *MongoDBSearchReconcileHelper) buildShardedPlan(shardedSource SearchSour
 			configMapName:       r.mdbSearch.MongotConfigMapForShard(shardName),
 			podLabels:           map[string]string{appLabelKey: stsName.Name, shardLabelKey: shardName},
 			additionalSvcLabels: map[string]string{shardLabelKey: shardName},
-			publishNotReady:     true,
 			logFields:           []any{"shard", shardName, "shardIdx", shardIdx},
 			tlsResource:         &perShardTLSResource{MongoDBSearch: r.mdbSearch, shardName: shardName},
 			mongotConfigFn:      mongot.Apply(baseMongotConfig(r.mdbSearch, hostSeeds), routerMongotMod(r.mdbSearch, shardedSource)),
@@ -923,7 +921,6 @@ func buildHeadlessService(search *searchv1.MongoDBSearch, unit reconcileUnit) co
 		SetLabels(svcLabels).
 		SetSelector(map[string]string{appLabelKey: unit.podLabels[appLabelKey]}).
 		SetClusterIP("None").
-		SetPublishNotReadyAddresses(unit.publishNotReady).
 		SetServiceType(corev1.ServiceTypeClusterIP).
 		SetOwnerReferences(search.GetOwnerReferences())
 

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -304,7 +304,6 @@ func newTestShardUnit(search *searchv1.MongoDBSearch, shardName string) reconcil
 		configMapName:       search.MongotConfigMapForShard(shardName),
 		podLabels:           map[string]string{appLabelKey: stsName.Name, shardLabelKey: shardName},
 		additionalSvcLabels: map[string]string{shardLabelKey: shardName},
-		publishNotReady:     true,
 	}
 }
 
@@ -1219,6 +1218,7 @@ func TestBuildShardSearchHeadlessService(t *testing.T) {
 	assert.Equal(t, "test", svc.Namespace)
 	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 	assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+	assert.False(t, svc.Spec.PublishNotReadyAddresses)
 
 	// Check selector points to the shard StatefulSet
 	assert.Equal(t, "test-search-search-0-my-cluster-0", svc.Spec.Selector["app"])


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1048

## Chain of upstream PRs as of 2026-05-15

* PR #1048:
  `master` ← `search/ga-base`

  * **PR #1111 (THIS ONE)**:
    `search/ga-base` ← `search/mongot-headless-publish-not-ready`

<!-- end git-machete generated -->

# Summary

[skip-ci]

The headless service that gets crated for a mongot group, respective to a mongodb shard, had `PublishNotReadyAddresses: true`. This means DNS resolves to the pod IPs even when the pod (from a mongot group) is not ready. 
Because envoy uses the headless service as upstream endpoint (via STRICT_DNS), it would forward the traffic to even that not ready pod which would result into failures. 

This PR fixes that by making sure that the service's `PublishNotReadyAddresses` is set to false. When it's false, the not ready pods' A record will not be discoverable using headless service, which would mean envoy would not forward traffic to those pods.

## Proof of Work

Unit tests pass.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
