### PR TITLE
SKUNK-209: refactor(appdb): collapse AppDB monitoring into single automation agent

### DIFF
--- a/api/mongodb/v1/om/appdb_types.go
+++ b/api/mongodb/v1/om/appdb_types.go
@@ -61,9 +61,9 @@ type AppDBSpec struct {
 	// specify configuration like startup flags and automation config settings for the AutomationAgent and MonitoringAgent
 	AutomationAgent mdbv1.AgentConfig `json:"agent,omitempty"`
 
-	// Specify configuration like startup flags just for the MonitoringAgent.
-	// These take precedence over
-	// the flags set in AutomationAgent
+	// Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
+	// into the automation agent. Remove this field from your configuration.
+	// +optional
 	MonitoringAgent mdbv1.MonitoringAgentConfig `json:"monitoringAgent,omitempty"`
 	ConnectionSpec  `json:",inline"`
 

--- a/api/mongodb/v1/om/appdb_types.go
+++ b/api/mongodb/v1/om/appdb_types.go
@@ -61,8 +61,9 @@ type AppDBSpec struct {
 	// specify configuration like startup flags and automation config settings for the AutomationAgent and MonitoringAgent
 	AutomationAgent mdbv1.AgentConfig `json:"agent,omitempty"`
 
-	// Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
-	// into the automation agent. Remove this field from your configuration.
+	// Deprecated: this field has no effect. The monitoring agent now runs inside the
+	// automation agent. Configure agent options, including log level and rotation, via
+	// spec.appDB.agent. Remove this field from your configuration.
 	// +optional
 	MonitoringAgent mdbv1.MonitoringAgentConfig `json:"monitoringAgent,omitempty"`
 	ConnectionSpec  `json:",inline"`

--- a/api/mongodb/v1/om/opsmanager_validation.go
+++ b/api/mongodb/v1/om/opsmanager_validation.go
@@ -267,6 +267,25 @@ func validateBackupS3Stores(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	return v1.ValidationSuccess()
 }
 
+func warnMonitoringAgentStartupParameters(os MongoDBOpsManagerSpec) v1.ValidationResult {
+	if len(os.AppDB.MonitoringAgent.StartupParameters) > 0 {
+		return v1.OpsManagerResourceValidationWarning("spec.appDB.monitoringAgent.startupOptions is deprecated and has no effect; the monitoring agent has been merged into the automation agent — remove this field from your configuration", status.AppDb)
+	}
+	return v1.ValidationSuccess()
+}
+
+func warnMonitoringAgentContainer(os MongoDBOpsManagerSpec) v1.ValidationResult {
+	if os.AppDB.PodSpec == nil || os.AppDB.PodSpec.PodTemplateWrapper.PodTemplate == nil {
+		return v1.ValidationSuccess()
+	}
+	for _, c := range os.AppDB.PodSpec.PodTemplateWrapper.PodTemplate.Spec.Containers {
+		if c.Name == "mongodb-agent-monitoring" {
+			return v1.OpsManagerResourceValidationWarning("spec.appDB.podSpec.podTemplate contains a deprecated 'mongodb-agent-monitoring' container; it will be removed automatically — remove it from your configuration", status.AppDb)
+		}
+	}
+	return v1.ValidationSuccess()
+}
+
 func (om *MongoDBOpsManager) RunValidations() []v1.ValidationResult {
 	validators := []func(m MongoDBOpsManagerSpec) v1.ValidationResult{
 		validOmVersion,
@@ -283,6 +302,8 @@ func (om *MongoDBOpsManager) RunValidations() []v1.ValidationResult {
 		validateBackupS3Stores,
 		featureCompatibilityVersionValidation,
 		validateAppDBUniqueExternalDomains,
+		warnMonitoringAgentStartupParameters,
+		warnMonitoringAgentContainer,
 	}
 
 	multiClusterAppDBSharedClusterValidators := []func(ms mdb.ClusterSpecList) v1.ValidationResult{

--- a/api/mongodb/v1/om/opsmanager_validation.go
+++ b/api/mongodb/v1/om/opsmanager_validation.go
@@ -269,7 +269,7 @@ func validateBackupS3Stores(os MongoDBOpsManagerSpec) v1.ValidationResult {
 
 func warnMonitoringAgentStartupParameters(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	if len(os.AppDB.MonitoringAgent.StartupParameters) > 0 {
-		return v1.OpsManagerResourceValidationWarning("spec.appDB.monitoringAgent.startupOptions is deprecated and has no effect; the monitoring agent has been merged into the automation agent — remove this field from your configuration", status.AppDb)
+		return v1.OpsManagerResourceValidationWarning("spec.appDB.monitoringAgent.startupOptions is deprecated and has no effect; the monitoring agent now runs inside the automation agent. Configure agent options, including log level and rotation, via spec.appDB.agent and remove spec.appDB.monitoringAgent from your configuration", status.AppDb)
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/mongodb/v1/om/opsmanager_validation_test.go
+++ b/api/mongodb/v1/om/opsmanager_validation_test.go
@@ -404,3 +404,32 @@ func TestOpsManager_RunValidations_InvalidPreRelease(t *testing.T) {
 	assert.Equal(t, uint64(5), version.Minor)
 	assert.Equal(t, uint64(0), version.Patch)
 }
+
+func TestWarnMonitoringAgentStartupParameters(t *testing.T) {
+	om := NewOpsManagerBuilderDefault().Build()
+	om.Spec.AppDB.MonitoringAgent.StartupParameters = mdbv1.StartupParameters{"key": "value"}
+
+	results := om.RunValidations()
+
+	warnings := warningsFromResults(results)
+	assert.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "startupOptions is deprecated")
+}
+
+func TestWarnMonitoringAgentStartupParameters_NoWarnWhenEmpty(t *testing.T) {
+	om := NewOpsManagerBuilderDefault().Build()
+
+	results := om.RunValidations()
+
+	assert.Empty(t, warningsFromResults(results))
+}
+
+func warningsFromResults(results []v1.ValidationResult) []string {
+	var warnings []string
+	for _, r := range results {
+		if r.Level == v1.WarningLevel {
+			warnings = append(warnings, r.Msg)
+		}
+	}
+	return warnings
+}

--- a/changelog/20260513_feature_appdb_single_agent_monitoring.md
+++ b/changelog/20260513_feature_appdb_single_agent_monitoring.md
@@ -3,4 +3,4 @@ kind: feature
 date: 2026-05-13
 ---
 
-* **MongoDBOpsManager**, **AppDB**: The `mongodb-agent-monitoring` sidecar container has been merged into the main `mongodb-agent` container. Both automation and monitoring now run as a single process in a single container. The `spec.appDB.monitoringAgent` field is now deprecated and has no effect; a webhook admission warning is emitted when it is set, the field is marked as deprecated in the CRD schema, and a warning is logged at runtime.
+* **MongoDBOpsManager**, **AppDB**: The `mongodb-agent-monitoring` sidecar container has been merged into the main `mongodb-agent` container. Both automation and monitoring now run as a single process in a single container. The `spec.appDB.monitoringAgent` field is now deprecated and has no effect; a webhook admission warning is emitted when it is set, the field is marked as deprecated in the CRD schema, and a warning is logged at runtime. Agent options for the AppDB — including log level and rotation — are configured via `spec.appDB.agent`, the same field used by `MongoDB` resources.

--- a/changelog/20260513_feature_appdb_single_agent_monitoring.md
+++ b/changelog/20260513_feature_appdb_single_agent_monitoring.md
@@ -1,0 +1,6 @@
+---
+kind: feature
+date: 2026-05-13
+---
+
+* **MongoDBOpsManager**, **AppDB**: The `mongodb-agent-monitoring` sidecar container has been merged into the main `mongodb-agent` container. Both automation and monitoring now run as a single process in a single container. The `spec.appDB.monitoringAgent` field is now deprecated and has no effect; a webhook admission warning is emitted when it is set, the field is marked as deprecated in the CRD schema, and a warning is logged at runtime.

--- a/config/crd/bases/mongodb.com_opsmanagers.yaml
+++ b/config/crd/bases/mongodb.com_opsmanagers.yaml
@@ -581,9 +581,8 @@ spec:
                     type: integer
                   monitoringAgent:
                     description: |-
-                      Specify configuration like startup flags just for the MonitoringAgent.
-                      These take precedence over
-                      the flags set in AutomationAgent
+                      Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
+                      into the automation agent. Remove this field from your configuration.
                     properties:
                       startupOptions:
                         additionalProperties:

--- a/config/crd/bases/mongodb.com_opsmanagers.yaml
+++ b/config/crd/bases/mongodb.com_opsmanagers.yaml
@@ -581,8 +581,9 @@ spec:
                     type: integer
                   monitoringAgent:
                     description: |-
-                      Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
-                      into the automation agent. Remove this field from your configuration.
+                      Deprecated: this field has no effect. The monitoring agent now runs inside the
+                      automation agent. Configure agent options, including log level and rotation, via
+                      spec.appDB.agent. Remove this field from your configuration.
                     properties:
                       startupOptions:
                         additionalProperties:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -72,16 +72,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -118,12 +118,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.2"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_0
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.0"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.0"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.0"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.8.2
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.9.0
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.8.1
+  replaces: mongodb-kubernetes.v1.8.2
   version: 0.0.0

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -1806,19 +1806,31 @@ func (r *ReconcileAppDbReplicaSet) readExistingPodVars(ctx context.Context, om *
 		return env.PodEnvVars{}, xerrors.Errorf("error reading credentials: %w", err)
 	}
 
-	agentAPIKey, err := secret.ReadKey(ctx, memberClient, util.OmAgentApiKey, kube.ObjectKey(om.Namespace, agents.ApiKeySecretName(projectId)))
-	if err != nil {
-		return env.PodEnvVars{}, xerrors.Errorf("error reading agent API key for project %s: %w", projectId, err)
-	}
-
-	return env.PodEnvVars{
-		User:        cred.PublicAPIKey,
-		ProjectID:   projectId,
-		AgentAPIKey: agentAPIKey,
+	podVars := env.PodEnvVars{
+		User:      cred.PublicAPIKey,
+		ProjectID: projectId,
 		SSLProjectConfig: env.SSLProjectConfig{
 			SSLMMSCAConfigMap: om.Spec.GetOpsManagerCA(),
 		},
-	}, nil
+	}
+
+	var appdbSecretPath string
+	if r.VaultClient != nil {
+		appdbSecretPath = r.VaultClient.AppDBSecretPath()
+	}
+
+	// Read through the Vault-aware SecretClient so the key resolves on Vault backends
+	// (where it has no plain Kubernetes Secret). A missing key is non-fatal: monitoring
+	// is simply left unconfigured until the key exists (configureMonitoring clears
+	// monitoringVersions when the key is empty).
+	agentAPIKey, err := r.getMemberCluster(r.getNameOfFirstMemberCluster()).SecretClient.ReadSecretKey(
+		ctx, kube.ObjectKey(om.Namespace, agents.ApiKeySecretName(projectId)), appdbSecretPath, util.OmAgentApiKey)
+	if err != nil {
+		log.Warnf("Agent API key for project %s not readable yet (%v); AppDB monitoring will be configured once it is available", projectId, err)
+		return podVars, nil
+	}
+	podVars.AgentAPIKey = agentAPIKey
+	return podVars, nil
 }
 
 func (r *ReconcileAppDbReplicaSet) publishACVersionAsConfigMap(ctx context.Context, cmName string, opsManager *omv1.MongoDBOpsManager, version int, memberCluster multicluster.MemberCluster) workflow.Status {

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	"github.com/mongodb/mongodb-kubernetes/pkg/agent"
-	"github.com/mongodb/mongodb-kubernetes/pkg/agentVersionManagement"
 	"github.com/mongodb/mongodb-kubernetes/pkg/authentication/scram"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/dns"
@@ -68,14 +67,9 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/vault"
 )
 
-type agentType string
-
 const (
 	appdbCAFilePath              = "/var/lib/mongodb-automation/secrets/ca/ca-pem"
 	appDBACConfigMapVersionField = "version"
-
-	monitoring agentType = "MONITORING"
-	automation agentType = "AUTOMATION"
 
 	// Used to note that for this particular case it is not necessary to pass
 	// the hash of the Prometheus certificate. This is to avoid having to
@@ -485,7 +479,7 @@ func (r *ReconcileAppDbReplicaSet) shouldReconcileAppDB(ctx context.Context, ops
 		return true, nil
 	}
 
-	desiredAc, err := r.buildAppDbAutomationConfig(ctx, opsManager, automation, UnusedPrometheusConfiguration, memberCluster.Name, log)
+	desiredAc, err := r.buildAppDbAutomationConfig(ctx, opsManager, nil, UnusedPrometheusConfiguration, memberCluster.Name, log)
 	if err != nil {
 		return false, xerrors.Errorf("error building AppDB Automation Config: %w", err)
 	}
@@ -605,15 +599,6 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 			appdbOpts.AgentImage = images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, agentVersion)
 		}
 	} else {
-		// instead of using a hard-coded monitoring version, we use the "newest" one based on the release.json.
-		// This ensures we need to care less about CVEs compared to the prior older hardcoded versions.
-		legacyMonitoringAgentVersion, err := r.getLegacyMonitoringAgentVersion(ctx, opsManager, log)
-		if err != nil {
-			return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error reading monitoring agent version: %w", err)), log, appDbStatusOption)
-		}
-
-		appdbOpts.LegacyMonitoringAgentImage = images.ContainerImage(r.imageUrls, util.AgentImageEnv, legacyMonitoringAgentVersion)
-
 		// AgentImageEnv contains the full container image uri e.g. quay.io/mongodb/mongodb-agent:107.0.0.8502-1
 		// In non-static containers we don't ask OM for the correct version, therefore we just rely on the provided
 		// environment variable.
@@ -660,7 +645,7 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 
 	workflowStatus = workflow.RunInGivenOrder(publishAutomationConfigFirst,
 		func() workflow.Status {
-			return r.deployAutomationConfigAndWaitForAgentsReachGoalState(ctx, log, opsManager, allStatefulSetsExist, appdbOpts)
+			return r.deployAutomationConfigAndWaitForAgentsReachGoalState(ctx, log, opsManager, &podVars, allStatefulSetsExist, appdbOpts)
 		},
 		func() workflow.Status {
 			return r.deployStatefulSet(ctx, opsManager, log, podVars, appdbOpts)
@@ -762,24 +747,8 @@ func (r *ReconcileAppDbReplicaSet) getNameOfFirstMemberCluster() string {
 	return firstMemberClusterName
 }
 
-// getLegacyMonitoringAgentVersion partially duplicates the functionality in (r *ReconcileCommonController).getAgentVersion to avoid
-// changing the signature of the general function that is used in static container setups as this method only considers the non-static
-// OpsManager. This should also make it easier to remove when switching to one architecture for containers.
-func (r *ReconcileAppDbReplicaSet) getLegacyMonitoringAgentVersion(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	m, err := agentVersionManagement.GetAgentVersionManager()
-	if err != nil || m == nil {
-		return "", xerrors.Errorf("not able to init agentVersionManager: %w", err)
-	}
-	if agentVersion, err := m.GetAgentVersion(nil, opsManager.Spec.Version, true); err != nil {
-		log.Errorf("Failed to get the agent version from the Agent Version manager: %s", err)
-		return "", xerrors.Errorf("Failed to get the agent version from the Agent Version manager: %w", err)
-	} else {
-		return agentVersion, nil
-	}
-}
-
-func (r *ReconcileAppDbReplicaSet) deployAutomationConfigAndWaitForAgentsReachGoalState(ctx context.Context, log *zap.SugaredLogger, opsManager *omv1.MongoDBOpsManager, allStatefulSetsExist bool, appdbOpts construct.AppDBStatefulSetOptions) workflow.Status {
-	configVersion, workflowStatus := r.deployAutomationConfigOnHealthyClusters(ctx, log, opsManager, appdbOpts)
+func (r *ReconcileAppDbReplicaSet) deployAutomationConfigAndWaitForAgentsReachGoalState(ctx context.Context, log *zap.SugaredLogger, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, allStatefulSetsExist bool, appdbOpts construct.AppDBStatefulSetOptions) workflow.Status {
+	configVersion, workflowStatus := r.deployAutomationConfigOnHealthyClusters(ctx, log, opsManager, podVars, appdbOpts)
 	if !workflowStatus.IsOK() {
 		return workflowStatus
 	}
@@ -792,10 +761,10 @@ func (r *ReconcileAppDbReplicaSet) deployAutomationConfigAndWaitForAgentsReachGo
 	return r.allAgentsReachedGoalState(ctx, opsManager, configVersion, log)
 }
 
-func (r *ReconcileAppDbReplicaSet) deployAutomationConfigOnHealthyClusters(ctx context.Context, log *zap.SugaredLogger, opsManager *omv1.MongoDBOpsManager, appdbOpts construct.AppDBStatefulSetOptions) (int, workflow.Status) {
+func (r *ReconcileAppDbReplicaSet) deployAutomationConfigOnHealthyClusters(ctx context.Context, log *zap.SugaredLogger, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, appdbOpts construct.AppDBStatefulSetOptions) (int, workflow.Status) {
 	configVersions := map[int]struct{}{}
 	for _, memberCluster := range r.GetHealthyMemberClusters() {
-		if configVersion, workflowStatus := r.deployAutomationConfig(ctx, opsManager, appdbOpts.PrometheusTLSCertHash, memberCluster, log); !workflowStatus.IsOK() {
+		if configVersion, workflowStatus := r.deployAutomationConfig(ctx, opsManager, podVars, appdbOpts.PrometheusTLSCertHash, memberCluster, log); !workflowStatus.IsOK() {
 			return 0, workflowStatus
 		} else {
 			log.Infof("Deployed Automation Config version: %d in cluster: %s", configVersion, memberCluster.Name)
@@ -1082,7 +1051,7 @@ func (r *ReconcileAppDbReplicaSet) getExistingAutomationConfig(ctx context.Conte
 	return latestAc, nil
 }
 
-func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, acType agentType, prometheusCertHash string, memberClusterName string, log *zap.SugaredLogger) (automationconfig.AutomationConfig, error) {
+func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, prometheusCertHash string, memberClusterName string, log *zap.SugaredLogger) (automationconfig.AutomationConfig, error) {
 	rs := opsManager.Spec.AppDB
 	domain := getDomain(rs.ServiceName(), opsManager.Namespace, opsManager.Spec.GetClusterDomain())
 
@@ -1096,9 +1065,6 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 	// the existing automation config is required as we compare it against what we build to determine
 	// if we need to increment the version.
 	secretName := rs.AutomationConfigSecretName()
-	if acType == monitoring {
-		secretName = rs.MonitoringAutomationConfigSecretName()
-	}
 
 	existingAutomationConfig, err := r.getExistingAutomationConfig(ctx, opsManager, secretName)
 	if err != nil {
@@ -1114,15 +1080,9 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 	}
 	certHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, opsManager.Namespace, tlsSecretName, appdbSecretPath, log)
 
-	prometheusModification := automationconfig.NOOP()
-	if acType == automation {
-		// There are 2 agents running in the AppDB Pods, we will configure Prometheus
-		// only on the Automation Agent.
-		prometheusModification, err = buildPrometheusModification(ctx, r.SecretClient, opsManager, prometheusCertHash)
-		if err != nil {
-			log.Errorf("Could not enable Prometheus: %s", err)
-		}
-
+	prometheusModification, err := buildPrometheusModification(ctx, r.SecretClient, opsManager, prometheusCertHash)
+	if err != nil {
+		log.Errorf("Could not enable Prometheus: %s", err)
 	}
 
 	processList := r.generateProcessList(opsManager)
@@ -1188,19 +1148,24 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 				systemLog = opsManager.Spec.AppDB.AutomationAgent.Mongod.SystemLog
 			}
 
-			if acType == automation {
-				if opsManager.Spec.AppDB.AutomationAgent.Mongod.HasLoggingConfigured() {
-					automationconfig.ConfigureAgentConfiguration(systemLog, opsManager.Spec.AppDB.AutomationAgent.Mongod.LogRotate, opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate, p)
-				} else {
-					automationconfig.ConfigureAgentConfiguration(systemLog, opsManager.Spec.AppDB.AutomationAgent.LogRotate, opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate, p)
-				}
+			if opsManager.Spec.AppDB.AutomationAgent.Mongod.HasLoggingConfigured() {
+				automationconfig.ConfigureAgentConfiguration(systemLog, opsManager.Spec.AppDB.AutomationAgent.Mongod.LogRotate, opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate, p)
+			} else {
+				automationconfig.ConfigureAgentConfiguration(systemLog, opsManager.Spec.AppDB.AutomationAgent.LogRotate, opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate, p)
 			}
 		}).
 		AddModifications(func(automationConfig *automationconfig.AutomationConfig) {
-			if acType == monitoring {
-				configureMonitoring(automationConfig, log, rs.GetSecurity().IsTLSEnabled())
-				automationConfig.ReplicaSets = []automationconfig.ReplicaSet{}
-				automationConfig.Processes = []automationconfig.Process{}
+			if construct.ShouldEnableMonitoring(podVars) {
+				configureMonitoring(
+					automationConfig, log,
+					rs.GetSecurity().IsTLSEnabled(),
+					podVars.ProjectID,
+					podVars.AgentAPIKey,
+					podVars.SSLRequireValidMMSServerCertificates,
+					map[string]string(opsManager.Spec.AppDB.MonitoringAgent.StartupParameters),
+				)
+			} else {
+				automationConfig.MonitoringVersions = []automationconfig.MonitoringVersion{}
 			}
 			setBaseUrlForAgents(automationConfig, opsManager.CentralURL())
 		}).
@@ -1226,38 +1191,33 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 		return automationconfig.AutomationConfig{}, err
 	}
 
-	if acType == automation && opsManager.Spec.AppDB.AutomationConfigOverride != nil {
+	if opsManager.Spec.AppDB.AutomationConfigOverride != nil {
 		acToMerge := overrideToAutomationConfig(*opsManager.Spec.AppDB.AutomationConfigOverride)
 		ac = merge.AutomationConfigs(ac, acToMerge)
 	}
 
-	// this is for logging automation config, ignoring monitoring as it doesn't contain any processes)
-	if acType == automation {
-		processHostnames := util.Transform(ac.Processes, func(obj automationconfig.Process) string {
-			return obj.HostName
-		})
+	processHostnames := util.Transform(ac.Processes, func(obj automationconfig.Process) string {
+		return obj.HostName
+	})
 
-		var replicaSetMembers []string
-		if len(ac.ReplicaSets) > 0 {
-			replicaSetMembers = util.Transform(ac.ReplicaSets[0].Members, func(member automationconfig.ReplicaSetMember) string {
-				return fmt.Sprintf("{Id=%d, Host=%s}", member.Id, member.Host)
-			})
-		}
-		log.Debugf("Created automation config object (in-memory) for cluster=%s, total process count=%d, process hostnames=%+v, replicaset config=%+v", memberClusterName, replicasThisReconciliation, processHostnames, replicaSetMembers)
+	var replicaSetMembers []string
+	if len(ac.ReplicaSets) > 0 {
+		replicaSetMembers = util.Transform(ac.ReplicaSets[0].Members, func(member automationconfig.ReplicaSetMember) string {
+			return fmt.Sprintf("{Id=%d, Host=%s}", member.Id, member.Host)
+		})
 	}
+	log.Debugf("Created automation config object (in-memory) for cluster=%s, total process count=%d, process hostnames=%+v, replicaset config=%+v", memberClusterName, replicasThisReconciliation, processHostnames, replicaSetMembers)
 
 	// this is for force reconfigure. This sets "currentVersion: -1" in automation config
 	// when forceReconfig is triggered.
-	if acType == automation {
-		if shouldPerformForcedReconfigure(opsManager.Annotations) {
-			log.Debug("Performing forced reconfigure of AppDB")
-			builder.SetForceReconfigureToVersion(-1)
+	if shouldPerformForcedReconfigure(opsManager.Annotations) {
+		log.Debug("Performing forced reconfigure of AppDB")
+		builder.SetForceReconfigureToVersion(-1)
 
-			ac, err = builder.Build()
-			if err != nil {
-				log.Errorf("failed to build AC: %w", err)
-				return ac, err
-			}
+		ac, err = builder.Build()
+		if err != nil {
+			log.Errorf("failed to build AC: %v", err)
+			return ac, err
 		}
 	}
 
@@ -1443,7 +1403,11 @@ func setBaseUrlForAgents(ac *automationconfig.AutomationConfig, url string) {
 	}
 }
 
-func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.SugaredLogger, tls bool) {
+func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.SugaredLogger, tls bool, projectID string, agentAPIKey string, requireValidCert bool, extraParams map[string]string) {
+	if projectID == "" || agentAPIKey == "" {
+		ac.MonitoringVersions = []automationconfig.MonitoringVersion{}
+		return
+	}
 	if len(ac.Processes) == 0 {
 		return
 	}
@@ -1453,26 +1417,39 @@ func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.Sugared
 		hostname := p.HostName
 		pemKeyFile := p.Args26.Get("net.tls.certificateKeyFile").String()
 
+		params := map[string]string{
+			"mmsGroupId": projectID,
+			"mmsApiKey":  agentAPIKey,
+		}
+		for k, v := range extraParams {
+			params[k] = v
+		}
+		if tls {
+			for k, v := range om.NewTLSParams(appdbCAFilePath, pemKeyFile) {
+				params[k] = v
+			}
+			if requireValidCert {
+				params["sslRequireValidMMSServerCertificates"] = "true"
+			} else {
+				params["sslRequireValidMMSServerCertificates"] = "false"
+			}
+		} else {
+			om.ClearTLSParams(params)
+		}
+
 		foundIdx := slices.IndexFunc(monitoringVersions, func(m automationconfig.MonitoringVersion) bool {
 			return m.Hostname == hostname
 		})
-
 		if foundIdx == -1 {
 			mv := automationconfig.MonitoringVersion{
-				Hostname: hostname,
-				Name:     om.MonitoringAgentDefaultVersion,
-			}
-			if tls {
-				mv.AdditionalParams = om.NewTLSParams(appdbCAFilePath, pemKeyFile)
+				Hostname:         hostname,
+				Name:             om.MonitoringAgentDefaultVersion,
+				AdditionalParams: params,
 			}
 			log.Debugw("Added monitoring agent configuration", "host", hostname, "tls", tls)
 			monitoringVersions = append(monitoringVersions, mv)
 		} else {
-			if tls {
-				monitoringVersions[foundIdx].AdditionalParams = om.NewTLSParams(appdbCAFilePath, pemKeyFile)
-			} else {
-				om.ClearTLSParams(monitoringVersions[foundIdx].AdditionalParams)
-			}
+			monitoringVersions[foundIdx].AdditionalParams = params
 		}
 	}
 	ac.MonitoringVersions = monitoringVersions
@@ -1756,9 +1733,14 @@ func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(ctx contex
 		return existingPodVars, xerrors.Errorf("error adding preferred hostnames: %w", err)
 	}
 
-	return env.PodEnvVars{User: conn.PublicKey(), ProjectID: conn.GroupID(), SSLProjectConfig: env.SSLProjectConfig{
-		SSLMMSCAConfigMap: opsManager.Spec.GetOpsManagerCA(),
-	}}, nil
+	return env.PodEnvVars{
+		User:        conn.PublicKey(),
+		ProjectID:   conn.GroupID(),
+		AgentAPIKey: agentApiKey,
+		SSLProjectConfig: env.SSLProjectConfig{
+			SSLMMSCAConfigMap: opsManager.Spec.GetOpsManagerCA(),
+		},
+	}, nil
 }
 
 func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMap(ctx context.Context, opsManager *omv1.MongoDBOpsManager, projectID string) error {
@@ -1824,9 +1806,15 @@ func (r *ReconcileAppDbReplicaSet) readExistingPodVars(ctx context.Context, om *
 		return env.PodEnvVars{}, xerrors.Errorf("error reading credentials: %w", err)
 	}
 
+	agentAPIKey, err := secret.ReadKey(ctx, memberClient, util.OmAgentApiKey, kube.ObjectKey(om.Namespace, agents.ApiKeySecretName(projectId)))
+	if err != nil {
+		return env.PodEnvVars{}, xerrors.Errorf("error reading agent API key for project %s: %w", projectId, err)
+	}
+
 	return env.PodEnvVars{
-		User:      cred.PublicAPIKey,
-		ProjectID: projectId,
+		User:        cred.PublicAPIKey,
+		ProjectID:   projectId,
+		AgentAPIKey: agentAPIKey,
 		SSLProjectConfig: env.SSLProjectConfig{
 			SSLMMSCAConfigMap: om.Spec.GetOpsManagerCA(),
 		},
@@ -1852,10 +1840,10 @@ func (r *ReconcileAppDbReplicaSet) publishACVersionAsConfigMap(ctx context.Conte
 
 // deployAutomationConfig updates the Automation Config secret if necessary and waits for the pods to fall to "not ready"
 // In this case the next StatefulSet update will be safe as the rolling upgrade will wait for the pods to get ready
-func (r *ReconcileAppDbReplicaSet) deployAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, prometheusCertHash string, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger) (int, workflow.Status) {
+func (r *ReconcileAppDbReplicaSet) deployAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, prometheusCertHash string, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger) (int, workflow.Status) {
 	rs := opsManager.Spec.AppDB
 
-	config, err := r.buildAppDbAutomationConfig(ctx, opsManager, automation, prometheusCertHash, memberCluster.Name, log)
+	config, err := r.buildAppDbAutomationConfig(ctx, opsManager, podVars, prometheusCertHash, memberCluster.Name, log)
 	if err != nil {
 		return 0, workflow.Failed(err)
 	}
@@ -1868,32 +1856,7 @@ func (r *ReconcileAppDbReplicaSet) deployAutomationConfig(ctx context.Context, o
 		return 0, workflowStatus
 	}
 
-	monitoringAc, err := r.buildAppDbAutomationConfig(ctx, opsManager, monitoring, UnusedPrometheusConfiguration, memberCluster.Name, log)
-	if err != nil {
-		return 0, workflow.Failed(err)
-	}
-
-	if err := r.deployMonitoringAgentAutomationConfig(ctx, opsManager, memberCluster, log); err != nil {
-		return 0, workflow.Failed(err)
-	}
-
-	if workflowStatus := r.publishACVersionAsConfigMap(ctx, opsManager.Spec.AppDB.MonitoringAutomationConfigConfigMapName(), opsManager, monitoringAc.Version, memberCluster); !workflowStatus.IsOK() {
-		return 0, workflowStatus
-	}
-
 	return configVersion, workflow.OK()
-}
-
-// deployMonitoringAgentAutomationConfig deploys the monitoring agent's automation config.
-func (r *ReconcileAppDbReplicaSet) deployMonitoringAgentAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger) error {
-	config, err := r.buildAppDbAutomationConfig(ctx, opsManager, monitoring, UnusedPrometheusConfiguration, memberCluster.Name, log)
-	if err != nil {
-		return err
-	}
-	if _, err = r.publishAutomationConfig(ctx, opsManager, config, opsManager.Spec.AppDB.MonitoringAutomationConfigSecretName(), memberCluster.SecretClient); err != nil {
-		return err
-	}
-	return nil
 }
 
 // GetAppDBUpdateStrategyType returns the update strategy type the AppDB Statefulset needs to be configured with.
@@ -1927,12 +1890,6 @@ func (r *ReconcileAppDbReplicaSet) deployStatefulSet(ctx context.Context, opsMan
 		if !memberCluster.Healthy {
 			// do not proceed if this is unhealthy cluster
 			continue
-		}
-
-		// in the case of an upgrade from the 1 to 3 container architecture, when the stateful set is updated before the agent automation config
-		// the monitoring agent automation config needs to exist for the volumes to mount correctly.
-		if err := r.deployMonitoringAgentAutomationConfig(ctx, opsManager, memberCluster, log); err != nil {
-			return workflow.Failed(err)
 		}
 
 		updateStrategy := r.GetAppDBUpdateStrategyType(opsManager)

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -1816,8 +1816,8 @@ func (r *ReconcileAppDbReplicaSet) readExistingPodVars(ctx context.Context, om *
 	}
 
 	// Read through the Vault-aware SecretClient so the key resolves on Vault backends
-	// (where it has no plain Kubernetes Secret). A missing key is non-fatal: monitoring
-	// is simply left unconfigured until the key exists (configureMonitoring clears
+	// (where it has no plain Kubernetes Secret). Any read failure is non-fatal: monitoring
+	// is simply left unconfigured until the key is available (configureMonitoring clears
 	// monitoringVersions when the key is empty).
 	agentAPIKey, err := r.getMemberCluster(r.getNameOfFirstMemberCluster()).SecretClient.ReadSecretKey(
 		ctx, kube.ObjectKey(om.Namespace, agents.ApiKeySecretName(projectId)), appdbSecretPath, util.OmAgentApiKey)

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -1162,7 +1162,6 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 					podVars.ProjectID,
 					podVars.AgentAPIKey,
 					podVars.SSLRequireValidMMSServerCertificates,
-					map[string]string(opsManager.Spec.AppDB.MonitoringAgent.StartupParameters),
 				)
 			} else {
 				automationConfig.MonitoringVersions = []automationconfig.MonitoringVersion{}
@@ -1403,7 +1402,7 @@ func setBaseUrlForAgents(ac *automationconfig.AutomationConfig, url string) {
 	}
 }
 
-func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.SugaredLogger, tls bool, projectID string, agentAPIKey string, requireValidCert bool, extraParams map[string]string) {
+func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.SugaredLogger, tls bool, projectID string, agentAPIKey string, requireValidCert bool) {
 	if projectID == "" || agentAPIKey == "" {
 		ac.MonitoringVersions = []automationconfig.MonitoringVersion{}
 		return
@@ -1420,9 +1419,6 @@ func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.Sugared
 		params := map[string]string{
 			"mmsGroupId": projectID,
 			"mmsApiKey":  agentAPIKey,
-		}
-		for k, v := range extraParams {
-			params[k] = v
 		}
 		if tls {
 			for k, v := range om.NewTLSParams(appdbCAFilePath, pemKeyFile) {

--- a/controllers/operator/appdbreplicaset_controller_multi_test.go
+++ b/controllers/operator/appdbreplicaset_controller_multi_test.go
@@ -106,8 +106,8 @@ func TestAppDB_MultiCluster(t *testing.T) {
 		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, opsManager.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
 		memberClusterChecks.checkAutomationConfigSecret(ctx, appdb.AutomationConfigSecretName())
 		memberClusterChecks.checkAutomationConfigConfigMap(ctx, appdb.AutomationConfigConfigMapName())
-		memberClusterChecks.checkAutomationConfigSecret(ctx, appdb.MonitoringAutomationConfigSecretName())
-		memberClusterChecks.checkAutomationConfigConfigMap(ctx, appdb.MonitoringAutomationConfigConfigMapName())
+		memberClusterChecks.checkSecretNotFound(ctx, appdb.MonitoringAutomationConfigSecretName())
+		memberClusterChecks.checkConfigMapNotFound(ctx, appdb.MonitoringAutomationConfigConfigMapName())
 		memberClusterChecks.checkTLSCAConfigMap(ctx, caConfigMapName)
 		// TLS secret should not be replicated, only PEM secret
 		memberClusterChecks.checkSecretNotFound(ctx, tlsCertSecretName)

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -1695,7 +1695,7 @@ func TestConfigureMonitoring_NonTLS(t *testing.T) {
 	ac := automationconfig.AutomationConfig{
 		Processes: []automationconfig.Process{{HostName: "host-0"}},
 	}
-	configureMonitoring(&ac, zap.S(), false, "myGroupId", "myApiKey", false, nil)
+	configureMonitoring(&ac, zap.S(), false, "myGroupId", "myApiKey", false)
 
 	require.Len(t, ac.MonitoringVersions, 1)
 	params := ac.MonitoringVersions[0].AdditionalParams
@@ -1708,7 +1708,7 @@ func TestConfigureMonitoring_TLS(t *testing.T) {
 	ac := automationconfig.AutomationConfig{
 		Processes: []automationconfig.Process{{HostName: "host-0"}},
 	}
-	configureMonitoring(&ac, zap.S(), true, "myGroupId", "myApiKey", true, nil)
+	configureMonitoring(&ac, zap.S(), true, "myGroupId", "myApiKey", true)
 
 	require.Len(t, ac.MonitoringVersions, 1)
 	params := ac.MonitoringVersions[0].AdditionalParams
@@ -1723,7 +1723,7 @@ func TestConfigureMonitoring_TLS_RequireValidCertFalse(t *testing.T) {
 	ac := automationconfig.AutomationConfig{
 		Processes: []automationconfig.Process{{HostName: "host-0"}},
 	}
-	configureMonitoring(&ac, zap.S(), true, "myGroupId", "myApiKey", false, nil)
+	configureMonitoring(&ac, zap.S(), true, "myGroupId", "myApiKey", false)
 
 	require.Len(t, ac.MonitoringVersions, 1)
 	params := ac.MonitoringVersions[0].AdditionalParams
@@ -1740,7 +1740,7 @@ func TestConfigureMonitoring_ClearsWhenDisabled(t *testing.T) {
 		},
 	}
 	// called with empty credentials simulates monitoring disabled
-	configureMonitoring(&ac, zap.S(), false, "", "", false, nil)
+	configureMonitoring(&ac, zap.S(), false, "", "", false)
 
 	assert.Empty(t, ac.MonitoringVersions)
 }
@@ -1819,7 +1819,7 @@ func TestClearTLSParams(t *testing.T) {
 	}
 }
 
-func TestMonitoringAgentStartupParametersForwardedToAdditionalParams(t *testing.T) {
+func TestMonitoringAgentStartupParametersIgnored(t *testing.T) {
 	t.Setenv(util.OpsManagerMonitorAppDB, "true")
 	ctx := context.Background()
 	builder := DefaultOpsManagerBuilder()
@@ -1840,5 +1840,6 @@ func TestMonitoringAgentStartupParametersForwardedToAdditionalParams(t *testing.
 	require.NoError(t, err)
 
 	require.NotEmpty(t, ac.MonitoringVersions)
-	assert.Equal(t, "myValue", ac.MonitoringVersions[0].AdditionalParams["myCustomParam"])
+	assert.NotContains(t, ac.MonitoringVersions[0].AdditionalParams, "myCustomParam",
+		"deprecated monitoringAgent.startupOptions must not be forwarded to monitoringVersions additionalParams")
 }

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -154,14 +154,14 @@ func TestPublishAutomationConfigCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	memberCluster := multicluster.GetLegacyCentralMemberCluster(opsManager.Spec.Replicas, 0, reconciler.client, reconciler.SecretClient)
-	automationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, automation, zap.S())
+	automationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, zap.S())
 	assert.NoError(t, err)
 
 	version, err := reconciler.publishAutomationConfig(ctx, opsManager, automationConfig, appdb.AutomationConfigSecretName(), memberCluster.SecretClient)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, version)
 
-	monitoringAutomationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, monitoring, zap.S())
+	monitoringAutomationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, zap.S())
 	assert.NoError(t, err)
 	version, err = reconciler.publishAutomationConfig(ctx, opsManager, monitoringAutomationConfig, appdb.MonitoringAutomationConfigSecretName(), memberCluster.SecretClient)
 	assert.NoError(t, err)
@@ -274,9 +274,7 @@ func TestBuildAppDbAutomationConfig(t *testing.T) {
 	err := createOpsManagerUserPasswordSecret(ctx, kubeClient, om, "omPass")
 	assert.NoError(t, err)
 
-	automationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, automation, zap.S())
-	assert.NoError(t, err)
-	monitoringAutomationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, monitoring, zap.S())
+	automationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, zap.S())
 	assert.NoError(t, err)
 	// processes
 	assert.Len(t, automationConfig.Processes, 2)
@@ -286,8 +284,6 @@ func TestBuildAppDbAutomationConfig(t *testing.T) {
 	assert.Equal(t, "4.2.11-ent", automationConfig.Processes[1].Version)
 	assert.Equal(t, "test-om-db-1.test-om-db-svc.my-namespace.svc.cluster.local", automationConfig.Processes[1].HostName)
 	assert.Equal(t, "4.0", automationConfig.Processes[1].FeatureCompatibilityVersion)
-	assert.Len(t, monitoringAutomationConfig.Processes, 0)
-	assert.Len(t, monitoringAutomationConfig.ReplicaSets, 0)
 	assert.Equal(t, automationconfig.ConvertCrdLogRotateToAC(logRotateConfig), automationConfig.Processes[0].LogRotate)
 	assert.Equal(t, "/tmp/test", automationConfig.Processes[0].Args26.Get("systemLog.path").String())
 	assert.Equal(t, "file", automationConfig.Processes[0].Args26.Get("systemLog.destination").String())
@@ -305,6 +301,89 @@ func TestBuildAppDbAutomationConfig(t *testing.T) {
 
 	// options
 	assert.Equal(t, automationconfig.Options{DownloadBase: util.AgentDownloadsDir}, automationConfig.Options)
+}
+
+func TestBuildAppDbAutomationConfig_MonitoringEmbedded(t *testing.T) {
+	// OPS_MANAGER_MONITOR_APPDB defaults true; set explicitly to avoid env-state sensitivity
+	t.Setenv(util.OpsManagerMonitorAppDB, "true")
+	ctx := context.Background()
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+	_ = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, "my-password")
+
+	podVars := &env.PodEnvVars{
+		ProjectID:   "abc123",
+		AgentAPIKey: "my-api-key",
+	}
+
+	ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, podVars, "", multicluster.LegacyCentralClusterName, zap.S())
+	require.NoError(t, err)
+
+	require.NotEmpty(t, ac.MonitoringVersions)
+	assert.Equal(t, "abc123", ac.MonitoringVersions[0].AdditionalParams["mmsGroupId"])
+	assert.Equal(t, "my-api-key", ac.MonitoringVersions[0].AdditionalParams["mmsApiKey"])
+}
+
+func TestBuildAppDbAutomationConfig_NoMonitoringWhenDisabled(t *testing.T) {
+	t.Setenv(util.OpsManagerMonitorAppDB, "false")
+	ctx := context.Background()
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+	_ = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, "my-password")
+
+	// nil podVars => ShouldEnableMonitoring returns false
+	ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, nil, "", multicluster.LegacyCentralClusterName, zap.S())
+	require.NoError(t, err)
+
+	assert.Empty(t, ac.MonitoringVersions)
+}
+
+func TestMonitoringToggledOff_ClearsMonitoringVersions(t *testing.T) {
+	t.Setenv(util.OpsManagerMonitorAppDB, "false")
+	ctx := context.Background()
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+	_ = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, "my-password")
+
+	// Non-nil podVars with a project ID — monitoring is disabled via the env var, not nil podVars
+	podVars := &env.PodEnvVars{
+		ProjectID:   "abc123",
+		AgentAPIKey: "some-key",
+	}
+
+	ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, podVars, "", multicluster.LegacyCentralClusterName, zap.S())
+	require.NoError(t, err)
+	assert.Empty(t, ac.MonitoringVersions, "MonitoringVersions must be empty when monitoring env var is false")
+}
+
+func TestMonitoringToggledBackOn_PopulatesMonitoringVersions(t *testing.T) {
+	ctx := context.Background()
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+	_ = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, "my-password")
+
+	podVars := &env.PodEnvVars{
+		ProjectID:   "abc123",
+		AgentAPIKey: "re-enabled-key",
+	}
+
+	ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, podVars, "", multicluster.LegacyCentralClusterName, zap.S())
+	require.NoError(t, err)
+	require.NotNil(t, ac.MonitoringVersions, "MonitoringVersions must be populated when monitoring is re-enabled")
+	assert.Equal(t, "abc123", ac.MonitoringVersions[0].AdditionalParams["mmsGroupId"])
+	assert.Equal(t, "re-enabled-key", ac.MonitoringVersions[0].AdditionalParams["mmsApiKey"])
 }
 
 func TestRegisterAppDBHostsWithProject(t *testing.T) {
@@ -438,7 +517,32 @@ func TestTryConfigureMonitoringInOpsManager(t *testing.T) {
 	appDbSts, err = construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, zap.S())
 	assert.NoError(t, err)
 
-	assert.NotNil(t, findVolumeByName(appDbSts.Spec.Template.Spec.Volumes, construct.AgentAPIKeyVolumeName))
+	assert.Nil(t, findVolumeByName(appDbSts.Spec.Template.Spec.Volumes, construct.AgentAPIKeyVolumeName))
+}
+
+func TestTryConfigureMonitoring_PopulatesAgentAPIKey(t *testing.T) {
+	ctx := context.Background()
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient()
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	// Create the OM API key secret (required by tryConfigureMonitoringInOpsManager)
+	APIKeySecretName, err := opsManager.APIKeySecretName(ctx, secrets.SecretClient{KubeClient: kubeClient}, "")
+	require.NoError(t, err)
+	apiKeySecret := secret.Builder().
+		SetNamespace(operatorNamespace()).
+		SetName(APIKeySecretName).
+		SetStringMapToData(map[string]string{util.OmPublicApiKey: "publicApiKey", util.OmPrivateKey: "privateApiKey"}).
+		Build()
+	err = reconciler.client.CreateSecret(ctx, apiKeySecret)
+	require.NoError(t, err)
+
+	podVars, err := reconciler.tryConfigureMonitoringInOpsManager(ctx, opsManager, "password", "/fake/cert", zap.S())
+	require.NoError(t, err)
+	// MockedOmConnection.AgentAPIKey is om.TestAgentKey by default
+	assert.Equal(t, om.TestAgentKey, podVars.AgentAPIKey)
 }
 
 // TestTryConfigureMonitoringInOpsManagerWithCustomTemplate runs different scenarios with activating monitoring and pod templates
@@ -484,14 +588,11 @@ func TestTryConfigureMonitoringInOpsManagerWithCustomTemplate(t *testing.T) {
 				assert.Equal(t, "quay.io/mongodb/mongodb:10", c.Image)
 				foundImages += 1
 			}
-			if c.Name == "mongodb-agent-monitoring" {
-				assert.Equal(t, "quay.io/mongodb/mongodb-agent:20", c.Image)
-				foundImages += 1
-			}
 		}
 
-		assert.Equal(t, 3, foundImages)
-		assert.Equal(t, 3, len(appDbSts.Spec.Template.Spec.Containers))
+		// monitoring container is stripped from user-supplied templates; only agent + mongod remain
+		assert.Equal(t, 2, foundImages)
+		assert.Equal(t, 2, len(appDbSts.Spec.Template.Spec.Containers))
 	})
 
 	t.Run("do not override images, but remove monitoring if not activated", func(t *testing.T) {
@@ -508,10 +609,6 @@ func TestTryConfigureMonitoringInOpsManagerWithCustomTemplate(t *testing.T) {
 			}
 			if c.Name == "mongod" {
 				assert.Equal(t, "quay.io/mongodb/mongodb:10", c.Image)
-				foundImages += 1
-			}
-			if c.Name == "mongodb-agent-monitoring" {
-				assert.Equal(t, "quay.io/mongodb/mongodb-agent:20", c.Image)
 				foundImages += 1
 			}
 		}
@@ -583,7 +680,7 @@ func TestTryConfigureMonitoringInOpsManagerWithExternalDomains(t *testing.T) {
 	appDbSts, err = construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, zap.S())
 	assert.NoError(t, err)
 
-	assert.NotNil(t, findVolumeByName(appDbSts.Spec.Template.Spec.Volumes, construct.AgentAPIKeyVolumeName))
+	assert.Nil(t, findVolumeByName(appDbSts.Spec.Template.Spec.Volumes, construct.AgentAPIKeyVolumeName))
 }
 
 func TestTryConfigureMonitoringInOpsManagerWithMalformedCredentials(t *testing.T) {
@@ -636,6 +733,47 @@ func TestTryConfigureMonitoringInOpsManagerWithMalformedCredentials(t *testing.T
 	assert.NotEmpty(t, podVars)
 	assert.Equal(t, om.TestGroupID, podVars.ProjectID)
 	assert.Equal(t, "publicApiKey", podVars.User)
+}
+
+func TestReadExistingPodVars_ReturnsAgentAPIKey(t *testing.T) {
+	ctx := context.Background()
+	projectID := "proj-123"
+	agentKey := "fallback-agent-key"
+
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient()
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	// 1. Create projectID configmap
+	err = reconciler.ensureProjectIDConfigMapForCluster(ctx, opsManager, projectID, reconciler.client)
+	require.NoError(t, err)
+
+	// 2. Create OM API key secret (needed by ReadCredentials for User field)
+	APIKeySecretName, err := opsManager.APIKeySecretName(ctx, secrets.SecretClient{KubeClient: kubeClient}, "")
+	require.NoError(t, err)
+	apiKeySecret := secret.Builder().
+		SetNamespace(operatorNamespace()).
+		SetName(APIKeySecretName).
+		SetStringMapToData(map[string]string{util.OmPublicApiKey: "publicApiKey", util.OmPrivateKey: "privateApiKey"}).
+		Build()
+	err = reconciler.client.CreateSecret(ctx, apiKeySecret)
+	require.NoError(t, err)
+
+	// 3. Create agent API key secret
+	agentKeySecret := secret.Builder().
+		SetNamespace(opsManager.Namespace).
+		SetName(agents.ApiKeySecretName(projectID)).
+		SetStringMapToData(map[string]string{util.OmAgentApiKey: agentKey}).
+		Build()
+	err = reconciler.client.CreateSecret(ctx, agentKeySecret)
+	require.NoError(t, err)
+
+	podVars, err := reconciler.readExistingPodVars(ctx, opsManager, zap.S())
+	require.NoError(t, err)
+	assert.Equal(t, agentKey, podVars.AgentAPIKey)
+	assert.Equal(t, projectID, podVars.ProjectID)
 }
 
 func TestAppDBServiceCreation_WithExternalName(t *testing.T) {
@@ -1228,7 +1366,7 @@ func TestAppDBSkipsReconciliation_IfAnyProcessesAreDisabled(t *testing.T) {
 		// if the automation is not there, we will always want to reconcile. Otherwise, we may not reconcile
 		// based on whether or not there are disabled processes.
 		if createAutomationConfig {
-			ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, automation, UnusedPrometheusConfiguration, multicluster.LegacyCentralClusterName, zap.S())
+			ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, nil, UnusedPrometheusConfiguration, multicluster.LegacyCentralClusterName, zap.S())
 			assert.NoError(t, err)
 
 			_, err = reconciler.publishAutomationConfig(ctx, opsManager, ac, opsManager.Spec.AppDB.AutomationConfigSecretName(), memberCluster.SecretClient)
@@ -1390,7 +1528,7 @@ func performAppDBScalingTest(ctx context.Context, t *testing.T, startingMembers,
 	assert.Equal(t, finalMembers, opsManager.Status.AppDbStatus.Members)
 }
 
-func buildAutomationConfigForAppDb(ctx context.Context, builder *omv1.OpsManagerBuilder, kubeClient client.Client, omConnectionFactoryFunc om.ConnectionFactory, acType agentType, log *zap.SugaredLogger) (automationconfig.AutomationConfig, error) {
+func buildAutomationConfigForAppDb(ctx context.Context, builder *omv1.OpsManagerBuilder, kubeClient client.Client, omConnectionFactoryFunc om.ConnectionFactory, log *zap.SugaredLogger) (automationconfig.AutomationConfig, error) {
 	opsManager := builder.Build()
 
 	// Ensure the password exists for the Ops Manager User. The Ops Manager controller will have ensured this.
@@ -1400,7 +1538,7 @@ func buildAutomationConfigForAppDb(ctx context.Context, builder *omv1.OpsManager
 	if err != nil {
 		return automationconfig.AutomationConfig{}, err
 	}
-	return reconciler.buildAppDbAutomationConfig(ctx, opsManager, acType, UnusedPrometheusConfiguration, multicluster.LegacyCentralClusterName, zap.S())
+	return reconciler.buildAppDbAutomationConfig(ctx, opsManager, nil, UnusedPrometheusConfiguration, multicluster.LegacyCentralClusterName, zap.S())
 }
 
 func checkDeploymentEqualToPublished(t *testing.T, expected automationconfig.AutomationConfig, s *corev1.Secret) {
@@ -1522,6 +1660,60 @@ func createRunningAppDB(ctx context.Context, t *testing.T, startingMembers int, 
 	return reconciler
 }
 
+func TestConfigureMonitoring_NonTLS(t *testing.T) {
+	ac := automationconfig.AutomationConfig{
+		Processes: []automationconfig.Process{{HostName: "host-0"}},
+	}
+	configureMonitoring(&ac, zap.S(), false, "myGroupId", "myApiKey", false, nil)
+
+	require.Len(t, ac.MonitoringVersions, 1)
+	params := ac.MonitoringVersions[0].AdditionalParams
+	assert.Equal(t, "myGroupId", params["mmsGroupId"])
+	assert.Equal(t, "myApiKey", params["mmsApiKey"])
+	assert.NotContains(t, params, "useSslForAllConnections")
+}
+
+func TestConfigureMonitoring_TLS(t *testing.T) {
+	ac := automationconfig.AutomationConfig{
+		Processes: []automationconfig.Process{{HostName: "host-0"}},
+	}
+	configureMonitoring(&ac, zap.S(), true, "myGroupId", "myApiKey", true, nil)
+
+	require.Len(t, ac.MonitoringVersions, 1)
+	params := ac.MonitoringVersions[0].AdditionalParams
+	assert.Equal(t, "myGroupId", params["mmsGroupId"])
+	assert.Equal(t, "myApiKey", params["mmsApiKey"])
+	assert.Equal(t, "true", params["useSslForAllConnections"])
+	assert.Equal(t, "true", params["sslRequireValidMMSServerCertificates"])
+	assert.Equal(t, appdbCAFilePath, params["sslTrustedServerCertificates"])
+}
+
+func TestConfigureMonitoring_TLS_RequireValidCertFalse(t *testing.T) {
+	ac := automationconfig.AutomationConfig{
+		Processes: []automationconfig.Process{{HostName: "host-0"}},
+	}
+	configureMonitoring(&ac, zap.S(), true, "myGroupId", "myApiKey", false, nil)
+
+	require.Len(t, ac.MonitoringVersions, 1)
+	params := ac.MonitoringVersions[0].AdditionalParams
+	assert.Equal(t, "myGroupId", params["mmsGroupId"])
+	assert.Equal(t, "true", params["useSslForAllConnections"])
+	assert.Equal(t, "false", params["sslRequireValidMMSServerCertificates"])
+}
+
+func TestConfigureMonitoring_ClearsWhenDisabled(t *testing.T) {
+	ac := automationconfig.AutomationConfig{
+		Processes: []automationconfig.Process{{HostName: "host-0"}},
+		MonitoringVersions: []automationconfig.MonitoringVersion{
+			{Hostname: "host-0", AdditionalParams: map[string]string{"mmsGroupId": "old"}},
+		},
+	}
+	// called with empty credentials simulates monitoring disabled
+	configureMonitoring(&ac, zap.S(), false, "", "", false, nil)
+
+	assert.Empty(t, ac.MonitoringVersions)
+}
+
 // TestClearTLSParams tests CLOUDP-351614 fix:
 // When TLS is disabled on AppDB, TLS-specific params should be cleared from
 // the monitoring config's additionalParams to prevent the monitoring agent
@@ -1594,4 +1786,28 @@ func TestClearTLSParams(t *testing.T) {
 			assert.Equal(t, tt.expectedOutput, tt.input)
 		})
 	}
+}
+
+func TestMonitoringAgentStartupParametersForwardedToAdditionalParams(t *testing.T) {
+	t.Setenv(util.OpsManagerMonitorAppDB, "true")
+	ctx := context.Background()
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	opsManager.Spec.AppDB.MonitoringAgent.StartupParameters = map[string]string{"myCustomParam": "myValue"}
+
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+	_ = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, "my-password")
+
+	podVars := &env.PodEnvVars{
+		ProjectID:   "abc123",
+		AgentAPIKey: "my-api-key",
+	}
+
+	ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, podVars, "", multicluster.LegacyCentralClusterName, zap.S())
+	require.NoError(t, err)
+
+	require.NotEmpty(t, ac.MonitoringVersions)
+	assert.Equal(t, "myValue", ac.MonitoringVersions[0].AdditionalParams["myCustomParam"])
 }

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -776,6 +776,37 @@ func TestReadExistingPodVars_ReturnsAgentAPIKey(t *testing.T) {
 	assert.Equal(t, projectID, podVars.ProjectID)
 }
 
+func TestReadExistingPodVars_MissingAgentKeyIsNonFatal(t *testing.T) {
+	ctx := context.Background()
+	projectID := "proj-123"
+
+	builder := DefaultOpsManagerBuilder()
+	opsManager := builder.Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient()
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	// projectID configmap exists (so the function gets past the projectId guard)...
+	err = reconciler.ensureProjectIDConfigMapForCluster(ctx, opsManager, projectID, reconciler.client)
+	require.NoError(t, err)
+
+	// OM API key secret exists (needed by ReadCredentials for the User field)...
+	APIKeySecretName, err := opsManager.APIKeySecretName(ctx, secrets.SecretClient{KubeClient: kubeClient}, "")
+	require.NoError(t, err)
+	apiKeySecret := secret.Builder().
+		SetNamespace(operatorNamespace()).
+		SetName(APIKeySecretName).
+		SetStringMapToData(map[string]string{util.OmPublicApiKey: "publicApiKey", util.OmPrivateKey: "privateApiKey"}).
+		Build()
+	require.NoError(t, reconciler.client.CreateSecret(ctx, apiKeySecret))
+
+	// ...but the agent API key secret is intentionally NOT created.
+	podVars, err := reconciler.readExistingPodVars(ctx, opsManager, zap.S())
+	require.NoError(t, err)
+	assert.Empty(t, podVars.AgentAPIKey, "missing agent key must not be fatal")
+	assert.Equal(t, projectID, podVars.ProjectID)
+}
+
 func TestAppDBServiceCreation_WithExternalName(t *testing.T) {
 	tests := map[string]struct {
 		members                int

--- a/controllers/operator/construct/appdb_agent_command.go
+++ b/controllers/operator/construct/appdb_agent_command.go
@@ -7,13 +7,11 @@ import (
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 )
 
-// Private constants — verbatim values from MCO's mongodbstatefulset.go and readiness/config/config.go.
 const (
 	appdbClusterFilePath                = "/var/lib/automation/config/cluster-config.json"
 	appdbAgentHealthStatusFilePathValue = "/var/log/mongodb-mms-automation/healthstatus/agent-health-status.json"
 	appdbAutomationAgentOptions         = " -skipMongoStart -noDaemonize -useLocalMongoDbTools"
 
-	// Readiness probe logger env var names — from MCO's pkg/readiness/config.
 	appdbReadinessProbeLoggerBackups  = "READINESS_PROBE_LOGGER_BACKUPS"
 	appdbReadinessProbeLoggerMaxSize  = "READINESS_PROBE_LOGGER_MAX_SIZE"
 	appdbReadinessProbeLoggerMaxAge   = "READINESS_PROBE_LOGGER_MAX_AGE"
@@ -22,30 +20,13 @@ const (
 	appdbAgentHealthStatusFilePathEnv = "AGENT_STATUS_FILEPATH"
 )
 
-// MongodbUserCommand is the bash preamble that sets up the correct UID mapping for mongod.
-// Verbatim copy from MCO's mongodbstatefulset.go.
-const MongodbUserCommand = `current_uid=$(id -u)
-declare -r current_uid
-if ! grep -q "${current_uid}" /etc/passwd ; then
-sed -e "s/^mongodb:/builder:/" /etc/passwd > /tmp/passwd
-echo "mongodb:x:$(id -u):$(id -g):,,,:/:/bin/bash" >> /tmp/passwd
-export NSS_WRAPPER_PASSWD=/tmp/passwd
-export LD_PRELOAD=libnss_wrapper.so
-export NSS_WRAPPER_GROUP=/etc/group
-fi
-`
-
 // BaseAgentCommand returns the core agent binary invocation flags.
-// Verbatim copy from MCO's mongodbstatefulset.go.
 func BaseAgentCommand() string {
 	return "agent/mongodb-agent -healthCheckFilePath=" + appdbAgentHealthStatusFilePathValue + " -serveStatusPort=5000"
 }
 
 // AutomationAgentCommand returns the full command array for the automation agent container.
-// withAgentAPIKeyExport detects whether we want to deploy this agent with the agent api key exported;
-// it can be used to register the agent with OM.
-// Verbatim copy from MCO's mongodbstatefulset.go.
-func AutomationAgentCommand(withStatic bool, withAgentAPIKeyExport bool, logLevel v1.LogLevel, logFile string, maxLogFileDurationHours int) []string {
+func AutomationAgentCommand(withStatic bool, logLevel v1.LogLevel, logFile string, maxLogFileDurationHours int) []string {
 	// This is somewhat undocumented at https://www.mongodb.com/docs/ops-manager/current/reference/mongodb-agent-settings/
 	// Not setting the -logFile option make the mongodb-agent log to stdout. Setting -logFile /dev/stdout will result in
 	// an error by the agent trying to open /dev/stdout-verbose and still trying to do log rotation.
@@ -58,15 +39,11 @@ func AutomationAgentCommand(withStatic bool, withAgentAPIKeyExport bool, logLeve
 		agentLogOptions += " -logFile " + logFile + " -logLevel " + string(logLevel) + " -maxLogFileDurationHrs " + strconv.Itoa(maxLogFileDurationHours)
 	}
 
-	if withAgentAPIKeyExport {
-		return []string{"/bin/bash", "-c", GetMongodbUserCommandWithAPIKeyExport(withStatic) + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions}
-	}
-	return []string{"/bin/bash", "-c", MongodbUserCommand + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions}
+	return []string{"/bin/bash", "-c", GetMongodbUserCommand(withStatic) + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions}
 }
 
-// GetMongodbUserCommandWithAPIKeyExport returns the bash preamble that exports AGENT_API_KEY from a file.
-// Verbatim copy from MCO's mongodbstatefulset.go.
-func GetMongodbUserCommandWithAPIKeyExport(withStatic bool) string {
+// GetMongodbUserCommand returns the bash preamble for the automation agent.
+func GetMongodbUserCommand(withStatic bool) string {
 	agentPrepareScript := ""
 	if withStatic {
 		agentPrepareScript = "/usr/local/bin/setup-agent-files.sh\n"
@@ -74,7 +51,6 @@ func GetMongodbUserCommandWithAPIKeyExport(withStatic bool) string {
 
 	//nolint:gosec //The credentials path is hardcoded in the container.
 	return fmt.Sprintf(`%scurrent_uid=$(id -u)
-AGENT_API_KEY="$(cat /mongodb-automation/agent-api-key/agentApiKey)"
 declare -r current_uid
 if ! grep -q "${current_uid}" /etc/passwd ; then
 sed -e "s/^mongodb:/builder:/" /etc/passwd > /tmp/passwd

--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -3,7 +3,6 @@ package construct
 import (
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 
 	"go.uber.org/zap"
@@ -13,9 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
-	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
-	"github.com/mongodb/mongodb-kubernetes/controllers/operator/agents"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/certs"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct/scalers/interfaces"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
@@ -42,28 +39,17 @@ const (
 	headlessAgentEnv             = "HEADLESS_AGENT"
 	clusterDomainEnv             = "CLUSTER_DOMAIN"
 	monitoringAgentContainerName = "mongodb-agent-monitoring"
-	// Since the Monitoring Agent is created based on Agent's Pod spec (we modfy it using addMonitoringContainer),
-	// We can not reuse "tmp" here - this name is already taken and could lead to a clash. It's better to
-	// come up with a unique name here.
-	tmpSubpathName = "mongodb-agent-monitoring-tmp"
-
-	monitoringAgentHealthStatusFilePathValue = "/var/log/mongodb-mms-automation/healthstatus/monitoring-agent-health-status.json"
 )
 
 type AppDBStatefulSetOptions struct {
 	VaultConfig vault.VaultConfiguration
 	CertHash    string
 
-	InitAppDBImage             string
-	MongodbImage               string
-	AgentImage                 string
-	LegacyMonitoringAgentImage string
+	InitAppDBImage string
+	MongodbImage   string
+	AgentImage     string
 
 	PrometheusTLSCertHash string
-}
-
-func getMonitoringAgentLogOptions(spec om.AppDBSpec) string {
-	return fmt.Sprintf(" -logFile=/var/log/mongodb-mms-automation/monitoring-agent.log -maxLogFileDurationHrs=%d -logLevel=%s", spec.GetAgentMaxLogFileDurationHours(), spec.GetAgentLogLevel())
 }
 
 // getContainerIndexByName returns the index of a container with the given name in a slice of containers.
@@ -235,11 +221,6 @@ func CAConfigMapName(appDb om.AppDBSpec, log *zap.SugaredLogger) string {
 func tlsVolumes(appDb om.AppDBSpec, podVars *env.PodEnvVars, log *zap.SugaredLogger) podtemplatespec.Modification {
 	volumesToAdd, volumeMounts := getTLSVolumesAndVolumeMounts(appDb, podVars, log)
 
-	// Add agent API key volume mount if not using vault and monitoring is enabled
-	if !vault.IsVaultSecretBackend() && ShouldEnableMonitoring(podVars) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(AgentAPIKeyVolumeName, AgentAPIKeySecretPath))
-	}
-
 	volumesFunc := func(spec *corev1.PodTemplateSpec) {
 		for _, v := range volumesToAdd {
 			podtemplatespec.WithVolume(v)(spec)
@@ -263,9 +244,6 @@ func vaultModification(appDB om.AppDBSpec, podVars *env.PodEnvVars, opts AppDBSt
 	modification := podtemplatespec.NOOP()
 	if vault.IsVaultSecretBackend() {
 		appDBSecretsToInject := vault.AppDBSecretsToInject{Config: opts.VaultConfig}
-		if podVars != nil && podVars.ProjectID != "" {
-			appDBSecretsToInject.AgentApiKey = agents.ApiKeySecretName(podVars.ProjectID)
-		}
 		if appDB.GetSecurity().IsTLSEnabled() {
 			secretName := appDB.GetSecurity().MemberCertificateSecretName(appDB.Name()) + certs.OperatorGeneratedCertSuffix
 			appDBSecretsToInject.TLSSecretName = secretName
@@ -286,14 +264,6 @@ func vaultModification(appDB om.AppDBSpec, podVars *env.PodEnvVars, opts AppDBSt
 			podtemplatespec.WithAnnotations(appDBSecretsToInject.AppDBAnnotations(appDB.Namespace)),
 		)
 
-	} else {
-		if ShouldEnableMonitoring(podVars) {
-			// AGENT-API-KEY volume
-			modification = podtemplatespec.Apply(
-				modification,
-				podtemplatespec.WithVolume(statefulset.CreateVolumeFromSecret(AgentAPIKeyVolumeName, agents.ApiKeySecretName(podVars.ProjectID))),
-			)
-		}
 	}
 	return modification
 }
@@ -358,7 +328,7 @@ func customPersistenceConfig(om *om.MongoDBOpsManager) statefulset.Modification 
 	}
 }
 
-// ShouldEnableMonitoring returns true if we need to add monitoring container (along with volume mounts) in the current reconcile loop.
+// ShouldEnableMonitoring returns true if monitoring should be configured in the automation config's monitoringVersions.
 func ShouldEnableMonitoring(podVars *env.PodEnvVars) bool {
 	return GlobalMonitoringSettingEnabled() && podVars != nil && podVars.ProjectID != ""
 }
@@ -368,7 +338,7 @@ func GlobalMonitoringSettingEnabled() bool {
 	return env.ReadBoolOrDefault(util.OpsManagerMonitorAppDB, util.OpsManagerMonitorAppDBDefault) // nolint:forbidigo
 }
 
-// ShouldMountSSLMMSCAConfigMap returns true if we need to mount MMSCA to monitoring container in the current reconcile loop.
+// ShouldMountSSLMMSCAConfigMap returns true if we need to mount the OM CA configmap to the automation agent for OM TLS connectivity.
 func ShouldMountSSLMMSCAConfigMap(podVars *env.PodEnvVars) bool {
 	return ShouldEnableMonitoring(podVars) && podVars.SSLMMSCAConfigMap != ""
 }
@@ -377,8 +347,6 @@ func ShouldMountSSLMMSCAConfigMap(podVars *env.PodEnvVars) bool {
 func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, opts AppDBStatefulSetOptions, scaler interfaces.MultiClusterReplicaSetScaler, updateStrategyType appsv1.StatefulSetUpdateStrategyType, log *zap.SugaredLogger) (appsv1.StatefulSet, error) {
 	appDb := &opsManager.Spec.AppDB
 
-	// If we can enable monitoring, let's fill in container modification function
-	monitoringModification := podtemplatespec.NOOP()
 	var podSpec *corev1.PodTemplateSpec
 	if appDb.PodSpec != nil && appDb.PodSpec.PodTemplateWrapper.PodTemplate != nil {
 		podSpec = appDb.PodSpec.PodTemplateWrapper.PodTemplate.DeepCopy()
@@ -386,18 +354,16 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 
 	externalDomain := appDb.GetExternalDomainForMemberCluster(scaler.MemberClusterName())
 
-	if ShouldEnableMonitoring(podVars) {
-		monitoringModification = addMonitoringContainer(*appDb, *podVars, opts, externalDomain, architectures.IsRunningStaticArchitecture(opsManager.Annotations), log)
-	} else {
-		// Otherwise, let's remove for now every podTemplateSpec related to monitoring
-		// We will apply them when enabling monitoring
-		if podSpec != nil {
-			podSpec.Spec.Containers = removeContainerByName(podSpec.Spec.Containers, monitoringAgentContainerName)
+	if podSpec != nil {
+		originalLen := len(podSpec.Spec.Containers)
+		podSpec.Spec.Containers = removeContainerByName(podSpec.Spec.Containers, monitoringAgentContainerName)
+		if len(podSpec.Spec.Containers) < originalLen {
+			log.Warnf("Removed deprecated container %q from user-supplied podTemplateSpec; monitoring is now managed via the automation config additionalParams", monitoringAgentContainerName)
 		}
 	}
 
 	// We copy the Automation Agent command from community and add the agent startup parameters
-	automationAgentCommand := AutomationAgentCommand(architectures.IsRunningStaticArchitecture(opsManager.Annotations), true, opsManager.Spec.AppDB.GetAgentLogLevel(), opsManager.Spec.AppDB.GetAgentLogFile(), opsManager.Spec.AppDB.GetAgentMaxLogFileDurationHours())
+	automationAgentCommand := AutomationAgentCommand(architectures.IsRunningStaticArchitecture(opsManager.Annotations), opsManager.Spec.AppDB.GetAgentLogLevel(), opsManager.Spec.AppDB.GetAgentLogFile(), opsManager.Spec.AppDB.GetAgentMaxLogFileDurationHours())
 	idx := len(automationAgentCommand) - 1
 	automationAgentCommand[idx] += appDb.AutomationAgent.StartupParameters.ToCommandLineArgs()
 
@@ -515,7 +481,6 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 				),
 				vaultModification(*appDb, podVars, opts),
 				appDbPodSpec(opts.InitAppDBImage, opsManager),
-				monitoringModification,
 				tlsVolumes(*appDb, podVars, log),
 			),
 		),
@@ -550,155 +515,17 @@ func IsEnterprise() bool {
 	return true
 }
 
-// getVolumeMountIndexByName returns the volume mount with the given name from the inut slice.
-// It returns -1 if this doesn't exist
-func getVolumeMountIndexByName(mounts []corev1.VolumeMount, name string) int {
-	for i, mount := range mounts {
-		if mount.Name == name {
-			return i
+func containerImageModification(containerName string, image string, args []string) statefulset.Modification {
+	return func(sts *appsv1.StatefulSet) {
+		for i, c := range sts.Spec.Template.Spec.Containers {
+			if c.Name == containerName {
+				c.Image = image
+				c.Args = args
+				sts.Spec.Template.Spec.Containers[i] = c
+				break
+			}
 		}
 	}
-	return -1
-}
-
-// addMonitoringContainer returns a podtemplatespec modification that adds the monitoring container to the AppDB Statefulset.
-// Note that this replicates some code from the functions that do this for the base AppDB Statefulset. After many iterations
-// this was deemed to be an acceptable compromise to make code clearer and more maintainable.
-func addMonitoringContainer(appDB om.AppDBSpec, podVars env.PodEnvVars, opts AppDBStatefulSetOptions, externalDomain *string, isStatic bool, log *zap.SugaredLogger) podtemplatespec.Modification {
-	var monitoringAcVolume corev1.Volume
-	var monitoringACFunc podtemplatespec.Modification
-
-	monitoringConfigMapVolume := statefulset.CreateVolumeFromConfigMap("monitoring-automation-config-goal-version", appDB.MonitoringAutomationConfigConfigMapName())
-	monitoringConfigMapVolumeFunc := podtemplatespec.WithVolume(monitoringConfigMapVolume)
-
-	if vault.IsVaultSecretBackend() {
-		secretsToInject := vault.AppDBSecretsToInject{Config: opts.VaultConfig}
-		secretsToInject.AutomationConfigSecretName = appDB.MonitoringAutomationConfigSecretName()
-		secretsToInject.AutomationConfigPath = util.AppDBMonitoringAutomationConfigKey
-		secretsToInject.AgentType = "monitoring-agent"
-		monitoringACFunc = podtemplatespec.WithAnnotations(secretsToInject.AppDBAnnotations(appDB.Namespace))
-	} else {
-		// Create a volume to store the monitoring automation config.
-		// This is different from the AC for the automation agent, since:
-		// - It contains entries for "MonitoringVersions"
-		// - It has empty entries for ReplicaSets and Processes
-		monitoringAcVolume = statefulset.CreateVolumeFromSecret("monitoring-automation-config", appDB.MonitoringAutomationConfigSecretName())
-		monitoringACFunc = podtemplatespec.WithVolume(monitoringAcVolume)
-	}
-	// Construct the command by concatenating:
-	// 1. The base command - from community
-	command := GetMongodbUserCommandWithAPIKeyExport(isStatic)
-	command += "agent/mongodb-agent"
-	command += " -healthCheckFilePath=" + monitoringAgentHealthStatusFilePathValue
-	command += " -serveStatusPort=5001"
-	command += getMonitoringAgentLogOptions(appDB)
-
-	// 2. Add the cluster config file path
-	// If we are using k8s secrets, this is the same as community (and the same as the other agent container)
-	// But this is not possible in vault so we need two separate paths
-	if vault.IsVaultSecretBackend() {
-		command += " -cluster=/var/lib/automation/config/" + util.AppDBMonitoringAutomationConfigKey
-	} else {
-		command += " -cluster=/var/lib/automation/config/" + util.AppDBAutomationConfigKey
-	}
-
-	// 2. Startup parameters for the agent to enable monitoring
-	startupParams := mdbv1.StartupParameters{
-		"mmsApiKey":  "${AGENT_API_KEY}",
-		"mmsGroupId": podVars.ProjectID,
-	}
-
-	// 3. Startup parameters for the agent to enable TLS
-	if podVars.SSLMMSCAConfigMap != "" {
-		trustedCACertLocation := path.Join(caCertMountPath, util.CaCertMMS)
-		startupParams["sslTrustedMMSServerCertificate"] = trustedCACertLocation
-	}
-
-	if podVars.SSLRequireValidMMSServerCertificates {
-		startupParams["sslRequireValidMMSServerCertificates"] = "true"
-	}
-
-	// 4. Custom startup parameters provided in the CR
-	// By default appDB.AutomationAgent.StartupParameters apply to both agents
-	// if appDB.MonitoringAgent.StartupParameters is specified, it overrides the former
-	monitoringStartupParams := appDB.AutomationAgent.StartupParameters
-	if appDB.MonitoringAgent.StartupParameters != nil {
-		monitoringStartupParams = appDB.MonitoringAgent.StartupParameters
-	}
-
-	for k, v := range monitoringStartupParams {
-		startupParams[k] = v
-	}
-
-	command += startupParams.ToCommandLineArgs()
-
-	command += overrideLocalHostFlag(&appDB, externalDomain)
-
-	monitoringCommand := []string{"/bin/bash", "-c", command}
-
-	// Add additional TLS volumes if needed
-	_, monitoringMounts := getTLSVolumesAndVolumeMounts(appDB, &podVars, log)
-
-	return podtemplatespec.Apply(
-		monitoringACFunc,
-		monitoringConfigMapVolumeFunc,
-		// This is a function that reads the automation agent containers, copies it and modifies it.
-		// We do this since the two containers are very similar with just a few differences
-		func(podTemplateSpec *corev1.PodTemplateSpec) {
-			monitoringContainer := podtemplatespec.FindContainerByName(util.AgentContainerName, podTemplateSpec).DeepCopy()
-			monitoringContainer.Name = monitoringAgentContainerName
-
-			// we ensure that the monitoring agent image is compatible with the input of Ops Manager we're using.
-			// once we make static containers the default, we can remove this code.
-			if opts.LegacyMonitoringAgentImage != "" {
-				monitoringContainer.Image = opts.LegacyMonitoringAgentImage
-			}
-
-			// Replace the automation config volume
-			volumeMounts := monitoringContainer.VolumeMounts
-			if !vault.IsVaultSecretBackend() {
-				// Replace the automation config volume
-				acMountIndex := getVolumeMountIndexByName(volumeMounts, "automation-config")
-				if acMountIndex != -1 {
-					volumeMounts[acMountIndex].Name = monitoringAcVolume.Name
-				}
-			}
-
-			configMapIndex := getVolumeMountIndexByName(volumeMounts, "automation-config-goal-input")
-			if configMapIndex != -1 {
-				volumeMounts[configMapIndex].Name = monitoringConfigMapVolume.Name
-			}
-
-			tmpVolumeMountIndex := getVolumeMountIndexByName(volumeMounts, util.PvcNameTmp)
-			if tmpVolumeMountIndex != -1 {
-				volumeMounts[tmpVolumeMountIndex].SubPath = tmpSubpathName
-			}
-
-			// Set up custom persistence options - see customPersistenceConfig() for an explanation
-			if appDB.HasSeparateDataAndLogsVolumes() {
-				journalVolumeMounts := statefulset.CreateVolumeMount(util.PvcNameJournal, util.PvcMountPathJournal)
-				volumeMounts = append(volumeMounts, journalVolumeMounts)
-			} else {
-				logsVolumeMount := statefulset.CreateVolumeMount(appDB.DataVolumeName(), util.PvcMountPathLogs, statefulset.WithSubPath(appDB.LogsVolumeName()))
-				journalVolumeMount := statefulset.CreateVolumeMount(appDB.DataVolumeName(), util.PvcMountPathJournal, statefulset.WithSubPath(util.PvcNameJournal))
-				volumeMounts = append(volumeMounts, journalVolumeMount, logsVolumeMount)
-			}
-
-			if !vault.IsVaultSecretBackend() {
-				// AGENT_API_KEY volume
-				volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(AgentAPIKeyVolumeName, AgentAPIKeySecretPath))
-			}
-			container.Apply(
-				container.WithVolumeMounts(volumeMounts),
-				container.WithCommand(monitoringCommand),
-				container.WithResourceRequirements(buildRequirementsFromPodSpec(*NewDefaultPodSpecWrapper(*appDB.PodSpec))),
-				container.WithVolumeMounts(monitoringMounts),
-				container.WithEnvs(appdbContainerEnv(appDB)...),
-				container.WithEnvs(readinessEnvironmentVariablesToEnvVars(appDB.AutomationAgent.ReadinessProbe.EnvironmentVariables)...),
-			)(monitoringContainer)
-			podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, *monitoringContainer)
-		},
-	)
 }
 
 // appdbContainerEnv returns the set of env var needed by the AppDB.

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,6 +15,7 @@ import (
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct/scalers"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
 
@@ -93,6 +95,53 @@ func TestAppDBMultiClusterPerClusterStatefulSetOverride(t *testing.T) {
 	assert.NotNil(t, stsB.Spec.Replicas)
 	assert.Equal(t, int32(1), *stsB.Spec.Replicas)
 	assert.NotEmpty(t, stsB.Spec.ServiceName)
+}
+
+func TestAppDbStatefulSet_SingleAgentContainer(t *testing.T) {
+	t.Setenv(util.OpsManagerMonitorAppDB, "true")
+	om := omv1.NewOpsManagerBuilderDefault().Build()
+	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
+	podVars := &env.PodEnvVars{ProjectID: "proj-123", AgentAPIKey: "key"}
+
+	sts, err := AppDbStatefulSet(*om, podVars, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, zap.S())
+	require.NoError(t, err)
+
+	containerNames := make([]string, 0)
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		containerNames = append(containerNames, c.Name)
+	}
+	assert.Contains(t, containerNames, util.AgentContainerName)
+	assert.NotContains(t, containerNames, monitoringAgentContainerName)
+}
+
+func TestAppDbStatefulSet_SingleAgentContainer_MonitoringDisabled(t *testing.T) {
+	om := omv1.NewOpsManagerBuilderDefault().Build()
+	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
+
+	sts, err := AppDbStatefulSet(*om, nil, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, zap.S())
+	require.NoError(t, err)
+
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		assert.NotEqual(t, monitoringAgentContainerName, c.Name)
+	}
+}
+
+func TestAppDbStatefulSet_UserTemplateMonitoringContainerStripped(t *testing.T) {
+	monitoringContainer := corev1.Container{Name: monitoringAgentContainerName}
+	podTemplate := corev1.PodTemplateSpec{}
+	podTemplate.Spec.Containers = []corev1.Container{monitoringContainer}
+	om := omv1.NewOpsManagerBuilderDefault().Build()
+	om.Spec.AppDB.PodSpec.PodTemplateWrapper = v1.PodTemplateSpecWrapper{
+		PodTemplate: &podTemplate,
+	}
+
+	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
+	sts, err := AppDbStatefulSet(*om, nil, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, zap.S())
+	require.NoError(t, err)
+
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		assert.NotEqual(t, monitoringAgentContainerName, c.Name, "monitoring container should be stripped from user template")
+	}
 }
 
 func TestResourceRequirements(t *testing.T) {

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -611,12 +611,11 @@ func TestOpsManagerReconcileContainerImages(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, appDBSts.Spec.Template.Spec.InitContainers, 1)
-	require.Len(t, appDBSts.Spec.Template.Spec.Containers, 3)
+	require.Len(t, appDBSts.Spec.Template.Spec.Containers, 2)
 
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:INIT_DATABASE_SHA", appDBSts.Spec.Template.Spec.InitContainers[0].Image)
 	assert.Equal(t, "quay.io/mongodb/mongodb-agent@sha256:AGENT_SHA", appDBSts.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:MONGODB_SHA", appDBSts.Spec.Template.Spec.Containers[1].Image)
-	assert.NotContains(t, appDBSts.Spec.Template.Spec.Containers[2].Image, util.OperatorVersion)
 }
 
 func TestOpsManagerReconcileContainerImagesWithStaticArchitecture(t *testing.T) {
@@ -669,10 +668,8 @@ func TestOpsManagerReconcileContainerImagesWithStaticArchitecture(t *testing.T) 
 	require.NoError(t, err)
 
 	require.Len(t, appDBSts.Spec.Template.Spec.InitContainers, 0)
-	require.Len(t, appDBSts.Spec.Template.Spec.Containers, 4)
+	require.Len(t, appDBSts.Spec.Template.Spec.Containers, 3)
 	assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:MONGODB_SHA", appDBSts.Spec.Template.Spec.Containers[1].Image)
-	// In static architecture this container is a copy of agent container
-	assert.Equal(t, appDBSts.Spec.Template.Spec.Containers[0].Image, appDBSts.Spec.Template.Spec.Containers[3].Image)
 }
 
 func TestOpsManagerConnectionString_IsPassedAsSecretRef(t *testing.T) {

--- a/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/opsmanager.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 import requests
 from kubeobject import CustomObject
 from kubernetes.client.rest import ApiException
-from kubetester import create_configmap, create_or_update_secret, read_secret
+from kubetester import create_configmap, create_or_update_secret, read_configmap, read_secret
 from kubetester.automation_config_tester import AutomationConfigTester
 from kubetester.kubetester import KubernetesTester, build_list_of_hosts, get_pods, is_default_architecture_static
 from kubetester.mongodb_common import MongoDBCommon
@@ -905,19 +905,22 @@ class MongoDBOpsManager(CustomObject, MongoDBCommon):
         return old_secret_name
 
     def agent_api_key(self, api_client: Optional[kubernetes.client.ApiClient] = None) -> Optional[str]:
-        secret_name = None
         member_cluster = self.pick_one_appdb_member_cluster_name()
+        member_client = get_member_cluster_api_client(member_cluster)
         appdb_sts = self.read_appdb_statefulset(member_cluster_name=member_cluster)
 
         for volume in appdb_sts.spec.template.spec.volumes:
             if volume.name == "agent-api-key":
-                secret_name = volume.secret.secret_name
-                break
+                return read_secret(self.namespace, volume.secret.secret_name, member_client)["agentApiKey"]
 
-        if secret_name == None:
+        # The agent-api-key volume is absent in the single-agent monitoring design.
+        # Derive the secret name from the project-id ConfigMap instead.
+        try:
+            cm = read_configmap(self.namespace, self.app_db_name() + "-project-id", member_client)
+            project_id = cm["projectId"]
+            return read_secret(self.namespace, f"{project_id}-group-secret", member_client)["agentApiKey"]
+        except Exception:
             return None
-
-        return read_secret(self.namespace, secret_name, get_member_cluster_api_client(member_cluster))["agentApiKey"]
 
     def om_sts_name(self, member_cluster_name: Optional[str] = None) -> str:
         if is_member_cluster(member_cluster_name):

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
@@ -308,7 +308,7 @@ class TestOperatorDowngrade:
     def test_om_running_after_downgrade(self, ops_manager: MongoDBOpsManager):
         ops_manager.load()
         ops_manager.appdb_status().assert_reaches_phase(Phase.Pending, timeout=60)
-        ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=350)
+        ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=700)
         ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=200)
 
     def test_scale_appdb(self, ops_manager: MongoDBOpsManager):

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_appdb_scram.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_appdb_scram.py
@@ -187,7 +187,7 @@ class TestChangeOpsManagerExistingUserPassword:
 
     def test_config_map_reached_v3(self, ops_manager: MongoDBOpsManager):
         KubernetesTester.wait_until(
-            lambda: ops_manager.get_automation_config_tester().reached_version(3),
+            lambda: ops_manager.get_automation_config_tester().reached_version(4),
             timeout=180,
         )
 
@@ -232,9 +232,8 @@ class TestOpsManagerGeneratesNewPasswordIfNoneSpecified:
     def test_new_password_was_created(self, ops_manager: MongoDBOpsManager):
         assert ops_manager.read_appdb_generated_password() != ""
 
-    def test_wait_for_config_map_reached_v4(self, ops_manager: MongoDBOpsManager):
-        # should reach version 4 as password should change back
-        assert ops_manager.get_automation_config_tester().reached_version(4)
+    def test_wait_for_config_map_reached_v5(self, ops_manager: MongoDBOpsManager):
+        assert ops_manager.get_automation_config_tester().reached_version(5)
 
     def test_cannot_authenticate_with_old_password(self, ops_manager: MongoDBOpsManager):
         app_db_tester = ops_manager.get_appdb_tester()

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_flags_and_config.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_flags_and_config.py
@@ -94,51 +94,20 @@ def test_appdb_has_agent_flags(ops_manager: MongoDBOpsManager):
 
 
 @mark.e2e_om_appdb_flags_and_config
-def test_appdb_monitoring_agent_flags_inherit_automation_agent_flags(
-    ops_manager: MongoDBOpsManager,
-):
-    cmd = [
-        "/bin/sh",
-        "-c",
-        "ls /var/log/mongodb-mms-automation/customLogFileMonitoring* | wc -l",
-    ]
-    for api_client, pod in ops_manager.read_appdb_pods():
-        result = KubernetesTester.run_command_in_pod_container(
-            pod.metadata.name,
-            ops_manager.namespace,
-            cmd,
-            container="mongodb-agent-monitoring",
-            api_client=api_client,
-        )
-        assert "No such file or directory" in result
-
-    cmd = [
-        "/bin/sh",
-        "-c",
-        "ls /var/log/mongodb-mms-automation/customLogFile* | wc -l",
-    ]
-    for api_client, pod in ops_manager.read_appdb_pods():
-        result = KubernetesTester.run_command_in_pod_container(
-            pod.metadata.name,
-            ops_manager.namespace,
-            cmd,
-            container="mongodb-agent-monitoring",
-            api_client=api_client,
-        )
-        assert result != "0"
+def test_monitoring_configured_in_automation_config(ops_manager: MongoDBOpsManager):
+    ac_tester = ops_manager.get_automation_config_tester()
+    monitoring_versions = ac_tester.automation_config.get("monitoringVersions", [])
+    assert len(monitoring_versions) > 0, "monitoringVersions should be configured in the automation config"
+    for mv in monitoring_versions:
+        params = mv.get("additionalParams", {})
+        assert "mmsGroupId" in params, "mmsGroupId should be present in monitoring additionalParams"
+        assert "mmsApiKey" in params, "mmsApiKey should be present in monitoring additionalParams"
 
 
 @mark.e2e_om_appdb_flags_and_config
 def test_appdb_flags_changed(ops_manager: MongoDBOpsManager):
     ops_manager.load()
     ops_manager["spec"]["applicationDatabase"]["agent"]["startupOptions"]["dialTimeoutSeconds"] = "70"
-
-    ops_manager["spec"]["applicationDatabase"]["monitoringAgent"] = {
-        "startupOptions": {
-            "logFile": "/var/log/mongodb-mms-automation/customLogFileMonitoring",
-            "dialTimeoutSeconds": "80",
-        }
-    }
     ops_manager.update()
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
 
@@ -160,16 +129,6 @@ def test_appdb_has_changed_agent_flags(ops_manager: MongoDBOpsManager, namespace
         )
         assert "-logFile=/var/log/mongodb-mms-automation/customLogFile" in result
         assert "-dialTimeoutSeconds=70" in result
-
-        result = KubernetesTester.run_command_in_pod_container(
-            pod.metadata.name,
-            namespace,
-            MMS_AUTOMATION_AGENT_PGREP,
-            container="mongodb-agent-monitoring",
-            api_client=api_client,
-        )
-        assert "-logFile=/var/log/mongodb-mms-automation/customLogFileMonitoring" in result
-        assert "-dialTimeoutSeconds=80" in result
 
 
 @mark.e2e_om_appdb_flags_and_config

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_flags_and_config.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_flags_and_config.py
@@ -105,6 +105,30 @@ def test_monitoring_configured_in_automation_config(ops_manager: MongoDBOpsManag
 
 
 @mark.e2e_om_appdb_flags_and_config
+def test_monitoring_reaches_om(ops_manager: MongoDBOpsManager):
+    """End-to-end check that the single agent actually reports monitoring data to OM.
+    Complements test_monitoring_configured_in_automation_config (which only verifies the
+    automation config is shaped correctly): here we query OM for the hosts in the AppDB
+    project and assert every AppDB process hostname is present AND actively monitored
+    (non-empty lastPing), then confirm real monitoring measurements have arrived.
+    """
+    expected_hostnames = ops_manager.get_appdb_hostnames_for_monitoring()
+    assert len(expected_hostnames) > 0, "expected at least one AppDB hostname for monitoring"
+
+    def appdb_hosts_are_actively_monitored() -> bool:
+        hosts_by_name = {h["hostname"]: h for h in ops_manager.get_appdb_hosts()}
+        for hostname in expected_hostnames:
+            host = hosts_by_name.get(hostname)
+            # lastPing is set by OM once a monitoring agent reports for this host.
+            if host is None or not host.get("lastPing"):
+                return False
+        return True
+
+    KubernetesTester.wait_until(appdb_hosts_are_actively_monitored, timeout=600, sleep_time=10)
+    ops_manager.assert_monitoring_data_exists(timeout=600)
+
+
+@mark.e2e_om_appdb_flags_and_config
 def test_appdb_flags_changed(ops_manager: MongoDBOpsManager):
     ops_manager.load()
     ops_manager["spec"]["applicationDatabase"]["agent"]["startupOptions"]["dialTimeoutSeconds"] = "70"

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_ops_manager_pod_spec.py
@@ -79,7 +79,7 @@ class TestOpsManagerCreation:
 
     def test_appdb_pod_template_containers(self, ops_manager: MongoDBOpsManager):
         appdb_sts = ops_manager.read_appdb_statefulset()
-        assert_container_count_with_static(len(appdb_sts.spec.template.spec.containers), 4)
+        assert_container_count_with_static(len(appdb_sts.spec.template.spec.containers), 3)
 
         assert appdb_sts.spec.template.spec.service_account_name == APPDB_SA_NAME
 
@@ -367,7 +367,7 @@ class TestOpsManagerUpdate:
 
     def test_appdb_pod_template(self, ops_manager: MongoDBOpsManager):
         appdb_sts = ops_manager.read_appdb_statefulset()
-        assert_container_count_with_static(len(appdb_sts.spec.template.spec.containers), 4)
+        assert_container_count_with_static(len(appdb_sts.spec.template.spec.containers), 3)
 
         # Find each container by name instead of position
         containers_by_name = {c.name: c for c in appdb_sts.spec.template.spec.containers}
@@ -375,7 +375,9 @@ class TestOpsManagerUpdate:
         # Check that all required containers exist
         assert "mongod" in containers_by_name, "mongod container not found"
         assert "mongodb-agent" in containers_by_name, "mongodb-agent container not found"
-        assert "mongodb-agent-monitoring" in containers_by_name, "mongodb-agent-monitoring container not found"
+        assert (
+            "mongodb-agent-monitoring" not in containers_by_name
+        ), "mongodb-agent-monitoring container should not be present"
 
         assert appdb_sts.spec.template.metadata.annotations == {"annotation1": "val"}
 

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
@@ -450,10 +450,10 @@ def test_no_admin_key_secret_in_kubernetes(namespace: str, ops_manager: MongoDBO
 @mark.e2e_vault_setup_om_backup
 def test_appdb_reached_running_and_pod_count(ops_manager: MongoDBOpsManager, namespace: str):
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
-    # check AppDB has 4 containers(+1 because of vault-agent)
+    # check AppDB has 3 containers: mongodb-agent, mongod, vault-agent
     for pod_name in get_pods(ops_manager.name + "-db-{}", 3):
         pod = client.CoreV1Api().read_namespaced_pod(pod_name, namespace)
-        assert_container_count_with_static(len(pod.spec.containers), 4)
+        assert_container_count_with_static(len(pod.spec.containers), 3)
 
 
 @mark.e2e_vault_setup_om_backup

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
@@ -268,10 +268,10 @@ def test_no_gen_key_secret_in_kubernetes(namespace: str, ops_manager: MongoDBOps
 @mark.e2e_vault_setup_om
 def test_appdb_reached_running_and_pod_count(ops_manager: MongoDBOpsManager, namespace: str):
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
-    # check AppDB has 4 containers(+1 because of vault-agent)
+    # check AppDB has 3 containers: mongodb-agent, mongod, vault-agent
     for pod_name in get_pods(ops_manager.name + "-db-{}", 3):
         pod = client.CoreV1Api().read_namespaced_pod(pod_name, namespace)
-        assert_container_count_with_static(len(pod.spec.containers), 4)
+        assert_container_count_with_static(len(pod.spec.containers), 3)
 
 
 @mark.e2e_vault_setup_om

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.8.2
+version: 1.9.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/crds/mongodb.com_opsmanagers.yaml
+++ b/helm_chart/crds/mongodb.com_opsmanagers.yaml
@@ -581,9 +581,8 @@ spec:
                     type: integer
                   monitoringAgent:
                     description: |-
-                      Specify configuration like startup flags just for the MonitoringAgent.
-                      These take precedence over
-                      the flags set in AutomationAgent
+                      Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
+                      into the automation agent. Remove this field from your configuration.
                     properties:
                       startupOptions:
                         additionalProperties:

--- a/helm_chart/crds/mongodb.com_opsmanagers.yaml
+++ b/helm_chart/crds/mongodb.com_opsmanagers.yaml
@@ -581,8 +581,9 @@ spec:
                     type: integer
                   monitoringAgent:
                     description: |-
-                      Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
-                      into the automation agent. Remove this field from your configuration.
+                      Deprecated: this field has no effect. The monitoring agent now runs inside the
+                      automation agent. Configure agent options, including log level and rotation, via
+                      spec.appDB.agent. Remove this field from your configuration.
                     properties:
                       startupOptions:
                         additionalProperties:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.8.2
+  version: 1.9.0
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.8.2
+  version: 1.9.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -131,11 +131,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.8.2
+  version: 1.9.0
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.8.2
+  version: 1.9.0
 
 ## Ops Manager
 opsManager:
@@ -143,7 +143,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.8.2
+  version: 1.9.0
 
 agent:
   name: mongodb-agent

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -70,7 +70,6 @@ type DatabaseSecretsToInject struct {
 }
 
 type AppDBSecretsToInject struct {
-	AgentApiKey    string
 	TLSSecretName  string
 	TLSClusterHash string
 
@@ -524,16 +523,6 @@ func (a AppDBSecretsToInject) AppDBAnnotations(namespace string) map[string]stri
 	} else {
 		appdbSecretPath = fmt.Sprintf("/secret/data/%s", APPDB_SECRET_BASE_PATH)
 	}
-	if a.AgentApiKey != "" {
-
-		apiKeySecretPath := fmt.Sprintf("%s/%s/%s", appdbSecretPath, namespace, a.AgentApiKey)
-		agentAPIKeyTemplate := fmt.Sprintf(DEFAULT_AGENT_INJECT_TEMPLATE, apiKeySecretPath, util.OmAgentApiKey)
-
-		annotations["vault.hashicorp.com/agent-inject-secret-agentApiKey"] = apiKeySecretPath
-		annotations["vault.hashicorp.com/secret-volume-path-agentApiKey"] = "/mongodb-automation/agent-api-key"
-		annotations["vault.hashicorp.com/agent-inject-template-agentApiKey"] = agentAPIKeyTemplate
-	}
-
 	if a.TLSSecretName != "" {
 		memberClusterPath := fmt.Sprintf("%s/%s/%s", appdbSecretPath, namespace, a.TLSSecretName)
 		annotations["vault.hashicorp.com/agent-inject-secret-tls-certificate"] = memberClusterPath

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -542,8 +542,6 @@ func (a AppDBSecretsToInject) AppDBAnnotations(namespace string) map[string]stri
 	}
 
 	if a.AutomationConfigSecretName != "" {
-		// There are two different type of annotations here: for the automation agent
-		// and for the monitoring agent.
 		acSecretPath := fmt.Sprintf("%s/%s/%s", appdbSecretPath, namespace, a.AutomationConfigSecretName)
 		annotations["vault.hashicorp.com/agent-inject-secret-"+a.AgentType] = acSecretPath
 		annotations["vault.hashicorp.com/agent-inject-file-"+a.AgentType] = a.AutomationConfigPath

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -5412,8 +5412,9 @@ spec:
                     type: integer
                   monitoringAgent:
                     description: |-
-                      Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
-                      into the automation agent. Remove this field from your configuration.
+                      Deprecated: this field has no effect. The monitoring agent now runs inside the
+                      automation agent. Configure agent options, including log level and rotation, via
+                      spec.appDB.agent. Remove this field from your configuration.
                     properties:
                       startupOptions:
                         additionalProperties:

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -5412,9 +5412,8 @@ spec:
                     type: integer
                   monitoringAgent:
                     description: |-
-                      Specify configuration like startup flags just for the MonitoringAgent.
-                      These take precedence over
-                      the flags set in AutomationAgent
+                      Deprecated: MonitoringAgent configuration has no effect. The monitoring agent has been merged
+                      into the automation agent. Remove this field from your configuration.
                     properties:
                       startupOptions:
                         additionalProperties:

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -332,7 +332,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -383,16 +383,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -329,7 +329,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -379,16 +379,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -423,12 +423,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.2"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_0
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.0"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.0"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.0"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -332,7 +332,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -380,16 +380,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "1.9.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.15.0.tgz"
   },
-  "mongodbOperator": "1.8.2",
-  "initDatabaseVersion": "1.8.2",
-  "initOpsManagerVersion": "1.8.2",
-  "databaseImageVersion": "1.8.2",
+  "mongodbOperator": "1.9.0",
+  "initDatabaseVersion": "1.9.0",
+  "initOpsManagerVersion": "1.9.0",
+  "databaseImageVersion": "1.9.0",
   "agentVersion": "108.0.12.8846-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -94,7 +94,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ],
       "variants": [
         "ubi"
@@ -285,7 +286,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ],
       "variants": [
         "ubi"
@@ -306,7 +308,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ],
       "variants": [
         "ubi"
@@ -327,7 +330,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ],
       "variants": [
         "ubi"


### PR DESCRIPTION
## Summary

- Removes the `mongodb-agent-monitoring` sidecar container from AppDB StatefulSets; both automation and monitoring now run as a single process in the `mongodb-agent` container
- Monitoring is activated by embedding `mmsGroupId`/`mmsApiKey` (plus optional TLS params) into `monitoringVersions[].additionalParams` in the main automation config — no pod restart required when Ops Manager credentials become available
- `spec.appDB.monitoringAgent` is deprecated: field marked as deprecated in CRD schema, admission webhook emits a non-blocking warning when set, and a runtime warning is logged

## Consequences & follow-ups

**Behavioral consequences (no code change, documented):**

- Upgrading to this version triggers a **one-time rolling restart** of all AppDB pods (sidecar removal); a downgrade triggers a second roll (re-adding it). No data-loss risk.
- Existing AppDBs get a **one-time automation-config version bump** as monitoring folds into the main automation config.
- The agent API key now resides in the main AppDB automation-config secret (`<name>-config`) instead of the removed `<name>-monitoring-config` secret — a relocation alongside the SCRAM creds/keyfile already there, not a new exposure.
- The old `*-monitoring-config` Secret/ConfigMap are **left orphaned** on upgrade. This is consistent with how the operator already treats the primary AC and agent-key secrets (no finalizer / scale-in cleanup); they may be deleted manually.
- **Observability change:** the dedicated `mongodb-agent-monitoring` container and its status port are removed. The monitoring component still writes its own `monitoring-agent.log`, now on the single `mongodb-agent` container's log volume — `kubectl logs -c mongodb-agent-monitoring` breaks; read the file in the `mongodb-agent` container instead.

**Out of scope (follow-ups):**

- Wiring `spec.appDB.agent.monitoringAgent.logRotate` / `backupAgent.logRotate` into the automation config (pre-existing MDB-parity gap).
- Cleanup of orphaned / operator-managed AppDB secrets on scale-in or resource deletion (pre-existing operator behavior).

**Product impact:** lower per-pod resource footprint, monitoring toggle without a pod restart, and architecture aligned with standard Ops Manager monitoring and the `MongoDB` resource (a step toward a single controller for both).

> [!NOTE]
> The additional benefit is that the EVG patch timespan was reduced by ~10 minutes (from 1h30m to 1h19m) and the overall cost of PR patch by 10% (from 80$ to 73$).

## Proof of Work

- `controllers/operator/appdbreplicaset_controller_test.go` — `TestConfigureMonitoring_*`, `TestBuildAppDbAutomationConfig_*`, `TestTryConfigureMonitoring_*`, `TestReadExistingPodVars_*` (incl. `TestReadExistingPodVars_MissingAgentKeyIsNonFatal`), `TestMonitoringToggled*`, `TestMonitoringAgentStartupParametersIgnored`, `TestStartupParametersDeprecationWarning`
- `controllers/operator/construct/appdb_construction_test.go` — `TestAppDbStatefulSet_SingleAgentContainer*`
- `api/mongodb/v1/om/opsmanager_validation_test.go` — `TestWarnMonitoringAgentStartupParameters*`

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?