### PR TITLE
[KUBE-7] Enable just some envoy (managed LB) admin endponits

### DIFF
--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -24,6 +24,7 @@ import (
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	upstreamhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 )
 
 // buildEnvoyConfigJSON builds the Envoy bootstrap configuration using
@@ -93,6 +94,12 @@ func buildEnvoyBootstrapConfig(routes []envoyRoute, tlsEnabled bool, caKeyName s
 	return &bootstrapv3.Bootstrap{
 		Admin: &bootstrapv3.Admin{
 			Address: socketAddress("0.0.0.0", uint32(envoyAdminPort)),
+			// enable just some endpoints because it's recommended to not enable al the admin endpoints by default
+			AllowPaths: []*matcherv3.StringMatcher{
+				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/ready"}},
+				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/stats"}},
+				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/drain_listeners"}},
+			},
 		},
 		StaticResources: &bootstrapv3.Bootstrap_StaticResources{
 			Listeners: []*listenerv3.Listener{


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1048

## Chain of upstream PRs as of 2026-05-15

* PR #1048:
  `master` ← `search/ga-base`

  * **PR #1113 (THIS ONE)**:
    `search/ga-base` ← `search/harden-envoy-admin-interface`

<!-- end git-machete generated -->

# Summary

When we enabled the admin interface in envoy boostrap config, to make sure that we can use `/ready` admin endpoint in readiness probe, that resulted into all the admin endpoints being enabled on admin interface. That means the endpoints like `/quitquitquit`, `/healthcheck/fail`, `/runtime_modify` were also enabled, which is not recommended.
That's why this PR makes it explicit and just enabled specific endpoints that are needed. 

`/ready` will be needed by readiness probe.
`/stats*` will be needed for enovy metrics.
`/drain_listeners` will be needed to gracefully drain listeners.

## Proof of Work

Run an E2E that involved managed LB and once LB is running port-forward to it and make sure only enabled endpoints are accessible. 

```
k port-forward -n mongodb pod/mdb-sh-search-search-lb-0-0-9cf776dcb-gwcgf 9901
Forwarding from 127.0.0.1:9901 -> 9901
Forwarding from [::1]:9901 -> 9901
Handling connection for 9901
Handling connection for 9901
```

```
~/work/opensource/mongodb-kubernetes (search/harden-envoy-admin-interface*) » curl localhost:9901/ready
LIVE

kctx: kind-kind
~/work/opensource/mongodb-kubernetes (search/harden-envoy-admin-interface*) » curl localhost:9901/config_dump
request to path /config_dump not allowed
```

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
