### PR TITLE
[KUBE-9] Add preStop hook in envoy pod to gracefully drain listeners

### DIFF
--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -24,6 +24,7 @@ import (
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	upstreamhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 )
 
 // buildEnvoyConfigJSON builds the Envoy bootstrap configuration using
@@ -93,6 +94,12 @@ func buildEnvoyBootstrapConfig(routes []envoyRoute, tlsEnabled bool, caKeyName s
 	return &bootstrapv3.Bootstrap{
 		Admin: &bootstrapv3.Admin{
 			Address: socketAddress("0.0.0.0", uint32(envoyAdminPort)),
+			// enable just some endpoints because it's recommended to not enable al the admin endpoints by default
+			AllowPaths: []*matcherv3.StringMatcher{
+				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/ready"}},
+				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/stats"}},
+				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/drain_listeners"}},
+			},
 		},
 		StaticResources: &bootstrapv3.Bootstrap_StaticResources{
 			Listeners: []*listenerv3.Listener{

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -619,6 +619,14 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 					InitialDelaySeconds: 5,
 					PeriodSeconds:       5,
 				},
+				Lifecycle: &corev1.Lifecycle{
+					PreStop: &corev1.LifecycleHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/drain_listeners",
+							Port: intstr.FromInt32(envoyAdminPort),
+						},
+					},
+				},
 				VolumeMounts: volumeMounts,
 			},
 		},


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1113

## Chain of upstream PRs as of 2026-05-15

* PR #1048:
  `master` ← `search/ga-base`

  * PR #1113:
    `search/ga-base` ← `search/harden-envoy-admin-interface`

    * **PR #1114 (THIS ONE)**:
      `search/harden-envoy-admin-interface` ← `search/envoy-prestop-drain-listeners`

<!-- end git-machete generated -->

# Summary

Whenever the envoy container is terminated, to make sure that all the already running connections are not abruptly killed we can call the `/drain_listeners` endpoint from admin interface. When this endpoint is called, it makes sure that no new TCP connections are started and already running connections are waited for either to finish or timeout.

To make sure that `/drain_listeners` is called before the container is terminated we configure the `preStop` hook of the pod. And that makes sure that `/drain_listeners` is called before these events
- When a pod is manually deleted or scaled down
- Rolling updates, when new pods are created to update version etc.
- When the pod is evicted because of resource contention on a node
- When the liveness/startup probe fail and pod restarts

## Proof of Work

NA. E2E tests will be coming later.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
