### PR TITLE
Fix `preflight_images` release job failure

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -21,6 +21,7 @@ tasks:
     commands:
       - func: clone
       - func: python_venv
+      - func: update_evergreen_expansions
       - func: setup_preflight
       - func: preflight_image
         vars:


### PR DESCRIPTION
# Summary

The preflight_images job failed with below error

```
Python venv was recreated successfully.
[2026/05/19 19:57:35.581] Finished command 'subprocess.exec' in function 'python_venv' (step 2 of 7) in 8.831693404s.
[2026/05/19 19:57:35.581] Running command 'subprocess.exec' in function 'setup_preflight' (step 3 of 7).
[2026/05/19 19:57:35.587] Downloading preflight binary
[2026/05/19 19:57:35.587] Adding 14s jitter to spread out concurrent downloads...
[2026/05/19 19:57:50.041] Installed preflight to /data/mci/4e2187cae1529982eeaa8cfb7052522a/src/github.com/mongodb/mongodb-kubernetes/bin
[2026/05/19 19:57:50.041] Finished command 'subprocess.exec' in function 'setup_preflight' (step 3 of 7) in 14.460163415s.
[2026/05/19 19:57:50.042] Running command 'subprocess.exec' in function 'preflight_image' (step 4 of 7).
[2026/05/19 19:57:50.504] usage: preflight_images.py [-h] --image IMAGE --submit SUBMIT
[2026/05/19 19:57:50.504]                            [--version VERSION]
[2026/05/19 19:57:50.504] preflight_images.py: error: argument --version: expected one argument
[2026/05/19 19:57:50.528] Command 'subprocess.exec' in function 'preflight_image' (step 4 of 7) failed: process encountered problem: exit code 2.
```

the script `preflight_images.py` expects a `--version` aregument that was not being passed properly because in below code

```
preflight_image:
    - command: subprocess.exec
      params:
        shell: bash
        <<: *e2e_include_expansions_in_env
        working_dir: src/github.com/mongodb/mongodb-kubernetes
        add_to_path:
          - ${workdir}/bin
        binary: scripts/dev/run_python.sh
        args:
          - scripts/preflight_images.py
          - --image
          - ${image_name}
          - --version
          - ${mongodbOperator}
          - --submit
          - ${preflight_submit}
```

`mongodbOperator` was not being set. This PR fixes that.


## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
