### PR TITLE
Never submit enterprise-server preflight result

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -582,7 +582,7 @@ functions:
           - --image
           - mongodb-enterprise-server
           - --submit
-          - ${preflight_submit}
+          - "false"
 
   # publish_helm_chart packages and publishes the MCK helm chart to the OCI container registry
   publish_helm_chart:


### PR DESCRIPTION
# Summary

Disabling preflight submit for enterprise-server images as we cannot submit those multiple times. The enterprise-server image release is not tied to MCK releases.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
