### PR TITLE
Fix pyxis credentials access for preflight checks

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -53,6 +53,7 @@ variables:
       - MDB_BASH_DEBUG
       - AI_MONGODB_EMBEDDING_INDEXING_KEY
       - AI_MONGODB_EMBEDDING_QUERY_KEY
+      - rh_pyxis
 
 functions:
 


### PR DESCRIPTION
# Summary

Preflight checks were unable to access the pyxis credentials

## Proof of Work

Ci must pass

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
