### PR TITLE
Fix Workflow does not contain permissions complaints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     needs: crate_draft_release_notes
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -66,6 +68,8 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     needs: approve_release
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Summary

This should fix the security complaints:
https://github.com/mongodb/mongodb-kubernetes/security/code-scanning/1
https://github.com/mongodb/mongodb-kubernetes/security/code-scanning/2

## Proof of Work

CI must pass, including github's Code QL.

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
