### PR TITLE
Improve E2E test-summary dashboard

### DIFF
--- a/scripts/evergreen/e2e/test_summary/collector.py
+++ b/scripts/evergreen/e2e/test_summary/collector.py
@@ -1090,8 +1090,7 @@ class TestSummaryGenerator:
         # Per-item synthetic entries may have already been written during parsing.
         self.data.setdefault("log_tails", {})
         total_bytes = sum(
-            len(entry.get("content", "").encode("utf-8", errors="replace"))
-            for entry in self.data["log_tails"].values()
+            len(entry.get("content", "").encode("utf-8", errors="replace")) for entry in self.data["log_tails"].values()
         )
 
         viewable_extensions = {".log", ".txt", ".json", ".conf", ".yaml", ".xml"}

--- a/scripts/evergreen/e2e/test_summary/collector.py
+++ b/scripts/evergreen/e2e/test_summary/collector.py
@@ -43,6 +43,7 @@ class TestSummaryGenerator:
             "error_patterns": [],
             "timeline": [],
             "artifacts": {"files": [], "summary": {}},
+            "log_tails": {},
         }
         self.error_id_counter = 0
         self.errors_by_pattern = defaultdict(list)
@@ -334,6 +335,28 @@ class TestSummaryGenerator:
             print(f"Warning: Failed to extract pod info: {e}", file=sys.stderr)
             return None
 
+    def _embed_item_yaml(self, key: str, item: Dict):
+        """Embed a single resource's YAML under a synthetic log_tails key.
+
+        Used so each row's "view" link in the Resource Browser opens only that
+        resource's YAML, instead of the whole `kubectl get <kind> -o yaml` dump.
+        """
+        if yaml is None or not item:
+            return
+        try:
+            content = yaml.safe_dump(item, default_flow_style=False, sort_keys=False)
+        except Exception as e:
+            print(f"Warning: Failed to serialize item for {key}: {e}", file=sys.stderr)
+            return
+        total_lines = content.count("\n") + (0 if content.endswith("\n") else 1)
+        self.data["log_tails"][key] = {
+            "content": content,
+            "total_lines": total_lines,
+            "shown_lines": total_lines,
+            "truncated": False,
+            "mode": "head",
+        }
+
     def _calculate_ready_status(self, containers: List[Dict]) -> str:
         """Calculate ready status string (e.g., '2/3')."""
         if not containers:
@@ -449,6 +472,9 @@ class TestSummaryGenerator:
 
                             sts_info = self._extract_statefulset_info(sts, cluster, namespace, sts_file.name)
                             if sts_info:
+                                item_key = f"{sts_file.name}#{sts_info['name']}"
+                                self._embed_item_yaml(item_key, sts)
+                                sts_info["files"]["yaml"] = item_key
                                 self.data["resources"]["statefulsets"].append(sts_info)
                     except yaml.YAMLError as e:
                         print(f"Warning: YAML parse error in {sts_file.name}: {e}", file=sys.stderr)
@@ -530,6 +556,9 @@ class TestSummaryGenerator:
 
                             deploy_info = self._extract_deployment_info(deploy, cluster, namespace, deploy_file.name)
                             if deploy_info:
+                                item_key = f"{deploy_file.name}#{deploy_info['name']}"
+                                self._embed_item_yaml(item_key, deploy)
+                                deploy_info["files"]["yaml"] = item_key
                                 self.data["resources"]["deployments"].append(deploy_info)
                     except yaml.YAMLError as e:
                         print(f"Warning: YAML parse error in {deploy_file.name}: {e}", file=sys.stderr)
@@ -664,28 +693,34 @@ class TestSummaryGenerator:
                             if not isinstance(item, dict):
                                 continue
                             metadata = item.get("metadata", {})
+                            name = metadata.get("name", "unknown")
+                            item_key = f"{f.name}#{name}"
+                            self._embed_item_yaml(item_key, item)
                             items.append(
                                 {
-                                    "name": metadata.get("name", "unknown"),
+                                    "name": name,
                                     "namespace": metadata.get("namespace", namespace),
                                     "cluster": cluster,
                                     "kind": item.get("kind", ""),
                                     "api_version": item.get("apiVersion", ""),
                                     "created": metadata.get("creationTimestamp", ""),
-                                    "source_file": f.name,
+                                    "source_file": item_key,
                                 }
                             )
                     elif isinstance(data, dict) and "metadata" in data:
                         metadata = data.get("metadata", {})
+                        name = metadata.get("name", "unknown")
+                        item_key = f"{f.name}#{name}"
+                        self._embed_item_yaml(item_key, data)
                         items.append(
                             {
-                                "name": metadata.get("name", "unknown"),
+                                "name": name,
                                 "namespace": metadata.get("namespace", namespace),
                                 "cluster": cluster,
                                 "kind": data.get("kind", ""),
                                 "api_version": data.get("apiVersion", ""),
                                 "created": metadata.get("creationTimestamp", ""),
-                                "source_file": f.name,
+                                "source_file": item_key,
                             }
                         )
                     # else: raw/describe file — no items, but source_files still tracked
@@ -1050,8 +1085,12 @@ class TestSummaryGenerator:
         For structured files (YAML, JSON, conf, txt dumps): embeds from the beginning
         since these are not append-only streams.
         """
-        self.data["log_tails"] = {}
-        total_bytes = 0
+        # Per-item synthetic entries may have already been written during parsing.
+        self.data.setdefault("log_tails", {})
+        total_bytes = sum(
+            len(entry.get("content", "").encode("utf-8", errors="replace"))
+            for entry in self.data["log_tails"].values()
+        )
 
         viewable_extensions = {".log", ".txt", ".json", ".conf", ".yaml", ".xml"}
         skip_patterns = ["test-summary"]

--- a/scripts/evergreen/e2e/test_summary/collector.py
+++ b/scripts/evergreen/e2e/test_summary/collector.py
@@ -16,6 +16,8 @@ except ImportError:
 
 from error_patterns import ERROR_PATTERNS, get_compiled_patterns
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
 
 class TestSummaryGenerator:
     """Generates comprehensive test summary from E2E artifacts."""
@@ -1097,7 +1099,7 @@ class TestSummaryGenerator:
 
         # Structured files should be read from the beginning, not tailed
         head_extensions = {".yaml", ".json", ".conf", ".xml"}
-        head_suffixes = {"_describe.txt", "_diagnostics.txt"}
+        head_suffixes = {"describe.txt", "diagnostics.txt"}
 
         for file_path in sorted(self.logs_dir.iterdir()):
             if not file_path.is_file():
@@ -1129,6 +1131,7 @@ class TestSummaryGenerator:
                     truncated = len(lines) > tail_lines
 
                 content = "".join(shown)
+                content = _ANSI_RE.sub("", content)
 
                 # Cap total embedded size
                 content_bytes = len(content.encode("utf-8", errors="replace"))

--- a/scripts/evergreen/e2e/test_summary/dashboard.css
+++ b/scripts/evergreen/e2e/test_summary/dashboard.css
@@ -20,6 +20,7 @@ h3 { color: #555; }
     align-items: center;
 }
 .metadata-item { display: flex; align-items: center; gap: 6px; }
+.metadata-item-right { margin-left: auto; }
 .metadata-label { font-size: 0.8em; color: #666; }
 .metadata-value { font-weight: 600; font-size: 0.95em; color: #333; }
 .status-badge {

--- a/scripts/evergreen/e2e/test_summary/dashboard.css
+++ b/scripts/evergreen/e2e/test_summary/dashboard.css
@@ -129,17 +129,6 @@ tr:hover { background: #f8f9fa; }
 .error-pattern.error { background: #fff3cd; border-left-color: #ffc107; }
 .error-pattern.warning { background: #d1ecf1; border-left-color: #17a2b8; }
 .error-pattern h4 { margin-top: 0; }
-.copy-button {
-    background: #007bff;
-    color: white;
-    border: none;
-    padding: 10px 20px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    margin: 10px 5px 10px 0;
-}
-.copy-button:hover { background: #0056b3; }
 .collapsible {
     cursor: pointer;
     user-select: none;

--- a/scripts/evergreen/e2e/test_summary/dashboard.css
+++ b/scripts/evergreen/e2e/test_summary/dashboard.css
@@ -672,3 +672,62 @@ code {
 .log-info { color: #4af; }
 .log-debug { color: #666; }
 .log-timestamp { color: #777; }
+
+/* Test output section */
+.test-output {
+    margin: 20px 0;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    background: #fafafa;
+}
+.test-output > summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 10px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    user-select: none;
+}
+.test-output > summary::-webkit-details-marker { display: none; }
+.test-output > summary::before {
+    content: '▶';
+    font-size: 0.7em;
+    color: #888;
+    transition: transform 0.15s;
+}
+.test-output[open] > summary::before {
+    transform: rotate(90deg);
+    display: inline-block;
+}
+.test-output-title {
+    font-weight: 600;
+    color: #444;
+}
+.test-output-info {
+    color: #888;
+    font-size: 0.85em;
+    flex: 1;
+}
+.test-output-open {
+    background: #007bff;
+    color: white;
+    border: none;
+    padding: 5px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+}
+.test-output-open:hover { background: #0056b3; }
+.test-output-preview {
+    max-height: 320px;
+    overflow: auto;
+    margin: 0;
+    padding: 12px 16px;
+    color: #d4d4d4;
+    background: #1e1e1e;
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.82em;
+    line-height: 1.5;
+    border-radius: 0 0 6px 6px;
+}

--- a/scripts/evergreen/e2e/test_summary/dashboard.css
+++ b/scripts/evergreen/e2e/test_summary/dashboard.css
@@ -724,10 +724,15 @@ code {
     overflow: auto;
     margin: 0;
     padding: 12px 16px;
-    color: #d4d4d4;
-    background: #1e1e1e;
+    color: #2d2d2d;
+    background: #fff;
+    border-top: 1px solid #e0e0e0;
     font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
     font-size: 0.82em;
     line-height: 1.5;
     border-radius: 0 0 6px 6px;
+}
+.test-output-preview .line-num {
+    color: #aaa;
+    border-right-color: #e0e0e0;
 }

--- a/scripts/evergreen/e2e/test_summary/dashboard.js
+++ b/scripts/evergreen/e2e/test_summary/dashboard.js
@@ -170,7 +170,20 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
-// Auto-collapse long sections on load
+// Scroll the inline Test Output preview to the bottom — matches the modal
+// behavior so the most recent pytest activity is visible without a manual scroll.
+function _scrollTestOutputToBottom(preview) {
+    if (preview) preview.scrollTop = preview.scrollHeight;
+}
+
 window.addEventListener('load', () => {
+    document.querySelectorAll('details.test-output').forEach(d => {
+        const preview = d.querySelector('.test-output-preview');
+        // Scroll once now (works if open), and again on every toggle to open.
+        _scrollTestOutputToBottom(preview);
+        d.addEventListener('toggle', () => {
+            if (d.open) _scrollTestOutputToBottom(preview);
+        });
+    });
     console.log('Test summary loaded.');
 });

--- a/scripts/evergreen/e2e/test_summary/dashboard.js
+++ b/scripts/evergreen/e2e/test_summary/dashboard.js
@@ -91,8 +91,15 @@ function openLogModal(filename) {
     const info = document.getElementById('log-modal-info');
     const body = document.getElementById('log-modal-body');
 
-    // Show just the short filename in the title
-    const shortName = filename.includes('_') ? filename.split('_').slice(-1)[0] || filename : filename;
+    // Synthetic per-item keys are formatted as "<source_file>#<resource_name>".
+    // For those, show just the resource name; otherwise fall back to the
+    // trailing chunk of the filename.
+    let shortName;
+    if (filename.includes('#')) {
+        shortName = filename.split('#').slice(-1)[0];
+    } else {
+        shortName = filename.includes('_') ? filename.split('_').slice(-1)[0] || filename : filename;
+    }
     title.textContent = shortName;
     title.title = filename;
 

--- a/scripts/evergreen/e2e/test_summary/dashboard.js
+++ b/scripts/evergreen/e2e/test_summary/dashboard.js
@@ -61,28 +61,6 @@ function toggleTestError(id) {
     }
 }
 
-function copyJSON() {
-    const jsonData = document.getElementById('test-data').textContent;
-    navigator.clipboard.writeText(jsonData).then(() => {
-        alert('JSON data copied to clipboard!');
-    }).catch(err => {
-        console.error('Failed to copy:', err);
-    });
-}
-
-function downloadJSON() {
-    const jsonData = document.getElementById('test-data').textContent;
-    const blob = new Blob([jsonData], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'test-summary.json';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-}
-
 // Log viewer modal
 const _logTails = JSON.parse(document.getElementById('log-tails-data').textContent);
 
@@ -187,5 +165,5 @@ document.addEventListener('keydown', (e) => {
 
 // Auto-collapse long sections on load
 window.addEventListener('load', () => {
-    console.log('Test summary loaded. JSON data available in #test-data element.');
+    console.log('Test summary loaded.');
 });

--- a/scripts/evergreen/e2e/test_summary/renderer.py
+++ b/scripts/evergreen/e2e/test_summary/renderer.py
@@ -666,12 +666,8 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
     # Parse reference time for age calculations (use generation time, not viewing time)
     reference_time = datetime.fromisoformat(data["meta"]["generated_at"].replace("Z", "+00:00"))
 
-    # Extract log tails before serializing — keep the copyable JSON clean
     log_tails = data.pop("log_tails", {})
     log_tails_json = json.dumps(log_tails)
-
-    json_data = json.dumps(data, indent=2)
-    escaped_json = escape(json_data)
 
     # Calculate quick stats
     failed_tests = data["test_run"].get("tests", {}).get("failed", 0)
@@ -763,12 +759,6 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
             {_render_artifacts_by_cluster(data)}
         </div>
 
-        <button class="copy-button" onclick="copyJSON()">\U0001f4cb Copy JSON Data</button>
-        <button class="copy-button" onclick="downloadJSON()">\U0001f4be Download JSON</button>
-        <h2 class="collapsible collapsed" onclick="toggleCollapse(this)">Full JSON Data</h2>
-        <div class="collapsible-content section">
-            <pre id="json-display">{escaped_json}</pre>
-        </div>
     </div>
 
     <!-- Log viewer modal -->
@@ -782,10 +772,6 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
             <pre id="log-modal-body" class="log-modal-body"></pre>
         </div>
     </div>
-
-    <script id="test-data" type="application/json">
-{json_data}
-    </script>
 
     <script id="log-tails-data" type="application/json">
 {log_tails_json}

--- a/scripts/evergreen/e2e/test_summary/renderer.py
+++ b/scripts/evergreen/e2e/test_summary/renderer.py
@@ -756,8 +756,6 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
 </head>
 <body>
     <div class="container">
-        <h1>E2E Test Summary</h1>
-
         <div class="metadata">
             <div class="metadata-item">
                 <span class="metadata-label">Status</span>
@@ -779,7 +777,7 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
                 <span class="metadata-label">Tests</span>
                 <span class="metadata-value">{total_tests} total ({failed_tests} failed)</span>
             </div>
-            <div class="metadata-item">
+            <div class="metadata-item metadata-item-right">
                 <span class="metadata-label">Generated</span>
                 <span class="metadata-value">{data['meta']['generated_at'][:19]}</span>
             </div>

--- a/scripts/evergreen/e2e/test_summary/renderer.py
+++ b/scripts/evergreen/e2e/test_summary/renderer.py
@@ -585,7 +585,7 @@ def _render_failed_tests(data: Dict) -> str:
     if failed_tests == 0:
         return ""
 
-    html = "<h2>Failed Tests</h2><div class='section'>"
+    html = "<h2>Failed Tests</h2>"
     for idx, test in enumerate(data["test_run"].get("tests", {}).get("details", [])):
         if test["status"] == "failed":
             html += "<div class='failed-test'>"
@@ -606,7 +606,6 @@ def _render_failed_tests(data: Dict) -> str:
                     html += f":{escape(test['line'])}"
                 html += "</div>"
             html += "</div>"
-    html += "</div>"
     return html
 
 
@@ -617,11 +616,68 @@ def _render_resource_inventory(data: Dict, log_tails: Dict, reference_time: date
     return diagnostics_html + tabs_html
 
 
+def _render_test_output(data: Dict, log_tails: Dict, preview_lines: int = 40) -> str:
+    """Render an inline tail preview of the pytest log with a button to open the full log.
+
+    Surfaces the pytest run output (test_app.log) directly on the dashboard so users
+    don't have to dig through CI artifacts. Falls back to the test pod's container
+    stdout log if test_app.log isn't present.
+    """
+    candidates = ["test_app.log"]
+    for fname in log_tails:
+        if fname.endswith("-mongodb-enterprise-operator-tests.log"):
+            candidates.append(fname)
+            break
+
+    log_file = next((f for f in candidates if f in log_tails), None)
+    if not log_file:
+        return ""
+
+    entry = log_tails[log_file]
+    content = entry.get("content", "")
+    if not content:
+        return ""
+
+    lines = content.splitlines()
+    preview = lines[-preview_lines:]
+    preview_start_num = (
+        entry["total_lines"] - len(preview) + 1
+        if entry.get("mode") == "tail" and not entry.get("truncated")
+        else max(1, len(lines) - len(preview) + 1)
+    )
+
+    failed = data["test_run"].get("tests", {}).get("failed", 0)
+    expanded = failed > 0
+
+    preview_html = ""
+    for i, line in enumerate(preview):
+        num = preview_start_num + i
+        preview_html += (
+            f"<span class='log-line'>"
+            f"<span class='line-num'>{num}</span>"
+            f"<span class='line-content'>{escape(line)}</span>"
+            f"</span>"
+        )
+
+    open_attr = "open" if expanded else ""
+    info = f"showing last {len(preview)} of {entry.get('total_lines', len(lines))} lines"
+    return f"""
+        <details class='test-output' {open_attr}>
+            <summary>
+                <span class='test-output-title'>Test Output</span>
+                <span class='test-output-info'>{info}</span>
+                <button class='test-output-open' onclick="event.preventDefault(); event.stopPropagation(); openLogModal('{escape(log_file)}')">View full log</button>
+            </summary>
+            <pre class='test-output-preview'>{preview_html}</pre>
+        </details>
+    """
+
+
 def _render_error_catalog(data: Dict) -> str:
     """Render error catalog with expandable sample errors."""
     top_errors = data["error_patterns"][:5]
 
-    html = "<h2>Error Catalog</h2><div class='section'>"
+    html = "<h2>Error Catalog</h2>"
     if top_errors:
         for idx, pattern in enumerate(top_errors):
             severity_class = pattern["severity"]
@@ -657,7 +713,6 @@ def _render_error_catalog(data: Dict) -> str:
             html += "</div>"
     else:
         html += "<p>No errors detected</p>"
-    html += "</div>"
     return html
 
 
@@ -681,6 +736,7 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
 
     # Build sections
     failed_tests_html = _render_failed_tests(data)
+    test_output_html = _render_test_output(data, log_tails)
     error_catalog_html = _render_error_catalog(data)
     resource_html = _render_resource_inventory(data, log_tails, reference_time)
     timeline_html = "".join([_render_timeline_entry(idx, entry) for idx, entry in enumerate(data["timeline"][:200])])
@@ -730,6 +786,8 @@ def generate_html(data: Dict[str, Any], test_name: str, variant: str, status: st
         </div>
 
         {failed_tests_html}
+
+        {test_output_html}
 
         {resource_html}
 


### PR DESCRIPTION
# Summary
Some fixes for the `!test-summary.html` that ships with each E2E task's artifacts.

- **Per-resource "view" in the Resource Browser now opens just that one resource's YAML**. It used to open the whole `kubectl get <kind> -o yaml` list for every row.
- New Test Output section with a tail preview of `test_app.log` plus a "View full log" button so the pytest output isn't buried in CI artifacts.
- Removed the "Copy/Download JSON" buttons and the "Full JSON Data" section. No one read them; they bloat the HTML.
- Modal now opens scrolled to the top for structured files and to the bottom for streaming logs (the heuristic was misclassifying `*-pod-describe.txt`).
- Visual cleanup: removed double-indent on Failed Tests / Error Catalog, smaller top bar.

## Proof of Work

Tested generation locally against two artifact dumps. The dashboard will also be visible on the artifacts of this PR's patch.

### Before

<img width="1282" height="1003" alt="image" src="https://github.com/user-attachments/assets/d1f88e10-dac2-4079-b094-e59f5623e64a" />

### After

<img width="1284" height="1296" alt="image" src="https://github.com/user-attachments/assets/f5854ed1-e8ad-427f-a852-767b13001a4a" />


## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
