### PR TITLE
CLOUDP-407997: Test all at merge time

### DIFF
--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -186,11 +186,11 @@ buildvariants:
     tasks:
       - name: kind_code_snippets_task_group
 
-    #TODO: this task was disabled from automatic runs due to GKE resource issues https://jira.mongodb.org/browse/CLOUDP-345083
+    #TODO: re-enabled for staging (master merge) to gate promote; was disabled due to GKE resource issues https://jira.mongodb.org/browse/CLOUDP-345083
   - name: private_gke_code_snippets
     display_name: private_gke_code_snippets
-    tags: [ "manual_patch", "e2e_test_suite" ]
-    allowed_requesters: [ "patch" ]
+    tags: [ "manual_patch", "staging", "e2e_test_suite" ]
+    allowed_requesters: [ "patch", "commit" ]
     run_on:
       - ubuntu2404-small
     <<: *base_om8_dependency

--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -1,6 +1,5 @@
 variables:
   - &setup_and_teardown_group_gke_code_snippets
-    max_execution: 2
     setup_task_can_fail_task: true
     setup_group:
       - func: clone

--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -1,5 +1,6 @@
 variables:
   - &setup_and_teardown_group_gke_code_snippets
+    max_execution: 2
     setup_task_can_fail_task: true
     setup_group:
       - func: clone

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -659,6 +659,15 @@ tasks:
             - scripts/dev/release/1.2.0.clusterserviceversion.yaml
             - --verbose
 
+  # Dummy placeholder: will call `mckctl release promote` once the tool is wired into CI.
+  # Runs after all staging tests pass on a master merge to confirm the build is promotable.
+  - name: mckctl_release_promote
+    commands:
+      - command: shell.exec
+        params:
+          script: |
+            echo "would run: mckctl release promote --version ${OPERATOR_VERSION}"
+
   # Notify Slack about build failures
   # On patches: stdout only. On mainline: stdout + Slack
   - name: notify_master_build_status
@@ -2203,6 +2212,20 @@ buildvariants:
       - name: release_om_and_agents
 
   # Notification task - runs after all staging tasks complete to report build status.
+  # Runs after all staging tests (including GKE snippets) succeed on master merge.
+  # Only on commit builds — see DEVPROD-27436 note on notify_master_build_status below.
+  - name: mckctl_release_promote
+    display_name: mckctl_release_promote
+    allowed_requesters: [ "commit" ]
+    depends_on:
+      - name: "*"
+        variant: ".staging"
+        status: "success"
+    run_on:
+      - ubuntu2404-small
+    tasks:
+      - name: mckctl_release_promote
+
   # Only runs on commit builds (not patches) because of Evergreen bug DEVPROD-27436:
   # depends_on with patch_optional:true generates phantom dependencies for tasks that
   # don't exist in the patch, causing the task to hang indefinitely.

--- a/public/architectures/setup-multi-cluster/ra-01-setup-gke/code_snippets/ra-01_0010_create_gke_cluster_0.sh
+++ b/public/architectures/setup-multi-cluster/ra-01-setup-gke/code_snippets/ra-01_0010_create_gke_cluster_0.sh
@@ -3,4 +3,4 @@ gcloud container clusters create "${K8S_CLUSTER_0}" \
       --num-nodes="${K8S_CLUSTER_0_NUMBER_OF_NODES}" \
       --machine-type "${K8S_CLUSTER_0_MACHINE_TYPE}" \
       --tags=mongodb \
-      "${GKE_SPOT_INSTANCES_SWITCH:-""}"
+      ${GKE_SPOT_INSTANCES_SWITCH:+${GKE_SPOT_INSTANCES_SWITCH}}

--- a/public/architectures/setup-multi-cluster/ra-01-setup-gke/code_snippets/ra-01_0010_create_gke_cluster_1.sh
+++ b/public/architectures/setup-multi-cluster/ra-01-setup-gke/code_snippets/ra-01_0010_create_gke_cluster_1.sh
@@ -3,4 +3,4 @@ gcloud container clusters create "${K8S_CLUSTER_1}" \
       --num-nodes="${K8S_CLUSTER_1_NUMBER_OF_NODES}" \
       --machine-type "${K8S_CLUSTER_1_MACHINE_TYPE}" \
       --tags=mongodb \
-      "${GKE_SPOT_INSTANCES_SWITCH:-""}"
+      ${GKE_SPOT_INSTANCES_SWITCH:+${GKE_SPOT_INSTANCES_SWITCH}}

--- a/public/architectures/setup-multi-cluster/ra-01-setup-gke/code_snippets/ra-01_0010_create_gke_cluster_2.sh
+++ b/public/architectures/setup-multi-cluster/ra-01-setup-gke/code_snippets/ra-01_0010_create_gke_cluster_2.sh
@@ -3,4 +3,4 @@ gcloud container clusters create "${K8S_CLUSTER_2}" \
       --num-nodes="${K8S_CLUSTER_2_NUMBER_OF_NODES}" \
       --machine-type "${K8S_CLUSTER_2_MACHINE_TYPE}" \
       --tags=mongodb \
-      "${GKE_SPOT_INSTANCES_SWITCH:-""}"
+      ${GKE_SPOT_INSTANCES_SWITCH:+${GKE_SPOT_INSTANCES_SWITCH}}

--- a/public/architectures/setup-multi-cluster/ra-01-setup-gke/env_variables.sh
+++ b/public/architectures/setup-multi-cluster/ra-01-setup-gke/env_variables.sh
@@ -21,6 +21,5 @@ export K8S_CLUSTER_2_NUMBER_OF_NODES=1
 export K8S_CLUSTER_2_MACHINE_TYPE="e2-standard-4"
 export K8S_CLUSTER_2_CONTEXT_NAME="gke_${MDB_GKE_PROJECT}_${K8S_CLUSTER_2_ZONE}_${K8S_CLUSTER_2}"
 
-# Comment out the following line so that the script does not create preemptible nodes.
-# DO NOT USE preemptible nodes in production.
-export GKE_SPOT_INSTANCES_SWITCH="--preemptible"
+# Preemptible nodes disabled — caused random mid-test evictions in CI.
+# export GKE_SPOT_INSTANCES_SWITCH="--preemptible"


### PR DESCRIPTION
# Summary

We should only release what has passed all tests, but GKE code snippet tests were never running automatically — only on manual patches. This wires them into the merge pipeline and adds a `mckctl_release_promote` placeholder that will become the gate: it only fires when every staging test succeeds, and will eventually call the real promote step.

Also:
- Removed the pre-empetive flag on gke tests to make them more reliable.
- And allowed gke test one extra retry to overcome flakiness.

## Proof of Work

The `mckctl_release_promote` variant depends on all `.staging` variants with status: "success", so it self-documents the gate in the Evergreen UI. GKE snippet tests now appear in mainline builds. The placeholder echoes the promote command so the wiring can be verified before the real tool is merged.

✅ [Test GKE stability NO preempetive 5](https://spruce.corp.mongodb.com/version/6a26b26f6e3f64000718e7e6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
