### PR TITLE
KUBE-2: fix JVM params accumulating in mms.conf across pod restarts

### DIFF
--- a/changelog/20260527_fix_jvm_params_accumulating_in_mms_conf.md
+++ b/changelog/20260527_fix_jvm_params_accumulating_in_mms_conf.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-05-27
 ---
 
-* **MongoDBOpsManager JVM parameters**: Fixed an issue in the `MongoDBOpsManager` resource where JVM parameter blocks were appended to `mms.conf` on every pod restart without removing previous entries, causing duplicate configuration entries to accumulate.
+* **MongoDBOpsManager**: Fixed an issue in the `MongoDBOpsManager` resource where JVM parameter blocks were appended to `mms.conf` on every pod restart without removing previous entries, causing duplicate configuration entries to accumulate.

--- a/changelog/20260527_fix_jvm_params_accumulating_in_mms_conf.md
+++ b/changelog/20260527_fix_jvm_params_accumulating_in_mms_conf.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-05-27
 ---
 
-* Fixed an issue where JVM parameter blocks were appended to `mms.conf` on every pod restart without removing previous entries.
+* **MongoDBOpsManager JVM parameters**: Fixed an issue in the `MongoDBOpsManager` resource where JVM parameter blocks were appended to `mms.conf` on every pod restart without removing previous entries, causing duplicate configuration entries to accumulate.

--- a/changelog/20260527_fix_jvm_params_accumulating_in_mms_conf.md
+++ b/changelog/20260527_fix_jvm_params_accumulating_in_mms_conf.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-05-27
+---
+
+* Fixed an issue where JVM parameter blocks were appended to `mms.conf` on every pod restart without removing previous entries.

--- a/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go
+++ b/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go
@@ -53,9 +53,9 @@ func updateConfFile(confFile string) error {
 	}
 
 	newMmsJvmParams := fmt.Sprintf(propOverwriteFmt, confFilePropertyName, confFilePropertyName, jvmParams)
-	fmt.Printf("Appending %s to %s\n", newMmsJvmParams, confFile)
+	fmt.Printf("Writing %s to %s\n", newMmsJvmParams, confFile)
 
-	return appendLinesToFile(confFile, getJvmParamDocString()+newMmsJvmParams+lineBreak)
+	return writeJvmParamsToFile(confFile, getJvmParamDocString()+newMmsJvmParams+lineBreak)
 }
 
 // getHostnameFQDN returns the FQDN name for this Pod, which is the Pod's hostname
@@ -152,18 +152,46 @@ func writeLinesToFile(name string, lines []string) error {
 	return nil
 }
 
-func appendLinesToFile(name string, lines string) error {
-	f, err := os.OpenFile(name, os.O_APPEND|os.O_WRONLY, 0o644)
+// writeJvmParamsToFile strips any previously written operator JVM blocks from
+// the conf file, then writes the cleaned content back together with the new
+// block. This ensures the file stays idempotent across multiple pod cycles.
+func writeJvmParamsToFile(name string, block string) error {
+	existing, err := os.ReadFile(name)
 	if err != nil {
-		return xerrors.Errorf("error opening file %s: %w", name, err)
+		return xerrors.Errorf("error reading file %s: %w", name, err)
 	}
 
-	if _, err = f.WriteString(lines); err != nil {
+	cleaned := removeOperatorJvmBlocks(string(existing))
+
+	err = os.WriteFile(name, []byte(cleaned+block), 0o644) // nolint:gosec
+	if err != nil {
 		return xerrors.Errorf("error writing to file %s: %w", name, err)
 	}
+	return nil
+}
 
-	err = f.Close()
-	return err
+// removeOperatorJvmBlocks removes every JVM parameter block that a previous
+// operator run wrote into the conf file. Each block begins with the banner
+// produced by getJvmParamDocString and is followed by a single parameter line.
+// Removing all existing copies before writing a fresh one keeps the file from
+// growing unboundedly across pod restarts.
+func removeOperatorJvmBlocks(content string) string {
+	docString := getJvmParamDocString()
+	for {
+		before, after, found := strings.Cut(content, docString)
+		if !found {
+			break
+		}
+		// Drop the single param line that follows the banner.
+		_, tail, _ := strings.Cut(after, lineBreak)
+		content = before + tail
+	}
+	return content
+}
+
+func getJvmParamDocString() string {
+	commentMarker := strings.Repeat("#", 55)
+	return fmt.Sprintf("%s\n## This is the custom JVM configuration set by the Operator\n%s\n\n", commentMarker, commentMarker)
 }
 
 func getOmPropertiesFromEnvVars() map[string]string {
@@ -204,11 +232,6 @@ func updateMmsProperties(lines []string, newProperties map[string]string) []stri
 		}
 	}
 	return lines
-}
-
-func getJvmParamDocString() string {
-	commentMarker := strings.Repeat("#", 55)
-	return fmt.Sprintf("%s\n## This is the custom JVM configuration set by the Operator\n%s\n\n", commentMarker, commentMarker)
 }
 
 func main() {

--- a/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration_test.go
+++ b/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration_test.go
@@ -15,8 +15,11 @@ func TestEditMmsConfiguration_UpdateConfFile_Mms(t *testing.T) {
 	t.Setenv("CUSTOM_JAVA_MMS_UI_OPTS", "-Xmx4000m -Xms4000m")
 	err := updateConfFile(confFile)
 	assert.NoError(t, err)
-	updatedContent := _readLinesFromFile(confFile)
-	assert.Equal(t, updatedContent[7], "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} -Xmx4000m -Xms4000m\"")
+
+	content, err := os.ReadFile(confFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} -Xmx4000m -Xms4000m\"")
+	assert.Contains(t, string(content), "## This is the custom JVM configuration set by the Operator")
 }
 
 func TestEditMmsConfiguration_UpdateConfFile_BackupDaemon(t *testing.T) {
@@ -26,6 +29,84 @@ func TestEditMmsConfiguration_UpdateConfFile_BackupDaemon(t *testing.T) {
 	t.Setenv("CUSTOM_JAVA_DAEMON_OPTS", "-Xmx4000m -Xms4000m")
 	err := updateConfFile(confFile)
 	assert.NoError(t, err)
+}
+
+// TestEditMmsConfiguration_UpdateConfFile_Idempotent verifies that running
+// updateConfFile many times does not accumulate duplicate JVM param blocks.
+// The file must contain the param line exactly once regardless of how many
+// reconciliation cycles have occurred.
+func TestEditMmsConfiguration_UpdateConfFile_Idempotent(t *testing.T) {
+	confFile := _createTestConfFile()
+	t.Setenv("CUSTOM_JAVA_MMS_UI_OPTS", "-Xmx4000m -Xms4000m")
+
+	for i := 0; i < 10; i++ {
+		err := updateConfFile(confFile)
+		assert.NoError(t, err)
+	}
+
+	content, err := os.ReadFile(confFile)
+	assert.NoError(t, err)
+
+	occurrences := strings.Count(string(content), "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} -Xmx4000m -Xms4000m\"")
+	assert.Equal(t, 1, occurrences, "JVM param line must appear exactly once after repeated reconciliations")
+}
+
+// TestEditMmsConfiguration_UpdateConfFile_ReplacesExistingBlock verifies that
+// a pre-existing operator block written by an older pod cycle is replaced
+// rather than duplicated when the params change.
+func TestEditMmsConfiguration_UpdateConfFile_ReplacesExistingBlock(t *testing.T) {
+	confFile := _createTestConfFile()
+
+	t.Setenv("CUSTOM_JAVA_MMS_UI_OPTS", "-Xmx2000m -Xms2000m")
+	err := updateConfFile(confFile)
+	assert.NoError(t, err)
+
+	t.Setenv("CUSTOM_JAVA_MMS_UI_OPTS", "-Xmx8000m -Xms8000m")
+	err = updateConfFile(confFile)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(confFile)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, string(content), "-Xmx2000m", "stale JVM params from a previous cycle must not remain in the file")
+	assert.Contains(t, string(content), "-Xmx8000m", "updated JVM params must be present in the file")
+}
+
+// TestEditMmsConfiguration_UpdateConfFile_PreservesBaseContent simulates a
+// file that has accumulated many duplicate operator blocks (the original bug)
+// and verifies that after one reconciliation: all duplicates are removed, the
+// base OM content that predates any operator writes is fully preserved, and
+// exactly one fresh operator block is present.
+func TestEditMmsConfiguration_UpdateConfFile_PreservesBaseContent(t *testing.T) {
+	baseContent := "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} -Xmx4352m -Xss328k  -Xms4352m -XX:NewSize=600m -Xmn1500m -XX:ReservedCodeCacheSize=128m -XX:-OmitStackTraceInFastThrow\"\n" +
+		"JAVA_DAEMON_OPTS= \"${JAVA_DAEMON_OPTS} -DMONGO.BIN.PREFIX=\"\n\n"
+
+	operatorBlock := func(params string) string {
+		return getJvmParamDocString() + "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} " + params + "\"\n"
+	}
+	accumulated := baseContent + operatorBlock("-Xmx1000m") + operatorBlock("-Xmx2000m") + operatorBlock("-Xmx3000m")
+	confFile := _writeTempFileWithContent(accumulated, "conf")
+
+	t.Setenv("CUSTOM_JAVA_MMS_UI_OPTS", "-Xmx4000m -Xms4000m")
+	err := updateConfFile(confFile)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(confFile)
+	assert.NoError(t, err)
+	text := string(content)
+
+	// Base content must be intact.
+	assert.Contains(t, text, "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} -Xmx4352m -Xss328k")
+	assert.Contains(t, text, "JAVA_DAEMON_OPTS= \"${JAVA_DAEMON_OPTS} -DMONGO.BIN.PREFIX=\"")
+
+	// All stale operator params must be gone.
+	assert.NotContains(t, text, "-Xmx1000m")
+	assert.NotContains(t, text, "-Xmx2000m")
+	assert.NotContains(t, text, "-Xmx3000m")
+
+	// Exactly one fresh operator block must be present.
+	assert.Equal(t, 1, strings.Count(text, "## This is the custom JVM configuration set by the Operator"))
+	assert.Equal(t, 1, strings.Count(text, "JAVA_MMS_UI_OPTS=\"${JAVA_MMS_UI_OPTS} -Xmx4000m -Xms4000m\""))
 }
 
 func TestEditMmsConfiguration_GetOmPropertiesFromEnvVars(t *testing.T) {


### PR DESCRIPTION
## Problem

The `mmsconfiguration` binary appended the `Xmx`/`Xms` JVM parameter block to `mms.conf` on every pod cycle without checking for or removing existing entries. Over time this caused the file to accumulate thousands of duplicate lines, eventually causing the JVM to fail at startup with:

```
bash: Argument list too long
```

The bug has existed since the operator's inception but only recently surfaced in a customer environment where the file had grown to tens of thousands of duplicate entries. The immediate workaround was to truncate `mms.conf` manually.

Root cause: [edit_mms_configuration.go](docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go) called `appendLinesToFile` unconditionally on every reconciliation.

## Solution

Replace the blind append with a read-strip-write approach:

1. Read the existing `mms.conf`.
2. Strip all previously written operator JVM blocks (identified by the existing banner comment used as a marker).
3. Write the cleaned content back with exactly one fresh block.

This makes the operation idempotent. Files that have already accumulated thousands of duplicate blocks are cleaned up on the first reconciliation after this change is deployed.

## Changes

- **`writeJvmParamsToFile`** (new): reads the file, strips existing operator blocks, writes cleaned content + one fresh block.
- **`removeOperatorJvmBlocks`** (new): strips every occurrence of the banner comment + param line pair using `strings.Cut`.
- **`appendLinesToFile`** (removed): dead code, no longer needed.
- **Tests** (4 new):
  - `UpdateConfFile_Idempotent`: 10 consecutive reconciliations produce exactly one param line.
  - `UpdateConfFile_ReplacesExistingBlock`: changing params removes the old value.
  - `UpdateConfFile_PreservesBaseContent`: a file pre-seeded with 3 duplicate operator blocks is cleaned up, base OM content is fully preserved, and exactly one fresh block is written.
  - `UpdateConfFile_Mms` (updated): switched from fragile line-index assertion to `Contains` check.

## Testing

```
ok  github.com/mongodb/mongodb-kubernetes/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration  (all 7 tests pass)
```