### PR TITLE
[KUBE-8] Add liveness probe to envoy load balancer

### DIFF
--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -628,6 +628,17 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 					InitialDelaySeconds: 5,
 					PeriodSeconds:       5,
 				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/ready",
+							Port: intstr.FromInt32(envoyAdminPort),
+						},
+					},
+					InitialDelaySeconds: 10,
+					PeriodSeconds:       10,
+					FailureThreshold:    3,
+				},
 				Lifecycle: &corev1.Lifecycle{
 					PreStop: &corev1.LifecycleHandler{
 						HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
# Summary

The envoy loadbalancer already had readiness probe which configures when envoy is ready/ready to accept traffic, but it lacked the liveness probe. Liveness probes are used to configure when a pod should be restarted, if in case it's stuck or something like that.
Figuring out the endpoint that can be used in liveness probe was a challenge because apart from `/ready` there is another endpoint `/server_info` that can be used to figure out if if envoy's admin interface is responsive. But after spending some time and looking at this PR https://github.com/envoyproxy/gateway/pull/5535 it looks like `/ready` would be a good idea because `/ready` is used in that upstream PR. 

## Proof of Work

NA

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
