### PR TITLE
KUBE-17: allow spec.replicas=0 on MongoDBSearch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,8 @@
 - [ ] Have you added changelog file?
     - use `skip-changelog` label if not needed
     - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
+
+---
+
+<!-- start git-machete generated -->
+<!-- end git-machete generated -->

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -89,8 +89,11 @@ type MongoDBSearchSpec struct {
 	// For Sharded source: the number mongot pods per shard.
 	// When Replicas > 1, a load balancer configuration (spec.loadBalancer)
 	// is required to distribute traffic across mongot instances.
+	// 0 is allowed so operators (and operator-driven test harnesses) can
+	// take mongot offline cleanly via the CR — the StatefulSet is scaled
+	// to 0 by the reconciler; the MongoDBSearch CR itself stays around.
 	// +optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Deprecated: In multi-cluster deployments, prefer spec.clusters[].statefulSet. When
 	// spec.clusters is omitted, this value auto-promotes into spec.clusters[0].statefulSet.
@@ -177,8 +180,9 @@ type ClusterSpec struct {
 	ClusterName string `json:"clusterName,omitempty"`
 	// Replicas overrides spec.replicas for this cluster's mongot StatefulSet.
 	// For sharded sources, this is mongot pods per shard, not total.
+	// 0 is allowed (StatefulSet scales to 0 — see spec.replicas docs).
 	// +optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 	// +optional
 	ResourceRequirements *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
@@ -824,9 +828,9 @@ func (s *MongoDBSearch) EffectiveClusterFor(clusterName string) (ClusterSpec, er
 
 func (s *MongoDBSearch) GetReplicas() int {
 	// Single legitimate read of the deprecated top-level field — this is the
-	// operator-side default ("1 when unset") for the legacy single-cluster path
-	// and for validators that only look at the top-level value.
-	// Multi-cluster reconcile readers should use GetReplicasForCluster instead.
+	// operator-side default ("1 when unset") for the legacy single-cluster path.
+	// An explicit 0 is honored (callers can take mongot offline via the CR).
+	// Multi-cluster readers go through EffectiveClusters() instead.
 	//nolint:staticcheck // SA1019: deprecated field is the documented fallback.
 	if s.Spec.Replicas != nil {
 		return int(*s.Spec.Replicas)

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -24,8 +24,17 @@ func TestGetReplicasReturnsExplicitValue(t *testing.T) {
 	assert.Equal(t, 3, s.GetReplicas())
 }
 
+func TestGetReplicasHonorsExplicitZero(t *testing.T) {
+	// spec.replicas=0 is a legitimate value (operator-driven scale-to-0
+	// for taking mongot offline via the CR). Distinguishing it from "unset"
+	// is the contract callers like search-connectivity tests rely on.
+	s := &MongoDBSearch{Spec: MongoDBSearchSpec{Replicas: ptr.To(int32(0))}}
+	assert.Equal(t, 0, s.GetReplicas())
+}
+
 func TestHasMultipleReplicas(t *testing.T) {
 	assert.False(t, (&MongoDBSearch{}).HasMultipleReplicas())
+	assert.False(t, (&MongoDBSearch{Spec: MongoDBSearchSpec{Replicas: ptr.To(int32(0))}}).HasMultipleReplicas())
 	assert.False(t, (&MongoDBSearch{Spec: MongoDBSearchSpec{Replicas: ptr.To(int32(1))}}).HasMultipleReplicas())
 	assert.True(t, (&MongoDBSearch{Spec: MongoDBSearchSpec{Replicas: ptr.To(int32(2))}}).HasMultipleReplicas())
 }

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -284,8 +284,9 @@ spec:
                       description: |-
                         Replicas overrides spec.replicas for this cluster's mongot StatefulSet.
                         For sharded sources, this is mongot pods per shard, not total.
+                        0 is allowed (StatefulSet scales to 0 — see spec.replicas docs).
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     resourceRequirements:
                       description: ResourceRequirements describes the compute resource
@@ -622,8 +623,11 @@ spec:
                   For Sharded source: the number mongot pods per shard.
                   When Replicas > 1, a load balancer configuration (spec.loadBalancer)
                   is required to distribute traffic across mongot instances.
+                  0 is allowed so operators (and operator-driven test harnesses) can
+                  take mongot offline cleanly via the CR — the StatefulSet is scaled
+                  to 0 by the reconciler; the MongoDBSearch CR itself stays around.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               resourceRequirements:
                 description: |-

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1322,11 +1322,11 @@ type x509AuthResource struct {
 }
 
 func (x *x509AuthResource) TLSSecretNamespacedName() types.NamespacedName {
-	return x.MongoDBSearch.X509ClientCertSecret()
+	return x.X509ClientCertSecret()
 }
 
 func (x *x509AuthResource) TLSOperatorSecretNamespacedName() types.NamespacedName {
-	return x.MongoDBSearch.X509OperatorManagedSecret()
+	return x.X509OperatorManagedSecret()
 }
 
 // ensureX509ClientCertConfig processes x509 client certificate configuration for the sync source in case of mongot to mongod communication.
@@ -1432,12 +1432,12 @@ type perShardTLSResource struct {
 
 // TLSSecretNamespacedName returns the per-(cluster, shard) source secret name.
 func (p *perShardTLSResource) TLSSecretNamespacedName() types.NamespacedName {
-	return p.MongoDBSearch.TLSSecretForClusterShard(p.clusterIndex, p.shardName)
+	return p.TLSSecretForClusterShard(p.clusterIndex, p.shardName)
 }
 
 // TLSOperatorSecretNamespacedName returns the per-(cluster, shard) operator-managed secret name.
 func (p *perShardTLSResource) TLSOperatorSecretNamespacedName() types.NamespacedName {
-	return p.MongoDBSearch.TLSOperatorSecretForClusterShard(p.clusterIndex, p.shardName)
+	return p.TLSOperatorSecretForClusterShard(p.clusterIndex, p.shardName)
 }
 
 func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context) (mongot.Modification, statefulset.Modification) {

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -284,8 +284,9 @@ spec:
                       description: |-
                         Replicas overrides spec.replicas for this cluster's mongot StatefulSet.
                         For sharded sources, this is mongot pods per shard, not total.
+                        0 is allowed (StatefulSet scales to 0 — see spec.replicas docs).
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     resourceRequirements:
                       description: ResourceRequirements describes the compute resource
@@ -622,8 +623,11 @@ spec:
                   For Sharded source: the number mongot pods per shard.
                   When Replicas > 1, a load balancer configuration (spec.loadBalancer)
                   is required to distribute traffic across mongot instances.
+                  0 is allowed so operators (and operator-driven test harnesses) can
+                  take mongot offline cleanly via the CR — the StatefulSet is scaled
+                  to 0 by the reconciler; the MongoDBSearch CR itself stays around.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               resourceRequirements:
                 description: |-

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4306,8 +4306,9 @@ spec:
                       description: |-
                         Replicas overrides spec.replicas for this cluster's mongot StatefulSet.
                         For sharded sources, this is mongot pods per shard, not total.
+                        0 is allowed (StatefulSet scales to 0 — see spec.replicas docs).
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     resourceRequirements:
                       description: ResourceRequirements describes the compute resource
@@ -4644,8 +4645,11 @@ spec:
                   For Sharded source: the number mongot pods per shard.
                   When Replicas > 1, a load balancer configuration (spec.loadBalancer)
                   is required to distribute traffic across mongot instances.
+                  0 is allowed so operators (and operator-driven test harnesses) can
+                  take mongot offline cleanly via the CR — the StatefulSet is scaled
+                  to 0 by the reconciler; the MongoDBSearch CR itself stays around.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               resourceRequirements:
                 description: |-


### PR DESCRIPTION
[skip-ci]

## Summary

Allow `spec.replicas` and `spec.clusters[].replicas` to be set to `0` on the `MongoDBSearch` CR. Previously the kubebuilder validation enforced `minimum: 1`, making it impossible to take mongot offline via the CR without deleting the resource. With this change the StatefulSet scales to 0 while the `MongoDBSearch` CR stays around, enabling operator-driven and test-harness-driven scale-to-zero workflows. `GetReplicas()` now honours an explicit `0` instead of silently falling back to the default of `1`.

## Proof of Work
- PoW-Patch: pending — https://evergreen.mongodb.com/version/6a16e0ca3d7cda0007155999
- Variants/tasks: `unit_tests,e2e_mdb_kind_ubi_cloudqa_large` / `unit_task_group,e2e_mdb_kind_search_task_group`

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->

# Based on PR #1048

## Chain of upstream PRs as of 2026-05-30

* PR #1048:
  `lsierant/devcontainer` ← `search/ga-base`

  * **PR #1147 (THIS ONE)**:
    `search/ga-base` ← `search/lsierant/KUBE-16-enable-scale-to-zero`

<!-- end git-machete generated -->