### PR TITLE
KUBE-16: unify envoy logging (JSON component + access logs)

### DIFF
--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"

--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -17,6 +17,7 @@ import (
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	stdoutaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	tlsinspectorv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -93,12 +94,13 @@ func buildEnvoyBootstrapConfig(routes []envoyRoute, tlsEnabled bool, caKeyName s
 
 	return &bootstrapv3.Bootstrap{
 		Admin: &bootstrapv3.Admin{
-			Address: socketAddress("0.0.0.0", uint32(envoyAdminPort)),
-			// enable just some endpoints because it's recommended to not enable al the admin endpoints by default
+			Address: socketAddress("0.0.0.0", uint32(EnvoyAdminPort)),
+			// enable just some endpoints because it's recommended to not enable all the admin endpoints by default.
 			AllowPaths: []*matcherv3.StringMatcher{
 				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/ready"}},
 				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/stats"}},
 				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/drain_listeners"}},
+				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/logging"}},
 			},
 		},
 		StaticResources: &bootstrapv3.Bootstrap_StaticResources{
@@ -146,6 +148,11 @@ func buildFilterChain(route envoyRoute, tlsEnabled bool, caKeyName string) (*lis
 		return nil, fmt.Errorf("failed to marshal router filter config: %w", err)
 	}
 
+	accessLog, err := buildHCMAccessLog()
+	if err != nil {
+		return nil, err
+	}
+
 	hcm := &hcmv3.HttpConnectionManager{
 		StatPrefix: fmt.Sprintf("ingress_%s", route.NameSafe),
 		CodecType:  hcmv3.HttpConnectionManager_AUTO,
@@ -186,6 +193,7 @@ func buildFilterChain(route envoyRoute, tlsEnabled bool, caKeyName string) (*lis
 		},
 		StreamIdleTimeout: durationpb.New(300 * time.Second),
 		RequestTimeout:    durationpb.New(300 * time.Second),
+		AccessLog:         accessLog,
 	}
 
 	hcmAny, err := anypb.New(hcm)
@@ -339,6 +347,74 @@ func buildDownstreamTLSTransportSocket(caKeyName string) (*corev3.TransportSocke
 	return &corev3.TransportSocket{
 		Name:       wellknown.TransportSocketTLS,
 		ConfigType: &corev3.TransportSocket_TypedConfig{TypedConfig: tlsAny},
+	}, nil
+}
+
+// buildHCMAccessLog returns the HCM access_log entries that emit one
+// JSON-formatted line to stdout per HTTP/HTTP2 stream close.
+//
+// Envoy emits exactly ONE access-log record per gRPC bidi stream — at
+// stream close — unless per-frame access logging is opted into (out of
+// scope for failure-mode tests). The single close record still captures
+// the load-bearing signals we need cross-side:
+//
+//   - %REQ(MONGODB-CLIENTID)% — the UUID the mongodb client puts on the
+//     request header. The exact same UUID mongod logs as
+//     attr.session.clientId at network:2 (id=7401401), giving us a
+//     deterministic envoy ↔ mongod join key without any time tolerance.
+//   - %RESPONSE_FLAGS% — envoy's encoded response disposition; surfaces
+//     UF/UR/etc when a mongot pod dies mid-stream so failure-mode tests
+//     can assert on the envoy-side signal in addition to mongod's
+//     "Remote error from mongot" / "RST_STREAM" surface error.
+//   - %UPSTREAM_HOST% — which mongot endpoint envoy actually picked.
+//   - %BYTES_RECEIVED% / %BYTES_SENT% / %DURATION% — basic per-stream
+//     traffic stats.
+func buildHCMAccessLog() ([]*accesslogv3.AccessLog, error) {
+	// Top-level keys (time / level / logger / message) match the envoy
+	// runtime --log-format template in mongodbsearchenvoy_controller.go.
+	// Tools that consume the envoy pod's stdout (analyzer, lnav, jq
+	// pipelines) only have to know one shape — the access-specific
+	// fields hang off the same record.
+	jsonFields, err := structpb.NewStruct(map[string]interface{}{
+		"time":           "%START_TIME(%Y-%m-%dT%H:%M:%E3S%Ez)%",
+		"level":          "info",
+		"logger":         "access",
+		"message":        "stream upstream=%UPSTREAM_HOST% path=%REQ(:PATH)% resp=%RESPONSE_CODE% grpc=%GRPC_STATUS% flags=%RESPONSE_FLAGS% dur=%DURATION%ms",
+		"duration_ms":    "%DURATION%",
+		"response_flags": "%RESPONSE_FLAGS%",
+		"response_code":  "%RESPONSE_CODE%",
+		"grpc_status":    "%GRPC_STATUS%",
+		"upstream_host":  "%UPSTREAM_HOST%",
+		"bytes_in":       "%BYTES_RECEIVED%",
+		"bytes_out":      "%BYTES_SENT%",
+		"client_id":      "%REQ(MONGODB-CLIENTID)%",
+		"path":           "%REQ(:PATH)%",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build access-log json format struct: %w", err)
+	}
+
+	stdoutLog := &stdoutaccesslogv3.StdoutAccessLog{
+		AccessLogFormat: &stdoutaccesslogv3.StdoutAccessLog_LogFormat{
+			LogFormat: &corev3.SubstitutionFormatString{
+				Format: &corev3.SubstitutionFormatString_JsonFormat{
+					JsonFormat: jsonFields,
+				},
+			},
+		},
+	}
+	stdoutAny, err := anypb.New(stdoutLog)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal stdout access-log config: %w", err)
+	}
+
+	return []*accesslogv3.AccessLog{
+		{
+			Name: "envoy.access_loggers.stdout",
+			ConfigType: &accesslogv3.AccessLog_TypedConfig{
+				TypedConfig: stdoutAny,
+			},
+		},
 	}, nil
 }
 

--- a/controllers/operator/envoy_config_builder_test.go
+++ b/controllers/operator/envoy_config_builder_test.go
@@ -55,7 +55,7 @@ func TestBuildEnvoyConfigJSON_SingleShard_NoTLS(t *testing.T) {
 	require.NotNil(t, bootstrap.Admin)
 	adminAddr := bootstrap.Admin.Address.GetSocketAddress()
 	assert.Equal(t, "0.0.0.0", adminAddr.GetAddress())
-	assert.Equal(t, uint32(envoyAdminPort), adminAddr.GetPortValue())
+	assert.Equal(t, uint32(EnvoyAdminPort), adminAddr.GetPortValue())
 
 	// Static resources
 	require.NotNil(t, bootstrap.StaticResources)

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -661,7 +661,7 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
 							Path: "/ready",
-							Port: intstr.FromInt32(envoyAdminPort),
+							Port: intstr.FromInt32(EnvoyAdminPort),
 						},
 					},
 					InitialDelaySeconds: 10,

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -45,7 +45,7 @@ import (
 const (
 	envoyReplicasDefault = int32(1)
 
-	envoyAdminPort = 9901
+	EnvoyAdminPort = 9901
 
 	envoyServerCertPath = "/etc/envoy/tls/server"
 	envoyClientCertPath = "/etc/envoy/tls/client"
@@ -508,10 +508,6 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 					Labels: podLabels,
 					Annotations: map[string]string{
 						envoyConfigHashAnnotation: configHash,
-						// Exclude the proxy port from Istio inbound capture: mongod's TLS to
-						// Envoy is raw app-TLS, not Istio mTLS, so capture in REDIRECT mode
-						// stalls the handshake (20s timeout → code 125). No-op without Istio.
-						"traffic.sidecar.istio.io/excludeInboundPorts": fmt.Sprintf("%d", searchv1.EnvoyDefaultProxyPort),
 					},
 				},
 				Spec: buildEnvoyPodSpec(search, clusterIndex, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
@@ -627,10 +623,27 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 				Name:    "envoy",
 				Image:   image,
 				Command: []string{"/usr/local/bin/envoy"},
-				Args:    []string{"-c", "/etc/envoy/envoy.json", "--log-level", "info"},
+				// --log-format emits component logs as JSON so they share a
+				// uniform shape with the JSON access log we configure in the
+				// HCM (see buildHCMAccessLog). %j escapes the message body
+				// (which can carry quotes from envoy "[Tags: ... ]" frames)
+				// so each line stays as a single well-formed JSON object.
+				//
+				// Token notes (spdlog):
+				//   time: %Y-%m-%dT%H:%M:%S.%e%z → ISO 8601 with ms and ±HH:MM
+				//     offset (matches mongod/mongot timestamp shape so any
+				//     downstream tooling can sort cross-layer by wall clock).
+				//   loc: %g:%# → "<source-path>:<line>". The field is named ``loc``
+				//     (not ``source``) on purpose to not confuse some log parsing
+				//     utilities, e.g. lnav.
+				Args: []string{
+					"-c", "/etc/envoy/envoy.json",
+					"--log-level", "info",
+					"--log-format", `{"time":"%Y-%m-%dT%H:%M:%S.%e%z","level":"%l","logger":"%n","thread":%t,"loc":"%g:%#","message":"%j"}`,
+				},
 				Ports: []corev1.ContainerPort{
 					{Name: "grpc", ContainerPort: searchv1.EnvoyDefaultProxyPort},
-					{Name: "admin", ContainerPort: envoyAdminPort},
+					{Name: "admin", ContainerPort: EnvoyAdminPort},
 				},
 				Resources:       resources,
 				SecurityContext: containerSecurityContext,
@@ -638,7 +651,7 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
 							Path: "/ready",
-							Port: intstr.FromInt32(envoyAdminPort),
+							Port: intstr.FromInt32(EnvoyAdminPort),
 						},
 					},
 					InitialDelaySeconds: 5,
@@ -659,7 +672,7 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 					PreStop: &corev1.LifecycleHandler{
 						HTTPGet: &corev1.HTTPGetAction{
 							Path: "/drain_listeners",
-							Port: intstr.FromInt32(envoyAdminPort),
+							Port: intstr.FromInt32(EnvoyAdminPort),
 						},
 					},
 				},

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -13,8 +13,6 @@ import (
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
-	"github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
-	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -13,6 +13,8 @@ import (
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
+	"github.com/mongodb/mongodb-kubernetes/api/v1/mdb"
+	searchv1 "github.com/mongodb/mongodb-kubernetes/api/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
@@ -223,13 +225,15 @@ func jvmFlags(userJVMFlags []string, resourceRequirements corev1.ResourceRequire
 		flags = append(flags, fmt.Sprintf("-Xms%dm", halfMB))
 	}
 
-	flagsValue := strings.Join(append(flags, userJVMFlags...), " ")
+	allFlags := append(flags, userJVMFlags...)
+	flagsValue := strings.Join(allFlags, " ")
 	return fmt.Sprintf(`--jvm-flags "%s"`, flagsValue)
 }
 
 func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster searchv1.ClusterSpec, volumeMounts []corev1.VolumeMount, searchImage string, usePerPodConfig bool) container.Modification {
 	_, containerSecurityContext := podtemplatespec.WithDefaultSecurityContextsModifications()
 	resourceRequirements := createSearchResourceRequirements(perCluster.ResourceRequirements)
+
 	jvmFlags := jvmFlags(perCluster.JVMFlags, resourceRequirements)
 
 	var mongotStartCommand string


### PR DESCRIPTION
[skip-ci] KUBE-16: unify envoy logging (JSON component + access logs)

# Summary

Why: the envoy proxy pod was emitting two disjoint log streams to stdout — spdlog component logs in envoy's default plain text and no per-request access log at all — making cross-side correlation with mongod/mongot logs (which are JSON) painful and forcing a separate parser per layer.

What: emit both component logs and HCM access logs as JSON on stdout, sharing the same `{time, level, logger, message, …}` top-level shape, so a single downstream consumer (lnav / jq pipelines / log analyzer) can parse the envoy pod's stdout uniformly.

How:
- `mongodbsearchenvoy_controller.go`: pass `--log-format` to the envoy command so component logs are JSON; the format mirrors mongod/mongot timestamp shape (ISO 8601 with ms + zone) and uses `%j` to escape message bodies that may contain quotes from envoy's `[Tags: …]` frames. Field `loc` (`%g:%#`) is named to avoid clashing with lnav's `source` heuristics.
- `envoy_config_builder.go`: add `buildHCMAccessLog()` returning a `StdoutAccessLog` with a JSON formatter. One record per stream close — captures `MONGODB-CLIENTID` (matches mongod's `attr.session.clientId` at network:2 / id=7401401 for a deterministic envoy ↔ mongod join), `RESPONSE_FLAGS` (UF/UR surface when an upstream mongot pod dies mid-stream), `UPSTREAM_HOST`, byte counts, and duration.
- Export `EnvoyAdminPort` and add `/logging` to the admin `AllowPaths` so log level can be tweaked at runtime via the admin port.
- Drop the `traffic.sidecar.istio.io/excludeInboundPorts` annotation on the envoy Deployment — no longer required after upstream istio handling moved.

## Proof of Work

- PoW-Patch: green — https://spruce.mongodb.com/version/6a16d6ea130f7700071428b3 (14 tasks succeeded).
- Variants/tasks: `unit_tests,e2e_mdb_kind_ubi_cloudqa_large` / `unit_task_group,e2e_search_community_basic`.
- Local: `make all-tests` green on rebased HEAD. `make precommit` skipped — only failure was `govulncheck` flagging a base-branch CVE in `golang.org/x/net@v0.53.0` (used by `controllers/om/api/initializer.go`, untouched by this branch).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->

# Based on PR #1147

## Chain of upstream PRs as of 2026-05-30

* PR #1048:
  `lsierant/devcontainer` ← `search/ga-base`

  * PR #1147:
    `search/ga-base` ← `search/lsierant/KUBE-16-enable-scale-to-zero`

    * **PR #1148 (THIS ONE)**:
      `search/lsierant/KUBE-16-enable-scale-to-zero` ← `search/lsierant/KUBE-16-unify-envoy-logging`

<!-- end git-machete generated -->
