### PR TITLE
[KUBE-6] Use pod antiaffinity for envoy to schedule them on diff nodes

### DIFF
--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -606,6 +606,23 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 
 	return corev1.PodSpec{
 		SecurityContext: podSecurityContext,
+		Affinity: &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					{
+						Weight: 100,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": search.LoadBalancerDeploymentNameForCluster(clusterIndex),
+								},
+							},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+		},
 		Containers: []corev1.Container{
 			{
 				Name:    "envoy",

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -184,9 +184,9 @@ func TestBuildShardRoutes(t *testing.T) {
 	shardNames := []string{"mdb-sh-0", "mdb-sh-1"}
 
 	tests := []struct {
-		name                   string
-		endpoint               string
-		expectedShardSNIs      []string
+		name                    string
+		endpoint                string
+		expectedShardSNIs       []string
 		expectedClusterLevelSNI string
 	}{
 		{
@@ -253,6 +253,23 @@ func TestBuildEnvoyPodSpec_DefaultResources(t *testing.T) {
 	assert.Equal(t, "envoy", podSpec.Containers[0].Name)
 	assert.Equal(t, resource.MustParse("100m"), podSpec.Containers[0].Resources.Requests[corev1.ResourceCPU])
 	assert.Equal(t, resource.MustParse("128Mi"), podSpec.Containers[0].Resources.Requests[corev1.ResourceMemory])
+
+	assert.NotNil(t, podSpec.Affinity.PodAntiAffinity)
+	assert.Equal(t, corev1.PodAntiAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+			{
+				Weight: 100,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": search.LoadBalancerDeploymentNameForCluster(0),
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}, *podSpec.Affinity.PodAntiAffinity)
 }
 
 // TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster regresses the MC-mode


### PR DESCRIPTION
# Summary

When running multiple replicas of envoy we should preferably run them in different K8s nodes to tolerate failure of K8s nodes.
This PR does that by adding pod anti affinity to the envoy pods. 

## Proof of Work

NA

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
