### PR TITLE
fix: IBM Z (s390x) smoke e2e tests rust/cargo version dependency

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
@@ -352,7 +352,7 @@ class TestReplicaSetScaleUp(KubernetesTester):
     def test_mdb_updated(self, replica_set: MongoDB):
         replica_set["spec"]["members"] = 5
         replica_set.update()
-        replica_set.assert_reaches_phase(Phase.Running, timeout=500)
+        replica_set.assert_reaches_phase(Phase.Running, timeout=700)
 
     def test_replica_set_sts_should_exist(self):
         sts = self.appsv1.read_namespaced_stateful_set(RESOURCE_NAME, self.namespace)

--- a/scripts/evergreen/setup_minikube_host.sh
+++ b/scripts/evergreen/setup_minikube_host.sh
@@ -60,6 +60,23 @@ if [[ "$(uname -m)" == "s390x" ]]; then
     fi
 fi
 
+# Install Rust/Cargo on s390x — system Cargo is too old to parse Cargo.lock v4
+# (required by cryptography >= 48.0.0 which uses maturin to build a Rust extension wheel)
+if [[ "$(uname -m)" == "s390x" ]]; then
+    MIN_RUST_VERSION="1.78.0"
+    installed_rust_version="$(rustc --version 2>/dev/null | awk '{print $2}' || echo "0.0.0")"
+    if [[ "$(printf '%s\n' "${MIN_RUST_VERSION}" "${installed_rust_version}" | sort -V | head -1)" != "${MIN_RUST_VERSION}" ]]; then
+        echo ">>> Installing Rust via rustup (system rustc ${installed_rust_version} < ${MIN_RUST_VERSION})..."
+        export CARGO_HOME="${PROJECT_DIR}/.cargo"
+        export RUSTUP_HOME="${PROJECT_DIR}/.rustup"
+        curl --proto '=https' --tlsv1.2 --retry 3 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --quiet
+        export PATH="${CARGO_HOME}/bin:${PATH}"
+        echo "✅ Rust $(rustc --version) installed"
+    else
+        echo "✅ Rust ${installed_rust_version} already >= ${MIN_RUST_VERSION}, skipping"
+    fi
+fi
+
 # Setup Python environment (needed for AWS CLI pip installation)
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 run_setup_step "Python Virtual Environment" "scripts/dev/recreate_python_venv.sh"


### PR DESCRIPTION
# Summary

The IBM Z (s390x) master build was permanently failing at the setup phase with `setup-failed` status. `cryptography==48.0.0` is a Rust-backed Python package built via `maturin`; its `Cargo.lock` uses format v4, which requires Rust/Cargo ≥ 1.78. The system Cargo on RHEL9/zseries hosts was too old to parse it, blocking the Python venv from being created.

This PR fixes setup by conditionally installing Rust via `rustup` on s390x before the Python venv step, scoped to `PROJECT_DIR` to avoid polluting the shared static host. The replica-set scale-up timeout is also bumped from 500s to 700s to account for s390x being slower than x86 when spinning up 5 MongoDB pods.

## Proof of Work

Evergreen patch [`6a18400eff61a40007cdd095`](https://evergreen.mongodb.com/version/6a18400eff61a40007cdd095) on `e2e_smoke_ibm_z / e2e_replica_set` — all 32 tests passed after this fix.

- `scripts/evergreen/setup_minikube_host.sh` — Rust install on s390x
- `docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py` — scale-up timeout 500s → 700s

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details