### PR TITLE
KUBE-78: bound automation-agent-stderr.log size with in-place rotation

### DIFF
--- a/changelog/20260528_fix_automation_agent_stderr_log_rotation.md
+++ b/changelog/20260528_fix_automation_agent_stderr_log_rotation.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-05-28
+---
+
+* Fixed an issue where `automation-agent-stderr.log` was never rotated and could grow unboundedly, exhausting all available PVC disk space. The operator now sets a default maximum size of 50 MB for this file (configurable via the `MDB_LOG_FILE_AUTOMATION_AGENT_STDERR_MAX_SIZE_MB` environment variable on the database pod).

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -60,13 +60,14 @@ const (
 	AgentAPIKeySecretPath = "/mongodb-automation/agent-api-key" //nolint
 	AgentAPIKeyVolumeName = "agent-api-key"                     //nolint
 
-	LogFileAutomationAgentEnv        = "MDB_LOG_FILE_AUTOMATION_AGENT"
-	LogFileAutomationAgentVerboseEnv = "MDB_LOG_FILE_AUTOMATION_AGENT_VERBOSE"
-	LogFileAutomationAgentStderrEnv  = "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR"
-	LogFileMongoDBAuditEnv           = "MDB_LOG_FILE_MONGODB_AUDIT"
-	LogFileMongoDBEnv                = "MDB_LOG_FILE_MONGODB"
-	LogFileAgentMonitoringEnv        = "MDB_LOG_FILE_MONITORING_AGENT"
-	LogFileAgentBackupEnv            = "MDB_LOG_FILE_BACKUP_AGENT"
+	LogFileAutomationAgentEnv               = "MDB_LOG_FILE_AUTOMATION_AGENT"
+	LogFileAutomationAgentVerboseEnv        = "MDB_LOG_FILE_AUTOMATION_AGENT_VERBOSE"
+	LogFileAutomationAgentStderrEnv         = "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR"
+	LogFileAutomationAgentStderrMaxSizeMBEnv = "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR_MAX_SIZE_MB"
+	LogFileMongoDBAuditEnv                  = "MDB_LOG_FILE_MONGODB_AUDIT"
+	LogFileMongoDBEnv                       = "MDB_LOG_FILE_MONGODB"
+	LogFileAgentMonitoringEnv               = "MDB_LOG_FILE_MONITORING_AGENT"
+	LogFileAgentBackupEnv                   = "MDB_LOG_FILE_BACKUP_AGENT"
 )
 
 type StsType int
@@ -959,6 +960,7 @@ func getAutomationLogEnvVars(parameters mdbv1.StartupParameters) []corev1.EnvVar
 	return []corev1.EnvVar{
 		{Name: LogFileAutomationAgentVerboseEnv, Value: verboseLogFile},
 		{Name: LogFileAutomationAgentStderrEnv, Value: stderrLogFile},
+		{Name: LogFileAutomationAgentStderrMaxSizeMBEnv, Value: "50"},
 		{Name: LogFileAutomationAgentEnv, Value: automationLogFile},
 	}
 }

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -228,7 +228,7 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 	})
 
 	envVars := logConfigurationToEnvVars(parameters, additionalMongodConfig)
-	assert.Len(t, envVars, 7)
+	assert.Len(t, envVars, 8)
 
 	logFileAutomationAgentEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "log.file")}
 	logFileAutomationAgentVerboseEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "log-verbose.file")}
@@ -242,7 +242,7 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 	logFileAgentMonitoringEnvVar := corev1.EnvVar{Name: LogFileAgentMonitoringEnv, Value: path.Join(util.PvcMountPathLogs, "monitoring-agent.log")}
 	logFileAgentBackupEnvVar := corev1.EnvVar{Name: LogFileAgentBackupEnv, Value: path.Join(util.PvcMountPathLogs, "backup-agent.log")}
 
-	numberOfLogFilesInEnvVars := 7
+	numberOfLogFilesInEnvVars := 8
 
 	t.Run("automation log is changed and audit log is changed", func(t *testing.T) {
 		envVars := logConfigurationToEnvVars(parameters, additionalMongodConfig)
@@ -294,11 +294,14 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 }
 
 func TestGetAutomationLogEnvVars(t *testing.T) {
+	stderrMaxSizeEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentStderrMaxSizeMBEnv, Value: "50"}
+
 	t.Run("automation log file with extension", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": "path/to/log.file"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: "path/to/log.file"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: "path/to/log-verbose.file"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: "path/to/log-stderr.file"})
+		assert.Contains(t, envVars, stderrMaxSizeEnvVar)
 	})
 
 	t.Run("automation log file without extension", func(t *testing.T) {
@@ -306,12 +309,14 @@ func TestGetAutomationLogEnvVars(t *testing.T) {
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: "path/to/logfile"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: "path/to/logfile-verbose"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: "path/to/logfile-stderr"})
+		assert.Contains(t, envVars, stderrMaxSizeEnvVar)
 	})
 	t.Run("invalid automation log file is not crashing", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": "path/to/"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: "path/to/"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: "path/to/-verbose"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: "path/to/-stderr"})
+		assert.Contains(t, envVars, stderrMaxSizeEnvVar)
 	})
 
 	t.Run("empty automation log file is falling back to default names", func(t *testing.T) {
@@ -319,6 +324,7 @@ func TestGetAutomationLogEnvVars(t *testing.T) {
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-stderr.log")})
+		assert.Contains(t, envVars, stderrMaxSizeEnvVar)
 	})
 
 	t.Run("not set logFile cause falling back to default names", func(t *testing.T) {
@@ -326,6 +332,7 @@ func TestGetAutomationLogEnvVars(t *testing.T) {
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-stderr.log")})
+		assert.Contains(t, envVars, stderrMaxSizeEnvVar)
 	})
 }
 

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
@@ -80,6 +80,35 @@ ensure_certs_symlinks() {
     fi
 }
 
+# rotate_log_if_needed checks a single log file and trims it in-place when it
+# exceeds max_size_bytes, keeping the most recent (max_size_bytes / 2) bytes.
+# Writing to a temp file and back avoids bash $(...) newline-stripping and keeps
+# the original inode so open file descriptors remain valid.
+rotate_log_if_needed() {
+    local file="$1"
+    local max_size_bytes="$2"
+    local keep_bytes=$(( max_size_bytes / 2 ))
+    if [ -f "${file}" ]; then
+        local size
+        size=$(( $(wc -c < "${file}") ))
+        if [ "${size}" -gt "${max_size_bytes}" ]; then
+            local tmp_file="${file}.rotating"
+            tail -c "${keep_bytes}" "${file}" > "${tmp_file}" && cat "${tmp_file}" > "${file}"
+            rm -f "${tmp_file}"
+        fi
+    fi
+}
+
+# watch_and_rotate_log runs rotate_log_if_needed every 30 seconds in a loop.
+watch_and_rotate_log() {
+    local file="$1"
+    local max_size_bytes="$2"
+    while true; do
+        sleep 30
+        rotate_log_if_needed "${file}" "${max_size_bytes}"
+    done
+}
+
 # download_agent function downloads and unpacks the Mongodb Agent
 download_agent() {
     pushd /tmp >/dev/null || true

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib_test.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib_test.sh
@@ -1,0 +1,101 @@
+#!/opt/homebrew/bin/bash
+# Tests for agent-launcher-lib.sh – run with: bash agent-launcher-lib_test.sh
+# Requires bash 4+ (uses &>> redirection from agent-launcher-lib.sh).
+set -eou pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MDB_LOG_FILE_AGENT_LAUNCHER_SCRIPT="/dev/null"
+source "${SCRIPT_DIR}/agent-launcher-lib.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        echo "PASS: ${desc}"
+        (( pass++ )) || true
+    else
+        echo "FAIL: ${desc} — expected '${expected}', got '${actual}'"
+        (( fail++ )) || true
+    fi
+}
+
+assert_file_size_le() {
+    local desc="$1" file="$2" max_bytes="$3"
+    local size
+    size=$(stat -c%s "${file}" 2>/dev/null || stat -f%z "${file}")
+    if [ "${size}" -le "${max_bytes}" ]; then
+        echo "PASS: ${desc} (size=${size})"
+        (( pass++ )) || true
+    else
+        echo "FAIL: ${desc} — size ${size} exceeds ${max_bytes}"
+        (( fail++ )) || true
+    fi
+}
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+make_log() {
+    local file="$1" size_bytes="$2"
+    python3 -c "import sys; sys.stdout.buffer.write(b'x' * ${size_bytes})" > "${file}"
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+# 1. File below threshold: not modified
+t1="${tmp_dir}/t1.log"
+make_log "${t1}" 100
+rotate_log_if_needed "${t1}" 200
+assert_eq "file below threshold is not rotated" "100" "$(stat -c%s "${t1}" 2>/dev/null || stat -f%z "${t1}")"
+
+# 2. File exactly at threshold: not modified (condition is strictly greater-than)
+t2="${tmp_dir}/t2.log"
+make_log "${t2}" 200
+rotate_log_if_needed "${t2}" 200
+assert_eq "file at threshold is not rotated" "200" "$(stat -c%s "${t2}" 2>/dev/null || stat -f%z "${t2}")"
+
+# 3. File above threshold: trimmed to keep_bytes (max/2)
+t3="${tmp_dir}/t3.log"
+make_log "${t3}" 300
+rotate_log_if_needed "${t3}" 200
+assert_eq "file above threshold is trimmed to keep_bytes" "100" "$(stat -c%s "${t3}" 2>/dev/null || stat -f%z "${t3}")"
+
+# 4. Most-recent content is preserved after rotation
+t4="${tmp_dir}/t4.log"
+printf '%0.s-' {1..100} > "${t4}"   # 100 bytes of dashes (older data)
+printf '%0.s+' {1..100} >> "${t4}"  # 100 bytes of plusses (newer data)
+rotate_log_if_needed "${t4}" 100    # max=100, keep=50 → last 50 bytes of plusses
+content=$(cat "${t4}")
+assert_eq "rotation keeps newest content" "$(printf '%0.s+' {1..50})" "${content}"
+
+# 5. Trailing newlines are preserved (no $(...) stripping)
+t5="${tmp_dir}/t5.log"
+{
+    printf '%0.s-' {1..60}   # 60 bytes older data
+    printf 'last line\n'     # 10 bytes newer data with trailing newline
+} > "${t5}"
+rotate_log_if_needed "${t5}" 40   # max=40, keep=20 → last 20 bytes
+last_char=$(tail -c 1 "${t5}" | xxd -p)
+assert_eq "trailing newline is preserved after rotation" "0a" "${last_char}"
+
+# 6. Non-existent file: no error
+rotate_log_if_needed "${tmp_dir}/does-not-exist.log" 100
+echo "PASS: non-existent file does not cause an error"
+(( pass++ )) || true
+
+# 7. Temp file is cleaned up after rotation
+t7="${tmp_dir}/t7.log"
+make_log "${t7}" 300
+rotate_log_if_needed "${t7}" 200
+assert_eq "temp file is removed after rotation" "" "$(ls "${tmp_dir}/t7.log.rotating" 2>/dev/null || true)"
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib_test.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib_test.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-MDB_LOG_FILE_AGENT_LAUNCHER_SCRIPT="/dev/null"
+export MDB_LOG_FILE_AGENT_LAUNCHER_SCRIPT="/dev/null"
 source "${SCRIPT_DIR}/agent-launcher-lib.sh"
 
 pass=0

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -232,6 +232,9 @@ fi
 export agentPid=$!
 script_log "Launched automation agent, pid=${agentPid}"
 
+stderr_max_size_mb="${MDB_LOG_FILE_AUTOMATION_AGENT_STDERR_MAX_SIZE_MB:-50}"
+watch_and_rotate_log "${MDB_LOG_FILE_AUTOMATION_AGENT_STDERR}" $(( stderr_max_size_mb * 1024 * 1024 )) &
+
 trap cleanup SIGTERM
 
 wait

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
@@ -560,6 +560,7 @@ def assert_container_env_vars(namespace: str, pod_name: str):
             "MULTI_CLUSTER_MODE",
             "MDB_LOG_FILE_AUTOMATION_AGENT_VERBOSE",
             "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR",
+            "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR_MAX_SIZE_MB",
             "MDB_LOG_FILE_AUTOMATION_AGENT",
             "MDB_LOG_FILE_MONITORING_AGENT",
             "MDB_LOG_FILE_BACKUP_AGENT",


### PR DESCRIPTION
## Problem

`automation-agent-stderr.log` is written via shell redirection (`2>>`) in `agent-launcher.sh` and is never rotated. Under normal operation the file stays small, but if the automation agent fails to initialise its own log (for example, due to corrupt `.slogger-state-*` files), it falls back to writing all trace and debug output to stderr. With nothing bounding the file, it can exhaust all available PVC disk space and crash the pod.

This has already caused a production incident: a customer's pod ran out of disk space, requiring a full recovery from S3 with oplog replay and manual PVC deletion.

## Solution

Add a background watchdog (`watch_and_rotate_log`) that runs alongside the agent and keeps `automation-agent-stderr.log` under a configurable size limit.

When the file exceeds the limit the watchdog trims it in-place — writing the last `limit / 2` bytes to a temp file and copying it back over the original — so the agent's open file descriptor stays valid and no data is lost from the agent's perspective.

The default limit is **50 MB**, injected by the operator as `MDB_LOG_FILE_AUTOMATION_AGENT_STDERR_MAX_SIZE_MB=50`. Users who need a tighter bound can override this via `podTemplate` env vars.

## Changes

- **`agent-launcher-lib.sh`**
  - `rotate_log_if_needed` — single-shot check: reads file size with portable `wc -c`, trims in-place via temp file + `cat` (avoids `$()` newline-stripping and preserves the inode).
  - `watch_and_rotate_log` — thin loop that calls `rotate_log_if_needed` every 30 seconds.
- **`agent-launcher.sh`** — starts `watch_and_rotate_log` in the background immediately after the agent is launched.
- **`database_construction.go`** — adds `MDB_LOG_FILE_AUTOMATION_AGENT_STDERR_MAX_SIZE_MB` constant and injects it with value `"50"` into the container env vars.
- **`agent-launcher-lib_test.sh`** — 7 bash tests covering: below/at/above threshold, content preservation, trailing newline correctness, non-existent file safety, temp file cleanup.
- **`database_construction_test.go`** — updated env var count assertions and added `stderrMaxSizeEnvVar` checks to all `TestGetAutomationLogEnvVars` subtests.
- **`changelog/`** — entry added.

## Testing

```
# Go unit tests
ok  github.com/mongodb/mongodb-kubernetes/controllers/operator/construct  (all pass)

# Shell unit tests
PASS: file below threshold is not rotated
PASS: file at threshold is not rotated
PASS: file above threshold is trimmed to keep_bytes
PASS: rotation keeps newest content
PASS: trailing newline is preserved after rotation
PASS: non-existent file does not cause an error
PASS: temp file is removed after rotation
Results: 7 passed, 0 failed
```