### PR TITLE
[KUBE-95] Add E2E test to verify paging cursor survives envoy config change

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1408,6 +1408,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_cds_hot_reload
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_connectivity_tool_mc_rs
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -903,6 +903,7 @@ task_groups:
       - e2e_search_connectivity_tool
       - e2e_search_connectivity_tool_sharded
       - e2e_search_connectivity_background_tester
+      - e2e_search_cds_hot_reload
     <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.

--- a/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
@@ -1,0 +1,182 @@
+"""E2E test: Envoy CDS hot-reload does not break active cursors.
+
+Proves that filesystem xDS CDS reload (triggered by ConfigMap update)
+does not disrupt in-flight gRPC streams. The test opens a paging cursor,
+patches the CDS ConfigMap with a circuit breaker change, waits for
+envoy to reload, then verifies the cursor still works.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from kubetester.kubetester import KubernetesTester, run_periodically
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from tests import test_logger
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import search_resource_names
+from tests.common.search.bootstrap_test_mixins import (
+    MongoDBShardedDeploymentConfig,
+    MongoDBShardedDeploymentTests,
+    SearchShardedDeploymentTests,
+    SearchShardedE2EFixtures,
+    SearchShardedSampleDataAndIndex,
+    _derive_user_defaults,
+)
+from tests.common.search.connectivity import SearchConnectivityTool, set_resource_disabled_annotation
+from tests.common.search.sharded_search_helper import get_search_tester
+
+logger = test_logger.get_test_logger(__name__)
+
+pytestmark = pytest.mark.e2e_search_cds_hot_reload
+
+def configure_mongodb_sharded_config(cfg: MongoDBShardedDeploymentConfig) -> MongoDBShardedDeploymentConfig:
+    cfg.mdb_resource_name = "mdb-sh-cds-reload"
+    cfg.mongot_replicas = 2
+    cfg.admin_user_name = ""
+    cfg.admin_user_password = ""
+    cfg.user_name = ""
+    cfg.user_password = ""
+    _derive_user_defaults(cfg)
+    return cfg
+
+class TestSearchWithShardedCluster(
+    SearchShardedDeploymentTests,
+    MongoDBShardedDeploymentTests,
+):
+    def build_mongodb_sharded_config(self) -> MongoDBShardedDeploymentConfig:
+        return configure_mongodb_sharded_config(super().build_mongodb_sharded_config())
+
+
+class TestSearchSampleDataAndIndex(
+    SearchShardedSampleDataAndIndex,
+    SearchShardedE2EFixtures,
+):
+    def build_mongodb_sharded_config(self) -> MongoDBShardedDeploymentConfig:
+        return configure_mongodb_sharded_config(super().build_mongodb_sharded_config())
+
+
+class TestSearchCDSHotReload(SearchShardedE2EFixtures):
+    def build_mongodb_sharded_config(self) -> MongoDBShardedDeploymentConfig:
+        return configure_mongodb_sharded_config(super().build_mongodb_sharded_config())
+
+    def test_cursor_survives_cds_hot_reload(
+        self,
+        mdb: MongoDB,
+        mdbs: MongoDBSearch,
+        namespace: str,
+        search_tools_pod: mongodb_tools_pod.ToolsPod,
+    ):
+        # Create connectivity tool (sharded — connects via mongos)
+        cfg = self.build_mongodb_sharded_config()
+        tester = get_search_tester(mdb, cfg.user_name, cfg.user_password, use_ssl=True)
+        tool = SearchConnectivityTool(tester)
+        _wait_for_search_serving(tool)
+
+        # Open paging cursor, read pre-reload pages
+        cursor = tool.paging_cursor_open(batch_size=10)
+        try:
+            pre_pages = tool.paging_cursor_read_pages(cursor, pages=3, interval_seconds=0.5, batch_size=10)
+            assert all(p.success for p in pre_pages), f"pre-reload pages should all succeed: {pre_pages}"
+            logger.info(f"Pre-reload: {len(pre_pages)} pages read successfully")
+
+            # Disable reconciliation so the operator won't overwrite our ConfigMap patch
+            set_resource_disabled_annotation(mdbs, True)
+
+            # Get current CDS reload count from envoy admin stats
+            envoy_pod_ip = _get_envoy_pod_ip(namespace, mdbs.name)
+            initial_cds_updates = _get_cds_update_count(search_tools_pod, envoy_pod_ip)
+            logger.info(f"Initial CDS update_success count: {initial_cds_updates}")
+
+            # Patch CDS ConfigMap with modified circuit breaker
+            cm_name = search_resource_names.lb_configmap_name(mdbs.name)
+            cm_data = KubernetesTester.read_configmap(namespace, cm_name)
+            patched_cds = _modify_cds_circuit_breaker(cm_data["cds.json"])
+            logger.info(f"Patching ConfigMap {cm_name} with modified circuit breaker (max_connections doubled)")
+            KubernetesTester.update_configmap(namespace, cm_name, {**cm_data, "cds.json": patched_cds})
+
+            # Wait for Envoy to reload (poll stats until cds.update_success increments)
+            _wait_for_cds_reload(search_tools_pod, envoy_pod_ip, initial_cds_updates)
+
+            # Read more pages — cursor should still work
+            post_pages = tool.paging_cursor_read_pages(
+                cursor, pages=5, interval_seconds=0.5, batch_size=10, first_page_index=len(pre_pages)
+            )
+            verdict = tool.verdict(post_pages)
+            logger.info(f"Post-reload verdict: {verdict.as_dict()}")
+            assert verdict.failed == 0, f"cursor broken after CDS reload: {verdict.as_dict()}"
+            assert verdict.succeeded > 0, "expected successful pages after reload"
+        finally:
+            cursor.close()
+            set_resource_disabled_annotation(mdbs, False)
+
+def _wait_for_search_serving(tool: SearchConnectivityTool, timeout: float = 300.0) -> None:
+    tool.wait_for_sentinel_indexed(timeout=timeout)
+
+
+def _get_envoy_pod_ip(namespace: str, search_name: str) -> str:
+    deployment_name = search_resource_names.lb_deployment_name(search_name)
+    pods = KubernetesTester.read_pod_labels(namespace, label_selector=f"app={deployment_name}")
+    assert pods.items, f"no envoy pods found with label app={deployment_name}"
+    pod_ip = pods.items[0].status.pod_ip
+    logger.info(f"Envoy pod IP: {pod_ip} (pod: {pods.items[0].metadata.name})")
+    return pod_ip
+
+
+def _get_cds_update_count(tools_pod: mongodb_tools_pod.ToolsPod, envoy_pod_ip: str) -> int:
+    """Query envoy admin stats via the tools pod to get CDS update count."""
+    output = tools_pod.run_command(["wget", "-qO-", f"http://{envoy_pod_ip}:9901/stats"])
+    for line in output.splitlines():
+        if "cluster_manager.cds.update_success" in line:
+            return int(line.split(":")[1].strip())
+    return 0
+
+
+def _wait_for_cds_reload(
+    tools_pod: mongodb_tools_pod.ToolsPod,
+    envoy_pod_ip: str,
+    initial_count: int,
+    timeout: float = 180.0,
+) -> None:
+    # Poll envoy's /stats endpoint until cds.update_success exceeds initial_count.
+    # that would mean that new config has been loaded by envoy
+
+    def check():
+        current = _get_cds_update_count(tools_pod, envoy_pod_ip)
+        if current > initial_count:
+            return True, f"CDS reloaded: {initial_count} -> {current}"
+        return False, f"CDS update_success still at {current} (waiting for > {initial_count})"
+
+    run_periodically(check, timeout=timeout, sleep_time=5, msg="Envoy CDS reload")
+
+
+def _modify_cds_circuit_breaker(cds_json: str) -> str:
+    """Parse CDS JSON and bump max_connections from 1024 to 2048 on all clusters.
+
+    Actual CDS JSON structure (from ConfigMap):
+    {
+      "resources": [{
+        "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+        "circuit_breakers": {
+          "thresholds": [{
+            "max_connections": 1024,
+            "max_pending_requests": 1024,
+            "max_requests": 1024,
+            "max_retries": 3
+          }]
+        }
+      }]
+    }
+    """
+    cds = json.loads(cds_json)
+    modified_count = 0
+    for resource in cds.get("resources", []):
+        thresholds = resource.get("circuit_breakers", {}).get("thresholds", [])
+        for threshold in thresholds:
+            current = threshold.get("max_connections", 1024)
+            threshold["max_connections"] = current * 2
+            modified_count += 1
+    logger.info(f"Modified circuit breaker max_connections on {modified_count} threshold(s)")
+    return json.dumps(cds, indent=2)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
@@ -19,12 +19,12 @@ from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import search_resource_names
 from tests.common.search.background_availability_tester import SearchAvailabilityBackgroundTester, assert_no_outage
 from tests.common.search.bootstrap_test_mixins import (
+    InstallOperatorTests,
     MongoDBShardedDeploymentConfig,
     MongoDBShardedDeploymentTests,
     SearchShardedDeploymentTests,
     SearchShardedE2EFixtures,
     SearchShardedSampleDataAndIndex,
-    _derive_user_defaults,
 )
 from tests.common.search.connectivity import SearchConnectivityTool, set_resource_disabled_annotation
 from tests.common.search.sharded_search_helper import get_search_tester
@@ -36,12 +36,15 @@ pytestmark = pytest.mark.e2e_search_cds_hot_reload
 
 def configure_mongodb_sharded_config(cfg: MongoDBShardedDeploymentConfig) -> MongoDBShardedDeploymentConfig:
     cfg.mdb_resource_name = "mdb-sh-cds-reload"
-    cfg.admin_user_name = ""
-    cfg.admin_user_password = ""
-    cfg.user_name = ""
-    cfg.user_password = ""
-    _derive_user_defaults(cfg)
+    cfg.admin_user_name = f"{cfg.mdb_resource_name}-admin-user"
+    cfg.admin_user_password = f"{cfg.admin_user_name}-pass"
+    cfg.user_name = f"{cfg.mdb_resource_name}-user"
+    cfg.user_password = f"{cfg.user_name}-pass"
     return cfg
+
+
+class TestInstallOperator(InstallOperatorTests):
+    pass
 
 
 class TestSearchWithShardedCluster(

--- a/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
@@ -85,8 +85,13 @@ class TestSearchCDSHotReload(SearchShardedE2EFixtures):
             # Disable reconciliation so the operator won't overwrite our ConfigMap patch
             set_resource_disabled_annotation(mdbs, True)
 
+            # Record envoy pod identity before the reload
+            envoy_pod = _get_envoy_pod(namespace, mdbs.name)
+            pre_pod_name = envoy_pod.metadata.name
+            pre_restart_count = _get_envoy_restart_count(envoy_pod)
+            envoy_pod_ip = envoy_pod.status.pod_ip
+
             # Get current CDS reload count from envoy admin stats
-            envoy_pod_ip = _get_envoy_pod_ip(namespace, mdbs.name)
             initial_cds_updates = _get_cds_update_count(search_tools_pod, envoy_pod_ip)
             logger.info(f"Initial CDS update_success count: {initial_cds_updates}")
 
@@ -99,6 +104,18 @@ class TestSearchCDSHotReload(SearchShardedE2EFixtures):
 
             # Wait for Envoy to reload (poll stats until cds.update_success increments)
             _wait_for_cds_reload(search_tools_pod, envoy_pod_ip, initial_cds_updates)
+
+            # Verify envoy pod was NOT restarted or replaced, other potential option was to check deployment's generation
+            # field but that would be indirect way to check pod was not restarted. That's why it's better to just verify pod itself.
+            post_pod = _get_envoy_pod(namespace, mdbs.name)
+            assert post_pod.metadata.name == pre_pod_name, (
+                f"envoy pod was replaced: {pre_pod_name} -> {post_pod.metadata.name}"
+            )
+            post_restart_count = _get_envoy_restart_count(post_pod)
+            assert post_restart_count == pre_restart_count, (
+                f"envoy pod restarted: restart_count {pre_restart_count} -> {post_restart_count}"
+            )
+            logger.info(f"Envoy pod {pre_pod_name} stable (no restart, no rollout)")
 
             # Read more pages — cursor should still work
             post_pages = tool.paging_cursor_read_pages(
@@ -116,13 +133,19 @@ def _wait_for_search_serving(tool: SearchConnectivityTool, timeout: float = 300.
     tool.wait_for_sentinel_indexed(timeout=timeout)
 
 
-def _get_envoy_pod_ip(namespace: str, search_name: str) -> str:
+def _get_envoy_pod(namespace: str, search_name: str):
+    """Return the first envoy pod object."""
     deployment_name = search_resource_names.lb_deployment_name(search_name)
     pods = KubernetesTester.read_pod_labels(namespace, label_selector=f"app={deployment_name}")
     assert pods.items, f"no envoy pods found with label app={deployment_name}"
-    pod_ip = pods.items[0].status.pod_ip
-    logger.info(f"Envoy pod IP: {pod_ip} (pod: {pods.items[0].metadata.name})")
-    return pod_ip
+    pod = pods.items[0]
+    logger.info(f"Envoy pod: {pod.metadata.name} (IP: {pod.status.pod_ip})")
+    return pod
+
+
+def _get_envoy_restart_count(pod) -> int:
+    """Sum of restart counts across all containers in the pod."""
+    return sum(cs.restart_count for cs in (pod.status.container_statuses or []))
 
 
 def _get_cds_update_count(tools_pod: mongodb_tools_pod.ToolsPod, envoy_pod_ip: str) -> int:

--- a/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
@@ -17,10 +17,7 @@ from kubetester.mongodb_search import MongoDBSearch
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import search_resource_names
-from tests.common.search.background_availability_tester import (
-    SearchAvailabilityBackgroundTester,
-    assert_no_outage,
-)
+from tests.common.search.background_availability_tester import SearchAvailabilityBackgroundTester, assert_no_outage
 from tests.common.search.bootstrap_test_mixins import (
     MongoDBShardedDeploymentConfig,
     MongoDBShardedDeploymentTests,
@@ -36,15 +33,16 @@ logger = test_logger.get_test_logger(__name__)
 
 pytestmark = pytest.mark.e2e_search_cds_hot_reload
 
+
 def configure_mongodb_sharded_config(cfg: MongoDBShardedDeploymentConfig) -> MongoDBShardedDeploymentConfig:
     cfg.mdb_resource_name = "mdb-sh-cds-reload"
-    cfg.mongot_replicas = 2
     cfg.admin_user_name = ""
     cfg.admin_user_password = ""
     cfg.user_name = ""
     cfg.user_password = ""
     _derive_user_defaults(cfg)
     return cfg
+
 
 class TestSearchWithShardedCluster(
     SearchShardedDeploymentTests,
@@ -114,13 +112,13 @@ class TestSearchCDSHotReload(SearchShardedE2EFixtures):
 
                 # Verify envoy pod was NOT restarted or replaced
                 post_pod = _get_envoy_pod(namespace, mdbs.name)
-                assert post_pod.metadata.name == pre_pod_name, (
-                    f"envoy pod was replaced: {pre_pod_name} -> {post_pod.metadata.name}"
-                )
+                assert (
+                    post_pod.metadata.name == pre_pod_name
+                ), f"envoy pod was replaced: {pre_pod_name} -> {post_pod.metadata.name}"
                 post_restart_count = _get_envoy_restart_count(post_pod)
-                assert post_restart_count == pre_restart_count, (
-                    f"envoy pod restarted: restart_count {pre_restart_count} -> {post_restart_count}"
-                )
+                assert (
+                    post_restart_count == pre_restart_count
+                ), f"envoy pod restarted: restart_count {pre_restart_count} -> {post_restart_count}"
                 logger.info(f"Envoy pod {pre_pod_name} stable (no restart, no rollout)")
 
             # Assert background tester saw zero failures during the entire window
@@ -139,6 +137,7 @@ class TestSearchCDSHotReload(SearchShardedE2EFixtures):
         finally:
             cursor.close()
             set_resource_disabled_annotation(mdbs, False)
+
 
 def _wait_for_search_serving(tool: SearchConnectivityTool, timeout: float = 300.0) -> None:
     tool.wait_for_sentinel_indexed(timeout=timeout)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py
@@ -17,6 +17,10 @@ from kubetester.mongodb_search import MongoDBSearch
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import search_resource_names
+from tests.common.search.background_availability_tester import (
+    SearchAvailabilityBackgroundTester,
+    assert_no_outage,
+)
 from tests.common.search.bootstrap_test_mixins import (
     MongoDBShardedDeploymentConfig,
     MongoDBShardedDeploymentTests,
@@ -95,31 +99,38 @@ class TestSearchCDSHotReload(SearchShardedE2EFixtures):
             initial_cds_updates = _get_cds_update_count(search_tools_pod, envoy_pod_ip)
             logger.info(f"Initial CDS update_success count: {initial_cds_updates}")
 
-            # Patch CDS ConfigMap with modified circuit breaker
-            cm_name = search_resource_names.lb_configmap_name(mdbs.name)
-            cm_data = KubernetesTester.read_configmap(namespace, cm_name)
-            patched_cds = _modify_cds_circuit_breaker(cm_data["cds.json"])
-            logger.info(f"Patching ConfigMap {cm_name} with modified circuit breaker (max_connections doubled)")
-            KubernetesTester.update_configmap(namespace, cm_name, {**cm_data, "cds.json": patched_cds})
+            # Start background availability tester — continuously reads pages
+            # throughout the disruption window to catch any transient blips.
+            with SearchAvailabilityBackgroundTester(tool, mode="paging") as bg:
+                # Patch CDS ConfigMap with modified circuit breaker
+                cm_name = search_resource_names.lb_configmap_name(mdbs.name)
+                cm_data = KubernetesTester.read_configmap(namespace, cm_name)
+                patched_cds = _modify_cds_circuit_breaker(cm_data["cds.json"])
+                logger.info(f"Patching ConfigMap {cm_name} with modified circuit breaker (max_connections doubled)")
+                KubernetesTester.update_configmap(namespace, cm_name, {**cm_data, "cds.json": patched_cds})
 
-            # Wait for Envoy to reload (poll stats until cds.update_success increments)
-            _wait_for_cds_reload(search_tools_pod, envoy_pod_ip, initial_cds_updates)
+                # Wait for Envoy to reload (poll stats until cds.update_success increments)
+                _wait_for_cds_reload(search_tools_pod, envoy_pod_ip, initial_cds_updates)
 
-            # Verify envoy pod was NOT restarted or replaced, other potential option was to check deployment's generation
-            # field but that would be indirect way to check pod was not restarted. That's why it's better to just verify pod itself.
-            post_pod = _get_envoy_pod(namespace, mdbs.name)
-            assert post_pod.metadata.name == pre_pod_name, (
-                f"envoy pod was replaced: {pre_pod_name} -> {post_pod.metadata.name}"
-            )
-            post_restart_count = _get_envoy_restart_count(post_pod)
-            assert post_restart_count == pre_restart_count, (
-                f"envoy pod restarted: restart_count {pre_restart_count} -> {post_restart_count}"
-            )
-            logger.info(f"Envoy pod {pre_pod_name} stable (no restart, no rollout)")
+                # Verify envoy pod was NOT restarted or replaced
+                post_pod = _get_envoy_pod(namespace, mdbs.name)
+                assert post_pod.metadata.name == pre_pod_name, (
+                    f"envoy pod was replaced: {pre_pod_name} -> {post_pod.metadata.name}"
+                )
+                post_restart_count = _get_envoy_restart_count(post_pod)
+                assert post_restart_count == pre_restart_count, (
+                    f"envoy pod restarted: restart_count {pre_restart_count} -> {post_restart_count}"
+                )
+                logger.info(f"Envoy pod {pre_pod_name} stable (no restart, no rollout)")
 
-            # Read more pages — cursor should still work
+            # Assert background tester saw zero failures during the entire window
+            bg_verdict = bg.verdict
+            logger.info(f"Background tester verdict: {bg_verdict.as_dict()}")
+            assert_no_outage(bg_verdict)
+
+            # Read more pages from the original cursor — cursor should still work
             post_pages = tool.paging_cursor_read_pages(
-                cursor, pages=5, interval_seconds=0.5, batch_size=10, first_page_index=len(pre_pages)
+                cursor, pages=50, interval_seconds=0.5, batch_size=10, first_page_index=len(pre_pages)
             )
             verdict = tool.verdict(post_pages)
             logger.info(f"Post-reload verdict: {verdict.as_dict()}")


### PR DESCRIPTION
# Summary

The [base PR](https://github.com/mongodb/mongodb-kubernetes/pull/1017) adds the mechanism to make sure that envoy pod is not rolled out/re-created if the envoy config is changed. To do that we configure envoy to read cds/lds from filesysytem.

This PR add E2E test that verifies that if we change the envoy config that change is successfully propagated/loaded to envoy without it being restarted. To do that this is what is done in order 
1. Start a paging cursor and get some documents to make sure things are working fine
2. Get the number of times cds/lds config  has been updated (using `/stats` endpoint) and store that in `initial_cds_updates`
3. Patch the configmap that has cds/lds config with a trivial change. This would result in the new config getting updated to the pod where CM is mounted and envoy would pick that updated change
4. Get the number of times cds/lds has been updated and make sure that it's greater than `initial_cds_updates`, this would mean that the config changes were picked up by envoy
5. Continue query from the paging cursor and make sure it returns the documents.

This would prove that the cursor was not killed/stopped and we were able to continuously work with that cursor.

## Proof of Work

```
~/work/opensource/mongodb-kubernetes (search/dynamic-cds-lds-config*) » pytest --setup-show docker/mongodb-kubernetes-tests/tests/search/search_cds_hot_reload.py 2>&1 | tee output.log
```

passes successfully.


### Manual Test that envoy loaded the updated config

The `/stats` admin endpoint can be queried to check the number of times changes has been made to the cds/lds config. At the start this is what we see

```
bash-5.1$ curl 10.244.0.34:9901/stats | grep -i update_success
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0cluster.mongot_cluster_level_cluster.update_success: 72
cluster.mongot_mdb_sh_cds_reload_0_cluster.update_success: 36
100 56785 cluster.mongot_mdb_sh_cds_reload_1_cluster.update_success: 36
   0 56785    0     0cluster_manager.cds.update_success: 1
  54.1M      listener_manager.lds.update_success: 1
0 --:--:-- --:--:-- --:--:-- 54.1M
```

as we can see `listener_manager.lds.update_success` is set to `1`. 
After the test finishes if we query the same endpoint again

```
bash-5.1$ curl 10.244.0.34:9901/stats | grep -i update_success
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0cluster.mongot_cluster_level_cluster.update_success: 358
100 cluster.mongot_mdb_sh_cds_reload_0_cluster.update_success: 179
598cluster.mongot_mdb_sh_cds_reload_1_cluster.update_success: 179
52cluster_manager.cds.update_success: 2
    0 59852    0     0  5listener_manager.lds.update_success: 2
7.0M      0 --:--:-- --:--:-- --:--:-- 57.0M
```

we can see that those values have been updated.


### Evergreen CI — full search e2e suite (green)

Ran the complete search e2e suite on Evergreen against both the non-static and static cloud-qa variants:

- Patch: https://spruce.mongodb.com/version/6a1c08507394ca00077afdf4 — **all 62 tasks succeeded**
- Variants: `e2e_mdb_kind_ubi_cloudqa_large`, `e2e_static_mdb_kind_ubi_cloudqa_large`
- All 27 search e2e tasks passed on each variant (54 total), including this PR's new **`e2e_search_cds_hot_reload`** test on both.

`e2e_search_cds_hot_reload` is now wired into the `e2e_mdb_kind_search_large_task_group` task group, so it runs in CI alongside the other search connectivity tests (`e2e_search_connectivity_tool`, `e2e_search_connectivity_tool_sharded`, `e2e_search_connectivity_background_tester`).


## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

<!-- start git-machete generated -->

# Based on PR #1169

## Chain of upstream PRs as of 2026-06-01

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1080:
      `search/ga-base` ← `lsierant/KUBE-17-connectivity-tool`

      * PR #1169:
        `lsierant/KUBE-17-connectivity-tool` ← `search/dynamic-cds-lds-config`

        * **PR #1161 (THIS ONE)**:
          `search/dynamic-cds-lds-config` ← `search/e2e-test-cds-lds-config`

<!-- end git-machete generated -->
