### PR TITLE
fix: find_previous_version_tag resolves tags from remote origin

### DIFF
--- a/scripts/release/tests/conftest.py
+++ b/scripts/release/tests/conftest.py
@@ -141,6 +141,13 @@ def git_repo(change_log_path: str = DEFAULT_CHANGELOG_PATH) -> Repo:
     repo.git.cherry_pick(fix_commit)
     repo.create_tag("1.2.4", message="Bug fix release")
 
+    ## Add a bare remote so get_remote_tags() can resolve tags via ls-remote
+    remote_dir = tempfile.mkdtemp()
+    Repo.init(remote_dir, bare=True)
+    repo.create_remote("origin", remote_dir)
+    repo.git.push("origin", "--all")
+    repo.git.push("origin", "--tags")
+
     return repo
 
 

--- a/scripts/release/tests/version_test.py
+++ b/scripts/release/tests/version_test.py
@@ -1,7 +1,10 @@
 import unittest
 
+import pytest
+from git import Repo
+
 from scripts.release.changelog import ChangeKind
-from scripts.release.version import increment_previous_version
+from scripts.release.version import find_previous_version_tag, increment_previous_version
 
 
 class TestCalculateNextReleaseVersion(unittest.TestCase):
@@ -73,3 +76,112 @@ class TestCalculateNextReleaseVersion(unittest.TestCase):
         changelog = [ChangeKind.OTHER, ChangeKind.OTHER]
         next_version = increment_previous_version(previous_version, changelog)
         self.assertEqual(next_version, "1.2.4")
+
+
+@pytest.fixture
+def repo_with_remote(tmp_path):
+    """
+    Linear history: commit_a (1.0.0) → commit_b (1.0.1) → commit_c (HEAD, untagged).
+    Remote is a bare clone; local is cloned from it with all tags initially in sync.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = Repo.init(str(source_dir))
+    source.git.checkout("-b", "master")
+
+    (source_dir / "a.txt").write_text("a")
+    source.index.add(["a.txt"])
+    source.index.commit("commit a")
+    source.create_tag("1.0.0")
+
+    (source_dir / "b.txt").write_text("b")
+    source.index.add(["b.txt"])
+    source.index.commit("commit b")
+    source.create_tag("1.0.1")
+
+    (source_dir / "c.txt").write_text("c")
+    source.index.add(["c.txt"])
+    source.index.commit("commit c")
+
+    remote_dir = tmp_path / "remote.git"
+    Repo.clone_from(str(source_dir), str(remote_dir), bare=True)
+    local = Repo.clone_from(str(remote_dir), str(tmp_path / "local"))
+    return local, remote_dir, tmp_path
+
+
+def test_returns_latest_ancestor_tag(repo_with_remote):
+    local, _, _ = repo_with_remote
+    result = find_previous_version_tag(local)
+    assert result is not None
+    assert result.name == "1.0.1"
+
+
+def test_finds_remote_tag_not_locally_fetched(repo_with_remote):
+    """A tag present on remote but absent locally must still be returned after fetch."""
+    local, _, _ = repo_with_remote
+    local.delete_tag(local.tags["1.0.1"])  # simulate tag not yet fetched
+
+    result = find_previous_version_tag(local)
+    assert result is not None
+    assert result.name == "1.0.1"
+
+
+def test_ignores_local_only_tag(repo_with_remote):
+    """A tag created locally but never pushed to remote must not be returned."""
+    local, _, _ = repo_with_remote
+    local.create_tag("1.0.2")  # local-only, higher than anything on remote
+
+    result = find_previous_version_tag(local)
+    assert result is not None
+    assert result.name == "1.0.1"
+
+
+def test_ignores_tags_from_unrelated_remote(repo_with_remote, tmp_path):
+    """Tags fetched from a second remote (e.g. MEKO) must not be returned."""
+    local, remote_dir, tmp_path = repo_with_remote
+
+    # Set up a second remote with its own tag history
+    other_remote_dir = tmp_path / "other_remote.git"
+    other_source_dir = tmp_path / "other_source"
+    other_source_dir.mkdir()
+    other_source = Repo.init(str(other_source_dir))
+    other_source.git.checkout("-b", "master")
+    (other_source_dir / "x.txt").write_text("x")
+    other_source.index.add(["x.txt"])
+    other_source.index.commit("other repo initial commit")
+    other_source.create_tag("5.0.0")  # higher version than anything on origin
+    Repo.clone_from(str(other_source_dir), str(other_remote_dir), bare=True)
+
+    local.create_remote("other", str(other_remote_dir))
+    local.git.fetch("other", "--tags")  # pulls 5.0.0 into local tag namespace
+
+    result = find_previous_version_tag(local)
+    assert result is not None
+    assert result.name == "1.0.1"  # not 5.0.0 from the other remote
+
+
+def test_returns_none_when_remote_has_no_tags(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = Repo.init(str(source_dir))
+    source.git.checkout("-b", "master")
+    (source_dir / "a.txt").write_text("a")
+    source.index.add(["a.txt"])
+    source.index.commit("commit a")
+
+    remote_dir = tmp_path / "remote.git"
+    Repo.clone_from(str(source_dir), str(remote_dir), bare=True)
+    local = Repo.clone_from(str(remote_dir), str(tmp_path / "local"))
+
+    assert find_previous_version_tag(local) is None
+
+
+def test_returns_none_when_no_origin_remote(tmp_path):
+    repo = Repo.init(str(tmp_path / "local"))
+    repo.git.checkout("-b", "master")
+    (tmp_path / "local" / "a.txt").write_text("a")
+    repo.index.add(["a.txt"])
+    repo.index.commit("commit a")
+    repo.create_tag("1.0.0")
+
+    assert find_previous_version_tag(repo) is None

--- a/scripts/release/version.py
+++ b/scripts/release/version.py
@@ -1,7 +1,15 @@
+from dataclasses import dataclass
+
 import semver
-from git import Commit, Repo, TagReference
+from git import BadName, Commit, Repo
 
 from scripts.release.changelog import ChangeEntry, ChangeKind, get_changelog_entries
+
+
+@dataclass
+class VersionTag:
+    name: str
+    commit: Commit
 
 
 def calculate_next_version(
@@ -29,7 +37,7 @@ def calculate_next_version_with_changelog(
     return version, changelog
 
 
-def find_previous_version(repo: Repo, initial_commit_sha: str = None) -> (TagReference | None, Commit):
+def find_previous_version(repo: Repo, initial_commit_sha: str = None) -> (VersionTag | None, Commit):
     """Find the most recent version that is an ancestor of the current HEAD commit."""
 
     previous_version_tag = find_previous_version_tag(repo)
@@ -45,13 +53,15 @@ def find_previous_version(repo: Repo, initial_commit_sha: str = None) -> (TagRef
     return previous_version_tag, previous_version_tag.commit
 
 
-def find_previous_version_tag(repo: Repo) -> TagReference | None:
-    """Find the most recent version tag that is an ancestor of the current HEAD commit."""
+def find_previous_version_tag(repo: Repo) -> VersionTag | None:
+    """Find the most recent version tag on remote origin that is an ancestor of the current HEAD commit."""
 
     head_commit = repo.head.commit
 
     # Filter tags that are ancestors of the current HEAD commit
-    ancestor_tags = filter(lambda t: repo.is_ancestor(t.commit, head_commit) and t.commit != head_commit, repo.tags)
+    ancestor_tags = filter(
+        lambda t: repo.is_ancestor(t.commit, head_commit) and t.commit != head_commit, get_remote_tags(repo)
+    )
 
     # Filter valid SemVer tags and sort them
     valid_tags = filter(lambda t: semver.VersionInfo.is_valid(t.name), ancestor_tags)
@@ -61,6 +71,45 @@ def find_previous_version_tag(repo: Repo) -> TagReference | None:
         return None
 
     return sorted_tags[0]
+
+
+def get_remote_tags(repo: Repo) -> list[VersionTag]:
+    """Returns VersionTags from remote origin without modifying local state.
+
+    Annotated tags are dereferenced to their target commit SHA via the ^{} ls-remote lines.
+    Tags whose commits are not present locally are skipped.
+    """
+
+    if not any(r.name == "origin" for r in repo.remotes):
+        return []
+
+    ls_output = repo.git.ls_remote("--tags", "origin")
+    if not ls_output:
+        return []
+
+    dereferenced: dict[str, str] = {}
+    direct: dict[str, str] = {}
+
+    for line in ls_output.splitlines():
+        sha, ref = line.split("\t")
+        if ref.endswith("^{}"):
+            name = ref.removeprefix("refs/tags/").removesuffix("^{}")
+            dereferenced[name] = sha
+        elif ref.startswith("refs/tags/"):
+            name = ref.removeprefix("refs/tags/")
+            direct[name] = sha
+
+    # Annotated tags appear twice: tag-object SHA and dereferenced (^{}) commit SHA.
+    # Use the dereferenced SHA when available; otherwise direct (lightweight tag).
+    resolved = {name: dereferenced.get(name, sha) for name, sha in direct.items()}
+
+    tags = []
+    for name, sha in resolved.items():
+        try:
+            tags.append(VersionTag(name=name, commit=repo.commit(sha)))
+        except BadName:
+            pass
+    return tags
 
 
 def increment_previous_version(previous_version_str: str, changelog: list[ChangeKind]) -> str:


### PR DESCRIPTION
# Summary

`find_previous_version_tag` previously iterated `repo.tags` — the local tag namespace, which is a global pool shared across all remotes. This caused two problems:

1. **Tags from unrelated remotes:** tags fetched from other remotes (e.g. MEKO, whose history precedes MCK) could appear as valid semver ancestors and produce the wrong result. This manifested as a real failure: `git fetch --tags` rejected with \"would clobber existing tag\" when local MEKO tags conflicted with MCK tags on `origin`.
2. **Stale local tags:** tags created on `origin` after the last fetch would be silently missed.

The fix introduces `get_remote_tags`, which uses `git ls-remote --tags origin` to get the authoritative tag list directly from `origin` without touching local state. It returns `list[VersionTag]` — a small dataclass holding `name` and `commit` — handling annotated tag dereferencing (via `^{}` lines) and skipping any tag whose commit is not locally present. `find_previous_version_tag` now filters this list instead of `repo.tags`, keeping the same filter-chain structure as before.

## Proof of Work

- `scripts/release/tests/version_test.py` — five new integration tests covering: baseline ancestor lookup, local-only tag ignored, tag from unrelated remote ignored, remote tag not locally fetched, no tags/no remote cases.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details