### PR TITLE
fix: preflight_check_smoke uses latest released operator version

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -54,16 +54,18 @@ tasks:
       - func: run_preflight_om_and_agents
 
   # One check-only preflight per commit: validates openshift-preflight + Quay + scripts still work.
+  # Uses "latest" tag (published by the release pipeline) so the image is always available on Quay,
+  # regardless of what release.json contains.
   - name: preflight_check_smoke
     tags: [ "image_preflight" ]
     commands:
       - func: clone
       - func: python_venv
-      - func: update_evergreen_expansions
       - func: setup_preflight
       - func: preflight_image
         vars:
           image_name: mongodb-kubernetes
+          mongodbOperator: "latest"
 
 # Code snippets tasks
 # Each task is selected by convention by running scripts/code_snippets/${task_name}_test.sh


### PR DESCRIPTION
# Summary

`preflight_check_smoke` validates the preflight toolchain on every master commit by running `openshift-preflight` against a published image. It used `update_evergreen_expansions` to set `${mongodbOperator}` from `release.json`, but `release.json` tracks the **next unreleased version** (bumped by the pre-commit hook after each release). This caused the task to attempt preflight against an image not yet on Quay, failing with `MANIFEST_UNKNOWN`.

The fix removes `update_evergreen_expansions` from the smoke task and passes `mongodbOperator: "latest"` as a `vars` override directly in the `preflight_image` call. The `latest` tag is published by the release pipeline on every release and is always available on Quay.

Before: `preflight check container quay.io/mongodb/mongodb-kubernetes:1.8.2` → `MANIFEST_UNKNOWN`.
After: `preflight check container quay.io/mongodb/mongodb-kubernetes:latest` → passes.

## Proof of Work

Evergreen patch: https://evergreen.mongodb.com/version/6a1d67b90719150007ae8ad5 — `preflight_check_smoke` on `preflight_release_images_check_only` **passed** ✓

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details