### PR TITLE
Devcontainers in isolated worktrees with evg hosts

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,76 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# Ensure UTF-8 locale so tmux, prompts, and any tool that prints non-ASCII
+# (e.g. starship's ❯, helm/kubectl box-drawing) renders correctly.
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Quiet apt/dpkg build noise (Get:/Fetched lines, download progress bars, the
+# dpkg pty progress redraw). Written before any apt call and inherited by the
+# devcontainer features layered on top of this image, so their apt output is
+# dampened too. Errors still go to stderr; nothing is hidden on failure.
+RUN printf '%s\n' \
+        'APT::Get::quiet "2";' \
+        'quiet "1";' \
+        'Dpkg::Use-Pty "0";' \
+        > /etc/apt/apt.conf.d/99mck-quiet
+
+RUN apt-get update && apt-get install -y \
+    # Install dependencies for python-ldap
+    libldap2-dev \
+    libsasl2-dev \
+    # Log navigator for browsing operator/agent logs
+    lnav \
+    # pip is used a few lines below to install tmuxp into the system
+    # python; keeps the layer count small.
+    python3-pip \
+    # Socat for ssh-agent socket forwarding
+    screen \
+    socat \
+    # Terminal multiplexer for the default workflow
+    tmux \
+ && pip3 install --break-system-packages --quiet tmuxp
+
+# Claude Code is not installed in the container. Install manually after
+# attaching: curl -fsSL https://claude.ai/install.sh | bash
+
+# Make zsh the default shell for vscode (matches host workflow for users who
+# prefer zsh; bash users can still `bash -l` explicitly).
+RUN chsh -s /usr/bin/zsh vscode
+
+# Workspace context loader + tmuxp auto-attach, sourced from .bashrc /
+# .zshrc on every shell start. The actual logic lives in shell-init.sh
+# (multi-line, version-controlled, easier to edit) — we just bake a
+# one-liner sourcing it into both rc files.
+COPY shell-init.sh /etc/mck/shell-init.sh
+RUN chmod 0644 /etc/mck/shell-init.sh \
+ && echo '[[ -f /etc/mck/shell-init.sh ]] && source /etc/mck/shell-init.sh' \
+    | tee -a /home/vscode/.bashrc /home/vscode/.zshrc > /dev/null \
+ && printf '%s\n' \
+        '[ -n "${BASH:-}" ] && [ -f /etc/mck/shell-init.sh ] && . /etc/mck/shell-init.sh' \
+        > /etc/profile.d/01-mck-shell-init.sh \
+ && chmod 0644 /etc/profile.d/01-mck-shell-init.sh
+# 01-mck-shell-init.sh loads shell-init.sh for non-interactive login shells
+# (e.g. `bash -lc CMD` from `wt-ctl attach -- bash -lc ...`); the .bashrc /
+# .zshrc sourcing above only fires for INTERACTIVE shells. Without this hook,
+# `devcontainer exec ... bash -lc` runs with KUBECONFIG / PROJECT_DIR unset and
+# kubectl falls back to localhost:8080. Idempotent: shell-init only re-sources
+# devenv. Bash-only — shell-init.sh uses bash syntax ([[ ]], $-) that breaks
+# under sh/dash; zsh login shells get shell-init via .zshrc separately.
+
+# Add /workspace/bin (per-worktree project binaries: kubectl, helm, etc.
+# pinned via Makefile install targets) to PATH for every login shell.
+# Container-only — host devs add the equivalent to their ~/.zshrc themselves.
+#
+# Debian/Ubuntu's stock /etc/zsh/zprofile is comments only — it does NOT
+# source /etc/profile, so /etc/profile.d/* never fires for zsh login
+# shells. Append an explicit sourcing line so zsh login shells get the
+# same PATH as bash login shells.
+RUN printf 'export PATH="/workspace/bin:${PATH}"\n' \
+        > /etc/profile.d/mck-bin.sh \
+ && chmod 0644 /etc/profile.d/mck-bin.sh \
+ && printf '\n# MCK: source /etc/profile.d/* for zsh login shells (Debian default zprofile is comment-only).\nemulate sh -c '\''source /etc/profile'\''\n' \
+        >> /etc/zsh/zprofile
+
+RUN bash -c 'mkdir -p /workspace/.generated /home/vscode/.cache/{go-build,pip,helm}' && \
+    chown -R vscode:vscode /workspace/.generated /home/vscode/.cache

--- a/.devcontainer/autossh.Dockerfile
+++ b/.devcontainer/autossh.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+RUN apt-get update && apt-get install -y autossh

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,183 @@
+x-k8s-proxy-config:
+  # proxy_address = 172.X.Y_BASE.10. Defaults map to stack index 0
+  # (X=16, Y_BASE=0) for ad-hoc invocations without the wt-ctl registry;
+  # in normal use, wt-ctl writes the four MCK_DEVC_NET_* vars into
+  # .devcontainer/.env so these defaults are never read.
+  proxy_address: &proxy_address 172.${MCK_DEVC_NET_X:-16}.${MCK_DEVC_NET_Y_BASE:-0}.10
+
+services:
+  devcontainer:
+    build: .
+
+    environment:
+      K8S_FWD_PROXY: *proxy_address
+      EVG_HOST_PROXY: "http://gost-proxy:8080"
+      GOTOOLCHAIN: local
+      # Forward the per-worktree network prefix so root-context (sourced inside
+      # the container during `make switch`) can derive a per-worktree NAMESPACE
+      # (ls-${MCK_DEVC_NET_PREFIX}). That makes cloud-qa OM project names
+      # (which everything downstream composes from ${NAMESPACE}) unique per
+      # worktree, so parallel worktrees don't delete each other's OM projects.
+      MCK_DEVC_NET_PREFIX: ${MCK_DEVC_NET_PREFIX:-0}
+
+      # The Python `evg` CLI (mck-dev plugin) reads oauth.token_file_path from
+      # ~/.evergreen.yml *literally* (no $HOME/~ expansion). That file is shared
+      # with the host, where the path must resolve under the macOS $HOME — so it
+      # points at /Users/<user>/.kanopy. Override it here so the same token
+      # resolves at the devc user's $HOME. Set in the environment block (not
+      # shell-init) so non-interactive script invocations inherit it too.
+      EVERGREEN_TOKEN_FILE: /home/vscode/.kanopy/token-oidclogin.json
+
+    volumes:
+      # Workspace
+      - ..:/workspace:cached
+
+      # Unique per devcontainer instance to avoid conflicts
+      - venv:/workspace/venv
+      # Override the bin directory so Linux-specific kubebuilder tools stay inside the container
+      - bin:/workspace/bin
+
+      # Named volumes for persistent caches, shared across all devcontainer instances
+      - gomodcache:/go/pkg/mod
+      - gocache:/home/vscode/.cache/go-build
+      - uvcache:/home/vscode/.cache/uv
+      - helmcache:/home/vscode/.cache/helm
+
+      # Evergreen auth. The token lives in ~/.kanopy (rw, shared so one refresh
+      # flow serves both sides). The config yaml is mounted READ-ONLY: the
+      # kanopy-backed Go CLI persists an absolute, $HOME-expanded
+      # oauth.token_file_path back into it, so a write from inside the container
+      # (where $HOME=/home/vscode) would poison this single host-shared file and
+      # break the host's evg CLI. Read-only keeps oauth.token_file_path pinned to
+      # the host path; the Python evg CLI reads it literally but EVERGREEN_TOKEN_FILE
+      # (above) overrides the path for the container.
+      - ${HOME}/.evergreen.yml:/home/vscode/.evergreen.yml:ro
+      - ${HOME}/.kanopy:/home/vscode/.kanopy:cached
+
+      # ~/.claude is intentionally NOT shared: an in-container marketplace
+      # registration rewrites the host's known_marketplaces.json installLocation
+      # to a /home/vscode path and breaks the marketplace on the host.
+      # - ${HOME}/.claude:/home/vscode/.claude:cached
+
+      # Share the SSH agent socket for evg-host-proxy to use
+      - ssh-auth-sock:/ssh-agent
+
+    extra_hosts:
+      # Ensure host.docker.internal resolves on Linux Docker
+      - "host.docker.internal:host-gateway"
+
+    depends_on:
+      - k8s-proxy
+    networks:
+      - devcontainer
+    dns:
+      - *proxy_address
+      - 127.0.0.11
+
+    command: sleep infinity
+  k8s-proxy:
+    # Pinned by digest: this image gets NET_ADMIN and receives the kubeconfig
+    # PATCH, so a mutable :latest is an unreviewed-code-with-credentials risk.
+    image: ghcr.io/fealebenpae/kube-forwarding-proxy:latest@sha256:91341cba1d41a374082d50552cc4ddacdd126ca8fa46a083ab8065776ecdbe8f
+    cap_add:
+      - NET_ADMIN
+    environment:
+      # Bind DNS to the container's assigned IP on devcontainer.
+      # VIPs (172.X.1.x where X = MCK_DEVC_NET_PREFIX) are also added to that interface.
+      INTERFACE: *proxy_address
+      VIP_CIDR: 172.${MCK_DEVC_NET_X:-16}.${MCK_DEVC_NET_Y_VIP:-1}.0/24
+      DNS_LISTEN: :53
+      HTTP_LISTEN: :80
+      CLUSTER_DOMAIN: svc.cluster.local
+      LOG_LEVEL: info
+    command: ["--dns"]
+    networks:
+      devcontainer:
+        ipv4_address: *proxy_address
+
+  # Create a SSH port-forwarding SOCKS proxy
+  evg-host-proxy:
+    build:
+      context: .
+      dockerfile: autossh.Dockerfile
+    environment:
+      SSH_AUTH_SOCK: /ssh-agent/socket
+    networks:
+      - devcontainer
+    restart: unless-stopped
+    volumes:
+      # Auto-resolved EVG_HOST_ADDRESS lives in .generated/ (written by
+      # root-context whenever switch_context runs). Sidecar reads it directly.
+      - ../.generated:/generated:ro
+      - ssh-auth-sock:/ssh-agent
+      # Use ${HOME} (consistent with the other host mounts, and reliably
+      # expanded by compose unlike a bare ~). initialize.sh touches this file
+      # first so Docker doesn't materialize it as a root-owned directory.
+      - ${HOME}/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro
+    command: |
+      bash -c '
+        set -Eeo pipefail
+        echo "evg-host-proxy: starting..."
+        # EVG_HOST_ADDRESS may be passed via compose env (e.g. compose.user.yml
+        # override). Otherwise fall back to the auto-resolved cache file.
+        # ($$ escapes the dollar so compose passes the variable name through to bash.)
+        if [ -z "$$EVG_HOST_ADDRESS" ] && [ -s /generated/.current-evg-host-address ]; then
+          EVG_HOST_ADDRESS=$$(cat /generated/.current-evg-host-address)
+        fi
+        if [ -z "$$EVG_HOST_ADDRESS" ]; then
+          # Local-kind mode: no EVG host pinned. kubectl from the devc bypasses
+          # the SOCKS5 chain entirely (devc kubeconfig points at
+          # host.docker.internal directly). Idle so the compose stack still
+          # comes up healthy; gost-proxy keeps trying to reach us, which is
+          # harmless when nothing forwards through it.
+          echo "evg-host-proxy: no EVG_HOST_ADDRESS (local-kind mode); idling."
+          exec tail -f /dev/null
+        fi
+        echo "evg-host-proxy: waiting for ssh-agent socket at $$SSH_AUTH_SOCK..."
+        until [ -S "$$SSH_AUTH_SOCK" ]; do sleep 1; done
+        echo "evg-host-proxy: ssh-agent ready; starting autossh to ubuntu@$$EVG_HOST_ADDRESS"
+        exec autossh -M 0 -N \
+          -o "ServerAliveInterval 30" \
+          -o "ServerAliveCountMax 3" \
+          -D 0.0.0.0:1080 \
+          ubuntu@$$EVG_HOST_ADDRESS
+      '
+
+  # Translate the SOCKS proxy from evg-host-proxy into an HTTP proxy because go-client doesn't support SPDY over SOCKS.
+  gost-proxy:
+    # Pinned by digest: gost forwards all kubectl traffic through the SOCKS
+    # chain, so freeze the version rather than tracking :latest.
+    image: gogost/gost:latest@sha256:68b97ddda9f8bda460eb0eaa4004d1b8821ee54636c94230837e851c1c14f795
+    depends_on:
+      - evg-host-proxy
+    networks:
+      - devcontainer
+    ports:
+      - "127.0.0.1:${MCK_DEVC_PROXY_PORT:-8000}:8080"
+    command: ["-L", "http://:8080", "-F", "socks5://evg-host-proxy:1080"]
+
+# Volumes with an explicit name are shared globally, otherwise they are prefixed with the project name generated for this compose stack
+volumes:
+  ssh-auth-sock:
+  venv:
+  bin:
+  gomodcache:
+    name: mck-devcontainer-gomodcache
+  gocache:
+    name: mck-devcontainer-gocache
+  uvcache:
+    name: mck-devcontainer-uvcache
+  helmcache:
+    name: mck-devcontainer-helmcache
+
+# Set up a custom network to carve out an address space for k8s-proxy to allocate virtual IPs in
+networks:
+  devcontainer:
+    driver: bridge
+    ipam:
+      config:
+        # Per-stack /23 carved out of 172.16.0.0/12. ip_range is the
+        # bottom /24 (where containers actually bind); the other /24
+        # (Y_VIP) is reserved for k8s-proxy VIPs.
+        - subnet: 172.${MCK_DEVC_NET_X:-16}.${MCK_DEVC_NET_Y_BASE:-0}.0/23
+          ip_range: 172.${MCK_DEVC_NET_X:-16}.${MCK_DEVC_NET_Y_BASE:-0}.0/24

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 
     "features": {
         "ghcr.io/devcontainers/features/go:1": {
-            "version": "1.26.4"
+            "version": "1.26.5"
         },
         "ghcr.io/devcontainers-extra/features/uv:1": {},
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,89 @@
+{
+    "name": "MCK",
+    "dockerComposeFile":
+    [
+        "compose.yml",
+        "compose.generated.yml",
+        "compose.user.yml"
+    ],
+
+    "service": "devcontainer",
+    "workspaceFolder": "/workspace",
+
+    "features": {
+        "ghcr.io/devcontainers/features/go:1": {
+            "version": "1.26.4"
+        },
+        "ghcr.io/devcontainers-extra/features/uv:1": {},
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+            "version": "latest",
+            "helm": "latest",
+            "minikube": "none"
+        },
+        // Installs the helm-unittest plugin; depends on kubectl-helm-minikube for helm.
+        "./features/helm-unittest": {},
+        // Installs separate docker inside the devcontainer
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        // AWS CLI for logging-in to ECR. Local quiet drop-in for
+        // ghcr.io/devcontainers/features/aws-cli:1 (installs with unzip -q so
+        // the build log isn't flooded with the CLI bundle's example files).
+        "./features/aws-cli": {},
+        "ghcr.io/devcontainers-extra/features/jira-cli:1": {},
+        "ghcr.io/devcontainers-extra/features/shellcheck:1": {},
+        "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+            "jqVersion": "latest",
+            "yqVersion": "latest"
+        },
+        // fzf — used by scripts/dev/switch_context.sh
+        "ghcr.io/devcontainers-extra/features/fzf:1": {},
+        "ghcr.io/mpriscella/features/kind:1": {},
+        "ghcr.io/mpriscella/features/helm-chart-testing:1": {},
+        // k9s — terminal UI for browsing kind/EVG-host clusters
+        "ghcr.io/dhoeric/features/k9s:1": {},
+        // Git pre-commit hooks
+        "ghcr.io/devcontainers-extra/features/pre-commit:2": {}
+    },
+
+    // --- Lifecycle Commands ---
+    "initializeCommand": "bash .devcontainer/scripts/initialize.sh",
+    "onCreateCommand": "bash .devcontainer/scripts/on-create.sh",
+    "postStartCommand": "bash .devcontainer/scripts/post-start.sh",
+
+    // Disable all auto port forwarding by default
+    "otherPortsAttributes": {
+        "onAutoForward": "ignore"
+    },
+
+    // --- VS Code Customizations (container-specific only) ---
+    // General editor/linter settings live in .vscode/settings.json.
+    // Only container-specific overrides belong here.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature includes this, but we don't need it
+                "golang.go",
+                "ms-python.python",
+                "ms-python.debugpy",
+                "ms-python.black-formatter",
+                "ms-python.isort",
+                "ms-python.flake8",
+                "ms-python.mypy-type-checker",
+                "ms-azuretools.vscode-docker",
+                "ms-kubernetes-tools.vscode-kubernetes-tools",
+                "redhat.vscode-yaml",
+                "editorconfig.editorconfig",
+                "timonwong.shellcheck"
+            ],
+            "settings": {
+                "vs-kubernetes.kubeconfig": "/workspace/.generated/current.devc.kubeconfig"
+            }
+        }
+    },
+
+    // --- Resource Recommendations ---
+    "hostRequirements": {
+        "cpus": 2,
+        "memory": "6gb",
+        "storage": "32gb"
+    }
+}

--- a/.devcontainer/features/aws-cli/devcontainer-feature.json
+++ b/.devcontainer/features/aws-cli/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "id": "aws-cli",
+    "version": "1.0.0",
+    "name": "AWS CLI (quiet)",
+    "description": "Installs the AWS CLI v2. Local drop-in for ghcr.io/devcontainers/features/aws-cli:1 that installs quietly (unzip -q) so the container build log isn't flooded with the CLI bundle's example files.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "AWS CLI v2 version to install ('latest' or a concrete version like 2.15.0)."
+        }
+    }
+}

--- a/.devcontainer/features/aws-cli/install.sh
+++ b/.devcontainer/features/aws-cli/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Devcontainer feature: aws-cli (quiet)
+#
+# Local drop-in for ghcr.io/devcontainers/features/aws-cli:1. The upstream
+# feature runs a bare `unzip awscliv2.zip`, which prints one `inflating:` line
+# per file in the CLI bundle (hundreds of `examples/**/*.rst`) and floods the
+# container build log. This installs the same AWS CLI v2 with `unzip -q` so the
+# build log stays readable. Errors still surface on stderr.
+
+set -euo pipefail
+
+VERSION="${VERSION:-latest}"
+
+case "$(uname -m)" in
+    x86_64 | amd64) ARCH="x86_64" ;;
+    aarch64 | arm64) ARCH="aarch64" ;;
+    *)
+        echo "aws-cli feature: unsupported architecture $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+if [ "${VERSION}" = "latest" ]; then
+    URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip"
+else
+    URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-${VERSION}.zip"
+fi
+
+# unzip is required and not guaranteed on the base image.
+if ! command -v unzip >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y unzip
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+echo "aws-cli feature: installing AWS CLI v2 (${VERSION}, ${ARCH})..."
+curl -fsSL "${URL}" -o "${WORK}/awscliv2.zip"
+unzip -q "${WORK}/awscliv2.zip" -d "${WORK}"
+"${WORK}/aws/install" --update >/dev/null
+
+echo "aws-cli feature: $(aws --version)"

--- a/.devcontainer/features/helm-unittest/devcontainer-feature.json
+++ b/.devcontainer/features/helm-unittest/devcontainer-feature.json
@@ -1,0 +1,9 @@
+{
+    "id": "helm-unittest",
+    "version": "1.0.0",
+    "name": "helm-unittest",
+    "description": "Installs the helm-unittest plugin (https://github.com/helm-unittest/helm-unittest).",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1"
+    ]
+}

--- a/.devcontainer/features/helm-unittest/install.sh
+++ b/.devcontainer/features/helm-unittest/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Devcontainer feature: helm-unittest
+#
+# Installs the helm-unittest plugin into the container image so it is available
+# without requiring a separate on-create step.
+# Requires helm to already be on PATH (provided by the kubectl-helm-minikube feature).
+#
+# We clone a pinned tag and install from the local checkout because the
+# install-binary.sh hook in newer releases (>=1.1.0) fetches a .sha256.txt file
+# that doesn't exist for linux-arm64, breaking image builds on Apple Silicon.
+
+set -euo pipefail
+
+REMOTE_USER="${_REMOTE_USER:-vscode}"
+PLUGIN_VERSION="v1.0.3"
+PLUGIN_DIR="/tmp/helm-unittest-${PLUGIN_VERSION}"
+
+echo "Installing helm-unittest plugin ${PLUGIN_VERSION} for user '${REMOTE_USER}'..."
+git clone --depth 1 --branch "${PLUGIN_VERSION}" \
+    https://github.com/helm-unittest/helm-unittest.git \
+    "${PLUGIN_DIR}"
+chown -R "${REMOTE_USER}:${REMOTE_USER}" "${PLUGIN_DIR}"
+su - "${REMOTE_USER}" -c "helm plugin install ${PLUGIN_DIR} --verify=false"

--- a/.devcontainer/scripts/initialize.py
+++ b/.devcontainer/scripts/initialize.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Host-side generator for the devcontainer compose override.
+
+Runs before any container (and any venv) exists, so it uses only the standard
+library. It rebuilds services.devcontainer.{environment,volumes} from scratch
+each run and writes the result to COMPOSE_OVERRIDE_FILE. JSON is valid YAML, so
+`docker compose -f` accepts the output directly.
+"""
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+
+def evergreen_cli_url():
+    """Resolve the Linux Evergreen CLI URL anchored on the host's evergreen
+    build revision. The download happens at on-create time so the image stays
+    stable across version bumps. Returns None when evergreen is absent."""
+    if shutil.which("evergreen") is None:
+        print("Evergreen CLI not found on host; skipping URL resolution. The on-create")
+        print("step will be a no-op and you'll need to install evergreen manually inside")
+        print("the container.")
+        return None
+
+    arch = platform.machine()
+    if arch == "x86_64":
+        arch = "amd64"
+    elif arch == "aarch64":
+        arch = "arm64"
+
+    revision = subprocess.check_output(["evergreen", "version", "--build-revision"], text=True).strip()
+    return (
+        "https://evg-bucket-evergreen.s3.amazonaws.com/evergreen/clients/"
+        f"evergreen_{revision}/linux_{arch}/evergreen"
+    )
+
+
+def git_common_dir():
+    """Absolute git common dir when the workspace is a worktree, else None."""
+    git_dir = subprocess.check_output(["git", "rev-parse", "--git-common-dir"], text=True).strip()
+    return git_dir if git_dir.startswith("/") else None
+
+
+def ssh_agent_socket():
+    """Host ssh-agent socket to forward, or empty string when unavailable.
+
+    macOS/Docker Desktop exposes a fixed forwarding socket; on Linux the host
+    shell's SSH_AUTH_SOCK is used (must be set when initializeCommand runs)."""
+    system = platform.system()
+    if system == "Darwin":
+        return "/run/host-services/ssh-auth.sock"
+    if system == "Linux":
+        return os.environ.get("SSH_AUTH_SOCK", "")
+    return ""
+
+
+def tmux_volumes():
+    """Read-only mounts for host tmux config paths that exist. Plugin dirs are
+    skipped: TPM plugins may carry platform-specific binaries."""
+    home = os.environ["HOME"]
+    entries = []
+    for src, dst in (
+        (os.path.join(home, ".tmux.conf"), "/home/vscode/.tmux.conf"),
+        (os.path.join(home, ".config", "tmux"), "/home/vscode/.config/tmux"),
+    ):
+        if os.path.exists(src):
+            entries.append((src, dst))
+    return entries
+
+
+def main():
+    override_file = os.environ["COMPOSE_OVERRIDE_FILE"]
+
+    environment = []
+    volumes = []
+
+    cli_url = evergreen_cli_url()
+    if cli_url is not None:
+        environment.append(f"EVERGREEN_CLI_URL={cli_url}")
+        print(f"Set EVERGREEN_CLI_URL={cli_url} on devcontainer service in " f"{os.path.basename(override_file)}")
+
+    git_dir = git_common_dir()
+    if git_dir is not None:
+        volumes.append(f"{git_dir}:{git_dir}:cached")
+        print(f"Added git worktree volume: {git_dir}")
+
+    # autossh in the sidecar blocks forever without this forward, breaking
+    # kubectl through gost-proxy.
+    host_sock = ssh_agent_socket()
+    if host_sock:
+        volumes.append(f"{host_sock}:/ssh-auth.sock")
+        environment.append("SSH_AUTH_SOCK=/ssh-auth.sock")
+        print(f"ssh-agent.sh: mounted {host_sock} -> /ssh-auth.sock and exported SSH_AUTH_SOCK")
+    else:
+        print("ssh-agent.sh: no host ssh-agent socket detected; skipping")
+
+    for src, dst in tmux_volumes():
+        entry = f"{src}:{dst}:ro"
+        volumes.append(entry)
+        print(f"Added tmux config volume: {entry}")
+
+    devcontainer = {}
+    if environment:
+        devcontainer["environment"] = environment
+    if volumes:
+        devcontainer["volumes"] = volumes
+
+    doc = {"services": {"devcontainer": devcontainer}}
+    with open(override_file, "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.devcontainer/scripts/initialize.sh
+++ b/.devcontainer/scripts/initialize.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Runs on the host before the devcontainer starts (devcontainer.json initializeCommand).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export ENV_DIR="${SCRIPT_DIR}/../.envs"
+mkdir -p "${ENV_DIR}"
+
+# Ensure the project-level .generated/ exists so the evg-host-proxy bind mount
+# resolves cleanly even before the first switch_context run.
+mkdir -p "${SCRIPT_DIR}/../../.generated"
+
+COMPOSE_OVERRIDE_FILE="${SCRIPT_DIR}/../compose.generated.yml"
+export COMPOSE_OVERRIDE_FILE
+
+function create_if_not_exists() {
+    # `|| touch` (not `&& touch`): under set -e a `[[ ! -f ]] && touch` returns
+    # non-zero when the file already exists (idempotent re-run) and aborts.
+    [[ -f "$1" ]] || touch "$1"
+}
+create_if_not_exists "${COMPOSE_OVERRIDE_FILE}"
+create_if_not_exists "${SCRIPT_DIR}/../compose.user.yml"
+
+# Ensure ~/.ssh/known_hosts exists as a FILE before the evg-host-proxy bind
+# mount resolves — otherwise Docker materializes it as a root-owned directory.
+mkdir -p "${HOME}/.ssh"
+create_if_not_exists "${HOME}/.ssh/known_hosts"
+
+python3 "${SCRIPT_DIR}/initialize.py"

--- a/.devcontainer/scripts/log_follower.sh
+++ b/.devcontainer/scripts/log_follower.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Robustly follow a log file inside a tmuxp pane.
+#
+# Used by the 'mck' tmuxp session to keep an operator-log pane and an
+# e2e-log pane permanently visible, regardless of whether the file
+# currently exists, was truncated, was replaced (new inode under the
+# same path / symlink target swap), or the underlying viewer crashed.
+#
+# Waits for the file to appear, then `tail -F` (follows by name, survives
+# truncation / rotation / replacement); restarts the loop with a banner if
+# tail ever exits.
+#
+# Usage:
+#   log_follower.sh <file> [label]
+#
+# Notes:
+#   - We deliberately use `tail -F` rather than `less +F`: less's
+#     follow-mode does not survive file replacement (it holds the old
+#     fd), and the panes need to keep showing fresh content with no
+#     user intervention. Use tmux's scrollback (prefix [) for paging.
+#
+
+set +e
+file="${1:?usage: log_follower.sh <file> [label]}"
+label="${2:-$(basename "${file}")}"
+
+banner() {
+    # Clear screen, home cursor, print one status line.
+    printf '\033[2J\033[H[%s] %s\n' "${label}" "$1"
+}
+
+while true; do
+    if [[ ! -e "${file}" ]]; then
+        banner "waiting for ${file} ..."
+        while [[ ! -e "${file}" ]]; do sleep 1; done
+        banner "following ${file}"
+    fi
+    # -F  = follow by name (handles truncation, rotation, replacement)
+    # -n +1 = include any pre-existing content from the start
+    tail -F -n +1 "${file}" 2>/dev/null
+    banner "tail exited; restarting in 1s"
+    sleep 1
+done

--- a/.devcontainer/scripts/on-create.sh
+++ b/.devcontainer/scripts/on-create.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# on-create.sh - Runs inside the container during creation.
+
+set -euo pipefail
+
+# Docker creates named volumes root-owned; fix ownership for the devcontainer
+# user. Only the KNOWN named volumes are chowned — never an enumeration of all
+# mounts, which on Linux hosts would recurse into the bind-mounted workspace,
+# ~/.kanopy and ~/.evergreen.yml and rewrite real host file ownership for any
+# dev whose host UID isn't 1000. These paths match compose.yml's named volumes.
+DEVCONTAINER_USER="$(whoami)"
+for mount_point in \
+    /workspace/venv \
+    /workspace/bin \
+    /go/pkg/mod \
+    "${HOME}/.cache/go-build" \
+    "${HOME}/.cache/uv" \
+    "${HOME}/.cache/helm"; do
+    [[ -d "${mount_point}" ]] || continue
+    sudo chown -R "${DEVCONTAINER_USER}:${DEVCONTAINER_USER}" "${mount_point}" 2>/dev/null || true
+done
+
+for file in .devcontainer/scripts/on-create/*.sh; do
+    bash "${file}"
+done

--- a/.devcontainer/scripts/on-create/01-switch-context.sh
+++ b/.devcontainer/scripts/on-create/01-switch-context.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Regenerate .generated/context.env + context.devc.env so PROJECT_DIR (and
+# friends) reflect the container's filesystem rather than whatever the host
+# last wrote. Must run before any on-create step that sources
+# scripts/dev/devenv (or set_env_context.sh, which wraps it) — otherwise
+# scripts like recreate_python_venv.sh `cd` into a host-only path that
+# doesn't exist inside the container.
+
+set -euo pipefail
+
+context=root-context
+if [ -f "/workspace/.generated/.current_context" ]; then
+    context=$(cat /workspace/.generated/.current_context)
+fi
+make switch context="${context}"

--- a/.devcontainer/scripts/on-create/05-evergreen-cli.sh
+++ b/.devcontainer/scripts/on-create/05-evergreen-cli.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Install the Evergreen CLI inside the container. Done at on-create time (not
+# in the Dockerfile) so the image stays stable across evergreen version bumps
+# and can be pre-built once and reused across worktrees.
+#
+# EVERGREEN_CLI_URL is resolved on the host by initialize/evergreen-cli.sh and
+# injected as an environment variable on the devcontainer service.
+
+set -euo pipefail
+
+if [ -z "${EVERGREEN_CLI_URL:-}" ]; then
+    echo "EVERGREEN_CLI_URL not set; skipping evergreen CLI install."
+    echo "(Re-open the devcontainer with the host evergreen binary on PATH to"
+    echo " auto-resolve, or install manually with:"
+    echo "    sudo curl -L <url> -o /usr/local/bin/evergreen && sudo chmod +x /usr/local/bin/evergreen)"
+    exit 0
+fi
+
+echo "Installing evergreen CLI from ${EVERGREEN_CLI_URL}"
+sudo curl -fsSL "${EVERGREEN_CLI_URL}" -o /usr/local/bin/evergreen
+sudo chmod +x /usr/local/bin/evergreen
+echo "Installed: $(/usr/local/bin/evergreen --version)"

--- a/.devcontainer/scripts/on-create/10-go.sh
+++ b/.devcontainer/scripts/on-create/10-go.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+go mod download

--- a/.devcontainer/scripts/on-create/10-go.sh
+++ b/.devcontainer/scripts/on-create/10-go.sh
@@ -2,4 +2,15 @@
 
 set -euo pipefail
 
-go mod download
+# proxy.golang.org egress from the EVG host flakes with HTTP/2 stream resets on a
+# cold module cache; force HTTP/1.1 and retry with backoff.
+export GODEBUG="${GODEBUG:+${GODEBUG},}http2client=0"
+for attempt in 1 2 3 4 5; do
+  if go mod download; then
+    exit 0
+  fi
+  echo "go mod download failed (attempt ${attempt}/5); retrying in $((attempt * 5))s..." >&2
+  sleep "$((attempt * 5))"
+done
+echo "go mod download failed after 5 attempts" >&2
+exit 1

--- a/.devcontainer/scripts/on-create/20-python-venv.sh
+++ b/.devcontainer/scripts/on-create/20-python-venv.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+/workspace/scripts/dev/recreate_python_venv.sh

--- a/.devcontainer/scripts/pane_runner.sh
+++ b/.devcontainer/scripts/pane_runner.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# pane_runner.sh — wrap a tmux pane command so Ctrl-C drops the user into
+# an interactive shell with the just-killed command sitting in history,
+# instead of closing the pane.
+#
+# Usage:
+#   pane_runner.sh <command...>
+#
+# Example (in tmuxp):
+#   shell_command:
+#     - exec /workspace/.devcontainer/scripts/pane_runner.sh \
+#         k9s --kubeconfig /workspace/.generated/current.devc.kubeconfig
+#
+# The command (joined and quoted) is pre-loaded into ${HISTFILE}, then run;
+# on exit (clean or Ctrl-C) an interactive zsh login shell is exec'd in its
+# place so the pane stays alive and Up recalls the command.
+#
+# We use zsh because the rest of the devcontainer's shell-init lives in
+# zsh (.zshrc invokes mck-env which sources context.env + context.devc.env
+# via scripts/dev/devenv, activates the venv, etc.).
+# Falls back to bash if zsh is missing.
+
+set -u
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <command...>" >&2
+  exit 64
+fi
+
+# Quote each arg so the recall in shell history reproduces the original
+# invocation faithfully (whitespace, special chars).
+quoted=""
+for a in "$@"; do
+  quoted+=" $(printf '%q' "${a}")"
+done
+quoted="${quoted# }"
+
+# Push into zsh and bash histories — whichever shell ends up running
+# the recall in, the entry is there. Use the user's actual home (HOME),
+# not /root, because the panes run as the devcontainer user.
+zsh_hist="${HOME}/.zsh_history"
+bash_hist="${HOME}/.bash_history"
+mkdir -p "$(dirname "${zsh_hist}")" 2>/dev/null || true
+# zsh extended history format: ': <ts>:0;<cmd>'
+printf ': %d:0;%s\n' "$(date +%s)" "${quoted}" >> "${zsh_hist}" 2>/dev/null || true
+printf '%s\n' "${quoted}" >> "${bash_hist}" 2>/dev/null || true
+
+# Catch (and ignore) SIGINT in the wrapper itself so a Ctrl-C in the
+# pane kills the wrapped command but doesn't kill *us* — the kernel
+# still delivers SIGINT to every process in the foreground process
+# group, so the child gets the signal directly; we just refuse to die.
+# Without this, bash exits with rc=130 after the child returns and tmux
+# closes the pane before we can `exec` the recovery shell below. (k9s
+# panes survived without this trap only because k9s installs its own
+# SIGINT handler and doesn't exit on Ctrl-C, so bash here stays parked
+# in `wait`. Anything that *does* exit on Ctrl-C — tail -F, sleep loops,
+# scripts — would otherwise take the pane down with it.)
+trap ':' INT
+"$@"
+rc=$?
+trap - INT
+
+echo
+echo "[pane_runner] command exited with code ${rc}; dropping into shell."
+echo "[pane_runner] press Up / run !! to recall: ${quoted}"
+echo
+
+if command -v zsh >/dev/null 2>&1; then
+  exec zsh -l
+else
+  exec bash -l
+fi

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# post-start.sh - Runs inside the container after starting.
+
+set -euo pipefail
+
+# In-container k8s-proxy doesn't persist its registered kubeconfig, so
+# every restart (force-recreate from a compose.user.yml override
+# reconcile, OOM, manual `docker compose restart`) drops it and silently
+# breaks cluster.local DNS. Re-PATCH on every container start so the
+# source-of-truth lives in /workspace/.generated/ (bind-mounted) rather
+# than the proxy's volatile memory. Best-effort, non-fatal: if the proxy
+# isn't reachable yet (e.g. the container is mid-boot) we skip.
+container_kubeconfig=/workspace/.generated/current.devc.kubeconfig
+if [[ -s "${container_kubeconfig}" ]]; then
+  curl --max-time 5 -fsS -X PATCH \
+    -H 'Content-Type: application/yaml' \
+    --data-binary @"${container_kubeconfig}" \
+    "http://k8s-proxy:80/kubeconfig" \
+    && echo "registered with in-container k8s-proxy on k8s-proxy:80" \
+    || echo "in-container k8s-proxy not reachable on k8s-proxy:80; skipping registration"
+else
+  echo "no .generated/current.devc.kubeconfig yet; skipping in-container k8s-proxy registration"
+fi
+
+# VS Code automatically forwards the host's ssh-agent socket and sets
+# SSH_AUTH_SOCK; the bare `devcontainer` CLI does not. If the var is unset we
+# simply skip the fan-out — the autossh sidecar will fail until the agent is
+# mounted explicitly via compose.user.yml, but the rest of the stack is fine.
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
+    echo "SSH_AUTH_SOCK is not set; skipping ssh-agent fan-out"
+    exit 0
+fi
+
+echo "SSH_AUTH_SOCK: ${SSH_AUTH_SOCK}"
+
+# The mounted host ssh-agent socket (Docker Desktop's
+# /run/host-services/ssh-auth.sock on macOS) is owned root:root mode 0660,
+# so the non-root user we run as (vscode) can't connect through it. socat
+# silently fails its upstream connect with "Permission denied" — the listen
+# socket /ssh-agent/socket accepts client connections but every forward
+# returns an error, autossh sees publickey-denied for every restart, and
+# kubectl through gost-proxy returns "Service Unavailable". chmod up the
+# mounted socket so the socat process can speak to the host agent.
+# Best-effort: the mount may be read-only on some hosts, so we don't fail
+# if it doesn't take.
+if [[ -S "${SSH_AUTH_SOCK}" ]]; then
+    sudo -n chmod 0666 "${SSH_AUTH_SOCK}" 2>/dev/null \
+        || chmod 0666 "${SSH_AUTH_SOCK}" 2>/dev/null \
+        || echo "post-start: warn: could not chmod ${SSH_AUTH_SOCK}; ssh-agent fan-out may fail"
+fi
+
+# The /ssh-agent volume mounts root:root on first creation, so the non-root
+# user can neither bind the relay socket there (socat fails EACCES) nor unlink
+# a stale socket a prior root process left. Take ownership up front.
+sudo -n chown "$(id -u):$(id -g)" /ssh-agent 2>/dev/null \
+    || echo "post-start: warn: could not chown /ssh-agent; ssh-agent relay may fail"
+
+# Tear down any prior relay before starting a fresh one. postStartCommand
+# re-fires on every container start and the socat loop is a persistent screen
+# session; `screen -wipe` only reaps DEAD sessions, so a still-running relay
+# would survive and race the new one — each rm-f'ing the other's listener so
+# /ssh-agent/socket never stays present. Quit live sessions by name, kill any
+# orphaned socat, then clear the stale socket socat refuses to re-bind.
+# `screen -ls` exits 1 when no sessions exist (the fresh-container case), which
+# would trip pipefail+set -e; swallow it so first boot doesn't fail here.
+{ screen -ls 2>/dev/null || true; } | awk '/[0-9]+\.ssh-agent-proxy\b/ {print $1}' | while read -r s; do
+    screen -S "${s}" -X quit 2>/dev/null || true
+done
+pkill -f 'UNIX-LISTEN:/ssh-agent/socket' 2>/dev/null || true
+screen -wipe >/dev/null 2>&1 || true
+rm -f /ssh-agent/socket
+
+# Wrap socat in a respawn loop: if the host's ssh-agent forwarding hiccups
+# (Docker Desktop restart, system sleep/wake, agent rotation) socat exits.
+# Without the loop the autossh sidecar would poll forever waiting for the
+# socket to come back, since post-start.sh only fires on devcontainer start.
+# SSH_AUTH_SOCK is expanded here on purpose so the value gets baked into the
+# command run inside the screen subshell. Everything else stays literal.
+# shellcheck disable=SC2016  # The $(...) / ${...} inside the body run in screen's bash, not here.
+screen -dmS ssh-agent-proxy bash -c '
+    while true; do
+        rm -f /ssh-agent/socket
+        socat -d UNIX-LISTEN:/ssh-agent/socket,fork,mode=777 \
+              UNIX-CONNECT:'"${SSH_AUTH_SOCK}"' \
+            >> /tmp/socat-ssh-agent.log 2>&1
+        echo "[$(date -Is)] socat exited; restarting in 1s" \
+            >> /tmp/socat-ssh-agent.log
+        sleep 1
+    done
+'
+
+# Best-effort registration with the host kube-forwarding-proxy. Routed through
+# wt-ctl so the cluster/context/user names get suffixed with the worktree's
+# MCK_DEVC_PROXY_PORT in-flight — without this, every devc start would
+# overwrite peer worktrees' entries on the shared launchd daemon.
+host_kubeconfig=/workspace/.generated/current.kubeconfig
+if [[ -s "${host_kubeconfig}" ]]; then
+  /workspace/scripts/dev/wt-ctl --quiet kfp register \
+    --url http://host.docker.internal:11616 \
+    --kubeconfig "${host_kubeconfig}" \
+    || echo "host kfp register failed (non-fatal); kubectl through proxy-url still works locally."
+else
+  echo "no .generated/current.kubeconfig yet; skipping host kfp registration"
+fi

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -23,14 +23,11 @@ else
 fi
 
 # VS Code automatically forwards the host's ssh-agent socket and sets
-# SSH_AUTH_SOCK; the bare `devcontainer` CLI does not. If the var is unset we
-# simply skip the fan-out — the autossh sidecar will fail until the agent is
-# mounted explicitly via compose.user.yml, but the rest of the stack is fine.
-if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
-    echo "SSH_AUTH_SOCK is not set; skipping ssh-agent fan-out"
-    exit 0
-fi
-
+# SSH_AUTH_SOCK; the bare `devcontainer` CLI does not. When it's unset we skip
+# only the ssh-agent fan-out (the autossh sidecar stays down until the agent
+# is mounted via compose.user.yml) and still run host kfp registration below —
+# agentless / local-kind devc modes need it after every proxy restart.
+if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
 echo "SSH_AUTH_SOCK: ${SSH_AUTH_SOCK}"
 
 # The mounted host ssh-agent socket (Docker Desktop's
@@ -88,6 +85,9 @@ screen -dmS ssh-agent-proxy bash -c '
         sleep 1
     done
 '
+else
+    echo "SSH_AUTH_SOCK is not set; skipping ssh-agent fan-out"
+fi
 
 # Best-effort registration with the host kube-forwarding-proxy. Routed through
 # wt-ctl so the cluster/context/user names get suffixed with the worktree's

--- a/.devcontainer/shell-init.sh
+++ b/.devcontainer/shell-init.sh
@@ -1,0 +1,44 @@
+# MCK devcontainer shell init.
+#
+# Loaded from /home/vscode/.bashrc and /home/vscode/.zshrc on every shell
+# start (sourced, not exec'd, so it cannot use shebang/set semantics).
+#
+# Two responsibilities:
+#   1. ALWAYS source the per-side env (.generated/context.env +
+#      .generated/context.devc.env via scripts/dev/devenv) and activate the
+#      project venv whenever devenv exists, regardless of shell mode.
+#      Bash interactive panes, zsh tmuxp panes, and orchestrator-spawned
+#      `bash -lc` shells must all see the same PROJECT_DIR / KUBECONFIG /
+#      NAMESPACE / PATH. Do not gate this on `[[ $- == *i* ]]`: some zsh
+#      contexts (tmuxp panes) aren't flagged interactive and would miss the
+#      project env.
+#   2. For interactive shells with no $TMUX (i.e. the user just attached
+#      to the devcontainer), exec the 'mck' tmuxp session. Set
+#      MCK_NO_TMUX=1 to opt out (dc_attach.sh does this when given args).
+
+if [[ -f /workspace/scripts/dev/devenv ]]; then
+    cd /workspace 2>/dev/null || true
+    # devenv detects /.dockerenv and picks context.devc.env automatically.
+    # If files are missing (on-create not finished, or fresh worktree
+    # without `make switch`), devenv prints a loud warning and we
+    # continue.
+    # shellcheck disable=SC1091
+    . /workspace/scripts/dev/devenv || true
+fi
+
+# mck-env: ergonomic re-source after `make switch`. Defined for every
+# shell, interactive or not, so scripts and dev shells share the same
+# entry point. Fails non-zero if files are missing — propagates to caller.
+mck-env() {
+    # shellcheck disable=SC1091
+    . /workspace/scripts/dev/devenv
+}
+
+if [[ -z "${TMUX:-}" && $- == *i* && -z "${MCK_NO_TMUX:-}" ]]; then
+    if command -v tmuxp >/dev/null 2>&1 \
+            && [[ -f /workspace/.devcontainer/tmuxp/mck.yaml ]]; then
+        exec tmuxp load -y /workspace/.devcontainer/tmuxp/mck.yaml
+    else
+        exec tmux new-session -A -s mck
+    fi
+fi

--- a/.devcontainer/tmuxp/mck.yaml
+++ b/.devcontainer/tmuxp/mck.yaml
@@ -1,0 +1,68 @@
+# tmuxp session for the MCK devcontainer.
+#
+# Loaded automatically when the user attaches to the devcontainer (see
+# .devcontainer/shell-init.sh) or via `scripts/dev/dc_attach.sh`. If a
+# session named 'mck' already exists, tmuxp attaches to it instead of
+# rebuilding it (because the shell-init invocation passes -y).
+#
+# Layout (main-horizontal):
+#
+#     +--------------------------------------------+
+#     |                                            |
+#     |                k9s                         |
+#     |                                            |
+#     +-----------+----------------+---------------+
+#     | operator  | e2e test       | zsh -l        |
+#     | log       | log            |               |
+#     +-----------+----------------+---------------+
+#
+# Both log panes use .devcontainer/scripts/log_follower.sh so they keep
+# showing logs across file truncation, rotation, and not-yet-existence.
+
+session_name: mck
+start_directory: /workspace
+
+windows:
+  - window_name: mck
+    # main-horizontal puts the first pane on top spanning full width
+    # and stacks the remaining panes side-by-side underneath.
+    layout: main-horizontal
+    options:
+      # tmux >= 3.2 accepts a percentage; gives the top (k9s) pane the
+      # bulk of the vertical space.
+      main-pane-height: 70%
+    panes:
+      # All panes (except the dedicated zsh) are wrapped in pane_runner.sh.
+      # Ctrl-C / clean-exit drops the user into an interactive zsh with
+      # the wrapped command pre-loaded into history (Up / !!), instead of
+      # closing the pane. Recover from a crash without rebuilding the
+      # whole tmux session.
+      #
+      # Top pane (k9s). The .devc.kubeconfig variant has its proxy-url
+      # patched to http://gost-proxy:8080 so it routes through the
+      # in-container HTTP-CONNECT tunnel. k9s reloads on disk change,
+      # so context switches inside the container propagate without
+      # restarting this pane.
+      #
+      # Source devenv so NAMESPACE is exported, then launch k9s pinned to
+      # the worktree's namespace and the pods view (otherwise k9s lands
+      # on the welcome screen / empty default namespace).
+      - shell_command:
+          - . /workspace/scripts/dev/devenv 2>/dev/null
+          - exec /workspace/.devcontainer/scripts/pane_runner.sh k9s --kubeconfig /workspace/.generated/current.devc.kubeconfig -n "${NAMESPACE:-default}" -c pods
+      # Bottom-left: operator log (logs/operator.log is the stable
+      # symlink op_run.sh maintains across runs).
+      - shell_command:
+          - exec /workspace/.devcontainer/scripts/pane_runner.sh /workspace/.devcontainer/scripts/log_follower.sh /workspace/logs/operator.log operator
+      # Bottom-middle: latest e2e test log (logs/test.log is the
+      # stable symlink e2e_run.sh maintains across runs).
+      - shell_command:
+          - exec /workspace/.devcontainer/scripts/pane_runner.sh /workspace/.devcontainer/scripts/log_follower.sh /workspace/logs/test.log e2e
+      # Bottom-right: an interactive zsh. The shell-init sourced from
+      # .zshrc loads /workspace/.generated/context.env +
+      # context.devc.env (via scripts/dev/devenv / mck-env) and activates
+      # the venv before the prompt appears. Not wrapped — it's already a
+      # shell.
+      - shell_command:
+          - exec zsh -l
+        focus: true

--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -323,6 +323,16 @@ functions:
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         binary: scripts/test/bash/run.sh
 
+  test_bash:
+    - command: subprocess.exec
+      type: test
+      params:
+        add_to_path:
+          - ${workdir}/bin
+          - ${workdir}/venv/bin
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        binary: scripts/test/bash/run.sh
+
   # Configures docker authentication to ECR and RH registries.
   setup_building_host:
     - *python_venv
@@ -654,7 +664,7 @@ functions:
         shell: bash
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         script: |
-          source .generated/context.export.env
+          source scripts/dev/set_env_context.sh
           scripts/dev/run_python.sh scripts/evergreen/e2e/setup_cloud_qa.py delete_all
 
   # Updates current expansions with variables from release.json file.
@@ -741,6 +751,30 @@ functions:
           - ${workdir}/bin
         binary: scripts/evergreen/e2e/e2e.sh
 
+  # e2e_devcontainer_local_kind runs an e2e marker via the wt-ctl --local-kind
+  # flow on the task host: kind on the host, operator as `go run`, tests as
+  # pytest, all inside the devcontainer. No images are built — everything
+  # resolves to :latest ECR tags — so tasks using this function carry no
+  # build_*_image dependencies. The pytest marker comes from the e2e_marker
+  # task var (falling back to task_name).
+  e2e_devcontainer_local_kind:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        # Forward the full e2e expansion set (workdir, cloud-qa/cognito/aws
+        # creds, build_variant, …). wt-ctl re-runs `make switch`, which sources
+        # evg-private-context (copied to private-context by setup_context) and
+        # references these under `set -u`.
+        <<: *e2e_include_expansions_in_env
+        add_to_path:
+          - ${workdir}/bin
+        env:
+          RUNNING_IN_EVG: "true"
+          e2e_marker: ${e2e_marker}
+          e2e_context: ${e2e_context}
+        binary: scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
+
   e2e_test_perf:
     # Perf tasks provision and roll many deployments; the 300-deployment task exceeds the
     # global 2h exec_timeout_secs. Raise the limit for perf tasks only.
@@ -788,7 +822,7 @@ functions:
         shell: bash
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         script: |
-          source .generated/context.export.env
+          source scripts/dev/set_env_context.sh
           make helm-tests
 
   test_python_unit:
@@ -824,7 +858,7 @@ functions:
         shell: bash
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         script: |
-          source .generated/context.export.env
+          source scripts/dev/set_env_context.sh
           scripts/dev/run_python.sh scripts/evergreen/e2e/performance/create_variants.py ${variant} ${size}> evergreen_tasks.json
           echo "tasks to run:"
           cat evergreen_tasks.json

--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -323,16 +323,6 @@ functions:
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         binary: scripts/test/bash/run.sh
 
-  test_bash:
-    - command: subprocess.exec
-      type: test
-      params:
-        add_to_path:
-          - ${workdir}/bin
-          - ${workdir}/venv/bin
-        working_dir: src/github.com/mongodb/mongodb-kubernetes
-        binary: scripts/test/bash/run.sh
-
   # Configures docker authentication to ECR and RH registries.
   setup_building_host:
     - *python_venv

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1467,6 +1467,49 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  # On-host devcontainer variants: each drives an e2e marker through wt-ctl
+  # --local-kind (kind + operator + pytest on the task host, no built images).
+  # e2e_marker + e2e_context fully parametrize the run — the runner derives
+  # topology and cloud_qa vs OM-in-cluster from the context itself. clone runs in
+  # the task group's setup_group; diagnostics are archived by teardown_task's
+  # upload_e2e_logs, exactly as for a normal e2e task.
+
+  # Search — multi-cluster replica set (cloud_qa).
+  - name: e2e_devc_search_connectivity_tool_mc_rs
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_devcontainer_local_kind"
+        vars:
+          e2e_marker: e2e_search_connectivity_tool_mc_rs
+          e2e_context: e2e_multi_cluster_kind
+
+  # Search — single-cluster replica set (cloud_qa).
+  - name: e2e_devc_search_connectivity_tool_rs
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_devcontainer_local_kind"
+        vars:
+          e2e_marker: e2e_search_connectivity_tool
+          e2e_context: e2e_mdb_kind_ubi_cloudqa
+
+  # OM8 — single-cluster (Ops Manager deployed in-cluster, no cloud_qa).
+  - name: e2e_devc_om8_ops_manager_pod_spec
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_devcontainer_local_kind"
+        vars:
+          e2e_marker: e2e_om_ops_manager_pod_spec
+          e2e_context: e2e_om80_kind_ubi
+
+  # OM8 — multi-cluster AppDB (Ops Manager deployed in-cluster, no cloud_qa).
+  - name: e2e_devc_om8_multi_cluster_om_appdb
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_devcontainer_local_kind"
+        vars:
+          e2e_marker: e2e_multi_cluster_om_appdb_no_mesh
+          e2e_context: e2e_multi_cluster_om_appdb
+
   - name: e2e_search_connectivity_tool_mc_sharded
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1501,15 +1501,6 @@ tasks:
           e2e_marker: e2e_om_ops_manager_pod_spec
           e2e_context: e2e_om80_kind_ubi
 
-  # OM8 — multi-cluster AppDB (Ops Manager deployed in-cluster, no cloud_qa).
-  - name: e2e_devc_om8_multi_cluster_om_appdb
-    tags: [ "patch-run" ]
-    commands:
-      - func: "e2e_devcontainer_local_kind"
-        vars:
-          e2e_marker: e2e_multi_cluster_om_appdb_no_mesh
-          e2e_context: e2e_multi_cluster_om_appdb
-
   - name: e2e_search_connectivity_tool_mc_sharded
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1930,7 +1930,7 @@ buildvariants:
   # :latest ECR tags, so nothing is built for this variant.
   - name: e2e_mck_devcontainer_local_kind
     display_name: e2e_mck_devcontainer_local_kind
-    tags: [ "e2e_test_suite", "cloudqa" ]
+    tags: [ "pr_patch_e2e", "e2e_test_suite", "cloudqa" ]
     <<: *production_code_paths
     run_on:
       - ubuntu2404-large

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -932,11 +932,14 @@ task_groups:
     teardown_task_can_fail_task: true
     teardown_task:
       - func: upload_e2e_logs
+    # No-mesh MC OM (e2e_devc_om8_multi_cluster_om_appdb) is deliberately
+    # excluded: this flow runs the operator locally via `go run`, whose Docker
+    # embedded DNS (127.0.0.11) can't resolve the external nginx-ext-svc-*
+    # interconnect the no-mesh topology relies on, so that test can't pass here.
     tasks:
       - e2e_devc_search_connectivity_tool_rs
       - e2e_devc_search_connectivity_tool_mc_rs
       - e2e_devc_om8_ops_manager_pod_spec
-      - e2e_devc_om8_multi_cluster_om_appdb
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.
   # Uses setup_and_teardown_task (not cloudqa) since ops_manager_version is not 'cloud_qa'.

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -916,6 +916,28 @@ task_groups:
       - e2e_search_sharded_internal_mongodb_single_mongot
     <<: *teardown_group
 
+  # On-host devcontainer local-kind group: each task drives an e2e marker
+  # through wt-ctl --local-kind on the task host (no images built). The runner
+  # does all its own host + container setup, so setup_group only needs clone.
+  # teardown_task's upload_e2e_logs archives ./logs (wt-ctl phase logs, pytest
+  # logs, gathered k8s diagnostics, the HTML summary) to S3 under this task's
+  # logs/${task_id}/${execution}/ — the same path a normal e2e task uses.
+  # max_hosts: -1 lets Evergreen give each task its own host (fresh clone +
+  # kind), avoiding cross-task state on a shared host.
+  - name: e2e_devc_local_kind_task_group
+    max_hosts: -1
+    setup_group_can_fail_task: true
+    setup_group:
+      - func: clone
+    teardown_task_can_fail_task: true
+    teardown_task:
+      - func: upload_e2e_logs
+    tasks:
+      - e2e_devc_search_connectivity_tool_rs
+      - e2e_devc_search_connectivity_tool_mc_rs
+      - e2e_devc_om8_ops_manager_pod_spec
+      - e2e_devc_om8_multi_cluster_om_appdb
+
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.
   # Uses setup_and_teardown_task (not cloudqa) since ops_manager_version is not 'cloud_qa'.
   # Metrics-forwarder tests require Ops Manager, so they run only on the om variant.
@@ -1901,6 +1923,19 @@ buildvariants:
     <<: *base_om7_dependency
     tasks:
       - name: e2e_multi_cluster_2_clusters_task_group
+
+  # On-host devcontainer variant: runs the wt-ctl --local-kind MC flow on the
+  # task host (kind + operator + pytest in the devcontainer). Deliberately no
+  # base_om7_dependency and no OVERRIDE_VERSION_ID — images resolve to the
+  # :latest ECR tags, so nothing is built for this variant.
+  - name: e2e_mck_devcontainer_local_kind
+    display_name: e2e_mck_devcontainer_local_kind
+    tags: [ "e2e_test_suite", "cloudqa" ]
+    <<: *production_code_paths
+    run_on:
+      - ubuntu2404-large
+    tasks:
+      - name: e2e_devc_local_kind_task_group
 
   - name: e2e_multi_cluster_om_appdb
     display_name: e2e_multi_cluster_om_appdb

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,15 @@ docker/mongodb-enterprise-ops-manager/scripts/mmsconfiguration
 docker/mongodb-kubernetes-tests/public
 
 my-*
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/launch.json
 .env
+/.devcontainer/.envs/
+/.devcontainer/compose.generated.yml
+/.devcontainer/compose.user.yml
+/.devcontainer/scripts/*/*.user.sh
 data
 cache
 **/__pycache__
@@ -35,6 +42,11 @@ __debug_bin*
 .generated/
 scripts/dev/contexts/private-context
 scripts/dev/contexts/private-context-*
+
+# On-disk backups bats tests keep beside the originals (they survive a SIGKILL
+# that skips teardown; the next run self-heals them). Ignore so an aborted run
+# never dirties the tree.
+*.bats-bak
 
 # On Evergreen we install uv in the project directory, so make sure it's ignored
 /.uv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,7 +186,22 @@ repos:
         exclude: |
           (?x)^(
             vendor/.*|
-            testdata/.*
+            testdata/.*|
+            \.devcontainer/devcontainer\.json$|
+            \.devcontainer/features/.*/devcontainer-feature\.json$
+          )
+
+  - repo: local
+    hooks:
+      - id: check-jsonc
+        name: check-jsonc
+        description: Validate JSONC files (JSON with //, /*…*/ comments and trailing commas).
+        entry: python3 scripts/dev/validate_jsonc.py
+        language: system
+        files: |
+          (?x)^(
+            \.devcontainer/devcontainer\.json$|
+            \.devcontainer/features/.*/devcontainer-feature\.json$
           )
         priority: 6
 
@@ -233,3 +248,5 @@ repos:
       - id: golangci-lint-fmt
         language_version: 1.26.5
         priority: 6
+
+

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,23 @@ switch:
 switcht:
 	@ scripts/dev/switch_context_by_test.sh $(test)
 
+# Re-run switch_context against whatever context is currently pinned in
+# .generated/.current_context. Useful after crossing the host/devcontainer
+# boundary: per-side files are .generated/context.<side>.env, so the OTHER
+# side's site bytes are written into a different file and don't clobber
+# this side's. `make regenerate-context` is the canonical fix-it-now
+# command (e.g. after a worktree move that changes PROJECT_DIR). Falls
+# back to a clear error if no context has been picked yet.
+regenerate-context:
+	@ if [[ ! -s .generated/.current_context ]]; then \
+		echo "ERROR: .generated/.current_context is missing or empty." >&2; \
+		echo "Run 'make switch context=<name>' first." >&2; \
+		exit 1; \
+	fi; \
+	current="$$(cat .generated/.current_context)"; \
+	echo "Regenerating context for: $${current}"; \
+	scripts/dev/switch_context.sh "$${current}"
+
 # runs the e2e test: make e2e test=e2e_sharded_cluster_pv. The Operator is redeployed before the test, the namespace is cleaned.
 # The e2e test image is built and pushed together with all main ones (operator, database, init containers)
 # Use 'light=true' parameter to skip images rebuilding - use this mode when you are focused on e2e tests development only

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -125,6 +125,38 @@ SLEEP_TIME = 2
 INFINITY = -1
 
 
+def load_proxy_config(
+    kube_config: config.kube_config.ConfigNode,
+    configuration: kubernetes.client.Configuration,
+    context_name: Optional[str] = None,
+):
+    """
+    Loads proxy configuration from kubeconfig if it exists for the current context and sets it in the provided configuration object.
+    Returns True if proxy configuration was found and set, False otherwise.
+    """
+    context_name = context_name or (str(kube_config["current-context"]) if "current-context" in kube_config else None)
+    context_entry = (
+        next((c for c in kube_config["contexts"] if c["name"] == context_name), None)
+        if "contexts" in kube_config
+        else None
+    )
+    cluster_name = context_entry["context"]["cluster"] if context_entry else None
+    cluster_entry = (
+        next((c for c in kube_config["clusters"] if c["name"] == cluster_name), None)
+        if "clusters" in kube_config
+        else None
+    )
+    proxy_url = (
+        cluster_entry["cluster"]["proxy-url"] if cluster_entry and "proxy-url" in cluster_entry["cluster"] else None
+    )
+
+    if isinstance(proxy_url, str) and len(proxy_url) > 0:
+        configuration.proxy = proxy_url
+        return True
+
+    return False
+
+
 class KubernetesTester(object):
     """
     KubernetesTester is the base class for all python tests. It deliberately doesn't have object state
@@ -381,7 +413,11 @@ class KubernetesTester(object):
     def load_configuration():
         "Loads kubernetes client configuration from kubectl config or incluster."
         try:
-            config.load_kube_config()
+            merger = config.kube_config.KubeConfigMerger(config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION)
+            configuration = kubernetes.client.Configuration()
+            config.load_kube_config_from_dict(merger.config, client_configuration=configuration)
+            load_proxy_config(merger.config, configuration)
+            client.Configuration.set_default(configuration)
         except Exception:
             config.load_incluster_config()
 

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -21,22 +21,35 @@ else:
 
 
 def _load_env_from_local_file_for_development():
-    """Load environment variables from .generated/context.env for local development.
-    Similar to operator's loadEnvFromLocalFileForDevelopment() - only loads if
-    NAMESPACE env var is not already set (i.e., not running in CI/Evergreen).
+    """Load environment variables from .generated/context.{env,<side>.env}
+    for local development. Mirrors the operator's
+    loadEnvFromLocalFileForDevelopment() — only loads if NAMESPACE env var
+    is not already set (i.e. not running in CI/Evergreen).
+
+    Side detection follows the same /.dockerenv rule used by
+    scripts/dev/devenv and main.go's env loader. Files are loaded with
+    override=True so site bytes layer over logical bytes correctly.
     """
-    # Path relative to this file: tests/conftest.py -> ../../../.. -> repo root
-    env_file = Path(__file__).joinpath("..", "..", "..", "..", ".generated", "context.env").resolve()
-
-    if not env_file.exists():
-        return
-
     if os.environ.get("NAMESPACE"):
-        print(f"NAMESPACE already set, skipping loading environment variables from {env_file}")
+        print("NAMESPACE already set, skipping loading environment variables from .generated/")
         return
 
-    load_dotenv(env_file)
-    print(f"Loaded environment variables from file {env_file}")
+    # Path relative to this file: tests/conftest.py -> ../../../.. -> repo root
+    repo_root = Path(__file__).joinpath("..", "..", "..", "..").resolve()
+    side = "devc" if Path("/.dockerenv").exists() else "host"
+
+    env_files = [
+        repo_root / ".generated" / "context.env",
+        repo_root / ".generated" / f"context.{side}.env",
+    ]
+    for env_file in env_files:
+        if not env_file.exists():
+            print(
+                f"WARN: env file {env_file} not found (run 'make switch' on the {side} side); skipping.",
+            )
+            continue
+        load_dotenv(env_file, override=True)
+        print(f"Loaded environment variables from file {env_file}")
 
 
 _load_env_from_local_file_for_development()
@@ -61,7 +74,7 @@ from kubetester.awss3client import AwsS3Client
 from kubetester.helm import helm_chart_path_and_version, helm_install_from_chart, helm_repo_add
 from kubetester.kubetester import KubernetesTester
 from kubetester.kubetester import fixture as _fixture
-from kubetester.kubetester import running_locally
+from kubetester.kubetester import load_proxy_config, running_locally
 from kubetester.multicluster_client import MultiClusterClient
 from kubetester.omtester import OMContext, OMTester
 from kubetester.operator import Operator
@@ -86,7 +99,14 @@ from tests.constants import (
 from tests.multicluster import prepare_multi_cluster_namespaces
 
 try:
-    kubernetes.config.load_kube_config()
+    # Merge kubeconfig and honor per-cluster proxy-url (e.g. gost-proxy in devcontainer).
+    # The plain load_kube_config() ignores proxy-url, which breaks API access from inside
+    # the devcontainer where the host-mapped 127.0.0.1:<port> is unreachable directly.
+    _merger = kubernetes.config.kube_config.KubeConfigMerger(kubernetes.config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION)
+    _configuration = kubernetes.client.Configuration()
+    kubernetes.config.load_kube_config_from_dict(_merger.config, client_configuration=_configuration)
+    load_proxy_config(_merger.config, _configuration)
+    kubernetes.client.Configuration.set_default(_configuration)
 except Exception:
     kubernetes.config.load_incluster_config()
 
@@ -1227,11 +1247,12 @@ def _get_client_for_cluster(
         raise ValueError(f"No token found for cluster {cluster_name}")
 
     configuration = kubernetes.client.Configuration()
-    kubernetes.config.load_kube_config(
-        context=cluster_name,
-        config_file=os.environ.get("KUBECONFIG", KUBECONFIG_FILEPATH),
-        client_configuration=configuration,
+    merger = kubernetes.config.kube_config.KubeConfigMerger(os.environ.get("KUBECONFIG", KUBECONFIG_FILEPATH))
+    load_proxy_config(merger.config, configuration, cluster_name)
+    kubernetes.config.load_kube_config_from_dict(
+        merger.config, context=cluster_name, client_configuration=configuration
     )
+
     configuration.host = CLUSTER_HOST_MAPPING.get(cluster_name, configuration.host)
 
     configuration.verify_ssl = False

--- a/docker/mongodb-kubernetes-tests/tests/kind_network.py
+++ b/docker/mongodb-kubernetes-tests/tests/kind_network.py
@@ -1,0 +1,51 @@
+"""Single source of truth for kind docker network IPs used by E2E tests.
+
+Mirrors `scripts/funcs/kind_network` (bash). Tests that hardcoded
+``172.18.255.x`` should import from here so the kind subnet stays
+configurable end-to-end via ``KIND_NETWORK_SUBNET`` (default
+``172.18.0.0/16``).
+
+Convention (10-IP-wide slots within ``${PREFIX}.255.0/24``):
+    .200-.209  kind-e2e-operator (and the single 'kind' cluster)
+    .210-.219  kind-e2e-cluster-1
+    .220-.229  kind-e2e-cluster-2
+    .230-.239  kind-e2e-cluster-3
+"""
+
+from __future__ import annotations
+
+import os
+from ipaddress import IPv4Address, IPv4Network
+
+
+def _prefix(subnet: str) -> str:
+    """Return the leading two octets of an IPv4 ``a.b.c.d/p`` subnet string."""
+    network = IPv4Network(subnet)
+    octets = str(network.network_address).split(".")
+    return f"{octets[0]}.{octets[1]}"
+
+
+# Defaults preserve the historical 172.18.0.0/16 hardcoding so existing
+# tests/tooling keep working unchanged. Override KIND_NETWORK_SUBNET in
+# the environment to use a different /16 (the bash side reads the same
+# variable from scripts/funcs/kind_network).
+KIND_NETWORK_SUBNET: str = os.environ.get("KIND_NETWORK_SUBNET", "172.18.0.0/16")
+KIND_NETWORK_PREFIX: str = _prefix(KIND_NETWORK_SUBNET)
+
+
+def kind_lb_ip(cluster_slot: int, offset: int = 0) -> IPv4Address:
+    """Return the metallb LB IP at ``${prefix}.255.{slot+offset}``."""
+    return IPv4Address(f"{KIND_NETWORK_PREFIX}.255.{cluster_slot + offset}")
+
+
+def kind_lb_ip_str(cluster_slot: int, offset: int = 0) -> str:
+    """String form of :func:`kind_lb_ip`. Convenient for code that builds
+    YAML manifests / passes IPs to kubectl as plain strings."""
+    return str(kind_lb_ip(cluster_slot, offset))
+
+
+# Per-cluster slot constants.
+KIND_LB_SLOT_OPERATOR = 200  # kind-e2e-operator (and single 'kind')
+KIND_LB_SLOT_CLUSTER_1 = 210
+KIND_LB_SLOT_CLUSTER_2 = 220
+KIND_LB_SLOT_CLUSTER_3 = 230

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
@@ -30,6 +30,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import assert_data_got_restored, update_coredns_hosts
+from tests.kind_network import KIND_LB_SLOT_CLUSTER_1, KIND_LB_SLOT_CLUSTER_2, KIND_LB_SLOT_CLUSTER_3, kind_lb_ip_str
 
 TEST_DATA = {"_id": "unique_id", "name": "John", "address": "Highway 37", "age": 30}
 
@@ -246,43 +247,43 @@ def oplog_user(
 @fixture(scope="module")
 def replica_set_external_hosts() -> List[Tuple[str, str]]:
     return [
-        ("172.18.255.211", "test.kind-e2e-cluster-1.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1), "test.kind-e2e-cluster-1.interconnected"),
         (
-            "172.18.255.211",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1),
             "multi-replica-set-one-0-0.kind-e2e-cluster-1.interconnected",
         ),
         (
-            "172.18.255.212",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 2),
             "multi-replica-set-one-0-1.kind-e2e-cluster-1.interconnected",
         ),
         (
-            "172.18.255.213",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 3),
             "multi-replica-set-one-0-2.kind-e2e-cluster-1.interconnected",
         ),
-        ("172.18.255.221", "test.kind-e2e-cluster-2.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 1), "test.kind-e2e-cluster-2.interconnected"),
         (
-            "172.18.255.221",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 1),
             "multi-replica-set-one-1-0.kind-e2e-cluster-2.interconnected",
         ),
         (
-            "172.18.255.222",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 2),
             "multi-replica-set-one-1-1.kind-e2e-cluster-2.interconnected",
         ),
         (
-            "172.18.255.223",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 3),
             "multi-replica-set-one-1-2.kind-e2e-cluster-2.interconnected",
         ),
-        ("172.18.255.231", "test.kind-e2e-cluster-3.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 1), "test.kind-e2e-cluster-3.interconnected"),
         (
-            "172.18.255.231",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 1),
             "multi-replica-set-one-2-0.kind-e2e-cluster-3.interconnected",
         ),
         (
-            "172.18.255.232",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 2),
             "multi-replica-set-one-2-1.kind-e2e-cluster-3.interconnected",
         ),
         (
-            "172.18.255.233",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 3),
             "multi-replica-set-one-2-2.kind-e2e-cluster-3.interconnected",
         ),
     ]

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
@@ -12,6 +12,7 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.common.placeholders import placeholders
 from tests.conftest import update_coredns_hosts
+from tests.kind_network import KIND_LB_SLOT_CLUSTER_1, KIND_LB_SLOT_CLUSTER_2, KIND_LB_SLOT_CLUSTER_3, kind_lb_ip_str
 from tests.multicluster.conftest import cluster_spec_list
 
 CERT_SECRET_PREFIX = "clustercert"
@@ -158,43 +159,43 @@ def server_certs(
 @mark.e2e_multi_cluster_tls_no_mesh
 def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient]):
     hosts = [
-        ("172.18.255.211", "test.kind-e2e-cluster-1.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1), "test.kind-e2e-cluster-1.interconnected"),
         (
-            "172.18.255.211",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1),
             "multi-cluster-replica-set-0-0.kind-e2e-cluster-1.interconnected",
         ),
         (
-            "172.18.255.212",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 2),
             "multi-cluster-replica-set-0-1.kind-e2e-cluster-1.interconnected",
         ),
         (
-            "172.18.255.213",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 3),
             "multi-cluster-replica-set-0-2.kind-e2e-cluster-1.interconnected",
         ),
-        ("172.18.255.221", "test.kind-e2e-cluster-2.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 1), "test.kind-e2e-cluster-2.interconnected"),
         (
-            "172.18.255.221",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 1),
             "multi-cluster-replica-set-1-0.kind-e2e-cluster-2.interconnected",
         ),
         (
-            "172.18.255.222",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 2),
             "multi-cluster-replica-set-1-1.kind-e2e-cluster-2.interconnected",
         ),
         (
-            "172.18.255.223",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 3),
             "multi-cluster-replica-set-1-2.kind-e2e-cluster-2.interconnected",
         ),
-        ("172.18.255.231", "test.kind-e2e-cluster-3.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 1), "test.kind-e2e-cluster-3.interconnected"),
         (
-            "172.18.255.231",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 1),
             "multi-cluster-replica-set-2-0.kind-e2e-cluster-3.interconnected",
         ),
         (
-            "172.18.255.232",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 2),
             "multi-cluster-replica-set-2-1.kind-e2e-cluster-3.interconnected",
         ),
         (
-            "172.18.255.233",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 3),
             "multi-cluster-replica-set-2-2.kind-e2e-cluster-3.interconnected",
         ),
     ]

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
@@ -27,6 +27,7 @@ from tests.conftest import (
     get_member_cluster_clients,
     update_coredns_hosts,
 )
+from tests.kind_network import KIND_LB_SLOT_CLUSTER_1, KIND_LB_SLOT_CLUSTER_2, KIND_LB_SLOT_CLUSTER_3, kind_lb_ip_str
 from tests.multicluster_appdb.conftest import create_s3_bucket_blockstore, create_s3_bucket_oplog
 
 from .. import test_logger
@@ -126,55 +127,55 @@ def s3_bucket_oplog(namespace: str, aws_s3_client: AwsS3Client) -> str:
 def test_configure_dns(disable_istio):
     host_mappings = [
         (
-            "172.18.255.211",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1),
             NGINX_EXT_SVC_COREDNS_HOSTNAME,
         ),
         (
-            "172.18.255.212",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 2),
             OM_DB_0_0_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.213",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 3),
             OM_1_EXT_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.214",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 4),
             MDB_0_0_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.221",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 1),
             OM_DB_1_0_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.222",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 2),
             OM_DB_1_1_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.223",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 3),
             OM_2_EXT_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.224",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_2, 4),
             MDB_1_0_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.231",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 1),
             OM_DB_2_0_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.232",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 2),
             OM_DB_2_1_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.233",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 3),
             OM_DB_2_2_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.234",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 4),
             OM_3_EXT_SVC_HOSTNAME,
         ),
         (
-            "172.18.255.235",
+            kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_3, 5),
             MDB_2_0_SVC_HOSTNAME,
         ),
     ]

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_connectivity.py
@@ -7,6 +7,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import is_multi_cluster
+from tests.kind_network import KIND_LB_SLOT_CLUSTER_1, kind_lb_ip_str
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 
 
@@ -55,7 +56,7 @@ def test_set_external_connectivity_load_balancer_with_default_port(
 ):
     ext_connectivity = {
         "type": "LoadBalancer",
-        "loadBalancerIP": "172.18.255.211",
+        "loadBalancerIP": kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1),
         "externalTrafficPolicy": "Local",
         "annotations": {
             "first-annotation": "first-value",
@@ -79,7 +80,7 @@ def test_set_external_connectivity_load_balancer_with_default_port(
         assert external.spec.type == "LoadBalancer"
         assert len(external.spec.ports) == 1
         assert external.spec.ports[0].port == 8080  # if not specified it will be the default port
-        assert external.spec.load_balancer_ip == "172.18.255.211"
+        assert external.spec.load_balancer_ip == kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1)
         assert external.spec.external_traffic_policy == "Local"
 
 
@@ -87,7 +88,7 @@ def test_set_external_connectivity_load_balancer_with_default_port(
 def test_set_external_connectivity(opsmanager: MongoDBOpsManager):
     ext_connectivity = {
         "type": "LoadBalancer",
-        "loadBalancerIP": "172.18.255.211",
+        "loadBalancerIP": kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1),
         "externalTrafficPolicy": "Local",
         "port": 443,
         "annotations": {
@@ -112,7 +113,7 @@ def test_set_external_connectivity(opsmanager: MongoDBOpsManager):
         assert external.spec.type == "LoadBalancer"
         assert len(external.spec.ports) == 1
         assert external.spec.ports[0].port == 443
-        assert external.spec.load_balancer_ip == "172.18.255.211"
+        assert external.spec.load_balancer_ip == kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1)
         assert external.spec.external_traffic_policy == "Local"
 
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_tls_custom_ca.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_backup_tls_custom_ca.py
@@ -12,6 +12,7 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.conftest import default_external_domain, external_domain_fqdns, is_multi_cluster, update_coredns_hosts
+from tests.kind_network import KIND_LB_SLOT_CLUSTER_1, KIND_LB_SLOT_OPERATOR, kind_lb_ip_str
 from tests.opsmanager.om_ops_manager_backup import BLOCKSTORE_RS_NAME, OPLOG_RS_NAME, S3_SECRET_NAME
 from tests.opsmanager.withMonitoredAppDB.conftest import enable_multi_cluster_deployment
 
@@ -156,17 +157,17 @@ def blockstore_replica_set(
 def test_update_coredns():
     if is_multi_cluster():
         hosts = [
-            ("172.18.255.211", "my-replica-set-0.mongodb.interconnected"),
-            ("172.18.255.212", "my-replica-set-1.mongodb.interconnected"),
-            ("172.18.255.213", "my-replica-set-2.mongodb.interconnected"),
-            ("172.18.255.214", "my-replica-set-3.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 1), "my-replica-set-0.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 2), "my-replica-set-1.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 3), "my-replica-set-2.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_CLUSTER_1, 4), "my-replica-set-3.mongodb.interconnected"),
         ]
     else:
         hosts = [
-            ("172.18.255.200", "my-replica-set-0.mongodb.interconnected"),
-            ("172.18.255.201", "my-replica-set-1.mongodb.interconnected"),
-            ("172.18.255.202", "my-replica-set-2.mongodb.interconnected"),
-            ("172.18.255.203", "my-replica-set-3.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR), "my-replica-set-0.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 1), "my-replica-set-1.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 2), "my-replica-set-2.mongodb.interconnected"),
+            (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 3), "my-replica-set-3.mongodb.interconnected"),
         ]
 
     update_coredns_hosts(hosts)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_external_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/withMonitoredAppDB/om_appdb_external_connectivity.py
@@ -10,6 +10,7 @@ from pytest import fixture, mark
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.common.placeholders import placeholders
 from tests.conftest import default_external_domain, external_domain_fqdns, update_coredns_hosts
+from tests.kind_network import KIND_LB_SLOT_OPERATOR, kind_lb_ip_str
 
 OM_NAME = "om-appdb-external"
 APPDB_NAME = f"{OM_NAME}-db"
@@ -79,15 +80,15 @@ def ops_manager(
 def test_configure_dns():
     host_mappings = [
         (
-            "172.18.255.200",
+            kind_lb_ip_str(KIND_LB_SLOT_OPERATOR),
             APPDB_EXTERNAL_DOMAINS[0],
         ),
         (
-            "172.18.255.201",
+            kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 1),
             APPDB_EXTERNAL_DOMAINS[1],
         ),
         (
-            "172.18.255.202",
+            kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 2),
             APPDB_EXTERNAL_DOMAINS[2],
         ),
     ]

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_process_hostnames.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_process_hostnames.py
@@ -16,6 +16,7 @@ from kubetester.phase import Phase
 from pytest import fixture
 from tests.common.placeholders import placeholders
 from tests.conftest import default_external_domain, external_domain_fqdns, update_coredns_hosts
+from tests.kind_network import KIND_LB_SLOT_OPERATOR, kind_lb_ip_str
 
 
 @fixture
@@ -49,10 +50,10 @@ def replica_set(
 @pytest.mark.e2e_replica_set_process_hostnames
 def test_update_coredns():
     hosts = [
-        ("172.18.255.200", "my-replica-set-0.mongodb.interconnected"),
-        ("172.18.255.201", "my-replica-set-1.mongodb.interconnected"),
-        ("172.18.255.202", "my-replica-set-2.mongodb.interconnected"),
-        ("172.18.255.203", "my-replica-set-3.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR), "my-replica-set-0.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 1), "my-replica-set-1.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 2), "my-replica-set-2.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 3), "my-replica-set-3.mongodb.interconnected"),
     ]
 
     update_coredns_hosts(hosts)

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/conftest.py
@@ -19,6 +19,13 @@ from tests.conftest import (
     read_deployment_state,
 )
 from tests.constants import LEGACY_CENTRAL_CLUSTER_NAME
+from tests.kind_network import (
+    KIND_LB_SLOT_CLUSTER_1,
+    KIND_LB_SLOT_CLUSTER_2,
+    KIND_LB_SLOT_CLUSTER_3,
+    KIND_LB_SLOT_OPERATOR,
+    kind_lb_ip,
+)
 from tests.multicluster.conftest import cluster_spec_list
 
 
@@ -72,17 +79,19 @@ class ClusterInfo:
         self.external_domain = external_domain
 
 
-KIND_SINGLE_CLUSTER = ClusterInfo("kind-kind", IPv4Address("172.18.255.200"), "kind-kind.interconnected")
+KIND_SINGLE_CLUSTER = ClusterInfo("kind-kind", kind_lb_ip(KIND_LB_SLOT_OPERATOR), "kind-kind.interconnected")
 KIND_E2E_CLUSTER_1 = ClusterInfo(
-    "kind-e2e-cluster-1", IPv4Address("172.18.255.210"), "kind-e2e-cluster-1.interconnected"
+    "kind-e2e-cluster-1", kind_lb_ip(KIND_LB_SLOT_CLUSTER_1), "kind-e2e-cluster-1.interconnected"
 )
 KIND_E2E_CLUSTER_2 = ClusterInfo(
-    "kind-e2e-cluster-2", IPv4Address("172.18.255.220"), "kind-e2e-cluster-2.interconnected"
+    "kind-e2e-cluster-2", kind_lb_ip(KIND_LB_SLOT_CLUSTER_2), "kind-e2e-cluster-2.interconnected"
 )
 KIND_E2E_CLUSTER_3 = ClusterInfo(
-    "kind-e2e-cluster-3", IPv4Address("172.18.255.230"), "kind-e2e-cluster-3.interconnected"
+    "kind-e2e-cluster-3", kind_lb_ip(KIND_LB_SLOT_CLUSTER_3), "kind-e2e-cluster-3.interconnected"
 )
-KIND_E2E_OPERATOR = ClusterInfo("kind-e2e-operator", IPv4Address("172.18.255.200"), "kind-e2e-operator.interconnected")
+KIND_E2E_OPERATOR = ClusterInfo(
+    "kind-e2e-operator", kind_lb_ip(KIND_LB_SLOT_OPERATOR), "kind-e2e-operator.interconnected"
+)
 
 cluster_map = {
     KIND_E2E_CLUSTER_1.cluster_name: KIND_E2E_CLUSTER_1,

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_replica_set_process_hostnames.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_replica_set_process_hostnames.py
@@ -18,6 +18,7 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.conftest import default_external_domain, external_domain_fqdns, update_coredns_hosts
+from tests.kind_network import KIND_LB_SLOT_OPERATOR, kind_lb_ip_str
 
 
 @fixture(scope="module")
@@ -74,10 +75,10 @@ def test_install_operator(operator: Operator):
 @mark.e2e_replica_set_tls_process_hostnames
 def test_update_coredns():
     hosts = [
-        ("172.18.255.200", "my-replica-set-0.mongodb.interconnected"),
-        ("172.18.255.201", "my-replica-set-1.mongodb.interconnected"),
-        ("172.18.255.202", "my-replica-set-2.mongodb.interconnected"),
-        ("172.18.255.203", "my-replica-set-3.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR), "my-replica-set-0.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 1), "my-replica-set-1.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 2), "my-replica-set-2.mongodb.interconnected"),
+        (kind_lb_ip_str(KIND_LB_SLOT_OPERATOR, 3), "my-replica-set-3.mongodb.interconnected"),
     ]
 
     update_coredns_hosts(hosts)

--- a/main.go
+++ b/main.go
@@ -561,19 +561,25 @@ func initializeEnvironment() {
 	printEnvVariables()
 }
 
-// loadEnvFromLocalFileForDevelopment loads env vars from .generated/context.operator.env if not running in "prod" env
+// loadEnvFromLocalFileForDevelopment loads .generated/context.operator.env
+// when not running in "prod" env.
 func loadEnvFromLocalFileForDevelopment() {
 	if getOperatorEnv() == util.OperatorEnvironmentProd {
 		return
 	}
 
 	envFile := ".generated/context.operator.env"
-	if _, err := os.Stat(envFile); err == nil {
-		if err := godotenv.Load(envFile); err != nil {
-			log.Warnf("Failed to load environment variables from file %s: %v", envFile, err)
-		} else {
-			log.Infof("Loaded environment variables from file %s", envFile)
-		}
+	if _, err := os.Stat(envFile); err != nil {
+		log.Warnf("Env file %s not found (run 'make switch'); skipping.", envFile)
+		return
+	}
+	// Load (not Overload): real environment variables win over the generated
+	// file, so ad-hoc overrides (WATCH_NAMESPACE=x go run ./main.go, IDE launch
+	// configs) survive.
+	if err := godotenv.Load(envFile); err != nil {
+		log.Warnf("Failed to load environment variables from file %s: %v", envFile, err)
+	} else {
+		log.Infof("Loaded environment variables from file %s", envFile)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -561,25 +561,38 @@ func initializeEnvironment() {
 	printEnvVariables()
 }
 
-// loadEnvFromLocalFileForDevelopment loads .generated/context.operator.env
-// when not running in "prod" env.
+// loadEnvFromLocalFileForDevelopment loads the generated context env files when
+// not running in "prod" env. The operator overlay omits KUBECONFIG/KUBE_CONFIG_PATH
+// (switch_context.sh strips them), so bare `go run`/IDE launches must also load
+// context.<side>.env to recover the generated kubeconfig; context.env supplies the
+// shared base. Side detection matches devenv (/.dockerenv → devc, else host).
 func loadEnvFromLocalFileForDevelopment() {
 	if getOperatorEnv() == util.OperatorEnvironmentProd {
 		return
 	}
 
-	envFile := ".generated/context.operator.env"
-	if _, err := os.Stat(envFile); err != nil {
-		log.Warnf("Env file %s not found (run 'make switch'); skipping.", envFile)
+	operatorEnvFile := ".generated/context.operator.env"
+	if _, err := os.Stat(operatorEnvFile); err != nil {
+		log.Warnf("Env file %s not found (run 'make switch'); skipping.", operatorEnvFile)
 		return
 	}
-	// Load (not Overload): real environment variables win over the generated
-	// file, so ad-hoc overrides (WATCH_NAMESPACE=x go run ./main.go, IDE launch
-	// configs) survive.
-	if err := godotenv.Load(envFile); err != nil {
-		log.Warnf("Failed to load environment variables from file %s: %v", envFile, err)
-	} else {
-		log.Infof("Loaded environment variables from file %s", envFile)
+	side := "host"
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		side = "devc"
+	}
+	// Load (not Overload) in precedence order — first file wins per key and real
+	// environment variables win over all files, so operator-specific values and
+	// ad-hoc overrides (WATCH_NAMESPACE=x go run ./main.go, IDE launch configs)
+	// survive while KUBECONFIG falls through from the side file.
+	for _, envFile := range []string{operatorEnvFile, ".generated/context." + side + ".env", ".generated/context.env"} {
+		if _, err := os.Stat(envFile); err != nil {
+			continue
+		}
+		if err := godotenv.Load(envFile); err != nil {
+			log.Warnf("Failed to load environment variables from file %s: %v", envFile, err)
+		} else {
+			log.Infof("Loaded environment variables from file %s", envFile)
+		}
 	}
 }
 

--- a/scripts/dev/cleanup-evg-docker.sh
+++ b/scripts/dev/cleanup-evg-docker.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
 
-# Note: running directly docker system prune and related commands won't be enough since
-# images are accumulated via containerd which is running in docker. So you need to jump into docker and cleanup
-# via crictl
+# docker system prune isn't enough: images accumulate in the containerd
+# running inside each kind node container, so prune them via crictl per node.
 
-
-# Get all container IDs
 container_ids=$(docker ps -q)
 
-# Iterate through each container ID
 for container_id in ${container_ids}; do
     echo "Cleaning up container ${container_id}"
-    # Use docker exec to run crictl rmi --prune inside the container
     docker exec "${container_id}" crictl rmi --prune
 done
 

--- a/scripts/dev/configure_container_auth.sh
+++ b/scripts/dev/configure_container_auth.sh
@@ -43,7 +43,6 @@ setup_validate_container_runtime() {
   fi
 }
 
-# Wrapper function to execute commands with or without sudo
 exec_cmd() {
   if [[ "${USE_SUDO}" == "true" ]]; then
     sudo env PATH="${PATH}" "$@"
@@ -52,7 +51,6 @@ exec_cmd() {
   fi
 }
 
-# Wrapper function to read files with or without sudo
 read_file() {
   local file="$1"
   if [[ "${USE_SUDO}" == "true" ]]; then
@@ -62,7 +60,6 @@ read_file() {
   fi
 }
 
-# Wrapper function to write files with or without sudo
 write_file() {
   local content="$1"
   local file="$2"
@@ -117,6 +114,8 @@ fi
 
 clear_undefined_credentials
 
+skip_login="false"
+
 if [[ -f "${CONFIG_PATH}" ]]; then
   if [[ "${RUNNING_IN_EVG:-"false"}" != "true" ]]; then
     echo "Checking if container registry credentials are valid..."
@@ -127,42 +126,47 @@ if [[ -f "${CONFIG_PATH}" ]]; then
         -H "Authorization: Basic ${ecr_auth}" 2>/dev/null || echo "error/timeout")
 
       if [[ "${http_status}" != "401" && "${http_status}" != "403" && "${http_status}" != "error/timeout" ]]; then
-        echo "Container registry credentials are up to date - not performing the new login!"
-        exit
+        echo "Container registry credentials are up to date - skipping login, will still re-distribute pull secrets"
+        skip_login="true"
+      else
+        echo "Container login required (HTTP status: ${http_status})"
       fi
-      echo "Container login required (HTTP status: ${http_status})"
     else
       echo "No ECR credentials found in container config - login required"
     fi
   fi
 
-  title "Performing container login to ECR registries"
+  if [[ "${skip_login}" != "true" ]]; then
+    title "Performing container login to ECR registries"
 
-  # There could be some leftovers on Evergreen (Docker-specific, skip for Podman)
-  if [[ "${CONTAINER_RUNTIME}" == "docker" ]]; then
-    if exec_cmd grep -q "credsStore" "${CONFIG_PATH}"; then
-      remove_element "credsStore"
-    fi
-    if exec_cmd grep -q "credHelpers" "${CONFIG_PATH}"; then
-      remove_element "credHelpers"
+    # There could be some leftovers on Evergreen (Docker-specific, skip for Podman)
+    if [[ "${CONTAINER_RUNTIME}" == "docker" ]]; then
+      if exec_cmd grep -q "credsStore" "${CONFIG_PATH}"; then
+        remove_element "credsStore"
+      fi
+      if exec_cmd grep -q "credHelpers" "${CONFIG_PATH}"; then
+        remove_element "credHelpers"
+      fi
     fi
   fi
 fi
 
-echo "$(aws --version)}"
+if [[ "${skip_login}" != "true" ]]; then
+  echo "$(aws --version)}"
 
-aws ecr get-login-password --region "us-east-1" | registry_login "AWS" "268558157000.dkr.ecr.us-east-1.amazonaws.com"
-
-# by default docker tries to store credentials in an external storage (e.g. OS keychain) - not in the config.json
-# We need to store it as base64 string in config.json instead so we need to remove the "credsStore" element
-# This is Docker-specific behavior, Podman stores credentials directly in auth.json
-if [[ "${CONTAINER_RUNTIME}" == "docker" ]] && exec_cmd grep -q "credsStore" "${CONFIG_PATH}"; then
-  remove_element "credsStore"
-
-  # login again to store the credentials into the config.json
   aws ecr get-login-password --region "us-east-1" | registry_login "AWS" "268558157000.dkr.ecr.us-east-1.amazonaws.com"
-fi
 
-aws ecr get-login-password --region "eu-west-1" | registry_login "AWS" "268558157000.dkr.ecr.eu-west-1.amazonaws.com"
+  # by default docker tries to store credentials in an external storage (e.g. OS keychain) - not in the config.json
+  # We need to store it as base64 string in config.json instead so we need to remove the "credsStore" element
+  # This is Docker-specific behavior, Podman stores credentials directly in auth.json
+  if [[ "${CONTAINER_RUNTIME}" == "docker" ]] && exec_cmd grep -q "credsStore" "${CONFIG_PATH}"; then
+    remove_element "credsStore"
+
+    # login again to store the credentials into the config.json
+    aws ecr get-login-password --region "us-east-1" | registry_login "AWS" "268558157000.dkr.ecr.us-east-1.amazonaws.com"
+  fi
+
+  aws ecr get-login-password --region "eu-west-1" | registry_login "AWS" "268558157000.dkr.ecr.eu-west-1.amazonaws.com"
+fi
 
 create_image_registries_secret

--- a/scripts/dev/contexts/private-context-template
+++ b/scripts/dev/contexts/private-context-template
@@ -19,6 +19,9 @@ export NAMESPACE="mongodb-test"
 #   Empty for start.
 export EVG_HOST_NAME=""
 
+# The DNS name of the host above. This is only required in the devcontainer and safe to leave empty otherwise.
+export EVG_HOST_ADDRESS=""
+
 # ECR repo used for deploying the images
 # Allowed values:
 # - a full path to the ECR repo

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -60,10 +60,17 @@ if [[ -f "${PROJECT_DIR}/.generated/.current-evg-host" ]]; then
   export EVG_HOST_NAME
 
   evg_host_address_file="${PROJECT_DIR}/.generated/.current-evg-host-address"
+  # Stock macOS has no GNU `timeout`; prefer `timeout`, fall back to `gtimeout`
+  # (coreutils), else run the query unbounded rather than fail resolution.
+  # Word-split on use is intentional (empty-array expansion is unsafe on bash 3.2).
+  if command -v timeout >/dev/null 2>&1; then evg_timeout="timeout 5s"
+  elif command -v gtimeout >/dev/null 2>&1; then evg_timeout="gtimeout 5s"
+  else evg_timeout=""; fi
   if command -v evergreen >/dev/null 2>&1; then
     # timeout + </dev/null guards against OIDC device-auth fallback hanging make switch
     # when the cached token has expired and no browser is available (devc).
-    evg_resolved="$(timeout 5s evergreen host list --json </dev/null 2>/dev/null \
+    # shellcheck disable=SC2086  # evg_timeout must word-split into argv (or vanish).
+    evg_resolved="$(${evg_timeout} evergreen host list --json </dev/null 2>/dev/null \
       | jq -r --arg name "${EVG_HOST_NAME}" \
           '[.[] | select(.name == $name and .status == "running")] | first | .host_name // empty' \
           2>/dev/null || true)"

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -12,77 +12,11 @@ export PROJECT_DIR
 
 source "${script_dir}/private-context"
 
-# Devcontainer worktrees: pull MCK_DEVC_* (network prefix + derived octets and
-# proxy port) from .devcontainer/.env when not already in env. The file only
-# exists in worktrees set up by wt-ctl; non-devc flows skip this whole block.
-if [[ -f "${PROJECT_DIR}/.devcontainer/.env" ]]; then
-  while IFS= read -r devc_env_line; do
-    case "${devc_env_line}" in
-      MCK_DEVC_*=*)
-        devc_env_key="${devc_env_line%%=*}"
-        [[ -z "${!devc_env_key:-}" ]] && export "${devc_env_line?}"
-        ;;
-    esac
-  done < "${PROJECT_DIR}/.devcontainer/.env"
-  unset devc_env_line devc_env_key
-fi
+# Devcontainer / EVG-host worktree overrides (MCK_DEVC_* loading, per-worktree
+# namespace suffix, CLUSTER_NAME alignment, EVG-host address resolution).
+# No-op outside a wt-ctl worktree.
+source "${script_dir}/root-devc-context"
 
-# Per-worktree namespace suffix. Only applied when running parallel devc
-# stacks (MCK_DEVC_NET_PREFIX set) and not inside an evergreen task; keeps
-# cloud-qa OM project names from colliding across worktrees. Idempotent.
-if [[ -z "${EVR_TASK_ID:-}" && -n "${MCK_DEVC_NET_PREFIX:-}" && -n "${NAMESPACE:-}" \
-      && "${NAMESPACE}" != *"-${MCK_DEVC_NET_PREFIX}" ]]; then
-  if [[ -n "${WATCH_NAMESPACE:-}" && "${WATCH_NAMESPACE}" == "${NAMESPACE}" ]]; then
-    export WATCH_NAMESPACE="${WATCH_NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
-  fi
-  export NAMESPACE="${NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
-fi
-
-# Devc-only: align CLUSTER_NAME with the kubeconfig's current-context so
-# kubectl matches the cluster wt-ctl actually prepared. EVG-host mode (next
-# block) overrides this. Other flows keep CLUSTER_NAME from
-# private-context unchanged.
-if [[ -n "${MCK_DEVC_NET_PREFIX:-}" \
-      && ! -f "${PROJECT_DIR}/.generated/.current-evg-host" \
-      && -f "${PROJECT_DIR}/.generated/current.kubeconfig" ]]; then
-  kc_ctx=$(yq '."current-context"' "${PROJECT_DIR}/.generated/current.kubeconfig" 2>/dev/null || echo "")
-  if [[ -n "${kc_ctx}" && "${kc_ctx}" != "null" ]]; then
-    export CLUSTER_NAME="${kc_ctx}"
-    export EVG_HOST_NAME=""
-  fi
-  unset kc_ctx
-fi
-
-# EVG-host worktree: resolve and cache the running host's address. The
-# evg-host-proxy sidecar reads the cache file (it has no evergreen CLI).
-if [[ -f "${PROJECT_DIR}/.generated/.current-evg-host" ]]; then
-  EVG_HOST_NAME="$(cat "${PROJECT_DIR}/.generated/.current-evg-host")"
-  export EVG_HOST_NAME
-
-  evg_host_address_file="${PROJECT_DIR}/.generated/.current-evg-host-address"
-  # Stock macOS has no GNU `timeout`; prefer `timeout`, fall back to `gtimeout`
-  # (coreutils), else run the query unbounded rather than fail resolution.
-  # Word-split on use is intentional (empty-array expansion is unsafe on bash 3.2).
-  if command -v timeout >/dev/null 2>&1; then evg_timeout="timeout 5s"
-  elif command -v gtimeout >/dev/null 2>&1; then evg_timeout="gtimeout 5s"
-  else evg_timeout=""; fi
-  if command -v evergreen >/dev/null 2>&1; then
-    # timeout + </dev/null guards against OIDC device-auth fallback hanging make switch
-    # when the cached token has expired and no browser is available (devc).
-    # shellcheck disable=SC2086  # evg_timeout must word-split into argv (or vanish).
-    evg_resolved="$(${evg_timeout} evergreen host list --json </dev/null 2>/dev/null \
-      | jq -r --arg name "${EVG_HOST_NAME}" \
-          '[.[] | select(.name == $name and .status == "running")] | first | .host_name // empty' \
-          2>/dev/null || true)"
-    if [[ -n "${evg_resolved}" ]]; then
-      echo "${evg_resolved}" > "${evg_host_address_file}"
-    fi
-  fi
-  if [[ -s "${evg_host_address_file}" ]]; then
-    EVG_HOST_ADDRESS="$(cat "${evg_host_address_file}")"
-    export EVG_HOST_ADDRESS
-  fi
-fi
 export IMAGE_TYPE=ubi
 export UBI_IMAGE_WITHOUT_SUFFIX=true
 export WATCH_NAMESPACE=${WATCH_NAMESPACE:-${NAMESPACE}}

--- a/scripts/dev/contexts/root-context
+++ b/scripts/dev/contexts/root-context
@@ -4,10 +4,78 @@ set -Eeou pipefail
 
 script_name=$(readlink -f "${BASH_SOURCE[0]}")
 script_dir=$(dirname "${script_name}")
+
+# site-context sets PROJECT_DIR; fall back to the canonical layout for direct
+# sourcing (flows that don't go through switch_context.sh).
+: "${PROJECT_DIR:=$(realpath "${script_dir}/../../..")}"
+export PROJECT_DIR
+
 source "${script_dir}/private-context"
 
-PROJECT_DIR="$(realpath "${script_dir}/../../..")"
-export PROJECT_DIR
+# Devcontainer worktrees: pull MCK_DEVC_* (network prefix + derived octets and
+# proxy port) from .devcontainer/.env when not already in env. The file only
+# exists in worktrees set up by wt-ctl; non-devc flows skip this whole block.
+if [[ -f "${PROJECT_DIR}/.devcontainer/.env" ]]; then
+  while IFS= read -r devc_env_line; do
+    case "${devc_env_line}" in
+      MCK_DEVC_*=*)
+        devc_env_key="${devc_env_line%%=*}"
+        [[ -z "${!devc_env_key:-}" ]] && export "${devc_env_line?}"
+        ;;
+    esac
+  done < "${PROJECT_DIR}/.devcontainer/.env"
+  unset devc_env_line devc_env_key
+fi
+
+# Per-worktree namespace suffix. Only applied when running parallel devc
+# stacks (MCK_DEVC_NET_PREFIX set) and not inside an evergreen task; keeps
+# cloud-qa OM project names from colliding across worktrees. Idempotent.
+if [[ -z "${EVR_TASK_ID:-}" && -n "${MCK_DEVC_NET_PREFIX:-}" && -n "${NAMESPACE:-}" \
+      && "${NAMESPACE}" != *"-${MCK_DEVC_NET_PREFIX}" ]]; then
+  if [[ -n "${WATCH_NAMESPACE:-}" && "${WATCH_NAMESPACE}" == "${NAMESPACE}" ]]; then
+    export WATCH_NAMESPACE="${WATCH_NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
+  fi
+  export NAMESPACE="${NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
+fi
+
+# Devc-only: align CLUSTER_NAME with the kubeconfig's current-context so
+# kubectl matches the cluster wt-ctl actually prepared. EVG-host mode (next
+# block) overrides this. Other flows keep CLUSTER_NAME from
+# private-context unchanged.
+if [[ -n "${MCK_DEVC_NET_PREFIX:-}" \
+      && ! -f "${PROJECT_DIR}/.generated/.current-evg-host" \
+      && -f "${PROJECT_DIR}/.generated/current.kubeconfig" ]]; then
+  kc_ctx=$(yq '."current-context"' "${PROJECT_DIR}/.generated/current.kubeconfig" 2>/dev/null || echo "")
+  if [[ -n "${kc_ctx}" && "${kc_ctx}" != "null" ]]; then
+    export CLUSTER_NAME="${kc_ctx}"
+    export EVG_HOST_NAME=""
+  fi
+  unset kc_ctx
+fi
+
+# EVG-host worktree: resolve and cache the running host's address. The
+# evg-host-proxy sidecar reads the cache file (it has no evergreen CLI).
+if [[ -f "${PROJECT_DIR}/.generated/.current-evg-host" ]]; then
+  EVG_HOST_NAME="$(cat "${PROJECT_DIR}/.generated/.current-evg-host")"
+  export EVG_HOST_NAME
+
+  evg_host_address_file="${PROJECT_DIR}/.generated/.current-evg-host-address"
+  if command -v evergreen >/dev/null 2>&1; then
+    # timeout + </dev/null guards against OIDC device-auth fallback hanging make switch
+    # when the cached token has expired and no browser is available (devc).
+    evg_resolved="$(timeout 5s evergreen host list --json </dev/null 2>/dev/null \
+      | jq -r --arg name "${EVG_HOST_NAME}" \
+          '[.[] | select(.name == $name and .status == "running")] | first | .host_name // empty' \
+          2>/dev/null || true)"
+    if [[ -n "${evg_resolved}" ]]; then
+      echo "${evg_resolved}" > "${evg_host_address_file}"
+    fi
+  fi
+  if [[ -s "${evg_host_address_file}" ]]; then
+    EVG_HOST_ADDRESS="$(cat "${evg_host_address_file}")"
+    export EVG_HOST_ADDRESS
+  fi
+fi
 export IMAGE_TYPE=ubi
 export UBI_IMAGE_WITHOUT_SUFFIX=true
 export WATCH_NAMESPACE=${WATCH_NAMESPACE:-${NAMESPACE}}
@@ -22,16 +90,9 @@ export TEST_POD_CLUSTER="${CLUSTER_NAME}"
 
 export CENTRAL_CLUSTER="${CLUSTER_NAME}"
 export MULTI_CLUSTER_CREATE_SERVICE_ACCOUNT_TOKEN_SECRETS=true
-export MULTI_CLUSTER_CONFIG_DIR=${PROJECT_DIR}/.multi_cluster_local_test_files
-export MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH=${PROJECT_DIR}/docker/mongodb-kubernetes-tests/multi-cluster-kube-config-creator
 
 # override for /etc/config/kubeconfig file mounted in operator's pod
 if [[ "${LOCAL_OPERATOR}" == "true" ]]; then
-  # This env var is used by the local operator to load multi-cluster kubeconfig.
-  # Normally, the pod is loading it from a path that is mounted from the mongodb-enterprise-operator-multi-cluster-kubeconfig secret.
-  # When running locally, we use cli tool to generate that kubeconfig secret and write it to this file.
-  # This way, the local operator is using kubeconfig create by cli tool the same way as it's used when running in a pod.
-  export KUBE_CONFIG_PATH=~/.operator-dev/multicluster_kubeconfig
   export PERFORM_FAILOVER=false
 fi
 
@@ -43,7 +104,6 @@ export AGENT_VERSION
 # Ops Manager
 export OPS_MANAGER_NAMESPACE="operator-testing-50-current"
 
-# Moved from the old set_env_context.sh
 export LOCAL_RUN=true
 
 if [[ "${OVERRIDE_VERSION_ID:-}" != "" ]]; then
@@ -88,25 +148,12 @@ export VERSION_UPGRADE_HOOK_IMAGE="${VERSION_UPGRADE_HOOK_REGISTRY}/mongodb-kube
 
 export KUBE_ENVIRONMENT_NAME=kind
 
-# when using EVG ec2 instance, we copy kubeconfig locally and use it
-if [[ "${EVG_HOST_NAME:-}" != "" ]]; then
-  KUBECONFIG=~/.operator-dev/evg-host.kubeconfig
-else
-  KUBECONFIG=~/.kube/config
-fi
-export KUBECONFIG
-
-if [[ "$(uname)" == "Linux" ]]; then
-  export GOROOT=/opt/golang/go1.25
-fi
-
 export SIGNING_PUBLIC_KEY_URL="https://cosign.mongodb.com/mongodb-enterprise-kubernetes-operator.pem"
 
 export CLUSTER_DOMAIN="cluster.local"
 
 export MDB_MAX_CONCURRENT_RECONCILES=10
 
-# leaving them empty for now
 export OM_HOST=https://cloud-qa.mongodb.com
 export OM_BASE_URL=https://cloud-qa.mongodb.com
 
@@ -166,14 +213,3 @@ export OPERATOR_CLUSTER_SCOPED=false
 # for downloading helm and kubectl binaries
 export HELM_VERSION="v3.19.4"
 export KUBECTL_VERSION="v1.35.0"
-
-# s390x-specific feature flags — use ${VAR:-default} so they can be overridden before sourcing this context.
-# PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: s390x requires pure Python protobuf implementation
-#   https://github.com/protocolbuffers/protobuf/issues/24103
-# SODIUM_INSTALL: pynacl must link against system libsodium (RHEL9 ships 1.0.18; bundled build broken on s390x+Python 3.13)
-# PYTEST_OTEL_ENABLED: grpcio segfaults at exit on s390x+Python 3.13; pytest-opentelemetry excluded from requirements
-if [[ "$(uname -m)" == "s390x" ]]; then
-  export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="${PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION:-python}"
-  export SODIUM_INSTALL="${SODIUM_INSTALL:-system}"
-  export PYTEST_OTEL_ENABLED="${PYTEST_OTEL_ENABLED:-false}"
-fi

--- a/scripts/dev/contexts/root-devc-context
+++ b/scripts/dev/contexts/root-devc-context
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Devcontainer / EVG-host worktree overrides. Sourced from root-context after
+# private-context, so PROJECT_DIR / NAMESPACE / CLUSTER_NAME are already set.
+# Every block is a no-op outside a wt-ctl worktree (no .devcontainer/.env,
+# no .generated EVG-host sentinels), so non-devc flows source it harmlessly.
+
+# Devcontainer worktrees: pull MCK_DEVC_* (network prefix + derived octets and
+# proxy port) from .devcontainer/.env when not already in env. The file only
+# exists in worktrees set up by wt-ctl; non-devc flows skip this whole block.
+if [[ -f "${PROJECT_DIR}/.devcontainer/.env" ]]; then
+  while IFS= read -r devc_env_line; do
+    case "${devc_env_line}" in
+      MCK_DEVC_*=*)
+        devc_env_key="${devc_env_line%%=*}"
+        [[ -z "${!devc_env_key:-}" ]] && export "${devc_env_line?}"
+        ;;
+    esac
+  done < "${PROJECT_DIR}/.devcontainer/.env"
+  unset devc_env_line devc_env_key
+fi
+
+# Per-worktree namespace suffix. Only applied when running parallel devc
+# stacks (MCK_DEVC_NET_PREFIX set) and not inside an evergreen task; keeps
+# cloud-qa OM project names from colliding across worktrees. Idempotent.
+if [[ -z "${EVR_TASK_ID:-}" && -n "${MCK_DEVC_NET_PREFIX:-}" && -n "${NAMESPACE:-}" \
+      && "${NAMESPACE}" != *"-${MCK_DEVC_NET_PREFIX}" ]]; then
+  if [[ -n "${WATCH_NAMESPACE:-}" && "${WATCH_NAMESPACE}" == "${NAMESPACE}" ]]; then
+    export WATCH_NAMESPACE="${WATCH_NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
+  fi
+  export NAMESPACE="${NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
+fi
+
+# Devc-only: align CLUSTER_NAME with the kubeconfig's current-context so
+# kubectl matches the cluster wt-ctl actually prepared. EVG-host mode (next
+# block) overrides this. Other flows keep CLUSTER_NAME from
+# private-context unchanged.
+if [[ -n "${MCK_DEVC_NET_PREFIX:-}" \
+      && ! -f "${PROJECT_DIR}/.generated/.current-evg-host" \
+      && -f "${PROJECT_DIR}/.generated/current.kubeconfig" ]]; then
+  kc_ctx=$(yq '."current-context"' "${PROJECT_DIR}/.generated/current.kubeconfig" 2>/dev/null || echo "")
+  if [[ -n "${kc_ctx}" && "${kc_ctx}" != "null" ]]; then
+    export CLUSTER_NAME="${kc_ctx}"
+    export EVG_HOST_NAME=""
+  fi
+  unset kc_ctx
+fi
+
+# EVG-host worktree: resolve and cache the running host's address. The
+# evg-host-proxy sidecar reads the cache file (it has no evergreen CLI).
+if [[ -f "${PROJECT_DIR}/.generated/.current-evg-host" ]]; then
+  EVG_HOST_NAME="$(cat "${PROJECT_DIR}/.generated/.current-evg-host")"
+  export EVG_HOST_NAME
+
+  evg_host_address_file="${PROJECT_DIR}/.generated/.current-evg-host-address"
+  # Stock macOS has no GNU `timeout`; prefer `timeout`, fall back to `gtimeout`
+  # (coreutils), else run the query unbounded rather than fail resolution.
+  # Word-split on use is intentional (empty-array expansion is unsafe on bash 3.2).
+  if command -v timeout >/dev/null 2>&1; then evg_timeout="timeout 5s"
+  elif command -v gtimeout >/dev/null 2>&1; then evg_timeout="gtimeout 5s"
+  else evg_timeout=""; fi
+  if command -v evergreen >/dev/null 2>&1; then
+    # timeout + </dev/null guards against OIDC device-auth fallback hanging make switch
+    # when the cached token has expired and no browser is available (devc).
+    # shellcheck disable=SC2086  # evg_timeout must word-split into argv (or vanish).
+    evg_resolved="$(${evg_timeout} evergreen host list --json </dev/null 2>/dev/null \
+      | jq -r --arg name "${EVG_HOST_NAME}" \
+          '[.[] | select(.name == $name and .status == "running")] | first | .host_name // empty' \
+          2>/dev/null || true)"
+    if [[ -n "${evg_resolved}" ]]; then
+      echo "${evg_resolved}" > "${evg_host_address_file}"
+    fi
+  fi
+  if [[ -s "${evg_host_address_file}" ]]; then
+    EVG_HOST_ADDRESS="$(cat "${evg_host_address_file}")"
+    export EVG_HOST_ADDRESS
+  fi
+fi

--- a/scripts/dev/contexts/site-context
+++ b/scripts/dev/contexts/site-context
@@ -1,0 +1,118 @@
+# site-context — site-derived environment variables (per-side bytes).
+# Sourced only (never executed directly).
+#
+# Sourced by scripts/dev/switch_context.sh in an `env -i` subshell, ON the
+# side that ran `make switch`. The values it exports depend on the
+# filesystem layout of the running side (PROJECT_DIR), the running shell's
+# Go install (GOROOT), the architecture (s390x conditionals), and the
+# in-container vs. on-host k8s-forwarding-proxy address (K8S_FWD_PROXY).
+#
+# Companion: scripts/dev/contexts/root-context (logical, side-agnostic).
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+PROJECT_DIR="$(realpath "${script_dir}/../../..")"
+export PROJECT_DIR
+
+# In devc, compose.yml's x-k8s-proxy-config anchor passes the resolved proxy
+# address in as K8S_FWD_PROXY — inherit it (it is authoritative). On host the
+# kfp daemon listens on 127.0.0.1:11616 (launchd-managed, not started/stopped
+# by wt-ctl; if down: `sudo launchctl kickstart -k system/...`).
+if [[ -f /.dockerenv ]]; then
+  : "${K8S_FWD_PROXY:?K8S_FWD_PROXY must be set in devc env (compose.yml passes it via x-k8s-proxy-config)}"
+else
+  K8S_FWD_PROXY="127.0.0.1:11616"
+fi
+export K8S_FWD_PROXY
+
+# KUBECONFIG — prefer the per-side per-worktree kubeconfig, falling back to the
+# user's default for a non-worktree / non-devcontainer checkout. The per-worktree
+# files are written by evg_host.sh get-kubeconfig (EVG-host) and
+# recreate_kind_clusters.sh (local-kind); the host file uses
+# proxy-url=http://127.0.0.1:${MCK_DEVC_PROXY_PORT}, the devc file
+# proxy-url=http://gost-proxy:8080.
+#
+# EVG_HOST_NAME isn't available here (not forwarded into switch_context.sh's
+# env -i capture; private-context is sourced later), so detect the EVG-host
+# kubeconfig by file presence rather than the env var.
+if [[ -f /.dockerenv ]]; then
+  # devc: the orchestrator always generates this file, so point at it
+  # unconditionally (a missing file yields a clear "no such file" from kubectl).
+  KUBECONFIG="${PROJECT_DIR}/.generated/current.devc.kubeconfig"
+elif [[ -f "${PROJECT_DIR}/.generated/current.kubeconfig" ]]; then
+  KUBECONFIG="${PROJECT_DIR}/.generated/current.kubeconfig"
+elif [[ -f "${HOME}/.operator-dev/evg-host.kubeconfig" ]]; then
+  # EVG-host worktree pointing at a copied kubeconfig.
+  KUBECONFIG="${HOME}/.operator-dev/evg-host.kubeconfig"
+else
+  # Non-worktree / non-devcontainer checkout: default to the user's kubeconfig.
+  KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+fi
+export KUBECONFIG
+
+# Multi-cluster kubeconfig path. The operator only consults it when
+# LOCAL_OPERATOR=true (set by private-context, which is sourced AFTER
+# this file in the switch_context.sh chain — so we can't condition on
+# LOCAL_OPERATOR here without missing the signal). Set the path
+# unconditionally; it's harmless when LOCAL_OPERATOR is unset.
+#
+# Per-side flavor, mirroring KUBECONFIG: the devc file has member
+# proxy-url=${EVG_HOST_PROXY} (or host.docker.internal rewrites);
+# the host file reaches members via 127.0.0.1:${MCK_DEVC_PROXY_PORT}.
+# Both are derived by `wt-ctl kubeconfig refresh` from the bare base.
+if [[ -f /.dockerenv ]]; then
+  export KUBE_CONFIG_PATH="${PROJECT_DIR}/.generated/multicluster.devc.kubeconfig"
+else
+  export KUBE_CONFIG_PATH="${PROJECT_DIR}/.generated/multicluster_kubeconfig"
+fi
+
+export MULTI_CLUSTER_CONFIG_DIR="${PROJECT_DIR}/.multi_cluster_local_test_files"
+export MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH="${PROJECT_DIR}/docker/mongodb-kubernetes-tests/multi-cluster-kube-config-creator"
+
+# PROJECT_DIR-derived path defaults that local-defaults-context also sets
+# (and which root-context / private-context may further override). We mirror
+# them here so the switch_context.sh subtraction algorithm classifies them
+# as site bytes — they MUST end up in context.<side>.env, not the shared
+# logical context.env, because their values include the worktree's
+# absolute path which differs between host and devc.
+#
+# `workdir` is an alias for PROJECT_DIR used by evergreen setup scripts
+# (scripts/evergreen/setup_*.sh). Default-only: on Evergreen the real task
+# workdir (/data/mci/<hash>) is forwarded via include_expansions_in_env and
+# must NOT be clobbered — every `add_to_path: ${workdir}/...` in the EVG YAML
+# expands to that dir, so overriding it here strands setup_gcloud_cli.sh /
+# setup_mongosh.sh output.
+export workdir="${workdir:-${PROJECT_DIR}}"
+export MDB_OM_VERSION_MAPPING_PATH="${PROJECT_DIR}/release.json"
+export ENV_FILE="${PROJECT_DIR}/.ops-manager-env"
+export NAMESPACE_FILE="${PROJECT_DIR}/.namespace"
+export DEFAULT_HELM_CHART_PATH="${PROJECT_DIR}/helm_chart"
+
+# GOPATH: default to Go's own computed value (typically ${HOME}/go) rather
+# than hardcoding a path. Exported here so switch_context.sh captures it as a
+# site byte; a private-context may still override it per side.
+if command -v go >/dev/null 2>&1; then
+  export GOPATH="${GOPATH:-$(go env GOPATH)}"
+fi
+
+if command -v go >/dev/null 2>&1; then
+  GOROOT="$(go env GOROOT)"
+  export GOROOT
+fi
+
+# s390x-specific feature flags — use ${VAR:-default} so the caller can
+# override before sourcing.
+# PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: s390x requires pure-Python
+#   protobuf; C++ extension crashes at import.
+#   https://github.com/protocolbuffers/protobuf/issues/24103
+# SODIUM_INSTALL: pynacl must link against system libsodium; bundled
+#   build broken on s390x+Python 3.13.
+# PYTEST_OTEL_ENABLED: grpcio segfaults at exit on s390x+Python 3.13.
+if [[ "$(uname -m)" == "s390x" ]]; then
+  export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="${PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION:-python}"
+  export SODIUM_INSTALL="${SODIUM_INSTALL:-system}"
+  export PYTEST_OTEL_ENABLED="${PYTEST_OTEL_ENABLED:-false}"
+fi

--- a/scripts/dev/create_worktree.sh
+++ b/scripts/dev/create_worktree.sh
@@ -3,7 +3,8 @@
 set -Eeou pipefail
 test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 
-# Derive PROJECT_DIR from script location so it works even if the caller didn't export it.
+# Derive PROJECT_DIR from this script's location (scripts/dev/create_worktree.sh)
+# so it works whether or not the caller exported it, matching sibling scripts.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${PROJECT_DIR:-$(cd "${script_dir}/../.." && pwd)}"
 export PROJECT_DIR
@@ -78,14 +79,14 @@ if [[ ! -f "${worktree_path}/scripts/dev/contexts/private-context" \
   echo "Initializing worktree in ${worktree_path}..."
   init_flags=()
   [[ ${force} == 1 ]] && init_flags+=(-f)
-  # Guarded expansion: empty array must not trip `set -u` on bash 3.2 (macOS).
+  # Guarded expansion so an empty array doesn't trip `set -u` on bash 3.2 (macOS).
   time "${PROJECT_DIR}/scripts/dev/init_worktree.sh" "${init_flags[@]+"${init_flags[@]}"}" "${worktree_path}" "${PROJECT_DIR}"
 fi
 
 (
   cd "${worktree_path}"
   make switch context="$(cat ".generated/.current_context")"
-  source .generated/context.export.env
+  . scripts/dev/devenv
 )
 
 echo "Worktree $(realpath "${worktree_path}") has been prepared"

--- a/scripts/dev/delete_om_projects.sh
+++ b/scripts/dev/delete_om_projects.sh
@@ -9,40 +9,80 @@ set -euo pipefail
 
 test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 
-source scripts/dev/set_env_context.sh
+_om_curl() {
+  # Silent + show-errors, fail on HTTP >=400, drop response body. Pin a
+  # generous timeout so a slow cloud-qa can't hang prepare-local-e2e.
+  curl -sS --digest -u "${OM_USER}:${OM_API_KEY}" \
+    --fail --max-time 30 --retry 2 --retry-delay 2 \
+    -o /dev/null "$@"
+}
 
 delete_project() {
-  project_name=$1
+  local project_name=$1
   echo "Deleting project id of ${project_name} from ${OM_HOST}"
-  project_id=$(curl -s -u "${OM_USER}:${OM_API_KEY}" --digest "${OM_HOST}/api/public/v1.0/groups/byName/${project_name}" | jq -r .id)
+  local project_id
+  project_id=$(curl -sS --digest -u "${OM_USER}:${OM_API_KEY}" \
+    --max-time 30 --retry 2 --retry-delay 2 \
+    "${OM_HOST}/api/public/v1.0/groups/byName/${project_name}" 2>/dev/null \
+    | jq -r 'if type == "object" then (.id // "") else "" end' 2>/dev/null) || project_id=""
   if [[ "${project_id}" != "" && "${project_id}" != "null" ]]; then
-    echo "Removing controlledFeature policies for project ${project_name} (${project_id})"
-    curl -X PUT --digest -u "${OM_USER}:${OM_API_KEY}" "${OM_HOST}/api/public/v1.0/groups/${project_id}/controlledFeature" -H 'Content-Type: application/json' -d '{"externalManagementSystem": {"name": "mongodb-enterprise-operator"},"policies": []}'
-    echo
-    echo "Removing any existing automationConfig for project ${project_name} (${project_id})"
-    curl -X PUT --digest -u "${OM_USER}:${OM_API_KEY}" "${OM_HOST}/api/public/v1.0/groups/${project_id}/automationConfig" -H 'Content-Type: application/json' -d '{}'
-    echo
-    echo "Deleting project ${project_name} (${project_id})"
-    curl -X DELETE --digest -u "${OM_USER}:${OM_API_KEY}" "${OM_HOST}/api/public/v1.0/groups/${project_id}"
-    echo
+    echo "  controlledFeature → reset (${project_id})"
+    _om_curl -X PUT "${OM_HOST}/api/public/v1.0/groups/${project_id}/controlledFeature" \
+      -H 'Content-Type: application/json' \
+      -d '{"externalManagementSystem": {"name": "mongodb-enterprise-operator"},"policies": []}'
+    echo "  automationConfig  → reset (${project_id})"
+    _om_curl -X PUT "${OM_HOST}/api/public/v1.0/groups/${project_id}/automationConfig" \
+      -H 'Content-Type: application/json' -d '{}'
+    echo "  group             → delete (${project_id})"
+    _om_curl -X DELETE "${OM_HOST}/api/public/v1.0/groups/${project_id}"
   else
-    echo "Project ${project_name} is already deleted"
+    echo "  already deleted"
   fi
 }
 
-delete_project "${NAMESPACE}"
+# Filter a groups-list JSON (read on stdin) to the project names that should be
+# deleted for the given base prefix. Pure (no network) so it can be unit-tested.
+#
+# Worktree safety: parallel devc stacks derive their namespace as
+# <base-namespace>-<MCK_DEVC_NET_PREFIX>, where the net prefix is numeric — so
+# every sibling worktree's projects live under "<base>-<digits>[-...]". A base
+# checkout (NAMESPACE=mongodb-test) must NOT prefix-delete those, or it wipes
+# the OM projects of its own other worktree stacks. We therefore skip any
+# candidate whose first path segment after the prefix is purely numeric;
+# resource-specific projects (non-numeric first segment) are still returned.
+filter_prefixed_projects() {
+  local prefix=$1
+  # Tolerate a non-object body (a bare number, an error page, an unexpected
+  # shape): only descend into .results when the top level is actually an
+  # object, otherwise emit nothing. Keeps teardown quiet when cloud-qa returns
+  # something other than a groups list.
+  jq -r --arg p "${prefix}-" '
+      (if type == "object" then .results else empty end)
+      | .[]?
+      | select(.name | startswith($p))
+      | select((.name | ltrimstr($p) | split("-")[0] | test("^[0-9]+$")) | not)
+      | .name'
+}
 
 # Delete resource-specific projects (e.g. mongodb-test-mdb-sh) that the operator
 # creates when a MongoDB CR uses a custom project name. Without this, stale
 # automation configs persist in Cloud Manager across test runs, causing cert
-# hash mismatches that deadlock the agent.
+# hash mismatches that deadlock the agent. The worktree's own exact namespace
+# is cleaned separately by the exact-name delete in main().
 delete_projects_with_prefix() {
   local prefix=$1
-  echo "Listing projects with prefix '${prefix}-' to clean up"
-  local projects
-  projects=$(curl -s -u "${OM_USER}:${OM_API_KEY}" --digest \
-    "${OM_HOST}/api/public/v1.0/groups?itemsPerPage=100" \
-    | jq -r ".results[]? | select(.name | startswith(\"${prefix}-\")) | .name") || true
+  echo "Listing projects with prefix '${prefix}-' to clean up (excluding sibling worktree stacks)"
+  local response projects
+  # --fail: on HTTP >=400 curl exits non-zero and emits nothing, so an error
+  # body never reaches jq. Any failure (network, auth, non-JSON) degrades to
+  # "nothing to clean" rather than aborting teardown.
+  if ! response=$(curl -sS --digest -u "${OM_USER}:${OM_API_KEY}" \
+    --fail --max-time 30 --retry 2 --retry-delay 2 \
+    "${OM_HOST}/api/public/v1.0/groups?itemsPerPage=100" 2>/dev/null); then
+    echo "  (could not list projects; skipping prefix cleanup)"
+    return 0
+  fi
+  projects=$(printf '%s' "${response}" | filter_prefixed_projects "${prefix}" 2>/dev/null) || true
   if [[ -z "${projects}" ]]; then
     echo "No prefixed projects found"
     return
@@ -52,11 +92,22 @@ delete_projects_with_prefix() {
   done
 }
 
-delete_projects_with_prefix "${NAMESPACE}"
+main() {
+  source scripts/dev/set_env_context.sh
 
-if [[ "${WATCH_NAMESPACE:-}" != "" && "${WATCH_NAMESPACE:-}" != "*" ]]; then
-  for ns in ${WATCH_NAMESPACE/,// }; do
-    delete_project "${ns}" || true
-    delete_projects_with_prefix "${ns}" || true
-  done
+  delete_project "${NAMESPACE}"
+  delete_projects_with_prefix "${NAMESPACE}"
+
+  if [[ "${WATCH_NAMESPACE:-}" != "" && "${WATCH_NAMESPACE:-}" != "*" ]]; then
+    for ns in ${WATCH_NAMESPACE/,// }; do
+      delete_project "${ns}" || true
+      delete_projects_with_prefix "${ns}" || true
+    done
+  fi
+}
+
+# Execute only when run directly; sourcing (e.g. from bats) exposes the pure
+# helpers for unit testing without touching the OM API.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
 fi

--- a/scripts/dev/devenv
+++ b/scripts/dev/devenv
@@ -1,0 +1,121 @@
+# scripts/dev/devenv — sourceable bootstrap for the per-side env.
+#
+# Usage (interactive shell):
+#   . scripts/dev/devenv
+#
+# Loads .generated/context.env (logical, side-agnostic) and
+# .generated/context.<side>.env (site, current side only) with allexport
+# (`set -a`) so every KEY=VALUE is exported into the calling shell.
+# Activates the venv if present.
+#
+# Fails loudly if either file is missing — first thing devs should do
+# on a fresh worktree is `make switch`. After switch, re-source.
+#
+# Both EVG-CI runners (side=host, no /.dockerenv) and laptop host/devc
+# shells go through the same code path: switch_context.sh writes the
+# per-side file uniformly.
+#
+# This file is sourceable, not executable. Do not add a shebang or
+# `set -Eeou` — it would change behavior in the calling shell.
+
+# shellcheck disable=SC2317  # `exit 1` after `return 1` is the
+# sourced-or-executed dual-form fallback; shellcheck can't see that.
+
+# Resolve worktree root via PWD or git, so this script works whether the
+# caller cd'd into the worktree or not.
+__mck_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ ! -d "${__mck_root}/.generated" ]]; then
+    echo "ERROR: .generated/ not found relative to $(pwd)." >&2
+    echo "       Are you in a worktree? Run 'cd <worktree>' first." >&2
+    unset __mck_root
+    return 1 2>/dev/null || exit 1
+fi
+
+__mck_side=$([[ -f /.dockerenv ]] && echo devc || echo host)
+
+if [[ ! -f "${__mck_root}/.generated/context.env" ]]; then
+    echo "ERROR: ${__mck_root}/.generated/context.env not found." >&2
+    echo "       Run 'make switch' first to generate it, then re-source." >&2
+    unset __mck_root __mck_side
+    return 1 2>/dev/null || exit 1
+fi
+
+if [[ ! -f "${__mck_root}/.generated/context.${__mck_side}.env" ]]; then
+    echo "ERROR: ${__mck_root}/.generated/context.${__mck_side}.env not found." >&2
+    echo "       You're on the ${__mck_side} side; run 'make switch' here to" >&2
+    echo "       generate it, then re-source." >&2
+    if [[ "${__mck_side}" == "devc" ]]; then
+        echo "       (If on-create just ran, wait a moment and re-source.)" >&2
+    fi
+    unset __mck_root __mck_side
+    return 1 2>/dev/null || exit 1
+fi
+
+# Staleness check: .generated/context.env and .generated/context.<side>.env
+# are deterministic outputs of the scripts under scripts/dev/contexts/ and
+# the logical inputs (EVG_HOST_NAME, MCK_DEVC_NET_PREFIX, K8S_FWD_PROXY,
+# LOCAL_OPERATOR) at the time switch_context.sh last ran. If any file under
+# scripts/dev/contexts/ is newer than either generated file, the generated
+# values may no longer reflect what the current context scripts would produce.
+#
+# Default: WARN ONLY. Sourcing devenv is a hot path (~40 scripts source
+# set_env_context.sh, some in parallel make targets / background jobs); we
+# must not silently mutate the user's kubectl context or race on regenerating
+# .generated/* just because a pull touched contexts/. The developer runs
+# `make switch` when convenient.
+#
+# Opt in to automatic regeneration with MCK_DEVENV_AUTO_SWITCH=true (or =1);
+# in that mode we pass MCK_SWITCH_NO_KUBECTL=1 so switch_context.sh only
+# rewrites the env files and does NOT touch kubectl current-context/namespace.
+# We pre-load context.env first so the logical inputs reach switch_context.sh.
+if [[ -s "${__mck_root}/.generated/.current_context" ]]; then
+    __mck_stale=$(find "${__mck_root}/scripts/dev/contexts" -type f \
+        \( -newer "${__mck_root}/.generated/context.env" \
+        -o -newer "${__mck_root}/.generated/context.${__mck_side}.env" \) \
+        -print -quit 2>/dev/null)
+    if [[ -n "${__mck_stale}" ]]; then
+        if [[ "${MCK_DEVENV_AUTO_SWITCH:-}" == "true" || "${MCK_DEVENV_AUTO_SWITCH:-}" == "1" ]]; then
+            echo "devenv: scripts/dev/contexts/ is newer than .generated/context.{env,${__mck_side}.env};" >&2
+            echo "        MCK_DEVENV_AUTO_SWITCH set — regenerating via switch_context.sh ($(cat "${__mck_root}/.generated/.current_context"))..." >&2
+            set -a
+            # shellcheck disable=SC1090,SC1091
+            . "${__mck_root}/.generated/context.env"
+            set +a
+            if ! ( cd "${__mck_root}" && MCK_SWITCH_NO_KUBECTL=1 scripts/dev/switch_context.sh \
+                   "$(cat "${__mck_root}/.generated/.current_context")" >&2 ); then
+                echo "ERROR: switch_context.sh regeneration failed." >&2
+                unset __mck_root __mck_side __mck_stale
+                return 1 2>/dev/null || exit 1
+            fi
+        else
+            echo "devenv: scripts/dev/contexts/ is newer than .generated/context.{env,${__mck_side}.env}." >&2
+            echo "        Run 'make switch' when convenient to regenerate (or set MCK_DEVENV_AUTO_SWITCH=true)." >&2
+        fi
+    fi
+    unset __mck_stale
+fi
+
+set -a
+# shellcheck disable=SC1090,SC1091
+. "${__mck_root}/.generated/context.env"
+# shellcheck disable=SC1090,SC1091
+. "${__mck_root}/.generated/context.${__mck_side}.env"
+set +a
+
+# Status echoes go to stderr so callers that capture stdout via $(...) — e.g.
+# `chart_info=$(scripts/dev/run_python.sh oci_chart_info.py ...)` followed by
+# `jq` — get clean output instead of devenv chatter mixed with their data.
+if [[ -f "${__mck_root}/.generated/.current_context" ]]; then
+    echo "Current context: $(cat "${__mck_root}/.generated/.current_context")" >&2
+fi
+
+# Per-worktree venv by default; PROJECT_VENV_PATH opts into a shared one.
+__mck_venv="${PROJECT_VENV_PATH:-${__mck_root}/venv}"
+if [[ -f "${__mck_venv}/bin/activate" ]]; then
+    type deactivate &>/dev/null && deactivate
+    # shellcheck disable=SC1091
+    . "${__mck_venv}/bin/activate"
+    echo "Activated venv ($(python --version 2>&1)): $(command -v python)" >&2
+fi
+
+unset __mck_root __mck_side __mck_venv

--- a/scripts/dev/e2e_gather_diagnostics.sh
+++ b/scripts/dev/e2e_gather_diagnostics.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Gather Kubernetes diagnostics + the HTML test summary into logs/ using the
+# same dump_cluster_information + generate_test_summary from
+# scripts/evergreen/e2e/diagnostics.sh that CI e2e.sh runs. Runs inside the
+# devcontainer after e2e_run.sh so the on-host --local-kind flow produces the
+# same artifact set under logs/ that upload_e2e_logs archives to S3.
+#
+# Usage: e2e_gather_diagnostics.sh <test_rc> [test_name] [variant]
+#
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+cd "${root}" || exit 1
+
+test_rc="${1:-0}"
+test_name="${2:-${TASK_NAME:-unknown}}"
+variant="${3:-unknown}"
+
+# shellcheck disable=SC1091
+source scripts/dev/set_env_context.sh
+source scripts/funcs/printing
+source scripts/evergreen/e2e/dump_diagnostic_information.sh
+source scripts/evergreen/e2e/diagnostics.sh
+
+# A single failed kubectl must never abort diagnostics; -u would trip on
+# MEMBER_CLUSTERS in the single-cluster branch.
+set +eu
+
+mkdir -p logs
+
+dump_cluster_information
+
+test_status="FAILED"
+[[ "${test_rc}" -eq 0 ]] && test_status="PASSED"
+generate_test_summary "${test_status}" "${test_name}" "${variant}" || true
+
+echo "Diagnostics gathered into ${root}/logs (status=${test_status})"

--- a/scripts/dev/e2e_run.sh
+++ b/scripts/dev/e2e_run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Run a single E2E test (or marker) locally against the kind cluster.
+#
+# Usage: e2e_run.sh <marker_or_path>
+#
+# Examples:
+#   e2e_run.sh e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb
+#   e2e_run.sh tests/search/search_replicaset_external_mongodb_multi_mongot_managed_lb.py
+#
+# Logs to logs/test-<sanitized-name>-<timestamp>.log.
+# Assumes the operator is already running (via op_run.sh).
+#
+
+set -Eeou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+if [[ $# -ne 1 ]]; then
+  sed -n '3,15p' "$0"
+  exit 1
+fi
+target="$1"
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+cd "${root}"
+
+# shellcheck disable=SC1091
+source scripts/dev/set_env_context.sh
+
+mkdir -p logs
+sanitized="${target//[^A-Za-z0-9._-]/_}"
+log_path="logs/test-${sanitized}-$(date +%Y%m%d-%H%M%S).log"
+# Stable symlink to the latest test log — the devcontainer tmuxp pane
+# tails this path so it picks up new runs automatically (matches the
+# logs/operator.log convention from op_run.sh).
+ln -sf "${log_path#logs/}" logs/test.log
+
+# --junitxml at the repo-root logs/ path the EVG `upload_e2e_logs` function's
+# attach.xunit_results expects; the on-host devc variant runs pytest directly
+# (no e2e-test pod) so this is the only producer of myreport.xml.
+pytest_args=(-v -s "--junitxml=${root}/logs/myreport.xml")
+# Treat anything that looks like a path as a positional, otherwise use -m.
+if [[ "${target}" == */* || "${target}" == *.py ]]; then
+  pytest_args+=("../../${target}")
+else
+  pytest_args+=(-m "${target}")
+fi
+
+cd docker/mongodb-kubernetes-tests
+echo "Running: pytest ${pytest_args[*]}"
+echo "Log: ${root}/${log_path}"
+exec pytest "${pytest_args[@]}" 2>&1 | tee "${root}/${log_path}"

--- a/scripts/dev/evg_host.sh
+++ b/scripts/dev/evg_host.sh
@@ -4,7 +4,6 @@
 # It allows to configure kind clusters and expose remote API servers on a local machine to
 # enable local development while running Kind cluster on EC2 instance.
 # Run "evg_host.sh help" command to see the full usage.
-# See docs/dev/local_e2e_testing.md for a tutorial how to use it.
 
 set -Eeou pipefail
 
@@ -14,34 +13,43 @@ source scripts/dev/set_env_context.sh
 source scripts/funcs/printing
 
 
-if [[ -z "${EVG_HOST_NAME}" ]]; then
-  echo "EVG_HOST_NAME env var is missing"
-  exit 1
-fi
+# Every command in this script talks to a remote EVG host. Non-EVG modes
+# (local-kind, BYOC) don't go through here at all — they touch the kubeconfig
+# via refresh_kubeconfig.sh directly. EVG_HOST_NAME's strict check is
+# deferred to get_host_url() so `help` / no-arg invocation doesn't fail.
 
 get_host_url() {
-  host=$(evergreen host list --json | jq -r ".[] | select (.name==\"${EVG_HOST_NAME}\") | .host_name ")
-  if [[ "${host}" == "" ]]; then
-    >&2 echo "Cannot find running EVG host with name ${EVG_HOST_NAME}.
-Run evergreen host list --json or visit https://spruce.mongodb.com/spawn/host."
+  if [[ -z "${EVG_HOST_NAME:-}" ]]; then
+    >&2 echo "EVG_HOST_NAME env var is missing (required for command '${cmd}')"
     exit 1
+  fi
+  if [[ -z "${EVG_HOST_ADDRESS:-}" ]]; then
+    host=$(evergreen host list --json | jq -r ".[] | select (.name==\"${EVG_HOST_NAME}\") | .host_name ")
+    if [[ "${host}" == "" ]]; then
+      >&2 echo "Cannot find running EVG host with name ${EVG_HOST_NAME}.
+  Run evergreen host list --json or visit https://spruce.mongodb.com/spawn/host."
+      exit 1
+    fi
+  else
+    host="${EVG_HOST_ADDRESS}"
   fi
   echo "ubuntu@${host}"
 }
 
 cmd=${1-""}
 
-if [[ "${cmd}" != "" && "${cmd}" != "help" ]]; then
-  host_url=$(get_host_url)
-fi
+# Every non-help command needs an EVG host to talk to. Resolve up-front.
+case "${cmd}" in
+  ""|help) ;;
+  *) host_url=$(get_host_url) ;;
+esac
 
-kubeconfig_path="${HOME}/.operator-dev/evg-host.kubeconfig"
+kubeconfig_path="${PROJECT_DIR}/.generated/current.kubeconfig"
 
 configure() {
   shift || true
   auto_recreate="false"
 
-  # Parse arguments
   while [[ $# -gt 0 ]]; do
     case $1 in
       --auto-recreate)
@@ -66,25 +74,17 @@ configure() {
 
   sync | prepend "sync"
 
-  ssh -T -q "${host_url}" "cd ~/mongodb-kubernetes; scripts/dev/switch_context.sh root-context; scripts/dev/setup_evg_host.sh ${auto_recreate}"
+  ssh -T -q "${host_url}" "cd ~/mongodb-kubernetes; scripts/dev/switch_context.sh root-context; . scripts/dev/devenv; scripts/dev/setup_evg_host.sh ${auto_recreate}"
 }
 
 sync() {
-  rsync --verbose --archive --compress --human-readable --recursive --progress \
+  rsync --archive --compress --human-readable --recursive \
   --delete --delete-excluded --max-size=1000000 --prune-empty-dirs \
   -e ssh \
   --include-from=.rsyncinclude \
   --exclude-from=.gitignore \
   --exclude-from=.rsyncignore \
   ./ "${host_url}:/home/ubuntu/mongodb-kubernetes/"
-
-  rsync --verbose --no-links --recursive --prune-empty-dirs --archive --compress --human-readable \
-    --max-size=1000000 \
-    -e ssh \
-    ~/.operator-dev/ \
-    "${host_url}:/home/ubuntu/.operator-dev" &
-
-  wait
 }
 
 remote-prepare-local-e2e-run() {
@@ -97,15 +97,49 @@ remote-prepare-local-e2e-run() {
     -e ssh \
     "${host_url}:/home/ubuntu/mongodb-kubernetes/.multi_cluster_local_test_files" \
     ./ &
-  scp "${host_url}:/home/ubuntu/.operator-dev/multicluster_kubeconfig" "${KUBE_CONFIG_PATH}" &
+  # Bare base lands at the fixed local base path (NOT ${KUBE_CONFIG_PATH},
+  # a per-side flavor). The bare 127.0.0.1 file is what tunnel
+  # users consume directly; inside the devcontainer the two flavors are
+  # derived by `evg_host.sh get-kubeconfig` / `wt-ctl kubeconfig refresh`.
+  scp "${host_url}:/home/ubuntu/mongodb-kubernetes/.generated/multicluster_kubeconfig" "${PROJECT_DIR}/.generated/multicluster_kubeconfig" &
 
   wait
 }
 
 get-kubeconfig() {
-  remote_path="${host_url}:/home/ubuntu/.operator-dev/evg-host.kubeconfig"
-  echo "Copying remote kubeconfig from ${remote_path} to ${kubeconfig_path}"
-  scp "${remote_path}" "${kubeconfig_path}"
+  # EVG-host kubeconfig flow: scp the host's current.kubeconfig down to
+  # this worktree, then delegate proxy-url patching + kfp registration to
+  # the host-agnostic refresh_kubeconfig.sh. Local-kind / BYOC modes don't
+  # go through this verb — they invoke refresh_kubeconfig.sh directly.
+  #
+  # Usage: get-kubeconfig [--no-fetch]
+  #   --no-fetch  Skip the scp step. Use when the kubeconfig already lives
+  #               in this filesystem (e.g. inside the devcontainer where
+  #               .generated/ is bind-mounted from the host) and we just
+  #               need to repatch + re-register.
+  shift || true
+  local no_fetch=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-fetch) no_fetch=1; shift ;;
+      *) echo "Unknown argument to get-kubeconfig: $1" >&2; return 1 ;;
+    esac
+  done
+
+  if [[ ${no_fetch} -eq 0 ]]; then
+    # The remote `kind export kubeconfig` writes to ${KUBECONFIG}, which on
+    # the EVG host site-context resolves to
+    # /home/ubuntu/mongodb-kubernetes/.generated/current.kubeconfig
+    # (the canonical per-side kubeconfig path). Scp from that exact path.
+    remote_path="${host_url}:/home/ubuntu/mongodb-kubernetes/.generated/current.kubeconfig"
+    echo "Copying remote kubeconfig from ${remote_path} to ${kubeconfig_path}"
+    mkdir -p "$(dirname "${kubeconfig_path}")"
+    scp "${remote_path}" "${kubeconfig_path}"
+  else
+    echo "Skipping kubeconfig fetch (--no-fetch); using existing ${kubeconfig_path}"
+  fi
+
+  "${PROJECT_DIR}/scripts/dev/wt-ctl" --quiet kubeconfig refresh
 }
 
 recreate-kind-clusters() {
@@ -125,6 +159,13 @@ recreate-kind-cluster() {
   echo "Recreating kind cluster ${cluster_name} on ${EVG_HOST_NAME} (${host_url})..."
   # shellcheck disable=SC2088
   ssh -T "${host_url}" "cd ~/mongodb-kubernetes; scripts/dev/recreate_kind_cluster.sh ${cluster_name}"
+  # Single-cluster verb: current.kubeconfig holds one context (the multi verb
+  # recreate-kind-clusters builds a multi-context file instead). setup_kind_cluster.sh
+  # runs under root-context on the host, where its `-e` export writes the cluster's
+  # kubeconfig to ~/.kube/${cluster_name}; copy it to the canonical
+  # ~/mongodb-kubernetes/.generated/current.kubeconfig so get-kubeconfig's scp finds it.
+  ssh -T -q "${host_url}" \
+    "mkdir -p ~/mongodb-kubernetes/.generated && cp -f ~/.kube/${cluster_name} ~/mongodb-kubernetes/.generated/current.kubeconfig"
   echo "Copying kubeconfig to ${kubeconfig_path}"
   get-kubeconfig
 }
@@ -167,7 +208,7 @@ retry_with_sleep() {
 ssh_to_host() {
   shift 1
   # shellcheck disable=SC2029
-  ssh "$@" "${host_url}"
+  ssh "${host_url}" "$@"
 }
 
 upload-my-ssh-private-key() {
@@ -199,10 +240,10 @@ PREREQUISITES:
 COMMANDS:
   recreate-kind-clusters                all-you-need to configure host and kind clusters; deletes and recreates all kind clusters (for single and multi runs)
   configure [--auto-recreate]           installs on a host: calls sync, switches context, installs necessary software
-  sync                                  rsync of project directory
+  sync                                  rsync of project directory (.git is intentionally not synced)
   recreate-kind-cluster test-cluster    executes scripts/dev/recreate_kind_cluster.sh test-cluster and executes get-kubeconfig
   remote-prepare-local-e2e-run          executes prepare-local-e2e on the remote evg host
-  get-kubeconfig                        copies remote kubeconfig locally to ~/.operator-dev/evg-host.kubeconfig
+  get-kubeconfig                        copies the remote .generated/current.kubeconfig into this worktree, then patches it per side + registers with kfp
   tunnel [args]                         creates ssh session with tunneling to all API servers
   ssh [args]                            creates ssh session passing optional arguments to ssh
   cmd [command with args]               execute command as if being on evg host
@@ -215,11 +256,11 @@ case ${cmd} in
 configure) configure "$@" ;;
 recreate-kind-clusters) recreate-kind-clusters "$@" ;;
 recreate-kind-cluster) recreate-kind-cluster "$@" ;;
-get-kubeconfig) get-kubeconfig ;;
+get-kubeconfig) get-kubeconfig "$@" ;;
 remote-prepare-local-e2e-run) remote-prepare-local-e2e-run ;;
 ssh) ssh_to_host "$@" ;;
 tunnel) retry_with_sleep tunnel "$@" ;;
-sync) sync ;;
+sync) shift; sync "$@" ;;
 cmd) cmd "$@" ;;
 upload-my-ssh-private-key) upload-my-ssh-private-key ;;
 help) usage ;;

--- a/scripts/dev/evg_prepare.sh
+++ b/scripts/dev/evg_prepare.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Prepare an Evergreen host for use with this worktree.
+#
+# Behaviour:
+#   1. Spawn (or resume — idempotent on displayName) a host named
+#      ${EVG_HOST_NAME} via `wt-ctl evg spawn`.
+#   2. Persist the host name into .generated/.current-evg-host so that
+#      scripts/dev/contexts/root-context picks it up.
+#   3. Re-run `make switch context=${current}` to regenerate context*.env
+#      with EVG_HOST_NAME and (now) EVG_HOST_ADDRESS resolved.
+#   4. Verify SSH via `scripts/dev/evg_host.sh ssh`.
+#   5. Recreate kind clusters on the host (single by default; --multi for
+#      the four-cluster setup; --skip-recreate to leave kind alone).
+#
+# Usage:
+#   evg_prepare.sh [--multi] [--skip-recreate] [--name NAME]
+#   evg_prepare.sh --name dev-myfeature
+#
+# Options:
+#   --name NAME       Display name to spawn / resume. Defaults to the worktree
+#                     basename (after slash-to-underscore conversion).
+#   --multi           Recreate the four-cluster multi setup (e2e-operator,
+#                     e2e-cluster-{1,2,3}, kind). Default is single (one
+#                     `kind` cluster).
+#   --skip-recreate   Don't recreate the kind cluster(s). Use to take over
+#                     an already-prepared host without touching kind.
+#   --distro DISTRO   evergreen distro for the spawn (default: evg spawn's own).
+#   --region REGION   AWS region for the spawn (default: evg spawn's own).
+
+set -Eeou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+usage() {
+  sed -n '3,29p' "$0"
+}
+
+multi_cluster=0
+skip_recreate=0
+explicit_name=""
+distro=""
+region=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --multi|--multi-cluster) multi_cluster=1; shift ;;
+    --skip-recreate)         skip_recreate=1; shift ;;
+    --name)                  explicit_name="$2"; shift 2 ;;
+    --distro)                distro="$2"; shift 2 ;;
+    --region)                region="$2"; shift 2 ;;
+    -h|--help)               usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+worktree_root="$(pwd)"
+worktree_basename="$(basename "${worktree_root}")"
+
+if [[ -n "${explicit_name}" ]]; then
+  evg_host_name="${explicit_name}"
+else
+  evg_host_name="${worktree_basename}"
+fi
+
+echo "==> evg_prepare: worktree=${worktree_root}, host=${evg_host_name}"
+
+# 1. Spawn (or resume) the host via wt-ctl's native EVG verb. Idempotent on
+#    the Evergreen displayName; resumes any non-terminal host with that name.
+echo "==> Spawning / resuming EVG host displayName='${evg_host_name}'"
+spawn_args=(--name "${evg_host_name}")
+[[ -n "${distro}" ]] && spawn_args+=(--distro "${distro}")
+[[ -n "${region}" ]] && spawn_args+=(--region "${region}")
+"${worktree_root}/scripts/dev/wt-ctl" --quiet evg spawn "${spawn_args[@]}"
+
+# 2. Pin the host into this worktree's .generated/ so root-context picks it up.
+mkdir -p "${worktree_root}/.generated"
+echo -n "${evg_host_name}" > "${worktree_root}/.generated/.current-evg-host"
+
+# 3. Re-run make switch so context*.env reflect the new EVG_HOST_NAME / ADDRESS.
+current_context_file="${worktree_root}/.generated/.current_context"
+if [[ ! -f "${current_context_file}" ]]; then
+  echo "ERROR: .generated/.current_context not found. Run 'make switch' once before this script." >&2
+  exit 1
+fi
+current_context="$(cat "${current_context_file}")"
+echo "==> Regenerating context files (context=${current_context})"
+make switch context="${current_context}"
+
+# 4. Verify SSH connectivity through evg_host.sh.
+echo "==> Verifying SSH to ${evg_host_name} via evg_host.sh"
+if ! scripts/dev/evg_host.sh ssh -o ConnectTimeout=20 -o BatchMode=yes -- 'echo evg_host_ready'; then
+  echo "ERROR: SSH check via evg_host.sh failed for ${evg_host_name}." >&2
+  exit 1
+fi
+
+# 5. Recreate kind clusters unless explicitly suppressed.
+if [[ ${skip_recreate} -eq 1 ]]; then
+  echo "==> --skip-recreate set; skipping kind cluster recreation"
+  echo "==> Refreshing kubeconfig from existing host"
+  scripts/dev/evg_host.sh get-kubeconfig
+elif [[ ${multi_cluster} -eq 1 ]]; then
+  echo "==> Recreating all (multi) kind clusters on ${evg_host_name}"
+  scripts/dev/evg_host.sh recreate-kind-clusters
+else
+  echo "==> Recreating single kind cluster on ${evg_host_name}"
+  scripts/dev/evg_host.sh recreate-kind-cluster kind
+fi
+
+echo "==> evg_prepare: done — host=${evg_host_name}"

--- a/scripts/dev/evg_prepare.sh
+++ b/scripts/dev/evg_prepare.sh
@@ -14,12 +14,14 @@
 #      the four-cluster setup; --skip-recreate to leave kind alone).
 #
 # Usage:
-#   evg_prepare.sh [--multi] [--skip-recreate] [--name NAME]
+#   evg_prepare.sh [--multi] [--skip-recreate] [--name NAME] [--context CTX]
 #   evg_prepare.sh --name dev-myfeature
 #
 # Options:
 #   --name NAME       Display name to spawn / resume. Defaults to the worktree
 #                     basename (after slash-to-underscore conversion).
+#   --context CTX     Context to regenerate. Falls back to
+#                     .generated/.current_context when omitted.
 #   --multi           Recreate the four-cluster multi setup (e2e-operator,
 #                     e2e-cluster-{1,2,3}, kind). Default is single (one
 #                     `kind` cluster).
@@ -38,6 +40,7 @@ usage() {
 multi_cluster=0
 skip_recreate=0
 explicit_name=""
+context_arg=""
 distro=""
 region=""
 while [[ $# -gt 0 ]]; do
@@ -45,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --multi|--multi-cluster) multi_cluster=1; shift ;;
     --skip-recreate)         skip_recreate=1; shift ;;
     --name)                  explicit_name="$2"; shift 2 ;;
+    --context)               context_arg="$2"; shift 2 ;;
     --distro)                distro="$2"; shift 2 ;;
     --region)                region="$2"; shift 2 ;;
     -h|--help)               usage; exit 0 ;;
@@ -76,12 +80,19 @@ mkdir -p "${worktree_root}/.generated"
 echo -n "${evg_host_name}" > "${worktree_root}/.generated/.current-evg-host"
 
 # 3. Re-run make switch so context*.env reflect the new EVG_HOST_NAME / ADDRESS.
+#    Prefer the caller-supplied --context (the orchestrator knows it
+#    authoritatively) over the .generated/.current_context sentinel, which a
+#    concurrent create phase (dc_build's initializeCommand) can transiently
+#    clear. make switch below regenerates .generated regardless.
 current_context_file="${worktree_root}/.generated/.current_context"
-if [[ ! -f "${current_context_file}" ]]; then
-  echo "ERROR: .generated/.current_context not found. Run 'make switch' once before this script." >&2
+if [[ -n "${context_arg}" ]]; then
+  current_context="${context_arg}"
+elif [[ -f "${current_context_file}" ]]; then
+  current_context="$(cat "${current_context_file}")"
+else
+  echo "ERROR: no --context given and .generated/.current_context not found. Run 'make switch' once before this script." >&2
   exit 1
 fi
-current_context="$(cat "${current_context_file}")"
 echo "==> Regenerating context files (context=${current_context})"
 make switch context="${current_context}"
 

--- a/scripts/dev/init_worktree.sh
+++ b/scripts/dev/init_worktree.sh
@@ -56,8 +56,8 @@ else
 fi
 
 # Per-worktree by default; opt into a shared venv by exporting PROJECT_VENV_PATH.
-venv_path="${PROJECT_VENV_PATH:-${worktree_root}/venv}"
 # Recreate on empty/broken venv (no activate script) too; the script is idempotent.
+venv_path="${PROJECT_VENV_PATH:-${worktree_root}/venv}"
 if [[ ! -f "${venv_path}/bin/activate" || ${force} == 1 ]]; then
     echo "init_worktree: recreating python venv"
     (cd "${worktree_root}" && scripts/dev/recreate_python_venv.sh)

--- a/scripts/dev/install_csi_driver.sh
+++ b/scripts/dev/install_csi_driver.sh
@@ -6,54 +6,49 @@ source scripts/dev/set_env_context.sh
 source scripts/funcs/kubernetes
 source scripts/funcs/install
 
-# Path to the deploy script
 DEPLOY_SCRIPT_PATH="./deploy/kubernetes-latest/deploy.sh"
-EXTRACTED_DIR="csi-driver-host-path-1.14.1"
+HOST_PATH_VERSION="1.14.1"
+EXTRACTED_DIR="/tmp/csi-driver-host-path-${HOST_PATH_VERSION}"
 
 csi_driver_download() {
     echo "install resizable csi"
-    # Define variables
-    REPO_URL="https://github.com/kubernetes-csi/csi-driver-host-path/archive/refs/tags/v1.14.1.tar.gz"
-    TAR_FILE="csi-driver-host-path-v1.14.1.tar.gz"
+    REPO_URL="https://github.com/kubernetes-csi/csi-driver-host-path/archive/refs/tags/v${HOST_PATH_VERSION}.tar.gz"
+    TAR_FILE="/tmp/csi-driver-host-path-v${HOST_PATH_VERSION}.tar.gz"
 
-    # Download the tar.gz file
     echo "Downloading ${REPO_URL}..."
     curl_with_retry -L -o "${TAR_FILE}" "${REPO_URL}"
 
-    # Extract the tar.gz file
     echo "Extracting ${TAR_FILE}..."
-    tar -xzf "${TAR_FILE}"
+    tar -xzf "${TAR_FILE}" -C /tmp
 }
 
-# Function to deploy to a single cluster
 csi_driver_deploy() {
     local context="$1"
 
-    # Navigate to the extracted directory
+    # Subshell so the cd into EXTRACTED_DIR (required for the relative deploy
+    # paths below) doesn't leak to the caller — recreate_kind_cluster.sh's
+    # trailing `cp .generated/current.kubeconfig` relies on cwd staying put.
+    (
     cd "${EXTRACTED_DIR}"
-    # Change to the latest supported snapshotter release branch
     SNAPSHOTTER_BRANCH=release-6.3
 
-    # Apply VolumeSnapshot CRDs
     kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
     kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
     kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 
-    # Change to the latest supported snapshotter version
     SNAPSHOTTER_VERSION=v6.3.3
 
-    # Create snapshot controller
     kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
     kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 
     # Run the deploy script with kubectl wrapped to force it to use specific context rather than rely on current context
     if ! run_script_with_wrapped_kubectl "${DEPLOY_SCRIPT_PATH}" "${context}"; then
-        return 1
+        exit 1
     fi
 
     echo "Installing csi storageClass"
     kubectl apply --context "${context}" -f ./examples/csi-storageclass.yaml
 
     echo "Deployment successful on ${context}"
-    return 0
+    )
 }

--- a/scripts/dev/op_run.sh
+++ b/scripts/dev/op_run.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Start the operator locally (go run ./main.go) inside a tmux session named
+# 'mck-operator' so it survives the devcontainer-exec call that started it.
+# Logs stream to logs/operator-<timestamp>.log; logs/operator.log is a
+# stable symlink to the latest run.
+#
+# Modes:
+#   (no args)  Start + wait for ready + tail the log. Ctrl-C stops the
+#              operator (kills the mck-operator tmux session) and exits.
+#   --detach   Start + wait for ready + return. Operator keeps running
+#              in the mck-operator session. Use this from scripted
+#              callers that need to know "operator is up" before
+#              proceeding (e.g. before launching e2e_run.sh).
+#
+
+set -Eeou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+mode="tail"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --detach) mode="detach"; shift ;;
+    -h|--help) sed -n '3,15p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+
+# Source the per-side env via the canonical bootstrap. devenv handles:
+#   - side detection via /.dockerenv
+#   - logical .generated/context.env + site .generated/context.<side>.env
+#   - venv activation if present
+# Operator-specific overlay (.generated/context.operator.env) is loaded
+# by main.go's loadEnvFromLocalFileForDevelopment, not by this shell.
+# shellcheck disable=SC1091
+. scripts/dev/devenv
+
+mkdir -p logs
+log_path="logs/operator-$(date +%Y%m%d-%H%M%S).log"
+ln -sf "${log_path#logs/}" logs/operator.log
+
+# Operator binds health/metrics on 8181 and webhook on 9443. Wipe stale ports
+# so a previous unclean exit doesn't crash this run with EADDRINUSE.
+for port in 8181 9443; do
+  pid="$(lsof -ti:"${port}" 2>/dev/null || true)"
+  if [[ -n "${pid}" ]]; then
+    echo "killing stale pid ${pid} on port ${port}"
+    kill -9 "${pid}" 2>/dev/null || true
+  fi
+done
+
+# Multi-cluster mode requires the operator to watch the mongodbmulticluster
+# CRD; otherwise no MongoDBMultiCluster controller starts and the CR is
+# silently ignored. The --watch-resource flag is repeatable; passing any
+# of them disables the default list, so we have to enumerate the full set.
+operator_args=""
+proxy_env=""
+if [[ "${KUBE_ENVIRONMENT_NAME:-}" == "multi" ]]; then
+  operator_args="--watch-resource=mongodb \
+--watch-resource=mongodbusers \
+--watch-resource=opsmanagers \
+--watch-resource=mongodbcommunity \
+--watch-resource=mongodbsearch \
+--watch-resource=clustermongodbroles \
+--watch-resource=mongodbmulticluster"
+
+  # The operator's memberwatch healthcheck reads MULTI_CLUSTER_HEALTHCHECK_PROXY
+  # explicitly (not the standard HTTP_PROXY env vars, because Go hardcodes a
+  # 127.0.0.1/localhost bypass that overrides NO_PROXY — and the member kind
+  # API servers ARE on 127.0.0.1:<port> on the EVG host's loopback, reachable
+  # from the devcontainer only via gost-proxy → SSH tunnel).
+  if [[ -n "${EVG_HOST_PROXY:-}" ]]; then
+    proxy_env="MULTI_CLUSTER_HEALTHCHECK_PROXY=${EVG_HOST_PROXY}"
+  fi
+fi
+
+tmux kill-session -t mck-operator 2>/dev/null || true
+tmux new-session -d -s mck-operator \
+  "bash -lc 'cd \"$(pwd)\"; . scripts/dev/devenv; ${proxy_env} go run ./main.go ${operator_args} 2>&1 | tee ${log_path}'"
+
+echo "Operator started in tmux session 'mck-operator'."
+echo "  log: ${log_path}  (symlinked as logs/operator.log)"
+echo "  attach: tmux a -t mck-operator"
+
+# Both modes wait for the operator to be ready first.
+echo -n "Waiting for operator to start "
+ready=0
+for _ in $(seq 1 90); do
+  if grep -qE 'Starting workers|webhook .* listening|Starting EventSource|controller=.* started' "${log_path}" 2>/dev/null; then
+    echo
+    echo "Operator is up."
+    ready=1
+    break
+  fi
+  if grep -qE 'panic:|fatal:|level=error' "${log_path}" 2>/dev/null; then
+    echo
+    echo "Operator log shows error:"
+    tail -n 40 "${log_path}"
+    exit 1
+  fi
+  echo -n "."
+  sleep 1
+done
+
+if [[ ${ready} -eq 0 ]]; then
+  echo
+  echo "Timed out waiting for operator readiness."
+  tail -n 40 "${log_path}"
+  exit 1
+fi
+
+if [[ ${mode} == detach ]]; then
+  exit 0
+fi
+
+# Tail mode: stream the log and, on Ctrl-C / SIGTERM, stop the operator.
+# bash defers pending signals while waiting on a foreground child, so
+# after tail dies on SIGINT bash runs this trap before exiting.
+trap '
+  echo
+  echo "[op_run] stopping operator (tmux session mck-operator)..."
+  tmux kill-session -t mck-operator 2>/dev/null || true
+  exit 0
+' INT TERM
+
+echo
+echo "[op_run] Tailing ${log_path}. Ctrl-C to stop the operator."
+echo
+tail -F "${log_path}"

--- a/scripts/dev/prepare-multi-cluster/main.go
+++ b/scripts/dev/prepare-multi-cluster/main.go
@@ -83,13 +83,17 @@ func main() {
 	}
 
 	// Phase 2: Ensure namespaces + label istio-injection (parallel per member cluster)
+	// The label is applied unconditionally to mirror the original bash flow
+	// in scripts/funcs/multicluster — tests that need no-mesh override it
+	// to "disabled" themselves (see e.g. multi_cluster_tls_no_mesh.py).
+	// STRICT PeerAuthentication remains mTLS-gated.
 	fmt.Println("Phase 2: Ensuring namespaces")
 	ensureNamespace(ctx, clients[cfg.centralCluster], cfg.centralCluster, cfg.namespace, cfg.taskID, collectErrorFor(cfg.centralCluster))
 	runParallel(cfg.memberClusters, func(cluster string) {
 		collectError := collectErrorFor(cluster)
 		ensureNamespace(ctx, clients[cluster], cluster, cfg.namespace, cfg.taskID, collectError)
+		labelNamespaceIstio(ctx, clients[cluster], cluster, cfg.namespace, collectError)
 		if cfg.applyMTLS {
-			labelNamespaceIstio(ctx, clients[cluster], cluster, cfg.namespace, collectError)
 			applyPeerAuthentication(ctx, dynamicClients[cluster], cluster, cfg.namespace, collectError)
 		}
 	})

--- a/scripts/dev/prepare_local_e2e_run.sh
+++ b/scripts/dev/prepare_local_e2e_run.sh
@@ -10,7 +10,10 @@ source scripts/funcs/operator_deployment
 source scripts/funcs/multicluster
 source scripts/funcs/kubernetes
 
-if [[ "$(uname)" == "Linux" ]]; then
+if [[ "$(uname)" == "Linux" && -d /opt/golang/go1.25 ]]; then
+  # Evergreen build hosts ship Go under /opt/golang/. Prepend it so this script
+  # uses that toolchain there. In other environments (devcontainer, local) the
+  # GOROOT exported by root-context (derived from `go env GOROOT`) wins.
   export PATH=/opt/golang/go1.25/bin:${PATH}
   export GOROOT=/opt/golang/go1.25
 fi
@@ -83,11 +86,12 @@ test -f "docker/mongodb-kubernetes-tests/.test_identifiers" && rm "docker/mongod
 # when DEPLOY_OPERATOR=true, but they're required even for local operator runs).
 # Add Helm ownership metadata so that when Helm runs (in this script or in pytest)
 # it can adopt these resources instead of failing with "invalid ownership metadata".
+helm_release_name="${OPERATOR_NAME:-mongodb-kubernetes-operator}"
 for sa in mongodb-kubernetes-database-pods mongodb-kubernetes-appdb; do
   kubectl create serviceaccount "${sa}" -n "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
   kubectl label serviceaccount "${sa}" -n "${NAMESPACE}" "app.kubernetes.io/managed-by=Helm" --overwrite
   kubectl annotate serviceaccount "${sa}" -n "${NAMESPACE}" \
-    "meta.helm.sh/release-name=mongodb-kubernetes-operator" \
+    "meta.helm.sh/release-name=${helm_release_name}" \
     "meta.helm.sh/release-namespace=${NAMESPACE}" \
     --overwrite
 done

--- a/scripts/dev/recreate_kind_cluster.sh
+++ b/scripts/dev/recreate_kind_cluster.sh
@@ -18,8 +18,39 @@ fi
 docker_create_kind_network
 docker_run_local_registry "kind-registry" "5000"
 
-scripts/dev/setup_kind_cluster.sh -r -e -n "${cluster_name}" -l "172.18.255.200-172.18.255.250" -c "${CLUSTER_DOMAIN}"
+# The kind node image is pulled from an ECR mirror (kubernetes-versions.json).
+# EVG spawn hosts have no ambient ECR auth (the instance role can't
+# GetAuthorizationToken, and any AMI-baked token is long expired), so log in
+# explicitly using the AWS creds from the sourced dev context before
+# setup_kind_cluster.sh triggers the node-image pull. No-op for non-ECR images.
+kind_node_image="${KIND_NODE_IMAGE:-$(scripts/get-kind-image.sh max)}"
+if [[ "${kind_node_image}" =~ ^([0-9]+\.dkr\.ecr\.([a-z0-9-]+)\.amazonaws\.com) ]]; then
+  ecr_registry="${BASH_REMATCH[1]}"
+  ecr_region="${BASH_REMATCH[2]}"
+  if docker image inspect "${kind_node_image}" >/dev/null 2>&1; then
+    # Already cached locally (the common case on a laptop) — no ECR round-trip
+    # needed, so don't fail when AWS CLI is missing / SSO expired / offline.
+    echo "Kind node image ${kind_node_image} already present locally; skipping ECR login"
+  else
+    echo "Logging in to ECR registry ${ecr_registry} (region ${ecr_region}) for kind node image"
+    if ! aws ecr get-login-password --region "${ecr_region}" \
+        | docker login --username AWS --password-stdin "${ecr_registry}"; then
+      echo "WARN: ECR login failed; the node-image pull will fail unless the image is cached" >&2
+    fi
+  fi
+fi
+
+# shellcheck source=../funcs/kind_network
+source scripts/funcs/kind_network
+scripts/dev/setup_kind_cluster.sh -r -e -n "${cluster_name}" -l "${KIND_METALLB_RANGE_SINGLE}" -c "${CLUSTER_DOMAIN}"
 
 source scripts/dev/install_csi_driver.sh
 csi_driver_download
-csi_driver_deploy "${cluster_name}-kind"
+csi_driver_deploy "kind-${cluster_name}"
+
+# Stamp the canonical per-side kubeconfig path so downstream tooling has
+# one source of truth for "kind cluster was just created on this host" —
+# the same artifact whether this runs on a laptop (local-kind) or an EVG
+# runner (EVG-CI). Mirrors recreate_kind_clusters.sh's tail.
+mkdir -p "${PROJECT_DIR}/.generated"
+cp -f "${HOME}/.kube/${cluster_name}" "${PROJECT_DIR}/.generated/current.kubeconfig"

--- a/scripts/dev/recreate_kind_clusters.sh
+++ b/scripts/dev/recreate_kind_clusters.sh
@@ -6,6 +6,7 @@ test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 source scripts/dev/set_env_context.sh
 source scripts/funcs/kubernetes
 source scripts/funcs/printing
+source scripts/funcs/kind_network
 
 docker_cleanup() {
   echo "Deleting all kind clusters"
@@ -23,23 +24,35 @@ docker_cleanup 2>&1| prepend "docker_cleanup"
 docker_create_kind_network
 docker_run_local_registry "kind-registry" "5000"
 
+# Fresh EVG spawn hosts only have the laptop's copied ~/.docker/config.json,
+# whose ECR token expires in ~12h; log in explicitly so the parallel kind
+# node-image pulls below can reach the ECR mirror.
+scripts/dev/configure_container_auth.sh 2>&1 | prepend "configure_container_auth"
+
 # To future maintainers: whenever modifying this bit, make sure you also update coredns.yaml
 cluster_pids=()
-(scripts/dev/setup_kind_cluster.sh -n "e2e-operator" -p "10.244.0.0/16" -s "10.96.0.0/16" -l "172.18.255.200-172.18.255.210" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-operator") &
+(scripts/dev/setup_kind_cluster.sh -n "e2e-operator" -p "10.244.0.0/16" -s "10.96.0.0/16" -l "${KIND_METALLB_RANGE_OPERATOR}" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-operator") &
 cluster_pids+=($!)
-(scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-1" -p "10.245.0.0/16" -s "10.97.0.0/16" -l "172.18.255.210-172.18.255.220" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-1") &
+(scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-1" -p "10.245.0.0/16" -s "10.97.0.0/16" -l "${KIND_METALLB_RANGE_CLUSTER_1}" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-1") &
 cluster_pids+=($!)
-(scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-2" -p "10.246.0.0/16" -s "10.98.0.0/16" -l "172.18.255.220-172.18.255.230" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-2") &
+(scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-2" -p "10.246.0.0/16" -s "10.98.0.0/16" -l "${KIND_METALLB_RANGE_CLUSTER_2}" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-2") &
 cluster_pids+=($!)
-(scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-3" -p "10.247.0.0/16" -s "10.99.0.0/16" -l "172.18.255.230-172.18.255.240" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-3") &
+(scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-3" -p "10.247.0.0/16" -s "10.99.0.0/16" -l "${KIND_METALLB_RANGE_CLUSTER_3}" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-3") &
 cluster_pids+=($!)
-(scripts/dev/setup_kind_cluster.sh -n "kind" -l "172.18.255.200-172.18.255.250" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "kind") &
+(scripts/dev/setup_kind_cluster.sh -n "kind" -l "${KIND_METALLB_RANGE_SINGLE}" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "kind") &
 cluster_pids+=($!)
 
 echo "Waiting for all kind clusters to be created"
 for pid in "${cluster_pids[@]}"; do wait "${pid}" || { echo "Cluster creation PID ${pid} failed" >&2; exit 1; }; done
 
 # we do exports sequentially as setup_kind_cluster.sh is run in parallel and we hit kube config locks
+# These exports go to ${KUBECONFIG} (set by set_env_context.sh sourced above).
+# Don't override KUBECONFIG here — downstream helpers (interconnect, istio,
+# csi) re-source set_env_context.sh and re-resolve KUBECONFIG from the
+# baked context env. Leaving exports at the default keeps every helper
+# looking at the same file. The merged kubeconfig is copied to
+# .generated/current.kubeconfig at the end of this script, where
+# evg_host.sh::get-kubeconfig scp's from.
 kind export kubeconfig --name "e2e-operator"
 kind export kubeconfig --name "e2e-cluster-1"
 kind export kubeconfig --name "e2e-cluster-2"
@@ -51,7 +64,7 @@ scripts/dev/interconnect_kind_clusters.sh -v e2e-cluster-1 e2e-cluster-2 e2e-clu
 
 export VERSION=${VERSION:-1.16.1}
 
-source multi_cluster/tools/download_istio.sh 2>&1 | prepend "download_istio"
+source multi_cluster/tools/download_istio.sh 2>&1 | prepend "download_istio" || true
 
 istio_pids=()
 VERSION=1.16.1 CTX_CLUSTER1=kind-e2e-cluster-1 CTX_CLUSTER2=kind-e2e-cluster-2 CTX_CLUSTER3=kind-e2e-cluster-3 multi_cluster/tools/install_istio.sh 2>&1 | prepend "install_istio" &
@@ -77,3 +90,12 @@ csi_driver_deploy kind-kind 2>&1 | prepend "install_csi_driver.sh kind-kind" &
 csi_pids+=($!)
 
 for pid in "${csi_pids[@]}"; do wait "${pid}" || { echo "CSI deploy PID ${pid} failed" >&2; exit 1; }; done
+
+# Make the merged kubeconfig available at the canonical worktree path so
+# evg_host.sh::get-kubeconfig (run from the laptop after this script
+# finishes on the remote) can scp it back.
+mkdir -p .generated
+src_kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+if [ ! "${src_kubeconfig}" -ef .generated/current.kubeconfig ]; then
+  cp -f "${src_kubeconfig}" .generated/current.kubeconfig
+fi

--- a/scripts/dev/recreate_python_venv.sh
+++ b/scripts/dev/recreate_python_venv.sh
@@ -61,9 +61,20 @@ ensure_required_python() {
 
 cd "${PROJECT_DIR}"
 if [[ -d "${venv_path}" ]]; then
-    echo "Removing existing venv at ${venv_path}..." >&2
-    rm -rf "${venv_path}"
-    echo "Existing venv removed" >&2
+    # Only wipe a directory that already holds a venv (or is empty) so a
+    # misconfigured PROJECT_VENV_PATH can't rm -rf unrelated files.
+    if [[ -f "${venv_path}/bin/activate" || -z "$(ls -A "${venv_path}")" ]]; then
+        echo "Removing existing venv at ${venv_path}..." >&2
+        # venv_path can be a mounted volume (the devcontainer mounts one at
+        # /workspace/venv) whose mountpoint can't be unlinked ("Device or
+        # resource busy"). Clear its contents (dotfiles included) instead so
+        # recreation works whether venv_path is a plain directory or a mount.
+        find "${venv_path}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+        echo "Existing venv removed" >&2
+    else
+        echo "Refusing to clear ${venv_path}: not a venv (no bin/activate)" >&2
+        exit 1
+    fi
 else
     echo "No existing venv found" >&2
 fi

--- a/scripts/dev/set_env_context.sh
+++ b/scripts/dev/set_env_context.sh
@@ -1,28 +1,40 @@
 #!/usr/bin/env bash
+#
+# Sourceable helper for scripts that want the per-side env loaded
+# without re-implementing the bootstrap. Prefer sourcing
+# scripts/dev/devenv directly; this is a thin wrapper for the many
+# scripts that source this helper to load the generated context env.
+#
+# Behavior:
+#   - Resolves the worktree root via the script's own location.
+#   - Sources scripts/dev/devenv (which fails loudly if env files
+#     are missing, picks the right side via /.dockerenv, sources
+#     logical .generated/context.env + site .generated/context.<side>.env
+#     with `set -a`, and activates venv if present).
+#   - Does NOT prepend ${PROJECT_DIR}/bin to PATH — that's handled
+#     in the container by /etc/profile.d/mck-bin.sh, and on the host
+#     by the dev's own ~/.zshrc / ~/.bashrc.
 
 set -Eeou pipefail
 test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 
-# shellcheck disable=1091
-source scripts/funcs/errors
+_set_env_context_script="$(readlink -f "${BASH_SOURCE[0]}")"
+_set_env_context_dir="$(dirname "${_set_env_context_script}")"
+_set_env_context_root="$(realpath "${_set_env_context_dir}/../..")"
 
-script_name=$(readlink -f "${BASH_SOURCE[0]}")
-script_dir=$(dirname "${script_name}")
-context_file="$(realpath "${script_dir}/../../.generated/context.export.env")"
+# shellcheck disable=SC1091
+. "${_set_env_context_root}/scripts/dev/devenv"
 
-if [[ ! -f ${context_file} ]]; then
-    fatal "File ${context_file} not found! Make sure to follow this guide to get started: https://wiki.corp.mongodb.com/display/MMS/Setting+up+local+development+and+E2E+testing#SettinguplocaldevelopmentandE2Etesting-GettingStartedGuide(VariantSwitching)"
+# Prepend the repo-local bin/ (downloaded kubectl/helm, bin/reset, chart-testing
+# tools) to PATH for the ~40 scripts that source this helper. Interactive shells
+# also get this via the user's rc (host) or
+# /etc/profile.d/mck-bin.sh (container), but non-interactive script invocations
+# don't — so restore it here. Idempotent: skip if already present.
+if [[ -n "${PROJECT_DIR:-}" ]]; then
+  case ":${PATH}:" in
+    *":${PROJECT_DIR}/bin:"*) ;;
+    *) export PATH="${PROJECT_DIR}/bin:${PATH}" ;;
+  esac
 fi
 
-# shellcheck disable=SC1090
-source "${context_file}"
-
-# Activate the python venv here so consumer scripts don't each activate it.
-# Per-worktree by default; opt into a shared venv by exporting PROJECT_VENV_PATH.
-venv_path="${PROJECT_VENV_PATH:-${PROJECT_DIR}/venv}"
-if [[ -f "${venv_path}/bin/activate" ]]; then
-    # shellcheck disable=SC1091
-    source "${venv_path}/bin/activate"
-fi
-
-export PATH="${PROJECT_DIR}/bin:${PATH}"
+unset _set_env_context_script _set_env_context_dir _set_env_context_root

--- a/scripts/dev/setup_kind_cluster.sh
+++ b/scripts/dev/setup_kind_cluster.sh
@@ -34,9 +34,11 @@ cluster_name=${CLUSTER_NAME:-"kind"}
 cluster_domain="cluster.local"
 export_kubeconfig=0
 recreate=0
+# shellcheck source=../funcs/kind_network
+source "$(dirname "${BASH_SOURCE[0]}")/../funcs/kind_network"
 pod_network="10.244.0.0/16"
 service_network="10.96.0.0/16"
-metallb_ip_range="172.18.255.200-172.18.255.250"
+metallb_ip_range="${KIND_METALLB_RANGE_SINGLE}"
 install_registry=0
 configure_docker_network=0
 while getopts ':n:p:s:c:l:egrhk' opt; do
@@ -61,11 +63,17 @@ kubeconfig_path="${HOME}/.kube/${cluster_name}"
 metallb_version="v0.13.7"
 metrics_server_version="v0.7.2"
 
-# local registry
 reg_name='kind-registry'
 reg_port='5000'
-# kind image source
 kind_image="${KIND_NODE_IMAGE:-$(scripts/get-kind-image.sh max)}"
+
+# REMOTE_CONTAINERS is set by VS Code's Dev Containers extension when the
+# worktree is opened inside the devcontainer. There kind's API server must bind
+# the container's eth0 IP rather than loopback to stay reachable.
+api_server_address="127.0.0.1"
+if [[ ${REMOTE_CONTAINERS:-false} == "true" ]]; then
+  api_server_address=$(ip addr show eth0 | awk '/inet /{print $2}' | cut -d/ -f1)
+fi
 
 kind_delete_cluster() {
   kind delete cluster --name "${cluster_name}" || true
@@ -110,12 +118,16 @@ nodes:
 networking:
   podSubnet: "${pod_network}"
   serviceSubnet: "${service_network}"
+  apiServerAddress: "${api_server_address}"
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta3
   kind: ClusterConfiguration
   networking:
     dnsDomain: "${cluster_domain}"
+  apiServer:
+    certSANs:
+      - "${api_server_address}"
 EOF
 }
 
@@ -132,12 +144,16 @@ nodes:
 networking:
   podSubnet: "${pod_network}"
   serviceSubnet: "${service_network}"
+  apiServerAddress: "${api_server_address}"
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta3
   kind: ClusterConfiguration
   networking:
     dnsDomain: "${cluster_domain}"
+  apiServer:
+    certSANs:
+      - "${api_server_address}"
 EOF
   echo "finished installing kind"
 }
@@ -224,8 +240,6 @@ kind_install_metrics_server() {
 export_kubeconfig() {
   kind export kubeconfig --name "${cluster_name}"
 }
-
-# main script
 
 if [[ "${install_registry}" == "1" ]]; then
   docker_run_local_registry "$@"

--- a/scripts/dev/switch_context.sh
+++ b/scripts/dev/switch_context.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
 set -Eeou pipefail
+
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
 # script prepares environment variables relevant for the current context
 
 source scripts/funcs/errors
+
+# Side detection: /.dockerenv exists only inside containers.
+# Used to pick which .generated/context.<side>.env file we write here,
+# and is the same rule used by scripts/dev/devenv at source time.
+side=$([[ -f /.dockerenv ]] && echo devc || echo host)
 
 script_name=$(readlink -f "${BASH_SOURCE[0]}")
 script_dir=$(dirname "${script_name}")
@@ -45,64 +53,182 @@ fi
 echo "Generating context files from: ${context}"
 
 
-# This means we are running on evergreen, in this case we need the environment variables from evg expansions.
-# If running locally, we don't need them since they are defined in the private-context already, so we don't need
-# any kind of current env var expansions
+# Two-step env capture:
+#   (a) site_envs — source site-context alone in an `env -i` subshell,
+#       forwarding only the inputs it reads (PWD/PATH/HOME + the wt-ctl stack
+#       vars + LOCAL_OPERATOR), yielding the site-derived bytes for this side.
+#   (b) current_envs — source the full chain (site + local-defaults +
+#       context_file + optional overrides). Locally in a second `env -i`
+#       subshell; on EVG-CI in the current shell so evergreen expansion vars
+#       (BUILD_VARIANT, EVR_TASK_ID, otel_*, TASK_NAME, IS_PATCH...) are
+#       visible to root-context + the per-variant context file.
+# logical_envs = current_envs − site_keys; both .env files are written below.
+
+# Step (a): capture site exports alone. site-context introspects the
+# running shell (PROJECT_DIR, GOROOT, /.dockerenv → KUBECONFIG variant,
+# K8S_FWD_PROXY, s390x conditionals).
+site_envs=$(env -i \
+    PWD="${PWD}" \
+    PATH="${PATH}" \
+    HOME="${HOME}" \
+    MCK_DEVC_NET_PREFIX="${MCK_DEVC_NET_PREFIX:-}" \
+    K8S_FWD_PROXY="${K8S_FWD_PROXY:-}" \
+    LOCAL_OPERATOR="${LOCAL_OPERATOR:-}" \
+    bash -c "source ${contexts_dir}/site-context && export -p")
+
 if [ -n "${EVR_TASK_ID-}" ]; then
-  # shellcheck disable=SC1090
+    # EVG-CI branch (step b): run the source chain in the current shell so
+    # evergreen expansion env vars (BUILD_VARIANT, IS_PATCH, ...) reach
+    # site-context / root-context / evg-private-context. site-context infers
+    # PROJECT_DIR from its own script location when not pre-set; we pre-set
+    # it here to the EVG-runner repo root so workdir-derived defaults are
+    # canonical regardless of where the script was invoked from.
+    : "${PROJECT_DIR:=$(realpath "${script_dir}/../..")}"
+    export PROJECT_DIR
+    # shellcheck disable=SC1091
+    source "${contexts_dir}/site-context"
+    # shellcheck disable=SC1090
     source "${context_file}"
     # shellcheck disable=SC2207
     export CURRENT_VARIANT_CONTEXT="${context}"
     current_envs=$(export -p)
 else
-  # env -i makes sure to start the shell with an empty shell, such that we only save into context.env the env vars we have
-  # defined.
-  base_command="source ${local_development_default_file} && source ${context_file}"
-  if [ -n "${additional_override}" ]; then
-      echo "Using additional override file: ${additional_override_file}."
-      base_command+=" && source ${additional_override_file}"
-  elif [ -f "${override_context_file}" ]; then
-      echo "Using override file: ${override_context_file}. If you do not want to use one, remove the file or its contents."
-      base_command+=" && source ${override_context_file}"
-  fi
-  # Execute the command in a clean environment and capture exported variables
-  # Let's use our PATH as a base to have utilities available.
-  current_envs=$(env -i PWD="${PWD}" PATH="${PATH}" CURRENT_VARIANT_CONTEXT="${context}" bash -c "${base_command} && export -p")
-
-  # `export -p` instead of `env` ensures we can safely re-source variables which we rely on further
-  # below like our operator.print.env script
-  # eval ensures we only use the exports and don't run the whole script against as done in base_command
-  eval "${current_envs}"
+    # Local-dev branch (step b): env -i clean capture, so context.env only
+    # picks up what the chain explicitly exports (no inherited login-shell
+    # cruft from the user's terminal).
+    base_command="source ${contexts_dir}/site-context"
+    base_command+=" && source ${local_development_default_file}"
+    base_command+=" && source ${context_file}"
+    if [ -n "${additional_override}" ]; then
+        echo "Using additional override file: ${additional_override_file}."
+        base_command+=" && source ${additional_override_file}"
+    elif [ -f "${override_context_file}" ]; then
+        echo "Using override file: ${override_context_file}. If you do not want to use one, remove the file or its contents."
+        base_command+=" && source ${override_context_file}"
+    fi
+    all_envs=$(env -i \
+        PWD="${PWD}" \
+        PATH="${PATH}" \
+        HOME="${HOME}" \
+        MCK_DEVC_NET_PREFIX="${MCK_DEVC_NET_PREFIX:-}" \
+        K8S_FWD_PROXY="${K8S_FWD_PROXY:-}" \
+        LOCAL_OPERATOR="${LOCAL_OPERATOR:-}" \
+        CURRENT_VARIANT_CONTEXT="${context}" \
+        bash -c "${base_command} && export -p")
+    # `export -p` instead of `env` so we can safely eval (declare -x ... syntax)
+    # to re-source the captures into our own shell for downstream consumers
+    # (print_operator_env.sh).
+    eval "${all_envs}"
+    current_envs="${all_envs}"
 fi
 
-# convert declare -x key=value or export key=value into key=value
-# filter out variables that don't have value (missing '=')
-current_envs=$(echo "${current_envs[@]}" | grep '=' | sed 's/^declare -x //g' | sed 's/^export //g' | sed 's/=/=/'| sort | uniq)
+# Normalize both captures: drop the `declare -x ` / `export ` prefix and sort.
+current_envs=$(echo "${current_envs[@]}" | grep '=' | sed 's/^declare -x //g' | sed 's/^export //g' | LC_ALL=C sort | uniq)
+site_envs=$(echo "${site_envs[@]}" | grep '=' | sed 's/^declare -x //g' | sed 's/^export //g' | LC_ALL=C sort | uniq)
 
-echo -e "## This file is automatically generated by switch_context.sh\n## Do not edit it!" > "${destination_envs_file}.env"
-# shellcheck disable=SC2129
-echo -e "## Regenerated at $(date)\n" >> "${destination_envs_file}.env"
-echo "${current_envs}" >> "${destination_envs_file}.env"
+# Drop env -i passthrough / shell-noise keys from both captures. PWD/HOME/
+# SHLVL/_ are inherited every time the script runs (they aren't site-derived),
+# and the explicitly-forwarded inputs (MCK_DEVC_NET_PREFIX, LOCAL_OPERATOR,
+# CURRENT_VARIANT_CONTEXT) are logical configuration — they belong in
+# context.env, not context.<side>.env.
+#
+# PATH is special: in EVG-CI the agent's shell PATH does NOT include
+# /opt/golang/go1.25/bin — evg-private-context prepends it at source time.
+# Filtering PATH there would strip the prepend, leaving downstream tasks
+# (build_kubectl_plugin's `go build`, etc.) without `go` on PATH. Local-dev
+# shells already have go on PATH via the user's profile, so the strip is
+# safe — keep it filtered there.
+if [ -n "${EVR_TASK_ID-}" ]; then
+    passthrough_re='^(PWD|HOME|SHLVL|_|MCK_DEVC_NET_PREFIX|LOCAL_OPERATOR|CURRENT_VARIANT_CONTEXT)='
+    current_passthrough_re='^(PWD|HOME|SHLVL|_)='
+else
+    passthrough_re='^(PWD|PATH|HOME|SHLVL|_|MCK_DEVC_NET_PREFIX|LOCAL_OPERATOR|CURRENT_VARIANT_CONTEXT)='
+    current_passthrough_re='^(PWD|PATH|HOME|SHLVL|_)='
+fi
+site_envs=$(echo "${site_envs}" | grep -Ev "${passthrough_re}" || true)
+current_envs=$(echo "${current_envs}" | grep -Ev "${current_passthrough_re}" || true)
 
-# Below is a list of special cases of variables that are called the same in EVG and local context.
-# This piece should probably be refactored as it's super easy to make a mistake and shadow the proper variable.
-if ! echo "${current_envs}" | grep -q "^workdir="; then
-  echo "workdir=\"${workdir:-.}\"" >> "${destination_envs_file}.env"
+# Logical = current_envs minus any line whose KEY appears in site_envs.
+# Variable names per POSIX are [A-Za-z_][A-Za-z0-9_]*, so '|' can never
+# appear in a name — safe to use as the alternation separator. We also
+# recompute site_envs from the FULL chain so any later overrides
+# (private-context's GOPATH=~/gosd, etc.) land in context.<side>.env.
+site_keys=$(echo "${site_envs}" | sed 's/=.*//' | LC_ALL=C sort -u)
+if [ -n "${site_keys}" ]; then
+    keys_alt=$(echo "${site_keys}" | paste -sd '|' -)
+    logical_envs=$(echo "${current_envs}" | awk -F= -v keys="${keys_alt}" '
+        $1 !~ "^("keys")$" { print }
+    ')
+    site_envs=$(echo "${current_envs}" | awk -F= -v keys="${keys_alt}" '
+        $1 ~ "^("keys")$" { print }
+    ')
+else
+    logical_envs="${current_envs}"
 fi
 
-# We need to tail +5 lines due to above generated comment.
-awk '{print "export " $0}' < "${destination_envs_file}".env | tail -n +5 > "${destination_envs_file}".export.env
+# Write env files atomically: stream stdin into a tmpfile in the same
+# directory, then rename over the destination. A concurrent reader (any of
+# the ~40 scripts that source set_env_context.sh, some in parallel make
+# targets / background jobs) then always sees either the old file or the new
+# one — never a half-written truncation.
+write_atomic() {
+    local dest="$1" tmp
+    tmp="$(mktemp "${dest}.XXXXXX")"
+    cat > "${tmp}"
+    mv -f "${tmp}" "${dest}"
+}
 
-scripts/dev/print_operator_env.sh | sort | uniq >"${destination_envs_file}.operator.env"
-awk 'NF {print "export " $0}' < "${destination_envs_file}".operator.env > "${destination_envs_file}".operator.export.env
+{
+    echo -e "## This file is automatically generated by switch_context.sh\n## Do not edit it!"
+    echo -e "## Regenerated at $(date)\n"
+    echo "${logical_envs}"
+} | write_atomic "${destination_envs_file}.env"
+
+# Write the per-side site bytes to .generated/context.<side>.env. The other
+# side's file is left untouched, so a host `make switch` does not clobber the
+# devc's site bytes (and vice versa). EVG-CI lands on side=host (no /.dockerenv
+# on the runner) and gets context.host.env exactly like a laptop host shell.
+site_destination="${destination_envs_dir}/context.${side}.env"
+{
+    echo -e "## This file is automatically generated by switch_context.sh\n## Do not edit it!"
+    echo -e "## Regenerated at $(date)\n## Side: ${side}\n"
+    echo "${site_envs}"
+} | write_atomic "${site_destination}"
+
+# Generate the operator overlay, stripping site-derived bytes
+# (KUBECONFIG and KUBE_CONFIG_PATH come from .generated/context.<side>.env).
+scripts/dev/print_operator_env.sh \
+    | LC_ALL=C sort | uniq \
+    | grep -Ev '^(KUBECONFIG|KUBE_CONFIG_PATH)=' \
+    | write_atomic "${destination_envs_file}.operator.env"
+
+# This generator does not emit .export.env files; consumers load context.env +
+# context.<side>.env via scripts/dev/devenv (or set_env_context.sh). Remove any
+# such files so a stale copy can't be sourced by accident.
+rm -f "${destination_envs_file}.export.env" "${destination_envs_file}.operator.export.env"
 
 echo -n "${context}" > "${destination_envs_dir}/.current_context"
+
+# Persist the resolved (prefix-suffixed) namespace as a single source of
+# truth for downstream tools, analogous to .current-evg-host. Cheaper than
+# re-deriving from context.env via sed/grep, and clearer in `ls .generated/`.
+if [ -n "${NAMESPACE:-}" ]; then
+    echo -n "${NAMESPACE}" > "${destination_envs_dir}/.current-namespace"
+fi
 
 echo "Generated env files in $(readlink -f "${destination_envs_dir}"):"
 # shellcheck disable=SC2010
 ls -l1 "${destination_envs_dir}" | grep "context"
 
-# Prefer kubectl from bin directory if it exists, otherwise use system kubectl
+# kubectl current-context/namespace mutation. Skipped when
+# MCK_SWITCH_NO_KUBECTL=1 (set by scripts/dev/devenv's opt-in auto-regen path),
+# so that merely sourcing set_env_context.sh only rewrites the env files and
+# never silently repoints the user's kubectl context/namespace.
+if [[ "${MCK_SWITCH_NO_KUBECTL:-}" == "1" ]]; then
+    echo "MCK_SWITCH_NO_KUBECTL set — skipping kubectl context/namespace mutation."
+    exit 0
+fi
+
 KUBECTL_CMD="kubectl"
 if [[ -n "${PROJECT_DIR:-}" && -x "${PROJECT_DIR}/bin/kubectl" ]]; then
     KUBECTL_CMD="${PROJECT_DIR}/bin/kubectl"
@@ -110,15 +236,24 @@ fi
 
 if [[ "${KUBECTL_CMD}" != "kubectl" ]] || which kubectl > /dev/null; then
     if [ "${CLUSTER_NAME-}" ]; then
-        # The convention: the cluster name must match the name of kubectl context
-        # We expect this not to be true if kubernetes cluster is still to be created (minikube/kops)
-        if ! "${KUBECTL_CMD}" config use-context "${CLUSTER_NAME}"; then
+        # The convention: the cluster name must match the name of kubectl context.
+        # Tolerated failure modes: kubernetes cluster still to be created
+        # (minikube/kops), or this runs inside the devcontainer at on-create time
+        # before the devc-side kubeconfig has been populated by the orchestrator's
+        # later phases — silence stderr so the kubectl error doesn't look like a
+        # real failure in the log.
+        if ! "${KUBECTL_CMD}" config use-context "${CLUSTER_NAME}" 2>/dev/null; then
             echo "Warning: failed to switch kubectl context to: ${CLUSTER_NAME}"
             echo "Does a matching Kubernetes context exist?"
         fi
 
-        # Setting the default namespace for current context
-        "${KUBECTL_CMD}" config set-context "$("${KUBECTL_CMD}" config current-context)" "--namespace=${NAMESPACE}" &>/dev/null || true
+        # Set the default namespace on the current context if there is one.
+        # Split the read so a failing inner command substitution (no contexts
+        # at all) doesn't trip set -e under newer bash.
+        current_ctx="$("${KUBECTL_CMD}" config current-context 2>/dev/null || true)"
+        if [[ -n "${current_ctx}" ]]; then
+            "${KUBECTL_CMD}" config set-context "${current_ctx}" "--namespace=${NAMESPACE}" &>/dev/null || true
+        fi
 
         # shellcheck disable=SC2153
         echo "Generated context: ${context}, set default kubectl context: ${CLUSTER_NAME}, namespace=${NAMESPACE}"

--- a/scripts/dev/test/e2e_local_parallel_devcontainers.sh
+++ b/scripts/dev/test/e2e_local_parallel_devcontainers.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Bring up N devc worktrees in parallel, each on its own fresh EVG host (own
+# Docker daemon -> stock kind cluster names never collide). Output per env is
+# prefixed [<tag>] and tee'd to logs/e2e_local_parallel_devcontainers/<tag>.log.
+# Unless --keep, everything is torn down at the end.
+set -Eeuo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WT_CTL="${REPO}/scripts/dev/wt-ctl"
+LOG_DIR="${REPO}/logs/e2e_local_parallel_devcontainers"
+
+# tag  context  marker  [extra wt-ctl create flags...]
+# marker is the pytest marker run (via e2e_run.sh) once the env is up; the
+# triples mirror the e2e_devc_* tasks in .evergreen-tasks.yml.
+ENVS=(
+  "search_mc_rs e2e_multi_cluster_kind   e2e_search_connectivity_tool_mc_rs"
+  "search_rs    e2e_mdb_kind_ubi_cloudqa e2e_search_connectivity_tool       --single-cluster"
+  "om_pod_spec  e2e_om80_kind_ubi        e2e_om_ops_manager_pod_spec        --single-cluster"
+)
+
+KEEP=0
+for a in "$@"; do [[ "${a}" == "--keep" ]] && KEEP=1; done
+
+branch_of() { echo "devc-e2e/$1"; }
+worktree_of() { echo "${REPO%/*}/devc-e2e_$1"; }
+
+mkdir -p "${LOG_DIR}"
+
+# Teardown leftovers up front so each env starts clean. Deleting the git
+# branch (not just the worktree) is essential: create_worktree.sh checks out
+# an EXISTING branch verbatim, so a stale devc-e2e/<tag> ref would run old
+# code. Removing it forces recreation from the current HEAD every run.
+for entry in "${ENVS[@]}"; do
+  read -ra p <<<"${entry}"
+  br="$(branch_of "${p[0]}")"
+  "${WT_CTL}" --color never delete "${br}" --all || true
+  git -C "${REPO}" worktree prune || true
+  git -C "${REPO}" branch -D "${br}" 2>/dev/null || true
+done
+
+# Fresh create per env, then run the marker inside its devc; in parallel.
+# create failure short-circuits the test (&&). Live output is prefixed
+# [<tag>] and tee'd to a per-env log; pipefail makes the pipeline exit
+# reflect create/test, not the tee.
+run_one() {
+  local tag=$1 context=$2 marker=$3; shift 3
+  set -o pipefail
+  {
+    "${WT_CTL}" --color never create "$(branch_of "${tag}")" --context "${context}" "$@" --force \
+      && ( cd "$(worktree_of "${tag}")" \
+             && "${WT_CTL}" --color never attach -- scripts/dev/e2e_run.sh "${marker}" )
+  } 2>&1 \
+    | tee "${LOG_DIR}/${tag}.log" \
+    | sed -u "s/^/[${tag}] /"
+}
+
+pids=(); tags=()
+for entry in "${ENVS[@]}"; do
+  read -ra p <<<"${entry}"
+  run_one "${p[0]}" "${p[1]}" "${p[2]}" "${p[@]:3}" &
+  pids+=("$!"); tags+=("${p[0]}")
+done
+
+rc=0
+for i in "${!pids[@]}"; do
+  if wait "${pids[i]}"; then echo "[${tags[i]}] OK"; else echo "[${tags[i]}] FAILED"; rc=1; fi
+done
+echo "logs under ${LOG_DIR}"
+
+if [[ "${KEEP}" == 1 ]]; then
+  echo "--keep: leaving worktrees + EVG hosts up."
+else
+  echo "tearing down..."
+  for entry in "${ENVS[@]}"; do
+    read -ra p <<<"${entry}"
+    "${WT_CTL}" --color never delete "$(branch_of "${p[0]}")" --all || true
+  done
+fi
+
+exit "${rc}"

--- a/scripts/dev/test/e2e_local_parallel_devcontainers.sh
+++ b/scripts/dev/test/e2e_local_parallel_devcontainers.sh
@@ -45,13 +45,22 @@ done
 run_one() {
   local tag=$1 context=$2 marker=$3; shift 3
   set -o pipefail
+  # Per-env TMPDIR: the devcontainer CLI stages features + compose fragments
+  # under $TMPDIR/devcontainercli/, and concurrent `devcontainer up` runs on one
+  # host clobber that shared tree (ENOENT on aws-cli_0/devcontainer-feature.json,
+  # or `docker compose up` failing on a vanished -f fragment). Isolate it per env.
+  local envtmp; envtmp="$(mktemp -d "${TMPDIR:-/tmp}/devc-par-${tag}.XXXXXX")"
+  export TMPDIR="${envtmp}"
+  local rc=0
   {
     "${WT_CTL}" --color never create "$(branch_of "${tag}")" --context "${context}" "$@" --force \
       && ( cd "$(worktree_of "${tag}")" \
              && "${WT_CTL}" --color never attach -- scripts/dev/e2e_run.sh "${marker}" )
   } 2>&1 \
     | tee "${LOG_DIR}/${tag}.log" \
-    | sed -u "s/^/[${tag}] /"
+    | sed -u "s/^/[${tag}] /" || rc=$?
+  rm -rf "${envtmp}" || true
+  return "${rc}"
 }
 
 pids=(); tags=()

--- a/scripts/dev/validate_jsonc.py
+++ b/scripts/dev/validate_jsonc.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate JSON-with-comments files (JSONC).
+
+Used by the pre-commit `check-jsonc` hook for devcontainer.json and other
+JSONC sources where the strict json schema check-json hook cannot apply.
+
+Strips // line comments, /* block */ comments, and trailing commas before
+parsing with the standard json module. Exits non-zero with the file path
+and the json error message if any file fails.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+_TRAILING_COMMA = re.compile(r",(\s*[\]}])")
+
+
+def strip_jsonc(raw: str) -> str:
+    """Strip JSONC comments (// line and /* block */) and trailing commas.
+
+    String literals are preserved untouched so URL substrings like
+    ``https://example`` aren't mis-parsed as comments.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(raw)
+    in_str = False
+    while i < n:
+        ch = raw[i]
+        if in_str:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(raw[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+            continue
+        if ch == '"':
+            in_str = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n:
+            nxt = raw[i + 1]
+            if nxt == "/":
+                end = raw.find("\n", i + 2)
+                i = n if end == -1 else end
+                continue
+            if nxt == "*":
+                end = raw.find("*/", i + 2)
+                i = n if end == -1 else end + 2
+                continue
+        out.append(ch)
+        i += 1
+    return _TRAILING_COMMA.sub(r"\1", "".join(out))
+
+
+def main(argv: list[str]) -> int:
+    rc = 0
+    for path in argv[1:]:
+        try:
+            with open(path, encoding="utf-8") as fp:
+                raw = fp.read()
+            json.loads(strip_jsonc(raw))
+        except json.JSONDecodeError as exc:
+            print(f"{path}: {exc}", file=sys.stderr)
+            rc = 1
+        except OSError as exc:
+            print(f"{path}: {exc}", file=sys.stderr)
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/dev/validate_jsonc.py
+++ b/scripts/dev/validate_jsonc.py
@@ -53,7 +53,9 @@ def strip_jsonc(raw: str) -> str:
                 continue
             if nxt == "*":
                 end = raw.find("*/", i + 2)
-                i = n if end == -1 else end + 2
+                if end == -1:
+                    raise ValueError("unterminated /* block comment")
+                i = end + 2
                 continue
         out.append(ch)
         i += 1
@@ -67,7 +69,7 @@ def main(argv: list[str]) -> int:
             with open(path, encoding="utf-8") as fp:
                 raw = fp.read()
             json.loads(strip_jsonc(raw))
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, ValueError) as exc:
             print(f"{path}: {exc}", file=sys.stderr)
             rc = 1
         except OSError as exc:

--- a/scripts/dev/wt-ctl
+++ b/scripts/dev/wt-ctl
@@ -2,28 +2,18 @@
 #
 # wt-ctl — unified worktree + devcontainer control plane.
 #
-# Thin shim that locates the wt_ctl python package in this repo, sets
-# PYTHONPATH so ``import wt_ctl`` works regardless of cwd, and execs
-# ``python3 -m wt_ctl "$@"``. See ``docs/dev/wt-ctl-plan.md``.
-#
-# Prefers the worktree's venv python so deps installed there (pyyaml for
-# kubeconfig parsing, etc.) are available. Falls back to system python3
-# when the venv isn't built yet (very early worktree_init phase).
+# Thin shim: load the worktree env via set_env_context (activates the venv and
+# prepends bin/ to PATH), put the wt_ctl package on PYTHONPATH so ``import
+# wt_ctl`` resolves regardless of cwd, then exec ``python3 -m wt_ctl``. wt-ctl
+# always runs from a worktree that worktree_init has already prepared, so the
+# env files and venv are present. See ``docs/dev/wt-ctl-plan.md``.
 #
 set -Eeuo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-pkg_parent="${script_dir}"  # wt_ctl/ lives at scripts/dev/wt_ctl
-repo_root="$(cd "${script_dir}/../.." && pwd)"
 
-if [[ -n "${PYTHONPATH:-}" ]]; then
-  PYTHONPATH="${pkg_parent}:${PYTHONPATH}"
-else
-  PYTHONPATH="${pkg_parent}"
-fi
-export PYTHONPATH
+# shellcheck source=set_env_context.sh
+source "${script_dir}/set_env_context.sh"
 
-if [[ -x "${repo_root}/venv/bin/python" ]]; then
-  exec "${repo_root}/venv/bin/python" -m wt_ctl "$@"
-fi
+export PYTHONPATH="${script_dir}${PYTHONPATH:+:${PYTHONPATH}}"
 exec python3 -m wt_ctl "$@"

--- a/scripts/dev/wt-ctl
+++ b/scripts/dev/wt-ctl
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# wt-ctl — unified worktree + devcontainer control plane.
+#
+# Thin shim that locates the wt_ctl python package in this repo, sets
+# PYTHONPATH so ``import wt_ctl`` works regardless of cwd, and execs
+# ``python3 -m wt_ctl "$@"``. See ``docs/dev/wt-ctl-plan.md``.
+#
+# Prefers the worktree's venv python so deps installed there (pyyaml for
+# kubeconfig parsing, etc.) are available. Falls back to system python3
+# when the venv isn't built yet (very early worktree_init phase).
+#
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pkg_parent="${script_dir}"  # wt_ctl/ lives at scripts/dev/wt_ctl
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  PYTHONPATH="${pkg_parent}:${PYTHONPATH}"
+else
+  PYTHONPATH="${pkg_parent}"
+fi
+export PYTHONPATH
+
+if [[ -x "${repo_root}/venv/bin/python" ]]; then
+  exec "${repo_root}/venv/bin/python" -m wt_ctl "$@"
+fi
+exec python3 -m wt_ctl "$@"

--- a/scripts/dev/wt_ctl/__init__.py
+++ b/scripts/dev/wt_ctl/__init__.py
@@ -1,0 +1,3 @@
+"""wt-ctl — unified worktree + devcontainer control plane."""
+
+__all__ = []

--- a/scripts/dev/wt_ctl/__main__.py
+++ b/scripts/dev/wt_ctl/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point: ``python3 -m wt_ctl ...`` dispatches into ``cli.main``."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/dev/wt_ctl/cli.py
+++ b/scripts/dev/wt_ctl/cli.py
@@ -1,0 +1,1196 @@
+"""argparse-based dispatcher. The **only** module that catches ``WtCtlError``."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Callable, Optional
+
+from . import display, orchestrator_state
+from .domains.compose import ComposeDomain, project_name_for
+from .domains.contextsw import ContextDomain
+from .domains.devcontainer import DevcontainerDomain
+from .domains.evg import EvgDomain
+from .domains.kfp import KFP_DEFAULT_URL, LAUNCHCTL_BOOTOUT, LAUNCHCTL_BOOTSTRAP, LAUNCHCTL_KICKSTART, KfpDomain
+from .domains.kubeconfig import KubeconfigDomain
+from .domains.network import NetworkDomain, gost_proxy_for, parse_devc_env, subnet_for
+from .domains.omprojects import OmDomain
+from .domains.worktree import WorktreeDomain
+from .errors import ExternalCommandFailed, NotInWorktree, ParallelPhaseFailures, StateConflict, ToolMissing, WtCtlError
+from .header import emit_banner
+from .orchestrator import CreateInputs, CreateOrchestrator, DeleteInputs, DeleteOrchestrator
+from .paths import WorktreeRefs, logs_dir, resolve_worktree
+from .runner import Runner
+from .state import GlobalStatus, KfpHostState, NetState, OrphanRegistration, WorktreeRow, WorktreeStatus
+
+# ---------------------------------------------------------------------------
+# top-level argparse
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="wt-ctl",
+        description="Unified worktree + devcontainer control plane.",
+    )
+    p.add_argument("--quiet", action="store_true", help="suppress the banner.")
+    p.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help="ANSI color mode (default: auto).",
+    )
+    sub = p.add_subparsers(dest="cmd", metavar="<verb>")
+
+    # high-level
+    s = sub.add_parser("status", help="status of current worktree (default) or all (--all).")
+    s.add_argument("branch", nargs="?")
+    s.add_argument("--all", dest="all_", action="store_true")
+
+    sc = sub.add_parser(
+        "create",
+        help="bring up a worktree end-to-end (worktree + EVG + devc + kubeconfig).",
+    )
+    sc.add_argument("branch")
+    sc.add_argument("--context", help="run `make switch context=CTX` after worktree_init.")
+    # Multi-cluster is the default topology; --single-cluster opts out.
+    # --multi-cluster is accepted as a no-op affirmation.
+    sc.add_argument(
+        "--single-cluster",
+        dest="single_cluster",
+        action="store_true",
+        help="single kind cluster instead of the default four-cluster (multi) setup.",
+    )
+    sc.add_argument("--multi-cluster", dest="multi_cluster", action="store_true", help=argparse.SUPPRESS)
+    sc.add_argument("--skip-recreate", dest="skip_recreate", action="store_true")
+    sc.add_argument("--skip-evg", dest="skip_evg", action="store_true")
+    sc.add_argument("--skip-devcontainer", dest="skip_devcontainer", action="store_true")
+    sc.add_argument("--skip-prepare-e2e", dest="skip_prepare_e2e", action="store_true")
+    sc.add_argument("--force", action="store_true")
+    sc.add_argument("--evg-host-name", dest="evg_host_name")
+    sc.add_argument(
+        "--distro",
+        dest="distro",
+        default=None,
+        help="evergreen distro for the EVG host spawn (default: evg spawn's own default).",
+    )
+    sc.add_argument(
+        "--region",
+        dest="region",
+        default=None,
+        help="AWS region for the EVG host spawn (default: evg spawn's own default).",
+    )
+    sc.add_argument(
+        "--local-kind",
+        dest="local_kind",
+        action="store_true",
+        help=(
+            "spin a kind cluster on the laptop instead of provisioning an "
+            "EVG host. Skips EVG host create entirely; the kubeconfig "
+            "lands in .generated/current.kubeconfig and KUBECONFIG points "
+            "at it."
+        ),
+    )
+    sc.add_argument(
+        "--cluster-name",
+        dest="cluster_name",
+        help="kind cluster name in --local-kind mode (default: branch_dir).",
+    )
+    sc.add_argument(
+        "--in-place",
+        dest="in_place",
+        action="store_true",
+        help=(
+            "operate in the current checkout instead of creating a sibling "
+            "git worktree. Required in CI (EVG patch): the diff lives as "
+            "uncommitted changes here, so a fresh worktree would miss it."
+        ),
+    )
+    sc.add_argument(
+        "--resume",
+        action="store_true",
+        help="resume a killed run from its first non-OK phase.",
+    )
+    sc.add_argument(
+        "--restart-from",
+        dest="restart_from",
+        default=None,
+        metavar="PHASE",
+        choices=orchestrator_state.PHASE_ORDER,
+        help=(
+            "clear this phase and all later phases from saved state, then "
+            "run from it. Phases (in order): " + ", ".join(orchestrator_state.PHASE_ORDER) + "."
+        ),
+    )
+
+    sd = sub.add_parser(
+        "delete",
+        help=(
+            "opt-in teardown: --evg / --devc / --worktree / --om "
+            "(or --all). Without targets, prints help. Branches are "
+            "never deleted from the git repo."
+        ),
+    )
+    sd.add_argument("branch", nargs="?")
+    # Opt-in target flags. Without any of these, the command is a no-op.
+    sd.add_argument(
+        "--all",
+        dest="delete_all",
+        action="store_true",
+        help="select every target below; combine with --keep-* to opt out.",
+    )
+    sd.add_argument(
+        "--evg",
+        dest="delete_evg",
+        action="store_true",
+        help="terminate the EVG host pinned to this worktree.",
+    )
+    sd.add_argument(
+        "--devc",
+        dest="delete_devc",
+        action="store_true",
+        help="docker compose down the devcontainer stack for this worktree.",
+    )
+    sd.add_argument(
+        "--worktree",
+        dest="delete_worktree",
+        action="store_true",
+        help="git-remove the worktree dir + release the net-prefix entry. " "(Branches are never deleted.)",
+    )
+    sd.add_argument(
+        "--om",
+        dest="delete_om",
+        action="store_true",
+        help="clean cloud-qa OM projects scoped to this worktree.",
+    )
+    # Opt-out modifiers (only meaningful with --all).
+    sd.add_argument("--keep-evg", dest="keep_evg", action="store_true")
+    sd.add_argument("--keep-devc", dest="keep_devc", action="store_true")
+    sd.add_argument("--keep-worktree", dest="keep_worktree", action="store_true")
+    sd.add_argument("--keep-om", dest="keep_om", action="store_true")
+    sd.add_argument("--evg-host-name", dest="evg_host_name")
+
+    sub.add_parser("up", help="bring devcontainer up (idempotent).")
+    sub.add_parser("down", help="stop the compose stack for this worktree.")
+
+    sb = sub.add_parser("build", help="build the devcontainer image.")
+    sb.add_argument("--no-cache", action="store_true")
+
+    sa = sub.add_parser("attach", help="attach (no args = tmuxp; args = exec verbatim).")
+    sa.add_argument("args", nargs=argparse.REMAINDER)
+
+    slg = sub.add_parser("logs", help="tail a setup-phase log.")
+    slg.add_argument("phase", nargs="?", default="build")
+    slg.add_argument("-f", "--follow", action="store_true")
+
+    # primitives
+    sn = sub.add_parser("network", help="network prefix registry primitives.")
+    sn_sub = sn.add_subparsers(dest="net_cmd")
+    sn_sub.add_parser("list")
+    sn_pr = sn_sub.add_parser("prune")
+    sn_pr.add_argument("--dry-run", action="store_true")
+    sn_pr.add_argument("--networks", action="store_true", help="also remove orphan docker networks (172.[16-31].x).")
+    sn_rl = sn_sub.add_parser("release")
+    sn_rl.add_argument("branch", nargs="?")
+    sn_rl.add_argument("--dry-run", action="store_true")
+    sn_al = sn_sub.add_parser("allocate")
+    sn_al.add_argument("branch", nargs="?")
+
+    se = sub.add_parser(
+        "evg",
+        help="EVG host primitives (status / kubeconfig / spawn / terminate / extend).",
+    )
+    se_sub = se.add_subparsers(dest="evg_cmd")
+    se_sub.add_parser(
+        "status",
+        help="render the EVG host pinned to this worktree (name/id/status/ssh).",
+    )
+    se_sub.add_parser(
+        "kubeconfig",
+        help="fetch (or print cached) kubeconfig for this worktree's EVG host.",
+    )
+    se_sp = se_sub.add_parser(
+        "spawn",
+        help="spawn (or resume) an EVG host with displayName=<name>.",
+    )
+    se_sp.add_argument("--name", required=True, help="EVG displayName to spawn / resume.")
+    se_sp.add_argument(
+        "--distro",
+        default="ubuntu2204-latest-large",
+        help="evergreen distro (default: ubuntu2204-latest-large).",
+    )
+    se_sp.add_argument(
+        "--region",
+        default="eu-west-1",
+        help="AWS region (default: eu-west-1).",
+    )
+    se_sp.add_argument(
+        "--key",
+        dest="key_name",
+        help=(
+            "evergreen-managed public-key name "
+            "(default: $MCK_DEVC_EVG_KEY_NAME or first key from 'evergreen keys list')."
+        ),
+    )
+    se_t = se_sub.add_parser(
+        "terminate",
+        help="terminate the EVG host pinned to this worktree (or --host-id).",
+    )
+    se_t.add_argument("--host-id")
+    se_e = se_sub.add_parser(
+        "extend",
+        help="extend the EVG host expiration by --hours (default: 4).",
+    )
+    se_e.add_argument("--hours", type=int, default=4)
+    se_e.add_argument("--host-id")
+
+    sk = sub.add_parser(
+        "kfp",
+        help=(
+            "on-host kube-forwarding-proxy daemon (pkg-installed, "
+            "launchd-managed). `start`/`stop` are launchctl ops — wt-ctl "
+            "only probes and PATCHes."
+        ),
+    )
+    sk_sub = sk.add_subparsers(dest="kfp_cmd")
+    sk_sub.add_parser("status")
+    sk_rg = sk_sub.add_parser(
+        "register",
+        help="PATCH a kubeconfig to the on-host kfp daemon's /kubeconfig endpoint.",
+    )
+    sk_rg.add_argument(
+        "--kubeconfig",
+        help="kubeconfig path to register (default: <worktree>/.generated/current.kubeconfig).",
+    )
+    sk_rg.add_argument(
+        "--replace",
+        action="store_true",
+        help=(
+            "HTTP PUT instead of PATCH — WIPES every sibling worktree's "
+            "registration. Default PATCH already overwrites same-name "
+            "entries idempotently; prefer the default."
+        ),
+    )
+    sk_rg.add_argument(
+        "--url",
+        default=None,
+        help=(
+            "Target kfp base URL (default: http://127.0.0.1:11616). Use "
+            "http://host.docker.internal:11616 to register from inside a "
+            "devcontainer."
+        ),
+    )
+    sk_sub.add_parser(
+        "reset",
+        help="HTTP DELETE the daemon's dynamic kubeconfig (wipes all registrations).",
+    )
+
+    so = sub.add_parser("om", help="cloud-qa OM project primitives.")
+    so_sub = so.add_subparsers(dest="om_cmd")
+    so_sub.add_parser("list")
+    so_sub.add_parser("clean")
+
+    sc = sub.add_parser("ctx", help="context primitives.")
+    sc_sub = sc.add_subparsers(dest="ctx_cmd")
+    sc_sub.add_parser("show")
+    sc_sw = sc_sub.add_parser("switch")
+    sc_sw.add_argument("ctx")
+
+    skc = sub.add_parser(
+        "kubeconfig",
+        help="post-process .generated/current.kubeconfig per side + register with kfp.",
+    )
+    skc_sub = skc.add_subparsers(dest="kubeconfig_cmd")
+    skc_sub.add_parser(
+        "refresh",
+        help=(
+            "Read .generated/current.kubeconfig, write .generated/current.devc.kubeconfig, "
+            "and PATCH the appropriate variant to K8S_FWD_PROXY/kubeconfig. "
+            "Dispatch: .current-evg-host present → proxy-url patch; absent + "
+            "loopback server → host.docker.internal rewrite; else → identity "
+            "copy (BYOC)."
+        ),
+    )
+
+    sw = sub.add_parser("wt", help="git-worktree primitives.")
+    sw_sub = sw.add_subparsers(dest="wt_cmd")
+    sw_sub.add_parser("list")
+    sw_n = sw_sub.add_parser("new")
+    sw_n.add_argument("branch")
+    sw_n.add_argument("-f", "--force", action="store_true")
+    sw_r = sw_sub.add_parser("rm")
+    sw_r.add_argument("branch", nargs="?")
+    sw_r.add_argument("-f", "--force", action="store_true")
+
+    return p
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    runner = Runner()
+
+    # `status --all`, `create <branch>`, and `delete <branch>` are allowed
+    # outside any worktree (they take an explicit target). Everything else
+    # resolves the cwd worktree first.
+    cmd = args.cmd
+    skip_wt = (
+        (cmd == "status" and getattr(args, "all_", False))
+        or (cmd == "status" and getattr(args, "branch", None))
+        or cmd == "create"
+        or (cmd == "delete" and getattr(args, "branch", None))
+        or cmd == "kfp"
+    )
+    refs: Optional[WorktreeRefs] = None
+    try:
+        if not skip_wt:
+            refs = resolve_worktree(runner)
+        else:
+            # Best-effort resolution: still useful for `delete` with no
+            # branch (default to current worktree's branch).
+            try:
+                refs = resolve_worktree(runner)
+            except WtCtlError:
+                refs = None
+        # ``status <branch>`` retargets refs (so the banner + body both
+        # describe the requested worktree, not the cwd).
+        if cmd == "status" and getattr(args, "branch", None) and not getattr(args, "all_", False):
+            target_refs = _refs_for_branch(runner, refs, args.branch)
+            if target_refs is None:
+                emit_banner(refs, quiet=args.quiet)
+                sys.stderr.write(f"[wt-ctl] error: no worktree for branch / dir " f"'{args.branch}'\n")
+                return 2
+            refs = target_refs
+        emit_banner(refs, quiet=args.quiet)
+        return _dispatch(args, runner, refs)
+    except WtCtlError as exc:
+        sys.stderr.write(f"[wt-ctl] error: {exc.render()}\n")
+        return getattr(exc, "exit_code", 1)
+
+
+def _dispatch(args: argparse.Namespace, runner: Runner, refs: Optional[WorktreeRefs]) -> int:
+    cmd = args.cmd
+    if cmd is None:
+        build_parser().print_help()
+        return 0
+    if cmd == "status":
+        if args.all_:
+            return cmd_status_all(runner, args)
+        assert refs is not None
+        return cmd_status(runner, refs, args)
+    if cmd == "create":
+        return cmd_create(runner, refs, args)
+    if cmd == "delete":
+        return cmd_delete(runner, refs, args)
+    if cmd == "up":
+        assert refs is not None
+        DevcontainerDomain(runner).up(refs.worktree_root)
+        return 0
+    if cmd == "down":
+        assert refs is not None
+        ComposeDomain(runner).down(refs.worktree_root)
+        return 0
+    if cmd == "build":
+        assert refs is not None
+        DevcontainerDomain(runner).build(refs.worktree_root, no_cache=args.no_cache)
+        return 0
+    if cmd == "attach":
+        assert refs is not None
+        # argparse REMAINDER may include a leading "--"; strip it.
+        attach_args = list(args.args or [])
+        if attach_args and attach_args[0] == "--":
+            attach_args = attach_args[1:]
+        DevcontainerDomain(runner).attach(refs.worktree_root, attach_args)
+        return 0  # never reached (exec)
+    if cmd == "logs":
+        assert refs is not None
+        return cmd_logs(refs, args)
+    if cmd == "network":
+        assert refs is not None
+        return cmd_network(runner, refs, args)
+    if cmd == "evg":
+        assert refs is not None
+        return cmd_evg(runner, refs, args)
+    if cmd == "kfp":
+        return cmd_kfp(runner, args)
+    if cmd == "om":
+        assert refs is not None
+        return cmd_om(runner, refs, args)
+    if cmd == "ctx":
+        assert refs is not None
+        return cmd_ctx(runner, refs, args)
+    if cmd == "kubeconfig":
+        assert refs is not None
+        return cmd_kubeconfig(runner, refs, args)
+    if cmd == "wt":
+        assert refs is not None
+        return cmd_wt(runner, refs, args)
+    sys.stderr.write(f"[wt-ctl] error: unknown subcommand: {cmd}\n")
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    wt_dom = WorktreeDomain(runner)
+    cp_dom = ComposeDomain(runner)
+    # Workhorse scripts live in each worktree (not the main repo's .git
+    # parent); pass the worktree root as their "repo_root".
+    nw_dom = NetworkDomain(runner, refs.worktree_root)
+    ev_dom = EvgDomain(runner, refs.worktree_root)
+    om_dom = OmDomain(runner, refs.worktree_root)
+    kc_dom = KubeconfigDomain(runner)
+    ctx_dom = ContextDomain(runner)
+
+    git = wt_dom.git_state(refs.worktree_root)
+    devc = cp_dom.project_state(refs.worktree_root)
+
+    devc_env = parse_devc_env(refs.worktree_root / ".devcontainer")
+    prefix_str = devc_env.get("MCK_DEVC_NET_PREFIX")
+    prefix: Optional[int] = None
+    if prefix_str and prefix_str.isdigit():
+        prefix = int(prefix_str)
+
+    entries = []
+    try:
+        entries = nw_dom.list_entries()
+    except ExternalCommandFailed:
+        pass
+    registered = any(e.branch_dir == refs.branch_dir for e in entries)
+    if prefix is None:
+        for e in entries:
+            if e.branch_dir == refs.branch_dir:
+                prefix = e.prefix
+                break
+    orphans = sum(1 for e in entries if e.status == "stale")
+
+    # Read NAMESPACE from rendered context.env if present (definitive).
+    ctx_env = _read_context_env(refs.worktree_root)
+    namespace = ctx_env.get("NAMESPACE")
+    if not namespace and prefix is not None:
+        namespace = f"<NAMESPACE>-{prefix}"  # show the suffix pattern even pre-switch
+
+    net = NetState(
+        prefix=prefix,
+        subnet=subnet_for(prefix) if prefix is not None else None,
+        namespace=namespace,
+        gost_proxy=gost_proxy_for(prefix) if prefix is not None else None,
+        registered=registered,
+        orphans=orphans,
+    )
+
+    # EVG host (best-effort; tolerate evergreen CLI being missing).
+    evg = None
+    try:
+        evg = ev_dom.state_for(refs.worktree_root)
+    except ToolMissing:
+        evg = None
+
+    kc = kc_dom.state_for(refs.worktree_root)
+    om = om_dom.state_for(refs.worktree_root)
+    ctx = ctx_dom.current(refs.worktree_root)
+
+    kfp_dom = KfpDomain(runner)
+    kfp_st = kfp_dom.status()
+    kfp_state = KfpHostState(
+        listening=kfp_st.listening,
+        health=kfp_st.health,
+        http_endpoint=kfp_st.http_endpoint,
+    )
+
+    next_hints = []
+    if devc and devc.state == "running":
+        next_hints.append("wt-ctl attach          # tmuxp mck")
+        next_hints.append("wt-ctl attach zsh      # bare shell")
+    elif devc and devc.state == "exited":
+        next_hints.append("wt-ctl up              # bring stack back online")
+    else:
+        next_hints.append("wt-ctl up              # boot devcontainer")
+
+    # EVG host expiry warning: surface an extend hint when < 8h left so the
+    # user can act before the host reaps mid-task.
+    if evg is not None and evg.expires_seconds is not None and evg.expires_seconds < 8 * 3600:
+        next_hints.append(f"wt-ctl evg extend      # EVG host expires in {evg.expires_in}")
+
+    snap = WorktreeStatus(
+        worktree_dir=refs.branch_dir,
+        worktree_path=str(refs.worktree_root),
+        git=git,
+        context=ctx,
+        devc=devc,
+        network=net,
+        evg=evg,
+        kubeconfig=kc,
+        om=om,
+        kfp=kfp_state,
+        next_hints=next_hints,
+    )
+    rendered = display.render_status(snap, color=args.color)
+    extra = _orchestrator_status_line(refs.worktree_root, refs.branch)
+    if extra:
+        rendered = rendered + "\n\n" + extra
+    print(rendered)
+    return 0
+
+
+def cmd_status_all(runner: Runner, args: argparse.Namespace) -> int:
+    """Repo-wide view: joins `git worktree list` with network registry + EVG data."""
+    # Resolved repo root, not cwd: NetworkDomain and EvgDomain anchor on it, and
+    # running from a subdirectory would otherwise mislabel live stacks.
+    main_repo = _resolve_main_repo(runner)
+    wt_dom = WorktreeDomain(runner)
+    cp_dom = ComposeDomain(runner)
+    nw_dom = NetworkDomain(runner, main_repo)
+    ev_dom = EvgDomain(runner, main_repo)
+
+    wts = wt_dom.list_worktrees(main_repo)
+    try:
+        net_entries = nw_dom.list_entries()
+    except ExternalCommandFailed:
+        net_entries = []
+    by_branch_dir = {e.branch_dir: e for e in net_entries}
+
+    try:
+        hosts = ev_dom.list_hosts(mine=True)
+    except ToolMissing:
+        hosts = []
+    hosts_by_name = {h.get("name"): h for h in hosts}
+
+    rows: list[WorktreeRow] = []
+    seen_branch_dirs: set[str] = set()
+    for wt in wts:
+        branch_dir = wt.path.name
+        seen_branch_dirs.add(branch_dir)
+        branch = wt.branch or "(detached)"
+        net = by_branch_dir.get(branch_dir)
+        prefix = net.prefix if net else None
+
+        devc_state = "-"
+        devc = cp_dom.project_state(wt.path)
+        if devc:
+            devc_state = devc.state
+        # Surface "incomplete" when the orchestrator state.json shows any
+        # non-OK phase. We render this as devc_state because the column is
+        # already there and a stalled create is exactly a partial devc.
+        try:
+            wt_state = orchestrator_state.load(wt.path)
+        except WtCtlError:
+            wt_state = None
+        if wt_state is not None and wt_state.first_non_ok() is not None:
+            devc_state = "incomplete" if devc_state in ("-", "exited", "running") else devc_state
+
+        # By convention the EVG host display name == branch_dir.
+        host = hosts_by_name.get(branch_dir)
+        evg_name = host.get("name") if host else None
+        evg_status = host.get("status") if host else None
+
+        ns = f"mck-devc-{prefix}-mongodb-test" if prefix is not None else None
+
+        prunable = False
+        reason: Optional[str] = None
+        delete_cmd: Optional[str] = None
+        if wt.prunable:
+            prunable, reason = True, "worktree-prunable"
+        elif devc and devc.state == "exited" and not (host and host.get("status") == "running"):
+            prunable, reason = True, "devc-exited"
+        elif evg_status in ("terminating", "terminated", "decommissioned"):
+            prunable, reason = True, f"evg-{evg_status}"
+        if prunable:
+            target_branch = wt.branch or branch_dir
+            delete_cmd = f"wt-ctl delete {target_branch}"
+
+        rows.append(
+            WorktreeRow(
+                worktree=branch_dir,
+                branch=branch,
+                prefix=prefix,
+                namespace=ns,
+                devc_state=devc_state,
+                evg_name=evg_name,
+                evg_status=evg_status,
+                evg_expires=None,
+                prunable=prunable,
+                prunable_reason=reason,
+                delete_cmd=delete_cmd,
+            )
+        )
+
+    orphans: list[OrphanRegistration] = []
+    for entry in net_entries:
+        if entry.branch_dir in seen_branch_dirs:
+            continue
+        # Registered but no matching worktree on this side → orphan.
+        if entry.status in ("active", "stale"):
+            orphans.append(
+                OrphanRegistration(
+                    branch_dir=entry.branch_dir,
+                    prefix=entry.prefix,
+                    release_cmd=f"wt-ctl network release {entry.branch_dir}",
+                )
+            )
+
+    g = GlobalStatus(rows=rows, orphans=orphans)
+    print(display.render_status_all(g, color=args.color))
+    return 0
+
+
+def _resolve_main_repo(runner: Runner) -> Path:
+    """Best-effort: walk up to find a `.git`, then ask git for the common dir
+    (which lives in the main repo). Falls back to cwd if outside.
+    """
+    cwd = Path.cwd().resolve()
+    cur = cwd
+    while True:
+        if (cur / ".git").exists():
+            break
+        if cur.parent == cur:
+            return cwd
+        cur = cur.parent
+    res = runner.run(
+        ["git", "-C", str(cur), "rev-parse", "--git-common-dir"],
+        check=False,
+    )
+    if res.rc != 0:
+        return cur
+    common = (cur / res.stdout.strip()).resolve()
+    return common.parent
+
+
+# ---------------------------------------------------------------------------
+# logs
+# ---------------------------------------------------------------------------
+
+
+def cmd_logs(refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    phase = args.phase or "build"
+    log_path = logs_dir(refs.worktree_root) / f"{phase}.log"
+    if not log_path.is_file():
+        # Also accept the `dc_<phase>.log` name.
+        alt = logs_dir(refs.worktree_root) / f"dc_{phase}.log"
+        if alt.is_file():
+            log_path = alt
+        else:
+            sys.stderr.write(f"[wt-ctl] no log at {log_path} (and no dc_{phase}.log)\n")
+            return 0
+    if args.follow:
+        # Use exec_replace so Ctrl-C reaches `tail` directly.
+        Runner().exec_replace(["tail", "-n", "200", "-f", str(log_path)])
+        return 0
+    print(log_path.read_text(), end="")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# network primitives
+# ---------------------------------------------------------------------------
+
+
+def cmd_network(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    nw = NetworkDomain(runner, refs.worktree_root)
+    sub = args.net_cmd or "list"
+    if sub == "list":
+        sys.stdout.write(nw.list_raw())
+        return 0
+    if sub == "prune":
+        sys.stdout.write(
+            nw.prune(
+                dry_run=args.dry_run,
+                prune_networks=getattr(args, "networks", False),
+            )
+        )
+        return 0
+    if sub == "release":
+        target = args.branch or refs.branch_dir
+        sys.stdout.write(nw.release(target, dry_run=getattr(args, "dry_run", False)))
+        return 0
+    if sub == "allocate":
+        target = args.branch or refs.branch_dir
+        sys.stdout.write(nw.allocate(target))
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown network subcommand: {sub}\n")
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# evg primitives
+# ---------------------------------------------------------------------------
+
+
+def cmd_evg(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    ev = EvgDomain(runner, refs.worktree_root)
+    sub = args.evg_cmd or "status"
+    if sub == "status":
+        st = ev.state_for(refs.worktree_root)
+        if st is None:
+            print("(no EVG host pinned)")
+            return 0
+        print(display.render_kv(_evg_state_pairs(st)))
+        return 0
+    if sub == "kubeconfig":
+        sys.stdout.write(ev.get_kubeconfig(refs.worktree_root))
+        return 0
+    if sub == "terminate":
+        host_id = args.host_id or _resolve_host_id(ev, refs, mine_only=True)
+        if not host_id:
+            sys.stderr.write("[wt-ctl] error: no host id (pass --host-id)\n")
+            return 2
+        sys.stdout.write(ev.terminate(host_id))
+        return 0
+    if sub == "extend":
+        host_id = args.host_id or _resolve_host_id(ev, refs, mine_only=True)
+        if not host_id:
+            sys.stderr.write("[wt-ctl] error: no host id (pass --host-id)\n")
+            return 2
+        sys.stdout.write(ev.extend(host_id, args.hours))
+        return 0
+    if sub == "spawn":
+        host_id = ev.spawn(
+            name=args.name,
+            distro=args.distro,
+            region=args.region,
+            key_name=args.key_name,
+            emit=lambda m: sys.stderr.write(m + "\n"),
+        )
+        print(host_id)
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown evg subcommand: {sub}\n")
+    return 2
+
+
+def _resolve_host_id(ev: EvgDomain, refs: WorktreeRefs, *, mine_only: bool = False) -> Optional[str]:
+    st = ev.state_for(refs.worktree_root, mine_only=mine_only)
+    return st.id if st else None
+
+
+def _evg_state_pairs(st):
+    pairs = [("name", st.name or "-"), ("id", st.id or "-"), ("status", st.status or "-")]
+    if st.host_name:
+        pairs.append(("host", st.host_name))
+    if st.ssh:
+        pairs.append(("ssh", st.ssh))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# kfp primitives
+# ---------------------------------------------------------------------------
+
+
+def cmd_kfp(runner: Runner, args: argparse.Namespace) -> int:
+    kfp = KfpDomain(runner)
+    sub = args.kfp_cmd or "status"
+    if sub == "status":
+        st = kfp.status()
+        if st.listening:
+            health = st.health or "unreachable"
+            print(f"running    http={st.http_endpoint}    health={health}")
+            return 0
+        print("not_running    (pkg-installed daemon; restart with: " f"{LAUNCHCTL_KICKSTART})")
+        return 0
+    if sub == "register":
+        explicit = getattr(args, "kubeconfig", None)
+        replace = getattr(args, "replace", False)
+        url = getattr(args, "url", None) or KFP_DEFAULT_URL
+        if explicit:
+            kc_path = Path(explicit).expanduser()
+        else:
+            # Default: current worktree's host-side kubeconfig.
+            try:
+                wt = resolve_worktree(runner, Path.cwd())
+            except NotInWorktree:
+                sys.stderr.write(
+                    "[wt-ctl] kfp register: not inside a worktree; " "pass --kubeconfig PATH explicitly.\n"
+                )
+                return 2
+            kc_path = wt.worktree_root / ".generated" / "current.kubeconfig"
+        body = kfp.register(kc_path, replace=replace, target_url=url)
+        verb = "replaced" if replace else "registered"
+        print(f"{verb}    kubeconfig={kc_path}    target={url}")
+        if body.strip():
+            print(f"  daemon response: {body.strip()}")
+        return 0
+    if sub == "reset":
+        kfp.reset()
+        print("reset    (kfp dynamic kubeconfig wiped)")
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown kfp subcommand: {sub}\n")
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# om primitives
+# ---------------------------------------------------------------------------
+
+
+def cmd_om(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    om = OmDomain(runner, refs.worktree_root)
+    sub = args.om_cmd or "list"
+    if sub == "list":
+        projects = om.list_projects(refs.worktree_root)
+        if not projects:
+            print("(no projects in scope)")
+            return 0
+        for p in projects:
+            print(f"{p.get('id', '-'):24}  {p.get('name', '-')}")
+        return 0
+    if sub == "clean":
+        om.clean(refs.worktree_root)
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown om subcommand: {sub}\n")
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# ctx primitives
+# ---------------------------------------------------------------------------
+
+
+def cmd_kubeconfig(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    sub = args.kubeconfig_cmd or "refresh"
+    if sub == "refresh":
+        # Merge the freshly-generated context env files on top of os.environ
+        # so callers who invoked us right after `make switch` see the new
+        # CLUSTER_NAME / MCK_DEVC_PROXY_PORT / EVG_HOST_PROXY / K8S_FWD_PROXY
+        # values without needing to re-source devenv first.
+        env = dict(os.environ)
+        for name in ("context.env", "context.host.env", "context.devc.env"):
+            p = refs.worktree_root / ".generated" / name
+            if not p.is_file():
+                continue
+            for raw in p.read_text().splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                v = v.strip()
+                if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                    v = v[1:-1]
+                env[k.strip()] = v
+        KubeconfigDomain(runner).refresh(refs.worktree_root, env=env)
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown kubeconfig subcommand: {sub}\n")
+    return 2
+
+
+def cmd_ctx(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    cx = ContextDomain(runner)
+    sub = args.ctx_cmd or "show"
+    if sub == "show":
+        cur = cx.current(refs.worktree_root)
+        if not cur:
+            print("(no context selected)")
+            return 0
+        print(cur)
+        return 0
+    if sub == "switch":
+        cx.switch(refs.worktree_root, args.ctx)
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown ctx subcommand: {sub}\n")
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# wt primitives
+# ---------------------------------------------------------------------------
+
+
+def cmd_wt(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace) -> int:
+    wd = WorktreeDomain(runner)
+    sub = args.wt_cmd or "list"
+    if sub == "list":
+        for wt in wd.list_worktrees(refs.main_repo_root):
+            tags = []
+            if wt.is_main:
+                tags.append("main")
+            if wt.detached:
+                tags.append("detached")
+            if wt.prunable:
+                tags.append("prunable")
+            tag_str = f" [{', '.join(tags)}]" if tags else ""
+            branch = wt.branch or "(detached)"
+            print(f"{branch:60} {wt.path}{tag_str}")
+        return 0
+    if sub == "new":
+        wd.add(refs.main_repo_root, args.branch, force=args.force)
+        return 0
+    if sub == "rm":
+        target = (
+            refs.worktree_root if not args.branch else _find_worktree_by_branch(wd, refs.main_repo_root, args.branch)
+        )
+        if target is None:
+            sys.stderr.write(f"[wt-ctl] error: no worktree for branch '{args.branch}'\n")
+            return 2
+        wd.remove(refs.main_repo_root, target, force=args.force)
+        return 0
+    sys.stderr.write(f"[wt-ctl] error: unknown wt subcommand: {sub}\n")
+    return 2
+
+
+def _find_worktree_by_branch(wd: WorktreeDomain, repo: Path, branch: str) -> Optional[Path]:
+    for wt in wd.list_worktrees(repo):
+        if wt.branch == branch:
+            return wt.path
+    return None
+
+
+def _refs_for_branch(
+    runner: Runner,
+    cwd_refs: Optional[WorktreeRefs],
+    target: str,
+) -> Optional[WorktreeRefs]:
+    """Resolve ``WorktreeRefs`` for an explicit branch (or directory basename).
+
+    Used by ``wt-ctl status <branch>``: lets the user inspect another
+    worktree without ``cd``-ing into it. Matches by exact branch name
+    first, then by directory basename (so ``lsierant_KUBE-17-…`` and
+    ``lsierant/KUBE-17-…`` both work).
+    """
+    main_repo = cwd_refs.main_repo_root if cwd_refs is not None else _resolve_main_repo(runner)
+    wd = WorktreeDomain(runner)
+    target_path: Optional[Path] = _find_worktree_by_branch(wd, main_repo, target)
+    if target_path is None:
+        for wt in wd.list_worktrees(main_repo):
+            if wt.path.name == target:
+                target_path = wt.path
+                break
+    if target_path is None:
+        return None
+    try:
+        return resolve_worktree(runner, cwd=target_path)
+    except WtCtlError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# create / delete
+# ---------------------------------------------------------------------------
+
+
+def cmd_create(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Namespace) -> int:
+    branch: str = args.branch
+    branch_dir = branch.replace("/", "_")
+    main_repo, worktree_path, host_worktree = _resolve_create_paths(runner, refs, branch_dir)
+    # In-place: operate in the current checkout (which holds the CI patch diff)
+    # rather than a sibling worktree that would only carry committed history.
+    if getattr(args, "in_place", False):
+        worktree_path = main_repo
+        host_worktree = main_repo
+    inputs = CreateInputs(
+        branch=branch,
+        branch_dir=branch_dir,
+        worktree_path=worktree_path,
+        main_repo_root=main_repo,
+        host_worktree_root=host_worktree,
+        context=args.context,
+        multi_cluster=not args.single_cluster,
+        skip_recreate=args.skip_recreate,
+        skip_evg=args.skip_evg,
+        skip_devcontainer=args.skip_devcontainer,
+        skip_prepare_e2e=args.skip_prepare_e2e,
+        force=args.force,
+        evg_host_name=args.evg_host_name,
+        distro=getattr(args, "distro", None),
+        region=getattr(args, "region", None),
+        local_kind=getattr(args, "local_kind", False),
+        cluster_name=getattr(args, "cluster_name", None),
+        in_place=getattr(args, "in_place", False),
+    )
+    # On resume/restart, reload behavioural flags from the prior run's state.json
+    # (see CreateInputs.with_persisted_flags); paths stay freshly resolved.
+    if args.resume or args.restart_from:
+        prior = orchestrator_state.load(worktree_path)
+        if prior is not None and prior.inputs:
+            inputs = inputs.with_persisted_flags(prior.inputs)
+    _ensure_host_kfp(runner, args.skip_evg)
+
+    orch = CreateOrchestrator(runner, inputs)
+    try:
+        orch.run(
+            resume=args.resume,
+            restart_from=args.restart_from,
+            emit=lambda msg: sys.stderr.write(msg + "\n"),
+        )
+    except WtCtlError as exc:
+        # Record the failing phase + resume hint for the user.
+        sys.stderr.write(
+            f"[wt-ctl] error: {exc.render()}\n" f"[wt-ctl] resume with: scripts/dev/wt-ctl create {branch} --resume\n"
+        )
+        return getattr(exc, "exit_code", 1)
+    return 0
+
+
+_DELETE_HELP = """\
+[wt-ctl] delete: no targets selected — nothing was deleted.
+
+Select what to tear down. Branches are NEVER deleted from the git repo.
+
+  --evg          terminate the EVG host
+  --devc         compose down the devcontainer stack
+  --worktree     remove the worktree dir + release the net-prefix entry
+  --om           clean cloud-qa OM projects for this worktree
+  --all          all of the above
+                 (combine with --keep-* to opt out of one target)
+
+Examples:
+  wt-ctl delete --evg --devc            # release cloud resources, keep worktree
+  wt-ctl delete --all                   # tear everything down
+  wt-ctl delete --all --keep-worktree   # everything but keep the worktree dir
+  wt-ctl delete --worktree --om         # local-only cleanup
+"""
+
+
+def cmd_delete(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Namespace) -> int:
+    # Default to the current worktree's branch when no positional arg was given.
+    branch: Optional[str] = args.branch
+    if not branch:
+        if refs is None:
+            sys.stderr.write("[wt-ctl] error: no branch given and not inside a worktree.\n")
+            return 2
+        branch = refs.branch
+    if not branch or branch == "HEAD":
+        sys.stderr.write("[wt-ctl] error: refusing to delete a detached HEAD\n")
+        return 2
+
+    # Resolve target set: --all expands to everything, then --keep-* opts out.
+    delete_evg = args.delete_evg or args.delete_all
+    delete_devc = args.delete_devc or args.delete_all
+    delete_worktree = args.delete_worktree or args.delete_all
+    delete_om = args.delete_om or args.delete_all
+    if args.keep_evg:
+        delete_evg = False
+    if args.keep_devc:
+        delete_devc = False
+    if args.keep_worktree:
+        delete_worktree = False
+    if args.keep_om:
+        delete_om = False
+
+    if not (delete_evg or delete_devc or delete_worktree or delete_om):
+        sys.stderr.write(_DELETE_HELP)
+        return 0
+
+    branch_dir = branch.replace("/", "_")
+    main_repo, worktree_path, _host = _resolve_create_paths(runner, refs, branch_dir)
+
+    inputs = DeleteInputs(
+        branch=branch,
+        branch_dir=branch_dir,
+        worktree_path=worktree_path,
+        main_repo_root=main_repo,
+        delete_om=delete_om,
+        delete_devc=delete_devc,
+        delete_evg=delete_evg,
+        delete_worktree=delete_worktree,
+        evg_host_name=args.evg_host_name,
+    )
+    orch = DeleteOrchestrator(runner, inputs)
+    orch.run(emit=lambda msg: sys.stderr.write(msg + "\n"))
+    return 0
+
+
+def _ensure_host_kfp(runner: Runner, skip_evg: bool) -> None:
+    """Probe that the on-host kfp daemon is listening on 127.0.0.1:11616. The
+    launchd-managed daemon isn't started here; if it's down, warn and continue
+    (in-pipeline PATCHes handle a missing daemon best-effort)."""
+    if skip_evg:
+        sys.stderr.write("[wt-ctl] kfp pre-flight: skipped (--skip-evg)\n")
+        return
+    if KfpDomain(runner).is_listening():
+        sys.stderr.write("[wt-ctl] kfp pre-flight: daemon reachable on 127.0.0.1:11616\n")
+        return
+    sys.stderr.write(
+        "[wt-ctl] kfp pre-flight: WARN daemon not listening on 127.0.0.1:11616. "
+        "Daemon is launchd-managed; bring it up with:\n"
+        f"           {LAUNCHCTL_KICKSTART}\n"
+        "         (or if the pkg was never installed: see kube-forwarding-proxy "
+        "packaging/macos/build.sh). Continuing best-effort.\n"
+    )
+
+
+def _resolve_create_paths(
+    runner: Runner,
+    refs: Optional[WorktreeRefs],
+    branch_dir: str,
+) -> tuple[Path, Path, Path]:
+    """Compute (main_repo_root, target_worktree_path, host_worktree_root).
+
+    The convention (see ``wt_setup.sh``): the new worktree is a sibling of
+    the calling worktree. When the user invokes wt-ctl from outside any
+    worktree, we fall back to the main repo's parent for the sibling slot.
+    """
+    if refs is not None:
+        anchor = refs.worktree_root
+        target = (anchor.parent / branch_dir).resolve()
+        return refs.main_repo_root, target, refs.worktree_root
+    main_repo = _resolve_main_repo(runner)
+    target = (main_repo.parent / branch_dir).resolve()
+    return main_repo, target, main_repo
+
+
+# ---------------------------------------------------------------------------
+# status integration with orchestrator state
+# ---------------------------------------------------------------------------
+
+
+def _orchestrator_status_line(worktree_root: Path, branch: str) -> Optional[str]:
+    """If ``.generated/wt-ctl/state.json`` exists and any phase is non-OK,
+    return a one-liner the status renderer can append; otherwise None.
+    """
+    try:
+        st = orchestrator_state.load(worktree_root)
+    except WtCtlError:
+        return None
+    if st is None:
+        return None
+    failed = next(
+        (
+            name
+            for name, rec in st.phases.items()
+            if rec.status in (orchestrator_state.FAILED, orchestrator_state.IN_PROGRESS)
+        ),
+        None,
+    )
+    if not failed:
+        # Find first non-OK to surface "incomplete" state.
+        non_ok = next(
+            (
+                name
+                for name in orchestrator_state.PHASE_ORDER
+                if (rec := st.phases.get(name)) is None
+                or rec.status not in (orchestrator_state.OK, orchestrator_state.SKIPPED)
+            ),
+            None,
+        )
+        if non_ok is None:
+            return None
+        return f"last_create  incomplete at {non_ok}  " f"(resume: wt-ctl create {branch} --resume)"
+    return f"last_create  failed at {failed}  " f"(resume: wt-ctl create {branch} --resume)"
+
+
+def _read_context_env(worktree_root: Path) -> dict[str, str]:
+    """Read context.env into a dict so ``status`` can read NAMESPACE without
+    instantiating OmDomain."""
+    out: dict[str, str] = {}
+    f = worktree_root / ".generated" / "context.env"
+    if not f.is_file():
+        return out
+    for raw in f.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        v = v.strip()
+        if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+            v = v[1:-1]
+        out[k.strip()] = v
+    return out

--- a/scripts/dev/wt_ctl/cli.py
+++ b/scripts/dev/wt_ctl/cli.py
@@ -1095,6 +1095,11 @@ def cmd_delete(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Name
     branch_dir = branch.replace("/", "_")
     main_repo, worktree_path, _host = _resolve_create_paths(runner, refs, branch_dir)
 
+    # Recover the create's topology so local-kind teardown deletes every owned
+    # cluster (MC create owns five), not just the current-context one.
+    prior = orchestrator_state.load(worktree_path)
+    multi_cluster = bool(prior.inputs.get("multi_cluster")) if prior is not None and prior.inputs else False
+
     inputs = DeleteInputs(
         branch=branch,
         branch_dir=branch_dir,
@@ -1105,6 +1110,7 @@ def cmd_delete(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Name
         delete_evg=delete_evg,
         delete_worktree=delete_worktree,
         evg_host_name=args.evg_host_name,
+        multi_cluster=multi_cluster,
     )
     orch = DeleteOrchestrator(runner, inputs)
     orch.run(emit=lambda msg: sys.stderr.write(msg + "\n"))

--- a/scripts/dev/wt_ctl/cli.py
+++ b/scripts/dev/wt_ctl/cli.py
@@ -983,13 +983,21 @@ def cmd_create(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Name
     branch: str = args.branch
     branch_dir = branch.replace("/", "_")
     main_repo, worktree_path, host_worktree = _resolve_create_paths(runner, refs, branch_dir)
+    in_place = getattr(args, "in_place", False)
     # In-place: operate in the invoking checkout (which holds the CI patch diff)
     # rather than a sibling worktree that would only carry committed history.
     # host_worktree is already the invoking checkout (refs.worktree_root, or
     # main_repo when run outside any worktree); target that, not the primary
     # checkout — the two differ when invoked from a linked worktree.
-    if getattr(args, "in_place", False):
+    if in_place:
         worktree_path = host_worktree
+    # Resume without repeating --in-place: the original run's state lives in the
+    # invoking checkout, not the sibling slot. Locate it there before falling
+    # back to a fresh create so `--resume` recovers an in-place run.
+    if (args.resume or args.restart_from) and not in_place:
+        if orchestrator_state.load(worktree_path) is None and orchestrator_state.load(host_worktree) is not None:
+            worktree_path = host_worktree
+            in_place = True
     inputs = CreateInputs(
         branch=branch,
         branch_dir=branch_dir,
@@ -1008,7 +1016,7 @@ def cmd_create(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Name
         region=getattr(args, "region", None),
         local_kind=getattr(args, "local_kind", False),
         cluster_name=getattr(args, "cluster_name", None),
-        in_place=getattr(args, "in_place", False),
+        in_place=in_place,
     )
     # On resume/restart, reload behavioural flags from the prior run's state.json
     # (see CreateInputs.with_persisted_flags); paths stay freshly resolved.

--- a/scripts/dev/wt_ctl/cli.py
+++ b/scripts/dev/wt_ctl/cli.py
@@ -861,9 +861,12 @@ def cmd_kubeconfig(runner: Runner, refs: WorktreeRefs, args: argparse.Namespace)
         # Merge the freshly-generated context env files on top of os.environ
         # so callers who invoked us right after `make switch` see the new
         # CLUSTER_NAME / MCK_DEVC_PROXY_PORT / EVG_HOST_PROXY / K8S_FWD_PROXY
-        # values without needing to re-source devenv first.
+        # values without needing to re-source devenv first. Load exactly one
+        # side file (same /.dockerenv detection as devenv) so the devc overlay
+        # never leaks into a host-shell refresh, and vice versa.
         env = dict(os.environ)
-        for name in ("context.env", "context.host.env", "context.devc.env"):
+        side = "devc" if Path("/.dockerenv").exists() else "host"
+        for name in ("context.env", f"context.{side}.env"):
             p = refs.worktree_root / ".generated" / name
             if not p.is_file():
                 continue

--- a/scripts/dev/wt_ctl/cli.py
+++ b/scripts/dev/wt_ctl/cli.py
@@ -980,11 +980,13 @@ def cmd_create(runner: Runner, refs: Optional[WorktreeRefs], args: argparse.Name
     branch: str = args.branch
     branch_dir = branch.replace("/", "_")
     main_repo, worktree_path, host_worktree = _resolve_create_paths(runner, refs, branch_dir)
-    # In-place: operate in the current checkout (which holds the CI patch diff)
+    # In-place: operate in the invoking checkout (which holds the CI patch diff)
     # rather than a sibling worktree that would only carry committed history.
+    # host_worktree is already the invoking checkout (refs.worktree_root, or
+    # main_repo when run outside any worktree); target that, not the primary
+    # checkout — the two differ when invoked from a linked worktree.
     if getattr(args, "in_place", False):
-        worktree_path = main_repo
-        host_worktree = main_repo
+        worktree_path = host_worktree
     inputs = CreateInputs(
         branch=branch,
         branch_dir=branch_dir,

--- a/scripts/dev/wt_ctl/display.py
+++ b/scripts/dev/wt_ctl/display.py
@@ -1,0 +1,237 @@
+"""Rendering. Inputs are dataclasses from ``state.py``; outputs are strings.
+
+ANSI auto: enabled only when stdout is a tty AND ``color != 'never'``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Iterable, Optional
+
+from .state import GlobalStatus, OrphanRegistration, WorktreeRow, WorktreeStatus
+
+
+class _Ansi:
+    RESET = "\033[0m"
+    BOLD = "\033[1m"
+    DIM = "\033[2m"
+    GREEN = "\033[32m"
+    YELLOW = "\033[33m"
+    RED = "\033[31m"
+    CYAN = "\033[36m"
+    GREY = "\033[90m"
+
+
+def _color_enabled(mode: str) -> bool:
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    # "auto"
+    if not sys.stdout.isatty():
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return True
+
+
+def _wrap(s: str, code: str, enabled: bool) -> str:
+    if not enabled or not s:
+        return s
+    return f"{code}{s}{_Ansi.RESET}"
+
+
+class KVTable:
+    """Right-pad keys to a common width, emit ``key   value`` lines."""
+
+    def __init__(self, indent: str = "") -> None:
+        self.rows: list[tuple[str, str]] = []
+        self.indent = indent
+
+    def add(self, key: str, value: str) -> None:
+        self.rows.append((key, value))
+
+    def blank(self) -> None:
+        self.rows.append(("", ""))
+
+    def render(self) -> str:
+        width = max((len(k) for k, _ in self.rows if k), default=0)
+        out: list[str] = []
+        for key, value in self.rows:
+            if not key and not value:
+                out.append("")
+                continue
+            if not key:
+                out.append(f"{self.indent}{' ' * width}  {value}")
+            else:
+                out.append(f"{self.indent}{key.ljust(width)}  {value}")
+        return "\n".join(out)
+
+
+def _git_summary(status: WorktreeStatus) -> str:
+    g = status.git
+    clean = "clean" if g.clean else "dirty"
+    parts = [clean]
+    if g.upstream:
+        parts.append(f"{g.ahead} ahead/{g.behind} behind {g.upstream}")
+    return f"{status.worktree_dir}  ({', '.join(parts)})"
+
+
+def render_status(status: WorktreeStatus, *, color: str = "auto") -> str:
+    enabled = _color_enabled(color)
+    t = KVTable()
+    t.add("worktree", _git_summary(status))
+    t.add("path", status.worktree_path)
+    if status.context:
+        t.add("context", status.context)
+    t.blank()
+
+    if status.devc:
+        d = status.devc
+        if d.state == "running":
+            state_str = _wrap(d.state, _Ansi.GREEN, enabled)
+        elif d.state in ("exited", "dead"):
+            state_str = _wrap(d.state, _Ansi.RED, enabled)
+        else:
+            state_str = _wrap(d.state, _Ansi.GREY, enabled)
+        details = f"project={d.project}"
+        details += f"  services={d.services_running}/{d.services_total}"
+        if d.image_age:
+            details += f"  image_age={d.image_age}"
+        t.add("devc", f"{state_str}    {details}")
+    else:
+        t.add("devc", _wrap("-", _Ansi.GREY, enabled) + "    no compose stack found")
+
+    n = status.network
+    if n.prefix is not None:
+        net_line = (
+            f"{n.subnet}    prefix={n.prefix}    "
+            f"registered={'yes' if n.registered else 'no'}    "
+            f"orphans={n.orphans}"
+        )
+        t.add("network", net_line)
+    else:
+        t.add("network", "(no prefix allocated)")
+
+    if n.namespace:
+        t.add("namespace", n.namespace)
+    if n.gost_proxy:
+        t.add("gost-proxy", n.gost_proxy)
+
+    t.blank()
+
+    if status.evg is not None:
+        e = status.evg
+        if e.status == "running":
+            ev_state = _wrap(e.status or "-", _Ansi.GREEN, enabled)
+        elif e.status in (None, "terminated", "terminating", "decommissioned"):
+            ev_state = _wrap(e.status or "-", _Ansi.GREY, enabled)
+        else:
+            ev_state = _wrap(e.status or "-", _Ansi.YELLOW, enabled)
+        ev_line = ev_state
+        if e.name:
+            ev_line += f"    name={e.name}"
+        if e.id:
+            ev_line += f"    id={e.id}"
+        if e.expires_in:
+            ev_line += f"    expires_in={e.expires_in}"
+        t.add("evg host", ev_line)
+        if e.ssh:
+            t.add("ssh", e.ssh)
+    else:
+        t.add("evg host", _wrap("-", _Ansi.GREY, enabled) + "    no EVG_HOST_NAME pinned")
+
+    if status.kubeconfig is not None:
+        kc = status.kubeconfig
+        line = (
+            f"{kc.path or '-'}    "
+            f"last_patch={kc.last_patch or '-'}    "
+            f"kfp_registered={'yes' if kc.kfp_registered else 'no'}"
+        )
+        t.add("kubeconfig", line)
+
+    if status.kfp is not None:
+        k = status.kfp
+        if k.listening:
+            state_str = _wrap("running", _Ansi.GREEN, enabled)
+            health_part = f"health={k.health or 'unreachable'}"
+            t.add(
+                "host-kfp",
+                f"{state_str}    http={k.http_endpoint}    {health_part}",
+            )
+        else:
+            state_str = _wrap("not_running", _Ansi.YELLOW, enabled)
+            t.add(
+                "host-kfp",
+                f"{state_str}    (pkg-installed, launchd-managed; check `launchctl print system/io.github.fealebenpae.k8s-proxy`)",
+            )
+
+    if status.om is not None:
+        om = status.om
+        count = om.project_count if om.project_count is not None else "?"
+        scope = om.scope or "(unknown scope)"
+        t.add("om", f"{count} projects in scope `{scope}`")
+
+    if status.next_hints:
+        t.blank()
+        first, *rest = status.next_hints
+        t.add("next", first)
+        for hint in rest:
+            t.add("", hint)
+
+    return t.render()
+
+
+_HEADERS = ("WORKTREE", "BRANCH", "NET", "NAMESPACE", "DEVC", "EVG-NAME", "EXPIRES")
+
+
+def _row_cells(row: WorktreeRow) -> tuple[str, ...]:
+    return (
+        row.worktree,
+        row.branch or "-",
+        str(row.prefix) if row.prefix is not None else "-",
+        row.namespace or "-",
+        row.devc_state or "-",
+        row.evg_name or "-",
+        row.evg_expires or row.evg_status or "-",
+    )
+
+
+def render_status_all(g: GlobalStatus, *, color: str = "auto") -> str:
+    enabled = _color_enabled(color)
+    cells = [_HEADERS] + [_row_cells(r) for r in g.rows]
+    widths = [max(len(c) for c in column) for column in zip(*cells)]
+    out: list[str] = []
+    out.append("  ".join(c.ljust(w) for c, w in zip(_HEADERS, widths)))
+    for row in g.rows:
+        line = "  ".join(c.ljust(w) for c, w in zip(_row_cells(row), widths))
+        if row.prunable:
+            line = _wrap(line, _Ansi.YELLOW, enabled)
+        out.append(line)
+
+    prunable = [r for r in g.rows if r.prunable]
+    if prunable:
+        out.append("")
+        out.append("prunable")
+        name_w = max(len(r.worktree) for r in prunable)
+        for r in prunable:
+            reason = r.prunable_reason or "?"
+            cmd = r.delete_cmd or "-"
+            out.append(f"  {r.worktree.ljust(name_w)}  reason={reason}  ->  {cmd}")
+
+    if g.orphans:
+        out.append("")
+        out.append("orphan registrations")
+        name_w = max(len(o.branch_dir) for o in g.orphans)
+        for o in g.orphans:
+            out.append(f"  {o.branch_dir.ljust(name_w)}  prefix={o.prefix}  ->  {o.release_cmd}")
+
+    return "\n".join(out)
+
+
+def render_kv(pairs: Iterable[tuple[str, str]]) -> str:
+    t = KVTable()
+    for k, v in pairs:
+        t.add(k, v)
+    return t.render()

--- a/scripts/dev/wt_ctl/domains/__init__.py
+++ b/scripts/dev/wt_ctl/domains/__init__.py
@@ -1,0 +1,5 @@
+"""Domain modules. None of these may import ``subprocess`` — they must
+receive a ``Runner`` instance via constructor injection.
+
+Enforced by ``scripts/test/wt_ctl_lint.py``.
+"""

--- a/scripts/dev/wt_ctl/domains/compose.py
+++ b/scripts/dev/wt_ctl/domains/compose.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from ..errors import ExternalCommandFailed
+from ..errors import ToolMissing
 from ..runner import Runner
 from ..state import DevcState
 
@@ -28,7 +28,10 @@ class ComposeDomain:
     # read
     # ------------------------------------------------------------------
     def list_projects(self) -> list[dict]:
-        res = self.runner.run(["docker", "compose", "ls", "--all", "--format", "json"], check=False)
+        try:
+            res = self.runner.run(["docker", "compose", "ls", "--all", "--format", "json"], check=False)
+        except ToolMissing:
+            return []
         if res.rc != 0:
             return []
         try:
@@ -43,10 +46,13 @@ class ComposeDomain:
         # for service detail. We deliberately don't load compose files here:
         # `compose ps -p <project>` works even when compose.generated.yml is
         # absent (e.g. during teardown).
-        res = self.runner.run(
-            ["docker", "compose", "-p", proj, "ps", "--all", "--format", "json"],
-            check=False,
-        )
+        try:
+            res = self.runner.run(
+                ["docker", "compose", "-p", proj, "ps", "--all", "--format", "json"],
+                check=False,
+            )
+        except ToolMissing:
+            return None
         if res.rc != 0:
             return None
         # `docker compose ps --format json` emits ONE json object per line,

--- a/scripts/dev/wt_ctl/domains/compose.py
+++ b/scripts/dev/wt_ctl/domains/compose.py
@@ -1,0 +1,130 @@
+"""Docker compose introspection — derive the project name and list services.
+
+Project name = lowercase ``<branch_dir>_devcontainer`` (compose normalizes
+project names to lowercase).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from ..errors import ExternalCommandFailed
+from ..runner import Runner
+from ..state import DevcState
+
+
+def project_name_for(worktree_root: Path) -> str:
+    return f"{worktree_root.name.lower()}_devcontainer"
+
+
+class ComposeDomain:
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+
+    # ------------------------------------------------------------------
+    # read
+    # ------------------------------------------------------------------
+    def list_projects(self) -> list[dict]:
+        res = self.runner.run(["docker", "compose", "ls", "--all", "--format", "json"], check=False)
+        if res.rc != 0:
+            return []
+        try:
+            return json.loads(res.stdout or "[]")
+        except json.JSONDecodeError:
+            return []
+
+    def project_state(self, worktree_root: Path) -> Optional[DevcState]:
+        """Return None if no compose stack matching this worktree exists."""
+        proj = project_name_for(worktree_root)
+        # Use `docker compose ls --all` to confirm the stack exists; then `ps`
+        # for service detail. We deliberately don't load compose files here:
+        # `compose ps -p <project>` works even when compose.generated.yml is
+        # absent (e.g. during teardown).
+        res = self.runner.run(
+            ["docker", "compose", "-p", proj, "ps", "--all", "--format", "json"],
+            check=False,
+        )
+        if res.rc != 0:
+            return None
+        # `docker compose ps --format json` emits ONE json object per line,
+        # not a JSON array.
+        services: list[dict] = []
+        for line in res.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, list):
+                services.extend(obj)
+            else:
+                services.append(obj)
+        if not services:
+            return None
+        running = sum(1 for s in services if s.get("State") == "running")
+        # Aggregate: stack is "running" if every service is up.
+        if running == len(services):
+            stack_state = "running"
+        elif running == 0:
+            stack_state = "exited"
+        else:
+            stack_state = "partial"
+        # Image age: report the age of the most-recently-created service image
+        # (newest CreatedAt), i.e. how long ago the stack was last (re)built.
+        image_age = self._newest_age(services)
+        return DevcState(
+            project=proj,
+            state=stack_state,
+            services_running=running,
+            services_total=len(services),
+            image_age=image_age,
+        )
+
+    def _newest_age(self, services: list[dict]) -> Optional[str]:
+        # Parse compose CreatedAt strings like "2026-05-10 16:45:39 +0200 CEST".
+        # Pull the date+time+offset portion and ignore trailing tz abbrev.
+        newest: Optional[datetime] = None
+        for svc in services:
+            raw = svc.get("CreatedAt") or ""
+            if not raw:
+                continue
+            try:
+                parts = raw.split(" ")
+                if len(parts) >= 3:
+                    iso = " ".join(parts[:3])
+                else:
+                    iso = raw
+                dt = datetime.strptime(iso, "%Y-%m-%d %H:%M:%S %z")
+            except ValueError:
+                continue
+            if newest is None or dt > newest:
+                newest = dt
+        if newest is None:
+            return None
+        delta = datetime.now(timezone.utc) - newest
+        secs = int(delta.total_seconds())
+        if secs < 60:
+            return f"{secs}s"
+        if secs < 3600:
+            return f"{secs // 60}m"
+        if secs < 86400:
+            return f"{secs // 3600}h"
+        return f"{secs // 86400}d"
+
+    # ------------------------------------------------------------------
+    # write
+    # ------------------------------------------------------------------
+    def down(self, worktree_root: Path) -> None:
+        proj = project_name_for(worktree_root)
+        compose = worktree_root / ".devcontainer" / "compose.yml"
+        gen = worktree_root / ".devcontainer" / "compose.generated.yml"
+        argv = ["docker", "compose", "-p", proj, "-f", str(compose)]
+        if gen.exists():
+            argv += ["-f", str(gen)]
+        argv += ["down"]
+        self.runner.run_streaming(argv)

--- a/scripts/dev/wt_ctl/domains/contextsw.py
+++ b/scripts/dev/wt_ctl/domains/contextsw.py
@@ -1,0 +1,49 @@
+"""Context-switch helpers.
+
+Read: parse ``.generated/.current_context``.
+Write: run ``scripts/dev/switch_context.sh <ctx>`` directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from ..runner import Runner
+
+
+class ContextDomain:
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+
+    def current(self, worktree_root: Path) -> Optional[str]:
+        f = worktree_root / ".generated" / ".current_context"
+        if not f.is_file():
+            return None
+        try:
+            return f.read_text().strip() or None
+        except OSError:
+            return None
+
+    def switch(self, worktree_root: Path, ctx: str) -> None:
+        self.runner.run_streaming(
+            ["scripts/dev/switch_context.sh", ctx],
+            prefix="[ctx] ",
+            cwd=worktree_root,
+        )
+
+    def list_available(self, repo_root: Path) -> list[str]:
+        ctx_dir = repo_root / "scripts" / "dev" / "contexts"
+        if not ctx_dir.is_dir():
+            return []
+        out = []
+        for child in sorted(ctx_dir.iterdir()):
+            if child.is_file() and not child.name.startswith("."):
+                # Filter out non-context helpers; the contexts dir mixes
+                # ``site-context`` / ``root-context`` / ``private-context``
+                # with the actual context files. The rendered contexts have
+                # no dash-prefix in practice; the helpers are dash-suffixed.
+                if child.name.endswith("-context"):
+                    continue
+                out.append(child.name)
+        return out

--- a/scripts/dev/wt_ctl/domains/devcontainer.py
+++ b/scripts/dev/wt_ctl/domains/devcontainer.py
@@ -1,0 +1,90 @@
+"""Wraps the ``devcontainer`` CLI — up / build / exec / attach."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from ..errors import ToolMissing
+from ..paths import logs_dir
+from ..runner import Runner
+
+_TMUX_LOAD_CMD = "exec tmuxp load -y /workspace/.devcontainer/tmuxp/mck.yaml"
+
+
+class DevcontainerDomain:
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+
+    # ------------------------------------------------------------------
+    # build / up
+    # ------------------------------------------------------------------
+    def build(self, worktree_root: Path, *, no_cache: bool = False) -> None:
+        if not self.runner.have("devcontainer"):
+            raise ToolMissing("devcontainer", hint="install via 'npm i -g @devcontainers/cli'")
+        argv = ["devcontainer", "build", "--workspace-folder", str(worktree_root)]
+        if no_cache:
+            argv.append("--no-cache")
+        log = logs_dir(worktree_root) / "build.log"
+        self.runner.run_streaming(argv, prefix="[build] ", log_path=log)
+
+    def up(self, worktree_root: Path) -> None:
+        if not self.runner.have("devcontainer"):
+            raise ToolMissing("devcontainer", hint="install via 'npm i -g @devcontainers/cli'")
+        argv = ["devcontainer", "up", "--workspace-folder", str(worktree_root)]
+        log = logs_dir(worktree_root) / "up.log"
+        self.runner.run_streaming(argv, prefix="[up] ", log_path=log)
+
+    # ------------------------------------------------------------------
+    # attach (exec-replace; never returns)
+    # ------------------------------------------------------------------
+    def attach(self, worktree_root: Path, args: list[str]) -> None:
+        """No args → drop into tmuxp. With args → exec verbatim with
+        ``MCK_NO_TMUX=1`` so shell-init doesn't auto-exec tmuxp.
+        """
+        if not self.runner.have("devcontainer"):
+            raise ToolMissing("devcontainer", hint="install via 'npm i -g @devcontainers/cli'")
+        env: Optional[dict] = None
+        argv: list[str]
+        if not args:
+            argv = [
+                "devcontainer",
+                "exec",
+                "--workspace-folder",
+                str(worktree_root),
+                "bash",
+                "-lc",
+                _TMUX_LOAD_CMD,
+            ]
+        else:
+            argv = [
+                "devcontainer",
+                "exec",
+                "--workspace-folder",
+                str(worktree_root),
+                "env",
+                "MCK_NO_TMUX=1",
+                *args,
+            ]
+        self.runner.exec_replace(argv, env=env, cwd=worktree_root)
+
+    def exec_capture(
+        self,
+        worktree_root: Path,
+        args: list[str],
+        *,
+        check: bool = True,
+    ):
+        """Helper: run a command in the container, capture stdout. Used by
+        higher-level verbs (kubeconfig, prepare-e2e) that need to read the
+        result programmatically.
+        """
+        argv = [
+            "devcontainer",
+            "exec",
+            "--workspace-folder",
+            str(worktree_root),
+            *args,
+        ]
+        return self.runner.run(argv, check=check)

--- a/scripts/dev/wt_ctl/domains/evg.py
+++ b/scripts/dev/wt_ctl/domains/evg.py
@@ -1,0 +1,877 @@
+"""Evergreen host domain.
+
+We rely on the ``evergreen`` CLI directly (the upstream JSON is the cleanest
+contract) and fall back to wrapping ``scripts/dev/evg_host.sh`` for the
+kubeconfig flow that already encapsulates yq + kfp registration.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import os
+import re
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+
+from ..errors import ExternalCommandFailed, ToolMissing, WtCtlError
+from ..runner import Runner
+from ..state import EvgHostState
+
+# Best-effort REST API probe for expiration_time (the --mine JSON omits it).
+# Read on demand; keep short to avoid blocking status rendering.
+_EVG_API_TIMEOUT_S = 3.0
+_EVG_CONFIG_PATH = Path.home() / ".evergreen.yml"
+
+
+# Statuses we treat as "dead" for resume detection.
+_DEAD_STATUSES = frozenset(
+    {
+        "terminated",
+        "decommissioned",
+        "quarantined",
+        "failed",
+    }
+)
+
+# Default spawn parameters.
+_DEFAULT_DISTRO = "ubuntu2204-latest-large"
+_DEFAULT_REGION = "eu-west-1"
+
+# Heuristic to spot an AWS-assigned instance id (vs. an interim ``evg-*``
+# placeholder).
+_RE_AWS_ID = re.compile(r"^i-[0-9a-fA-F]+$")
+
+# Best-effort host-id parse from ``evergreen host create`` stdout. Output
+# format isn't documented; both ``Host i-deadbeef ...`` and bare-id lines
+# have been observed across server versions.
+_RE_CREATE_HOST_ID = re.compile(r"\b(i-[0-9a-fA-F]+|evg-[0-9a-zA-Z\-]+)\b")
+
+
+def _tail_diag(text: Optional[str], *, lines: int = 1) -> str:
+    """Last non-empty line(s) of a command's stderr/stdout, for a terse
+    one-line diagnostic in spawn-retry logs."""
+    non_empty = [ln.strip() for ln in (text or "").splitlines() if ln.strip()]
+    return " | ".join(non_empty[-lines:]) if non_empty else ""
+
+
+class EvgDomain:
+    def __init__(self, runner: Runner, repo_root: Path) -> None:
+        self.runner = runner
+        self.repo_root = repo_root
+
+    # ------------------------------------------------------------------
+    def list_hosts(self, *, mine: bool = True) -> list[dict]:
+        """Non-raising host list for status-rendering AND the delete/terminate
+        path. Retries transient CLI flakes (rc!=0 / banner-corrupted JSON — see
+        _host_list_with_retry) so teardown doesn't silently skip a real host and
+        leak it; returns [] only after retries are genuinely exhausted.
+        """
+        if not self.runner.have("evergreen"):
+            raise ToolMissing("evergreen", hint="https://spruce.mongodb.com/preferences/cli")
+        data = self._host_list_with_retry(mine=mine)
+        return data if isinstance(data, list) else []
+
+    def find_by_name(self, name: str, *, mine_only: bool = False) -> Optional[dict]:
+        if not name:
+            return None
+        for h in self.list_hosts(mine=True):
+            if h.get("name") == name:
+                return h
+        # The global-list fallback is unsafe for destructive verbs: a display-name
+        # collision could resolve a teammate's host. Callers that terminate/extend
+        # pass mine_only=True.
+        if mine_only:
+            return None
+        for h in self.list_hosts(mine=False):
+            if h.get("name") == name:
+                return h
+        return None
+
+    # ------------------------------------------------------------------
+    def state_for(self, worktree_root: Path, *, mine_only: bool = False) -> Optional[EvgHostState]:
+        """Resolve the EVG host pinned to this worktree.
+
+        Pin source order:
+          1. ``.generated/.current-evg-host`` (set by evg_prepare.sh).
+          2. By convention the EVG host display name == ``branch_dir`` —
+             we fall back to that if no pin file exists.
+
+        ``mine_only=True`` refuses the global-list fallback — required for
+        destructive verbs so a name collision can't hit a teammate's host.
+        """
+        pin = worktree_root / ".generated" / ".current-evg-host"
+        if pin.is_file():
+            name = pin.read_text().strip()
+        else:
+            name = worktree_root.name
+        if not name:
+            return None
+        try:
+            host = self.find_by_name(name, mine_only=mine_only)
+        except ToolMissing:
+            return EvgHostState(
+                name=name,
+                id=None,
+                status=None,
+                host_name=None,
+                expires_in=None,
+                ssh=None,
+            )
+        if host is None:
+            return EvgHostState(
+                name=name,
+                id=None,
+                status="not-found",
+                host_name=None,
+                expires_in=None,
+                ssh=None,
+            )
+        host_name = host.get("host_name") or None
+        user = host.get("user") or "ubuntu"
+        ssh = f"ssh {user}@{host_name}" if host_name else None
+        host_id = host.get("id")
+        # --mine JSON omits expiration; fetch via REST (best-effort).
+        expires_human, expires_secs = self.fetch_expires_in(host_id) if host_id else (None, None)
+        return EvgHostState(
+            name=host.get("name"),
+            id=host_id,
+            status=host.get("status"),
+            host_name=host_name,
+            expires_in=expires_human,
+            ssh=ssh,
+            expires_seconds=expires_secs,
+        )
+
+    # ------------------------------------------------------------------
+    def terminate(self, host_id: str) -> str:
+        return self.runner.run(
+            ["evergreen", "host", "terminate", "--host", host_id],
+        ).stdout
+
+    def extend(self, host_id: str, hours: int) -> str:
+        # Upstream CLI flag is ``--extend HOURS`` (not ``--extend-by``).
+        return self.runner.run(
+            ["evergreen", "host", "modify", "--extend", str(hours), "--host", host_id],
+        ).stdout
+
+    # ------------------------------------------------------------------
+    def fetch_expires_in(self, host_id: str) -> tuple[Optional[str], Optional[int]]:
+        """Return ``(human "Xh Ym", remaining_seconds)`` for ``host_id``,
+        or ``(None, None)`` on any failure.
+
+        The ``host list --json`` payload omits expiration, so we hit the
+        REST API directly. Best-effort: missing config, network error, or
+        parse failure all collapse to ``(None, None)`` and status rendering
+        carries on.
+        """
+        if not host_id:
+            return None, None
+        expiration = _fetch_expiration_time(host_id)
+        if expiration is None:
+            return None, None
+        secs = int((expiration - datetime.now(timezone.utc)).total_seconds())
+        return _format_remaining_secs(secs), secs
+
+    # ------------------------------------------------------------------
+    def spawn(
+        self,
+        *,
+        name: str,
+        distro: str = _DEFAULT_DISTRO,
+        region: str = _DEFAULT_REGION,
+        key_name: Optional[str] = None,
+        poll_interval_s: float = 5.0,
+        timeout_s: float = 600.0,
+        create_retries: int = 2,
+        create_timeout_s: float = 180.0,
+        reconcile_timeout_s: Optional[float] = None,
+        resolve_timeout_s: float = 240.0,
+        emit: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        """Spawn (or resume) an EVG host with the given display name.
+
+        Idempotency contract: if a host with ``displayName == name`` and
+        ``status NOT IN {terminated, decommissioned, quarantined, failed}``
+        already exists, resume it (no new spawn). Otherwise call
+        ``evergreen host create`` once, then poll ``evergreen host list``
+        until the spawned host reaches ``status == "running"``. Once AWS
+        assigns an ``i-*`` id we best-effort tag + rename it to ``name``.
+        Finally we attempt an SSH probe (warn-only — does not raise).
+
+        Returns the final host id. Raises ``WtCtlError`` on terminal status
+        in the poll loop or on timeout.
+
+        Note: the upstream ``evergreen`` CLI has no ``--expiration`` flag;
+        hosts inherit the server default. ``wt-ctl delete`` reaps them.
+        """
+        if not self.runner.have("evergreen"):
+            raise ToolMissing("evergreen", hint="https://spruce.mongodb.com/preferences/cli")
+
+        def _emit(msg: str) -> None:
+            if emit is not None:
+                emit(msg)
+
+        # 1. Resume detection.
+        existing = self._find_live_by_display_name(name)
+        if existing is not None:
+            host_id = existing.get("id") or ""
+            status = (existing.get("status") or "").lower()
+            _emit(f"[wt-ctl evg spawn] resume: existing host {host_id} " f"displayName={name!r} status={status!r}")
+            if status == "running":
+                self._ssh_verify(existing, emit=_emit)
+                return host_id
+            # Fall through to the poll loop with the existing id.
+            return self._poll_until_running(
+                host_id=host_id,
+                name=name,
+                poll_interval_s=poll_interval_s,
+                timeout_s=timeout_s,
+                emit=_emit,
+            )
+
+        # 2. Fresh spawn.
+        if key_name:
+            resolved_key, resolve_diag = key_name, ""
+        else:
+            resolved_key, resolve_diag = self._resolve_key_name()
+        if not resolved_key:
+            raise WtCtlError(
+                "evg spawn: cannot resolve a public-key name. Set "
+                "MCK_DEVC_EVG_KEY_NAME or pass --key (see "
+                "'evergreen keys list'). "
+                f"Diagnostic: {resolve_diag or 'no key candidates'}"
+            )
+        _emit(
+            f"[wt-ctl evg spawn] spawning: distro={distro} region={region} " f"key={resolved_key} displayName={name!r}"
+        )
+        # The `evergreen host create` placeholder id is deterministic in
+        # (distro, timestamp-to-the-second), so parallel same-distro spawns
+        # collide on one `evg-*` id and the snapshot-diff can't tell the real
+        # `i-*` hosts apart, leaking nameless hosts. Serialize just the
+        # create→resolve→name critical section with a host-local lock; the long
+        # wait-for-running below stays unlocked so spawns still overlap.
+        with self._spawn_lock(emit=_emit):
+            # Snapshot --mine host ids before create: any id absent here but
+            # present after is ours. Under the lock this set-diff yields exactly
+            # one new host.
+            try:
+                pre_known_ids = {h.get("id") for h in self._list_my_hosts_json() if h.get("id")}
+            except ExternalCommandFailed:
+                pre_known_ids = set()
+            # Tag at create (not just in the follow-up modify): the tag rides
+            # the create request, so it survives a create whose POST times out
+            # client-side but succeeds server-side — otherwise a nameless,
+            # unattributable leaked host. `name` is reserved by the API, so use
+            # the same `wt-ctl=<name>` side label the rename step applies.
+            create_argv = [
+                "evergreen",
+                "host",
+                "create",
+                "--distro",
+                distro,
+                "--key",
+                resolved_key,
+                "--region",
+                region,
+                "--tag",
+                f"wt-ctl={name}",
+            ]
+            # Reconcile-then-retry: a `host create` POST can time out client-
+            # side while succeeding server-side. So we NEVER blindly re-create —
+            # after each attempt (success, timeout, or error) we look for a host
+            # that appeared since pre_known_ids and adopt it; only when nothing
+            # appeared do we re-issue create. This makes retries leak-free.
+            host_id: Optional[str] = None
+            last_diag = ""
+            attempts = max(1, create_retries + 1)
+            for attempt in range(1, attempts + 1):
+                timed_out = False
+                try:
+                    create_res = self.runner.run(create_argv, check=False, timeout=create_timeout_s)
+                    if create_res.rc == 0:
+                        host_id = self._parse_host_id_from_create(create_res.stdout)
+                    else:
+                        last_diag = _tail_diag(create_res.stderr or create_res.stdout)
+                        _emit(
+                            f"[wt-ctl evg spawn] 'host create' attempt {attempt}/{attempts} "
+                            f"rc={create_res.rc}; reconciling ({last_diag})"
+                        )
+                except ExternalCommandFailed as exc:
+                    # Client-side timeout / transport error: server may have made
+                    # the host regardless — reconcile, don't re-create blindly.
+                    timed_out = True
+                    last_diag = _tail_diag(exc.stderr or exc.stdout)
+                    _emit(
+                        f"[wt-ctl evg spawn] 'host create' attempt {attempt}/{attempts} "
+                        f"failed to return ({last_diag}); reconciling for a server-created host"
+                    )
+                if host_id is None:
+                    # Adopt a host that appeared post-snapshot (covers a timed-
+                    # out-but-succeeded create and an unparseable stdout). A
+                    # timeout gets a generous window; a fast reject a short one.
+                    deadline_s = (
+                        reconcile_timeout_s if reconcile_timeout_s is not None else (90.0 if timed_out else 20.0)
+                    )
+                    host_id = self._await_new_host_id(
+                        pre_known_ids,
+                        emit=_emit,
+                        deadline_s=deadline_s,
+                        poll_interval_s=poll_interval_s,
+                    )
+                if host_id is not None:
+                    break
+                if attempt < attempts:
+                    _emit(f"[wt-ctl evg spawn] no host appeared; retrying create ({attempt}/{attempts})")
+            if host_id is None:
+                raise WtCtlError(
+                    f"evg spawn: 'host create' produced no host after {attempts} "
+                    f"attempt(s) and no server-created host appeared. last diag: {last_diag or 'n/a'}"
+                )
+            _emit(f"[wt-ctl evg spawn] new host id={host_id}")
+            # Resolve the interim `evg-*` placeholder to the real `i-*` id and
+            # rename it, still under the lock. Once named + real-id'd it is no
+            # longer an ambiguous nameless candidate for the next spawn.
+            host_id = self._resolve_real_id(
+                host_id,
+                name,
+                pre_known_ids,
+                emit=_emit,
+                poll_interval_s=poll_interval_s,
+                timeout_s=resolve_timeout_s,
+            )
+        # Lock released: the host has a real id and display name. Wait for
+        # 'running' unlocked so sibling spawns proceed in parallel.
+        return self._poll_until_running(
+            host_id=host_id,
+            name=name,
+            poll_interval_s=poll_interval_s,
+            timeout_s=timeout_s,
+            emit=_emit,
+            pre_known_ids=pre_known_ids,
+            already_tagged=True,
+        )
+
+    # ------------------------------------------------------------------
+    # spawn helpers
+    # ------------------------------------------------------------------
+    def _list_my_hosts_json(self, *, retries: int = 4, retry_interval_s: float = 3.0) -> list[dict]:
+        """``evergreen host list --mine --json`` — raises on non-zero (vs.
+        ``list_hosts`` which swallows errors for status-rendering paths).
+
+        Hardened against transient CLI flakes: the Evergreen client prepends a
+        status banner (e.g. GitHub-API-slowness) to stdout, corrupting the JSON,
+        and occasionally exits non-zero under that load. Both are retried; the
+        banner is stripped before parsing. Raises only after retries are
+        exhausted so a persistent failure still surfaces (never silently []).
+        """
+        data = self._host_list_with_retry(mine=True, retries=retries, retry_interval_s=retry_interval_s)
+        if isinstance(data, list):
+            return data
+        raise ExternalCommandFailed(
+            argv=list(data.argv),
+            rc=data.rc,
+            stdout=data.stdout,
+            stderr=data.stderr,
+        )
+
+    def _host_list_with_retry(self, *, mine: bool, retries: int = 4, retry_interval_s: float = 3.0):
+        """``host list [--mine] --json`` with retry + banner-strip. Returns the
+        parsed list on success, or the last failed ``CmdResult`` sentinel when
+        all attempts fail (rc!=0 or unparseable). Callers choose whether a
+        persistent failure raises (``_list_my_hosts_json``) or degrades to []
+        (``list_hosts``).
+        """
+        argv = ["evergreen", "host", "list", "--json"]
+        if mine:
+            argv.insert(-1, "--mine")
+        last = None
+        for attempt in range(retries + 1):
+            res = self.runner.run(argv, check=False)
+            if res.rc == 0:
+                data = self._parse_hosts_json(res.stdout)
+                if data is not None:
+                    return data
+            last = res
+            if attempt < retries:
+                time.sleep(retry_interval_s)
+        return last
+
+    @staticmethod
+    def _parse_hosts_json(stdout: str) -> Optional[list[dict]]:
+        """Extract the JSON array from ``host list --json`` stdout, tolerating a
+        leading banner line. Returns None if no parseable array is present.
+        """
+        text = stdout or ""
+        start = text.find("[")
+        if start == -1:
+            return None
+        try:
+            data = json.loads(text[start:])
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, list) else None
+
+    def _find_live_by_display_name(self, name: str) -> Optional[dict]:
+        """Return the first --mine host with displayName==name in a non-dead
+        status; None if no such host exists.
+        """
+        for h in self._list_my_hosts_json():
+            display = h.get("display_name") or h.get("displayName") or h.get("name")
+            if display != name:
+                continue
+            status = (h.get("status") or "").lower()
+            if status in _DEAD_STATUSES:
+                continue
+            return h
+        return None
+
+    def _find_host_by_id(self, hosts: list[dict], host_id: str) -> Optional[dict]:
+        for h in hosts:
+            if h.get("id") == host_id:
+                return h
+        return None
+
+    @contextlib.contextmanager
+    def _spawn_lock(self, *, emit: Callable[[str], None]) -> Iterator[None]:
+        """Serialize the create→resolve→name critical section across parallel
+        wt-ctl processes via an advisory ``flock`` on a shared host-local file.
+
+        The lock is process-wide (not per-name) on purpose: the `evg-*`
+        placeholder collision is between ANY two concurrent same-distro
+        creates, so all spawns must take turns naming their host. Overridable
+        via ``MCK_DEVC_EVG_SPAWN_LOCK`` (mainly for tests / isolation).
+        """
+        lock_path = os.environ.get(
+            "MCK_DEVC_EVG_SPAWN_LOCK",
+            str(Path(tempfile.gettempdir()) / "wt-ctl-evg-spawn.lock"),
+        )
+        f = open(lock_path, "w")  # noqa: SIM115 — held for the with-body
+        try:
+            emit("[wt-ctl evg spawn] waiting for spawn lock (serialized id resolution)")
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            emit("[wt-ctl evg spawn] acquired spawn lock")
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            f.close()
+
+    def _resolve_real_id(
+        self,
+        host_id: str,
+        name: str,
+        pre_known_ids: set,
+        *,
+        emit: Callable[[str], None],
+        poll_interval_s: float = 5.0,
+        timeout_s: float = 240.0,
+    ) -> str:
+        """Poll until our host has a real AWS ``i-*`` id, then rename it to
+        ``name``. Returns the ``i-*`` id. Must be called under ``_spawn_lock``
+        so the "one nameless new host" invariant holds and the snapshot-diff is
+        unambiguous. Raises ``WtCtlError`` on terminal status / timeout.
+        """
+        deadline = time.monotonic() + timeout_s
+        while True:
+            hosts = self._list_my_hosts_json()
+            # Prefer a host already bearing our display name (idempotent
+            # re-entry), else the single new nameless real-id host.
+            host = next(
+                (h for h in hosts if (h.get("display_name") or h.get("displayName") or h.get("name")) == name),
+                None,
+            )
+            if host is None:
+                new_real_nameless = [
+                    h
+                    for h in hosts
+                    if h.get("id")
+                    and h.get("id") not in pre_known_ids
+                    and _RE_AWS_ID.match(h.get("id") or "")
+                    and not (h.get("display_name") or h.get("displayName") or h.get("name"))
+                ]
+                if len(new_real_nameless) == 1:
+                    host = new_real_nameless[0]
+            if host is not None:
+                status = (host.get("status") or "").lower()
+                if status in _DEAD_STATUSES:
+                    raise WtCtlError(
+                        f"evg spawn: host {host.get('id')} entered terminal status={status!r} during id resolution"
+                    )
+                rid = host.get("id") or ""
+                if _RE_AWS_ID.match(rid):
+                    if rid != host_id:
+                        emit(f"[wt-ctl evg spawn] host id resolved: {host_id} -> {rid}")
+                    if self._tag_and_rename(rid, name):
+                        emit(f"[wt-ctl evg spawn] named {rid} displayName={name!r}")
+                    else:
+                        emit(f"[wt-ctl evg spawn] WARN: rename failed for {rid}; poll loop will retry")
+                    return rid
+            if time.monotonic() >= deadline:
+                raise WtCtlError(f"evg spawn: host {host_id} did not resolve to a real AWS id within {timeout_s:g}s")
+            time.sleep(poll_interval_s)
+
+    def _await_new_host_id(
+        self,
+        pre_known_ids: set,
+        *,
+        emit: Callable[[str], None],
+        deadline_s: float = 90.0,
+        poll_interval_s: float = 5.0,
+    ) -> Optional[str]:
+        """Poll ``host list`` for a non-dead host that appeared AFTER the
+        pre-create snapshot and adopt it; return its id, or None by deadline.
+
+        This is the anti-leak reconcile: a ``host create`` that times out
+        client-side often still creates the host server-side. Rather than
+        re-create (and leak), we discover the new host by id set-diff and adopt
+        it. If MORE than one new host appears (a prior attempt already leaked),
+        adopt the freshest and terminate the surplus so nothing is orphaned.
+        """
+        deadline = time.monotonic() + deadline_s
+        while True:
+            try:
+                hosts = self._list_my_hosts_json()
+            except ExternalCommandFailed:
+                hosts = []
+            new = [
+                h
+                for h in hosts
+                if h.get("id")
+                and h.get("id") not in pre_known_ids
+                and (h.get("status") or "").lower() not in _DEAD_STATUSES
+            ]
+            if new:
+                new.sort(
+                    key=lambda h: h.get("creation_time") or h.get("creationTime") or "",
+                    reverse=True,
+                )
+                adopted = new[0].get("id") or ""
+                for extra in new[1:]:
+                    eid = extra.get("id") or ""
+                    emit(f"[wt-ctl evg spawn] WARN: surplus new host {eid}; terminating to avoid leak")
+                    try:
+                        self.terminate(eid)
+                    except (ExternalCommandFailed, WtCtlError):
+                        emit(f"[wt-ctl evg spawn] WARN: could not terminate surplus host {eid}")
+                emit(f"[wt-ctl evg spawn] adopted server-created host {adopted}")
+                return adopted
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(poll_interval_s)
+
+    def _resolve_key_name(self) -> tuple[str, str]:
+        """Return the EVG-managed public-key *name* to pass to ``--key``.
+
+        Order:
+        1. ``MCK_DEVC_EVG_KEY_NAME`` env var.
+        2. ``evg-host`` if the user has it registered (canonical per the
+           project's SSH policy — the evg-host private key lives in
+           ``~/.ssh/evg-host`` and ``evg_host.sh`` uses it for SSH probes).
+        3. First key listed by ``evergreen keys list``.
+
+        The upstream CLI has no ``--json`` flag for ``keys list``; output
+        is plain text of the form ``Name: 'NAME', Key: 'TYPE KEYBLOB COMMENT'``.
+
+        Returns ``(name, diag)`` where ``name`` is empty when resolution
+        failed and ``diag`` is a short human-readable reason for the empty
+        result — useful in the spawn-time error message because the
+        upstream ``evergreen keys list`` itself can fail transiently
+        (e.g. when several wt-ctl runs hit the API concurrently).
+        """
+        env_name = os.environ.get("MCK_DEVC_EVG_KEY_NAME", "").strip()
+        if env_name:
+            return env_name, ""
+        res = self.runner.run(
+            ["evergreen", "keys", "list"],
+            check=False,
+        )
+        if res.rc != 0:
+            tail_stderr = (res.stderr or "").strip().splitlines()[-3:]
+            return "", (f"`evergreen keys list` failed rc={res.rc} " f"stderr_tail={tail_stderr!r}")
+        names: list[str] = []
+        for line in (res.stdout or "").splitlines():
+            m = re.match(r"^\s*Name:\s*'([^']+)'", line)
+            if m:
+                names.append(m.group(1))
+        if not names:
+            head_stdout = (res.stdout or "").strip().splitlines()[:3]
+            return "", (
+                "`evergreen keys list` returned no parseable 'Name: ...' " f"entries; stdout_head={head_stdout!r}"
+            )
+        if "evg-host" in names:
+            return "evg-host", ""
+        return names[0], ""
+
+    def _tag_and_rename(self, host_id: str, name: str) -> bool:
+        """Set display name + ``wt-ctl`` label on ``host_id``; True on rc==0.
+
+        Evergreen reserves the ``name`` tag key (400 from the API), so we
+        ride a ``wt-ctl=<name>`` side label with the ``--name`` rename in a
+        single call (``modify`` needs at least one tag/expire/type op).
+        """
+        res = self.runner.run(
+            [
+                "evergreen",
+                "host",
+                "modify",
+                "--host",
+                host_id,
+                "--name",
+                name,
+                "--tag",
+                f"wt-ctl={name}",
+            ],
+            check=False,
+        )
+        return res.rc == 0
+
+    def _parse_host_id_from_create(self, stdout: str) -> Optional[str]:
+        """Best-effort host-id parse from ``evergreen host create`` stdout."""
+        if not stdout:
+            return None
+        # Prefer an i-* id (final AWS instance); otherwise an evg-* placeholder.
+        i_match = re.search(r"\bi-[0-9a-fA-F]+\b", stdout)
+        if i_match:
+            return i_match.group(0)
+        match = _RE_CREATE_HOST_ID.search(stdout)
+        return match.group(0) if match else None
+
+    def _poll_until_running(
+        self,
+        *,
+        host_id: str,
+        name: str,
+        poll_interval_s: float,
+        timeout_s: float,
+        emit: Callable[[str], None],
+        pre_known_ids: Optional[set[str]] = None,
+        already_tagged: bool = False,
+    ) -> str:
+        """Poll ``host list`` until our host reaches status=running.
+
+        Resolution is primarily by display name (set by ``_resolve_real_id``
+        under the spawn lock); ``pre_known_ids`` is a fallback set-diff for
+        when the name is still empty. ``already_tagged`` skips the in-loop
+        rename retry when naming already succeeded; otherwise, once AWS issues
+        an ``i-*`` id, we best-effort retry ``host modify --name --tag``
+        (warn-only on failure). Returns the host id at status=running; raises
+        ``WtCtlError`` on terminal status or timeout.
+        """
+        deadline = time.monotonic() + timeout_s
+        tagged = already_tagged
+        last_status: Optional[str] = None
+        current_id = host_id
+        if pre_known_ids is None:
+            pre_known_ids = set()
+        while True:
+            hosts = self._list_my_hosts_json()
+            host = self._find_host_by_id(hosts, current_id)
+            if host is None:
+                # Sometimes the host id we have is an ``evg-*`` placeholder
+                # that flips to ``i-*``; try matching by name as a fallback.
+                host = self._find_live_by_display_name(name)
+                if host is None and not _RE_AWS_ID.match(current_id):
+                    # Placeholder ``evg-*`` not in list and name not yet
+                    # tagged → fall back to "any new id we didn't see before
+                    # the create call". With concurrent spawns by sibling
+                    # orchestrators the pre-snapshot diff is the only way to
+                    # pick the right host.
+                    new_candidates = [
+                        h
+                        for h in hosts
+                        if h.get("id") and h.get("id") not in pre_known_ids and _RE_AWS_ID.match(h.get("id") or "")
+                    ]
+                    # Only flip the id when exactly one candidate is new —
+                    # otherwise (zero or 2+) keep polling for clarity.
+                    if len(new_candidates) == 1:
+                        host = new_candidates[0]
+                if host is not None and host.get("id"):
+                    new_id = host["id"]
+                    if new_id != current_id:
+                        emit(f"[wt-ctl evg spawn] host id transitioned: " f"{current_id} -> {new_id}")
+                        current_id = new_id
+            status = ((host or {}).get("status") or "").lower()
+            if status != last_status:
+                emit(f"[wt-ctl evg spawn] host {current_id} status={status!r}")
+                last_status = status
+            if status in _DEAD_STATUSES:
+                raise WtCtlError(
+                    f"evg spawn: host {current_id} entered terminal " f"status={status!r} before reaching 'running'"
+                )
+            # Retry tag + rename if the early claim failed, once we have a
+            # real AWS id.
+            if not tagged and host is not None and _RE_AWS_ID.match(current_id):
+                if self._tag_and_rename(current_id, name):
+                    emit(f"[wt-ctl evg spawn] tagged + renamed {current_id} " f"displayName={name!r}")
+                    tagged = True
+                else:
+                    emit(f"[wt-ctl evg spawn] WARN: tag/rename failed for " f"{current_id}; will retry on next poll")
+            if status == "running":
+                if host is not None:
+                    self._ssh_verify(host, emit=emit)
+                return current_id
+            if time.monotonic() >= deadline:
+                raise WtCtlError(
+                    f"evg spawn: timed out after {timeout_s:g}s waiting for "
+                    f"host {current_id} to reach 'running' (last status="
+                    f"{status!r})"
+                )
+            time.sleep(poll_interval_s)
+
+    def _ssh_verify(self, host: dict, *, emit: Callable[[str], None]) -> bool:
+        """Best-effort SSH probe to ``ubuntu@<host.host_name>``.
+
+        Uses the canonical evg-host key from ``~/.ssh``; never ssh-keyscans.
+        Logs and returns False on failure — the spawn return value still wins.
+        """
+        host_name = host.get("host_name") or host.get("dns_name") or host.get("dnsName")
+        if not host_name:
+            emit("[wt-ctl evg spawn] SSH verify: skipped (no host_name in JSON)")
+            return False
+        user = host.get("user") or "ubuntu"
+        ssh_key = Path.home() / ".ssh" / "evg-host"
+        argv = [
+            "ssh",
+            "-i",
+            str(ssh_key),
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=5",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            f"{user}@{host_name}",
+            "true",
+        ]
+        res = self.runner.run(argv, check=False)
+        if res.rc == 0:
+            emit(f"[wt-ctl evg spawn] SSH verify ok: {user}@{host_name}")
+            return True
+        emit(
+            f"[wt-ctl evg spawn] WARN: SSH verify failed (rc={res.rc}) "
+            f"for {user}@{host_name}; spawn returns host id anyway"
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    def get_kubeconfig(self, worktree_root: Path, *, no_fetch: bool = False) -> str:
+        """Wrap ``scripts/dev/evg_host.sh get-kubeconfig`` (so all the yq +
+        kfp PATCH logic stays in one place — the workhorse).
+        """
+        env = self._evg_env(worktree_root)
+        if env is None:
+            return "(no EVG_HOST_NAME pinned; skipping)"
+        argv = [
+            str(self.repo_root / "scripts/dev/evg_host.sh"),
+            "get-kubeconfig",
+        ]
+        if no_fetch:
+            argv.append("--no-fetch")
+        res = self.runner.run(argv, env=env, cwd=worktree_root)
+        return res.stdout
+
+    # ------------------------------------------------------------------
+    def _evg_env(self, worktree_root: Path) -> Optional[dict]:
+        """Build env for evg_host.sh: PROJECT_DIR + EVG_HOST_NAME."""
+        host_pin = worktree_root / ".generated" / ".current-evg-host"
+        host_name = host_pin.read_text().strip() if host_pin.is_file() else worktree_root.name
+        if not host_name:
+            return None
+        return {
+            "PROJECT_DIR": str(worktree_root),
+            "EVG_HOST_NAME": host_name,
+        }
+
+
+# ----------------------------------------------------------------------
+# REST helpers (expiration). Module-level (no Runner) so unit tests can
+# import without spinning up a domain instance.
+# ----------------------------------------------------------------------
+
+
+def _read_evg_config() -> Optional[dict]:
+    """Parse ~/.evergreen.yml. Returns None when unreadable."""
+    if not _EVG_CONFIG_PATH.is_file():
+        return None
+    try:
+        import yaml  # type: ignore  # pyyaml — venv dep
+    except ImportError:
+        return None
+    try:
+        data = yaml.safe_load(_EVG_CONFIG_PATH.read_text())
+    except (OSError, yaml.YAMLError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _fetch_expiration_time(host_id: str) -> Optional[datetime]:
+    """GET /rest/v2/hosts/{host_id} and return expiration_time as a UTC
+    datetime, or None on any failure.
+    """
+    cfg = _read_evg_config()
+    if not cfg:
+        return None
+    api_server = (cfg.get("api_server_host") or "").rstrip("/")
+    api_user = cfg.get("user") or ""
+    api_key = cfg.get("api_key") or ""
+    if not (api_server and api_user and api_key):
+        return None
+    # api_server already ends in ``/api``; REST routes hang off ``/rest/v2``.
+    url = f"{api_server}/rest/v2/hosts/{host_id}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Api-User": api_user,
+            "Api-Key": api_key,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_EVG_API_TIMEOUT_S) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+        return None
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    raw = payload.get("expiration_time") if isinstance(payload, dict) else None
+    if not raw:
+        return None
+    return _parse_rfc3339(raw)
+
+
+def _parse_rfc3339(value: str) -> Optional[datetime]:
+    """Parse the RFC3339 / ISO-8601 form Evergreen returns (e.g.
+    ``2026-05-21T15:34:00Z``) into a tz-aware UTC datetime.
+    """
+    if not isinstance(value, str):
+        return None
+    # ``fromisoformat`` accepts trailing ``+00:00`` but not ``Z`` until 3.11.
+    text = value.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _format_remaining_secs(secs: int) -> str:
+    """Human ``Xh Ym`` for ``secs`` remaining. Returns ``expired`` when
+    non-positive.
+    """
+    if secs <= 0:
+        return "expired"
+    hours, rem = divmod(secs, 3600)
+    minutes = rem // 60
+    if hours == 0:
+        return f"{minutes}m"
+    return f"{hours}h{minutes:02d}m"

--- a/scripts/dev/wt_ctl/domains/kfp.py
+++ b/scripts/dev/wt_ctl/domains/kfp.py
@@ -1,0 +1,247 @@
+"""On-host kube-forwarding-proxy (kfp) — pkg-installed, launchd-owned.
+
+The daemon ships as a macOS pkg (``packaging/macos/build.sh`` in the
+``kube-forwarding-proxy`` repo). The pkg installs:
+
+  - ``/usr/local/bin/k8s-service-proxy``
+  - ``/Library/LaunchDaemons/io.github.fealebenpae.k8s-proxy.plist``
+    (RunAtLoad + KeepAlive in the ``system`` launchd domain)
+  - ``/private/etc/resolver/svc.cluster.local`` (resolver entry for the
+    macOS DNS lookup chain so ``*.svc.cluster.local`` queries reach the
+    daemon on ``127.0.0.1:11617``)
+
+Endpoints (per the shipped plist):
+
+  - HTTP control on ``127.0.0.1:11616`` (``/healthz`` + kubeconfig PATCH API)
+  - DNS server  on ``127.0.0.1:11617``
+  - SOCKS proxy on ``127.0.0.1:11618`` (only when started with ``-socks``;
+    the shipped plist does not enable it)
+
+The daemon is started by launchd at boot and respawned automatically
+(KeepAlive=true). **wt-ctl does not start or stop it.** Lifecycle ops are
+manual ``launchctl`` calls — see ``cmd_kfp`` for the exact strings.
+
+What this domain still does:
+
+  - ``is_listening()`` — fast TCP check on port 11616.
+  - ``health()`` — GET ``/healthz``.
+  - ``status()`` — combines the two for display.
+  - ``register()`` — HTTP PATCH/PUT a kubeconfig onto ``/kubeconfig``.
+    kfp's per-context shutdown means peer worktrees' registrations survive.
+  - ``reset()``  — HTTP DELETE the daemon's dynamic kubeconfig.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..errors import WtCtlError
+from ..runner import Runner
+from .kubeconfig import _suffix_kubeconfig_names
+
+KFP_HOST = "127.0.0.1"
+KFP_HTTP_PORT = 11616
+KFP_DNS_PORT = 11617
+KFP_DEFAULT_URL = f"http://{KFP_HOST}:{KFP_HTTP_PORT}"
+KFP_HEALTH_URL = f"{KFP_DEFAULT_URL}/healthz"
+
+LAUNCHD_LABEL = "io.github.fealebenpae.k8s-proxy"
+LAUNCHCTL_KICKSTART = f"sudo launchctl kickstart -k system/{LAUNCHD_LABEL}"
+LAUNCHCTL_BOOTOUT = f"sudo launchctl bootout system/{LAUNCHD_LABEL}"
+LAUNCHCTL_BOOTSTRAP = f"sudo launchctl bootstrap system " f"/Library/LaunchDaemons/{LAUNCHD_LABEL}.plist"
+
+LISTEN_PROBE_TIMEOUT_S = 0.25
+HEALTH_PROBE_TIMEOUT_S = 1.0
+
+
+def _resolve_suffix_port(kubeconfig_path: Path) -> Optional[str]:
+    """Derive ``MCK_DEVC_PROXY_PORT`` for the worktree owning ``kubeconfig_path``.
+
+    Looks up two parents (``.generated/<file>`` → worktree root), then reads
+    the line out of ``.devcontainer/.env``. Falls back to the environment
+    variable; returns ``None`` if neither source has it (the caller then
+    skips the suffix and PATCHes bare bytes — fine for non-devc workflows).
+    """
+    env_port = os.environ.get("MCK_DEVC_PROXY_PORT")
+    worktree = kubeconfig_path.resolve().parent.parent
+    env_file = worktree / ".devcontainer" / ".env"
+    if env_file.is_file():
+        for line in env_file.read_text().splitlines():
+            if line.startswith("MCK_DEVC_PROXY_PORT="):
+                value = line.split("=", 1)[1].strip()
+                if value:
+                    return value
+    return env_port or None
+
+
+class KfpUnavailable(WtCtlError):
+    """The on-host kfp daemon isn't reachable on 127.0.0.1:11616."""
+
+    exit_code = 1
+
+
+@dataclass
+class KfpStatus:
+    listening: bool
+    health: Optional[str]
+    http_endpoint: str = f"{KFP_HOST}:{KFP_HTTP_PORT}"
+    dns_endpoint: str = f"{KFP_HOST}:{KFP_DNS_PORT}"
+
+
+class KfpDomain:
+    """Thin HTTP client for the on-host kfp daemon.
+
+    Daemon lifecycle is owned by launchd via the macOS pkg; this domain
+    only probes liveness and PATCHes kubeconfigs. ``runner`` is kept on the
+    signature for symmetry with other domains (unused: status() spawns no
+    subprocesses).
+    """
+
+    def __init__(
+        self,
+        runner: Runner,
+        *,
+        binary: Optional[Path] = None,  # kept for test-seam compat; unused
+        state_dir: Optional[Path] = None,  # kept for test-seam compat; unused
+    ) -> None:
+        self.runner = runner
+        # `binary` / `state_dir` retained as kwargs for test-fixture compat; no
+        # runtime effect (lifecycle is launchd's job).
+        self.binary = binary
+        self.state_dir = state_dir
+
+    # ------------------------------------------------------------------
+    # liveness probes
+    # ------------------------------------------------------------------
+    def is_listening(self, host: str = KFP_HOST, port: int = KFP_HTTP_PORT) -> bool:
+        """``True`` if anything binds ``host:port`` right now."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(LISTEN_PROBE_TIMEOUT_S)
+        try:
+            s.connect((host, port))
+            return True
+        except (OSError, socket.timeout):
+            return False
+        finally:
+            try:
+                s.close()
+            except OSError:
+                pass
+
+    def health(self) -> Optional[str]:
+        """Return ``'ok'`` if ``/healthz`` returns 200 with body containing
+        ``ok``; otherwise ``None``. Never raises.
+        """
+        try:
+            with urllib.request.urlopen(KFP_HEALTH_URL, timeout=HEALTH_PROBE_TIMEOUT_S) as resp:
+                if resp.status != 200:
+                    return None
+                body = resp.read().decode("utf-8", errors="replace").strip()
+                if not body:
+                    return None
+                return "ok" if "ok" in body.lower() else body
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+            return None
+
+    def status(self) -> KfpStatus:
+        return KfpStatus(
+            listening=self.is_listening(),
+            health=self.health(),
+        )
+
+    def register(
+        self,
+        kubeconfig_path: Path,
+        *,
+        replace: bool = False,
+        target_url: str = KFP_DEFAULT_URL,
+        suffix_port: Optional[str] = None,
+    ) -> str:
+        """Send the kubeconfig file's contents to the kfp daemon at
+        ``<target_url>/kubeconfig``. Defaults to the host's launchd kfp on
+        ``http://127.0.0.1:11616``.
+
+        Identity inside the daemon is ``(name, proxy-port)``. We rewrite the
+        cluster/context/user names in-flight to ``<name>-<suffix_port>`` so
+        peer worktrees don't collide on bare names. ``suffix_port`` falls
+        back to ``$MCK_DEVC_PROXY_PORT``; on-disk files stay bare for the
+        in-devc sidecar and ``bin/reset``-style tooling.
+
+        ``replace=True`` uses PUT to wipe every other registration. Prefer
+        the default PATCH, which only merges same-name entries.
+        """
+        if not kubeconfig_path.is_file():
+            raise WtCtlError(f"kubeconfig not found: {kubeconfig_path}")
+
+        parsed = urllib.parse.urlsplit(target_url)
+        probe_host = parsed.hostname or KFP_HOST
+        probe_port = parsed.port or KFP_HTTP_PORT
+        if not self.is_listening(probe_host, probe_port):
+            raise KfpUnavailable(
+                f"kfp daemon not listening at {probe_host}:{probe_port}. "
+                f"Daemon is pkg-installed and launchd-managed; "
+                f"restart with: {LAUNCHCTL_KICKSTART}"
+            )
+
+        port = suffix_port or _resolve_suffix_port(kubeconfig_path)
+        if port:
+            try:
+                import yaml  # type: ignore
+            except ImportError as exc:
+                raise WtCtlError(
+                    "wt-ctl kfp register requires pyyaml to suffix cluster "
+                    "names for the on-wire PATCH; pip install pyyaml."
+                ) from exc
+            data = yaml.safe_load(kubeconfig_path.read_text())
+            if not isinstance(data, dict):
+                raise WtCtlError(f"{kubeconfig_path} did not parse as a YAML mapping")
+            _suffix_kubeconfig_names(data, port)
+            body = yaml.safe_dump(data, sort_keys=False).encode("utf-8")
+        else:
+            body = kubeconfig_path.read_bytes()
+
+        method = "PUT" if replace else "PATCH"
+        endpoint = target_url.rstrip("/") + "/kubeconfig"
+        req = urllib.request.Request(endpoint, data=body, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            raise WtCtlError(f"kfp {method.lower()} failed: HTTP {exc.code} {exc.reason}") from exc
+        except (urllib.error.URLError, OSError) as exc:
+            raise WtCtlError(f"kfp {method.lower()} failed: {exc}") from exc
+
+    def reset(self) -> None:
+        """HTTP DELETE the daemon's dynamic kubeconfig — wipes all
+        registered contexts. Use to clean up stale entries whose proxy-url
+        ports are invalid (e.g. ``kind-kind-80640``) before re-registering
+        active worktrees.
+
+        Raises ``WtCtlError`` if the daemon isn't listening or the
+        HTTP call fails.
+        """
+        if not self.is_listening():
+            raise KfpUnavailable(
+                f"kfp daemon not listening at {KFP_HOST}:{KFP_HTTP_PORT}. "
+                f"Daemon is pkg-installed and launchd-managed; "
+                f"restart with: {LAUNCHCTL_KICKSTART}"
+            )
+        req = urllib.request.Request(
+            f"http://{KFP_HOST}:{KFP_HTTP_PORT}/kubeconfig",
+            method="DELETE",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                # 204 No Content on success
+                _ = resp.read()
+        except urllib.error.HTTPError as exc:
+            raise WtCtlError(f"kfp delete failed: HTTP {exc.code} {exc.reason}") from exc
+        except (urllib.error.URLError, OSError) as exc:
+            raise WtCtlError(f"kfp delete failed: {exc}") from exc

--- a/scripts/dev/wt_ctl/domains/kubeconfig.py
+++ b/scripts/dev/wt_ctl/domains/kubeconfig.py
@@ -1,0 +1,555 @@
+"""Kubeconfig domain — read summary, post-process per-side variants, register with kfp.
+
+`state_for` and `_age` back ``wt-ctl status``.
+
+`refresh` post-processes the kubeconfig (pyyaml parsing, stdlib urllib for the
+kfp PATCH, unit-testable). Dispatch:
+   .current-evg-host present → EVG-host: host file gets
+       proxy-url=http://127.0.0.1:<PROXY_PORT>; devc variant ${EVG_HOST_PROXY}.
+   host server is loopback   → local-kind: rewrite the devc variant's server so
+       the devcontainer reaches the kind apiserver (insecure-skip-tls-verify, CA
+       stripped). macOS: https://host.docker.internal:<hostport>. Linux:
+       host.docker.internal can't reach a 127.0.0.1 host port, so the devc +
+       k8s-proxy containers join the `kind` network (dc_up) and target the node
+       container IP at :6443; resolving that IP needs host-side docker, so the
+       in-devc refresh reuses the host-written server.
+   else                      → BYOC: identity-copy host kubeconfig to the devc variant.
+Both modes pin `current-context` to ${CLUSTER_NAME} and PATCH the per-side
+variant to ${K8S_FWD_PROXY}/kubeconfig. The multi-cluster kubeconfig gets the
+same split (``multicluster_kubeconfig`` host / ``multicluster.devc.kubeconfig``
+devc), selected by ${KUBE_CONFIG_PATH}.
+
+Name disambiguation: the shared on-host kfp daemon is multi-tenant, so when
+MCK_DEVC_PROXY_PORT is set the bytes PATCHed to it (only) get every
+cluster/context/user name suffixed with ``-<port>``; on-disk files stay bare.
+Daemon identity becomes ``(name, port)`` — re-PATCHing a worktree is idempotent
+and peers keep their own entries. On-disk stays bare because every other
+consumer (variant context files, ``bin/reset``, host-shell kubectl) expects
+bare names.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import platform
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from ..errors import ToolMissing, WtCtlError
+from ..runner import Runner
+from ..state import KubeconfigState
+
+
+def _import_yaml() -> Any:
+    """Lazy import so ``wt-ctl <other-verb>`` doesn't crash on the import
+    when pyyaml isn't installed (e.g. early worktree_init before the venv
+    is built). refresh() raises a friendly error if the dep is missing.
+    """
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:
+        raise WtCtlError(
+            "wt-ctl kubeconfig refresh requires pyyaml; install it into the "
+            "worktree venv or pip install pyyaml into the python that wt-ctl "
+            "is using."
+        ) from exc
+    return yaml
+
+
+_LOOPBACK_SERVER_RE = re.compile(r"^https?://(?:127\.0\.0\.1|localhost)(?::(?P<port>\d+))?(?:/|$)")
+_KFP_PATCH_TIMEOUT_S = 5.0
+
+
+def _age(path: Path) -> Optional[str]:
+    if not path.is_file():
+        return None
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+    delta = datetime.now(timezone.utc) - mtime
+    secs = int(delta.total_seconds())
+    if secs < 60:
+        return f"{secs}s_ago"
+    if secs < 3600:
+        return f"{secs // 60}m_ago"
+    if secs < 86400:
+        return f"{secs // 3600}h_ago"
+    return f"{secs // 86400}d_ago"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    yaml = _import_yaml()
+    text = path.read_text()
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WtCtlError(f"failed to parse {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise WtCtlError(f"{path} did not parse as a YAML mapping")
+    return data
+
+
+def _dump_yaml(path: Path, data: dict[str, Any]) -> None:
+    yaml = _import_yaml()
+    body = yaml.safe_dump(data, sort_keys=False)
+    # Atomic replace: kubectl / other tools actively read these files while we
+    # rewrite them, so write a tempfile sibling then os.replace to avoid handing
+    # a reader a transient empty/partial YAML document.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _first_server(kc: dict[str, Any]) -> Optional[str]:
+    clusters = kc.get("clusters")
+    if not isinstance(clusters, list) or not clusters:
+        return None
+    entry = clusters[0]
+    if not isinstance(entry, dict):
+        return None
+    inner = entry.get("cluster")
+    if not isinstance(inner, dict):
+        return None
+    server = inner.get("server")
+    return server if isinstance(server, str) else None
+
+
+def _set_proxy_url(kc: dict[str, Any], proxy_url: Optional[str]) -> None:
+    """Set or strip clusters[*].cluster.proxy-url across every cluster entry."""
+    for entry in kc.get("clusters") or []:
+        inner = entry.get("cluster") if isinstance(entry, dict) else None
+        if not isinstance(inner, dict):
+            continue
+        if proxy_url is None:
+            inner.pop("proxy-url", None)
+        else:
+            inner["proxy-url"] = proxy_url
+
+
+def _strip_kubeconfig_suffix(kc: dict[str, Any], port: str) -> None:
+    """Inverse of ``_suffix_kubeconfig_names``: strip the ``-<port>`` tail
+    from every cluster/context/user name (plus cross-refs and
+    ``current-context``). Idempotent; entries without the suffix are
+    left alone.
+
+    refresh() calls this on the loaded host kubeconfig before any other
+    mutation so the downstream deep-copy snapshot for the devc variant
+    sees bare names. Without the strip, a second refresh against an
+    already-suffixed on-disk file would propagate the suffix into the
+    devc kubeconfig (the in-container k8s-proxy sidecar would then
+    register under the suffixed name — the opposite of what we want).
+    """
+    sfx = f"-{port}"
+
+    def _strip(name: Any) -> Any:
+        if isinstance(name, str) and name.endswith(sfx) and len(name) > len(sfx):
+            return name[: -len(sfx)]
+        return name
+
+    for key in ("clusters", "contexts", "users"):
+        for entry in kc.get(key) or []:
+            if isinstance(entry, dict) and "name" in entry:
+                entry["name"] = _strip(entry["name"])
+
+    for entry in kc.get("contexts") or []:
+        inner = entry.get("context") if isinstance(entry, dict) else None
+        if not isinstance(inner, dict):
+            continue
+        if "cluster" in inner:
+            inner["cluster"] = _strip(inner["cluster"])
+        if "user" in inner:
+            inner["user"] = _strip(inner["user"])
+
+    cur = kc.get("current-context")
+    if isinstance(cur, str):
+        kc["current-context"] = _strip(cur)
+
+
+def _suffix_kubeconfig_names(kc: dict[str, Any], port: str) -> None:
+    """Rename every cluster/context/user in ``kc`` to ``<original>-<port>``,
+    fix the cross-references in ``contexts[*].context.{cluster,user}``, and
+    rewrite ``current-context`` to the suffixed form.
+
+    Identity becomes ``(name, port)`` so peer worktrees don't collide on bare
+    names. Skips entries whose name already ends with the suffix so re-runs of
+    refresh() on an already-suffixed file are no-ops (idempotent).
+    """
+    sfx = f"-{port}"
+
+    def _rename(name: Any) -> Any:
+        if not isinstance(name, str) or name.endswith(sfx):
+            return name
+        return f"{name}{sfx}"
+
+    for key in ("clusters", "contexts", "users"):
+        for entry in kc.get(key) or []:
+            if isinstance(entry, dict) and "name" in entry:
+                entry["name"] = _rename(entry["name"])
+
+    for entry in kc.get("contexts") or []:
+        inner = entry.get("context") if isinstance(entry, dict) else None
+        if not isinstance(inner, dict):
+            continue
+        if "cluster" in inner:
+            inner["cluster"] = _rename(inner["cluster"])
+        if "user" in inner:
+            inner["user"] = _rename(inner["user"])
+
+    cur = kc.get("current-context")
+    if isinstance(cur, str) and cur and not cur.endswith(sfx):
+        kc["current-context"] = f"{cur}{sfx}"
+
+
+def _kind_node_ip(runner: Runner, cluster_entry_name: Optional[str]) -> Optional[str]:
+    """IP of the kind control-plane container on the ``kind`` docker network.
+    Kind names its cluster ``kind-<name>`` and node ``<name>-control-plane``.
+    None when docker is absent (in-devc) or the container/network isn't there."""
+    if not cluster_entry_name:
+        return None
+    name = cluster_entry_name.removeprefix("kind-")
+    try:
+        res = runner.run(
+            ["docker", "inspect", "-f", "{{.NetworkSettings.Networks.kind.IPAddress}}", f"{name}-control-plane"],
+            check=False,
+        )
+    except ToolMissing:
+        return None
+    ip = res.stdout.strip() if res.rc == 0 else ""
+    return ip or None
+
+
+def _existing_devc_servers(path: Path) -> dict[str, str]:
+    """Map cluster-entry-name → server from an existing devc kubeconfig. The
+    in-devc refresh (no docker) reuses this instead of re-resolving the Linux
+    kind node IP the host-side refresh already wrote."""
+    if not path.is_file():
+        return {}
+    try:
+        data = _load_yaml(path)
+    except WtCtlError:
+        return {}
+    out: dict[str, str] = {}
+    for entry in data.get("clusters") or []:
+        if not isinstance(entry, dict):
+            continue
+        inner = entry.get("cluster")
+        server = inner.get("server") if isinstance(inner, dict) else None
+        if isinstance(entry.get("name"), str) and isinstance(server, str):
+            out[entry["name"]] = server
+    return out
+
+
+def _make_devc_server_resolver(runner: Runner, emit: Any, prior: dict[str, str]) -> Any:
+    """Build ``resolve(entry_name, loopback_port) -> url | None`` for the
+    devc-side apiserver.
+
+    ``loopback_port`` is the host port of a ``127.0.0.1:<port>`` server, or
+    None when the current server is non-loopback (e.g. a ClusterIP from the
+    MC operator Secret). ``None`` return means "leave the server unchanged".
+
+    Linux: the kind node container IP on the shared ``kind`` network at :6443,
+    resolved by context name — works for both loopback and ClusterIP bases. If
+    docker can't resolve it (in-devc), reuse a prior non-loopback server we
+    already wrote host-side; else fall back to host.docker.internal for a
+    loopback base, or leave a non-loopback one untouched.
+    macOS: host.docker.internal:<port> (needs the host port, so loopback only;
+    a non-loopback base is left unchanged)."""
+    is_linux = platform.system() == "Linux"
+
+    def resolve(entry_name: Optional[str], loopback_port: Optional[str]) -> Optional[str]:
+        if is_linux:
+            ip = _kind_node_ip(runner, entry_name)
+            if ip:
+                return f"https://{ip}:6443"
+            prev = prior.get(entry_name or "")
+            if prev and not _LOOPBACK_SERVER_RE.match(prev):
+                return prev
+            if loopback_port is not None:
+                emit(
+                    f"WARN: could not resolve kind node IP for {entry_name!r}; using host.docker.internal (may be unreachable on Linux)"
+                )
+                return f"https://host.docker.internal:{loopback_port}"
+            emit(f"WARN: could not resolve kind node IP for non-loopback member {entry_name!r}; leaving unchanged")
+            return None
+        if loopback_port is not None:
+            return f"https://host.docker.internal:{loopback_port}"
+        return None
+
+    return resolve
+
+
+def _rewrite_member_servers_for_devc(kc: dict[str, Any], resolve: Any) -> None:
+    """Rewrite each member server to the devc-reachable apiserver URL returned
+    by ``resolve`` (+ TLS-skip, strip CA). Loopback servers pass their host
+    port to the resolver; non-loopback servers (ClusterIP from the MC Secret)
+    are rewritten by context name on Linux. A ``None`` resolution leaves the
+    entry unchanged (BYOC / unsupported macOS non-loopback)."""
+    for entry in kc.get("clusters") or []:
+        inner = entry.get("cluster") if isinstance(entry, dict) else None
+        if not isinstance(inner, dict):
+            continue
+        server = inner.get("server")
+        m = _LOOPBACK_SERVER_RE.match(server) if isinstance(server, str) else None
+        new = resolve(entry.get("name"), (m.group("port") or "443") if m else None)
+        if not new:
+            continue
+        inner["server"] = new
+        inner["insecure-skip-tls-verify"] = True
+        inner.pop("certificate-authority-data", None)
+        inner.pop("certificate-authority", None)
+
+
+def _patch_kfp(url: str, kubeconfig_bytes: bytes, log: Any) -> bool:
+    """HTTP PATCH the kubeconfig onto K8S_FWD_PROXY/kubeconfig. Returns True
+    on 2xx, False otherwise. Best-effort: kfp may not be listening (host
+    daemon down, in-devc proxy not yet healthy) and we don't want that to
+    fail the larger refresh."""
+    req = Request(
+        url,
+        data=kubeconfig_bytes,
+        method="PATCH",
+        headers={"Content-Type": "application/yaml"},
+    )
+    try:
+        with urlopen(req, timeout=_KFP_PATCH_TIMEOUT_S) as resp:
+            ok = 200 <= resp.status < 300
+            if ok:
+                log(f"registered kubeconfig with kfp at {url}")
+            else:
+                log(f"kfp rejected kubeconfig (status={resp.status}) at {url}")
+            return ok
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        log(f"kfp not reachable at {url}: {exc.__class__.__name__}: {exc}; skipping registration")
+        return False
+
+
+class KubeconfigDomain:
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+
+    def state_for(self, worktree_root: Path) -> Optional[KubeconfigState]:
+        gen = worktree_root / ".generated"
+        # Prefer the host-side file; fall back to the devc variant.
+        host_kc = gen / "current.kubeconfig"
+        devc_kc = gen / "current.devc.kubeconfig"
+        path = host_kc if host_kc.is_file() else (devc_kc if devc_kc.is_file() else None)
+        if path is None:
+            return None
+        last_patch = _age(path)
+        # kfp registration is ephemeral and not probed from the host side;
+        # "devc variant exists" is the cheapest signal that get-kubeconfig has
+        # run inside the container at least once.
+        kfp = devc_kc.is_file() if path else None
+        return KubeconfigState(
+            path=str(path),
+            last_patch=last_patch,
+            kfp_registered=kfp,
+        )
+
+    def refresh(
+        self,
+        worktree_root: Path,
+        *,
+        env: Optional[dict[str, str]] = None,
+        in_devc: Optional[bool] = None,
+        emit: Any = None,
+    ) -> None:
+        """Per-side post-process the host kubeconfig and register the result
+        with kfp. See module docstring for the dispatch table.
+
+        Arguments:
+            worktree_root: the worktree containing ``.generated/``.
+            env: env-var bag (defaults to os.environ). Lets tests inject.
+            in_devc: side hint; defaults to detecting `/.dockerenv`.
+            emit: logger callable (defaults to stderr writer).
+        """
+        if env is None:
+            env = dict(os.environ)
+        if in_devc is None:
+            in_devc = Path("/.dockerenv").is_file()
+        if emit is None:
+            emit = lambda msg: sys.stderr.write(msg + "\n")
+
+        gen = worktree_root / ".generated"
+        host_kc = gen / "current.kubeconfig"
+        devc_kc = gen / "current.devc.kubeconfig"
+        evg_pin = gen / ".current-evg-host"
+
+        if not host_kc.is_file():
+            raise WtCtlError(
+                f"{host_kc} not found. Run recreate_kind_cluster.sh (local kind), "
+                "evg_host.sh get-kubeconfig (EVG host), or copy a BYOC "
+                "kubeconfig into place first."
+            )
+
+        host_data = _load_yaml(host_kc)
+        cluster_name = env.get("CLUSTER_NAME") or None
+        k8s_fwd_proxy = env.get("K8S_FWD_PROXY") or None
+        suffix_port = env.get("MCK_DEVC_PROXY_PORT") or None
+
+        # A file inherited from a prior refresh may carry a ``-<port>`` suffix;
+        # normalise back to bare so this run writes bare files.
+        if suffix_port:
+            _strip_kubeconfig_suffix(host_data, suffix_port)
+
+        def _pin_current_context(kc: dict[str, Any]) -> None:
+            if cluster_name:
+                kc["current-context"] = cluster_name
+
+        if evg_pin.is_file():
+            # EVG-host mode: both files get proxy-url.
+            if not suffix_port:
+                raise WtCtlError(
+                    "MCK_DEVC_PROXY_PORT must be set (`make switch` first to "
+                    "source .devcontainer/.env via root-context)"
+                )
+            host_proxy = f"http://127.0.0.1:{suffix_port}"
+            emit(f"Patching {host_kc}: proxy={host_proxy} " f"context={cluster_name or '<inherited>'} (bare on disk)")
+            _set_proxy_url(host_data, host_proxy)
+            _pin_current_context(host_data)
+            _dump_yaml(host_kc, host_data)
+
+            evg_host_proxy = env.get("EVG_HOST_PROXY") or None
+            if evg_host_proxy:
+                emit(
+                    f"Patching {devc_kc}: proxy={evg_host_proxy} "
+                    f"context={cluster_name or '<inherited>'} (bare on disk)"
+                )
+                devc_data = copy.deepcopy(host_data)
+                _set_proxy_url(devc_data, evg_host_proxy)
+                _dump_yaml(devc_kc, devc_data)
+                self._maybe_register(
+                    k8s_fwd_proxy,
+                    devc_kc if in_devc else host_kc,
+                    emit,
+                    suffix_port=None if in_devc else suffix_port,
+                )
+            else:
+                self._maybe_register(k8s_fwd_proxy, host_kc, emit, suffix_port=suffix_port)
+            self._refresh_multicluster_evg(gen, host_proxy, evg_host_proxy, emit)
+            return
+
+        # Non-EVG branch: dispatch on the apiserver URL.
+        server = _first_server(host_data)
+        # Strip stale proxy-url left over from a previous EVG-host run.
+        _set_proxy_url(host_data, None)
+        _pin_current_context(host_data)
+        _dump_yaml(host_kc, host_data)
+
+        if server is None:
+            raise WtCtlError(f"{host_kc} has no clusters[0].cluster.server")
+
+        m = _LOOPBACK_SERVER_RE.match(server)
+        if m:
+            resolve = _make_devc_server_resolver(self.runner, emit, _existing_devc_servers(devc_kc))
+            devc_data = copy.deepcopy(host_data)
+            _rewrite_member_servers_for_devc(devc_data, resolve)
+            emit(f"Local-kind: {devc_kc}: server={_first_server(devc_data)} (TLS verify off)")
+            _dump_yaml(devc_kc, devc_data)
+        else:
+            emit(f"BYOC: {devc_kc}: identity copy of {host_kc} (server={server})")
+            _dump_yaml(devc_kc, host_data)
+
+        # Local-kind / BYOC: the host kubeconfig's apiserver is locally
+        # reachable (no proxy-url). Suffix only the bytes PATCHed to the
+        # on-host kfp so concurrent worktrees don't clobber each other's
+        # registrations; on-disk files stay bare for the in-devc sidecar
+        # and bin/reset-style tooling.
+        self._maybe_register(
+            k8s_fwd_proxy,
+            devc_kc if in_devc else host_kc,
+            emit,
+            suffix_port=None if in_devc else suffix_port,
+        )
+        self._refresh_multicluster_local(gen, emit)
+
+    def _refresh_multicluster_evg(
+        self,
+        gen: Path,
+        host_proxy: str,
+        devc_proxy: Optional[str],
+        emit: Any,
+    ) -> None:
+        """EVG-host mode: derive the two multi-cluster flavors from the bare
+        base. Host flavor gets ``host_proxy`` in place; devc flavor gets
+        ``devc_proxy`` (only available inside the container). No-op when the
+        base file hasn't been produced yet."""
+        base = gen / "multicluster_kubeconfig"
+        if not base.is_file():
+            return
+        data = _load_yaml(base)
+        _set_proxy_url(data, host_proxy)
+        emit(f"Patching {base}: proxy={host_proxy} (member clusters, host flavor)")
+        _dump_yaml(base, data)
+        if devc_proxy:
+            devc_data = copy.deepcopy(data)
+            _set_proxy_url(devc_data, devc_proxy)
+            emit(f"Patching {gen / 'multicluster.devc.kubeconfig'}: proxy={devc_proxy} (member clusters, devc flavor)")
+            _dump_yaml(gen / "multicluster.devc.kubeconfig", devc_data)
+
+    def _refresh_multicluster_local(self, gen: Path, emit: Any) -> None:
+        """local-kind / BYOC mode: host flavor is the bare base (laptop kind
+        is directly reachable from host shells); devc flavor rewrites loopback
+        member servers to host.docker.internal. No-op without a base file."""
+        base = gen / "multicluster_kubeconfig"
+        if not base.is_file():
+            return
+        data = _load_yaml(base)
+        _set_proxy_url(data, None)
+        _dump_yaml(base, data)
+        devc_path = gen / "multicluster.devc.kubeconfig"
+        resolve = _make_devc_server_resolver(self.runner, emit, _existing_devc_servers(devc_path))
+        devc_data = copy.deepcopy(data)
+        _rewrite_member_servers_for_devc(devc_data, resolve)
+        emit(f"Multi-cluster: {devc_path} (devc flavor)")
+        _dump_yaml(devc_path, devc_data)
+
+    def _maybe_register(
+        self,
+        k8s_fwd_proxy: Optional[str],
+        path: Path,
+        emit: Any,
+        *,
+        suffix_port: Optional[str] = None,
+    ) -> None:
+        """PATCH the kubeconfig at ``path`` onto ``k8s_fwd_proxy``.
+
+        When ``suffix_port`` is set, the bytes sent over the wire have
+        every cluster/context/user name + current-context suffixed with
+        ``-<port>`` for kfp's multi-tenant disambiguation. The file on
+        disk is unchanged — every other consumer (variant context env
+        vars, ``bin/reset``, in-container k8s-proxy sidecar) keeps
+        using bare names.
+        """
+        if not k8s_fwd_proxy:
+            return
+        url = f"http://{k8s_fwd_proxy}/kubeconfig"
+        if suffix_port:
+            data = _load_yaml(path)
+            _suffix_kubeconfig_names(data, suffix_port)
+            yaml = _import_yaml()
+            body = yaml.safe_dump(data, sort_keys=False).encode("utf-8")
+            emit(f"Loading kubeconfig from {path} onto {k8s_fwd_proxy} " f"(names suffixed -{suffix_port} in-flight)")
+        else:
+            emit(f"Loading kubeconfig from {path} onto {k8s_fwd_proxy}")
+            body = path.read_bytes()
+        _patch_kfp(url, body, emit)

--- a/scripts/dev/wt_ctl/domains/network.py
+++ b/scripts/dev/wt_ctl/domains/network.py
@@ -1,0 +1,913 @@
+"""Network prefix domain — native Python registry.
+
+Public surface:
+
+  - ``NetworkDomain.list_entries()`` -> ``[NetEntry]``
+  - ``NetworkDomain.list_raw()``     -> str (rendered table for ``network list``)
+  - ``NetworkDomain.prefix_for(branch_dir)``
+  - ``NetworkDomain.prune(dry_run=False)`` -> str
+  - ``NetworkDomain.release(branch_dir)``  -> str
+  - ``NetworkDomain.allocate(branch_dir)`` -> str (5 ``KEY=VALUE`` lines:
+        ``MCK_DEVC_NET_PREFIX``, ``MCK_DEVC_NET_X``, ``MCK_DEVC_NET_Y_BASE``,
+        ``MCK_DEVC_NET_Y_VIP``, ``MCK_DEVC_PROXY_PORT``)
+
+# Address-space layout — /23 per stack within 172.16.0.0/12
+
+Index ``N`` (0..2047) maps to:
+
+```
+X       = 16 + (N >> 7)        # second octet, 16..31
+Y_BASE  = (N & 0x7F) << 1      # third octet base, even, 0..254
+Y_VIP   = Y_BASE + 1           # third octet for VIPs
+PORT    = 8000 + N             # gost-proxy host port, 8000..10047
+```
+
+Per-stack:
+- subnet:        ``172.X.Y_BASE.0/23`` (the docker network CIDR)
+- ip_range:      ``172.X.Y_BASE.0/24``
+- VIP_CIDR:      ``172.X.Y_VIP.0/24``
+- proxy_address: ``172.X.Y_BASE.10``
+- gost-proxy:    ``127.0.0.1:PORT``
+
+# Persisted format
+
+```
+<branch_dir>=<N>:<X>:<Y_BASE>:<Y_VIP>:<PORT>
+```
+
+Subprocess discipline: this module **never** imports subprocess. Docker
+network discovery and ``git worktree list`` go through the injected
+``Runner`` (per ``runner.py`` contract).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import ipaddress
+import os
+import re
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Iterator, Optional
+
+from ..errors import ExternalCommandFailed, LockTimeout, RegistryError, ToolMissing
+from ..runner import Runner
+from ..state import NetEntry
+
+# Index space — 0..MAX_INDEX (inclusive) maps to X/Y/PORT via stack_params().
+INDEX_LO = 0
+INDEX_HI = 2047
+
+# Public aliases for out-of-tree callers / tests.
+VALID_RANGE_LO = INDEX_LO
+VALID_RANGE_HI = INDEX_HI
+
+LOCK_TIMEOUT_SECS = 30  # max wait to acquire a lock
+LOCK_POLL_INTERVAL_SECS = 0.1
+
+
+# ---------------------------------------------------------------------------
+# math
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StackParams:
+    """All four derived address-space parameters for a stack index ``N``."""
+
+    index: int
+    x: int
+    y_base: int
+    y_vip: int
+    port: int
+
+    @property
+    def subnet(self) -> str:
+        return f"172.{self.x}.{self.y_base}.0/23"
+
+    @property
+    def ip_range(self) -> str:
+        return f"172.{self.x}.{self.y_base}.0/24"
+
+    @property
+    def vip_cidr(self) -> str:
+        return f"172.{self.x}.{self.y_vip}.0/24"
+
+    @property
+    def proxy_address(self) -> str:
+        return f"172.{self.x}.{self.y_base}.10"
+
+
+def stack_params(index: int) -> StackParams:
+    """Compute (X, Y_BASE, Y_VIP, PORT) for stack index ``index``."""
+    if not (INDEX_LO <= index <= INDEX_HI):
+        raise RegistryError(f"stack index {index} outside [{INDEX_LO},{INDEX_HI}]")
+    x = 16 + (index >> 7)
+    y_base = (index & 0x7F) << 1
+    y_vip = y_base + 1
+    port = 8000 + index
+    return StackParams(
+        index=index,
+        x=x,
+        y_base=y_base,
+        y_vip=y_vip,
+        port=port,
+    )
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _registry_dir() -> Path:
+    override = os.environ.get("MCK_DEVC_REGISTRY_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".cache" / "mck-devc"
+
+
+def _registry_file() -> Path:
+    return _registry_dir() / "net-prefix-registry"
+
+
+def _lock_file() -> Path:
+    return _registry_dir() / "net-prefix-registry.lock"
+
+
+def _ensure_registry() -> tuple[Path, Path]:
+    rdir = _registry_dir()
+    rdir.mkdir(parents=True, exist_ok=True)
+    rfile = _registry_file()
+    if not rfile.exists():
+        rfile.touch()
+    return rdir, rfile
+
+
+# ---------------------------------------------------------------------------
+# locking
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _registry_lock(*, timeout: float = LOCK_TIMEOUT_SECS) -> Iterator[None]:
+    """Exclusive advisory lock via ``fcntl.flock`` on a dedicated lock file.
+
+    The kernel releases the lock automatically when the holding process exits
+    (or the fd closes), so there is no stale-lock heuristic to get wrong and no
+    way to steal a lock a live process still holds. We poll ``LOCK_NB`` until
+    ``timeout``.
+
+    flock is on the open file *description*: two contenders (threads or
+    processes) each ``os.open`` the lock file, so they get distinct
+    descriptions and mutually exclude even within one process. Targets are the
+    Linux devcontainer and macOS host, both of which support flock.
+    """
+    _ensure_registry()
+    lockfile = _lock_file()
+    deadline = time.monotonic() + timeout
+    fd = os.open(str(lockfile), os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644)
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise LockTimeout(str(lockfile), timeout)
+                time.sleep(LOCK_POLL_INTERVAL_SECS)
+        try:  # holder pid, purely informational for humans debugging a stuck lock
+            os.ftruncate(fd, 0)
+            os.write(fd, f"{os.getpid()}\n".encode())
+        except OSError:
+            pass
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# native Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _OrphanNetwork:
+    """Docker network in 172.[16-31].x.x with name pattern
+    ``*_devcontainer_devcontainer``, 0 attached containers, and no
+    surviving worktree.
+    """
+
+    name: str
+    prefix: int
+
+
+@dataclass
+class _DockerNet:
+    name: str
+    prefix: int  # X octet (172.<prefix>.x.x)
+    subnet: str = ""  # full CIDR, e.g. "172.18.0.0/16" or "172.16.4.0/23"
+
+
+@dataclass(frozen=True)
+class _RegistryRow:
+    """One persisted registry line, parsed.
+
+    ``params.index`` is 0..2047 (a /23 stack index).
+    """
+
+    branch_dir: str
+    params: StackParams
+
+
+class Registry:
+    """Native Python implementation of the net-prefix registry.
+
+    All public methods grab the lock as needed. Lock acquisition is
+    re-entrant within a single ``allocate``/``prune`` call: each call
+    grabs once, mutates atomically, releases.
+    """
+
+    def __init__(self, runner: Runner, *, worktree_parent: Path) -> None:
+        self.runner = runner
+        self.worktree_parent = worktree_parent.resolve()
+
+    # ------------------------------------------------------------------
+    # raw read/write
+    # ------------------------------------------------------------------
+    def _read(self) -> list[_RegistryRow]:
+        _, rfile = _ensure_registry()
+        out: list[_RegistryRow] = []
+        try:
+            text = rfile.read_text()
+        except OSError as exc:
+            raise RegistryError(f"failed to read {rfile}: {exc}") from exc
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line or "=" not in line:
+                continue
+            bd, rhs = line.split("=", 1)
+            bd = bd.strip()
+            rhs = rhs.strip()
+            if not bd or not rhs:
+                continue
+            row = _parse_rhs(bd, rhs)
+            if row is None:
+                sys.stderr.write(f"[wt-ctl] network: WARN dropping unparseable registry " f"row {bd}={rhs}\n")
+                continue
+            out.append(row)
+        return out
+
+    def _write(self, rows: list[_RegistryRow]) -> None:
+        rdir, rfile = _ensure_registry()
+        body = "".join(_format_row(r) + "\n" for r in rows)
+        # Atomic replace: write a tempfile sibling then os.replace, so a crash
+        # mid-write can never truncate the registry and lose live allocations
+        # (which would let a later allocate() collide with a running stack).
+        try:
+            fd, tmp = tempfile.mkstemp(prefix=".net-prefix-registry.", suffix=".tmp", dir=str(rdir))
+            try:
+                with os.fdopen(fd, "w") as fh:
+                    fh.write(body)
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp, str(rfile))
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError as exc:
+            raise RegistryError(f"failed to write {rfile}: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # branch_dir liveness check
+    # ------------------------------------------------------------------
+    def _is_stale_branch_dir(self, bd: str, *, git_basenames: set[str]) -> bool:
+        if (self.worktree_parent / bd).is_dir():
+            return False
+        if bd in git_basenames:
+            return False
+        return True
+
+    def _git_worktree_basenames(self, repo_root: Path) -> set[str]:
+        """Return basenames from ``git worktree list --porcelain`` for the
+        repo at ``repo_root``. Best-effort: returns empty on any failure.
+        """
+        if not (repo_root / ".git").exists():
+            return set()
+        try:
+            res = self.runner.run(
+                ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+                check=False,
+            )
+        except ToolMissing:
+            return set()
+        if res.rc != 0:
+            return set()
+        names: set[str] = set()
+        for line in res.stdout.splitlines():
+            if line.startswith("worktree "):
+                p = line[len("worktree ") :].strip()
+                if p:
+                    names.add(Path(p).name)
+        return names
+
+    # ------------------------------------------------------------------
+    # docker network discovery
+    # ------------------------------------------------------------------
+    def _docker_networks_in_range(self) -> list[_DockerNet]:
+        try:
+            res = self.runner.run(
+                ["docker", "network", "ls", "--format", "{{.Name}}"],
+                check=False,
+            )
+        except ToolMissing:
+            return []
+        if res.rc != 0:
+            return []
+        out: list[_DockerNet] = []
+        subnet_re = re.compile(r"^172\.(\d+)\.")
+        for raw in res.stdout.splitlines():
+            name = raw.strip()
+            if not name:
+                continue
+            try:
+                ins = self.runner.run(
+                    [
+                        "docker",
+                        "network",
+                        "inspect",
+                        name,
+                        "--format",
+                        "{{range .IPAM.Config}}{{.Subnet}}{{end}}",
+                    ],
+                    check=False,
+                )
+            except ToolMissing:
+                return []
+            if ins.rc != 0:
+                continue
+            subnet = ins.stdout.strip()
+            m = subnet_re.match(subnet)
+            if not m:
+                continue
+            x = int(m.group(1))
+            if 16 <= x <= 31:
+                out.append(_DockerNet(name=name, prefix=x, subnet=subnet))
+        return out
+
+    def _docker_network_inspect_containers(self, name: str) -> Optional[int]:
+        try:
+            res = self.runner.run(
+                [
+                    "docker",
+                    "network",
+                    "inspect",
+                    name,
+                    "--format",
+                    "{{len .Containers}}",
+                ],
+                check=False,
+            )
+        except ToolMissing:
+            return None
+        if res.rc != 0:
+            return None
+        out = res.stdout.strip()
+        if out.isdigit():
+            return int(out)
+        return None
+
+    # ------------------------------------------------------------------
+    # public surface
+    # ------------------------------------------------------------------
+    def list(self, *, repo_root: Optional[Path] = None) -> tuple[list[NetEntry], list[NetEntry]]:
+        """Return ``(active_or_stale_rows_in_registry_order, [])``.
+
+        Orphans are represented as rows with ``status="stale"`` inside the
+        first list; callers wanting the explicit orphan view filter on status.
+        The empty second slot is reserved for future divergence.
+        """
+        with _registry_lock():
+            return self._list_locked(repo_root=repo_root)
+
+    def _list_locked(self, *, repo_root: Optional[Path]) -> tuple[list[NetEntry], list[NetEntry]]:
+        rows = self._read()
+        git_names: set[str] = set()
+        if repo_root is not None:
+            git_names = self._git_worktree_basenames(repo_root)
+        entries: list[NetEntry] = []
+        for row in rows:
+            bd = row.branch_dir
+            if self._is_stale_branch_dir(bd, git_basenames=git_names):
+                entries.append(
+                    NetEntry(
+                        branch_dir=bd,
+                        prefix=row.params.index,
+                        status="stale",
+                        worktree_path=None,
+                    )
+                )
+            else:
+                entries.append(
+                    NetEntry(
+                        branch_dir=bd,
+                        prefix=row.params.index,
+                        status="active",
+                        worktree_path=str(self.worktree_parent / bd),
+                    )
+                )
+        return entries, []
+
+    def list_rows(self) -> list[_RegistryRow]:
+        """Return the parsed registry rows verbatim (no liveness check).
+
+        Exposes index/X/Y/PORT to callers (CLI ``network list`` renderer).
+        """
+        with _registry_lock():
+            return self._read()
+
+    def release(self, branch_dir: str, *, dry_run: bool = False) -> str:
+        out = StringIO()
+        with _registry_lock():
+            rows = self._read()
+            match: Optional[_RegistryRow] = next((r for r in rows if r.branch_dir == branch_dir), None)
+            if match is None:
+                out.write(f"No registry entry for {branch_dir}; nothing to release.\n")
+                return out.getvalue()
+            label = _format_rhs(match.params)
+            if dry_run:
+                out.write(f"[dry-run] would release {branch_dir}={label}\n")
+                return out.getvalue()
+            kept = [r for r in rows if r.branch_dir != branch_dir]
+            self._write(kept)
+            out.write(f"Released {branch_dir}={label}.\n")
+        return out.getvalue()
+
+    def prune(self, *, dry_run: bool = False, prune_networks: bool = False, repo_root: Optional[Path] = None) -> str:
+        """Drop stale registry entries. Optionally also remove orphan
+        docker networks (``--networks``).
+        """
+        out = StringIO()
+        with _registry_lock():
+            rows = self._read()
+            git_names: set[str] = set()
+            if repo_root is not None:
+                git_names = self._git_worktree_basenames(repo_root)
+            kept: list[_RegistryRow] = []
+            removed = 0
+            out.write("Scanning registry for stale entries…\n")
+            for row in rows:
+                bd = row.branch_dir
+                label = _format_rhs(row.params)
+                if self._is_stale_branch_dir(bd, git_basenames=git_names):
+                    if dry_run:
+                        out.write(f"[dry-run] stale: {bd}={label}\n")
+                    else:
+                        out.write(f"Pruning stale registry entry: {bd}={label}\n")
+                    removed += 1
+                else:
+                    kept.append(row)
+            if not dry_run and removed > 0:
+                self._write(kept)
+            verb = "would be" if dry_run else "were"
+            out.write(f"Registry: {removed} stale entries {verb} removed.\n")
+
+            if prune_networks:
+                out.write("\n")
+                out.write("Scanning docker networks for orphan devc compose stacks…\n")
+                self._scan_orphan_networks(out, dry_run=dry_run, repo_root=repo_root, git_names=git_names)
+        return out.getvalue()
+
+    def _scan_orphan_networks(
+        self, out: StringIO, *, dry_run: bool, repo_root: Optional[Path], git_names: set[str]
+    ) -> None:
+        nets = self._docker_networks_in_range()
+        for net in nets:
+            if not net.name.endswith("_devcontainer_devcontainer"):
+                continue
+            containers = self._docker_network_inspect_containers(net.name)
+            if containers != 0:
+                continue
+            project_name = net.name[: -len("_devcontainer")]
+            branch_lc = project_name[: -len("_devcontainer")]
+            # Compose normalizes project names to lowercase, so we
+            # match worktrees case-insensitively.
+            wt_lc = {n.lower() for n in git_names}
+            wt_lc |= (
+                {p.name.lower() for p in self.worktree_parent.glob("*")} if self.worktree_parent.is_dir() else set()
+            )
+            if branch_lc in wt_lc:
+                out.write(
+                    f"Skipping {net.name} (172.{net.prefix}.x.x): worktree '{branch_lc}' still exists. "
+                    f"Use 'docker network rm {net.name}' if you really want it gone.\n"
+                )
+                continue
+            if dry_run:
+                out.write(f"[dry-run] orphan docker network: {net.name} (172.{net.prefix}.x.x)\n")
+            else:
+                out.write(f"Removing orphan docker network: {net.name} (172.{net.prefix}.x.x)\n")
+                try:
+                    res = self.runner.run(
+                        ["docker", "network", "rm", net.name],
+                        check=False,
+                    )
+                    body = (res.stdout or "") + (res.stderr or "")
+                    for line in body.splitlines():
+                        out.write(f"    {line}\n")
+                except ToolMissing:
+                    out.write("    (docker missing — cannot remove)\n")
+
+    def allocate(
+        self,
+        branch_dir: Optional[str] = None,
+        *,
+        auto_prune: bool = True,
+        repo_root: Optional[Path] = None,
+        emit_warning: Optional[callable] = None,
+    ) -> StackParams:
+        """Allocate (or return existing) stack parameters for ``branch_dir``.
+
+        Returns a ``StackParams``. Callers that just want the index can
+        read ``.index``. The CLI wrapper composes the env-var lines.
+
+        ``MCK_DEVC_NET_PREFIX`` env override is honored — caller takes
+        ownership; we skip both the registry and the docker scan and
+        return synthesized StackParams.
+        """
+        env_pref = os.environ.get("MCK_DEVC_NET_PREFIX")
+        if env_pref:
+            if env_pref.isdigit():
+                v = int(env_pref)
+                if INDEX_LO <= v <= INDEX_HI:
+                    return stack_params(v)
+            raise RegistryError(
+                f"MCK_DEVC_NET_PREFIX='{env_pref}' is not a valid stack index " f"[{INDEX_LO},{INDEX_HI}]"
+            )
+
+        warn = emit_warning if emit_warning is not None else (lambda m: sys.stderr.write(m + "\n"))
+
+        with _registry_lock():
+            rows = self._read()
+
+            # Idempotent: branch already has a registration?
+            if branch_dir:
+                for row in rows:
+                    if row.branch_dir == branch_dir:
+                        return row.params
+
+            # Auto-prune stale entries.
+            if auto_prune and rows:
+                git_names = self._git_worktree_basenames(repo_root) if repo_root else set()
+                kept: list[_RegistryRow] = []
+                pruned = 0
+                for row in rows:
+                    if self._is_stale_branch_dir(row.branch_dir, git_basenames=git_names):
+                        warn(f"Auto-pruning stale registry entry: {row.branch_dir}={_format_rhs(row.params)}")
+                        pruned += 1
+                    else:
+                        kept.append(row)
+                if pruned > 0:
+                    self._write(kept)
+                    rows = kept
+
+            used_indices: set[int] = {row.params.index for row in rows}
+
+            # A docker network blocks only the /23 slots its CIDR overlaps: a
+            # foreign /16 (docker bridge, kind, k3d) fills its whole X octet,
+            # but a sibling /23 compose network blocks only its own slot and
+            # leaves the other 127 in that octet free to allocate.
+            docker_nets = self._docker_networks_in_range()
+            blocked_subnets = [ipaddress.ip_network(net.subnet, strict=False) for net in docker_nets]
+
+            for cand in range(INDEX_LO, INDEX_HI + 1):
+                if cand in used_indices:
+                    continue
+                params = stack_params(cand)
+                slot = ipaddress.ip_network(params.subnet)
+                if any(slot.overlaps(blocked) for blocked in blocked_subnets):
+                    continue
+                if branch_dir:
+                    rows.append(_RegistryRow(branch_dir=branch_dir, params=params))
+                    self._write(rows)
+                return params
+
+            raise RegistryError(
+                "no free stack index available "
+                f"({len(used_indices)} registry slots used, "
+                f"{len(docker_nets)} docker networks in 172.[16-31].x.x block the rest; "
+                "run 'wt-ctl network prune --networks' to reclaim orphans)"
+            )
+
+    # ------------------------------------------------------------------
+    # rendering
+    # ------------------------------------------------------------------
+    def render_list(self, *, repo_root: Optional[Path] = None, script_self: Optional[str] = None) -> str:
+        """Return the full ``network list`` text body (registry table +
+        summary + docker networks + pruning hints).
+        """
+        out = StringIO()
+        rfile = _registry_file()
+        out.write(f"Registry: {rfile}\n")
+        out.write(f"Worktree parent (conventional): {self.worktree_parent}\n")
+        out.write("\n")
+
+        out.write(f"{'BRANCH_DIR':<55}  {'PREFIX':<6}  {'STATUS':<6}  WORKTREE\n")
+        out.write(f"{'----------':<55}  {'------':<6}  {'------':<6}  --------\n")
+
+        with _registry_lock():
+            entries, _ = self._list_locked(repo_root=repo_root)
+            rows = self._read()
+            stale = active = 0
+            for e in entries:
+                if e.status == "stale":
+                    out.write(f"{e.branch_dir:<55}  {e.prefix:<6}  {'stale':<6}  (missing)\n")
+                    stale += 1
+                else:
+                    wt = e.worktree_path or ""
+                    out.write(f"{e.branch_dir:<55}  {e.prefix:<6}  {'active':<6}  {wt}\n")
+                    active += 1
+            out.write("\n")
+            out.write(f"Summary: {active} active, {stale} stale (run with --prune to GC).\n")
+
+            # Stack-params extension table: shows N/X/Y_BASE/Y_VIP/PORT.
+            # Only emitted when the registry is non-empty.
+            if rows:
+                out.write("\n")
+                out.write(f"{'BRANCH_DIR':<55}  {'N':>5}  {'X':>3}  {'Y_BASE':>6}  {'Y_VIP':>5}  {'PORT':>5}\n")
+                out.write(f"{'----------':<55}  {'-':>5}  {'-':>3}  {'------':>6}  {'-----':>5}  {'----':>5}\n")
+                for row in rows:
+                    p = row.params
+                    out.write(
+                        f"{row.branch_dir:<55}  " f"{p.index:>5}  {p.x:>3}  {p.y_base:>6}  {p.y_vip:>5}  {p.port:>5}\n"
+                    )
+
+            out.write("\n")
+            out.write("Docker networks in 172.[16-31].x.x:\n")
+            out.write(f"{'NETWORK':<65}  X\n")
+            out.write(f"{'-------':<65}  -\n")
+            nets = sorted(self._docker_networks_in_range(), key=lambda n: n.prefix)
+            for net in nets:
+                out.write(f"{net.name:<65}  {net.prefix}\n")
+            out.write("\n")
+            out.write(
+                f"Free range: 172.16.0.0/12 carved into /23 stacks "
+                f"(indices [{INDEX_LO},{INDEX_HI}]). "
+                "Used by registry + docker networks listed above are blocked.\n"
+            )
+            out.write("\n")
+            self_ref = script_self or "wt-ctl network"
+            out.write("Pruning info:\n")
+            out.write(f"  - Stale registry entries:  {self_ref} prune [--dry-run]\n")
+            out.write(f"  - Plus orphan docker nets: {self_ref} prune --networks [--dry-run]\n")
+            out.write(f"  - Specific entry:          {self_ref} release <branch_dir>\n")
+            out.write("  - When you tear down a worktree via wt-ctl delete, the registry\n")
+            out.write("    entry is released automatically.\n")
+        return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# row parsing/formatting
+# ---------------------------------------------------------------------------
+
+
+def _parse_rhs(branch_dir: str, rhs: str) -> Optional[_RegistryRow]:
+    """Parse ``<N>:<X>:<Y_BASE>:<Y_VIP>:<PORT>``.
+
+    Returns ``None`` for any malformed line so the registry tolerates a
+    user hand-edit. A bare-int row (``<NN>`` alone) is treated as malformed.
+    """
+    parts = rhs.split(":")
+    if len(parts) != 5:
+        return None
+    try:
+        n, x, y_base, y_vip, port = (int(s) for s in parts)
+    except ValueError:
+        return None
+    if not (INDEX_LO <= n <= INDEX_HI):
+        return None
+    # Trust the persisted X/Y/PORT verbatim (don't recompute) so a
+    # human-edited registry round-trips. We DO sanity-check that
+    # it's internally consistent — if a row claims a different X
+    # than stack_params says, log and skip rather than mis-route
+    # traffic.
+    derived = stack_params(n)
+    if (x, y_base, y_vip, port) != (derived.x, derived.y_base, derived.y_vip, derived.port):
+        sys.stderr.write(
+            f"[wt-ctl] network: WARN registry row {branch_dir}={rhs} "
+            f"is internally inconsistent — using derived values.\n"
+        )
+        params = derived
+    else:
+        params = StackParams(index=n, x=x, y_base=y_base, y_vip=y_vip, port=port)
+    return _RegistryRow(branch_dir=branch_dir, params=params)
+
+
+def _format_rhs(p: StackParams) -> str:
+    return f"{p.index}:{p.x}:{p.y_base}:{p.y_vip}:{p.port}"
+
+
+def _format_row(row: _RegistryRow) -> str:
+    return f"{row.branch_dir}={_format_rhs(row.params)}"
+
+
+# ---------------------------------------------------------------------------
+# .env helpers
+# ---------------------------------------------------------------------------
+
+# Names of the four derived env-vars compose.yml reads.
+DERIVED_ENV_KEYS = (
+    "MCK_DEVC_NET_X",
+    "MCK_DEVC_NET_Y_BASE",
+    "MCK_DEVC_NET_Y_VIP",
+    "MCK_DEVC_PROXY_PORT",
+)
+
+
+def env_lines_for(params: StackParams) -> list[str]:
+    """Return the 5 ``KEY=VALUE`` lines compose.yml expects, in order:
+    ``MCK_DEVC_NET_PREFIX``, then the four derived vars.
+    """
+    return [
+        f"MCK_DEVC_NET_PREFIX={params.index}",
+        f"MCK_DEVC_NET_X={params.x}",
+        f"MCK_DEVC_NET_Y_BASE={params.y_base}",
+        f"MCK_DEVC_NET_Y_VIP={params.y_vip}",
+        f"MCK_DEVC_PROXY_PORT={params.port}",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# NetworkDomain — adapter over Registry
+# ---------------------------------------------------------------------------
+
+_LIST_HEADER = re.compile(r"^BRANCH_DIR\s+PREFIX\s+STATUS\s+WORKTREE\s*$")
+_DOCKER_HEADER = re.compile(r"^Docker networks in 172\.\[")
+
+
+class NetworkDomain:
+    """``repo_root`` is the worktree root from which we derive (a) the
+    conventional worktree-parent dir for stale checks and (b) the git repo
+    to query ``git worktree list``.
+    """
+
+    def __init__(self, runner: Runner, repo_root: Path) -> None:
+        self.runner = runner
+        self.repo_root = repo_root
+        self._registry = Registry(runner, worktree_parent=repo_root.parent)
+
+    # ------------------------------------------------------------------
+    @property
+    def registry(self) -> Registry:
+        return self._registry
+
+    # ------------------------------------------------------------------
+    def list_entries(self) -> list[NetEntry]:
+        entries, _ = self._registry.list(repo_root=self.repo_root)
+        return entries
+
+    def list_raw(self, *, script_self: Optional[str] = None) -> str:
+        return self._registry.render_list(repo_root=self.repo_root, script_self=script_self)
+
+    # ------------------------------------------------------------------
+    def prefix_for(self, branch_dir: str) -> Optional[int]:
+        for entry in self.list_entries():
+            if entry.branch_dir == branch_dir:
+                return entry.prefix
+        return None
+
+    # ------------------------------------------------------------------
+    def prune(self, *, dry_run: bool = False, prune_networks: bool = False) -> str:
+        return self._registry.prune(
+            dry_run=dry_run,
+            prune_networks=prune_networks,
+            repo_root=self.repo_root,
+        )
+
+    def release(self, branch_dir: str, *, dry_run: bool = False) -> str:
+        return self._registry.release(branch_dir, dry_run=dry_run)
+
+    def allocate(self, branch_dir: Optional[str] = None) -> str:
+        """Allocate a stack and return the env-var block compose.yml needs.
+
+        Output format (terminated, multiple lines):
+
+            MCK_DEVC_NET_PREFIX=<N>
+            MCK_DEVC_NET_X=<X>
+            MCK_DEVC_NET_Y_BASE=<Y_BASE>
+            MCK_DEVC_NET_Y_VIP=<Y_VIP>
+            MCK_DEVC_PROXY_PORT=<PORT>
+        """
+        params = self._registry.allocate(
+            branch_dir=branch_dir,
+            auto_prune=True,
+            repo_root=self.repo_root,
+        )
+        return "\n".join(env_lines_for(params)) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# text parser for bash-formatted registry output stored in test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _parse_list_output(text: str) -> list[NetEntry]:
+    out: list[NetEntry] = []
+    in_table = False
+    for line in text.splitlines():
+        if _LIST_HEADER.match(line):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.strip():
+            in_table = False
+            continue
+        if line.startswith("Summary:"):
+            in_table = False
+            continue
+        if line.startswith("---"):
+            continue
+        if _DOCKER_HEADER.match(line):
+            in_table = False
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        branch_dir = parts[0]
+        try:
+            prefix = int(parts[1])
+        except ValueError:
+            continue
+        status = parts[2]
+        worktree_path = " ".join(parts[3:]) if len(parts) >= 4 else None
+        if worktree_path == "(missing)":
+            worktree_path = None
+        out.append(
+            NetEntry(
+                branch_dir=branch_dir,
+                prefix=prefix,
+                status=status,
+                worktree_path=worktree_path,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# small pure helpers (used by status renderer)
+# ---------------------------------------------------------------------------
+
+
+def subnet_for(prefix: int) -> str:
+    """Status-renderer helper. Renders a stack index as ``172.X.Y_BASE.0/23``."""
+    if INDEX_LO <= prefix <= INDEX_HI:
+        return stack_params(prefix).subnet
+    return f"<out-of-range {prefix}>"
+
+
+def gost_proxy_for(prefix: int) -> str:
+    """Map a stack index to the gost-proxy URL (``port = 8000 + index``)."""
+    if INDEX_LO <= prefix <= INDEX_HI:
+        return f"http://127.0.0.1:{8000 + prefix}"
+    return f"<out-of-range {prefix}>"
+
+
+def namespace_for_prefix(prefix: int, base: str = "mck-devc") -> str:
+    """NAMESPACE construction uses the stack index verbatim as a unique
+    per-stack suffix.
+    """
+    return f"{base}-{prefix}-mongodb-test"
+
+
+def parse_devc_env(devcontainer_dir: Path) -> dict[str, str]:
+    """Tiny KEY=VALUE parser for ``.devcontainer/.env``."""
+    out: dict[str, str] = {}
+    env_file = devcontainer_dir / ".env"
+    if not env_file.is_file():
+        return out
+    try:
+        for raw in env_file.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            out[k.strip()] = v.strip()
+    except OSError as exc:
+        raise RegistryError(f"failed to read {env_file}: {exc}") from exc
+    return out

--- a/scripts/dev/wt_ctl/domains/omprojects.py
+++ b/scripts/dev/wt_ctl/domains/omprojects.py
@@ -1,0 +1,155 @@
+"""Cloud-QA OM project listing + cleanup.
+
+For ``om list`` we make a direct REST call (read-only) so we don't have to
+go through the in-container delete script. Cleanup (``om clean``) wraps
+``scripts/dev/delete_om_projects.sh``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+from ..errors import ExternalCommandFailed, ToolMissing, WtCtlError
+from ..runner import Runner
+from ..state import OmState
+
+
+def _read_context_env(worktree_root: Path) -> dict[str, str]:
+    """Read the rendered ``.generated/context.env`` (a `.env`-style file).
+    Returns an empty dict when the file is absent.
+    """
+    out: dict[str, str] = {}
+    f = worktree_root / ".generated" / "context.env"
+    if not f.is_file():
+        return out
+    for raw in f.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        v = v.strip()
+        if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+            v = v[1:-1]
+        out[k.strip()] = v
+    return out
+
+
+class OmDomain:
+    def __init__(self, runner: Runner, repo_root: Path) -> None:
+        self.runner = runner
+        self.repo_root = repo_root
+
+    # ------------------------------------------------------------------
+    def state_for(self, worktree_root: Path) -> OmState:
+        ctx = _read_context_env(worktree_root)
+        ns = ctx.get("NAMESPACE")
+        scope = f"{ns}, {ns}-*" if ns else None
+        count = self._count_projects_in_scope(ctx) if ns else None
+        return OmState(namespace=ns, project_count=count, scope=scope)
+
+    def list_projects(self, worktree_root: Path) -> list[dict]:
+        ctx = _read_context_env(worktree_root)
+        ns = ctx.get("NAMESPACE")
+        if not ns:
+            return []
+        return self._fetch_projects(ctx, ns)
+
+    # ------------------------------------------------------------------
+    def clean(self, worktree_root: Path) -> None:
+        env = _read_context_env(worktree_root)
+        env.setdefault("PROJECT_DIR", str(worktree_root))
+        argv = [str(self.repo_root / "scripts/dev/delete_om_projects.sh")]
+        self.runner.run_streaming(argv, prefix="[om-clean] ", env=env, cwd=worktree_root)
+
+    # ------------------------------------------------------------------
+    def _fetch_projects(self, ctx: dict[str, str], ns: str) -> list[dict]:
+        """Single GET against /api/public/v1.0/groups, filter client-side by
+        the same prefix that delete_om_projects.sh uses (``${ns}`` and
+        ``${ns}-*``).
+
+        Raises ``WtCtlError`` on any non-transient failure (HTTP error,
+        auth, bad JSON). Network OSErrors (DNS, timeout) return ``[]``
+        with a stderr warning — those are routinely flaky and we don't
+        want ``wt-ctl status`` to die on a slow VPN.
+        """
+        import sys
+
+        host = ctx.get("OM_HOST") or os.environ.get("OM_HOST")
+        user = ctx.get("OM_USER") or os.environ.get("OM_USER")
+        api_key = ctx.get("OM_API_KEY") or os.environ.get("OM_API_KEY")
+        if not (host and user and api_key):
+            return []
+        url = f"{host.rstrip('/')}/api/public/v1.0/groups?itemsPerPage=200"
+        try:
+            data = _digest_get_json(url, user, api_key)
+        except urllib.error.HTTPError as exc:
+            raise WtCtlError(
+                f"OM /groups query failed: HTTP {exc.code} {exc.reason} "
+                f"(host={host}, user={user}); check OM_USER/OM_API_KEY in "
+                f"context.env"
+            ) from exc
+        except urllib.error.URLError as exc:
+            sys.stderr.write(f"[wt-ctl om] WARN: network error querying {host} ({exc}); " f"reporting 0 projects.\n")
+            return []
+        except ValueError as exc:
+            # Non-JSON body (a proxy / load-balancer HTML error page, a
+            # truncated response, ...). json.loads raises JSONDecodeError, a
+            # ValueError; degrade like a network error rather than killing the
+            # read-only `wt-ctl status` render.
+            sys.stderr.write(f"[wt-ctl om] WARN: non-JSON response from {host} ({exc}); reporting 0 projects.\n")
+            return []
+        if not isinstance(data, dict):
+            return []
+        results = data.get("results") or []
+        out: list[dict] = []
+        for g in results:
+            name = g.get("name") or ""
+            if name == ns or name.startswith(f"{ns}-"):
+                out.append(g)
+        return out
+
+    def _count_projects_in_scope(self, ctx: dict[str, str]) -> Optional[int]:
+        ns = ctx.get("NAMESPACE")
+        if not ns:
+            return None
+        try:
+            return len(self._fetch_projects(ctx, ns))
+        except WtCtlError as exc:
+            # `om` is a status-time call; render-error path: report None so
+            # the row reads "om <err>: ..." instead of dying the whole
+            # `wt-ctl status` render.
+            import sys
+
+            sys.stderr.write(f"[wt-ctl om] WARN: {exc}\n")
+            return None
+
+
+# ---------------------------------------------------------------------------
+# tiny digest GET helper (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+def _digest_get_json(url: str, user: str, api_key: str):
+    """Minimal HTTP-Digest GET. We avoid pip deps; OM uses MD5 digest auth.
+
+    Realm is left None so the digest handler matches whatever the server
+    advertises in its WWW-Authenticate header (OM's is "MMS Public API"). A
+    pinned realm that differs makes urllib silently skip the credentialed retry
+    and the request 401s.
+    """
+    mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    mgr.add_password(None, url, user, api_key)
+    handler = urllib.request.HTTPDigestAuthHandler(mgr)
+    opener = urllib.request.build_opener(handler)
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    # Very short timeout — `om list` is a status-time call and we don't want
+    # to block status rendering when cloud-qa is slow.
+    with opener.open(req, timeout=5) as resp:
+        return json.loads(resp.read().decode("utf-8"))

--- a/scripts/dev/wt_ctl/domains/worktree.py
+++ b/scripts/dev/wt_ctl/domains/worktree.py
@@ -1,0 +1,158 @@
+"""git-worktree introspection (read-only) + thin wrappers around
+``create_worktree.sh`` and ``git worktree remove``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..errors import ExternalCommandFailed, WtCtlError
+from ..runner import Runner
+from ..state import GitState
+
+
+@dataclass
+class WorktreeEntry:
+    path: Path
+    branch: Optional[str]
+    head: str
+    is_main: bool
+    detached: bool
+    prunable: bool
+
+
+class WorktreeDomain:
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+
+    # ------------------------------------------------------------------
+    # read
+    # ------------------------------------------------------------------
+    def list_worktrees(self, repo_root: Path) -> list[WorktreeEntry]:
+        """Parse ``git worktree list --porcelain`` from the perspective of the
+        main repo. ``repo_root`` should be the worktree root *or* main repo —
+        git resolves either.
+        """
+        res = self.runner.run(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+        )
+        out: list[WorktreeEntry] = []
+        cur_path: Optional[Path] = None
+        cur_head: str = ""
+        cur_branch: Optional[str] = None
+        cur_detached = False
+        cur_prunable = False
+        cur_is_main = False
+        for line in res.stdout.splitlines() + [""]:
+            if line.startswith("worktree "):
+                cur_path = Path(line[len("worktree ") :]).resolve()
+                cur_is_main = cur_path == repo_root.resolve()
+            elif line.startswith("HEAD "):
+                cur_head = line[len("HEAD ") :].strip()
+            elif line.startswith("branch "):
+                cur_branch = line[len("branch ") :].strip()
+                if cur_branch.startswith("refs/heads/"):
+                    cur_branch = cur_branch[len("refs/heads/") :]
+            elif line == "detached":
+                cur_detached = True
+            elif line == "prunable":
+                cur_prunable = True
+            elif line == "":
+                if cur_path is not None:
+                    out.append(
+                        WorktreeEntry(
+                            path=cur_path,
+                            branch=cur_branch,
+                            head=cur_head,
+                            is_main=cur_is_main,
+                            detached=cur_detached,
+                            prunable=cur_prunable,
+                        )
+                    )
+                cur_path = None
+                cur_branch = None
+                cur_head = ""
+                cur_detached = False
+                cur_prunable = False
+                cur_is_main = False
+        return out
+
+    def git_state(self, worktree_root: Path) -> GitState:
+        """Branch + clean/dirty + ahead/behind summary."""
+        try:
+            branch = self.runner.run(
+                ["git", "-C", str(worktree_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            ).stdout.strip()
+        except ExternalCommandFailed:
+            branch = "HEAD"
+        # porcelain v1: any line == dirty
+        status = self.runner.run(
+            ["git", "-C", str(worktree_root), "status", "--porcelain"],
+        ).stdout
+        clean = status.strip() == ""
+        upstream: Optional[str] = None
+        ahead = 0
+        behind = 0
+        upstream_res = self.runner.run(
+            [
+                "git",
+                "-C",
+                str(worktree_root),
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{u}",
+            ],
+            check=False,
+        )
+        if upstream_res.rc == 0:
+            upstream = upstream_res.stdout.strip()
+            counts = self.runner.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree_root),
+                    "rev-list",
+                    "--left-right",
+                    "--count",
+                    "HEAD...@{u}",
+                ],
+                check=False,
+            )
+            if counts.rc == 0:
+                parts = counts.stdout.strip().split()
+                if len(parts) == 2:
+                    try:
+                        ahead = int(parts[0])
+                        behind = int(parts[1])
+                    except ValueError:
+                        pass
+        return GitState(
+            branch=branch,
+            clean=clean,
+            ahead=ahead,
+            behind=behind,
+            upstream=upstream,
+        )
+
+    # ------------------------------------------------------------------
+    # write
+    # ------------------------------------------------------------------
+    def add(self, repo_root: Path, branch: str, *, force: bool = False) -> None:
+        """Wrap ``scripts/dev/create_worktree.sh``."""
+        argv = [str(repo_root / "scripts/dev/create_worktree.sh")]
+        if force:
+            argv.append("-f")
+        argv.append(branch)
+        # create_worktree.sh assumes PROJECT_DIR is set; set it explicitly.
+        env = {"PROJECT_DIR": str(repo_root)}
+        self.runner.run_streaming(argv, env=env, cwd=repo_root)
+
+    def remove(self, repo_root: Path, target_path: Path, *, force: bool = False) -> None:
+        argv = ["git", "-C", str(repo_root), "worktree", "remove"]
+        if force:
+            argv.append("--force")
+        argv.append(str(target_path))
+        self.runner.run(argv)

--- a/scripts/dev/wt_ctl/errors.py
+++ b/scripts/dev/wt_ctl/errors.py
@@ -1,0 +1,118 @@
+"""Typed exceptions for wt-ctl. ``cli.py`` is the only place that catches
+``WtCtlError``; everything else raises and lets the CLI translate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class WtCtlError(Exception):
+    """Base class for typed wt-ctl errors. CLI catches this, prints, exits."""
+
+    # 1 = command failure; subclasses for misuse / preconditions override to 2.
+    exit_code: int = 1
+
+    def __init__(self, message: str = ""):
+        super().__init__(message)
+        self.message = message
+
+    def render(self) -> str:
+        return self.message
+
+
+class ToolMissing(WtCtlError):
+    """A required external CLI is not on PATH (docker, devcontainer, ...)."""
+
+    exit_code = 2
+
+    def __init__(self, tool: str, hint: str = ""):
+        msg = f"required tool not found on PATH: {tool}"
+        if hint:
+            msg += f"\n  hint: {hint}"
+        super().__init__(msg)
+        self.tool = tool
+
+
+class NotInWorktree(WtCtlError):
+    """Cwd is not inside a git worktree of the main repo."""
+
+    exit_code = 2
+
+    def __init__(self, cwd: str, hint: str = ""):
+        msg = f"not inside a git worktree of the main repo (cwd={cwd})"
+        if hint:
+            msg += f"\n  hint: {hint}"
+        super().__init__(msg)
+        self.cwd = cwd
+
+
+class BranchNotFound(WtCtlError):
+    """Branch was specified but not found locally or on origin."""
+
+    exit_code = 2
+
+    def __init__(self, branch: str):
+        super().__init__(f"branch not found: {branch}")
+        self.branch = branch
+
+
+@dataclass
+class ExternalCommandFailed(WtCtlError):
+    """A wrapped subprocess returned non-zero. Carries the raw command details
+    for the CLI / caller to render.
+    """
+
+    argv: list[str] = field(default_factory=list)
+    rc: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+    def __post_init__(self) -> None:
+        cmd = " ".join(self.argv) if self.argv else "<no argv>"
+        msg = f"command failed (rc={self.rc}): {cmd}"
+        if self.stderr.strip():
+            tail = "\n".join(self.stderr.strip().splitlines()[-10:])
+            msg += f"\n--- stderr ---\n{tail}"
+        WtCtlError.__init__(self, msg)
+
+
+@dataclass
+class ParallelPhaseFailures(WtCtlError):
+    """Aggregated failures from ``Runner.run_parallel``."""
+
+    failures: dict[str, ExternalCommandFailed] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        names = ", ".join(self.failures.keys())
+        msg = f"parallel phase failures: {names}"
+        WtCtlError.__init__(self, msg)
+
+
+class StateConflict(WtCtlError):
+    """A precondition / state assertion failed (e.g. devc not running)."""
+
+    exit_code = 2
+
+
+class RegistryError(WtCtlError):
+    """Network registry parse / write error."""
+
+    exit_code = 1
+
+
+class LockTimeout(WtCtlError):
+    """Failed to acquire a lock within the configured timeout."""
+
+    exit_code = 1
+
+    def __init__(self, lock_path: str, timeout_s: float):
+        super().__init__(f"could not acquire lock at {lock_path} within {timeout_s:g}s " f"(if stale: rmdir it)")
+        self.lock_path = lock_path
+        self.timeout_s = timeout_s
+
+
+class OrphanDetected(WtCtlError):
+    """Raised when a destructive op finds an unexpected orphan registration."""
+
+    exit_code = 2

--- a/scripts/dev/wt_ctl/errors.py
+++ b/scripts/dev/wt_ctl/errors.py
@@ -79,7 +79,8 @@ class ExternalCommandFailed(WtCtlError):
 
 @dataclass
 class ParallelPhaseFailures(WtCtlError):
-    """Aggregated failures from ``Runner.run_parallel``."""
+    """Aggregated failures from a parallel phase pair (see
+    ``CreateOrchestrator._run_parallel_pair``)."""
 
     failures: dict[str, ExternalCommandFailed] = field(default_factory=dict)
 

--- a/scripts/dev/wt_ctl/header.py
+++ b/scripts/dev/wt_ctl/header.py
@@ -1,0 +1,20 @@
+"""First-line banner. Always written to **stderr** so stdout is parseable."""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from .paths import WorktreeRefs
+
+
+def emit_banner(refs: Optional[WorktreeRefs], *, quiet: bool = False) -> None:
+    """Print ``[wt-ctl] worktree=<dir>  branch=<branch>`` to stderr.
+
+    Skipped entirely when ``quiet`` or when ``refs is None`` (verbs that
+    work outside a worktree, e.g. ``status --all``).
+    """
+    if quiet or refs is None:
+        return
+    sys.stderr.write(f"[wt-ctl] worktree={refs.branch_dir}  branch={refs.branch}\n")
+    sys.stderr.flush()

--- a/scripts/dev/wt_ctl/orchestrator.py
+++ b/scripts/dev/wt_ctl/orchestrator.py
@@ -1,0 +1,1335 @@
+"""``wt-ctl create`` and ``wt-ctl delete`` orchestrators.
+
+``create`` runs a data-driven phase pipeline with per-phase state tracking and
+resume; ``delete`` is a forward-only best-effort teardown. Both take a Runner
+and a worktree path; neither imports subprocess directly.
+
+A ``Phase`` carries its name, action, and input-hash function; the runner
+iterates the phase tuple and decides skip / restart / fail / record in one
+place. The ``evg_prepare`` + ``dc_build`` pair is detected by name and run
+concurrently when both are due, recording each individually. Delete steps are
+best-effort (logged and continued on failure) with no state file.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from . import orchestrator_state as ostate
+from .domains.compose import project_name_for
+from .domains.network import DERIVED_ENV_KEYS, NetworkDomain, env_lines_for, stack_params
+from .errors import ExternalCommandFailed, ParallelPhaseFailures, StateConflict, ToolMissing, WtCtlError
+from .paths import logs_dir
+from .runner import Runner
+
+# ---------------------------------------------------------------------------
+# shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_context_env(wt: Path) -> dict[str, str]:
+    """Parse .generated/context*.env (plain, possibly-quoted KEY=value) into a
+    dict so it can be passed to in-process KubeconfigDomain.refresh without
+    pre-loading the orchestrator's shell env."""
+    out: dict[str, str] = {}
+    for name in ("context.env", "context.host.env"):
+        path = wt / ".generated" / name
+        if not path.is_file():
+            continue
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            v = v.strip()
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            out[k.strip()] = v
+    return out
+
+
+def _devc_bash(wt: Path, script: str) -> list[str]:
+    """``devcontainer exec ... bash -lc <script>`` argv — a non-interactive
+    login shell in the worktree's devcontainer. ``script`` is the inner
+    command, typically ``set -Eeou pipefail; cd /workspace; . scripts/dev/devenv; <action>``."""
+    return [
+        "devcontainer",
+        "exec",
+        "--workspace-folder",
+        str(wt),
+        "bash",
+        "-lc",
+        script,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# inputs the user passes to `wt-ctl create`
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CreateInputs:
+    """Flags passed to ``wt-ctl create``. Stored verbatim in state.json so
+    resume can detect changed inputs and invalidate hashes."""
+
+    branch: str
+    branch_dir: str
+    worktree_path: Path  # target worktree root (may not yet exist)
+    main_repo_root: Path  # the main repo (parent of .git/common dir)
+    # The worktree the user invoked from; PROJECT_DIR for create_worktree.sh so
+    # the new worktree is its sibling. Falls back to main_repo_root outside any worktree.
+    host_worktree_root: Path
+    context: Optional[str] = None
+    # CLI default is multi-cluster (--single-cluster opts out); False here is
+    # only the unset baseline for programmatic/test construction.
+    multi_cluster: bool = False
+    skip_recreate: bool = False
+    skip_evg: bool = False
+    skip_devcontainer: bool = False
+    skip_prepare_e2e: bool = False
+    force: bool = False
+    evg_host_name: Optional[str] = None  # default: branch_dir
+    # EVG spawn overrides; None → evg spawn's defaults (ubuntu2204-latest-large / eu-west-1).
+    distro: Optional[str] = None
+    region: Optional[str] = None
+    # Local-kind: kind cluster on this laptop instead of an EVG host; cluster_name defaults to branch_dir.
+    local_kind: bool = False
+    cluster_name: Optional[str] = None
+    # In-place: operate in the current checkout (worktree_path == main_repo_root)
+    # instead of creating a worktree. Used in CI where the patch diff is uncommitted.
+    in_place: bool = False
+
+    def resolved_evg_host_name(self) -> str:
+        return self.evg_host_name or self.branch_dir
+
+    def resolved_cluster_name(self) -> str:
+        # branch_dir keeps parallel worktrees off the same kind cluster.
+        return self.cluster_name or self.branch_dir
+
+    def to_dict(self) -> dict:
+        return {
+            "branch": self.branch,
+            "branch_dir": self.branch_dir,
+            "worktree_path": str(self.worktree_path),
+            "main_repo_root": str(self.main_repo_root),
+            "host_worktree_root": str(self.host_worktree_root),
+            "context": self.context,
+            "multi_cluster": self.multi_cluster,
+            "skip_recreate": self.skip_recreate,
+            "skip_evg": self.skip_evg,
+            "skip_devcontainer": self.skip_devcontainer,
+            "skip_prepare_e2e": self.skip_prepare_e2e,
+            "force": self.force,
+            "evg_host_name": self.resolved_evg_host_name(),
+            "distro": self.distro,
+            "region": self.region,
+            "local_kind": self.local_kind,
+            "cluster_name": self.resolved_cluster_name() if self.local_kind else None,
+            "in_place": self.in_place,
+        }
+
+    def with_persisted_flags(self, saved: dict) -> "CreateInputs":
+        """Copy with behavioural flags reloaded from a prior run's persisted
+        ``inputs`` but paths kept fresh. On --resume this stops an omitted flag
+        (e.g. dropping --local-kind) from silently re-defaulting and flipping
+        phase branches / invalidating hashes."""
+        return replace(
+            self,
+            context=saved.get("context"),
+            multi_cluster=saved.get("multi_cluster", self.multi_cluster),
+            skip_recreate=saved.get("skip_recreate", self.skip_recreate),
+            skip_evg=saved.get("skip_evg", self.skip_evg),
+            skip_devcontainer=saved.get("skip_devcontainer", self.skip_devcontainer),
+            skip_prepare_e2e=saved.get("skip_prepare_e2e", self.skip_prepare_e2e),
+            force=saved.get("force", self.force),
+            evg_host_name=saved.get("evg_host_name"),
+            distro=saved.get("distro"),
+            region=saved.get("region"),
+            local_kind=saved.get("local_kind", self.local_kind),
+            cluster_name=saved.get("cluster_name"),
+            in_place=saved.get("in_place", self.in_place),
+        )
+
+    def worktree_path_or_main(self) -> Path:
+        """Where the orchestrator state file lives — always the target worktree
+        dir, so .generated/wt-ctl/ is removed with the worktree at teardown."""
+        return self.worktree_path
+
+
+# ---------------------------------------------------------------------------
+# Phase
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Phase:
+    name: str
+    run: Callable[[], None]  # idempotent action
+    input_hash: Callable[[], str]  # hash inputs
+    skip: Callable[[], bool] = lambda: False  # static skip (e.g. --skip-evg)
+    log_relpath: Optional[str] = None  # for state.log
+
+
+# ---------------------------------------------------------------------------
+# CreateOrchestrator
+# ---------------------------------------------------------------------------
+
+
+class CreateOrchestrator:
+    """End-to-end ``wt-ctl create``."""
+
+    def __init__(self, runner: Runner, inputs: CreateInputs) -> None:
+        self.runner = runner
+        self.inputs = inputs
+        # Workhorse scripts live in main_repo_root (where the tool is invoked
+        # from when the worktree doesn't exist yet) until the worktree is
+        # created — at which point each phase runs scripts inside the new
+        # worktree (cwd-anchored) so it has its own checked-out scripts.
+        self.scripts = inputs.main_repo_root / "scripts" / "dev"
+        # Same in-worktree scripts, used after worktree_init.
+        self._wt_scripts = inputs.worktree_path / "scripts" / "dev"
+
+    # ------------------------------------------------------------------
+    # public entry point
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        *,
+        resume: bool = False,
+        restart_from: Optional[str] = None,
+        emit: Callable[[str], None] = lambda _msg: None,
+    ) -> None:
+        state = self._load_or_init_state(resume=resume, restart_from=restart_from)
+        # An in_progress phase without --resume/--restart-from means a prior run
+        # was killed uncleanly; picking up requires explicit acknowledgement.
+        if not (resume or restart_from):
+            stuck = state.has_in_progress() if state is not None else None
+            if stuck:
+                raise StateConflict(
+                    f"phase '{stuck}' was left in_progress by a previous run; "
+                    "re-run with --resume or --restart-from <phase>"
+                )
+
+        if state is None:
+            # First invocation: build fresh state but DON'T save yet — writing
+            # .generated/wt-ctl/state.json under the target path would make
+            # `git worktree add` refuse to populate it. Persisted after worktree_init.
+            state = ostate.OrchestratorState.initial(
+                branch=self.inputs.branch,
+                inputs=self.inputs.to_dict(),
+            )
+        else:
+            # Resume / restart: keep existing state, refresh inputs so hash
+            # comparisons run against the current command.
+            state.inputs = self.inputs.to_dict()
+            state.branch = self.inputs.branch
+
+        phases = self._phases()
+        plan = self._plan(state, phases, resume=resume, restart_from=restart_from)
+        if not plan:
+            emit("[wt-ctl] create: nothing to do (all phases ok).")
+            return
+
+        i = 0
+        while i < len(plan):
+            phase = plan[i]
+            # Run the PARALLEL_GROUP pair concurrently when both are adjacent in the plan.
+            if (
+                phase.name == ostate.PARALLEL_GROUP[0]
+                and i + 1 < len(plan)
+                and plan[i + 1].name == ostate.PARALLEL_GROUP[1]
+            ):
+                self._run_parallel_pair(state, phase, plan[i + 1], emit=emit)
+                i += 2
+                continue
+            self._run_one(state, phase, emit=emit)
+            i += 1
+
+        # Record intentionally-skipped phases as SKIPPED (not PENDING) so status
+        # doesn't report "incomplete" and --resume won't re-run them.
+        host = self.inputs.worktree_path_or_main()
+        if host.is_dir():
+            for phase in phases:
+                if not phase.skip():
+                    continue
+                rec = state.phases.get(phase.name)
+                if rec is None or rec.status not in (ostate.OK, ostate.SKIPPED):
+                    state.set_status(phase.name, ostate.SKIPPED, input_hash=phase.input_hash())
+            ostate.save(host, state)
+
+        emit("[wt-ctl] create: done.")
+
+    # ------------------------------------------------------------------
+    # phase definitions
+    # ------------------------------------------------------------------
+    def _phases(self) -> list[Phase]:
+        i = self.inputs
+        wt = i.worktree_path
+        log_dir = logs_dir(wt)
+
+        def _h(payload: dict) -> str:
+            return ostate.hash_inputs(payload)
+
+        # ---- worktree_init ------------------------------------------------
+        def _do_worktree_init() -> None:
+            # Already inside the target worktree: skip create_worktree.sh but
+            # still apply --context below.
+            already_inside = i.in_place or (_is_same_path(self.runner_cwd_or_main(), wt) and wt.exists())
+            if not already_inside:
+                host = i.host_worktree_root
+                argv = [
+                    str(host / "scripts" / "dev" / "create_worktree.sh"),
+                ]
+                if i.force:
+                    argv.append("-f")
+                argv.append(i.branch)
+                # create_worktree.sh reads PROJECT_DIR as the dir siblings live under.
+                env = {"PROJECT_DIR": str(host)}
+                # Log into the host worktree's logs dir (git worktree add refuses a
+                # non-empty target), named per-target so parallel creates don't collide.
+                host_log = logs_dir(host) / f"worktree_init-{i.branch_dir}.log"
+                self.runner.run_streaming(
+                    argv,
+                    prefix="[worktree] ",
+                    log_path=host_log,
+                    env=env,
+                    cwd=host,
+                )
+            # Switch context before initialize.sh renders compose.generated.yml.
+            if i.context:
+                self.runner.run_streaming(
+                    ["make", "switch", f"context={i.context}"],
+                    prefix="[ctx] ",
+                    log_path=log_dir / "context_switch.log",
+                    cwd=wt,
+                )
+
+        # ---- initialize_hook ---------------------------------------------
+        def _do_initialize_hook() -> None:
+            init_sh = wt / ".devcontainer" / "scripts" / "initialize.sh"
+            if not init_sh.is_file():
+                return
+            self.runner.run_streaming(
+                ["bash", str(init_sh)],
+                prefix="[init] ",
+                log_path=log_dir / "initialize_hook.log",
+                cwd=wt,
+            )
+
+        # ---- net_allocate -------------------------------------------------
+        def _do_net_allocate() -> None:
+            env_file = wt / ".devcontainer" / ".env"
+            existing_prefix = _read_existing_prefix(env_file)
+            if existing_prefix is not None:
+                # Prefix already pinned. If a prior run crashed before writing the
+                # four derived vars (NET_X / NET_Y_BASE / NET_Y_VIP / PROXY_PORT),
+                # compose.yml falls back to its ${VAR:-default} and clobbers other
+                # worktrees' subnets — repair in place rather than re-allocating,
+                # keeping the registry-owned index.
+                missing_derived = _missing_derived_env_keys(env_file)
+                if missing_derived:
+                    params = stack_params(existing_prefix)
+                    all_lines = env_lines_for(params)
+                    key_to_line = {ln.split("=", 1)[0]: ln for ln in all_lines}
+                    repair_lines = [
+                        key_to_line[key] for key in DERIVED_ENV_KEYS if key in missing_derived and key in key_to_line
+                    ]
+                    if repair_lines:
+                        with env_file.open("a") as fh:
+                            cur = env_file.read_text()
+                            if cur and not cur.endswith("\n"):
+                                fh.write("\n")
+                            fh.write("\n".join(repair_lines) + "\n")
+                return
+            block = NetworkDomain(self.runner, wt).allocate(i.branch_dir)
+            if not block.startswith("MCK_DEVC_NET_PREFIX="):
+                raise WtCtlError(f"NetworkDomain.allocate produced unexpected output: {block!r}")
+            # Append the 5-line block, preserving any other keys.
+            env_file.parent.mkdir(parents=True, exist_ok=True)
+            with env_file.open("a") as fh:
+                # Guard against a hand-edited .env lacking a trailing newline.
+                if env_file.exists():
+                    cur = env_file.read_text()
+                    if cur and not cur.endswith("\n"):
+                        fh.write("\n")
+                fh.write(block)
+
+        # ---- evg_prepare --------------------------------------------------
+        def _do_evg_prepare() -> None:
+            if i.local_kind:
+                # Local-kind: kind cluster on this laptop, no EVG host.
+                #   1. drop any stale EVG-host pin so root-context's EVG_HOST_NAME
+                #      resolution doesn't inherit a defunct host's identity.
+                #   2. recreate_kind_cluster.sh writes .generated/current.kubeconfig
+                #      and keeps DELETE_KIND_NETWORK=false to spare sibling worktrees.
+                #   3. make switch regenerates context env so CLUSTER_NAME (derived
+                #      from the kubeconfig's current-context) lands in context.env.
+                generated = wt / ".generated"
+                generated.mkdir(parents=True, exist_ok=True)
+                for f in (".current-evg-host", ".current-evg-host-address"):
+                    p = generated / f
+                    if p.is_file():
+                        p.unlink()
+                if i.multi_cluster:
+                    # Switch to the context FIRST: it defines the member/central
+                    # cluster names and MetalLB ranges recreate_kind_clusters.sh
+                    # reads via set_env_context. All 5 kind clusters share the
+                    # `kind` docker network; the devc reaches each apiserver at
+                    # its node-container IP (kubeconfig rewrite + dc_up net join).
+                    mc_ctx = i.context or "e2e_multi_cluster_kind"
+                    self.runner.run_streaming(
+                        ["make", "switch", f"context={mc_ctx}"],
+                        prefix="[local-kind] ",
+                        log_path=log_dir / "evg_prepare.log",
+                        cwd=wt,
+                    )
+                    if not i.skip_recreate:
+                        self.runner.run_streaming(
+                            [str(wt / "scripts" / "dev" / "recreate_kind_clusters.sh")],
+                            prefix="[local-kind] ",
+                            log_path=log_dir / "evg_prepare.log",
+                            env={"DELETE_KIND_NETWORK": "false"},
+                            cwd=wt,
+                        )
+                    else:
+                        sys.stderr.write("[local-kind] --skip-recreate set; skipping recreate_kind_clusters.sh\n")
+                else:
+                    cluster = i.resolved_cluster_name()
+                    if not i.skip_recreate:
+                        self.runner.run_streaming(
+                            [str(wt / "scripts" / "dev" / "recreate_kind_cluster.sh"), cluster],
+                            prefix="[local-kind] ",
+                            log_path=log_dir / "evg_prepare.log",
+                            env={"DELETE_KIND_NETWORK": "false"},
+                            cwd=wt,
+                        )
+                    else:
+                        sys.stderr.write("[local-kind] --skip-recreate set; skipping recreate_kind_cluster.sh\n")
+                    # Re-derive context env against the now-current kubeconfig.
+                    current_ctx_file = generated / ".current_context"
+                    if current_ctx_file.is_file():
+                        ctx = current_ctx_file.read_text().strip()
+                        self.runner.run_streaming(
+                            ["make", "switch", f"context={ctx}"],
+                            prefix="[local-kind] ",
+                            log_path=log_dir / "evg_prepare.log",
+                            cwd=wt,
+                        )
+                # On-host kfp registration (the devc-side registration runs later
+                # in the `kubeconfig` phase). refresh needs CLUSTER_NAME /
+                # K8S_FWD_PROXY / MCK_DEVC_* from the just-regenerated context env.
+                env_for_refresh = _load_context_env(wt)
+                from .domains.kubeconfig import KubeconfigDomain  # local import avoids a module cycle
+
+                KubeconfigDomain(self.runner).refresh(
+                    wt,
+                    env=env_for_refresh,
+                    in_devc=False,
+                    emit=lambda m: sys.stderr.write(f"[local-kind] {m}\n"),
+                )
+                return
+            argv = [
+                str(wt / "scripts" / "dev" / "evg_prepare.sh"),
+                "--name",
+                i.resolved_evg_host_name(),
+            ]
+            if i.multi_cluster:
+                argv.append("--multi")
+            if i.skip_recreate:
+                argv.append("--skip-recreate")
+            if i.distro:
+                argv += ["--distro", i.distro]
+            if i.region:
+                argv += ["--region", i.region]
+            self.runner.run_streaming(
+                argv,
+                prefix="[evg-host] ",
+                log_path=log_dir / "evg_prepare.log",
+                cwd=wt,
+            )
+
+        # ---- dc_build -----------------------------------------------------
+        def _do_dc_build() -> None:
+            argv = ["devcontainer", "build", "--workspace-folder", str(wt)]
+            self.runner.run_streaming(
+                argv,
+                prefix="[build] ",
+                log_path=log_dir / "dc_build.log",
+                cwd=wt,
+            )
+
+        # ---- dc_up --------------------------------------------------------
+        def _do_dc_up() -> None:
+            # `compose down` the whole project first so `devcontainer up` rebuilds
+            # a fresh stack against current state. `devcontainer up` alone no-ops
+            # when a container exists, and --remove-existing-container only tears
+            # down the devcontainer service + its depends_on chain (k8s-proxy),
+            # leaving siblings like gost-proxy on stale config.
+            # project name = worktree basename (what the CLI uses), not branch_dir
+            # — they diverge under --in-place.
+            project = project_name_for(wt)
+            ps = self.runner.run(
+                ["docker", "compose", "-p", project, "ps", "--format", "{{.Name}}"],
+                check=False,
+                cwd=wt,
+            )
+            if ps.rc == 0 and ps.stdout.strip():
+                self.runner.run_streaming(
+                    ["docker", "compose", "-p", project, "down", "--remove-orphans"],
+                    prefix="[up:down] ",
+                    log_path=log_dir / "dc_up.log",
+                    cwd=wt,
+                )
+
+            argv = ["devcontainer", "up", "--workspace-folder", str(wt)]
+            self.runner.run_streaming(
+                argv,
+                prefix="[up] ",
+                log_path=log_dir / "dc_up.log",
+                cwd=wt,
+            )
+            # Linux local-kind: kind binds the apiserver to 127.0.0.1:<hostport>,
+            # unreachable from the devc. Join devc + k8s-proxy to the `kind`
+            # network so they reach each node container at <node-ip>:6443 (what
+            # the kubeconfig phase rewrites to). No-op on macOS / EVG-host paths.
+            if i.local_kind and platform.system() == "Linux":
+                self._join_kind_network(wt, project, log_dir / "dc_up.log")
+
+        # ---- reconcile ----------------------------------------------------
+        def _do_reconcile() -> None:
+            user_yml = wt / ".devcontainer" / "compose.user.yml"
+            if not user_yml.is_file() or user_yml.stat().st_size == 0:
+                return  # no overrides → nothing to reconcile
+            # Reconcile the auxiliary sidecars only. Force-recreating the main
+            # `devcontainer` service via raw compose desyncs the CLI (later
+            # `devcontainer exec` fails with "Dev container not found").
+            services = [s for s in _services_in(user_yml) if s != "devcontainer"]
+            if not services:
+                return
+            compose = wt / ".devcontainer" / "compose.yml"
+            generated = wt / ".devcontainer" / "compose.generated.yml"
+            project = project_name_for(wt)
+            base = ["docker", "compose", "-p", project, "-f", str(compose)]
+            if generated.is_file():
+                base += ["-f", str(generated)]
+            base += ["-f", str(user_yml)]
+            for svc in services:
+                argv = base + ["up", "-d", "--force-recreate", "--no-deps", svc]
+                self.runner.run_streaming(
+                    argv,
+                    prefix=f"[reconcile {svc}] ",
+                    log_path=log_dir / "reconcile.log",
+                    cwd=wt,
+                )
+
+        # ---- post_start ---------------------------------------------------
+        def _do_post_start() -> None:
+            cmd = (
+                "if [[ ! -S /ssh-agent/socket ]]; then "
+                "echo 'ssh-agent socket missing; re-running post-start.sh'; "
+                "bash /workspace/.devcontainer/scripts/post-start.sh; "
+                "else echo 'ssh-agent socket already present'; fi"
+            )
+            self.runner.run_streaming(
+                _devc_bash(wt, cmd),
+                prefix="[post-start] ",
+                log_path=log_dir / "post_start.log",
+                cwd=wt,
+            )
+
+        # ---- kubeconfig ---------------------------------------------------
+        def _do_kubeconfig() -> None:
+            # `bash -lc` is a login shell but shell-init.sh only auto-sources
+            # devenv for interactive shells, so source it explicitly to export
+            # PROJECT_DIR / KUBECONFIG before `make`. site-context picks
+            # KUBECONFIG by side alone, so `make switch` yields the right
+            # context.devc.env. The refresh works for both EVG-host and
+            # local-kind, whichever populated .generated/current.kubeconfig.
+            cmd = (
+                "set -Eeou pipefail; "
+                "cd /workspace; "
+                "if [[ -f scripts/dev/devenv ]]; then . scripts/dev/devenv 2>/dev/null || true; fi; "
+                'make switch context="$(cat .generated/.current_context)"; '
+                "scripts/dev/wt-ctl --quiet kubeconfig refresh"
+            )
+            self.runner.run_streaming(
+                _devc_bash(wt, cmd),
+                prefix="[refresh] ",
+                log_path=log_dir / "refresh_kubeconfig.log",
+                cwd=wt,
+            )
+
+        # ---- prepare_e2e --------------------------------------------------
+        def _do_prepare_e2e() -> None:
+            # dc_up is hash-cached, so on --resume its one-shot kind-network join
+            # never re-runs — but a compose recreate drops the attachment. Re-apply.
+            if i.local_kind and platform.system() == "Linux":
+                self._join_kind_network(wt, project_name_for(wt), log_dir / "dc_up.log")
+            # prepare-local-e2e's first kubectl request is unbuffered and can race
+            # k8s-proxy / autossh stabilisation right after up, 503-ing the whole
+            # phase. Poll readyz until 200 first.
+            self._wait_apiserver_ready(
+                wt,
+                deadline_s=60.0,
+                interval_s=2.0,
+            )
+            # Source devenv (as in the kubeconfig phase): prepare-local-e2e's
+            # scripts expect KUBECONFIG / PROJECT_DIR / context.env exported.
+            self.runner.run_streaming(
+                _devc_bash(
+                    wt,
+                    "set -Eeou pipefail; " "cd /workspace; " ". scripts/dev/devenv; " "make prepare-local-e2e",
+                ),
+                prefix="[prepare-e2e] ",
+                log_path=log_dir / "prepare_local_e2e.log",
+                cwd=wt,
+            )
+            # local-kind: prepare-local-e2e's in-devc refresh can't resolve kind
+            # node IPs (no docker in the container). Re-run refresh host-side so
+            # the member servers get rewritten to node IPs.
+            if i.local_kind:
+                from .domains.kubeconfig import KubeconfigDomain  # local import avoids a module cycle
+
+                KubeconfigDomain(self.runner).refresh(
+                    wt,
+                    env=_load_context_env(wt),
+                    in_devc=False,
+                    emit=lambda m: sys.stderr.write(f"[local-kind] {m}\n"),
+                )
+
+        # ---- op_run ------------------------------------------------------
+        def _do_op_run() -> None:
+            # dc_up's compose-down killed any prior operator, so launch op_run.sh
+            # detached to leave the operator up against the current kubeconfig.
+            # Then kill the `mck` tmux session so the next attach reloads the
+            # layout fresh (a cached one pins stale kubeconfig handles / zsh
+            # command-hash). Both calls soft-fail so create still finishes.
+            self.runner.run_streaming(
+                _devc_bash(
+                    wt,
+                    "set -Eeou pipefail; "
+                    "cd /workspace; "
+                    ". scripts/dev/devenv; "
+                    "scripts/dev/op_run.sh --detach || "
+                    "echo '[op_run] start failed (continuing; run op_run.sh manually)'; "
+                    "tmux kill-session -t mck 2>/dev/null && "
+                    "echo '[op_run] killed stale mck tmux session; next wt-ctl attach will re-load tmuxp' || "
+                    "echo '[op_run] no mck tmux session to refresh'",
+                ),
+                prefix="[op_run] ",
+                log_path=log_dir / "op_run.log",
+                cwd=wt,
+            )
+
+        # The hash payloads are intentionally narrow: only fields that
+        # *actually* affect the phase get hashed, so flipping unrelated flags
+        # (e.g. --multi-cluster) doesn't invalidate net_allocate.
+        return [
+            Phase(
+                name="worktree_init",
+                run=_do_worktree_init,
+                input_hash=lambda: _h({"branch": i.branch, "force": i.force}),
+                log_relpath="logs/setup_worktree/worktree_init.log",
+            ),
+            Phase(
+                name="initialize_hook",
+                run=_do_initialize_hook,
+                input_hash=lambda: _h({"branch_dir": i.branch_dir}),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/initialize_hook.log",
+            ),
+            Phase(
+                # Hash includes the env-file's completeness: if a prior run wrote
+                # only MCK_DEVC_NET_PREFIX and crashed before the derived lines,
+                # resume must re-enter to append them. Hashing by branch_dir alone
+                # would keep the phase ok and let compose fall back to its default
+                # /23, colliding with sibling worktrees.
+                name="net_allocate",
+                run=_do_net_allocate,
+                input_hash=lambda: _h(
+                    {
+                        "branch_dir": i.branch_dir,
+                        "missing_derived": _missing_derived_env_keys(
+                            i.worktree_path_or_main() / ".devcontainer" / ".env",
+                        ),
+                    }
+                ),
+                skip=lambda: i.skip_devcontainer,
+            ),
+            Phase(
+                name="evg_prepare",
+                run=_do_evg_prepare,
+                input_hash=lambda: _h(
+                    {
+                        "evg_host_name": i.resolved_evg_host_name(),
+                        "multi_cluster": i.multi_cluster,
+                        "skip_recreate": i.skip_recreate,
+                        "local_kind": i.local_kind,
+                        "cluster_name": i.resolved_cluster_name() if i.local_kind else None,
+                    }
+                ),
+                skip=lambda: i.skip_evg,
+                log_relpath="logs/setup_worktree/evg_prepare.log",
+            ),
+            Phase(
+                name="dc_build",
+                run=_do_dc_build,
+                input_hash=lambda: _h({"branch_dir": i.branch_dir}),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/dc_build.log",
+            ),
+            Phase(
+                name="dc_up",
+                run=_do_dc_up,
+                input_hash=lambda: _h({"branch_dir": i.branch_dir}),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/dc_up.log",
+            ),
+            Phase(
+                name="reconcile",
+                run=_do_reconcile,
+                input_hash=lambda: _h({"branch_dir": i.branch_dir}),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/reconcile.log",
+            ),
+            Phase(
+                name="post_start",
+                run=_do_post_start,
+                input_hash=lambda: _h({"branch_dir": i.branch_dir}),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/post_start.log",
+            ),
+            Phase(
+                name="kubeconfig",
+                run=_do_kubeconfig,
+                input_hash=lambda: _h(
+                    {
+                        "branch_dir": i.branch_dir,
+                        "context": i.context or "",
+                    }
+                ),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/refresh_kubeconfig.log",
+            ),
+            Phase(
+                name="prepare_e2e",
+                run=_do_prepare_e2e,
+                input_hash=lambda: _h({"branch_dir": i.branch_dir}),
+                skip=lambda: i.skip_devcontainer or i.skip_prepare_e2e,
+                log_relpath="logs/setup_worktree/prepare_local_e2e.log",
+            ),
+            Phase(
+                name="op_run",
+                run=_do_op_run,
+                # Time-based hash so the state.json skip never short-circuits this
+                # phase: reaching the tail of the plan always restarts the operator
+                # against the current kubeconfig and re-wires tmux, even on a no-op
+                # resume (dc_up's compose-down nuked both). op_run.sh is idempotent.
+                input_hash=lambda: _h({"ts": time.time_ns()}),
+                skip=lambda: i.skip_devcontainer,
+                log_relpath="logs/setup_worktree/op_run.log",
+            ),
+        ]
+
+    # ------------------------------------------------------------------
+    # plan
+    # ------------------------------------------------------------------
+    def _plan(
+        self,
+        state: ostate.OrchestratorState,
+        phases: list[Phase],
+        *,
+        resume: bool,
+        restart_from: Optional[str],
+    ) -> list[Phase]:
+        """Decide which phases to run this invocation.
+
+        * ``--restart-from <phase>`` clears that phase and later, then runs every
+          non-skipped phase from there.
+        * ``--resume`` runs from the first phase that isn't OK or whose input_hash
+          no longer matches; skipped phases are passed over silently.
+        * Default: run every non-skipped phase (all are idempotent).
+        """
+        if restart_from:
+            state.clear_from(restart_from)
+            host = self.inputs.worktree_path_or_main()
+            if host.is_dir():
+                ostate.save(host, state)
+
+        if resume:
+            # Find the earliest non-OK or hash-mismatched phase among
+            # non-skipped phases.
+            first_idx: Optional[int] = None
+            for idx, phase in enumerate(phases):
+                if phase.skip():
+                    continue
+                rec = state.phases.get(phase.name)
+                # A phase recorded SKIPPED by an earlier run stays skipped on
+                # resume even if the opt-out flag was dropped — otherwise
+                # resume would spawn the EVG host the user opted out of. Force
+                # it explicitly with --restart-from <phase>.
+                if rec is not None and rec.status == ostate.SKIPPED:
+                    continue
+                want_hash = phase.input_hash()
+                if rec is None or rec.status != ostate.OK or rec.input_hash != want_hash:
+                    first_idx = idx
+                    break
+            if first_idx is None:
+                return []
+            return [p for p in phases[first_idx:] if not p.skip()]
+
+        # Default / restart-from: run every non-skipped phase from the
+        # current cursor (post-restart-from) onward. For default (no flags),
+        # the cursor is index 0 — every phase runs (idempotent).
+        if restart_from:
+            try:
+                first_idx = ostate.PHASE_ORDER.index(restart_from)
+            except ValueError as exc:
+                raise StateConflict(f"unknown phase: {restart_from}") from exc
+            relevant = phases[first_idx:]
+        else:
+            relevant = list(phases)
+        return [p for p in relevant if not p.skip()]
+
+    # ------------------------------------------------------------------
+    # execution helpers
+    # ------------------------------------------------------------------
+    def _run_one(
+        self,
+        state: ostate.OrchestratorState,
+        phase: Phase,
+        *,
+        emit: Callable[[str], None],
+    ) -> None:
+        emit(f"[wt-ctl] phase: {phase.name}")
+        # Save lazily: pre-worktree_init the target dir doesn't exist, and writing
+        # .generated/wt-ctl/ there would stop git worktree add from populating it.
+        host = self.inputs.worktree_path_or_main()
+        if host.is_dir():
+            state.set_status(phase.name, ostate.IN_PROGRESS, log=phase.log_relpath)
+            ostate.save(host, state)
+        try:
+            phase.run()
+        except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+            state.set_status(
+                phase.name,
+                ostate.FAILED,
+                input_hash=phase.input_hash(),
+                log=phase.log_relpath,
+            )
+            # The worktree may now exist (worktree_init failed mid-way) — try
+            # to save; tolerate a missing host dir silently.
+            if host.is_dir():
+                ostate.save(host, state)
+            raise
+        state.set_status(
+            phase.name,
+            ostate.OK,
+            input_hash=phase.input_hash(),
+            log=phase.log_relpath,
+        )
+        # After worktree_init succeeds the dir exists — save now persists
+        # the just-completed phase's record.
+        if host.is_dir():
+            ostate.save(host, state)
+
+    def _run_parallel_pair(
+        self,
+        state: ostate.OrchestratorState,
+        a: Phase,
+        b: Phase,
+        *,
+        emit: Callable[[str], None],
+    ) -> None:
+        """Run two phases in worker threads, recording each individually."""
+        emit(f"[wt-ctl] parallel phases: {a.name} + {b.name}")
+        host = self.inputs.worktree_path_or_main()
+        for ph in (a, b):
+            state.set_status(ph.name, ostate.IN_PROGRESS, log=ph.log_relpath)
+        if host.is_dir():
+            ostate.save(host, state)
+
+        # Thread directly (not Runner.run_parallel) to capture each phase's failure
+        # and let both finish before surfacing them via ParallelPhaseFailures.
+        results: dict[str, Optional[Exception]] = {a.name: None, b.name: None}
+
+        import threading
+
+        def _worker(phase: Phase) -> None:
+            try:
+                phase.run()
+            except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+                results[phase.name] = exc
+            except Exception as exc:  # noqa: BLE001
+                # Record unexpected exceptions too; otherwise the phase would be
+                # marked OK and --resume would silently skip the crash.
+                results[phase.name] = WtCtlError(f"unexpected error in phase {phase.name}: {exc!r}")
+
+        ta = threading.Thread(target=_worker, args=(a,))
+        tb = threading.Thread(target=_worker, args=(b,))
+        ta.start()
+        tb.start()
+        ta.join()
+        tb.join()
+
+        for ph in (a, b):
+            status = ostate.OK if results[ph.name] is None else ostate.FAILED
+            state.set_status(ph.name, status, input_hash=ph.input_hash(), log=ph.log_relpath)
+        if host.is_dir():
+            ostate.save(host, state)
+
+        failures = {name: err for name, err in results.items() if err is not None}
+        if failures:
+            ecfs = {name: err for name, err in failures.items() if isinstance(err, ExternalCommandFailed)}
+            if ecfs:
+                raise ParallelPhaseFailures(failures=ecfs)
+            for err in failures.values():
+                raise err
+
+    # ------------------------------------------------------------------
+    # state file location helpers
+    # ------------------------------------------------------------------
+    def _load_or_init_state(
+        self,
+        *,
+        resume: bool,
+        restart_from: Optional[str],
+    ) -> Optional[ostate.OrchestratorState]:
+        host = self.inputs.worktree_path_or_main()
+        # Don't mkdir here — git worktree add refuses a non-empty target; save()
+        # creates .generated/wt-ctl/ once worktree_init has populated the dir.
+        if not host.is_dir():
+            return None
+        return ostate.load(host)
+
+    def runner_cwd_or_main(self) -> Path:
+        """Where the user invoked wt-ctl from. Used to detect "already inside
+        the target worktree" so worktree_init can short-circuit.
+        """
+        try:
+            return Path(os.getcwd()).resolve()
+        except OSError:
+            return self.inputs.main_repo_root
+
+    def _wait_apiserver_ready(
+        self,
+        wt: Path,
+        *,
+        deadline_s: float,
+        interval_s: float,
+    ) -> None:
+        """Poll ``kubectl get --raw=/readyz`` in the devcontainer until it
+        returns 200, raising ``WtCtlError`` on timeout. Probe output goes to
+        stderr only (the phase's run_streaming owns the phase log)."""
+        argv = _devc_bash(
+            wt,
+            "set -Eeou pipefail; "
+            "cd /workspace; "
+            ". scripts/dev/devenv; "
+            "kubectl --request-timeout=3s get --raw=/readyz",
+        )
+        deadline = time.monotonic() + deadline_s
+        attempts = 0
+        last_stderr = ""
+        while True:
+            attempts += 1
+            result = self.runner.run(argv, check=False, cwd=wt)
+            if result.rc == 0:
+                sys.stderr.write(
+                    f"[prepare-e2e] apiserver ready after " f"{attempts} probe{'' if attempts == 1 else 's'}\n"
+                )
+                return
+            last_stderr = (result.stderr or result.stdout or "").strip()
+            # Liveness tick every 5 probes so a slow handshake isn't silent.
+            if attempts % 5 == 0:
+                sys.stderr.write(
+                    f"[prepare-e2e] still waiting for apiserver "
+                    f"(probe {attempts}, last: {last_stderr or '(empty)'})\n"
+                )
+            if time.monotonic() >= deadline:
+                raise WtCtlError(
+                    f"apiserver readyz never returned 200 after "
+                    f"{int(deadline_s)}s ({attempts} probes); last stderr: "
+                    f"{last_stderr or '(empty)'}"
+                )
+            time.sleep(interval_s)
+
+    def _join_kind_network(self, wt: Path, project: str, log_path: Path) -> None:
+        """Join the devc + k8s-proxy containers to the shared ``kind`` docker
+        network (Linux local-kind only). Idempotent — skips a container already
+        attached. Best-effort: a failure is logged, not fatal, since the
+        kubeconfig phase's readyz probe will surface an unreachable apiserver."""
+        for svc in ("devcontainer", "k8s-proxy"):
+            ps = self.runner.run(["docker", "compose", "-p", project, "ps", "-q", svc], check=False, cwd=wt)
+            cid = (ps.stdout.strip().splitlines() or [""])[0]
+            if not cid:
+                sys.stderr.write(f"[kind-net] no running container for service {svc!r}; skipping\n")
+                continue
+            # `{{if}}` yields "yes" only when the endpoint pointer is non-nil.
+            # `{{index ...}}` alone prints "<nil>" for an absent key, which is
+            # truthy as a string — so gate the check with `{{if}}`.
+            attached = self.runner.run(
+                ["docker", "inspect", "-f", '{{if index .NetworkSettings.Networks "kind"}}yes{{end}}', cid],
+                check=False,
+            ).stdout.strip()
+            if attached == "yes":
+                sys.stderr.write(f"[kind-net] {svc} already on kind network\n")
+                continue
+            res = self.runner.run(["docker", "network", "connect", "kind", cid], check=False)
+            if res.rc == 0:
+                sys.stderr.write(f"[kind-net] joined {svc} to kind network\n")
+            else:
+                sys.stderr.write(f"[kind-net] WARN: failed to join {svc} to kind network: {res.stderr.strip()}\n")
+
+
+# ---------------------------------------------------------------------------
+# DeleteOrchestrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DeleteInputs:
+    """Opt-in delete targets; every flag defaults False, so ``wt-ctl delete``
+    with no flags is a no-op. Git branches are never deleted (branch is
+    metadata only)."""
+
+    branch: str
+    branch_dir: str
+    worktree_path: Path
+    main_repo_root: Path
+    delete_om: bool = False
+    delete_devc: bool = False
+    delete_evg: bool = False
+    delete_worktree: bool = False
+    evg_host_name: Optional[str] = None
+
+    def resolved_evg_host_name(self) -> str:
+        return self.evg_host_name or self.branch_dir
+
+    def any_target(self) -> bool:
+        return any(
+            [
+                self.delete_om,
+                self.delete_devc,
+                self.delete_evg,
+                self.delete_worktree,
+            ]
+        )
+
+
+class DeleteOrchestrator:
+    """Opt-in teardown. Each step runs only when its target flag is set;
+    failures log and continue so other targets still run. Git branches are
+    never deleted — worktrees are cheap to recreate, lost work isn't."""
+
+    def __init__(self, runner: Runner, inputs: DeleteInputs) -> None:
+        self.runner = runner
+        self.inputs = inputs
+        self.scripts = inputs.main_repo_root / "scripts" / "dev"
+
+    def run(self, *, emit: Callable[[str], None] = lambda _msg: None) -> None:
+        i = self.inputs
+        targets = (
+            ", ".join(
+                t
+                for t, on in [
+                    ("om", i.delete_om),
+                    ("devc", i.delete_devc),
+                    ("evg", i.delete_evg),
+                    ("worktree", i.delete_worktree),
+                ]
+                if on
+            )
+            or "(none)"
+        )
+        evg_pin = i.worktree_path / ".generated" / ".current-evg-host"
+        evg_tag = f"evg_host={i.resolved_evg_host_name()}" if evg_pin.is_file() else "local"
+        emit(f"[wt-ctl] delete: branch={i.branch} targets=[{targets}] " f"worktree={i.worktree_path} {evg_tag}")
+        if i.delete_om:
+            self._step_om_clean(emit)
+        if i.delete_devc:
+            self._step_compose_down(emit)
+        if i.delete_evg:
+            self._step_evg_terminate(emit)
+        if i.delete_worktree:
+            self._step_worktree_remove(emit)
+            # Network registry entry is tied to the worktree's net prefix;
+            # release it only when the worktree itself goes away.
+            self._step_prefix_release(emit)
+        emit("[wt-ctl] delete: done")
+
+    # ------------------------------------------------------------------
+    def _step_om_clean(self, emit: Callable[[str], None]) -> None:
+        wt = self.inputs.worktree_path
+        if not wt.is_dir():
+            emit("[wt-ctl] om: skipped (worktree dir gone)")
+            return
+        env_file = wt / ".devcontainer" / ".env"
+        prefix = _read_existing_prefix(env_file)
+        if prefix is None:
+            emit("[wt-ctl] om: skipped (no MCK_DEVC_NET_PREFIX in .devcontainer/.env)")
+            return
+        emit("[wt-ctl] om: deleting cloud-qa OM projects scoped to this worktree")
+        try:
+            self.runner.run_streaming(
+                [str(wt / "scripts" / "dev" / "delete_om_projects.sh")],
+                prefix="[om-clean] ",
+                cwd=wt,
+            )
+        except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+            emit(f"[wt-ctl] om: cleanup hit an error (continuing): {exc.render()}")
+
+    def _step_compose_down(self, emit: Callable[[str], None]) -> None:
+        project = project_name_for(self.inputs.worktree_path)
+        ps = self.runner.run(
+            ["docker", "compose", "-p", project, "ps", "--format", "{{.Name}}"],
+            check=False,
+        )
+        if ps.rc != 0 or not ps.stdout.strip():
+            emit(f"[wt-ctl] compose: no running stack for project '{project}'")
+            return
+        emit(f"[wt-ctl] compose: stopping stack '{project}'")
+        try:
+            self.runner.run_streaming(
+                ["docker", "compose", "-p", project, "down", "--remove-orphans"],
+                prefix="[compose-down] ",
+            )
+        except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+            emit(f"[wt-ctl] compose: down failed (continuing): {exc.render()}")
+
+    def _read_current_context(self, kubeconfig: Path) -> Optional[str]:
+        """Return the kubeconfig's ``current-context``, or None if unreadable /
+        malformed / unset. yaml is imported lazily so ``wt-ctl delete`` still
+        runs (minus kind teardown) when pyyaml isn't installed yet."""
+        try:
+            import yaml  # type: ignore  # pyyaml — venv dep, may be missing on fresh runners
+        except ImportError:
+            return None
+        try:
+            data = yaml.safe_load(kubeconfig.read_text())
+        except (OSError, yaml.YAMLError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        value = data.get("current-context")
+        if isinstance(value, str) and value:
+            return value
+        return None
+
+    def _step_evg_terminate(self, emit: Callable[[str], None]) -> None:
+        # No `.current-evg-host` pinned → local-kind or BYOC. Delete the kind
+        # cluster named by the kubeconfig's current-context when it exists;
+        # otherwise no-op (BYOC tears itself down).
+        wt = self.inputs.worktree_path
+        evg_pin = wt / ".generated" / ".current-evg-host"
+        if not evg_pin.is_file():
+            kc_path = wt / ".generated" / "current.kubeconfig"
+            if not kc_path.is_file():
+                emit("[wt-ctl] evg: no .current-evg-host and no current.kubeconfig; nothing to tear down")
+                return
+            ctx = self._read_current_context(kc_path)
+            if not ctx or not ctx.startswith("kind-"):
+                emit(
+                    f"[wt-ctl] evg: kubeconfig current-context={ctx!r} is not a kind cluster (BYOC?); skipping teardown"
+                )
+                return
+            cluster = ctx[len("kind-") :]
+            if not self.runner.have("kind"):
+                emit("[wt-ctl] evg: kind CLI not on PATH — skipping local-kind teardown")
+                return
+            listing = self.runner.run(["kind", "get", "clusters"], check=False)
+            if listing.rc != 0 or cluster not in (listing.stdout or "").splitlines():
+                emit(f"[wt-ctl] evg: kind cluster '{cluster}' not in `kind get clusters`; skipping (already gone?)")
+                return
+            emit(f"[wt-ctl] evg: deleting local kind cluster '{cluster}'")
+            try:
+                self.runner.run_streaming(
+                    ["kind", "delete", "cluster", "--name", cluster],
+                    prefix="[kind-delete] ",
+                )
+            except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+                emit(f"[wt-ctl] evg: kind delete failed (continuing): {exc.render()}")
+            return
+
+        if not self.runner.have("evergreen"):
+            emit("[wt-ctl] evg: evergreen CLI not on PATH — skipping termination")
+            return
+        res = self.runner.run(
+            ["evergreen", "host", "list", "--mine", "--json"],
+            check=False,
+        )
+        if res.rc != 0:
+            emit(f"[wt-ctl] evg: host list failed rc={res.rc} — skipping termination")
+            return
+        host_id = _find_host_id_by_name(
+            res.stdout or "[]",
+            self.inputs.resolved_evg_host_name(),
+        )
+        if host_id is None:
+            emit(f"[wt-ctl] evg: no running host with displayName " f"'{self.inputs.resolved_evg_host_name()}'")
+            return
+        emit(f"[wt-ctl] evg: terminating " f"'{self.inputs.resolved_evg_host_name()}' (host_id={host_id})")
+        try:
+            self.runner.run_streaming(
+                ["evergreen", "host", "terminate", "--host", host_id],
+                prefix="[evg-term] ",
+            )
+        except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+            emit(f"[wt-ctl] evg: terminate failed (continuing): {exc.render()}")
+
+    def _step_worktree_remove(self, emit: Callable[[str], None]) -> None:
+        wt = self.inputs.worktree_path
+        # Move cwd off the worktree we're about to delete — otherwise a later
+        # os.getcwd() / subprocess raises FileNotFoundError once the dir vanishes.
+        try:
+            cwd = os.getcwd()
+            if Path(cwd).resolve() == wt.resolve() or wt in Path(cwd).resolve().parents:
+                os.chdir(wt.parent)
+        except (FileNotFoundError, OSError):
+            os.chdir(Path.home())
+        if wt.is_dir():
+            emit(f"[wt-ctl] worktree: removing {wt}")
+            try:
+                self.runner.run(
+                    [
+                        "git",
+                        "-C",
+                        str(self.inputs.main_repo_root),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(wt),
+                    ],
+                )
+            except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+                emit(f"[wt-ctl] worktree: remove failed (continuing): {exc.render()}")
+        else:
+            emit(f"[wt-ctl] worktree: dir {wt} doesn't exist; skipping")
+        try:
+            self.runner.run(
+                ["git", "-C", str(self.inputs.main_repo_root), "worktree", "prune"],
+            )
+        except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+            emit(f"[wt-ctl] worktree: prune failed (continuing): {exc.render()}")
+
+    def _step_prefix_release(self, emit: Callable[[str], None]) -> None:
+        emit(f"[wt-ctl] network: releasing registry entry for '{self.inputs.branch_dir}'")
+        try:
+            # release() ignores worktree_parent, so main_repo_root (always set) is fine.
+            domain = NetworkDomain(self.runner, self.inputs.main_repo_root)
+            output = domain.release(self.inputs.branch_dir).rstrip("\n")
+            if output:
+                emit(f"[net-release] {output}")
+        except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+            emit(f"[wt-ctl] network: release failed (continuing): {exc.render()}")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_same_path(a: Path, b: Path) -> bool:
+    try:
+        return a.resolve() == b.resolve()
+    except OSError:
+        return False
+
+
+def _read_existing_prefix(env_file: Path) -> Optional[int]:
+    if not env_file.is_file():
+        return None
+    try:
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("MCK_DEVC_NET_PREFIX="):
+                value = line.split("=", 1)[1]
+                if value.isdigit():
+                    return int(value)
+    except OSError:
+        return None
+    return None
+
+
+def _missing_derived_env_keys(env_file: Path) -> list[str]:
+    """``DERIVED_ENV_KEYS`` entries absent from ``env_file`` — lets net_allocate
+    resume recover from a partial first-write of only ``MCK_DEVC_NET_PREFIX``."""
+    if not env_file.is_file():
+        return list(DERIVED_ENV_KEYS)
+    try:
+        text = env_file.read_text()
+    except OSError:
+        return list(DERIVED_ENV_KEYS)
+    present: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        for key in DERIVED_ENV_KEYS:
+            if line.startswith(f"{key}="):
+                present.add(key)
+    return [k for k in DERIVED_ENV_KEYS if k not in present]
+
+
+def _services_in(compose_yml: Path) -> list[str]:
+    """Top-level service keys under ``services:``. Stdlib-only (no PyYAML);
+    relies on compose.user.yml's consistent 2-space indentation."""
+    if not compose_yml.is_file():
+        return []
+    try:
+        text = compose_yml.read_text()
+    except OSError:
+        return []
+    services: list[str] = []
+    in_services = False
+    for raw in text.splitlines():
+        if raw.strip().startswith("#"):
+            continue
+        if not raw.strip():
+            continue
+        if raw.startswith("services:"):
+            in_services = True
+            continue
+        if in_services:
+            # New top-level key ends the services block.
+            if raw[:1] not in (" ", "\t"):
+                in_services = False
+                continue
+            stripped = raw.lstrip()
+            indent = len(raw) - len(stripped)
+            # services children are indented at 2 spaces; nested keys are 4+.
+            if indent == 2 and stripped.endswith(":"):
+                services.append(stripped[:-1])
+    return services
+
+
+def _find_host_id_by_name(json_text: str, name: str) -> Optional[str]:
+    """Parse `evergreen host list --json` and return the id of the running
+    host whose name matches. Skips terminated/decommissioned hosts.
+    """
+    import json
+
+    try:
+        data = json.loads(json_text or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    dead = {"terminated", "decommissioned"}
+    for h in data:
+        if not isinstance(h, dict):
+            continue
+        if h.get("name") != name:
+            continue
+        status = (h.get("status") or "").lower()
+        if status in dead:
+            continue
+        host_id = h.get("id")
+        if host_id:
+            return host_id
+    return None

--- a/scripts/dev/wt_ctl/orchestrator.py
+++ b/scripts/dev/wt_ctl/orchestrator.py
@@ -1059,10 +1059,14 @@ class DeleteOrchestrator:
         if i.delete_evg:
             self._step_evg_terminate(emit)
         if i.delete_worktree:
-            self._step_worktree_remove(emit)
+            removed = self._step_worktree_remove(emit)
             # Network registry entry is tied to the worktree's net prefix;
-            # release it only when the worktree itself goes away.
-            self._step_prefix_release(emit)
+            # release it only when the worktree is confirmed gone — otherwise a
+            # live worktree keeps its subnet/port while another run reclaims it.
+            if removed:
+                self._step_prefix_release(emit)
+            else:
+                emit("[wt-ctl] network: keeping registry entry (worktree still present)")
         emit("[wt-ctl] delete: done")
 
     # ------------------------------------------------------------------
@@ -1190,7 +1194,9 @@ class DeleteOrchestrator:
         except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
             emit(f"[wt-ctl] evg: terminate failed (continuing): {exc.render()}")
 
-    def _step_worktree_remove(self, emit: Callable[[str], None]) -> None:
+    def _step_worktree_remove(self, emit: Callable[[str], None]) -> bool:
+        """Return True when the worktree is confirmed gone (removed now or
+        already absent), False when a removal was attempted and failed."""
         wt = self.inputs.worktree_path
         # Move cwd off the worktree we're about to delete — otherwise a later
         # os.getcwd() / subprocess raises FileNotFoundError once the dir vanishes.
@@ -1200,6 +1206,7 @@ class DeleteOrchestrator:
                 os.chdir(wt.parent)
         except (FileNotFoundError, OSError):
             os.chdir(Path.home())
+        removed = True
         if wt.is_dir():
             emit(f"[wt-ctl] worktree: removing {wt}")
             try:
@@ -1216,6 +1223,7 @@ class DeleteOrchestrator:
                 )
             except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
                 emit(f"[wt-ctl] worktree: remove failed (continuing): {exc.render()}")
+                removed = False
         else:
             emit(f"[wt-ctl] worktree: dir {wt} doesn't exist; skipping")
         try:
@@ -1224,6 +1232,7 @@ class DeleteOrchestrator:
             )
         except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
             emit(f"[wt-ctl] worktree: prune failed (continuing): {exc.render()}")
+        return removed
 
     def _step_prefix_release(self, emit: Callable[[str], None]) -> None:
         emit(f"[wt-ctl] network: releasing registry entry for '{self.inputs.branch_dir}'")

--- a/scripts/dev/wt_ctl/orchestrator.py
+++ b/scripts/dev/wt_ctl/orchestrator.py
@@ -1088,10 +1088,14 @@ class DeleteOrchestrator:
 
     def _step_compose_down(self, emit: Callable[[str], None]) -> None:
         project = project_name_for(self.inputs.worktree_path)
-        ps = self.runner.run(
-            ["docker", "compose", "-p", project, "ps", "--format", "{{.Name}}"],
-            check=False,
-        )
+        try:
+            ps = self.runner.run(
+                ["docker", "compose", "-p", project, "ps", "--format", "{{.Name}}"],
+                check=False,
+            )
+        except ToolMissing:
+            emit("[wt-ctl] compose: docker unavailable — skipping stack teardown")
+            return
         if ps.rc != 0 or not ps.stdout.strip():
             emit(f"[wt-ctl] compose: no running stack for project '{project}'")
             return

--- a/scripts/dev/wt_ctl/orchestrator.py
+++ b/scripts/dev/wt_ctl/orchestrator.py
@@ -440,6 +440,11 @@ class CreateOrchestrator:
                 "--name",
                 i.resolved_evg_host_name(),
             ]
+            if i.context:
+                # Pass the context explicitly so evg_prepare.sh doesn't depend on
+                # the .generated/.current_context sentinel, which the concurrent
+                # dc_build phase can transiently clear.
+                argv += ["--context", i.context]
             if i.multi_cluster:
                 argv.append("--multi")
             if i.skip_recreate:

--- a/scripts/dev/wt_ctl/orchestrator.py
+++ b/scripts/dev/wt_ctl/orchestrator.py
@@ -1009,6 +1009,7 @@ class DeleteInputs:
     delete_evg: bool = False
     delete_worktree: bool = False
     evg_host_name: Optional[str] = None
+    multi_cluster: bool = False
 
     def resolved_evg_host_name(self) -> str:
         return self.evg_host_name or self.branch_dir
@@ -1022,6 +1023,12 @@ class DeleteInputs:
                 self.delete_worktree,
             ]
         )
+
+
+# Cluster names a local-kind multi-cluster create owns (recreate_kind_clusters.sh:
+# one operator + three members + the single 'kind'). Teardown deletes every one
+# that's present, not just the current-context cluster.
+_MC_LOCAL_KIND_CLUSTERS = ("e2e-operator", "e2e-cluster-1", "e2e-cluster-2", "e2e-cluster-3", "kind")
 
 
 class DeleteOrchestrator:
@@ -1148,22 +1155,33 @@ class DeleteOrchestrator:
                     f"[wt-ctl] evg: kubeconfig current-context={ctx!r} is not a kind cluster (BYOC?); skipping teardown"
                 )
                 return
-            cluster = ctx[len("kind-") :]
             if not self.runner.have("kind"):
                 emit("[wt-ctl] evg: kind CLI not on PATH — skipping local-kind teardown")
                 return
             listing = self.runner.run(["kind", "get", "clusters"], check=False)
-            if listing.rc != 0 or cluster not in (listing.stdout or "").splitlines():
-                emit(f"[wt-ctl] evg: kind cluster '{cluster}' not in `kind get clusters`; skipping (already gone?)")
+            if listing.rc != 0:
+                emit(f"[wt-ctl] evg: `kind get clusters` failed rc={listing.rc} — skipping teardown")
                 return
-            emit(f"[wt-ctl] evg: deleting local kind cluster '{cluster}'")
-            try:
-                self.runner.run_streaming(
-                    ["kind", "delete", "cluster", "--name", cluster],
-                    prefix="[kind-delete] ",
-                )
-            except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
-                emit(f"[wt-ctl] evg: kind delete failed (continuing): {exc.render()}")
+            present = set((listing.stdout or "").splitlines())
+            # MC create owns the whole cluster set; single-cluster owns only the
+            # one the kubeconfig points at.
+            if self.inputs.multi_cluster:
+                wanted = [c for c in _MC_LOCAL_KIND_CLUSTERS if c in present]
+            else:
+                current = ctx[len("kind-") :]
+                wanted = [current] if current in present else []
+            if not wanted:
+                emit("[wt-ctl] evg: no owned kind clusters present; skipping (already gone?)")
+                return
+            for cluster in wanted:
+                emit(f"[wt-ctl] evg: deleting local kind cluster '{cluster}'")
+                try:
+                    self.runner.run_streaming(
+                        ["kind", "delete", "cluster", "--name", cluster],
+                        prefix="[kind-delete] ",
+                    )
+                except (ExternalCommandFailed, ToolMissing, WtCtlError) as exc:
+                    emit(f"[wt-ctl] evg: kind delete '{cluster}' failed (continuing): {exc.render()}")
             return
 
         if not self.runner.have("evergreen"):

--- a/scripts/dev/wt_ctl/orchestrator.py
+++ b/scripts/dev/wt_ctl/orchestrator.py
@@ -1165,6 +1165,11 @@ class DeleteOrchestrator:
         if not self.runner.have("evergreen"):
             emit("[wt-ctl] evg: evergreen CLI not on PATH — skipping termination")
             return
+        # The pin records the actual displayName the host was created with; prefer
+        # it so a host made with --evg-host-name isn't missed (and leaked) when the
+        # delete invocation omits that flag.
+        pinned = evg_pin.read_text().strip()
+        host_name = pinned or self.inputs.resolved_evg_host_name()
         res = self.runner.run(
             ["evergreen", "host", "list", "--mine", "--json"],
             check=False,
@@ -1172,14 +1177,11 @@ class DeleteOrchestrator:
         if res.rc != 0:
             emit(f"[wt-ctl] evg: host list failed rc={res.rc} — skipping termination")
             return
-        host_id = _find_host_id_by_name(
-            res.stdout or "[]",
-            self.inputs.resolved_evg_host_name(),
-        )
+        host_id = _find_host_id_by_name(res.stdout or "[]", host_name)
         if host_id is None:
-            emit(f"[wt-ctl] evg: no running host with displayName " f"'{self.inputs.resolved_evg_host_name()}'")
+            emit(f"[wt-ctl] evg: no running host with displayName '{host_name}'")
             return
-        emit(f"[wt-ctl] evg: terminating " f"'{self.inputs.resolved_evg_host_name()}' (host_id={host_id})")
+        emit(f"[wt-ctl] evg: terminating '{host_name}' (host_id={host_id})")
         try:
             self.runner.run_streaming(
                 ["evergreen", "host", "terminate", "--host", host_id],

--- a/scripts/dev/wt_ctl/orchestrator_state.py
+++ b/scripts/dev/wt_ctl/orchestrator_state.py
@@ -1,0 +1,225 @@
+"""State file for the ``wt-ctl create`` orchestrator.
+
+Persists per-phase status + input hash to
+``<worktree>/.generated/wt-ctl/state.json`` so ``--resume`` and
+``--restart-from`` can pick up after a failure. Read/write is atomic via
+``os.replace`` on a tempfile sibling.
+
+No subprocess. No domain imports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from .errors import StateConflict, WtCtlError
+from .paths import state_dir
+
+SCHEMA_VERSION = 1
+
+
+PENDING = "pending"
+IN_PROGRESS = "in_progress"
+OK = "ok"
+FAILED = "failed"
+# Distinct from PENDING so status doesn't report "incomplete" and --resume
+# doesn't re-run (and re-spawn) what the user opted out of.
+SKIPPED = "skipped"
+
+
+PHASE_ORDER = (
+    "worktree_init",
+    "initialize_hook",
+    "net_allocate",
+    "evg_prepare",
+    "dc_build",
+    "dc_up",
+    "reconcile",
+    "post_start",
+    "kubeconfig",
+    "prepare_e2e",
+    "op_run",
+)
+
+# Recorded individually but launched together.
+PARALLEL_GROUP = ("evg_prepare", "dc_build")
+
+
+@dataclass
+class PhaseRecord:
+    status: str = PENDING
+    ts: Optional[str] = None
+    input_hash: Optional[str] = None
+    log: Optional[str] = None  # relative to worktree_root, when known
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "PhaseRecord":
+        return cls(
+            status=d.get("status", PENDING),
+            ts=d.get("ts"),
+            input_hash=d.get("input_hash"),
+            log=d.get("log"),
+        )
+
+
+@dataclass
+class OrchestratorState:
+    """In-memory mirror of state.json. Loadable, mutable, atomically savable."""
+
+    branch: str = ""
+    started_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    inputs: dict = field(default_factory=dict)
+    phases: dict[str, PhaseRecord] = field(default_factory=dict)
+    schema: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": self.schema,
+            "branch": self.branch,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "inputs": dict(self.inputs),
+            "phases": {k: v.to_dict() for k, v in self.phases.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OrchestratorState":
+        return cls(
+            schema=int(data.get("schema", SCHEMA_VERSION)),
+            branch=data.get("branch", ""),
+            started_at=data.get("started_at"),
+            updated_at=data.get("updated_at"),
+            inputs=dict(data.get("inputs") or {}),
+            phases={name: PhaseRecord.from_dict(rec) for name, rec in (data.get("phases") or {}).items()},
+        )
+
+    @classmethod
+    def initial(cls, *, branch: str, inputs: dict, phase_order=PHASE_ORDER) -> "OrchestratorState":
+        now = _now_iso()
+        return cls(
+            branch=branch,
+            started_at=now,
+            updated_at=now,
+            inputs=dict(inputs),
+            phases={name: PhaseRecord(status=PENDING) for name in phase_order},
+        )
+
+    def ensure_phase(self, name: str) -> PhaseRecord:
+        rec = self.phases.get(name)
+        if rec is None:
+            rec = PhaseRecord(status=PENDING)
+            self.phases[name] = rec
+        return rec
+
+    def set_status(
+        self,
+        name: str,
+        status: str,
+        *,
+        input_hash: Optional[str] = None,
+        log: Optional[str] = None,
+    ) -> None:
+        rec = self.ensure_phase(name)
+        rec.status = status
+        rec.ts = _now_iso()
+        if input_hash is not None:
+            rec.input_hash = input_hash
+        if log is not None:
+            rec.log = log
+        self.updated_at = rec.ts
+
+    def has_in_progress(self) -> Optional[str]:
+        for name, rec in self.phases.items():
+            if rec.status == IN_PROGRESS:
+                return name
+        return None
+
+    def first_non_ok(self, phase_order=PHASE_ORDER) -> Optional[str]:
+        """First phase whose status is neither OK nor SKIPPED. ``input_hash``
+        mismatch is the caller's concern; this returns purely on stored status.
+        """
+        for name in phase_order:
+            rec = self.phases.get(name)
+            if rec is None or rec.status not in (OK, SKIPPED):
+                return name
+        return None
+
+    def clear_from(self, phase: str, phase_order=PHASE_ORDER) -> None:
+        """Reset ``phase`` and every later phase to PENDING. Phases not in
+        ``phase_order`` are left alone.
+        """
+        if phase not in phase_order:
+            raise StateConflict(f"unknown phase: {phase}")
+        idx = phase_order.index(phase)
+        for name in phase_order[idx:]:
+            rec = self.ensure_phase(name)
+            rec.status = PENDING
+            rec.ts = None
+            rec.input_hash = None
+            rec.log = None
+        self.updated_at = _now_iso()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def state_path(worktree_root: Path) -> Path:
+    return state_dir(worktree_root) / "state.json"
+
+
+def load(worktree_root: Path) -> Optional[OrchestratorState]:
+    """Return None when no state.json exists yet."""
+    path = state_path(worktree_root)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise StateConflict(f"failed to read {path}: {exc}") from exc
+    try:
+        data = json.loads(text or "{}")
+    except json.JSONDecodeError as exc:
+        raise StateConflict(f"state file at {path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise StateConflict(f"state file at {path} must be a JSON object")
+    return OrchestratorState.from_dict(data)
+
+
+def save(worktree_root: Path, state: OrchestratorState) -> Path:
+    """Atomically persist the state to ``state.json``."""
+    state.updated_at = _now_iso()
+    path = state_path(worktree_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix="state.", suffix=".json", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(state.to_dict(), fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, str(path))
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise StateConflict(f"failed to write {path}: {exc}") from exc
+    return path
+
+
+def hash_inputs(payload: dict) -> str:
+    """SHA256 of a json-canonicalized dict, first 16 hex chars (collision
+    risk is irrelevant here — this is a "did inputs change?" guard).
+    """
+    canon = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]

--- a/scripts/dev/wt_ctl/paths.py
+++ b/scripts/dev/wt_ctl/paths.py
@@ -1,0 +1,115 @@
+"""Worktree resolution + log directory helpers.
+
+Walks up from cwd to a ``.git`` (file=worktree, dir=main repo) and confirms
+the result is a worktree of the main repo. ``Runner`` is required for git
+calls — domain modules never import subprocess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .errors import ExternalCommandFailed, NotInWorktree, WtCtlError
+from .runner import Runner
+
+
+@dataclass
+class WorktreeRefs:
+    """Where we are on disk + the main repo we belong to."""
+
+    worktree_root: Path  # absolute path of the current worktree
+    main_repo_root: Path  # absolute path of the main checkout
+    branch: str  # current branch (or "HEAD" when detached)
+    is_main: bool  # True iff worktree_root == main_repo_root
+
+    @property
+    def branch_dir(self) -> str:
+        """Directory basename — what dc_select_network.sh stores in the
+        registry, what compose normalizes to lowercase as project name.
+        """
+        return self.worktree_root.name
+
+
+def _find_git_anchor(start: Path) -> Optional[Path]:
+    """Walk up looking for a ``.git`` (dir or file). Stop at filesystem root."""
+    cur = start.resolve()
+    while True:
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def resolve_worktree(runner: Runner, cwd: Optional[Path] = None) -> WorktreeRefs:
+    """Resolve the worktree the user is currently inside.
+
+    Raises ``NotInWorktree`` (with a hint that cli.py renders) if cwd is not
+    inside a worktree.
+    """
+    cwd = (cwd or Path.cwd()).resolve()
+    anchor = _find_git_anchor(cwd)
+    if anchor is None:
+        raise NotInWorktree(
+            cwd=str(cwd),
+            hint="run inside a checkout, or use 'wt-ctl status --all' for a global view.",
+        )
+    # Resolve the toplevel for *this* checkout (which may be the worktree
+    # itself, when .git is a file pointing at .git/worktrees/<name>).
+    try:
+        top = runner.run(
+            ["git", "-C", str(anchor), "rev-parse", "--show-toplevel"],
+        ).stdout.strip()
+    except ExternalCommandFailed as exc:
+        raise NotInWorktree(cwd=str(cwd), hint=str(exc)) from exc
+    if not top:
+        raise NotInWorktree(cwd=str(cwd))
+    worktree_root = Path(top).resolve()
+
+    # Find the common dir → tells us the main repo's .git directory location.
+    common_dir = runner.run(
+        ["git", "-C", str(worktree_root), "rev-parse", "--git-common-dir"],
+    ).stdout.strip()
+    common_path = (
+        (worktree_root / common_dir).resolve() if not Path(common_dir).is_absolute() else Path(common_dir).resolve()
+    )
+    main_repo_root = common_path.parent  # `.git` parent → repo root
+
+    # Branch name (HEAD when detached → return literal "HEAD").
+    try:
+        branch = runner.run(
+            ["git", "-C", str(worktree_root), "rev-parse", "--abbrev-ref", "HEAD"],
+        ).stdout.strip()
+    except ExternalCommandFailed:
+        branch = "HEAD"
+
+    return WorktreeRefs(
+        worktree_root=worktree_root,
+        main_repo_root=main_repo_root,
+        branch=branch,
+        is_main=(worktree_root == main_repo_root),
+    )
+
+
+def logs_dir(worktree_root: Path) -> Path:
+    """Setup-phase log directory used by orchestrator scripts."""
+    return worktree_root / "logs" / "setup_worktree"
+
+
+def state_dir(worktree_root: Path) -> Path:
+    """Orchestrator state location (created lazily by `create`).
+
+    Lives under ``.generated/`` alongside the other generated artefacts
+    (``context.env``, ``current.kubeconfig``, …) so the worktree root stays
+    clean and a single gitignore entry covers everything.
+    """
+    return worktree_root / ".generated" / "wt-ctl"
+
+
+def package_root() -> Path:
+    """Absolute path of the wt_ctl package directory (used by the bash shim
+    to set PYTHONPATH).
+    """
+    return Path(__file__).resolve().parent

--- a/scripts/dev/wt_ctl/runner.py
+++ b/scripts/dev/wt_ctl/runner.py
@@ -1,0 +1,298 @@
+"""Subprocess façade. **Only file in the package permitted to import
+``subprocess``** — domain modules receive a ``Runner`` instance.
+
+The lint at ``scripts/test/wt_ctl_lint.py`` enforces this rule.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # noqa: S404 — the single allowed call site (lint excludes runner.py)
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from .errors import ExternalCommandFailed, ParallelPhaseFailures, ToolMissing
+
+
+@dataclass
+class CmdResult:
+    argv: list[str]
+    rc: int
+    stdout: str
+    stderr: str
+    duration_s: float
+
+
+@dataclass
+class Job:
+    name: str
+    argv: list[str]
+    log_path: Optional[Path] = None
+    cwd: Optional[Path] = None
+    env: Optional[dict] = None
+
+
+class Runner:
+    """Wraps subprocess calls.
+
+    ``popen_factory`` / ``which`` are injectable so unit tests can supply fakes
+    without monkey-patching; they default to ``subprocess.Popen`` / ``shutil.which``.
+    """
+
+    def __init__(
+        self,
+        popen_factory: Optional[Callable] = None,
+        which: Optional[Callable[[str], Optional[str]]] = None,
+    ) -> None:
+        self._popen = popen_factory or subprocess.Popen
+        self._which = which or shutil.which
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        check: bool = True,
+        capture: bool = True,
+        env: Optional[dict] = None,
+        cwd: Optional[Path] = None,
+        timeout: Optional[float] = None,
+        input_text: Optional[str] = None,
+    ) -> CmdResult:
+        if not argv:
+            raise ValueError("argv must be non-empty")
+        merged_env = self._merge_env(env)
+        start = time.monotonic()
+        if capture:
+            stdout_arg = subprocess.PIPE
+            stderr_arg = subprocess.PIPE
+        else:
+            stdout_arg = None
+            stderr_arg = None
+        try:
+            proc = self._popen(
+                argv,
+                stdin=subprocess.PIPE if input_text is not None else None,
+                stdout=stdout_arg,
+                stderr=stderr_arg,
+                env=merged_env,
+                cwd=str(cwd) if cwd else None,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise ToolMissing(argv[0], hint=str(exc)) from exc
+        try:
+            stdout, stderr = proc.communicate(input=input_text, timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            raise ExternalCommandFailed(
+                argv=list(argv),
+                rc=proc.returncode if proc.returncode is not None else -1,
+                stdout=stdout or "",
+                stderr=(stderr or "") + f"\n[wt-ctl] timeout after {timeout}s",
+            ) from exc
+        duration = time.monotonic() - start
+        rc = proc.returncode
+        result = CmdResult(
+            argv=list(argv),
+            rc=rc,
+            stdout=stdout or "",
+            stderr=stderr or "",
+            duration_s=duration,
+        )
+        if check and rc != 0:
+            raise ExternalCommandFailed(
+                argv=result.argv,
+                rc=rc,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
+
+    def run_streaming(
+        self,
+        argv: list[str],
+        *,
+        prefix: str = "",
+        log_path: Optional[Path] = None,
+        env: Optional[dict] = None,
+        cwd: Optional[Path] = None,
+    ) -> CmdResult:
+        """Forward stdout+stderr to the parent's stderr (live), optionally
+        tee'd to ``log_path``. Returns CmdResult with empty stdout/stderr.
+        """
+        merged_env = self._merge_env(env)
+        if log_path is not None:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_fh = log_path.open("a")
+        else:
+            log_fh = None
+        start = time.monotonic()
+        try:
+            try:
+                proc = self._popen(
+                    argv,
+                    stdin=None,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    env=merged_env,
+                    cwd=str(cwd) if cwd else None,
+                    text=True,
+                    bufsize=1,
+                )
+            except FileNotFoundError as exc:
+                raise ToolMissing(argv[0], hint=str(exc)) from exc
+            assert proc.stdout is not None
+            tty = sys.stderr.isatty()
+            for line in proc.stdout:
+                out = f"{prefix}{line}" if prefix else line
+                # Tools reading a PTY in raw mode emit bare \n; on a TTY without
+                # ONLCR that staircases. Normalize to CRLF on TTY only — logs stay LF.
+                if tty:
+                    out = out.replace("\r\n", "\n").replace("\n", "\r\n")
+                sys.stderr.write(out)
+                sys.stderr.flush()
+                if log_fh is not None:
+                    log_fh.write(line)
+                    log_fh.flush()
+            proc.wait()
+        finally:
+            if log_fh is not None:
+                log_fh.close()
+        rc = proc.returncode
+        duration = time.monotonic() - start
+        result = CmdResult(argv=list(argv), rc=rc, stdout="", stderr="", duration_s=duration)
+        if rc != 0:
+            raise ExternalCommandFailed(argv=result.argv, rc=rc, stdout="", stderr="")
+        return result
+
+    def run_detached(
+        self,
+        argv: list[str],
+        *,
+        stdout_path: Optional[Path] = None,
+        stderr_path: Optional[Path] = None,
+        env: Optional[dict] = None,
+        cwd: Optional[Path] = None,
+    ) -> int:
+        """Start ``argv`` in the background, fully detached from this process.
+
+        New session so it survives the orchestrator exiting; stdin from
+        /dev/null; stdout/stderr appended to the given paths (opened once when
+        both point at the same path). Returns the PID immediately without
+        waiting for the child to come up — callers should health-check.
+        """
+        if not argv:
+            raise ValueError("argv must be non-empty")
+        merged_env = self._merge_env(env)
+        out_fh = None
+        err_fh = None
+        try:
+            stdin_fh = open(os.devnull, "rb")
+            if stdout_path is not None:
+                stdout_path.parent.mkdir(parents=True, exist_ok=True)
+                out_fh = open(stdout_path, "ab")
+            if stderr_path is not None:
+                if stderr_path == stdout_path and out_fh is not None:
+                    err_fh = out_fh
+                else:
+                    stderr_path.parent.mkdir(parents=True, exist_ok=True)
+                    err_fh = open(stderr_path, "ab")
+            try:
+                proc = self._popen(
+                    argv,
+                    stdin=stdin_fh,
+                    stdout=out_fh if out_fh is not None else subprocess.DEVNULL,
+                    stderr=err_fh if err_fh is not None else subprocess.DEVNULL,
+                    env=merged_env,
+                    cwd=str(cwd) if cwd else None,
+                    start_new_session=True,
+                    close_fds=True,
+                )
+            except FileNotFoundError as exc:
+                raise ToolMissing(argv[0], hint=str(exc)) from exc
+            return proc.pid
+        finally:
+            # Close the parent's FD copies; the child has its own from Popen.
+            try:
+                stdin_fh.close()
+            except (OSError, NameError):
+                pass
+            try:
+                if out_fh is not None:
+                    out_fh.close()
+            except OSError:
+                pass
+            if err_fh is not None and err_fh is not out_fh:
+                try:
+                    err_fh.close()
+                except OSError:
+                    pass
+
+    def exec_replace(
+        self,
+        argv: list[str],
+        *,
+        env: Optional[dict] = None,
+        cwd: Optional[Path] = None,
+    ) -> None:
+        """Replace the current process with ``argv`` — never returns."""
+        if not argv:
+            raise ValueError("argv must be non-empty")
+        merged_env = self._merge_env(env)
+        if cwd is not None:
+            os.chdir(str(cwd))
+        path = self._which(argv[0])
+        if path is None:
+            raise ToolMissing(argv[0])
+        os.execvpe(path, argv, merged_env or os.environ.copy())
+
+    def run_parallel(self, jobs: list[Job]) -> dict[str, CmdResult]:
+        """Run jobs concurrently, aggregating failures into
+        ``ParallelPhaseFailures``.
+        """
+        results: dict[str, CmdResult] = {}
+        failures: dict[str, ExternalCommandFailed] = {}
+        lock = threading.Lock()
+
+        def _one(job: Job) -> None:
+            try:
+                if job.log_path is not None:
+                    res = self.run_streaming(
+                        job.argv,
+                        prefix=f"[{job.name}] ",
+                        log_path=job.log_path,
+                        env=job.env,
+                        cwd=job.cwd,
+                    )
+                else:
+                    res = self.run(job.argv, env=job.env, cwd=job.cwd)
+                with lock:
+                    results[job.name] = res
+            except ExternalCommandFailed as failure:
+                with lock:
+                    failures[job.name] = failure
+
+        if not jobs:
+            return results
+        with ThreadPoolExecutor(max_workers=max(1, len(jobs))) as pool:
+            list(pool.map(_one, jobs))
+        if failures:
+            raise ParallelPhaseFailures(failures=failures)
+        return results
+
+    def have(self, tool: str) -> bool:
+        return self._which(tool) is not None
+
+    def _merge_env(self, env: Optional[dict]) -> Optional[dict]:
+        if env is None:
+            return None
+        merged = os.environ.copy()
+        merged.update({k: str(v) for k, v in env.items()})
+        return merged

--- a/scripts/dev/wt_ctl/runner.py
+++ b/scripts/dev/wt_ctl/runner.py
@@ -10,14 +10,12 @@ import os
 import shutil
 import subprocess  # noqa: S404 — the single allowed call site (lint excludes runner.py)
 import sys
-import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
-from .errors import ExternalCommandFailed, ParallelPhaseFailures, ToolMissing
+from .errors import ExternalCommandFailed, ToolMissing
 
 
 @dataclass
@@ -27,15 +25,6 @@ class CmdResult:
     stdout: str
     stderr: str
     duration_s: float
-
-
-@dataclass
-class Job:
-    name: str
-    argv: list[str]
-    log_path: Optional[Path] = None
-    cwd: Optional[Path] = None
-    env: Optional[dict] = None
 
 
 class Runner:
@@ -252,40 +241,6 @@ class Runner:
         if path is None:
             raise ToolMissing(argv[0])
         os.execvpe(path, argv, merged_env or os.environ.copy())
-
-    def run_parallel(self, jobs: list[Job]) -> dict[str, CmdResult]:
-        """Run jobs concurrently, aggregating failures into
-        ``ParallelPhaseFailures``.
-        """
-        results: dict[str, CmdResult] = {}
-        failures: dict[str, ExternalCommandFailed] = {}
-        lock = threading.Lock()
-
-        def _one(job: Job) -> None:
-            try:
-                if job.log_path is not None:
-                    res = self.run_streaming(
-                        job.argv,
-                        prefix=f"[{job.name}] ",
-                        log_path=job.log_path,
-                        env=job.env,
-                        cwd=job.cwd,
-                    )
-                else:
-                    res = self.run(job.argv, env=job.env, cwd=job.cwd)
-                with lock:
-                    results[job.name] = res
-            except ExternalCommandFailed as failure:
-                with lock:
-                    failures[job.name] = failure
-
-        if not jobs:
-            return results
-        with ThreadPoolExecutor(max_workers=max(1, len(jobs))) as pool:
-            list(pool.map(_one, jobs))
-        if failures:
-            raise ParallelPhaseFailures(failures=failures)
-        return results
 
     def have(self, tool: str) -> bool:
         return self._which(tool) is not None

--- a/scripts/dev/wt_ctl/state.py
+++ b/scripts/dev/wt_ctl/state.py
@@ -1,0 +1,135 @@
+"""Pure dataclasses describing the snapshot of state that ``display`` renders.
+
+No subprocess, no IO. Domain modules build these and hand them off.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class GitState:
+    branch: str
+    clean: bool
+    ahead: int
+    behind: int
+    upstream: Optional[str]
+
+
+@dataclass
+class DevcState:
+    """Devcontainer compose stack."""
+
+    project: str
+    state: str  # running | exited | -
+    services_running: int
+    services_total: int
+    image_age: Optional[str]  # human "2h" | None
+
+
+@dataclass
+class NetEntry:
+    """One row from dc_select_network.sh --list / registry."""
+
+    branch_dir: str
+    prefix: int
+    status: str  # active | stale
+    worktree_path: Optional[str]
+
+
+@dataclass
+class NetState:
+    prefix: Optional[int]  # this worktree's prefix (None when not allocated)
+    subnet: Optional[str]
+    namespace: Optional[str]
+    gost_proxy: Optional[str]
+    registered: bool
+    orphans: int  # count of stale registry entries elsewhere
+
+
+@dataclass
+class EvgHostState:
+    name: Optional[str]
+    id: Optional[str]
+    status: Optional[str]  # running | terminated | terminating | …
+    host_name: Optional[str]  # ec2-… DNS
+    expires_in: Optional[str]  # human "3h12m" | None
+    ssh: Optional[str]
+    # Parallel to expires_in so hint logic needn't re-parse the human string.
+    # Negative when already expired; None when unknown.
+    expires_seconds: Optional[int] = None
+
+
+@dataclass
+class KubeconfigState:
+    path: Optional[str]
+    last_patch: Optional[str]  # human age
+    kfp_registered: Optional[bool]
+
+
+@dataclass
+class KfpHostState:
+    """On-host kube-forwarding-proxy daemon snapshot.
+
+    PID is owned by launchd and not surfaced here; only liveness signals.
+    """
+
+    listening: bool
+    health: Optional[str]  # "ok" when /healthz is happy
+    http_endpoint: str  # "127.0.0.1:11616"
+
+
+@dataclass
+class OmState:
+    namespace: Optional[str]
+    project_count: Optional[int]
+    scope: Optional[str]
+
+
+@dataclass
+class WorktreeStatus:
+    """Everything `wt-ctl status` (current worktree) renders."""
+
+    worktree_dir: str
+    worktree_path: str
+    git: GitState
+    context: Optional[str]
+    devc: Optional[DevcState]
+    network: NetState
+    evg: Optional[EvgHostState]
+    kubeconfig: Optional[KubeconfigState]
+    om: Optional[OmState]
+    kfp: Optional[KfpHostState] = None
+    next_hints: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WorktreeRow:
+    """One line in `status --all`."""
+
+    worktree: str
+    branch: str
+    prefix: Optional[int]
+    namespace: Optional[str]
+    devc_state: str
+    evg_name: Optional[str]
+    evg_status: Optional[str]
+    evg_expires: Optional[str]
+    prunable: bool = False
+    prunable_reason: Optional[str] = None
+    delete_cmd: Optional[str] = None
+
+
+@dataclass
+class OrphanRegistration:
+    branch_dir: str
+    prefix: int
+    release_cmd: str
+
+
+@dataclass
+class GlobalStatus:
+    rows: list[WorktreeRow]
+    orphans: list[OrphanRegistration]

--- a/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
+++ b/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
@@ -172,7 +172,11 @@ rm -rf logs && mkdir -p logs
 header "wt-ctl create --local-kind --in-place ${TOPOLOGY_FLAG} (context=${CONTEXT})"
 # --in-place: the CI patch diff is uncommitted in this checkout; a fresh git
 # worktree would check out committed history only and miss it.
-scripts/dev/wt-ctl create --local-kind --in-place "${TOPOLOGY_FLAG}" --context "${CONTEXT}" "${WT_NAME}"
+# --cluster-name kind: the e2e contexts hardcode CLUSTER_NAME=kind-kind, so the
+# single-cluster kind cluster must be named `kind` (context kind-kind) or the
+# kubeconfig's pinned current-context dangles. Ignored on --multi-cluster
+# (recreate_kind_clusters.sh names its own clusters).
+scripts/dev/wt-ctl create --local-kind --in-place "${TOPOLOGY_FLAG}" --cluster-name kind --context "${CONTEXT}" "${WT_NAME}"
 
 # Cloud-QA org + API key: standard cloud_qa e2e tasks run setup_cloud_qa (via
 # the `setup_cloud_qa` EVG function) to provision a scoped programmatic key and

--- a/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
+++ b/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
@@ -82,6 +82,24 @@ if [[ -z "${OVERRIDE_VERSION_ID:-}" ]]; then
   export DATABASE_VERSION=latest INIT_DATABASE_VERSION=latest INIT_OPS_MANAGER_VERSION=latest
 fi
 
+# These pins must also reach the container: wt-ctl runs make switch inside the
+# devcontainer, which re-sources evg-private-context. With no pin, its staging
+# branch defaults OPERATOR_VERSION to `git rev-parse --short=8 HEAD` (and
+# root-context cascades that onto INIT_DATABASE_VERSION), so pods try to pull
+# staging/...:<commit-sha> — an image this variant never builds
+# (ImagePullBackOff). The container only inherits vars written into
+# compose.user.yml, so collect the ones to forward here.
+DEVC_ENV_FORWARD=(
+  "BUILD_SCENARIO=${BUILD_SCENARIO:-}"
+  "OVERRIDE_VERSION_ID=${OVERRIDE_VERSION_ID:-}"
+  "OPERATOR_VERSION=${OPERATOR_VERSION:-}"
+  "READINESS_PROBE_VERSION=${READINESS_PROBE_VERSION:-}"
+  "VERSION_UPGRADE_HOOK_VERSION=${VERSION_UPGRADE_HOOK_VERSION:-}"
+  "DATABASE_VERSION=${DATABASE_VERSION:-}"
+  "INIT_DATABASE_VERSION=${INIT_DATABASE_VERSION:-}"
+  "INIT_OPS_MANAGER_VERSION=${INIT_OPS_MANAGER_VERSION:-}"
+)
+
 # A bare EVG task host has no kind/kubectl/helm; setup_evg_host.sh installs
 # them (and raises inotify/file limits kind needs). Idempotent to re-run.
 command -v kind >/dev/null || { header "setup_evg_host.sh (kind/kubectl/helm)"; scripts/dev/setup_evg_host.sh; }
@@ -158,13 +176,24 @@ fi
 # EVG host's outbound to sum.golang.org (the checksum DB) is blocked, so go's
 # module verification fails ("open /go/pkg/sumdb/.../latest: no such file").
 # Disabling the sumdb skips that verification (fine for throwaway CI).
-cat >.devcontainer/compose.user.yml <<YAML
+{
+  cat <<YAML
 services:
   devcontainer:
     environment:
       EVR_TASK_ID: "${EVR_TASK_ID:-}"
       GOSUMDB: "off"
 YAML
+  # Forward the image-version pins so the container's make switch keeps them
+  # (evg-private-context/root-context respect a pre-set value via `${var:-…}`)
+  # instead of falling back to the commit-sha staging tag. Skip empties so an
+  # unset pin still uses the context defaults.
+  for kv in "${DEVC_ENV_FORWARD[@]}"; do
+    v="${kv#*=}"
+    [[ -z "${v}" ]] && continue
+    printf '      %s: "%s"\n' "${kv%%=*}" "${v}"
+  done
+} >.devcontainer/compose.user.yml
 
 # Fresh artifact dir per task: under --in-place the worktree root is this
 # checkout, so wt-ctl phase logs, test logs and gathered diagnostics all land in

--- a/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
+++ b/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
@@ -41,6 +41,10 @@ for d in /opt/golang/go*/bin; do [[ -d "${d}" ]] && PATH="${d}:${PATH}"; done
 export PATH
 command -v go >/dev/null || { echo "go not on PATH (expected under /opt/golang)"; exit 1; }
 
+# Pin the devcontainer CLI so a new npm release can't break CI without a repo
+# change; bump deliberately.
+DEVCONTAINER_CLI_VERSION="0.87.0"
+
 # The devcontainer CLI needs Node >=18. EVG distros vary wildly (2204 ships
 # v24, 2404 ships v8) and /opt is root-owned, so we pick the newest usable
 # /opt Node and otherwise install a modern one under $HOME. The CLI itself
@@ -63,7 +67,7 @@ fi
 export PATH
 if ! command -v devcontainer >/dev/null; then
   npm config set prefix "${HOME}/.npm-global"
-  npm i -g @devcontainers/cli
+  npm i -g "@devcontainers/cli@${DEVCONTAINER_CLI_VERSION}"
   PATH="${HOME}/.npm-global/bin:${PATH}"; export PATH
 fi
 

--- a/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
+++ b/scripts/evergreen/e2e/devcontainer_local_kind_e2e.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+
+# On-host e2e: drive the wt-ctl --local-kind flow directly on the EVG task
+# host. kind runs on the task host, the operator runs as `go run ./main.go`
+# and the tests run as pytest — both inside the devcontainer. No operator /
+# init / database images are built: everything resolves to the :latest ECR
+# tags (OVERRIDE_VERSION_ID is intentionally unset), so this variant carries
+# no build_*_image dependencies.
+
+set -Eeou pipefail
+
+source scripts/funcs/printing
+
+# wt-ctl streams per-phase output to logs/<phase>.log; parallel phases
+# (evg_prepare + dc_build) don't all echo to stdout, and these logs aren't
+# uploaded as task artifacts. On any failure, surface the tails so the EVG
+# task log alone is enough to diagnose.
+# shellcheck disable=SC2317  # body runs via the EXIT trap, not inline.
+dump_logs_on_error() {
+  local rc=$?
+  [[ ${rc} -eq 0 ]] && return 0
+  header "FAILURE (rc=${rc}) - dumping wt-ctl phase logs"
+  while IFS= read -r f; do
+    echo "===== tail -n 120 ${f} ====="
+    tail -n 120 "${f}"
+  done < <(find . -path ./.git -prune -o -type f -path '*/logs/*.log' -print 2>/dev/null | sort)
+  return "${rc}"
+}
+trap dump_logs_on_error EXIT
+
+# Marker to run: task-level e2e_marker expansion, else the task name (the
+# native e2e.sh convention where TASK_NAME == pytest marker).
+MARKER="${e2e_marker:-${TASK_NAME:?e2e_marker or TASK_NAME required}}"
+CONTEXT="${e2e_context:-e2e_multi_cluster_kind}"
+# Worktree/branch name doubles as the single-cluster kind cluster name, which
+# must match ^[a-z0-9.-]+$ — markers carry underscores, so map them to dashes.
+WT_NAME="${e2e_wt_name:-onhost-${MARKER//_/-}}"
+
+# Go ships under /opt on EVG distros.
+for d in /opt/golang/go*/bin; do [[ -d "${d}" ]] && PATH="${d}:${PATH}"; done
+export PATH
+command -v go >/dev/null || { echo "go not on PATH (expected under /opt/golang)"; exit 1; }
+
+# The devcontainer CLI needs Node >=18. EVG distros vary wildly (2204 ships
+# v24, 2404 ships v8) and /opt is root-owned, so we pick the newest usable
+# /opt Node and otherwise install a modern one under $HOME. The CLI itself
+# goes to a writable npm prefix to dodge EACCES on /opt.
+node_bin="" node_major=0
+for b in /opt/nodejs/node-v*/bin; do
+  [[ -x "${b}/node" ]] || continue
+  v="$("${b}/node" -e 'process.stdout.write(process.versions.node.split(".")[0])' 2>/dev/null)" || continue
+  if [[ "${v}" =~ ^[0-9]+$ ]] && (( v > node_major )); then node_major="${v}"; node_bin="${b}"; fi
+done
+if [[ -n "${node_bin}" && "${node_major}" -ge 18 ]]; then
+  PATH="${node_bin}:${PATH}"
+else
+  header "installing local Node (task-host Node too old: v${node_major})"
+  node_ver="v22.14.0"; case "$(uname -m)" in x86_64) na="x64";; aarch64|arm64) na="arm64";; *) na="x64";; esac
+  dest="${HOME}/.local/node"; mkdir -p "${dest}"
+  curl -fsSL "https://nodejs.org/dist/${node_ver}/node-${node_ver}-linux-${na}.tar.xz" | tar -xJ -C "${dest}" --strip-components=1
+  PATH="${dest}/bin:${PATH}"
+fi
+export PATH
+if ! command -v devcontainer >/dev/null; then
+  npm config set prefix "${HOME}/.npm-global"
+  npm i -g @devcontainers/cli
+  PATH="${HOME}/.npm-global/bin:${PATH}"; export PATH
+fi
+
+# This variant builds no images. By default use staging :latest (as the
+# validated dev-host run did) rather than the per-patch tags the patch build
+# scenario would force. But if OVERRIDE_VERSION_ID pins a specific build,
+# honor it — root-context maps it onto every image tag — and don't force
+# latest/staging over it.
+if [[ -z "${OVERRIDE_VERSION_ID:-}" ]]; then
+  export BUILD_SCENARIO=staging
+  export OPERATOR_VERSION=latest READINESS_PROBE_VERSION=latest VERSION_UPGRADE_HOOK_VERSION=latest
+  export DATABASE_VERSION=latest INIT_DATABASE_VERSION=latest INIT_OPS_MANAGER_VERSION=latest
+fi
+
+# A bare EVG task host has no kind/kubectl/helm; setup_evg_host.sh installs
+# them (and raises inotify/file limits kind needs). Idempotent to re-run.
+command -v kind >/dev/null || { header "setup_evg_host.sh (kind/kubectl/helm)"; scripts/dev/setup_evg_host.sh; }
+
+# Topology and cloud_qa vs OM-in-cluster are properties of the context, not
+# separate task vars. Switch to it and source the generated env so the context's
+# variables are available here directly: a multi-cluster context exports
+# KUBE_ENVIRONMENT_NAME=multi; a cloud_qa context exports
+# ops_manager_version=cloud_qa (OM contexts export a concrete OM version and
+# must NOT run setup_cloud_qa). The host has the EVG expansions private-context
+# reads, so the switch resolves here; wt-ctl re-switches inside the container.
+header "switching to context ${CONTEXT}"
+make switch context="${CONTEXT}" >/dev/null
+# shellcheck disable=SC1091
+source scripts/dev/set_env_context.sh
+
+TOPOLOGY_FLAG="--single-cluster"
+[[ "${KUBE_ENVIRONMENT_NAME:-kind}" == "multi" ]] && TOPOLOGY_FLAG="--multi-cluster"
+CLOUD_QA="false"
+[[ "${ops_manager_version:-}" == "cloud_qa" ]] && CLOUD_QA="true"
+echo "context ${CONTEXT}: KUBE_ENVIRONMENT_NAME=${KUBE_ENVIRONMENT_NAME:-kind} ops_manager_version=${ops_manager_version:-} -> ${TOPOLOGY_FLAG}, cloud_qa=${CLOUD_QA}"
+
+# recreate_kind_clusters.sh (run by wt-ctl evg_prepare in local-kind mode)
+# handles ECR login via configure_container_auth.sh, so image pulls of the
+# :latest tags are already authenticated.
+
+# `make switch` runs inside the devcontainer (devcontainer.json onCreate, and
+# again in wt-ctl's kubeconfig phase), sourcing private-context (the copied
+# evg-private-context) which reads these EVG expansions under `set -u`. The
+# host shell has them but the container does not. private-context is
+# bind-mounted (/workspace), so resolve the expansions to literal exports in
+# the file itself — the container then sources concrete values, no env
+# injection. Prepending keeps the existing `${var}` references satisfied and
+# the host make switch (which already has the expansions) still works.
+pc="scripts/dev/contexts/private-context"
+if [[ -f "${pc}" ]]; then
+  header "resolving EVG cred expansions into private-context"
+  # The external inputs private-context reads with no `set -u` default. Only
+  # host-agnostic values: the credential expansions plus EVR_TASK_ID. NOT
+  # workdir — it's a host path (/data/mci/...) invalid inside the container,
+  # which supplies its own valid workdir.
+  { for v in EVR_TASK_ID \
+             mms_eng_test_aws_access_key mms_eng_test_aws_secret mms_eng_test_aws_region \
+             e2e_cloud_qa_apikey_owner_ubi_cloudqa e2e_cloud_qa_orgid_owner_ubi_cloudqa \
+             e2e_cloud_qa_user_owner_ubi_cloudqa \
+             cognito_user_name cognito_user_password cognito_user_pool_id \
+             cognito_workload_federation_client_id cognito_workload_federation_client_secret \
+             cognito_workload_url cognito_workload_user_id \
+             community_private_preview_pullsecret_dockerconfigjson; do
+      printf 'export %s=%q\n' "${v}" "${!v:-}"
+    done
+    cat "${pc}"
+    # Container-only overrides for evg-private-context's CI-pod-oriented values
+    # (host keeps its own — /.dockerenv is absent there):
+    #  - GOROOT: the hardcoded /opt/golang/... is a host path, invalid in the
+    #    container (which has its own go with a correct built-in GOROOT).
+    #  - LOCAL_OPERATOR=true: this flow runs the operator locally via `go run`,
+    #    so prepare-local-e2e must run the multi-cluster kube-config creator
+    #    (which builds the operator member-list ConfigMap); it's skipped when
+    #    LOCAL_OPERATOR=false (the deployed-pod CI default).
+    echo 'if [ -f /.dockerenv ]; then unset GOROOT; export LOCAL_OPERATOR=true; fi'
+  } >"${pc}.resolved"
+  mv "${pc}.resolved" "${pc}"
+fi
+
+# switch_context.sh branches on EVR_TASK_ID: when set it sources the context
+# chain directly (correct for CI); when unset it captures the chain's stdout
+# and `eval`s it, so private-context's diagnostic echoes become bogus commands
+# ("generating: command not found"). The container doesn't inherit EVR_TASK_ID,
+# so forward it via a compose.user.yml environment override (reliable, same
+# mechanism as MCK_DEVC_NET_PREFIX). It's an opaque id, YAML-safe unquoted.
+# create_if_not_exists in initialize.sh won't clobber this pre-written file.
+# GOSUMDB=off: modules download fine via GOPROXY inside the container, but the
+# EVG host's outbound to sum.golang.org (the checksum DB) is blocked, so go's
+# module verification fails ("open /go/pkg/sumdb/.../latest: no such file").
+# Disabling the sumdb skips that verification (fine for throwaway CI).
+cat >.devcontainer/compose.user.yml <<YAML
+services:
+  devcontainer:
+    environment:
+      EVR_TASK_ID: "${EVR_TASK_ID:-}"
+      GOSUMDB: "off"
+YAML
+
+# Fresh artifact dir per task: under --in-place the worktree root is this
+# checkout, so wt-ctl phase logs, test logs and gathered diagnostics all land in
+# ./logs — which upload_e2e_logs archives to logs/${task_id}/${execution}/. On a
+# task-group host shared across tasks, clear stale files so they aren't
+# re-uploaded under the wrong task_id.
+rm -rf logs && mkdir -p logs
+
+header "wt-ctl create --local-kind --in-place ${TOPOLOGY_FLAG} (context=${CONTEXT})"
+# --in-place: the CI patch diff is uncommitted in this checkout; a fresh git
+# worktree would check out committed history only and miss it.
+scripts/dev/wt-ctl create --local-kind --in-place "${TOPOLOGY_FLAG}" --context "${CONTEXT}" "${WT_NAME}"
+
+# Cloud-QA org + API key: standard cloud_qa e2e tasks run setup_cloud_qa (via
+# the `setup_cloud_qa` EVG function) to provision a scoped programmatic key and
+# write OM_* into $ENV_FILE, which evg-private-context sources. We can't run it
+# on the bare host (run_python.sh needs the in-container venv), so provision
+# inside the container — it has the venv, requests, cloud-qa reachability, and
+# the owner creds in context.env. ENV_FILE resolves to /workspace/.ops-manager-env
+# (container workdir=/workspace). Then re-run prepare-local-e2e so
+# configure_operator creates the my-credentials secret now that OM_* are set
+# (the first create-phase run skipped it: OM_USER/OM_API_KEY were unset).
+# OM-in-cluster contexts skip this entirely — the test deploys Ops Manager.
+if [[ "${CLOUD_QA}" == "true" ]]; then
+  header "provisioning cloud-qa org api key (setup_cloud_qa create)"
+  scripts/dev/wt-ctl attach -- bash -lc \
+    'export ops_manager_version=cloud_qa; scripts/dev/run_python.sh scripts/evergreen/e2e/setup_cloud_qa.py create'
+
+  header "re-running prepare-local-e2e with OM credentials"
+  scripts/dev/wt-ctl attach -- bash -lc "set -Eeuo pipefail; make switch context='${CONTEXT}'; make prepare-local-e2e"
+fi
+
+header "starting operator (go run) in devcontainer"
+scripts/dev/wt-ctl attach -- bash scripts/dev/op_run.sh --detach
+
+# All wt-ctl phases have succeeded by here; drop the phase-log dump trap so a
+# plain test failure doesn't spam wt-ctl phase logs (diagnostics come from the
+# gather step below instead).
+trap - EXIT
+
+# Run the test, but capture its status instead of aborting: diagnostics must be
+# gathered on failure (mirroring CI e2e.sh) so upload_e2e_logs archives the same
+# artifact set to S3. Gather runs inside the container while kind is still up.
+header "running e2e marker: ${MARKER}"
+set +e
+scripts/dev/wt-ctl attach -- bash scripts/dev/e2e_run.sh "${MARKER}"
+test_rc=$?
+set -e
+
+header "gathering diagnostics (rc=${test_rc})"
+scripts/dev/wt-ctl attach -- bash -lc \
+  "scripts/dev/e2e_gather_diagnostics.sh ${test_rc} '${MARKER}' '${build_variant:-e2e_mck_devcontainer_local_kind}'" || true
+
+exit "${test_rc}"

--- a/scripts/evergreen/e2e/diagnostics.sh
+++ b/scripts/evergreen/e2e/diagnostics.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Post-run diagnostics shared by the CI e2e.sh and the on-host devcontainer
+# e2e_gather_diagnostics.sh: dump per-cluster diagnostics and render the HTML
+# test summary. Callers must source scripts/evergreen/e2e/dump_diagnostic_information.sh
+# (for dump_all) before calling these.
+
+# Dump diagnostics for every cluster in scope. Multi reads CENTRAL_CLUSTER +
+# MEMBER_CLUSTERS; single uses the current kube context.
+dump_cluster_information() {
+  # TODO: ensure cluster name is included in log files so there is no overwriting of cross cluster files.
+  # shellcheck disable=SC2154
+  if [[ "${KUBE_ENVIRONMENT_NAME:-}" = "multi" ]]; then
+    echo "Dumping diagnostics for context ${CENTRAL_CLUSTER}"
+    dump_all "${CENTRAL_CLUSTER}" || true
+
+    for member_cluster in ${MEMBER_CLUSTERS}; do
+      echo "Dumping diagnostics for context ${member_cluster}"
+      dump_all "${member_cluster}" || true
+    done
+  else
+    dump_all "$(kubectl config current-context)" || true
+  fi
+}
+
+# Render the HTML test summary. Fails silently so it never breaks the pipeline.
+# The '!' output prefix sorts it to the top of Evergreen's file list.
+# Usage: generate_test_summary <PASSED|FAILED> <test_name> <variant>
+generate_test_summary() {
+  local test_status="$1" test_name="$2" variant="$3"
+  echo "Generating test summary..."
+  if python3 scripts/evergreen/e2e/test_summary/generate_test_summary.py \
+    logs \
+    --output "logs/!test-summary.html" \
+    --test-name "${test_name}" \
+    --variant "${variant}" \
+    --status "${test_status}" 2>&1 | tee logs/summary_generation.log; then
+    echo "Test summary generated: logs/!test-summary.html"
+  else
+    echo "Warning: Failed to generate test summary (continuing anyway)"
+  fi
+}

--- a/scripts/evergreen/e2e/e2e.sh
+++ b/scripts/evergreen/e2e/e2e.sh
@@ -7,6 +7,7 @@ source scripts/funcs/checks
 source scripts/funcs/kubernetes
 source scripts/funcs/printing
 source scripts/evergreen/e2e/dump_diagnostic_information.sh
+source scripts/evergreen/e2e/diagnostics.sh
 source scripts/evergreen/e2e/lib.sh
 source scripts/dev/set_env_context.sh
 
@@ -26,24 +27,6 @@ run_e2e_mco_tests() {
   set -e
 
   return ${test_results}
-}
-
-dump_cluster_information() {
-  # Dump information from all clusters.
-  # TODO: ensure cluster name is included in log files so there is no overwriting of cross cluster files.
-  # shellcheck disable=SC2154
-  if [[ "${KUBE_ENVIRONMENT_NAME:-}" = "multi" ]]; then
-    echo "Dumping diagnostics for context ${CENTRAL_CLUSTER}"
-    dump_all "${CENTRAL_CLUSTER}" || true
-
-    for member_cluster in ${MEMBER_CLUSTERS}; do
-      echo "Dumping diagnostics for context ${member_cluster}"
-      dump_all "${member_cluster}" || true
-    done
-  else
-    # Dump all the information we can from this namespace
-    dump_all "$(kubectl config current-context)" || true
-  fi
 }
 
 cleanup_openshift_cluster(){
@@ -185,32 +168,13 @@ fi
 
 dump_cluster_information
 
-# Generate comprehensive test summary (fail silently if script fails)
-generate_test_summary() {
-  echo "Generating test summary..."
-
-  # Determine test status
-  local test_status="FAILED"
-  if [[ "${TEST_RESULTS}" -eq 0 ]]; then
-    test_status="PASSED"
-  fi
-
-  # Run the test summary generator (fail silently to not break the pipeline)
-  # The output file name starts with '!' to appear at top of file list in Evergreen
-  if python3 scripts/evergreen/e2e/test_summary/generate_test_summary.py \
-    logs \
-    --output "logs/!test-summary.html" \
-    --test-name "${task_name:-${TEST_NAME:-unknown}}" \
-    --variant "${build_variant:-unknown}" \
-    --status "${test_status}" 2>&1 | tee logs/summary_generation.log; then
-    echo "✅ Test summary generated: logs/!test-summary.html"
-  else
-    echo "⚠️  Warning: Failed to generate test summary (continuing anyway)"
-  fi
-}
-
-# Generate test summary (will fail silently if there's an error)
-generate_test_summary || true
+# Generate test summary (fails silently so it never breaks the pipeline).
+e2e_test_status="FAILED"
+[[ "${TEST_RESULTS}" -eq 0 ]] && e2e_test_status="PASSED"
+generate_test_summary \
+  "${e2e_test_status}" \
+  "${task_name:-${TEST_NAME:-unknown}}" \
+  "${build_variant:-unknown}" || true
 
 # We only have static clusters in OpenShift; otherwise, there's no need to mark and clean them up here.
 if [[ "${KUBE_ENVIRONMENT_NAME}" == *openshift* ]]; then

--- a/scripts/funcs/kind_network
+++ b/scripts/funcs/kind_network
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Single source of truth for the kind docker network subnet and the
+# per-cluster MetalLB IP ranges.
+#
+# Defaults to kind's own 172.18.0.0/16 subnet. Override by setting
+# KIND_NETWORK_SUBNET in the environment (or context) before sourcing this file.
+#
+# Conventions (10-IP-wide slots within ${PREFIX}.255.0/24):
+#   .200-.209  kind-e2e-operator (and the single 'kind' cluster)
+#   .210-.219  kind-e2e-cluster-1
+#   .220-.229  kind-e2e-cluster-2
+#   .230-.239  kind-e2e-cluster-3
+#   .200-.250  single 'kind' cluster (uses the full lower half)
+#
+# Sourcing this file is idempotent.
+
+# Allow KIND_NETWORK_SUBNET to be set externally; default to kind's subnet.
+export KIND_NETWORK_SUBNET="${KIND_NETWORK_SUBNET:-172.18.0.0/16}"
+
+# Extract the leading two octets ("172.18" by default).
+KIND_NETWORK_PREFIX="$(printf '%s' "${KIND_NETWORK_SUBNET}" | awk -F'.' '{print $1"."$2}')"
+export KIND_NETWORK_PREFIX
+
+# Helper: IP within the metallb row at offset N.
+# kind_lb_ip <cluster_slot> <offset>
+#   cluster_slot ∈ {200,210,220,230}
+#   offset       ∈ {0..9}
+kind_lb_ip() {
+  local slot="$1" offset="$2"
+  printf '%s.255.%d' "${KIND_NETWORK_PREFIX}" "$((slot + offset))"
+}
+
+# Per-cluster metallb ranges as "<from>-<to>" strings (the format
+# setup_kind_cluster.sh -l expects).
+export KIND_METALLB_RANGE_OPERATOR="$(kind_lb_ip 200 0)-$(kind_lb_ip 200 10)"
+export KIND_METALLB_RANGE_CLUSTER_1="$(kind_lb_ip 210 0)-$(kind_lb_ip 210 10)"
+export KIND_METALLB_RANGE_CLUSTER_2="$(kind_lb_ip 220 0)-$(kind_lb_ip 220 10)"
+export KIND_METALLB_RANGE_CLUSTER_3="$(kind_lb_ip 230 0)-$(kind_lb_ip 230 10)"
+# Single 'kind' cluster uses the full lower half (.200-.250).
+export KIND_METALLB_RANGE_SINGLE="$(kind_lb_ip 200 0)-$(kind_lb_ip 200 50)"

--- a/scripts/funcs/kubernetes
+++ b/scripts/funcs/kubernetes
@@ -139,11 +139,6 @@ create_image_registries_secret() {
       echo "Using Docker config: ${config_file}"
     fi
 
-    if kubectl --context "${context}" get secret "${secret_name}" -n "${namespace}" &>/dev/null; then
-      echo "${context}: Secret ${namespace}/${secret_name} already exists, skipping"
-      return
-    fi
-
     # shellcheck disable=SC2154
     if kubectl --context "${context}" get namespace "${namespace}"; then
       echo "${context}: Applying ${namespace}/${secret_name} pull secret"
@@ -287,11 +282,13 @@ docker_run_local_registry() {
 
 docker_create_kind_network() {
   # We create docker network primarily so that all kind clusters use the same network.
-  # We hardcode 172.18/16 subnet in few places, so we must ensure the network uses that subnet:
-  #   - we set IP ranges for MetalLB
-  #   - we write into coredns config map with IP used for exposing pods externally and for no-mesh test
-  # In case of any errors, verify if any other subnet is not already using that subnet.
-  docker network create --subnet=172.18.0.0/16 kind || true
+  # The subnet must match KIND_NETWORK_SUBNET in scripts/funcs/kind_network — it
+  # drives the MetalLB IP ranges and the IPs the no-mesh tests assume. Override
+  # KIND_NETWORK_SUBNET in the context to use a different /16; the bash scripts
+  # and the Python test fixtures both derive their addresses from the same var.
+  # shellcheck source=scripts/funcs/kind_network
+  source "$(dirname "${BASH_SOURCE[0]}")/kind_network"
+  docker network create --subnet="${KIND_NETWORK_SUBNET}" kind || true
 }
 
 docker_network_connect_to_kind() {

--- a/scripts/funcs/kubernetes
+++ b/scripts/funcs/kubernetes
@@ -288,7 +288,22 @@ docker_create_kind_network() {
   # and the Python test fixtures both derive their addresses from the same var.
   # shellcheck source=scripts/funcs/kind_network
   source "$(dirname "${BASH_SOURCE[0]}")/kind_network"
-  docker network create --subnet="${KIND_NETWORK_SUBNET}" kind || true
+  if docker network inspect kind >/dev/null 2>&1; then
+    # A pre-existing 'kind' net with a different subnet silently breaks the
+    # MetalLB ranges derived from KIND_NETWORK_SUBNET — fail loudly instead.
+    local existing
+    existing="$(docker network inspect -f '{{range .IPAM.Config}}{{.Subnet}} {{end}}' kind 2>/dev/null)"
+    case " ${existing} " in
+      *" ${KIND_NETWORK_SUBNET} "*) : ;;
+      *)
+        echo "ERROR: docker network 'kind' exists with subnet(s) '${existing% }' but KIND_NETWORK_SUBNET=${KIND_NETWORK_SUBNET}." >&2
+        echo "       Remove it (docker network rm kind) or align KIND_NETWORK_SUBNET." >&2
+        return 1
+        ;;
+    esac
+  else
+    docker network create --subnet="${KIND_NETWORK_SUBNET}" kind
+  fi
 }
 
 docker_network_connect_to_kind() {

--- a/scripts/funcs/multicluster
+++ b/scripts/funcs/multicluster
@@ -288,5 +288,13 @@ run_multi_cluster_kube_config_creator() {
   echo "${MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH} multicluster setup ${params[*]}"
   ${MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH} multicluster setup "${params[@]}"
 
-  kubectl get secret --context "${CENTRAL_CLUSTER}" -n "${NAMESPACE}" mongodb-enterprise-operator-multi-cluster-kubeconfig -o json | jq -rc '.data.kubeconfig' | base64 -d >"${KUBE_CONFIG_PATH}"
+  # Write the bare base. Non-devc callers (tunnel users, the EVG host during
+  # remote-prepare) consume this bare 127.0.0.1 file directly via SSH
+  # port-forwards and must NOT get a proxy-url. Only inside the devcontainer
+  # do we derive the two flavors (host + devc proxy) via wt-ctl.
+  multicluster_base="${PROJECT_DIR}/.generated/multicluster_kubeconfig"
+  kubectl get secret --context "${CENTRAL_CLUSTER}" -n "${NAMESPACE}" mongodb-enterprise-operator-multi-cluster-kubeconfig -o json | jq -rc '.data.kubeconfig' | base64 -d >"${multicluster_base}"
+  if [[ -f /.dockerenv ]]; then
+    "${PROJECT_DIR}/scripts/dev/wt-ctl" --quiet kubeconfig refresh
+  fi
 }

--- a/scripts/funcs/printing
+++ b/scripts/funcs/printing
@@ -19,6 +19,21 @@ prepend() {
   awk -v prefix="${prefix}" '{printf "%s: %s\n", prefix, $0; fflush()}'
 }
 
+# Drop high-volume low-signal lines from buildx / docker build output and
+# similar tooling. Keeps step headers, RUN output, errors, warnings, and
+# final markers. Use line-buffered grep so the pipeline stays interactive.
+#
+# Matches both buildx plain-mode (`#N transferring …`, `#N DONE 0.0s`, …) and
+# TTY-mode (` => => transferring …`) progress lines.
+filter_buildx_noise() {
+  grep --line-buffered -v -E \
+    '^(#[0-9]+|[[:space:]]*=>([[:space:]]*=>)*)[[:space:]]+(transferring|extracting|unpacking|resolving|naming|copying|exporting|preparing|writing|sending|sha256:|CACHED|DONE [0-9])' \
+  | grep --line-buffered -v -E \
+    '^#[0-9]+ \.\.\.$' \
+  | grep --line-buffered -v -E \
+    '^[[:space:]]*$'
+}
+
 export RED='\033[0;31m'
 export GREEN='\033[0;32m'
 export NO_COLOR='\033[0m'

--- a/scripts/release/kubectl_mongodb/download_kubectl_plugin.py
+++ b/scripts/release/kubectl_mongodb/download_kubectl_plugin.py
@@ -38,6 +38,10 @@ def download_kubectl_plugin_from_s3(
 
         if copy_to_bin_path:
             kubectl_mongodb_workdir_path = os.path.join(os.getenv("workdir", ""), KUBECTL_MONGODB_PLUGIN_BIN_PATH)
+            # bin/ is .gitignore'd so it doesn't exist on a fresh clone (EVG
+            # runners); create it before copying so the script doesn't trip
+            # on a missing parent dir.
+            os.makedirs(os.path.dirname(kubectl_mongodb_workdir_path), exist_ok=True)
             # copy content, stat-info (mode too), timestamps..
             shutil.copy2(local_path, kubectl_mongodb_workdir_path)
             # preserve owner and group

--- a/scripts/test/bash/run.sh
+++ b/scripts/test/bash/run.sh
@@ -54,7 +54,7 @@ cd "${project_dir}"
 # triggers `make switch` fails with "workdir: unbound variable".
 # Note: set_env_context.sh redefines $script_dir, so any local of that name
 # inherited from this script would be overwritten — keep our names distinct.
-if [[ -f .generated/context.export.env && -f scripts/dev/set_env_context.sh ]]; then
+if [[ -f .generated/context.env && -f scripts/dev/set_env_context.sh ]]; then
     # shellcheck disable=SC1091
     source scripts/dev/set_env_context.sh
 fi

--- a/scripts/test/bash/worktree/test_om_project_namespace.bats
+++ b/scripts/test/bash/worktree/test_om_project_namespace.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+#
+# Per-worktree OM project isolation against two real scripts:
+#   1. scripts/dev/contexts/root-context — appends `-${MCK_DEVC_NET_PREFIX}`
+#      to NAMESPACE (idempotent).
+#   2. scripts/dev/delete_om_projects.sh `filter_prefixed_projects` — must
+#      never delete a sibling worktree stack's OM projects.
+#
+# Tests mutate .devcontainer/.env and scripts/dev/contexts/private-context,
+# then restore in teardown(); backups live beside the originals on disk (not
+# in BATS_TEST_TMPDIR) so an aborted run stays recoverable.
+
+setup() {
+    PROJECT_DIR="$(git rev-parse --show-toplevel)"
+    cd "${PROJECT_DIR}"
+
+    # Stub private-context (a gitignored, credential-bearing file) with a known
+    # NAMESPACE. The backup lives BESIDE the original on disk — never in
+    # BATS_TEST_TMPDIR, which bats deletes on exit, so a SIGKILL mid-run would
+    # otherwise destroy the developer's real private-context unrecoverably.
+    PC_FILE="${PROJECT_DIR}/scripts/dev/contexts/private-context"
+    PC_BACKUP="${PC_FILE}.bats-bak"
+    # Self-heal: a leftover backup from a previously aborted run is the real
+    # file — restore it before we stub, so we never stack stubs or lose data.
+    [[ -f "${PC_BACKUP}" ]] && mv -f "${PC_BACKUP}" "${PC_FILE}"
+    if [[ -f "${PC_FILE}" ]]; then
+        cp -p "${PC_FILE}" "${PC_BACKUP}"
+        PC_HAD_FILE=1
+    else
+        PC_HAD_FILE=0
+    fi
+    KNOWN_NS="bats-namespace"
+    cat >"${PC_FILE}" <<EOF
+#!/bin/bash
+export NAMESPACE="${KNOWN_NS}"
+EOF
+
+    # Snapshot .devcontainer/.env (some tests mutate it to verify the
+    # file-loading fallback). Same on-disk backup discipline as above.
+    DEVC_ENV_FILE="${PROJECT_DIR}/.devcontainer/.env"
+    DEVC_ENV_BACKUP="${DEVC_ENV_FILE}.bats-bak"
+    [[ -f "${DEVC_ENV_BACKUP}" ]] && mv -f "${DEVC_ENV_BACKUP}" "${DEVC_ENV_FILE}"
+    if [[ -f "${DEVC_ENV_FILE}" ]]; then
+        cp -p "${DEVC_ENV_FILE}" "${DEVC_ENV_BACKUP}"
+        DEVC_ENV_HAD_FILE=1
+    else
+        DEVC_ENV_HAD_FILE=0
+    fi
+}
+
+teardown() {
+    if [[ "${PC_HAD_FILE}" == "1" ]]; then
+        mv -f "${PC_BACKUP}" "${PC_FILE}"
+    else
+        rm -f "${PC_FILE}" "${PC_BACKUP}"
+    fi
+    if [[ "${DEVC_ENV_HAD_FILE}" == "1" ]]; then
+        mv -f "${DEVC_ENV_BACKUP}" "${DEVC_ENV_FILE}"
+    else
+        rm -f "${DEVC_ENV_FILE}" "${DEVC_ENV_BACKUP}"
+    fi
+}
+
+# Source root-context in a clean subshell with a controlled env, capture the
+# resulting NAMESPACE. Subshell isolation prevents the source from polluting
+# the bats process; redirecting stdout/stderr keeps EVG-host probing chatter
+# out of the captured value.
+namespace_after_root_context() {
+    bash -c '
+        set -e
+        cd "${PROJECT_DIR}"
+        # shellcheck disable=SC1091
+        source scripts/dev/contexts/root-context >/dev/null 2>&1
+        printf "%s" "${NAMESPACE}"
+    '
+}
+
+# ---------------------------------------------------------------------------
+# root-context derivation
+# ---------------------------------------------------------------------------
+
+@test "root-context: appends -PREFIX to the user's NAMESPACE" {
+    export MCK_DEVC_NET_PREFIX=20
+    result="$(namespace_after_root_context)"
+
+    [[ "${result}" == "${KNOWN_NS}-20" ]]
+}
+
+@test "root-context: idempotent — already-suffixed NAMESPACE is left alone" {
+    # private-context exports the un-suffixed NAMESPACE. After the first
+    # source, NAMESPACE ends in -20. A second source must not append again.
+    export MCK_DEVC_NET_PREFIX=20
+
+    result="$(bash -c '
+        set -e
+        cd "${PROJECT_DIR}"
+        # shellcheck disable=SC1091
+        source scripts/dev/contexts/root-context >/dev/null 2>&1
+        first="${NAMESPACE}"
+        # shellcheck disable=SC1091
+        source scripts/dev/contexts/root-context >/dev/null 2>&1
+        printf "%s|%s" "${first}" "${NAMESPACE}"
+    ')"
+
+    first="${result%%|*}"
+    second="${result#*|}"
+    [[ "${first}" == "${second}" ]]
+    [[ "${first}" == "${KNOWN_NS}-20" ]]
+}
+
+@test "root-context: no MCK_DEVC_NET_PREFIX in env or .devcontainer/.env -> NAMESPACE untouched" {
+    unset MCK_DEVC_NET_PREFIX
+    rm -f "${DEVC_ENV_FILE}"
+
+    result="$(namespace_after_root_context)"
+
+    [[ "${result}" == "${KNOWN_NS}" ]]
+}
+
+@test "root-context: loads MCK_DEVC_NET_PREFIX from .devcontainer/.env when not in env" {
+    unset MCK_DEVC_NET_PREFIX
+    mkdir -p "$(dirname "${DEVC_ENV_FILE}")"
+    echo "MCK_DEVC_NET_PREFIX=24" > "${DEVC_ENV_FILE}"
+
+    result="$(namespace_after_root_context)"
+
+    [[ "${result}" == "${KNOWN_NS}-24" ]]
+}
+
+@test "root-context: env-set MCK_DEVC_NET_PREFIX wins over .devcontainer/.env" {
+    export MCK_DEVC_NET_PREFIX=18
+    mkdir -p "$(dirname "${DEVC_ENV_FILE}")"
+    echo "MCK_DEVC_NET_PREFIX=24" > "${DEVC_ENV_FILE}"
+
+    result="$(namespace_after_root_context)"
+
+    [[ "${result}" == "${KNOWN_NS}-18" ]]
+}
+
+# ---------------------------------------------------------------------------
+# delete_om_projects.sh prefix filter (worktree isolation)
+# ---------------------------------------------------------------------------
+#
+# Sourcing the script hits its BASH_SOURCE guard, so main() (and every OM API
+# call) is skipped and we can drive the pure filter with a fixed JSON payload.
+
+# Sample OM /groups response covering: the bare base namespace, base resource-
+# specific projects, and two sibling worktree stacks (numeric net-prefix).
+groups_json() {
+    cat <<'EOF'
+{"results":[
+  {"name":"mongodb-test"},
+  {"name":"mongodb-test-mdb-sh"},
+  {"name":"mongodb-test-mdb"},
+  {"name":"mongodb-test-30"},
+  {"name":"mongodb-test-30-mdb-sh"},
+  {"name":"mongodb-test-42"},
+  {"name":"other-project"}
+]}
+EOF
+}
+
+@test "delete_om_projects.sh: base prefix deletes own resource projects, spares sibling worktrees" {
+    # shellcheck disable=SC1091
+    source scripts/dev/delete_om_projects.sh
+    run bash -c "$(declare -f filter_prefixed_projects); $(declare -f groups_json); groups_json | filter_prefixed_projects mongodb-test"
+    [[ "${status}" -eq 0 ]]
+    # Own resource-specific projects: deleted.
+    [[ "${output}" == *"mongodb-test-mdb-sh"* ]]
+    [[ "${output}" == *"mongodb-test-mdb"* ]]
+    # Sibling worktree stacks and their sub-projects: never touched.
+    [[ "${output}" != *"mongodb-test-30"* ]]
+    [[ "${output}" != *"mongodb-test-42"* ]]
+    # Non-matching org projects: never touched.
+    [[ "${output}" != *"other-project"* ]]
+}
+
+@test "delete_om_projects.sh: worktree prefix cleans only its own sub-projects" {
+    # shellcheck disable=SC1091
+    source scripts/dev/delete_om_projects.sh
+    run bash -c "$(declare -f filter_prefixed_projects); $(declare -f groups_json); groups_json | filter_prefixed_projects mongodb-test-30"
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" == *"mongodb-test-30-mdb-sh"* ]]
+    # Must not reach up to the base namespace's resource projects or siblings.
+    [[ "${output}" != *"mongodb-test-mdb-sh"* ]]
+    [[ "${output}" != *"mongodb-test-42"* ]]
+}

--- a/scripts/test/bash/worktree/test_om_project_namespace.bats
+++ b/scripts/test/bash/worktree/test_om_project_namespace.bats
@@ -14,6 +14,11 @@ setup() {
     PROJECT_DIR="$(git rev-parse --show-toplevel)"
     cd "${PROJECT_DIR}"
 
+    # root-context suppresses the per-worktree NAMESPACE suffix inside an
+    # evergreen task (EVR_TASK_ID set). These tests exercise that suffix logic,
+    # so scrub EVR_TASK_ID here — the bash -c subshells below inherit this env.
+    unset EVR_TASK_ID
+
     # Stub private-context (a gitignored, credential-bearing file) with a known
     # NAMESPACE. The backup lives BESIDE the original on disk — never in
     # BATS_TEST_TMPDIR, which bats deletes on exit, so a SIGKILL mid-run would

--- a/scripts/test/bash/worktree/test_worktree.bats
+++ b/scripts/test/bash/worktree/test_worktree.bats
@@ -45,6 +45,17 @@ require_init_in_main_repo() {
         || skip "init_worktree.sh not present in main clone (${MAIN_REPO}); merge this branch first or run from main clone"
 }
 
+# create_worktree.sh sources scripts/dev/devenv from the freshly-added worktree.
+# `git worktree add` checks out HEAD's committed tree; in an EVG patch build the
+# patch is applied to the working tree but files newly added by the branch are
+# not in the checkout-able HEAD tree, so the child worktree lacks devenv and
+# create_worktree fails sourcing it. Skip when HEAD can't reproduce devenv —
+# runs normally on a committed checkout (local dev, post-merge CI).
+require_committed_worktree_files() {
+    git -C "${PROJECT_DIR}" cat-file -e "HEAD:scripts/dev/devenv" 2>/dev/null \
+        || skip "HEAD tree lacks scripts/dev/devenv (uncommitted patch build); git worktree add can't reproduce it into the child worktree"
+}
+
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
@@ -96,6 +107,7 @@ install_hook() {
 # ---------------------------------------------------------------------------
 
 @test "create_worktree: places worktree in parent dir with slashes converted to underscores" {
+    require_committed_worktree_files
     run env PROJECT_DIR="${PROJECT_DIR}" "${PROJECT_DIR}/scripts/dev/create_worktree.sh" "${TEST_BRANCH}"
 
     [ "$status" -eq 0 ]
@@ -103,6 +115,7 @@ install_hook() {
 }
 
 @test "create_worktree: creates branch when it does not exist yet" {
+    require_committed_worktree_files
     run env PROJECT_DIR="${PROJECT_DIR}" "${PROJECT_DIR}/scripts/dev/create_worktree.sh" "${TEST_BRANCH}"
 
     [ "$status" -eq 0 ]
@@ -110,6 +123,7 @@ install_hook() {
 }
 
 @test "create_worktree: worktree is fully initialized after creation" {
+    require_committed_worktree_files
     run env PROJECT_DIR="${PROJECT_DIR}" "${PROJECT_DIR}/scripts/dev/create_worktree.sh" "${TEST_BRANCH}"
 
     [ "$status" -eq 0 ]
@@ -120,6 +134,7 @@ install_hook() {
 }
 
 @test "create_worktree: uses existing local branch without error" {
+    require_committed_worktree_files
     git -C "${PROJECT_DIR}" branch "${TEST_BRANCH}"
 
     run env PROJECT_DIR="${PROJECT_DIR}" "${PROJECT_DIR}/scripts/dev/create_worktree.sh" "${TEST_BRANCH}"
@@ -129,6 +144,7 @@ install_hook() {
 }
 
 @test "create_worktree -f: re-initializes an already-initialized worktree" {
+    require_committed_worktree_files
     env PROJECT_DIR="${PROJECT_DIR}" "${PROJECT_DIR}/scripts/dev/create_worktree.sh" "${TEST_BRANCH}"
     echo "corrupted" > "${WORKTREE_PATH}/scripts/dev/contexts/private-context"
 
@@ -144,6 +160,11 @@ install_hook() {
 
 @test "post-checkout hook: initializes worktree automatically on git worktree add" {
     require_init_in_main_repo
+    # Apple Git (macOS/Xcode) does not run the post-checkout hook on
+    # `git worktree add`, so auto-init is unobservable here. Upstream git (EVG,
+    # Linux) does fire it, so the test still provides coverage there.
+    git --version | grep -q "Apple Git" \
+        && skip "Apple Git does not fire post-checkout on 'git worktree add'"
     install_hook
     git -C "${PROJECT_DIR}" worktree add -b "${TEST_BRANCH}" "${WORKTREE_PATH}"
 

--- a/scripts/test/test_validate_jsonc.py
+++ b/scripts/test/test_validate_jsonc.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "dev"))
+
+from validate_jsonc import strip_jsonc  # noqa: E402
+
+
+def _load(raw: str):
+    return json.loads(strip_jsonc(raw))
+
+
+def test_line_and_block_comments_and_trailing_comma():
+    assert _load('{"a": 1, // line\n "b": 2, /* block */ "c": [1, 2,],}') == {
+        "a": 1,
+        "b": 2,
+        "c": [1, 2],
+    }
+
+
+def test_comment_markers_inside_strings_are_preserved():
+    assert _load('{"url": "https://example.com/*x*/", "p": "a // b"}') == {
+        "url": "https://example.com/*x*/",
+        "p": "a // b",
+    }
+
+
+def test_escaped_quote_in_string():
+    assert _load(r'{"q": "he said \"hi\" /* not a comment */"}') == {"q": 'he said "hi" /* not a comment */'}
+
+
+def test_unterminated_block_comment_raises():
+    with pytest.raises(ValueError, match="unterminated"):
+        strip_jsonc('{"a": 1} /* oops')

--- a/scripts/test/wt_ctl/_common.py
+++ b/scripts/test/wt_ctl/_common.py
@@ -1,0 +1,70 @@
+"""Shared test scaffolding: fake Popen + helpers to load wt_ctl from source."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Make `import wt_ctl` work when this test is run from any cwd.
+_REPO = Path(__file__).resolve().parents[3]
+_PKG_PARENT = _REPO / "scripts" / "dev"
+if str(_PKG_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PKG_PARENT))
+
+
+class FakeProc:
+    """Mimics subprocess.Popen sufficiently for Runner.run + run_streaming."""
+
+    def __init__(self, stdout: str = "", stderr: str = "", rc: int = 0) -> None:
+        self._stdout = io.StringIO(stdout)
+        self._stderr_text = stderr
+        self.returncode: Optional[int] = rc
+        self.stdin: Optional[io.StringIO] = None
+
+    @property
+    def stdout(self) -> io.StringIO:
+        return self._stdout
+
+    @property
+    def stderr(self) -> io.StringIO:
+        return io.StringIO(self._stderr_text)
+
+    def communicate(self, input: Optional[str] = None, timeout: Optional[float] = None):
+        return self._stdout.getvalue(), self._stderr_text
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        return self.returncode or 0
+
+    def kill(self) -> None:
+        pass
+
+
+class FakePopenFactory:
+    """Pluggable popen-factory: maps argv tuples (or first argv element) to
+    canned (stdout, stderr, rc) tuples. Falls back to `default`.
+    """
+
+    def __init__(self, mapping: dict[tuple, tuple[str, str, int]], default: tuple[str, str, int] = ("", "", 0)) -> None:
+        self.mapping = mapping
+        self.default = default
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, **kwargs) -> FakeProc:
+        self.calls.append(list(argv))
+        key = tuple(argv)
+        if key in self.mapping:
+            stdout, stderr, rc = self.mapping[key]
+            return FakeProc(stdout, stderr, rc)
+        # try matching by leading prefix (handy for git -C variations)
+        for k, v in self.mapping.items():
+            if tuple(argv[: len(k)]) == k:
+                return FakeProc(*v)
+        return FakeProc(*self.default)
+
+
+def fake_which(_name: str) -> str:
+    """Always-present tool: tests don't actually exec anything."""
+    return f"/usr/bin/{_name}"

--- a/scripts/test/wt_ctl/conftest.py
+++ b/scripts/test/wt_ctl/conftest.py
@@ -1,0 +1,15 @@
+"""Put this directory on sys.path so `from _common import ...` resolves.
+
+Pytest's rootdir-walking adds `scripts/test/` (the nearest ancestor without
+`__init__.py`), which imports the `wt_ctl` package but not the bare
+`_common` symbol when pytest runs from the repo root. This closes the gap.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_THIS_DIR = str(Path(__file__).resolve().parent)
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)

--- a/scripts/test/wt_ctl/test_delete.py
+++ b/scripts/test/wt_ctl/test_delete.py
@@ -330,6 +330,36 @@ class DeletePipelineTests(unittest.TestCase):
             ).run()
             joined = [" ".join(c) for c in runner.calls]
             self.assertTrue(any("kind delete cluster --name lk-smoke" in j for j in joined))
+            self.assertFalse(any("--name other-cluster" in j for j in joined))
+
+    def test_local_kind_mc_deletes_all_owned_clusters(self) -> None:
+        # A multi-cluster local-kind create owns five clusters; teardown must
+        # delete every owned one that's present and leave unrelated clusters.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(Path(tmp), with_compose_running=False, with_evg_host=False)
+            generated = target / ".generated"
+            generated.mkdir(parents=True, exist_ok=True)
+            (generated / "current.kubeconfig").write_text(
+                "apiVersion: v1\nkind: Config\ncurrent-context: kind-e2e-operator\nclusters: []\n"
+            )
+            runner.handlers.insert(
+                0,
+                (
+                    lambda argv: argv[:3] == ["kind", "get", "clusters"],
+                    lambda _argv: CmdResult(
+                        argv=list(_argv),
+                        rc=0,
+                        stdout="e2e-operator\ne2e-cluster-1\ne2e-cluster-2\ne2e-cluster-3\nkind\nunrelated\n",
+                        stderr="",
+                        duration_s=0.0,
+                    ),
+                ),
+            )
+            DeleteOrchestrator(runner, self._inputs(repo, target, delete_evg=True, multi_cluster=True)).run()
+            joined = [" ".join(c) for c in runner.calls]
+            for owned in ("e2e-operator", "e2e-cluster-1", "e2e-cluster-2", "e2e-cluster-3", "kind"):
+                self.assertTrue(any(f"kind delete cluster --name {owned}" in j for j in joined), owned)
+            self.assertFalse(any("--name unrelated" in j for j in joined))
             self.assertFalse(any("evergreen host terminate" in j for j in joined))
 
     def test_byoc_evg_step_skips_when_context_not_kind(self) -> None:

--- a/scripts/test/wt_ctl/test_delete.py
+++ b/scripts/test/wt_ctl/test_delete.py
@@ -245,6 +245,26 @@ class DeletePipelineTests(unittest.TestCase):
             self.assertTrue(any("worktree prune" in j for j in joined))
             self.assertNotIn("topic_x", reg.read_text())
 
+    def test_failed_worktree_removal_keeps_net_prefix(self) -> None:
+        # A live worktree must keep its subnet/port; releasing after a failed
+        # `git worktree remove` would let another run reclaim an in-use prefix.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=False,
+            )
+            runner.handlers.insert(
+                0,
+                (
+                    lambda argv: "worktree" in argv and "remove" in argv,
+                    lambda _argv: CmdResult(argv=list(_argv), rc=1, stdout="", stderr="locked", duration_s=0.0),
+                ),
+            )
+            reg = self._seed_registry("topic_x")
+            DeleteOrchestrator(runner, self._inputs(repo, target, delete_worktree=True)).run()
+            self.assertIn("topic_x", reg.read_text())
+
     def test_only_om_runs_om_clean(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo, target, runner = _make_fixture(

--- a/scripts/test/wt_ctl/test_delete.py
+++ b/scripts/test/wt_ctl/test_delete.py
@@ -184,6 +184,34 @@ class DeletePipelineTests(unittest.TestCase):
             # Net registry untouched when --worktree wasn't selected.
             self.assertIn("topic_x", reg.read_text())
 
+    def test_evg_terminate_recovers_custom_host_name_from_pin(self) -> None:
+        # Host created with --evg-host-name; delete invoked without the flag.
+        # The pin records the real displayName, so termination must still match.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=True,
+            )
+            (target / ".generated" / ".current-evg-host").write_text("my-custom-host")
+            runner.handlers.insert(
+                0,
+                (
+                    lambda argv: argv[:3] == ["evergreen", "host", "list"],
+                    lambda _argv: CmdResult(
+                        argv=list(_argv),
+                        rc=0,
+                        stdout=_evg_host_json("my-custom-host", "i-custom"),
+                        stderr="",
+                        duration_s=0.0,
+                    ),
+                ),
+            )
+            self._seed_registry("topic_x")
+            DeleteOrchestrator(runner, self._inputs(repo, target, delete_evg=True)).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("evergreen host terminate --host i-custom" in j for j in joined))
+
     def test_only_devc_runs_compose_down_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo, target, runner = _make_fixture(

--- a/scripts/test/wt_ctl/test_delete.py
+++ b/scripts/test/wt_ctl/test_delete.py
@@ -1,0 +1,345 @@
+"""``wt-ctl delete`` orchestrator — each step runs only when its
+``delete_*`` flag is True; the orchestrator never deletes git branches."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from _common import FakePopenFactory  # noqa: E402,F401  (path side-effect only)
+from wt_ctl.errors import ExternalCommandFailed  # noqa: E402
+from wt_ctl.orchestrator import DeleteInputs, DeleteOrchestrator  # noqa: E402
+from wt_ctl.runner import CmdResult  # noqa: E402
+
+
+@dataclass
+class FakeRunner:
+    calls: list[list[str]] = field(default_factory=list)
+    handlers: list[tuple[Callable[[list[str]], bool], Callable[[list[str]], CmdResult]]] = field(default_factory=list)
+
+    def add(self, match, result: CmdResult) -> None:
+        self.handlers.append((match, lambda _argv, r=result: r))
+
+    def have(self, name: str) -> bool:
+        return True
+
+    def _resolve(self, argv):
+        for match, handler in self.handlers:
+            if match(argv):
+                return handler(argv)
+        return CmdResult(argv=list(argv), rc=0, stdout="", stderr="", duration_s=0.0)
+
+    def run(self, argv, *, check=True, capture=True, env=None, cwd=None, timeout=None, input_text=None):
+        self.calls.append(list(argv))
+        result = self._resolve(list(argv))
+        if check and result.rc != 0:
+            raise ExternalCommandFailed(argv=list(argv), rc=result.rc, stdout=result.stdout, stderr=result.stderr)
+        return result
+
+    def run_streaming(self, argv, *, prefix="", log_path=None, env=None, cwd=None):
+        self.calls.append(list(argv))
+        return self._resolve(list(argv))
+
+
+def _evg_host_json(name: str, host_id: str, status: str = "running") -> str:
+    return json.dumps([{"name": name, "id": host_id, "status": status}])
+
+
+def _make_fixture(tmp: Path, *, with_compose_running: bool, with_evg_host: bool) -> tuple[Path, Path, FakeRunner]:
+    repo = tmp / "main_repo"
+    (repo / "scripts" / "dev").mkdir(parents=True)
+    target = tmp / "topic_x"
+    (target / "scripts" / "dev").mkdir(parents=True)
+    (target / ".devcontainer").mkdir()
+    (target / ".devcontainer" / ".env").write_text("MCK_DEVC_NET_PREFIX=29\n")
+    for script in ("delete_om_projects.sh", "dc_select_network.sh"):
+        (target / "scripts" / "dev" / script).write_text("#!/bin/sh\n")
+        (target / "scripts" / "dev" / script).chmod(0o755)
+        (repo / "scripts" / "dev" / script).write_text("#!/bin/sh\n")
+        (repo / "scripts" / "dev" / script).chmod(0o755)
+    if with_evg_host:
+        # The `.current-evg-host` pin selects EVG-host mode; without it the
+        # --evg dispatch falls through to the local-kind / BYOC branch.
+        generated = target / ".generated"
+        generated.mkdir(parents=True, exist_ok=True)
+        (generated / ".current-evg-host").write_text("topic_x")
+    runner = FakeRunner()
+    runner.add(
+        lambda argv: argv[:2] == ["docker", "compose"] and "ps" in argv,
+        CmdResult(
+            argv=[],
+            rc=0,
+            stdout="topic_x_devcontainer\n" if with_compose_running else "",
+            stderr="",
+            duration_s=0.0,
+        ),
+    )
+    runner.add(
+        lambda argv: argv[:3] == ["evergreen", "host", "list"],
+        CmdResult(
+            argv=[],
+            rc=0,
+            stdout=_evg_host_json("topic_x", "i-deadbeef") if with_evg_host else "[]",
+            stderr="",
+            duration_s=0.0,
+        ),
+    )
+    return repo, target, runner
+
+
+class DeletePipelineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Isolate the network-prefix registry so tests never touch ~/.cache/mck-devc/*.
+        self._reg_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._reg_tmp.cleanup)
+        self._prev_reg = os.environ.get("MCK_DEVC_REGISTRY_DIR")
+        os.environ["MCK_DEVC_REGISTRY_DIR"] = self._reg_tmp.name
+
+    def tearDown(self) -> None:
+        if self._prev_reg is None:
+            os.environ.pop("MCK_DEVC_REGISTRY_DIR", None)
+        else:
+            os.environ["MCK_DEVC_REGISTRY_DIR"] = self._prev_reg
+
+    def _seed_registry(self, branch_dir: str, index: int = 24) -> Path:
+        reg = Path(self._reg_tmp.name) / "net-prefix-registry"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        x = 16 + (index >> 7)
+        y_base = (index & 0x7F) << 1
+        y_vip = y_base + 1
+        port = 8000 + index
+        reg.write_text(f"{branch_dir}={index}:{x}:{y_base}:{y_vip}:{port}\n")
+        return reg
+
+    def _inputs(self, repo: Path, target: Path, **flags) -> DeleteInputs:
+        return DeleteInputs(
+            branch="topic/x",
+            branch_dir="topic_x",
+            worktree_path=target,
+            main_repo_root=repo,
+            **flags,
+        )
+
+    def test_no_targets_is_a_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=True,
+                with_evg_host=True,
+            )
+            self._seed_registry("topic_x")
+            DeleteOrchestrator(runner, self._inputs(repo, target)).run()
+            self.assertEqual(runner.calls, [])
+
+    def test_all_targets_runs_every_step(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=True,
+                with_evg_host=True,
+            )
+            reg = self._seed_registry("topic_x")
+            inputs = self._inputs(
+                repo,
+                target,
+                delete_om=True,
+                delete_devc=True,
+                delete_evg=True,
+                delete_worktree=True,
+            )
+            DeleteOrchestrator(runner, inputs).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("delete_om_projects.sh" in j for j in joined))
+            self.assertTrue(any("docker compose -p topic_x_devcontainer down" in j for j in joined))
+            self.assertTrue(any("evergreen host list" in j for j in joined))
+            self.assertTrue(any("evergreen host terminate" in j and "i-deadbeef" in j for j in joined))
+            self.assertTrue(any("worktree remove --force" in j for j in joined))
+            self.assertTrue(any("worktree prune" in j for j in joined))
+            self.assertNotIn("topic_x", reg.read_text())
+            # Branch is never deleted, regardless of flag combinations.
+            self.assertFalse(any("branch -D" in j for j in joined))
+
+    def test_only_evg_terminates_just_the_host(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=True,
+                with_evg_host=True,
+            )
+            reg = self._seed_registry("topic_x")
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_evg=True),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("evergreen host terminate" in j for j in joined))
+            self.assertFalse(any("docker compose" in j for j in joined))
+            self.assertFalse(any("worktree remove" in j for j in joined))
+            self.assertFalse(any("delete_om_projects" in j for j in joined))
+            # Net registry untouched when --worktree wasn't selected.
+            self.assertIn("topic_x", reg.read_text())
+
+    def test_only_devc_runs_compose_down_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=True,
+                with_evg_host=True,
+            )
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_devc=True),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("docker compose -p topic_x_devcontainer down" in j for j in joined))
+            self.assertFalse(any("evergreen host" in j for j in joined))
+            self.assertFalse(any("worktree remove" in j for j in joined))
+
+    def test_worktree_target_releases_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=False,
+            )
+            reg = self._seed_registry("topic_x")
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_worktree=True),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("worktree remove --force" in j for j in joined))
+            self.assertTrue(any("worktree prune" in j for j in joined))
+            self.assertNotIn("topic_x", reg.read_text())
+
+    def test_only_om_runs_om_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=False,
+            )
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_om=True),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("delete_om_projects.sh" in j for j in joined))
+            self.assertFalse(any("docker compose" in j for j in joined))
+            self.assertFalse(any("worktree remove" in j for j in joined))
+
+    def test_prefix_release_works_after_worktree_dir_is_gone(self) -> None:
+        """Native Registry.release() doesn't depend on any script living
+        inside the (already-removed) target worktree.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=False,
+            )
+            for f in (target / "scripts" / "dev").glob("*"):
+                f.unlink()
+            (target / "scripts" / "dev").rmdir()
+            reg = self._seed_registry("topic_x")
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_worktree=True),
+            ).run()
+            self.assertNotIn("topic_x", reg.read_text())
+
+    def test_local_kind_evg_step_deletes_kind_cluster(self) -> None:
+        """With no `.current-evg-host`, --evg reads the kubeconfig
+        `current-context`; a `kind-` context whose cluster exists is deleted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=False,
+            )
+            generated = target / ".generated"
+            generated.mkdir(parents=True, exist_ok=True)
+            (generated / "current.kubeconfig").write_text(
+                "apiVersion: v1\nkind: Config\ncurrent-context: kind-lk-smoke\nclusters: []\n"
+            )
+            runner.handlers.insert(
+                0,
+                (
+                    lambda argv: argv[:3] == ["kind", "get", "clusters"],
+                    lambda _argv: CmdResult(
+                        argv=list(_argv), rc=0, stdout="lk-smoke\nother-cluster\n", stderr="", duration_s=0.0
+                    ),
+                ),
+            )
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_evg=True),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("kind delete cluster --name lk-smoke" in j for j in joined))
+            self.assertFalse(any("evergreen host terminate" in j for j in joined))
+
+    def test_byoc_evg_step_skips_when_context_not_kind(self) -> None:
+        """A non-`kind-` current-context is a BYOC cluster we don't own, so
+        --evg is a no-op (no kind delete, no evergreen terminate)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=False,
+                with_evg_host=False,
+            )
+            generated = target / ".generated"
+            generated.mkdir(parents=True, exist_ok=True)
+            (generated / "current.kubeconfig").write_text(
+                "apiVersion: v1\nkind: Config\ncurrent-context: gke_my-proj_us-east1-b_prod\n"
+            )
+            DeleteOrchestrator(
+                runner,
+                self._inputs(repo, target, delete_evg=True),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertFalse(any("kind delete cluster" in j for j in joined))
+            self.assertFalse(any("evergreen host terminate" in j for j in joined))
+
+    def test_failure_in_one_step_does_not_abort_pipeline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, runner = _make_fixture(
+                Path(tmp),
+                with_compose_running=True,
+                with_evg_host=True,
+            )
+
+            def _term(_argv):
+                raise ExternalCommandFailed(argv=list(_argv), rc=2, stdout="", stderr="boom")
+
+            runner.handlers.insert(
+                0,
+                (
+                    lambda argv: argv[:3] == ["evergreen", "host", "terminate"],
+                    _term,
+                ),
+            )
+            reg = self._seed_registry("topic_x")
+            DeleteOrchestrator(
+                runner,
+                self._inputs(
+                    repo,
+                    target,
+                    delete_om=True,
+                    delete_devc=True,
+                    delete_evg=True,
+                    delete_worktree=True,
+                ),
+            ).run()
+            joined = [" ".join(c) for c in runner.calls]
+            self.assertTrue(any("worktree remove" in j for j in joined))
+            self.assertNotIn("topic_x", reg.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_display.py
+++ b/scripts/test/wt_ctl/test_display.py
@@ -1,0 +1,143 @@
+"""Renders fixture state into the expected key-value text."""
+
+from __future__ import annotations
+
+import unittest
+
+from _common import FakePopenFactory  # noqa: E402  (path side-effect only)
+from wt_ctl.display import render_status, render_status_all  # noqa: E402
+from wt_ctl.state import (  # noqa: E402
+    DevcState,
+    EvgHostState,
+    GitState,
+    GlobalStatus,
+    KubeconfigState,
+    NetState,
+    OmState,
+    OrphanRegistration,
+    WorktreeRow,
+    WorktreeStatus,
+)
+
+
+def _fixture() -> WorktreeStatus:
+    return WorktreeStatus(
+        worktree_dir="lsierant_devcontainer",
+        worktree_path="/Users/x/mdb/lsierant_devcontainer",
+        git=GitState(
+            branch="lsierant/devcontainer",
+            clean=True,
+            ahead=0,
+            behind=0,
+            upstream="origin/lsierant/devcontainer",
+        ),
+        context="e2e_smoke",
+        devc=DevcState(
+            project="lsierant_devcontainer_devcontainer",
+            state="running",
+            services_running=4,
+            services_total=4,
+            image_age="2h",
+        ),
+        network=NetState(
+            prefix=28,
+            subnet="172.28.0.0/16",
+            namespace="mck-devc-28-mongodb-test",
+            gost_proxy="http://127.0.0.1:8028",
+            registered=True,
+            orphans=0,
+        ),
+        evg=EvgHostState(
+            name="lsierant_devcontainer",
+            id="i-0abc",
+            status="running",
+            host_name="ec2-1-2-3-4.compute-1.amazonaws.com",
+            expires_in="3h12m",
+            ssh="ssh ubuntu@ec2-1-2-3-4.compute-1.amazonaws.com",
+        ),
+        kubeconfig=KubeconfigState(
+            path="/x/.generated/current.kubeconfig",
+            last_patch="12m_ago",
+            kfp_registered=True,
+        ),
+        om=OmState(
+            namespace="ls-28",
+            project_count=2,
+            scope="ls-28, ls-28-*",
+        ),
+        next_hints=["wt-ctl attach"],
+    )
+
+
+class StatusRenderTests(unittest.TestCase):
+    def test_keys_present(self) -> None:
+        out = render_status(_fixture(), color="never")
+        for k in (
+            "worktree",
+            "path",
+            "context",
+            "devc",
+            "network",
+            "namespace",
+            "gost-proxy",
+            "evg host",
+            "kubeconfig",
+            "om",
+            "next",
+        ):
+            self.assertIn(k, out, f"missing key {k!r} in:\n{out}")
+        self.assertIn("172.28.0.0/16", out)
+        self.assertIn("http://127.0.0.1:8028", out)
+
+    def test_no_devc_renders_clean(self) -> None:
+        snap = _fixture()
+        snap.devc = None
+        out = render_status(snap, color="never")
+        self.assertIn("no compose stack found", out)
+
+
+class StatusAllRenderTests(unittest.TestCase):
+    def test_basic_table(self) -> None:
+        rows = [
+            WorktreeRow(
+                worktree="alpha",
+                branch="topic/a",
+                prefix=20,
+                namespace="ns-20",
+                devc_state="running",
+                evg_name="alpha",
+                evg_status="running",
+                evg_expires="2h",
+            ),
+            WorktreeRow(
+                worktree="beta",
+                branch="topic/b",
+                prefix=21,
+                namespace="ns-21",
+                devc_state="exited",
+                evg_name=None,
+                evg_status=None,
+                evg_expires=None,
+                prunable=True,
+                prunable_reason="devc-exited",
+                delete_cmd="wt-ctl delete topic/b",
+            ),
+        ]
+        orphans = [
+            OrphanRegistration(
+                branch_dir="ghost",
+                prefix=22,
+                release_cmd="wt-ctl network release ghost",
+            ),
+        ]
+        out = render_status_all(GlobalStatus(rows=rows, orphans=orphans), color="never")
+        self.assertIn("WORKTREE", out)
+        self.assertIn("alpha", out)
+        self.assertIn("beta", out)
+        self.assertIn("prunable", out)
+        self.assertIn("orphan registrations", out)
+        self.assertIn("ghost", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_evg_spawn.py
+++ b/scripts/test/wt_ctl/test_evg_spawn.py
@@ -1,0 +1,681 @@
+"""``wt-ctl evg spawn`` unit tests.
+
+A FakeRunner records argv and returns scripted ``host list`` payloads across
+poll iterations; ``poll_interval_s`` is near zero so the tests don't sleep.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+from unittest import mock
+
+from _common import FakePopenFactory  # noqa: E402  (path side-effect only)
+from wt_ctl.domains.evg import EvgDomain  # noqa: E402
+from wt_ctl.errors import ExternalCommandFailed, WtCtlError  # noqa: E402
+from wt_ctl.runner import CmdResult  # noqa: E402
+
+
+@dataclass
+class FakeRunner:
+    """Same shape as test_delete.FakeRunner; matchers consult a per-test
+    queue of ``host list`` payloads so we can simulate state transitions.
+    """
+
+    calls: list[list[str]] = field(default_factory=list)
+    handlers: list[tuple[Callable[[list[str]], bool], Callable[[list[str]], CmdResult]]] = field(default_factory=list)
+
+    def add(self, match, result: CmdResult) -> None:
+        self.handlers.append((match, lambda _argv, r=result: r))
+
+    def add_fn(self, match, fn: Callable[[list[str]], CmdResult]) -> None:
+        self.handlers.append((match, fn))
+
+    def have(self, name: str) -> bool:
+        return True
+
+    def _resolve(self, argv):
+        for match, handler in self.handlers:
+            if match(argv):
+                return handler(argv)
+        return CmdResult(argv=list(argv), rc=0, stdout="", stderr="", duration_s=0.0)
+
+    def run(self, argv, *, check=True, capture=True, env=None, cwd=None, timeout=None, input_text=None):
+        self.calls.append(list(argv))
+        result = self._resolve(list(argv))
+        if check and result.rc != 0:
+            raise ExternalCommandFailed(
+                argv=list(argv),
+                rc=result.rc,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
+
+
+def _host_list_result(hosts: list[dict]) -> CmdResult:
+    return CmdResult(
+        argv=[],
+        rc=0,
+        stdout=json.dumps(hosts),
+        stderr="",
+        duration_s=0.0,
+    )
+
+
+def _ok(stdout: str = "") -> CmdResult:
+    return CmdResult(argv=[], rc=0, stdout=stdout, stderr="", duration_s=0.0)
+
+
+class _ListQueue:
+    """Returns scripted ``host list`` payloads in sequence; the last entry
+    is replayed indefinitely once the queue is exhausted (saves boilerplate
+    in tests that poll past 'running').
+    """
+
+    def __init__(self, payloads: list[list[dict]]) -> None:
+        self.payloads = payloads
+        self.idx = 0
+
+    def __call__(self, _argv) -> CmdResult:
+        i = min(self.idx, len(self.payloads) - 1)
+        self.idx += 1
+        return _host_list_result(self.payloads[i])
+
+
+class _MatchArgv:
+    """Helpers for handler match-clauses."""
+
+    @staticmethod
+    def host_list(argv: list[str]) -> bool:
+        return argv[:3] == ["evergreen", "host", "list"]
+
+    @staticmethod
+    def host_create(argv: list[str]) -> bool:
+        return argv[:3] == ["evergreen", "host", "create"]
+
+    @staticmethod
+    def host_modify(argv: list[str]) -> bool:
+        return argv[:3] == ["evergreen", "host", "modify"]
+
+    @staticmethod
+    def keys_list(argv: list[str]) -> bool:
+        return argv[:3] == ["evergreen", "keys", "list"]
+
+    @staticmethod
+    def ssh(argv: list[str]) -> bool:
+        return argv[:1] == ["ssh"]
+
+
+class EvgSpawnTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._prev_key = os.environ.get("MCK_DEVC_EVG_KEY_NAME")
+        os.environ["MCK_DEVC_EVG_KEY_NAME"] = "lsierant-evg-key"
+
+    def tearDown(self) -> None:
+        if self._prev_key is None:
+            os.environ.pop("MCK_DEVC_EVG_KEY_NAME", None)
+        else:
+            os.environ["MCK_DEVC_EVG_KEY_NAME"] = self._prev_key
+
+    def _domain(self, runner: FakeRunner) -> EvgDomain:
+        return EvgDomain(runner=runner, repo_root=Path("/tmp/repo"))
+
+    # ------------------------------------------------------------------
+    def test_resume_when_host_exists_running(self) -> None:
+        runner = FakeRunner()
+        runner.add(
+            _MatchArgv.host_list,
+            _host_list_result(
+                [
+                    {
+                        "id": "i-aaaa1111",
+                        "display_name": "alpha",
+                        "status": "running",
+                        "host_name": "ec2-1-2-3-4.compute.amazonaws.com",
+                        "user": "ubuntu",
+                    }
+                ]
+            ),
+        )
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="alpha",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+        )
+        self.assertEqual(host_id, "i-aaaa1111")
+        joined = [" ".join(c) for c in runner.calls]
+        self.assertFalse(any("host create" in j for j in joined))
+        # SSH probe used the canonical evg-host key (not ssh-keyscan).
+        ssh_calls = [c for c in runner.calls if c[0] == "ssh"]
+        self.assertEqual(len(ssh_calls), 1)
+        self.assertIn("-i", ssh_calls[0])
+        key_idx = ssh_calls[0].index("-i") + 1
+        self.assertTrue(ssh_calls[0][key_idx].endswith("/.ssh/evg-host"))
+
+    # ------------------------------------------------------------------
+    def test_resume_when_host_exists_starting(self) -> None:
+        runner = FakeRunner()
+        # Two host_list calls: first the resume-detection probe (starting),
+        # then the poll loop (running).
+        q = _ListQueue(
+            [
+                [{"id": "i-bbbb2222", "display_name": "beta", "status": "starting"}],
+                [
+                    {
+                        "id": "i-bbbb2222",
+                        "display_name": "beta",
+                        "status": "running",
+                        "host_name": "ec2-9-8-7-6.compute.amazonaws.com",
+                        "user": "ubuntu",
+                    }
+                ],
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="beta",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+        )
+        self.assertEqual(host_id, "i-bbbb2222")
+        joined = [" ".join(c) for c in runner.calls]
+        self.assertFalse(any("host create" in j for j in joined))
+
+    # ------------------------------------------------------------------
+    def test_fresh_spawn_then_poll_until_running(self) -> None:
+        runner = FakeRunner()
+        # Resume probe -> empty. Then `host create` returns an id. Then
+        # successive `host list` calls walk provisioning -> starting -> running.
+        q = _ListQueue(
+            [
+                [],  # resume detection: no match
+                [],  # pre-create snapshot: empty (host appears after)
+                [{"id": "i-cccc3333", "display_name": "", "status": "provisioning"}],  # resolve
+                [
+                    {
+                        "id": "i-cccc3333",
+                        "display_name": "gamma",
+                        "status": "running",
+                        "host_name": "ec2-5-5-5-5.compute.amazonaws.com",
+                        "user": "ubuntu",
+                    }
+                ],
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(
+            _MatchArgv.host_create,
+            _ok(stdout="Host i-cccc3333 spawned with displayName=''.\n"),
+        )
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="gamma",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+            resolve_timeout_s=2.0,
+        )
+        self.assertEqual(host_id, "i-cccc3333")
+        joined = [" ".join(c) for c in runner.calls]
+        creates = [j for j in joined if "evergreen host create" in j]
+        self.assertEqual(len(creates), 1)
+        # And used the env-var key + the requested distro/region defaults.
+        self.assertIn("--key lsierant-evg-key", creates[0])
+        self.assertIn("--distro ubuntu2204-latest-large", creates[0])
+        self.assertIn("--region eu-west-1", creates[0])
+        # Tagged at create so a timed-out-but-server-succeeded create still
+        # leaves an attributable host (name is reserved -> wt-ctl side label).
+        self.assertIn("--tag wt-ctl=gamma", creates[0])
+
+    # ------------------------------------------------------------------
+    def test_tag_and_rename_after_aws_id(self) -> None:
+        runner = FakeRunner()
+        q = _ListQueue(
+            [
+                [],  # resume probe: empty
+                [],  # pre-create snapshot: empty
+                [{"id": "i-dddd4444", "display_name": "", "status": "starting"}],  # resolve
+                [
+                    {
+                        "id": "i-dddd4444",
+                        "display_name": "delta",
+                        "status": "running",
+                        "host_name": "ec2-7-7-7-7.compute.amazonaws.com",
+                        "user": "ubuntu",
+                    }
+                ],
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(_MatchArgv.host_create, _ok(stdout="Host i-dddd4444 spawned.\n"))
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        self._domain(runner).spawn(
+            name="delta",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+            resolve_timeout_s=2.0,
+        )
+        modify_calls = [c for c in runner.calls if c[:3] == ["evergreen", "host", "modify"]]
+        self.assertEqual(len(modify_calls), 1, modify_calls)
+        argv = modify_calls[0]
+        self.assertIn("--host", argv)
+        self.assertEqual(argv[argv.index("--host") + 1], "i-dddd4444")
+        self.assertIn("--name", argv)
+        self.assertEqual(argv[argv.index("--name") + 1], "delta")
+        self.assertIn("--tag", argv)
+        # Evergreen reserves the ``name`` tag key — using it triggers a
+        # 400 from the API, so wt-ctl uses ``wt-ctl=<name>`` as a side
+        # label instead.
+        self.assertEqual(argv[argv.index("--tag") + 1], "wt-ctl=delta")
+
+    # ------------------------------------------------------------------
+    def test_terminal_failure_status_raises(self) -> None:
+        runner = FakeRunner()
+        q = _ListQueue(
+            [
+                [],  # resume probe: empty
+                [],  # pre-create snapshot: empty
+                [{"id": "i-eeee5555", "display_name": "", "status": "failed"}],  # resolve sees it dead
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(_MatchArgv.host_create, _ok(stdout="Host i-eeee5555 spawned.\n"))
+        with self.assertRaises(WtCtlError) as ctx:
+            self._domain(runner).spawn(
+                name="eps",
+                poll_interval_s=0.0,
+                timeout_s=2.0,
+                resolve_timeout_s=2.0,
+            )
+        self.assertIn("terminal", str(ctx.exception).lower())
+
+    # ------------------------------------------------------------------
+    def test_timeout_raises(self) -> None:
+        runner = FakeRunner()
+        # Always 'starting' — never reaches running. Repeated indefinitely
+        # because _ListQueue replays the last entry.
+        q = _ListQueue(
+            [
+                [],  # resume
+                [],  # pre-create snapshot
+                [{"id": "i-ffff6666", "display_name": "", "status": "starting"}],  # resolve: pick + rename
+                [{"id": "i-ffff6666", "display_name": "zeta", "status": "starting"}],  # poll: never running
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(_MatchArgv.host_create, _ok(stdout="Host i-ffff6666 spawned.\n"))
+        runner.add(_MatchArgv.host_modify, _ok())
+        with self.assertRaises(WtCtlError) as ctx:
+            self._domain(runner).spawn(
+                name="zeta",
+                poll_interval_s=0.0,
+                timeout_s=0.05,
+                resolve_timeout_s=2.0,
+            )
+        self.assertIn("timed out", str(ctx.exception).lower())
+
+    # ------------------------------------------------------------------
+    def test_create_failure_adopts_server_created_host_without_recreating(self) -> None:
+        """A `host create` that fails client-side but made the host server-side
+        must be ADOPTED via the pre-create snapshot diff — never re-created
+        (which would leak)."""
+        runner = FakeRunner()
+        q = _ListQueue(
+            [
+                [],  # resume probe: empty
+                [],  # pre-create snapshot: empty
+                [{"id": "i-7777aaaa", "display_name": "", "status": "provisioning"}],  # reconcile: adopt
+                [{"id": "i-7777aaaa", "display_name": "", "status": "provisioning"}],
+                [
+                    {
+                        "id": "i-7777aaaa",
+                        "display_name": "eta",
+                        "status": "running",
+                        "host_name": "ec2-9-9-9-9.compute.amazonaws.com",
+                        "user": "ubuntu",
+                    }
+                ],
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(_MatchArgv.host_create, CmdResult(argv=[], rc=1, stdout="", stderr="timeout", duration_s=0.0))
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="eta",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+            reconcile_timeout_s=0.0,
+        )
+        self.assertEqual(host_id, "i-7777aaaa")
+        creates = [c for c in runner.calls if c[:3] == ["evergreen", "host", "create"]]
+        self.assertEqual(len(creates), 1, "must adopt, never re-create")
+
+    # ------------------------------------------------------------------
+    def test_retry_recreates_only_when_no_host_appeared(self) -> None:
+        """When the first create genuinely made no host, a retry re-issues
+        `host create`; the second attempt succeeds."""
+        runner = FakeRunner()
+        q = _ListQueue(
+            [
+                [],  # resume probe
+                [],  # pre-create snapshot
+                [],  # reconcile after attempt 1: nothing appeared -> retry
+                [{"id": "i-8888bbbb", "display_name": "", "status": "starting"}],
+                [
+                    {
+                        "id": "i-8888bbbb",
+                        "display_name": "theta",
+                        "status": "running",
+                        "host_name": "ec2-8-8-8-8.compute.amazonaws.com",
+                        "user": "ubuntu",
+                    }
+                ],
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        create_calls = {"n": 0}
+
+        def _create(_argv):
+            create_calls["n"] += 1
+            if create_calls["n"] == 1:
+                return CmdResult(argv=[], rc=1, stdout="", stderr="quota", duration_s=0.0)
+            return _ok(stdout="Host i-8888bbbb spawned.\n")
+
+        runner.add_fn(_MatchArgv.host_create, _create)
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="theta",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+            reconcile_timeout_s=0.0,
+        )
+        self.assertEqual(host_id, "i-8888bbbb")
+        self.assertEqual(create_calls["n"], 2, "retry should re-create when nothing appeared")
+
+    # ------------------------------------------------------------------
+    def test_placeholder_resolves_via_pre_create_snapshot_diff(self) -> None:
+        """When ``host create`` returns only an ``evg-*`` placeholder id and
+        a sibling spawn is running concurrently (so the list payload has
+        multiple untagged hosts), the poll loop must pick the right host by
+        diffing the pre-create snapshot — *not* by display_name (still
+        empty) nor by "freshest untagged" (ambiguous).
+        """
+        runner = FakeRunner()
+        # Pre-existing sibling host (already in flight before our create).
+        # Note: _RE_AWS_ID requires the id-suffix to be hex (0-9a-f) — so
+        # we use ``ab1...`` / ``cd2...`` here, not human-readable labels.
+        sibling = {"id": "i-ab1aaaaa", "name": "", "status": "starting", "host_name": "", "user": "ubuntu"}
+        # Our new host appears post-create with an unfamiliar id.
+        ours_starting = {"id": "i-cd2bbbbb", "name": "", "status": "starting", "host_name": "", "user": "ubuntu"}
+        ours_running = {
+            "id": "i-cd2bbbbb",
+            "name": "wt-x",
+            "status": "running",
+            "host_name": "ec2-2-2-2-2.compute.amazonaws.com",
+            "user": "ubuntu",
+        }
+        q = _ListQueue(
+            [
+                [sibling],  # resume probe: no match by name
+                [sibling],  # pre-create snapshot: only sibling
+                [sibling, ours_starting],  # first poll: ours appears, unnamed
+                [sibling, ours_running],  # second poll: ours running, named
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        # create returns the placeholder id (no i-* in stdout).
+        runner.add(
+            _MatchArgv.host_create,
+            _ok(stdout="Host evg-ubuntu2204-9999 spawned.\n"),
+        )
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="wt-x",
+            poll_interval_s=0.0,
+            timeout_s=5.0,
+            resolve_timeout_s=2.0,
+        )
+        # Resolution must pick i-cd2bbbbb (ours), *not* i-ab1aaaaa (the
+        # pre-existing sibling, excluded by the pre-create snapshot).
+        self.assertEqual(host_id, "i-cd2bbbbb")
+        # Sibling id must never appear in any host modify call.
+        modify_calls = [c for c in runner.calls if c[:3] == ["evergreen", "host", "modify"]]
+        self.assertTrue(modify_calls)
+        for c in modify_calls:
+            self.assertNotIn("i-ab1aaaaa", c)
+
+    # ------------------------------------------------------------------
+    def test_resolve_renames_real_id_ignoring_preexisting_hosts(self) -> None:
+        """The spawn lock guarantees at most one NEW nameless host exists
+        while we resolve. Resolution renames that host's real ``i-*`` id (not
+        the interim ``evg-*`` placeholder), and never touches a pre-existing
+        nameless host that was already in the pre-create snapshot.
+        """
+        runner = FakeRunner()
+        # Pre-existing nameless host: present in the snapshot -> excluded.
+        preexisting = {"id": "i-ab1aaaaa", "name": "", "status": "starting", "host_name": "", "user": "ubuntu"}
+        ours_starting = {"id": "i-cd2bbbbb", "name": "", "status": "starting", "host_name": "", "user": "ubuntu"}
+        ours_running = {
+            "id": "i-cd2bbbbb",
+            "name": "wt-y",
+            "status": "running",
+            "host_name": "ec2-2-2-2-2.compute.amazonaws.com",
+            "user": "ubuntu",
+        }
+        q = _ListQueue(
+            [
+                [preexisting],  # resume probe: no match by name
+                [preexisting],  # pre-create snapshot -> pre_known = {i-ab1aaaaa}
+                [preexisting, ours_starting],  # resolve: only ours is new + nameless
+                [preexisting, ours_running],  # poll: ours running
+            ]
+        )
+        runner.add_fn(_MatchArgv.host_list, q)
+        runner.add(_MatchArgv.host_create, _ok(stdout="Host evg-ubuntu2204-7777 spawned.\n"))
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        host_id = self._domain(runner).spawn(
+            name="wt-y",
+            poll_interval_s=0.0,
+            timeout_s=5.0,
+            resolve_timeout_s=2.0,
+        )
+        self.assertEqual(host_id, "i-cd2bbbbb")
+        # Rename targets the resolved REAL id, not the evg-* placeholder.
+        modify_calls = [c for c in runner.calls if c[:3] == ["evergreen", "host", "modify"]]
+        self.assertTrue(modify_calls)
+        first = modify_calls[0]
+        self.assertEqual(first[first.index("--host") + 1], "i-cd2bbbbb")
+        self.assertEqual(first[first.index("--name") + 1], "wt-y")
+        self.assertEqual(first[first.index("--tag") + 1], "wt-ctl=wt-y")
+        # The pre-existing host is never touched.
+        for c in modify_calls:
+            self.assertNotIn("i-ab1aaaaa", c)
+
+
+_KEYS_LIST_STDOUT = (
+    "Public keys stored in Evergreen:\n"
+    "Name: 'lukasz.sierant@mongodb.com', Key: 'ssh-rsa AAAA... lukasz.sierant@mongodb.com'\n"
+    "Name: 'evg-host', Key: 'ssh-ed25519 AAAAC3... evg-host'\n"
+)
+
+
+class ResolveKeyNameTests(unittest.TestCase):
+    """Cover _resolve_key_name's three resolution branches.
+
+    Order is: MCK_DEVC_EVG_KEY_NAME env var → 'evg-host' if registered →
+    first listed key. The upstream ``evergreen keys list`` is plain text
+    (no ``--json`` flag), so we parse ``Name: '...'`` lines.
+    """
+
+    def setUp(self) -> None:
+        self._prev_key = os.environ.pop("MCK_DEVC_EVG_KEY_NAME", None)
+
+    def tearDown(self) -> None:
+        if self._prev_key is not None:
+            os.environ["MCK_DEVC_EVG_KEY_NAME"] = self._prev_key
+
+    def _domain(self, runner: FakeRunner) -> EvgDomain:
+        return EvgDomain(runner=runner, repo_root=Path("/tmp/repo"))
+
+    def test_env_var_takes_precedence(self) -> None:
+        os.environ["MCK_DEVC_EVG_KEY_NAME"] = "custom-key"
+        runner = FakeRunner()
+        # No keys_list handler registered — must not be called.
+        self.assertEqual(self._domain(runner)._resolve_key_name(), ("custom-key", ""))
+        self.assertFalse(any(c[:3] == ["evergreen", "keys", "list"] for c in runner.calls))
+
+    def test_prefers_evg_host_when_listed(self) -> None:
+        runner = FakeRunner()
+        runner.add(_MatchArgv.keys_list, _ok(stdout=_KEYS_LIST_STDOUT))
+        self.assertEqual(self._domain(runner)._resolve_key_name(), ("evg-host", ""))
+
+    def test_falls_back_to_first_listed_key(self) -> None:
+        runner = FakeRunner()
+        runner.add(
+            _MatchArgv.keys_list,
+            _ok(stdout=("Public keys stored in Evergreen:\n" "Name: 'only-one', Key: 'ssh-rsa AAAA only-one'\n")),
+        )
+        self.assertEqual(self._domain(runner)._resolve_key_name(), ("only-one", ""))
+
+    def test_returns_empty_when_keys_list_fails(self) -> None:
+        runner = FakeRunner()
+        runner.add(
+            _MatchArgv.keys_list,
+            CmdResult(argv=[], rc=1, stdout="", stderr="boom", duration_s=0.0),
+        )
+        name, diag = self._domain(runner)._resolve_key_name()
+        self.assertEqual(name, "")
+        self.assertIn("rc=1", diag)
+        self.assertIn("boom", diag)
+
+    def test_returns_empty_when_no_keys_listed(self) -> None:
+        runner = FakeRunner()
+        runner.add(
+            _MatchArgv.keys_list,
+            _ok(stdout="Public keys stored in Evergreen:\n"),
+        )
+        name, diag = self._domain(runner)._resolve_key_name()
+        self.assertEqual(name, "")
+        self.assertIn("no parseable", diag)
+
+    def test_spawn_uses_evg_host_when_env_var_unset(self) -> None:
+        """End-to-end: with the env var unset, fresh spawn passes
+        ``--key evg-host`` to ``evergreen host create``.
+        """
+        runner = FakeRunner()
+        # No live host with this displayName, so resume detection misses.
+        runner.add_fn(
+            _MatchArgv.host_list,
+            _ListQueue(
+                [
+                    [],
+                    [
+                        {
+                            "id": "i-9999",
+                            "display_name": "wt-x",
+                            "status": "running",
+                            "host_name": "ec2-1-1-1-1.compute.amazonaws.com",
+                            "user": "ubuntu",
+                        }
+                    ],
+                ]
+            ),
+        )
+        runner.add(_MatchArgv.keys_list, _ok(stdout=_KEYS_LIST_STDOUT))
+        runner.add(_MatchArgv.host_create, _ok(stdout="Host i-9999 spawned.\n"))
+        runner.add(_MatchArgv.host_modify, _ok())
+        runner.add(_MatchArgv.ssh, _ok())
+        self._domain(runner).spawn(
+            name="wt-x",
+            poll_interval_s=0.0,
+            timeout_s=2.0,
+        )
+        create_calls = [c for c in runner.calls if c[:3] == ["evergreen", "host", "create"]]
+        self.assertEqual(len(create_calls), 1)
+        self.assertIn("--key", create_calls[0])
+        ki = create_calls[0].index("--key")
+        self.assertEqual(create_calls[0][ki + 1], "evg-host")
+
+
+class ListMyHostsJsonTests(unittest.TestCase):
+    """`_list_my_hosts_json` must tolerate the Evergreen status banner (prepended
+    to stdout) and transient non-zero exits, retrying rather than raising/[]."""
+
+    def _domain(self, runner: FakeRunner) -> EvgDomain:
+        return EvgDomain(runner=runner, repo_root=Path("/tmp/repo"))
+
+    def test_parse_strips_leading_banner(self) -> None:
+        stdout = 'Banner: We are encountering some slowness with the Github API.\n[{"id": "i-1"}]'
+        self.assertEqual(EvgDomain._parse_hosts_json(stdout), [{"id": "i-1"}])
+
+    def test_parse_returns_none_without_array(self) -> None:
+        self.assertIsNone(EvgDomain._parse_hosts_json("Banner: totally broken, no json"))
+
+    def test_list_retries_transient_rc_then_succeeds(self) -> None:
+        seq = [
+            CmdResult(argv=[], rc=1, stdout="", stderr="github slowness", duration_s=0.0),
+            CmdResult(argv=[], rc=0, stdout='[{"id": "i-ok"}]', stderr="", duration_s=0.0),
+        ]
+        runner = FakeRunner()
+        it = iter(seq)
+        runner.add_fn(_MatchArgv.host_list, lambda _argv: next(it))
+        with mock.patch("wt_ctl.domains.evg.time.sleep"):
+            out = self._domain(runner)._list_my_hosts_json(retries=2, retry_interval_s=0.0)
+        self.assertEqual(out, [{"id": "i-ok"}])
+
+    def test_list_retries_banner_corruption_then_succeeds(self) -> None:
+        seq = [
+            CmdResult(argv=[], rc=0, stdout="Banner: slowness\nnot-json-at-all", stderr="", duration_s=0.0),
+            CmdResult(argv=[], rc=0, stdout='Banner: slowness\n[{"id": "i-ok"}]', stderr="", duration_s=0.0),
+        ]
+        runner = FakeRunner()
+        it = iter(seq)
+        runner.add_fn(_MatchArgv.host_list, lambda _argv: next(it))
+        with mock.patch("wt_ctl.domains.evg.time.sleep"):
+            out = self._domain(runner)._list_my_hosts_json(retries=2, retry_interval_s=0.0)
+        self.assertEqual(out, [{"id": "i-ok"}])
+
+    def test_list_raises_after_retries_exhausted(self) -> None:
+        runner = FakeRunner()
+        runner.add(_MatchArgv.host_list, CmdResult(argv=[], rc=1, stdout="", stderr="down", duration_s=0.0))
+        with mock.patch("wt_ctl.domains.evg.time.sleep"):
+            with self.assertRaises(ExternalCommandFailed):
+                self._domain(runner)._list_my_hosts_json(retries=2, retry_interval_s=0.0)
+
+    def test_list_hosts_retries_transient_rc_then_succeeds(self) -> None:
+        """The delete/terminate path (list_hosts) must ride out a transient rc=1
+        rather than return [] and silently skip termination -> leak."""
+        seq = [
+            CmdResult(argv=[], rc=1, stdout="", stderr="github slowness", duration_s=0.0),
+            CmdResult(argv=[], rc=0, stdout='[{"id": "i-ok", "name": "wt-x"}]', stderr="", duration_s=0.0),
+        ]
+        runner = FakeRunner()
+        it = iter(seq)
+        runner.add_fn(_MatchArgv.host_list, lambda _argv: next(it))
+        with mock.patch("wt_ctl.domains.evg.time.sleep"):
+            with mock.patch.object(FakeRunner, "have", return_value=True):
+                out = self._domain(runner)._host_list_with_retry(mine=True, retries=2, retry_interval_s=0.0)
+        self.assertEqual(out, [{"id": "i-ok", "name": "wt-x"}])
+
+    def test_list_hosts_returns_empty_after_exhaustion(self) -> None:
+        runner = FakeRunner()
+        runner.add(_MatchArgv.host_list, CmdResult(argv=[], rc=1, stdout="", stderr="down", duration_s=0.0))
+        with mock.patch("wt_ctl.domains.evg.time.sleep"):
+            self.assertEqual(self._domain(runner).list_hosts(mine=True), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_kfp.py
+++ b/scripts/test/wt_ctl/test_kfp.py
@@ -1,0 +1,210 @@
+"""KfpDomain — on-host kfp daemon HTTP client (launchctl owns lifecycle).
+
+* ``is_listening()`` — True/False from an injected socket class.
+* ``health()`` — injected urlopen: 200/ok parses to "ok"; 503 and
+  connection-refused map to None.
+* the ``kfp`` CLI parser accepts ``status``/``register`` but not start/stop.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+import urllib.error
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from _common import fake_which  # noqa: E402
+from wt_ctl import cli  # noqa: E402
+from wt_ctl.domains import kfp as kfp_mod  # noqa: E402
+from wt_ctl.domains.kfp import KfpDomain  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# fake socket / urlopen helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeSocket:
+    """Minimal stand-in for ``socket.socket(AF_INET, SOCK_STREAM)``."""
+
+    def __init__(self, *, connect_ok: bool, exc: Optional[Exception] = None) -> None:
+        self._connect_ok = connect_ok
+        self._exc = exc
+        self.timeout: Optional[float] = None
+        self.closed = False
+
+    def settimeout(self, t: float) -> None:
+        self.timeout = t
+
+    def connect(self, _addr) -> None:
+        if not self._connect_ok:
+            raise self._exc or ConnectionRefusedError("refused")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+
+@dataclass
+class _DetachedRecorder:
+    """Stand-in Runner that records ``run_detached`` calls."""
+
+    detached_calls: list[dict] = field(default_factory=list)
+    spawn_pid: int = 4242
+
+    def run_detached(self, argv, *, stdout_path=None, stderr_path=None, env=None, cwd=None) -> int:
+        self.detached_calls.append(
+            {
+                "argv": list(argv),
+                "stdout_path": stdout_path,
+                "stderr_path": stderr_path,
+            }
+        )
+        return self.spawn_pid
+
+
+# ---------------------------------------------------------------------------
+# is_listening
+# ---------------------------------------------------------------------------
+
+
+class IsListeningTests(unittest.TestCase):
+    def _domain(self, *, connect_ok: bool, tmp: str, exc: Optional[Exception] = None) -> KfpDomain:
+        d = KfpDomain(
+            runner=None,  # not used by is_listening
+            binary=Path("/nonexistent/proxy"),
+            state_dir=Path(tmp) / "kfp",
+        )
+
+        def _factory(_family, _type):
+            return _FakeSocket(connect_ok=connect_ok, exc=exc)
+
+        # Monkey-patch the socket.socket symbol KfpDomain.is_listening uses.
+        self._patched_socket = kfp_mod.socket.socket
+        kfp_mod.socket.socket = _factory  # type: ignore[assignment]
+        return d
+
+    def tearDown(self) -> None:
+        if hasattr(self, "_patched_socket"):
+            kfp_mod.socket.socket = self._patched_socket
+
+    def test_listening_when_connect_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = self._domain(connect_ok=True, tmp=tmp)
+            self.assertTrue(d.is_listening())
+
+    def test_not_listening_on_connection_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = self._domain(
+                connect_ok=False,
+                tmp=tmp,
+                exc=ConnectionRefusedError("refused"),
+            )
+            self.assertFalse(d.is_listening())
+
+    def test_not_listening_on_timeout(self) -> None:
+        import socket as _socket
+
+        with tempfile.TemporaryDirectory() as tmp:
+            d = self._domain(connect_ok=False, tmp=tmp, exc=_socket.timeout())
+            self.assertFalse(d.is_listening())
+
+
+# ---------------------------------------------------------------------------
+# health()
+# ---------------------------------------------------------------------------
+
+
+class HealthTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_urlopen = kfp_mod.urllib.request.urlopen
+
+    def tearDown(self) -> None:
+        kfp_mod.urllib.request.urlopen = self._orig_urlopen
+
+    def _patch(self, fn: Callable) -> None:
+        kfp_mod.urllib.request.urlopen = fn  # type: ignore[assignment]
+
+    def _domain(self, tmp: str) -> KfpDomain:
+        return KfpDomain(
+            runner=None,
+            binary=Path("/nonexistent/proxy"),
+            state_dir=Path(tmp) / "kfp",
+        )
+
+    def test_200_ok_returns_ok(self) -> None:
+        self._patch(lambda _u, timeout=None: _FakeHTTPResponse(200, b"ok"))
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(self._domain(tmp).health(), "ok")
+
+    def test_503_returns_none(self) -> None:
+        self._patch(lambda _u, timeout=None: _FakeHTTPResponse(503, b"down"))
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(self._domain(tmp).health())
+
+    def test_connection_refused_returns_none(self) -> None:
+        def _boom(_u, timeout=None):
+            raise urllib.error.URLError("Connection refused")
+
+        self._patch(_boom)
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(self._domain(tmp).health())
+
+    def test_oserror_returns_none(self) -> None:
+        def _boom(_u, timeout=None):
+            raise OSError("boom")
+
+        self._patch(_boom)
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(self._domain(tmp).health())
+
+
+# ---------------------------------------------------------------------------
+# CLI parser
+# ---------------------------------------------------------------------------
+
+
+class KfpCliParserTests(unittest.TestCase):
+    def test_kfp_status_parses(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["kfp", "status"])
+        self.assertEqual(args.cmd, "kfp")
+        self.assertEqual(args.kfp_cmd, "status")
+
+    def test_kfp_register_parses(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["kfp", "register", "--kubeconfig", "/tmp/x"])
+        self.assertEqual(args.cmd, "kfp")
+        self.assertEqual(args.kfp_cmd, "register")
+        self.assertEqual(args.kubeconfig, "/tmp/x")
+
+    def test_kfp_start_rejected(self) -> None:
+        parser = cli.build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["kfp", "start"])
+
+    def test_kfp_stop_rejected(self) -> None:
+        parser = cli.build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["kfp", "stop"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_kubeconfig.py
+++ b/scripts/test/wt_ctl/test_kubeconfig.py
@@ -1,0 +1,417 @@
+"""``KubeconfigDomain.refresh`` — three dispatch branches.
+
+- EVG-host mode (.current-evg-host present): proxy-url is patched on the
+  host file (loopback:PROXY_PORT) and the devc variant (EVG_HOST_PROXY).
+- Local-kind (no pin, loopback server URL): devc variant gets server
+  rewritten to host.docker.internal:<port>, TLS-skip flag set, CA stripped.
+- BYOC (no pin, non-loopback server URL): devc variant is a verbatim copy.
+
+In all branches, kfp registration is attempted when K8S_FWD_PROXY is set.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import wt_ctl.domains.kubeconfig as kubeconfig_module  # noqa: E402
+import yaml  # noqa: E402
+from _common import FakePopenFactory  # noqa: F401  (sys.path side-effect)
+from wt_ctl.domains.kubeconfig import KubeconfigDomain  # noqa: E402
+from wt_ctl.runner import Runner  # noqa: E402
+
+_KIND_KUBECONFIG = """\
+apiVersion: v1
+kind: Config
+current-context: kind-foo
+clusters:
+- name: kind-foo
+  cluster:
+    server: https://127.0.0.1:54321
+    certificate-authority-data: BASE64_CA_BLOB
+contexts:
+- name: kind-foo
+  context:
+    cluster: kind-foo
+    user: kind-foo
+users:
+- name: kind-foo
+  user:
+    client-certificate-data: BLOB
+    client-key-data: BLOB
+"""
+
+
+_GKE_KUBECONFIG = """\
+apiVersion: v1
+kind: Config
+current-context: gke_proj_zone_cluster
+clusters:
+- name: gke_proj_zone_cluster
+  cluster:
+    server: https://203.0.113.42
+    certificate-authority-data: BASE64_CA_BLOB
+contexts:
+- name: gke_proj_zone_cluster
+  context:
+    cluster: gke_proj_zone_cluster
+    user: gke_proj_zone_cluster
+users: []
+"""
+
+
+_MC_KUBECONFIG = """\
+apiVersion: v1
+kind: Config
+current-context: kind-e2e-cluster-1
+clusters:
+- name: kind-e2e-cluster-1
+  cluster:
+    server: https://127.0.0.1:37737
+    certificate-authority-data: BASE64_CA_BLOB
+- name: kind-e2e-cluster-2
+  cluster:
+    server: https://127.0.0.1:36145
+    certificate-authority-data: BASE64_CA_BLOB
+contexts:
+- name: kind-e2e-cluster-1
+  context:
+    cluster: kind-e2e-cluster-1
+    user: kind-e2e-cluster-1
+users: []
+"""
+
+
+class FakeKfp:
+    """Records every PATCH attempt instead of doing real HTTP."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes]] = []
+        self.success = True
+
+    def __call__(self, url: str, body: bytes, log: Any) -> bool:
+        self.calls.append((url, body))
+        log(f"FAKE-PATCH {url} bytes={len(body)}")
+        return self.success
+
+    def last_body_yaml(self) -> dict:
+        """Parse the most recent PATCH body as YAML."""
+        return yaml.safe_load(self.calls[-1][1])
+
+
+class KubeconfigRefreshTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_obj = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_obj.cleanup)
+        self.wt = Path(self.tmp_obj.name)
+        (self.wt / ".generated").mkdir(parents=True)
+        self.host_kc = self.wt / ".generated" / "current.kubeconfig"
+        self.devc_kc = self.wt / ".generated" / "current.devc.kubeconfig"
+        self.evg_pin = self.wt / ".generated" / ".current-evg-host"
+        self.mc_base = self.wt / ".generated" / "multicluster_kubeconfig"
+        self.mc_devc = self.wt / ".generated" / "multicluster.devc.kubeconfig"
+
+        self.fake_kfp = FakeKfp()
+        self._orig_patch = kubeconfig_module._patch_kfp
+        kubeconfig_module._patch_kfp = self.fake_kfp
+        self.addCleanup(lambda: setattr(kubeconfig_module, "_patch_kfp", self._orig_patch))
+
+        # Pin the devc-server resolution to the macOS branch (host.docker.internal)
+        # by default so the local-kind assertions don't depend on the test host's
+        # OS or a real docker. Linux-path tests override via _force_linux.
+        self._set_platform("Darwin")
+
+    def _set_platform(self, system: str) -> None:
+        orig = kubeconfig_module.platform.system
+        kubeconfig_module.platform.system = lambda: system
+        self.addCleanup(lambda: setattr(kubeconfig_module.platform, "system", orig))
+
+    def _force_linux(self, node_ip: dict[str, str] | None) -> None:
+        """Switch to the Linux branch and stub kind-node-IP resolution.
+        node_ip maps cluster-entry-name → IP; None entries simulate an
+        unresolvable node (docker miss / in-devc)."""
+        self._set_platform("Linux")
+        orig = kubeconfig_module._kind_node_ip
+        kubeconfig_module._kind_node_ip = lambda _runner, name: (node_ip or {}).get(name)
+        self.addCleanup(lambda: setattr(kubeconfig_module, "_kind_node_ip", orig))
+
+    def _refresh(self, **env_overrides: str) -> None:
+        env = {"K8S_FWD_PROXY": "127.0.0.1:11616", **env_overrides}
+        KubeconfigDomain(Runner()).refresh(self.wt, env=env, in_devc=False, emit=lambda _m: None)
+
+    # ------------------------------------------------------------------
+    # Local-kind branch (no pin, loopback server).
+    # ------------------------------------------------------------------
+    def test_local_kind_rewrites_devc_server_and_tls_skip(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self._refresh(CLUSTER_NAME="kind-foo")
+        devc = yaml.safe_load(self.devc_kc.read_text())
+        cluster = devc["clusters"][0]["cluster"]
+        self.assertEqual(cluster["server"], "https://host.docker.internal:54321")
+        self.assertIs(cluster["insecure-skip-tls-verify"], True)
+        self.assertNotIn("certificate-authority-data", cluster)
+        # host file still server=127.0.0.1, no proxy-url, current-context pinned.
+        host = yaml.safe_load(self.host_kc.read_text())
+        self.assertEqual(host["clusters"][0]["cluster"]["server"], "https://127.0.0.1:54321")
+        self.assertNotIn("proxy-url", host["clusters"][0]["cluster"])
+        self.assertEqual(host["current-context"], "kind-foo")
+
+    def test_local_kind_linux_rewrites_devc_server_to_kind_node_ip(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self._force_linux({"kind-foo": "172.18.0.2"})
+        self._refresh(CLUSTER_NAME="kind-foo")
+        cluster = yaml.safe_load(self.devc_kc.read_text())["clusters"][0]["cluster"]
+        self.assertEqual(cluster["server"], "https://172.18.0.2:6443")
+        self.assertIs(cluster["insecure-skip-tls-verify"], True)
+
+    def test_local_kind_linux_indevc_preserves_host_written_server(self) -> None:
+        # Host-side wrote the node IP; the in-devc refresh (no docker → node IP
+        # unresolvable) must keep it, not clobber back to host.docker.internal.
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.devc_kc.write_text(_KIND_KUBECONFIG.replace("https://127.0.0.1:54321", "https://172.18.0.2:6443"))
+        self._force_linux(None)
+        self._refresh(CLUSTER_NAME="kind-foo")
+        cluster = yaml.safe_load(self.devc_kc.read_text())["clusters"][0]["cluster"]
+        self.assertEqual(cluster["server"], "https://172.18.0.2:6443")
+
+    def test_local_kind_registers_host_variant_on_host_side(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self._refresh()
+        self.assertEqual(len(self.fake_kfp.calls), 1)
+        url, body = self.fake_kfp.calls[0]
+        self.assertEqual(url, "http://127.0.0.1:11616/kubeconfig")
+        # host file's bytes — server is still 127.0.0.1.
+        self.assertIn(b"127.0.0.1:54321", body)
+        self.assertNotIn(b"host.docker.internal", body)
+
+    def test_local_kind_no_suffix_when_proxy_port_unset(self) -> None:
+        """No MCK_DEVC_PROXY_PORT → no in-flight suffix. Mirrors EVG-CI
+        runs that don't have a devc stack."""
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self._refresh(CLUSTER_NAME="kind-foo")  # no MCK_DEVC_PROXY_PORT
+        host = yaml.safe_load(self.host_kc.read_text())
+        self.assertEqual(host["current-context"], "kind-foo")
+        self.assertEqual(host["clusters"][0]["name"], "kind-foo")
+        # PATCH body matches the on-disk file (no suffix transform).
+        body = self.fake_kfp.last_body_yaml()
+        self.assertEqual(body["current-context"], "kind-foo")
+        self.assertEqual(body["clusters"][0]["name"], "kind-foo")
+
+    def test_local_kind_suffix_in_flight_when_proxy_port_set(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self._refresh(CLUSTER_NAME="kind-foo", MCK_DEVC_PROXY_PORT="9152")
+        host = yaml.safe_load(self.host_kc.read_text())
+        devc = yaml.safe_load(self.devc_kc.read_text())
+        # On-disk files: bare on both sides.
+        self.assertEqual(host["current-context"], "kind-foo")
+        self.assertEqual(host["clusters"][0]["name"], "kind-foo")
+        self.assertEqual(devc["current-context"], "kind-foo")
+        self.assertEqual(devc["clusters"][0]["name"], "kind-foo")
+        self.assertEqual(
+            devc["clusters"][0]["cluster"]["server"],
+            "https://host.docker.internal:54321",
+        )
+        # Wire bytes (host-side PATCH): suffixed for kfp.
+        body = self.fake_kfp.last_body_yaml()
+        self.assertEqual(body["current-context"], "kind-foo-9152")
+        self.assertEqual(body["clusters"][0]["name"], "kind-foo-9152")
+
+    # ------------------------------------------------------------------
+    # BYOC branch (no pin, non-loopback server).
+    # ------------------------------------------------------------------
+    def test_byoc_identity_copies_to_devc(self) -> None:
+        self.host_kc.write_text(_GKE_KUBECONFIG)
+        self._refresh(CLUSTER_NAME="gke_proj_zone_cluster")
+        host = yaml.safe_load(self.host_kc.read_text())
+        devc = yaml.safe_load(self.devc_kc.read_text())
+        self.assertEqual(
+            host["clusters"][0]["cluster"]["server"],
+            "https://203.0.113.42",
+        )
+        self.assertEqual(
+            devc["clusters"][0]["cluster"]["server"],
+            "https://203.0.113.42",
+        )
+        # No TLS-skip / CA strip for BYOC (the cert is presumed valid).
+        self.assertNotIn("insecure-skip-tls-verify", devc["clusters"][0]["cluster"])
+        self.assertIn("certificate-authority-data", devc["clusters"][0]["cluster"])
+
+    # ------------------------------------------------------------------
+    # Multi-cluster two-flavor derivation from the bare base.
+    # ------------------------------------------------------------------
+    def test_evg_host_multicluster_two_flavors(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.mc_base.write_text(_MC_KUBECONFIG)
+        self.evg_pin.write_text("my-evg-host")
+        self._refresh(MCK_DEVC_PROXY_PORT="8000", EVG_HOST_PROXY="http://gost-proxy:8080")
+        # Host flavor (base) — every member gets the loopback host proxy.
+        base = yaml.safe_load(self.mc_base.read_text())
+        self.assertEqual([c["cluster"]["proxy-url"] for c in base["clusters"]], ["http://127.0.0.1:8000"] * 2)
+        # Devc flavor — every member gets EVG_HOST_PROXY; servers unchanged.
+        devc = yaml.safe_load(self.mc_devc.read_text())
+        self.assertEqual([c["cluster"]["proxy-url"] for c in devc["clusters"]], ["http://gost-proxy:8080"] * 2)
+        self.assertEqual(devc["clusters"][0]["cluster"]["server"], "https://127.0.0.1:37737")
+
+    def test_evg_host_no_multicluster_base_is_noop(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.evg_pin.write_text("my-evg-host")
+        self._refresh(MCK_DEVC_PROXY_PORT="8000", EVG_HOST_PROXY="http://gost-proxy:8080")
+        self.assertFalse(self.mc_base.exists())
+        self.assertFalse(self.mc_devc.exists())
+
+    def test_local_kind_multicluster_devc_host_docker_internal(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.mc_base.write_text(_MC_KUBECONFIG)
+        self._refresh()
+        # Host flavor: bare loopback (laptop kind reachable directly), no proxy.
+        base = yaml.safe_load(self.mc_base.read_text())
+        self.assertNotIn("proxy-url", base["clusters"][0]["cluster"])
+        self.assertEqual(base["clusters"][0]["cluster"]["server"], "https://127.0.0.1:37737")
+        # Devc flavor: per-member host.docker.internal rewrite + TLS skip.
+        devc = yaml.safe_load(self.mc_devc.read_text())
+        self.assertEqual(
+            [c["cluster"]["server"] for c in devc["clusters"]],
+            ["https://host.docker.internal:37737", "https://host.docker.internal:36145"],
+        )
+
+    def test_local_kind_multicluster_linux_per_member_node_ip(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.mc_base.write_text(_MC_KUBECONFIG)
+        self._force_linux({"kind-e2e-cluster-1": "172.18.0.3", "kind-e2e-cluster-2": "172.18.0.4"})
+        self._refresh()
+        devc = yaml.safe_load(self.mc_devc.read_text())
+        self.assertEqual(
+            [c["cluster"]["server"] for c in devc["clusters"]],
+            ["https://172.18.0.3:6443", "https://172.18.0.4:6443"],
+        )
+        self.assertIs(devc["clusters"][0]["cluster"]["insecure-skip-tls-verify"], True)
+        self.assertNotIn("certificate-authority-data", devc["clusters"][0]["cluster"])
+
+    def test_local_kind_multicluster_linux_rewrites_clusterip_secret_by_context(self) -> None:
+        # The MC operator Secret carries per-cluster ClusterIPs (non-loopback).
+        # On Linux they must be rewritten to node IPs by context name, not
+        # skipped as "already-rewritten".
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.mc_base.write_text(
+            _MC_KUBECONFIG.replace("https://127.0.0.1:37737", "https://10.97.0.1:443").replace(
+                "https://127.0.0.1:36145", "https://10.98.0.1:443"
+            )
+        )
+        self._force_linux({"kind-e2e-cluster-1": "172.18.0.3", "kind-e2e-cluster-2": "172.18.0.4"})
+        self._refresh()
+        devc = yaml.safe_load(self.mc_devc.read_text())
+        self.assertEqual(
+            [c["cluster"]["server"] for c in devc["clusters"]],
+            ["https://172.18.0.3:6443", "https://172.18.0.4:6443"],
+        )
+
+    # ------------------------------------------------------------------
+    # EVG-host branch (pin present).
+    # ------------------------------------------------------------------
+    def test_evg_host_patches_proxy_url_on_both_variants(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.evg_pin.write_text("my-evg-host")
+        self._refresh(
+            MCK_DEVC_PROXY_PORT="8000",
+            EVG_HOST_PROXY="http://gost-proxy:8080",
+            CLUSTER_NAME="kind-foo",
+        )
+        host = yaml.safe_load(self.host_kc.read_text())
+        devc = yaml.safe_load(self.devc_kc.read_text())
+        self.assertEqual(
+            host["clusters"][0]["cluster"]["proxy-url"],
+            "http://127.0.0.1:8000",
+        )
+        self.assertEqual(
+            devc["clusters"][0]["cluster"]["proxy-url"],
+            "http://gost-proxy:8080",
+        )
+        # On-disk files: bare everywhere. Variant context env vars
+        # (CLUSTER_NAME / MEMBER_CLUSTERS / TEST_POD_CLUSTER) reference
+        # bare names; bin/reset calls kubectl --context "${CLUSTER_NAME}"
+        # and would fail against suffixed entries.
+        self.assertEqual(host["current-context"], "kind-foo")
+        self.assertEqual(host["clusters"][0]["name"], "kind-foo")
+        self.assertEqual(devc["current-context"], "kind-foo")
+        self.assertEqual(devc["clusters"][0]["name"], "kind-foo")
+        # PATCH-to-kfp body: suffixed in-flight so the on-host kfp can
+        # disambiguate concurrent worktrees.
+        body = self.fake_kfp.last_body_yaml()
+        self.assertEqual(body["current-context"], "kind-foo-8000")
+        self.assertEqual(body["clusters"][0]["name"], "kind-foo-8000")
+        self.assertEqual(body["contexts"][0]["name"], "kind-foo-8000")
+        self.assertEqual(body["contexts"][0]["context"]["cluster"], "kind-foo-8000")
+        self.assertEqual(body["contexts"][0]["context"]["user"], "kind-foo-8000")
+        self.assertEqual(body["users"][0]["name"], "kind-foo-8000")
+
+    def test_evg_host_devc_side_kfp_patch_stays_bare(self) -> None:
+        """When refresh runs INSIDE the devc, the PATCH goes to the
+        in-container k8s-proxy sidecar (single-tenant per worktree) — no
+        suffix needed and no suffix applied."""
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.evg_pin.write_text("my-evg-host")
+        KubeconfigDomain(Runner()).refresh(
+            self.wt,
+            env={
+                "K8S_FWD_PROXY": "172.21.0.10:80",
+                "MCK_DEVC_PROXY_PORT": "8000",
+                "EVG_HOST_PROXY": "http://gost-proxy:8080",
+                "CLUSTER_NAME": "kind-foo",
+            },
+            in_devc=True,
+            emit=lambda _m: None,
+        )
+        body = self.fake_kfp.last_body_yaml()
+        self.assertEqual(body["current-context"], "kind-foo")
+        self.assertEqual(body["clusters"][0]["name"], "kind-foo")
+
+    def test_evg_host_rerun_normalises_stale_on_disk_suffix(self) -> None:
+        """A host kubeconfig with suffixed on-disk names must be normalised
+        back to bare on disk while the kfp PATCH stays suffixed."""
+        suffixed = _KIND_KUBECONFIG.replace("kind-foo", "kind-foo-8000")
+        self.host_kc.write_text(suffixed)
+        self.evg_pin.write_text("my-evg-host")
+        self._refresh(
+            MCK_DEVC_PROXY_PORT="8000",
+            EVG_HOST_PROXY="http://gost-proxy:8080",
+            CLUSTER_NAME="kind-foo",
+        )
+        host = yaml.safe_load(self.host_kc.read_text())
+        # Normalised back to bare on disk.
+        self.assertEqual(host["current-context"], "kind-foo")
+        self.assertEqual(host["clusters"][0]["name"], "kind-foo")
+        # Wire bytes: suffixed.
+        body = self.fake_kfp.last_body_yaml()
+        self.assertEqual(body["current-context"], "kind-foo-8000")
+        self.assertEqual(body["clusters"][0]["name"], "kind-foo-8000")
+
+    def test_evg_host_missing_proxy_port_raises(self) -> None:
+        from wt_ctl.errors import WtCtlError
+
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        self.evg_pin.write_text("my-evg-host")
+        with self.assertRaises(WtCtlError):
+            self._refresh()  # no MCK_DEVC_PROXY_PORT
+
+    # ------------------------------------------------------------------
+    # devc-side registration choice.
+    # ------------------------------------------------------------------
+    def test_local_kind_devc_side_registers_devc_variant(self) -> None:
+        self.host_kc.write_text(_KIND_KUBECONFIG)
+        KubeconfigDomain(Runner()).refresh(
+            self.wt,
+            env={"K8S_FWD_PROXY": "172.21.0.10:80", "CLUSTER_NAME": "kind-foo"},
+            in_devc=True,
+            emit=lambda _m: None,
+        )
+        self.assertEqual(len(self.fake_kfp.calls), 1)
+        url, body = self.fake_kfp.calls[0]
+        self.assertEqual(url, "http://172.21.0.10:80/kubeconfig")
+        # devc variant bytes — server rewritten to host.docker.internal.
+        self.assertIn(b"host.docker.internal:54321", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_lint.py
+++ b/scripts/test/wt_ctl/test_lint.py
@@ -1,0 +1,26 @@
+"""Run the no-subprocess-in-domains lint as a unit test."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+LINT = REPO / "scripts" / "test" / "wt_ctl_lint.py"
+
+
+class LintTests(unittest.TestCase):
+    def test_no_subprocess_in_domains(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(LINT)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr or proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_network_parse.py
+++ b/scripts/test/wt_ctl/test_network_parse.py
@@ -1,0 +1,44 @@
+"""Parser test for ``dc_select_network.sh --list`` output."""
+
+from __future__ import annotations
+
+import unittest
+
+from _common import FakePopenFactory  # noqa: E402
+from wt_ctl.domains.network import _parse_list_output  # noqa: E402
+
+SAMPLE = """\
+Registry: /home/x/.cache/mck-devc/net-prefix-registry
+Worktree parent (conventional): /home/x/mdb
+
+BRANCH_DIR                                               PREFIX  STATUS  WORKTREE
+----------                                               ------  ------  --------
+alpha_devcontainer                                       28      active  /home/x/mdb/alpha_devcontainer
+beta                                                     30      stale   (missing)
+
+Summary: 1 active, 1 stale (run with --prune to GC).
+
+Docker networks in 172.[16-31].0.0/16:
+NETWORK                                                            PREFIX
+-------                                                            ------
+alpha_devcontainer_devcontainer_devcontainer                       28
+
+Free range: 172.[16-31].0.0/16.
+"""
+
+
+class NetworkParseTests(unittest.TestCase):
+    def test_parses_active_and_stale_rows(self) -> None:
+        rows = _parse_list_output(SAMPLE)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0].branch_dir, "alpha_devcontainer")
+        self.assertEqual(rows[0].prefix, 28)
+        self.assertEqual(rows[0].status, "active")
+        self.assertEqual(rows[0].worktree_path, "/home/x/mdb/alpha_devcontainer")
+        self.assertEqual(rows[1].branch_dir, "beta")
+        self.assertEqual(rows[1].status, "stale")
+        self.assertIsNone(rows[1].worktree_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_network_registry.py
+++ b/scripts/test/wt_ctl/test_network_registry.py
@@ -1,0 +1,587 @@
+"""Registry tests: index→StackParams math, /23 allocation, flock locking,
+orphan detection, and prune. Docker/git go through a fake Runner so the
+tests don't depend on the host environment.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from _common import FakePopenFactory, fake_which  # noqa: E402
+from wt_ctl.domains.network import (  # noqa: E402
+    DERIVED_ENV_KEYS,
+    INDEX_HI,
+    INDEX_LO,
+    VALID_RANGE_HI,
+    VALID_RANGE_LO,
+    Registry,
+    StackParams,
+    _format_rhs,
+    _parse_rhs,
+    _RegistryRow,
+    env_lines_for,
+    stack_params,
+)
+from wt_ctl.errors import LockTimeout, RegistryError  # noqa: E402
+from wt_ctl.runner import Runner  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+class _MakeFakes:
+    """Minimal Runner that fakes docker + git calls deterministically.
+
+    - `docker network ls --format {{.Name}}` -> empty (no docker nets)
+    - `docker network inspect <name> --format ...` -> always rc=1
+    - `git -C <repo> worktree list --porcelain` -> empty
+    """
+
+    def runner(self) -> Runner:
+        fake = FakePopenFactory(
+            mapping={
+                ("docker", "network", "ls", "--format", "{{.Name}}"): ("", "", 0),
+            },
+            default=("", "", 0),
+        )
+        return Runner(popen_factory=fake, which=fake_which)
+
+
+def _patch_registry_dir(tmp: Path):
+    """Point the module's `_registry_dir` lookup at a tmp dir."""
+    return patch.dict(os.environ, {"MCK_DEVC_REGISTRY_DIR": str(tmp)})
+
+
+# ---------------------------------------------------------------------------
+# math: stack_params + boundary indices
+# ---------------------------------------------------------------------------
+
+
+class StackParamsMathTests(unittest.TestCase):
+    """Confirm the index -> X/Y/PORT mapping at every load-bearing boundary."""
+
+    def _check(self, n: int, x: int, y_base: int, y_vip: int, port: int) -> None:
+        p = stack_params(n)
+        self.assertEqual(p.index, n)
+        self.assertEqual(p.x, x)
+        self.assertEqual(p.y_base, y_base)
+        self.assertEqual(p.y_vip, y_vip)
+        self.assertEqual(p.port, port)
+        self.assertEqual(p.subnet, f"172.{x}.{y_base}.0/23")
+        self.assertEqual(p.ip_range, f"172.{x}.{y_base}.0/24")
+        self.assertEqual(p.vip_cidr, f"172.{x}.{y_vip}.0/24")
+        self.assertEqual(p.proxy_address, f"172.{x}.{y_base}.10")
+
+    def test_n0(self) -> None:
+        self._check(0, x=16, y_base=0, y_vip=1, port=8000)
+
+    def test_n127_last_in_x16(self) -> None:
+        self._check(127, x=16, y_base=254, y_vip=255, port=8127)
+
+    def test_n128_first_in_x17(self) -> None:
+        self._check(128, x=17, y_base=0, y_vip=1, port=8128)
+
+    def test_n1023(self) -> None:
+        self._check(1023, x=23, y_base=254, y_vip=255, port=9023)
+
+    def test_n2047_max(self) -> None:
+        self._check(2047, x=31, y_base=254, y_vip=255, port=10047)
+
+    def test_out_of_range_raises(self) -> None:
+        with self.assertRaises(RegistryError):
+            stack_params(-1)
+        with self.assertRaises(RegistryError):
+            stack_params(INDEX_HI + 1)
+
+
+# ---------------------------------------------------------------------------
+# row parsing/formatting round-trip
+# ---------------------------------------------------------------------------
+
+
+class RowFormatTests(unittest.TestCase):
+    def test_composite_round_trip(self) -> None:
+        # N=128 -> X=17, Y_BASE=0, Y_VIP=1, PORT=8128
+        row = _parse_rhs("bar", "128:17:0:1:8128")
+        assert row is not None
+        self.assertEqual(row.params.index, 128)
+        self.assertEqual(_format_rhs(row.params), "128:17:0:1:8128")
+
+    def test_malformed_drops(self) -> None:
+        self.assertIsNone(_parse_rhs("x", "not-a-number"))
+        self.assertIsNone(_parse_rhs("x", "1:2:3"))  # wrong arity
+        self.assertIsNone(_parse_rhs("x", "24"))  # bare-int form (rejected)
+        self.assertIsNone(_parse_rhs("x", "9999"))  # out of index range
+        self.assertIsNone(_parse_rhs("x", "9999:1:2:3:4"))
+
+    def test_inconsistent_composite_falls_back_to_derived(self) -> None:
+        # Claim N=0 (which derives X=16) but write X=99 — registry must
+        # warn and fall back to the derived values rather than route
+        # traffic to a phantom subnet.
+        row = _parse_rhs("zz", "0:99:0:1:8000")
+        assert row is not None
+        self.assertEqual(row.params.x, 16)
+
+
+# ---------------------------------------------------------------------------
+# round-trip — write then read
+# ---------------------------------------------------------------------------
+
+
+class RoundTripTests(unittest.TestCase):
+    def test_write_then_read(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                # Make matching worktree dirs so entries are "active".
+                for bd in ("alpha", "beta", "gamma", "delta"):
+                    (wt_parent / bd).mkdir()
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+                rows = [
+                    _RegistryRow("alpha", stack_params(0)),
+                    _RegistryRow("beta", stack_params(127)),
+                    _RegistryRow("gamma", stack_params(128)),
+                    _RegistryRow("delta", stack_params(1023)),
+                ]
+                reg._write(rows)
+                rows_back = reg._read()
+                self.assertEqual(
+                    [(r.branch_dir, r.params.index) for r in rows_back],
+                    [
+                        ("alpha", 0),
+                        ("beta", 127),
+                        ("gamma", 128),
+                        ("delta", 1023),
+                    ],
+                )
+                entries, _ = reg.list()
+                self.assertEqual(
+                    [(e.branch_dir, e.prefix, e.status) for e in entries],
+                    [
+                        ("alpha", 0, "active"),
+                        ("beta", 127, "active"),
+                        ("gamma", 128, "active"),
+                        ("delta", 1023, "active"),
+                    ],
+                )
+
+
+# ---------------------------------------------------------------------------
+# allocate
+# ---------------------------------------------------------------------------
+
+
+class AllocateTests(unittest.TestCase):
+    def test_empty_registry_first_index(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                (wt_parent / "newcomer").mkdir()
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+                params = reg.allocate(
+                    branch_dir="newcomer",
+                    auto_prune=False,
+                    emit_warning=lambda _m: None,
+                )
+                self.assertEqual(params.index, 0)
+                self.assertEqual(params.x, 16)
+
+    def test_allocator_skips_blocked_x_octet(self) -> None:
+        """A foreign /16 docker network at X=16 (e.g. kind) overlaps every
+        /23 in that octet, so all 128 indices with X==16 are blocked and the
+        allocator returns the first index in X=17.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                (wt_parent / "newcomer").mkdir()
+
+                # Fake a docker network at 172.16.0.0/16 (e.g. "kind").
+                fake = FakePopenFactory(
+                    mapping={
+                        ("docker", "network", "ls", "--format", "{{.Name}}"): ("kind\n", "", 0),
+                        (
+                            "docker",
+                            "network",
+                            "inspect",
+                            "kind",
+                            "--format",
+                            "{{range .IPAM.Config}}{{.Subnet}}{{end}}",
+                        ): ("172.16.0.0/16", "", 0),
+                    },
+                    default=("", "", 0),
+                )
+                runner = Runner(popen_factory=fake, which=fake_which)
+                reg = Registry(runner, worktree_parent=wt_parent)
+                params = reg.allocate(
+                    branch_dir="newcomer",
+                    auto_prune=False,
+                    emit_warning=lambda _m: None,
+                )
+                # X=16 is blocked, so first free index is 128 (X=17, Y_BASE=0).
+                self.assertEqual(params.x, 17)
+                self.assertEqual(params.index, 128)
+
+    def test_sibling_slash23_blocks_only_its_slot(self) -> None:
+        """A sibling /23 compose network at 172.16.0.0/23 occupies only index
+        0's slot; the allocator must stay in X=16 and hand out index 1
+        (172.16.2.0/23), not skip the whole octet.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                (wt_parent / "newcomer").mkdir()
+
+                fake = FakePopenFactory(
+                    mapping={
+                        ("docker", "network", "ls", "--format", "{{.Name}}"): (
+                            "sibling_devcontainer_devcontainer\n",
+                            "",
+                            0,
+                        ),
+                        (
+                            "docker",
+                            "network",
+                            "inspect",
+                            "sibling_devcontainer_devcontainer",
+                            "--format",
+                            "{{range .IPAM.Config}}{{.Subnet}}{{end}}",
+                        ): ("172.16.0.0/23", "", 0),
+                    },
+                    default=("", "", 0),
+                )
+                runner = Runner(popen_factory=fake, which=fake_which)
+                reg = Registry(runner, worktree_parent=wt_parent)
+                params = reg.allocate(
+                    branch_dir="newcomer",
+                    auto_prune=False,
+                    emit_warning=lambda _m: None,
+                )
+                self.assertEqual(params.x, 16)
+                self.assertEqual(params.index, 1)
+                self.assertEqual(params.subnet, "172.16.2.0/23")
+
+
+# ---------------------------------------------------------------------------
+# release + re-allocate round-trip
+# ---------------------------------------------------------------------------
+
+
+class ReleaseRoundTripTests(unittest.TestCase):
+    def test_release_frees_index_for_reallocation(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                names = ["a0", "a200", "a300"]
+                for bd in names:
+                    (wt_parent / bd).mkdir()
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+                reg._write(
+                    [
+                        _RegistryRow("a0", stack_params(0)),
+                        _RegistryRow("a200", stack_params(200)),
+                        _RegistryRow("a300", stack_params(300)),
+                    ]
+                )
+                for bd in names:
+                    reg.release(bd)
+                self.assertEqual(reg._read(), [])
+                # Now re-allocate; the freed indices come back in order.
+                (wt_parent / "rebooked").mkdir()
+                params = reg.allocate(
+                    branch_dir="rebooked",
+                    auto_prune=False,
+                    emit_warning=lambda _m: None,
+                )
+                self.assertEqual(params.index, 0)
+
+
+# ---------------------------------------------------------------------------
+# env_lines_for
+# ---------------------------------------------------------------------------
+
+
+class EnvLinesTests(unittest.TestCase):
+    def test_index_zero_block(self) -> None:
+        params = stack_params(0)
+        lines = env_lines_for(params)
+        self.assertEqual(
+            lines,
+            [
+                "MCK_DEVC_NET_PREFIX=0",
+                "MCK_DEVC_NET_X=16",
+                "MCK_DEVC_NET_Y_BASE=0",
+                "MCK_DEVC_NET_Y_VIP=1",
+                "MCK_DEVC_PROXY_PORT=8000",
+            ],
+        )
+
+    def test_mid_range_block(self) -> None:
+        params = stack_params(200)
+        # 200 >> 7 == 1 -> X=17; 200 & 0x7F == 72; 72*2 == 144
+        self.assertEqual(
+            env_lines_for(params),
+            [
+                "MCK_DEVC_NET_PREFIX=200",
+                "MCK_DEVC_NET_X=17",
+                "MCK_DEVC_NET_Y_BASE=144",
+                "MCK_DEVC_NET_Y_VIP=145",
+                "MCK_DEVC_PROXY_PORT=8200",
+            ],
+        )
+
+    def test_derived_keys_present(self) -> None:
+        for k in DERIVED_ENV_KEYS:
+            self.assertTrue(k.startswith("MCK_DEVC_"))
+
+
+# ---------------------------------------------------------------------------
+# locking — concurrent allocate
+# ---------------------------------------------------------------------------
+
+
+class LockTests(unittest.TestCase):
+    def test_concurrent_allocate_serializes(self) -> None:
+        """Two threads racing on allocate() must:
+        (a) both succeed,
+        (b) get distinct indices,
+        (c) leave the registry with two valid entries.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                runner = _MakeFakes().runner()
+
+                results: dict[str, int] = {}
+                errors: list[BaseException] = []
+
+                def alloc(name: str) -> None:
+                    try:
+                        # Make matching worktree dir so the entry isn't
+                        # auto-pruned on the next call.
+                        (wt_parent / name).mkdir(exist_ok=True)
+                        reg = Registry(runner, worktree_parent=wt_parent)
+                        params = reg.allocate(
+                            branch_dir=name,
+                            auto_prune=False,
+                            emit_warning=lambda _m: None,
+                        )
+                        results[name] = params.index
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                t1 = threading.Thread(target=alloc, args=("first",))
+                t2 = threading.Thread(target=alloc, args=("second",))
+                t1.start()
+                t2.start()
+                t1.join()
+                t2.join()
+                self.assertFalse(errors, msg=f"thread raised: {errors}")
+                self.assertEqual(set(results.keys()), {"first", "second"})
+                self.assertEqual(len(set(results.values())), 2, msg=f"expected distinct indices; got {results}")
+                # both indices in valid range
+                for v in results.values():
+                    self.assertGreaterEqual(v, INDEX_LO)
+                    self.assertLessEqual(v, INDEX_HI)
+                # registry still valid (two lines, no garbage)
+                rows = Registry(runner, worktree_parent=wt_parent)._read()
+                self.assertEqual(len(rows), 2)
+                self.assertEqual({r.branch_dir for r in rows}, {"first", "second"})
+
+
+# ---------------------------------------------------------------------------
+# lock contention — a held (live) lock must not be stolen
+# ---------------------------------------------------------------------------
+
+
+class LockContentionTests(unittest.TestCase):
+    def test_held_lock_blocks_second_acquirer(self) -> None:
+        """While one holder is inside ``_registry_lock``, a second acquirer
+        must wait — never steal the lock. The flock scheme has no stale
+        heuristic, so a live lock is always honored until released."""
+        import tempfile
+
+        from wt_ctl.domains.network import _registry_lock
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                acquired_first = threading.Event()
+                release_first = threading.Event()
+                order: list[str] = []
+
+                def holder() -> None:
+                    with _registry_lock():
+                        order.append("first-acquired")
+                        acquired_first.set()
+                        # Hold until the main thread has proven it can't steal.
+                        release_first.wait(timeout=5)
+                        order.append("first-released")
+
+                t = threading.Thread(target=holder)
+                t.start()
+                self.assertTrue(acquired_first.wait(timeout=5), msg="holder never acquired the lock")
+
+                # The lock is held by the live holder thread; a short-timeout
+                # acquire must time out rather than proceed.
+                with self.assertRaises(LockTimeout):
+                    with _registry_lock(timeout=0.5):
+                        order.append("STOLE-LOCK")  # pragma: no cover
+
+                # Once released, acquisition succeeds.
+                release_first.set()
+                t.join(timeout=5)
+                with _registry_lock(timeout=5):
+                    order.append("second-acquired")
+
+                self.assertNotIn("STOLE-LOCK", order)
+                self.assertEqual(order[0], "first-acquired")
+                self.assertIn("first-released", order)
+                self.assertEqual(order[-1], "second-acquired")
+
+
+# ---------------------------------------------------------------------------
+# orphan detection + prune
+# ---------------------------------------------------------------------------
+
+
+class OrphanTests(unittest.TestCase):
+    def test_list_flags_stale_and_prune_removes(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                # `live` has a directory; `dead` does not.
+                (wt_parent / "live").mkdir()
+
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+                reg._write(
+                    [
+                        _RegistryRow("live", stack_params(0)),
+                        _RegistryRow("dead", stack_params(1)),
+                    ]
+                )
+
+                entries, _ = reg.list()
+                kinds = {e.branch_dir: e.status for e in entries}
+                self.assertEqual(kinds, {"live": "active", "dead": "stale"})
+
+                out = reg.prune()
+                self.assertIn("dead=", out)
+                rows_after = reg._read()
+                self.assertEqual(len(rows_after), 1)
+                self.assertEqual(rows_after[0].branch_dir, "live")
+
+
+# ---------------------------------------------------------------------------
+# allocate auto-prune
+# ---------------------------------------------------------------------------
+
+
+class AutoPruneTests(unittest.TestCase):
+    def test_allocate_auto_reclaims_stale_slot(self) -> None:
+        """Index 0 occupied but the holding worktree is gone (stale); a
+        fresh allocate auto-prunes that slot and reclaims it.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+
+                # Occupy index 0 with a stale entry (no matching dir).
+                reg._write([_RegistryRow("ghost", stack_params(0))])
+
+                (wt_parent / "newcomer").mkdir()
+                params = reg.allocate(
+                    branch_dir="newcomer",
+                    auto_prune=True,
+                    emit_warning=lambda _m: None,
+                )
+                self.assertEqual(params.index, 0)
+                rows_after = reg._read()
+                bds = {r.branch_dir for r in rows_after}
+                self.assertNotIn("ghost", bds)
+                self.assertIn("newcomer", bds)
+
+
+# ---------------------------------------------------------------------------
+# release
+# ---------------------------------------------------------------------------
+
+
+class ReleaseTests(unittest.TestCase):
+    def test_release_drops_matching_entry(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                (wt_parent / "alpha").mkdir()
+                (wt_parent / "beta").mkdir()
+
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+                reg._write(
+                    [
+                        _RegistryRow("alpha", stack_params(0)),
+                        _RegistryRow("beta", stack_params(1)),
+                    ]
+                )
+                out = reg.release("alpha")
+                self.assertIn("Released alpha=", out)
+                rows = reg._read()
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0].branch_dir, "beta")
+
+    def test_release_unknown_is_noop(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            with _patch_registry_dir(Path(td)):
+                wt_parent = Path(td) / "mdb"
+                wt_parent.mkdir()
+                runner = _MakeFakes().runner()
+                reg = Registry(runner, worktree_parent=wt_parent)
+                reg._write([_RegistryRow("alpha", stack_params(0))])
+                out = reg.release("nope")
+                self.assertIn("nothing to release", out)
+                rows = reg._read()
+                self.assertEqual(len(rows), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_orchestrator.py
+++ b/scripts/test/wt_ctl/test_orchestrator.py
@@ -1,0 +1,543 @@
+"""``wt-ctl create`` orchestrator.
+
+A fake Runner records ``run`` / ``run_streaming`` and lets every call
+succeed; the tests assert phase order, state.json transitions, resume /
+restart-from behaviour, and concurrency of the parallel pair.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import time
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from _common import FakePopenFactory, fake_which  # noqa: E402
+from wt_ctl import orchestrator_state as ostate  # noqa: E402
+from wt_ctl.errors import ExternalCommandFailed, StateConflict  # noqa: E402
+from wt_ctl.orchestrator import CreateInputs, CreateOrchestrator  # noqa: E402
+from wt_ctl.runner import CmdResult  # noqa: E402
+
+
+@dataclass
+class FakeRunner:
+    """In-test runner that records calls and returns canned results.
+
+    Per-argv handlers are looked up by an "argv signature" function so we
+    don't have to enumerate every shell invocation up front.
+    """
+
+    calls: list[list[str]] = field(default_factory=list)
+    handlers: list[tuple[Callable[[list[str]], bool], Callable[[list[str]], CmdResult]]] = field(default_factory=list)
+    parallel_lock: threading.Lock = field(default_factory=threading.Lock)
+    concurrent_max: int = 0
+    concurrent_now: int = 0
+
+    def add(
+        self,
+        match: Callable[[list[str]], bool],
+        result: CmdResult,
+    ) -> None:
+        self.handlers.append((match, lambda _argv, r=result: r))
+
+    def add_failure(
+        self,
+        match: Callable[[list[str]], bool],
+        rc: int = 1,
+        stderr: str = "boom",
+    ) -> None:
+        def _fail(argv: list[str]):
+            raise ExternalCommandFailed(argv=list(argv), rc=rc, stdout="", stderr=stderr)
+
+        self.handlers.append((match, _fail))
+
+    def have(self, _name: str) -> bool:
+        return True
+
+    def _resolve(self, argv: list[str]) -> CmdResult:
+        with self.parallel_lock:
+            self.concurrent_now += 1
+            if self.concurrent_now > self.concurrent_max:
+                self.concurrent_max = self.concurrent_now
+        try:
+            for match, handler in self.handlers:
+                if match(argv):
+                    return handler(argv)
+            return CmdResult(argv=list(argv), rc=0, stdout="", stderr="", duration_s=0.0)
+        finally:
+            with self.parallel_lock:
+                self.concurrent_now -= 1
+
+    def run(self, argv, *, check=True, capture=True, env=None, cwd=None, timeout=None, input_text=None):
+        self.calls.append(list(argv))
+        result = self._resolve(list(argv))
+        if check and result.rc != 0:
+            raise ExternalCommandFailed(argv=list(argv), rc=result.rc, stdout=result.stdout, stderr=result.stderr)
+        return result
+
+    def run_streaming(self, argv, *, prefix="", log_path=None, env=None, cwd=None):
+        self.calls.append(list(argv))
+        with self.parallel_lock:
+            self.concurrent_now += 1
+            if self.concurrent_now > self.concurrent_max:
+                self.concurrent_max = self.concurrent_now
+        try:
+            # Slow down the parallel pair so the other thread can observe
+            # concurrent_now=2.
+            joined = " ".join(argv)
+            if "evg_prepare.sh" in joined or ("devcontainer" in argv and "build" in argv):
+                time.sleep(0.05)
+            for match, handler in self.handlers:
+                if match(argv):
+                    return handler(argv)
+            return CmdResult(argv=list(argv), rc=0, stdout="", stderr="", duration_s=0.0)
+        finally:
+            with self.parallel_lock:
+                self.concurrent_now -= 1
+
+    def run_parallel(self, jobs):  # not used by the orchestrator directly
+        raise NotImplementedError
+
+    def exec_replace(self, argv, *, env=None, cwd=None):
+        raise NotImplementedError("not exercised by the orchestrator tests")
+
+
+def _make_repo_fixture(tmp: Path) -> tuple[Path, Path, str, str]:
+    """Build a fake main repo + (target) worktree dir layout that satisfies
+    the orchestrator's filesystem assumptions:
+
+      tmp/
+        main_repo/
+          scripts/dev/{create_worktree.sh,dc_select_network.sh,evg_prepare.sh}
+          .devcontainer/scripts/initialize.sh
+          .devcontainer/.env  (we let the orchestrator append to this)
+          .generated/.current_context
+        target/        <- target worktree dir; created by worktree_init.
+    """
+    repo = tmp / "main_repo"
+    (repo / "scripts" / "dev").mkdir(parents=True)
+    (repo / ".devcontainer" / "scripts").mkdir(parents=True)
+    (repo / ".generated").mkdir(parents=True)
+    # Stub scripts so existence checks pass.
+    for script in ("create_worktree.sh", "dc_select_network.sh", "evg_prepare.sh", "delete_om_projects.sh"):
+        (repo / "scripts" / "dev" / script).write_text("#!/bin/sh\n")
+        (repo / "scripts" / "dev" / script).chmod(0o755)
+    target = tmp / "target_wt"
+
+    # The target worktree's scripts/dev tree must also exist (orchestrator
+    # invokes them inside the target after worktree_init). We pre-create
+    # the directory so the orchestrator can write its state.json.
+    (target / "scripts" / "dev").mkdir(parents=True)
+    for script in ("dc_select_network.sh", "evg_prepare.sh", "delete_om_projects.sh"):
+        (target / "scripts" / "dev" / script).write_text("#!/bin/sh\n")
+        (target / "scripts" / "dev" / script).chmod(0o755)
+    (target / ".devcontainer").mkdir(parents=True)
+    (target / ".devcontainer" / "scripts").mkdir(parents=True)
+    # initialize.sh is detected via .is_file(); we leave it absent in some
+    # tests and present in others.
+    return repo, target, "topic/x", "topic_x"
+
+
+def _make_inputs(repo: Path, target: Path, branch: str, branch_dir: str, **overrides) -> CreateInputs:
+    return CreateInputs(
+        branch=branch,
+        branch_dir=branch_dir,
+        worktree_path=target,
+        main_repo_root=repo,
+        host_worktree_root=repo,
+        **overrides,
+    )
+
+
+class CreatePipelineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Isolate the network-prefix registry so net_allocate doesn't
+        # touch the real ~/.cache/mck-devc/* during unit tests.
+        self._reg_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._reg_tmp.cleanup)
+        self._prev_reg = os.environ.get("MCK_DEVC_REGISTRY_DIR")
+        os.environ["MCK_DEVC_REGISTRY_DIR"] = self._reg_tmp.name
+
+    def tearDown(self) -> None:
+        if self._prev_reg is None:
+            os.environ.pop("MCK_DEVC_REGISTRY_DIR", None)
+        else:
+            os.environ["MCK_DEVC_REGISTRY_DIR"] = self._prev_reg
+
+    def test_full_pipeline_records_all_phases_ok(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            # initialize.sh present so initialize_hook actually runs.
+            (target / ".devcontainer" / "scripts" / "initialize.sh").write_text("#!/bin/sh\n")
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            orch = CreateOrchestrator(runner, inputs)
+            orch.run()
+            state = ostate.load(target)
+            self.assertIsNotNone(state)
+            assert state is not None
+            for name in ostate.PHASE_ORDER:
+                if name == "prepare_e2e":
+                    # Opted out via skip_prepare_e2e → recorded SKIPPED (not
+                    # left PENDING) so status isn't "incomplete" and --resume
+                    # won't re-run it.
+                    self.assertEqual(state.phases[name].status, ostate.SKIPPED)
+                    continue
+                self.assertEqual(
+                    state.phases[name].status,
+                    ostate.OK,
+                    f"phase {name} not ok: {state.phases[name]}",
+                )
+            # Registry.allocate() writes the 5-line stack-params block:
+            # MCK_DEVC_NET_PREFIX plus four derived vars compose.yml reads.
+            env_text = (target / ".devcontainer" / ".env").read_text()
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_PREFIX=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_X=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_Y_BASE=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_Y_VIP=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_PROXY_PORT=\d+$")
+
+    def test_phase_order_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            orch = CreateOrchestrator(runner, inputs)
+            orch.run()
+            # net_allocate issues no subprocess; detect it via the .env prefix
+            # line. Order is asserted on the OK-phase sequence in state.json.
+            state = ostate.load(target)
+            assert state is not None
+            for name in (
+                "worktree_init",
+                "net_allocate",
+                "evg_prepare",
+                "dc_build",
+                "dc_up",
+                "post_start",
+                "kubeconfig",
+            ):
+                self.assertEqual(state.phases[name].status, ostate.OK, f"{name} not ok")
+            env_text = (target / ".devcontainer" / ".env").read_text()
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_PREFIX=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_X=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_Y_BASE=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_Y_VIP=\d+$")
+            self.assertRegex(env_text, r"(?m)^MCK_DEVC_PROXY_PORT=\d+$")
+            # Subprocess-detectable phase order still tolerates the
+            # parallel pair (evg_prepare, dc_build) in either order.
+            sigs = []
+            for argv in runner.calls:
+                joined = " ".join(argv)
+                if "create_worktree.sh" in joined:
+                    sigs.append("worktree_init")
+                elif "evg_prepare.sh" in joined:
+                    sigs.append("evg_prepare")
+                elif "devcontainer" in argv and "build" in argv:
+                    sigs.append("dc_build")
+                elif "devcontainer" in argv and "up" in argv:
+                    sigs.append("dc_up")
+                elif "post-start.sh" in joined:
+                    sigs.append("post_start")
+                elif "wt-ctl --quiet kubeconfig refresh" in joined:
+                    sigs.append("kubeconfig")
+            seen = []
+            for s in sigs:
+                if s not in seen:
+                    seen.append(s)
+            allowed = [
+                ["worktree_init", "evg_prepare", "dc_build", "dc_up", "post_start", "kubeconfig"],
+                ["worktree_init", "dc_build", "evg_prepare", "dc_up", "post_start", "kubeconfig"],
+            ]
+            self.assertIn(seen, allowed, msg=f"unexpected subprocess order: {seen}")
+
+    def test_parallel_pair_runs_concurrently(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            runner.add(
+                lambda argv: argv[0].endswith("dc_select_network.sh") and "--branch-dir" in argv,
+                CmdResult(argv=[], rc=0, stdout="MCK_DEVC_NET_PREFIX=21\n", stderr="", duration_s=0.0),
+            )
+            orch = CreateOrchestrator(runner, inputs)
+            orch.run()
+            self.assertGreaterEqual(
+                runner.concurrent_max,
+                2,
+                msg=f"expected 2 concurrent runners during parallel pair, got {runner.concurrent_max}",
+            )
+
+    def test_failure_marks_phase_failed_and_records_resume_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            runner.add(
+                lambda argv: argv[0].endswith("dc_select_network.sh") and "--branch-dir" in argv,
+                CmdResult(argv=[], rc=0, stdout="MCK_DEVC_NET_PREFIX=22\n", stderr="", duration_s=0.0),
+            )
+            # Make evg_prepare fail.
+            runner.add_failure(
+                lambda argv: any(a.endswith("evg_prepare.sh") for a in argv),
+                rc=42,
+            )
+            orch = CreateOrchestrator(runner, inputs)
+            with self.assertRaises(Exception):
+                orch.run()
+            state = ostate.load(target)
+            assert state is not None
+            self.assertEqual(state.phases["evg_prepare"].status, ostate.FAILED)
+            # dc_build runs in parallel with evg_prepare; it should still
+            # have completed OK (the FakeRunner is a no-op).
+            self.assertEqual(state.phases["dc_build"].status, ostate.OK)
+            # Phases after the failed step never started.
+            self.assertEqual(state.phases["dc_up"].status, ostate.PENDING)
+
+    def test_unexpected_exception_in_parallel_phase_marks_failed(self) -> None:
+        """A parallel phase that raises a non-ExternalCommandFailed exception
+        (i.e. a bug — KeyError here) must still be recorded FAILED, not left as
+        OK. Otherwise the exception escapes the worker thread, the phase is
+        marked OK with a valid input hash, and --resume silently skips the
+        crash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+
+            def _boom(_argv):
+                raise KeyError("unexpected boom in evg_prepare")
+
+            # evg_prepare runs in the parallel pair (via run_streaming).
+            runner.handlers.append((lambda argv: any(a.endswith("evg_prepare.sh") for a in argv), _boom))
+            orch = CreateOrchestrator(runner, inputs)
+            with self.assertRaises(Exception):
+                orch.run()
+            state = ostate.load(target)
+            assert state is not None
+            self.assertEqual(
+                state.phases["evg_prepare"].status,
+                ostate.FAILED,
+                msg="unexpected exception must record FAILED, not OK",
+            )
+            # Later phases must not have started.
+            self.assertEqual(state.phases["dc_up"].status, ostate.PENDING)
+
+    def test_net_allocate_repairs_partial_env(self) -> None:
+        """A ``.devcontainer/.env`` with only ``MCK_DEVC_NET_PREFIX=<N>`` and
+        none of the four derived keys must be repaired on resume, not treated
+        as ``done`` — without the derived keys compose.yml's defaults
+        (``X=16, Y_BASE=0``) reuse 172.16.0.0/23 across every worktree.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            # Seed a partial .env (prefix only, no derived keys).
+            env_file = target / ".devcontainer" / ".env"
+            env_file.parent.mkdir(parents=True, exist_ok=True)
+            env_file.write_text("MCK_DEVC_NET_PREFIX=29\n")
+            inputs = _make_inputs(
+                repo,
+                target,
+                branch,
+                branch_dir,
+                skip_prepare_e2e=True,
+            )
+            runner = FakeRunner()
+            CreateOrchestrator(runner, inputs).run()
+            text = env_file.read_text()
+            # Prefix line preserved exactly — we don't re-allocate when
+            # the prefix is already pinned, we only repair the derived
+            # keys that were never written.
+            self.assertIn("MCK_DEVC_NET_PREFIX=29", text)
+            # Derived keys are now present, computed from prefix 29
+            # (stack_params(29) → X=16, Y_BASE=58, Y_VIP=59, PORT=8029).
+            self.assertIn("MCK_DEVC_NET_X=16", text)
+            self.assertIn("MCK_DEVC_NET_Y_BASE=58", text)
+            self.assertIn("MCK_DEVC_NET_Y_VIP=59", text)
+            self.assertIn("MCK_DEVC_PROXY_PORT=8029", text)
+            # No duplicate prefix line.
+            self.assertEqual(text.count("MCK_DEVC_NET_PREFIX="), 1)
+
+    def test_resume_skips_ok_phases(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            runner.add(
+                lambda argv: argv[0].endswith("dc_select_network.sh") and "--branch-dir" in argv,
+                CmdResult(argv=[], rc=0, stdout="MCK_DEVC_NET_PREFIX=23\n", stderr="", duration_s=0.0),
+            )
+            CreateOrchestrator(runner, inputs).run()
+            # Now corrupt state so kubeconfig is failed.
+            state = ostate.load(target)
+            assert state is not None
+            state.set_status("kubeconfig", ostate.FAILED, input_hash=state.phases["kubeconfig"].input_hash)
+            ostate.save(target, state)
+            # Resume: only kubeconfig should re-run.
+            runner2 = FakeRunner()
+            runner2.add(
+                lambda argv: argv[0].endswith("dc_select_network.sh") and "--branch-dir" in argv,
+                CmdResult(argv=[], rc=0, stdout="MCK_DEVC_NET_PREFIX=23\n", stderr="", duration_s=0.0),
+            )
+            CreateOrchestrator(runner2, inputs).run(resume=True)
+            kc_calls = [c for c in runner2.calls if any("wt-ctl --quiet kubeconfig refresh" in a for a in c)]
+            self.assertEqual(len(kc_calls), 1)
+            # Worktree_init should NOT have re-run.
+            wi_calls = [c for c in runner2.calls if any(a.endswith("create_worktree.sh") for a in c)]
+            self.assertEqual(len(wi_calls), 0)
+            state = ostate.load(target)
+            assert state is not None
+            self.assertEqual(state.phases["kubeconfig"].status, ostate.OK)
+
+    def test_restart_from_clears_phase_and_later(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            runner.add(
+                lambda argv: argv[0].endswith("dc_select_network.sh") and "--branch-dir" in argv,
+                CmdResult(argv=[], rc=0, stdout="MCK_DEVC_NET_PREFIX=24\n", stderr="", duration_s=0.0),
+            )
+            CreateOrchestrator(runner, inputs).run()
+            # Restart from reconcile: only reconcile + post_start + kubeconfig should re-run.
+            runner2 = FakeRunner()
+            runner2.add(
+                lambda argv: argv[0].endswith("dc_select_network.sh") and "--branch-dir" in argv,
+                CmdResult(argv=[], rc=0, stdout="MCK_DEVC_NET_PREFIX=24\n", stderr="", duration_s=0.0),
+            )
+            CreateOrchestrator(runner2, inputs).run(restart_from="reconcile")
+            # No worktree_init / evg_prepare / dc_build / dc_up should fire.
+            for keyword in ("create_worktree.sh", "evg_prepare.sh"):
+                cs = [c for c in runner2.calls if any(keyword in a for a in c)]
+                self.assertEqual(cs, [], f"phase ran when it shouldn't: {keyword}")
+            # kubeconfig DID re-run.
+            kc = [c for c in runner2.calls if any("wt-ctl --quiet kubeconfig refresh" in a for a in c)]
+            self.assertEqual(len(kc), 1)
+
+    def test_default_run_with_in_progress_state_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(repo, target, branch, branch_dir)
+            # Pre-write state where evg_prepare is in_progress.
+            state = ostate.OrchestratorState.initial(branch=branch, inputs=inputs.to_dict())
+            state.set_status("evg_prepare", ostate.IN_PROGRESS, input_hash="x")
+            ostate.save(target, state)
+            runner = FakeRunner()
+            with self.assertRaises(StateConflict):
+                CreateOrchestrator(runner, inputs).run()
+
+
+class JoinKindNetworkTests(unittest.TestCase):
+    """The join guard must connect a container whose ``kind`` endpoint is
+    absent. ``docker inspect '{{index ...}}'`` prints ``<nil>`` for a missing
+    key — only a live endpoint yields ``yes`` under the ``{{if}}`` template."""
+
+    def _orch(self, runner: FakeRunner) -> CreateOrchestrator:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            return CreateOrchestrator(runner, _make_inputs(repo, target, branch, branch_dir))
+
+    def _runner(self, inspect_stdout: str) -> FakeRunner:
+        runner = FakeRunner()
+        runner.add(
+            lambda argv: "compose" in argv and "ps" in argv,
+            CmdResult(argv=[], rc=0, stdout="cid123\n", stderr="", duration_s=0.0),
+        )
+        runner.add(
+            lambda argv: "inspect" in argv,
+            CmdResult(argv=[], rc=0, stdout=inspect_stdout, stderr="", duration_s=0.0),
+        )
+        return runner
+
+    def _connects(self, runner: FakeRunner) -> list[list[str]]:
+        return [c for c in runner.calls if "network" in c and "connect" in c]
+
+    def test_absent_endpoint_nil_triggers_connect(self) -> None:
+        runner = self._runner("<nil>")
+        self._orch(runner)._join_kind_network(Path("/wt"), "proj", Path("/tmp/x.log"))
+        self.assertEqual(len(self._connects(runner)), 2)  # devcontainer + k8s-proxy
+
+    def test_live_endpoint_skips_connect(self) -> None:
+        runner = self._runner("yes")
+        self._orch(runner)._join_kind_network(Path("/wt"), "proj", Path("/tmp/x.log"))
+        self.assertEqual(self._connects(runner), [])
+
+
+class InPlaceTests(unittest.TestCase):
+    """--in-place skips create_worktree.sh and operates in the checkout."""
+
+    def test_in_place_skips_create_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            # worktree_path == main repo, as cmd_create sets for --in-place.
+            inputs = _make_inputs(repo, repo, branch, branch_dir, in_place=True, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            CreateOrchestrator(runner, inputs).run()
+            created = [c for c in runner.calls if any("create_worktree.sh" in a for a in c)]
+            self.assertEqual(created, [], "create_worktree.sh must not run with --in-place")
+
+
+class WithPersistedFlagsTests(unittest.TestCase):
+    """--resume must reload behavioural flags from state.json, not re-default
+    an omitted CLI flag (which flips phase branches / invalidates hashes)."""
+
+    def test_omitted_local_kind_reloads_from_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            original = _make_inputs(repo, target, branch, branch_dir, local_kind=True, multi_cluster=True)
+            saved = original.to_dict()
+            # Simulate a bare `--resume`: CLI re-defaults local_kind to False.
+            resumed = _make_inputs(repo, target, branch, branch_dir, local_kind=False, multi_cluster=True)
+            merged = resumed.with_persisted_flags(saved)
+            self.assertTrue(merged.local_kind)
+            self.assertTrue(merged.multi_cluster)
+            # Paths stay freshly resolved (not clobbered by persisted strings).
+            self.assertEqual(merged.worktree_path, resumed.worktree_path)
+
+    def test_single_cluster_run_not_flipped_to_multi_on_resume(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            saved = _make_inputs(repo, target, branch, branch_dir, multi_cluster=False).to_dict()
+            # Bare resume: CLI default is multi_cluster=True.
+            resumed = _make_inputs(repo, target, branch, branch_dir, multi_cluster=True)
+            self.assertFalse(resumed.with_persisted_flags(saved).multi_cluster)
+
+
+class ReconcileTests(unittest.TestCase):
+    """reconcile force-recreates sidecar services from compose.user.yml but
+    never the main `devcontainer` service (the devcontainer CLI owns it;
+    recreating it out-of-band breaks subsequent `devcontainer exec`)."""
+
+    def _recreated_services(self, calls: list[list[str]]) -> list[str]:
+        out = []
+        for c in calls:
+            if "--force-recreate" in c and "up" in c:
+                out.append(c[-1])  # svc is the trailing arg
+        return out
+
+    def test_reconcile_skips_devcontainer_service(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            (target / ".devcontainer" / "compose.user.yml").write_text(
+                "services:\n"
+                "  devcontainer:\n"
+                "    environment:\n"
+                '      EVR_TASK_ID: "abc"\n'
+                "  k8s-proxy:\n"
+                "    environment:\n"
+                "      FOO: bar\n"
+            )
+            inputs = _make_inputs(repo, target, branch, branch_dir, skip_prepare_e2e=True)
+            runner = FakeRunner()
+            CreateOrchestrator(runner, inputs).run()
+            recreated = self._recreated_services(runner.calls)
+            self.assertIn("k8s-proxy", recreated)
+            self.assertNotIn("devcontainer", recreated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_orchestrator.py
+++ b/scripts/test/wt_ctl/test_orchestrator.py
@@ -201,6 +201,20 @@ class CreatePipelineTests(unittest.TestCase):
             self.assertRegex(env_text, r"(?m)^MCK_DEVC_NET_Y_VIP=\d+$")
             self.assertRegex(env_text, r"(?m)^MCK_DEVC_PROXY_PORT=\d+$")
 
+    def test_evg_prepare_gets_context_explicitly(self) -> None:
+        # evg_prepare must receive --context so it doesn't depend on the
+        # .generated/.current_context sentinel the concurrent dc_build can clear.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))
+            inputs = _make_inputs(
+                repo, target, branch, branch_dir, context="e2e_multi_cluster_kind", skip_prepare_e2e=True
+            )
+            runner = FakeRunner()
+            CreateOrchestrator(runner, inputs).run()
+            prep = next(c for c in runner.calls if any(a.endswith("evg_prepare.sh") for a in c))
+            self.assertIn("--context", prep)
+            self.assertEqual(prep[prep.index("--context") + 1], "e2e_multi_cluster_kind")
+
     def test_phase_order_is_canonical(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo, target, branch, branch_dir = _make_repo_fixture(Path(tmp))

--- a/scripts/test/wt_ctl/test_paths.py
+++ b/scripts/test/wt_ctl/test_paths.py
@@ -1,0 +1,51 @@
+"""Cwd resolution: inside / outside a worktree."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from _common import FakePopenFactory, fake_which  # noqa: E402
+from wt_ctl.errors import NotInWorktree  # noqa: E402
+from wt_ctl.paths import resolve_worktree  # noqa: E402
+from wt_ctl.runner import Runner  # noqa: E402
+
+
+class PathsTests(unittest.TestCase):
+    def test_outside_worktree_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            r = Runner(popen_factory=FakePopenFactory({}), which=fake_which)
+            with self.assertRaises(NotInWorktree):
+                resolve_worktree(r, cwd=Path(tmp))
+
+    def test_inside_worktree_resolves(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            # macOS routes /var/folders -> /private/var/folders; resolve up
+            # front so the FakePopenFactory keys match the real argv.
+            wt = (Path(tmp) / "wt").resolve()
+            wt.mkdir()
+            (wt / ".git").write_text("gitdir: /fake\n")
+            wt_str = str(wt)
+            factory = FakePopenFactory(
+                {
+                    ("git", "-C", wt_str, "rev-parse", "--show-toplevel"): (wt_str + "\n", "", 0),
+                    ("git", "-C", wt_str, "rev-parse", "--git-common-dir"): (
+                        str(Path(tmp).resolve() / "main" / ".git") + "\n",
+                        "",
+                        0,
+                    ),
+                    ("git", "-C", wt_str, "rev-parse", "--abbrev-ref", "HEAD"): ("topic/x\n", "", 0),
+                }
+            )
+            r = Runner(popen_factory=factory, which=fake_which)
+            refs = resolve_worktree(r, cwd=wt)
+            self.assertEqual(refs.worktree_root, wt)
+            self.assertEqual(refs.branch, "topic/x")
+            self.assertEqual(refs.branch_dir, "wt")
+            self.assertFalse(refs.is_main)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_runner.py
+++ b/scripts/test/wt_ctl/test_runner.py
@@ -1,0 +1,48 @@
+"""Runner.run happy path + failure mapping with an injected fake Popen."""
+
+from __future__ import annotations
+
+import unittest
+
+from _common import FakePopenFactory, fake_which  # noqa: E402
+from wt_ctl.errors import ExternalCommandFailed, ToolMissing  # noqa: E402
+from wt_ctl.runner import Runner  # noqa: E402
+
+
+class RunnerHappyTests(unittest.TestCase):
+    def test_run_captures_stdout(self) -> None:
+        factory = FakePopenFactory({("echo", "hi"): ("hi\n", "", 0)})
+        r = Runner(popen_factory=factory, which=fake_which)
+        result = r.run(["echo", "hi"])
+        self.assertEqual(result.rc, 0)
+        self.assertEqual(result.stdout, "hi\n")
+        self.assertEqual(factory.calls, [["echo", "hi"]])
+
+    def test_run_check_false_returns_nonzero(self) -> None:
+        factory = FakePopenFactory({("git", "status"): ("", "boom", 7)})
+        r = Runner(popen_factory=factory, which=fake_which)
+        result = r.run(["git", "status"], check=False)
+        self.assertEqual(result.rc, 7)
+        self.assertIn("boom", result.stderr)
+
+
+class RunnerFailureMappingTests(unittest.TestCase):
+    def test_check_true_raises(self) -> None:
+        factory = FakePopenFactory({("git", "fail"): ("", "msg", 2)})
+        r = Runner(popen_factory=factory, which=fake_which)
+        with self.assertRaises(ExternalCommandFailed) as ctx:
+            r.run(["git", "fail"])
+        self.assertEqual(ctx.exception.rc, 2)
+        self.assertEqual(ctx.exception.argv, ["git", "fail"])
+
+    def test_missing_tool_maps_to_ToolMissing(self) -> None:
+        def boom(argv, **kw):
+            raise FileNotFoundError("no such file: " + argv[0])
+
+        r = Runner(popen_factory=boom, which=lambda _n: None)
+        with self.assertRaises(ToolMissing):
+            r.run(["nonexistent-tool"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl/test_state.py
+++ b/scripts/test/wt_ctl/test_state.py
@@ -1,0 +1,113 @@
+"""Orchestrator state file (.generated/wt-ctl/state.json): round-trip
+read/write, hash-mismatch detection, and ``clear_from`` (used by
+--restart-from).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from _common import FakePopenFactory  # noqa: E402  (path side-effect only)
+from wt_ctl import orchestrator_state as ostate  # noqa: E402
+from wt_ctl.errors import StateConflict  # noqa: E402
+
+
+class StateRoundTripTests(unittest.TestCase):
+    def test_initial_state_has_all_phases_pending(self) -> None:
+        st = ostate.OrchestratorState.initial(
+            branch="topic/x",
+            inputs={"branch": "topic/x"},
+        )
+        self.assertEqual(st.branch, "topic/x")
+        self.assertEqual(set(st.phases.keys()), set(ostate.PHASE_ORDER))
+        for rec in st.phases.values():
+            self.assertEqual(rec.status, ostate.PENDING)
+
+    def test_save_then_load_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = Path(tmp) / "wt"
+            wt.mkdir()
+            st = ostate.OrchestratorState.initial(
+                branch="lsierant/wtctl-phase2",
+                inputs={"context": "e2e_smoke"},
+            )
+            st.set_status(
+                "worktree_init",
+                ostate.OK,
+                input_hash="aaa",
+                log="logs/setup_worktree/x.log",
+            )
+            ostate.save(wt, st)
+            loaded = ostate.load(wt)
+            self.assertIsNotNone(loaded)
+            assert loaded is not None  # for type-checker
+            self.assertEqual(loaded.branch, "lsierant/wtctl-phase2")
+            self.assertEqual(loaded.phases["worktree_init"].status, ostate.OK)
+            self.assertEqual(loaded.phases["worktree_init"].input_hash, "aaa")
+            self.assertEqual(loaded.phases["dc_up"].status, ostate.PENDING)
+
+    def test_load_returns_none_when_no_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(ostate.load(Path(tmp) / "wt"))
+
+    def test_load_raises_on_invalid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = Path(tmp) / "wt"
+            (wt / ".generated" / "wt-ctl").mkdir(parents=True)
+            (wt / ".generated" / "wt-ctl" / "state.json").write_text("{not-json")
+            with self.assertRaises(StateConflict):
+                ostate.load(wt)
+
+    def test_save_writes_atomic_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = Path(tmp) / "wt"
+            st = ostate.OrchestratorState.initial(branch="b", inputs={})
+            ostate.save(wt, st)
+            # Should be exactly state.json + nothing else (no leaked tempfile).
+            files = sorted(p.name for p in (wt / ".generated" / "wt-ctl").iterdir())
+            self.assertEqual(files, ["state.json"])
+
+
+class HashMismatchTests(unittest.TestCase):
+    def test_hash_inputs_is_deterministic(self) -> None:
+        a = ostate.hash_inputs({"k": 1, "j": 2})
+        b = ostate.hash_inputs({"j": 2, "k": 1})  # key order shouldn't matter
+        self.assertEqual(a, b)
+        c = ostate.hash_inputs({"k": 2, "j": 2})
+        self.assertNotEqual(a, c)
+
+
+class RestartFromTests(unittest.TestCase):
+    def test_clear_from_resets_phase_and_later(self) -> None:
+        st = ostate.OrchestratorState.initial(branch="b", inputs={})
+        for name in ostate.PHASE_ORDER:
+            st.set_status(name, ostate.OK, input_hash=f"h-{name}")
+        st.clear_from("dc_build")
+        # Earlier ones still OK.
+        self.assertEqual(st.phases["worktree_init"].status, ostate.OK)
+        self.assertEqual(st.phases["evg_prepare"].status, ostate.OK)
+        # dc_build itself + later are PENDING with cleared hash.
+        self.assertEqual(st.phases["dc_build"].status, ostate.PENDING)
+        self.assertIsNone(st.phases["dc_build"].input_hash)
+        self.assertEqual(st.phases["prepare_e2e"].status, ostate.PENDING)
+
+    def test_clear_from_unknown_phase_raises(self) -> None:
+        st = ostate.OrchestratorState.initial(branch="b", inputs={})
+        with self.assertRaises(StateConflict):
+            st.clear_from("not-a-phase")
+
+    def test_first_non_ok(self) -> None:
+        st = ostate.OrchestratorState.initial(branch="b", inputs={})
+        for name in ostate.PHASE_ORDER[:3]:
+            st.set_status(name, ostate.OK, input_hash="h")
+        self.assertEqual(st.first_non_ok(), ostate.PHASE_ORDER[3])
+        for name in ostate.PHASE_ORDER:
+            st.set_status(name, ostate.OK, input_hash="h")
+        self.assertIsNone(st.first_non_ok())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/wt_ctl_lint.py
+++ b/scripts/test/wt_ctl_lint.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Lint: domain modules MUST NOT import ``subprocess``.
+
+Per ``docs/dev/wt-ctl-plan.md``, ``runner.py`` is the only file in the
+package permitted to import subprocess. Domain modules receive a Runner
+via constructor injection.
+
+Exits non-zero if any forbidden import is found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DOMAINS = REPO / "scripts" / "dev" / "wt_ctl" / "domains"
+
+PATTERN = re.compile(r"^(import|from)\s+subprocess\b")
+
+
+def main() -> int:
+    if not DOMAINS.is_dir():
+        print(f"[lint] domains dir not found: {DOMAINS}", file=sys.stderr)
+        return 2
+    failures: list[tuple[Path, int, str]] = []
+    for path in sorted(DOMAINS.glob("*.py")):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if PATTERN.search(line):
+                failures.append((path, lineno, line.strip()))
+    if failures:
+        print("[lint] forbidden subprocess import in domain modules:", file=sys.stderr)
+        for path, lineno, line in failures:
+            print(f"  {path.relative_to(REPO)}:{lineno}: {line}", file=sys.stderr)
+        return 1
+    print("[lint] ok: no domain module imports subprocess.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test/wt_ctl_smoke.sh
+++ b/scripts/test/wt_ctl_smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Smoke test: ``wt-ctl status`` from inside this worktree must print
+# the banner + the keys ``worktree``, ``path``, ``network``, ``gost-proxy``.
+#
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+wt_ctl="${repo_root}/scripts/dev/wt-ctl"
+
+stdout="$(mktemp)"
+stderr="$(mktemp)"
+trap 'rm -f "${stdout}" "${stderr}"' EXIT
+
+if ! "${wt_ctl}" --color=never status 1>"${stdout}" 2>"${stderr}"; then
+  echo "[smoke] wt-ctl status exited non-zero" >&2
+  cat "${stderr}" >&2
+  exit 1
+fi
+
+# Banner is on stderr.
+if ! grep -q "^\[wt-ctl\] worktree=" "${stderr}"; then
+  echo "[smoke] missing banner on stderr" >&2
+  cat "${stderr}" >&2
+  exit 1
+fi
+
+failures=0
+for key in worktree path network gost-proxy; do
+  if ! grep -q "^${key}\b" "${stdout}"; then
+    echo "[smoke] missing key '${key}' in stdout" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+if (( failures > 0 )); then
+  echo "[smoke] FAIL (${failures} missing keys)" >&2
+  echo "--- stdout ---" >&2
+  cat "${stdout}" >&2
+  echo "--- stderr ---" >&2
+  cat "${stderr}" >&2
+  exit 1
+fi
+
+echo "[smoke] ok"


### PR DESCRIPTION
# Isolated local e2e environments: worktrees + devcontainers (`wt-ctl`)

This introduces devcontainer tooling for running fully isolated local e2e tests in git worktrees. It builds on top of `scripts/dev/create_worktree.sh` (#1037) and adds `scripts/dev/wt-ctl` as a single entrypoint for managing everything worktree/local-e2e related. One command creates a worktree with its own devcontainer and a short-lived Evergreen host, recreates kind clusters, prepares the environment, and starts the operator - several such environments can run in parallel on one machine without stepping on each other.

```bash
scripts/dev/wt-ctl create <branch> --context <variant>     # bring everything up
scripts/dev/wt-ctl status                                  # state of this worktree's stack
scripts/dev/wt-ctl attach                                  # tmux inside the devc: k9s, operator log, e2e log, zsh
scripts/dev/wt-ctl attach -- bash scripts/dev/e2e_run.sh <marker>   # run a test
scripts/dev/wt-ctl delete --all <branch>                   # tear everything down (EVG host included)
```

## What `wt-ctl create` does

It creates the devcontainer and the EVG host in parallel, then executes all the steps a developer would otherwise run manually to get to a working local-operator e2e setup:

- rsyncs the local branch sources to the EVG host
- recreates kind clusters - the multi setup by default (`e2e-operator`, `e2e-cluster-{1,2,3}` + `kind`), or one cluster with `--single-cluster`; `--local-kind` skips the EVG host and runs kind on the laptop instead
- switches the context (`--context`)
- runs `prepare-local-e2e`
- downloads kubeconfigs locally, adjusting ports/proxy-url for the topology (remote EVG host, local kind, or directly on a Linux EVG host in CI)
- starts the operator inside the devcontainer as a local process (new `scripts/dev/op_run.sh`); tests run via the new `scripts/dev/e2e_run.sh`; both capture output under `logs/`

Every phase is resumable: `--resume` continues a failed run, `--restart-from <phase>` forces re-running from a given point. Setup logs land in `logs/setup_worktree/` (`wt-ctl logs <phase> -f`).

## Isolation

- Every worktree gets its own devcontainer stack and a fresh EVG host.
- `wt-ctl` assigns each worktree a free network prefix (`MCK_DEVC_NET_PREFIX`, 0-2047) from a host-local registry. The prefix carves a dedicated `/23` docker subnet per stack, offsets the gost-proxy loopback port (`8000 + N`), and is appended to `NAMESPACE` from private-context (`ls` + prefix `134` -> `ls-134`). Unique namespaces are what keep cloud-qa projects per-worktree.
- Kind cluster names stay hardcoded (`kind`, `e2e-operator`, etc.), so when registering kubeconfigs with the on-host kube-forwarding-proxy, `wt-ctl` suffixes contexts with the worktree's proxy port; on-disk kubeconfigs stay bare.

## The devcontainer

Preinstalled tooling via devcontainer features (go, kubectl, helm, kind, k9s, etc.); the worktree is bind-mounted at `/workspace`. Sidecars handle EVG host connectivity:

- `evg-host-proxy` - autossh keeping a persistent SOCKS5 tunnel to the EVG host
- `k8s-proxy` - [kube-forwarding-proxy](https://github.com/fealebenpae/kube-forwarding-proxy): captures `*.svc.cluster.local` DNS and lazily port-forwards, resilient to pod restarts; also installable as a Mac daemon for in-IDE work on the host
- `gost-proxy` - a SOCKS5-to-HTTP bridge, because client-go doesn't support SPDY over SOCKS

All access goes through `proxy-url` in the generated kubeconfigs; the python test harness was taught to honor it too.

## Changes to existing workflows

- `context.export.env` / `context.operator.export.env` are gone; the operator (`main.go`) and pytest (`conftest.py`) load `context.env` + the per-side `context.<side>.env` directly.
- `KUBECONFIG` selection moved out of `root-context`: host shells use `.generated/current.kubeconfig`, in-devc shells `.generated/current.devc.kubeconfig` (side detection via `/.dockerenv`).
- New `scripts/dev/devenv` - source it after cd-ing into a worktree to get that worktree's context env + python venv.
- No-mesh multi-cluster tests use `tests/kind_network.py` instead of hardcoded `172.18.255.x` LB IPs; the kind subnet is configurable via `KIND_NETWORK_SUBNET`.

## Validation

- CI: the `e2e_mck_devcontainer_local_kind` variant drives `wt-ctl create --local-kind --in-place` end-to-end on an EVG task host (no image builds) and runs three real e2e tasks through it: search connectivity (single- and multi-cluster) and OM8 pod spec. It is wired into the GitHub PR patch alias (`pr_patch_e2e` tag), so these run on every PR patch. (No-mesh MC OM AppDB is intentionally excluded: under a `go run` local operator, Docker's embedded DNS can't resolve the external `nginx-ext-svc-*` interconnect - see Known limitations.)
- Locally (the mac-side path CI can't cover): `scripts/dev/test/e2e_local_parallel_devcontainers.sh` brings up three worktrees in parallel, each on its own fresh EVG host, runs their e2e markers inside the devcontainers, and tears everything down.
- Unit tests for the orchestrator and domains under `scripts/test/wt_ctl/` (stdlib unittest, subprocess-injection lint), plus bats integration fixtures under `scripts/test/bash/worktree/`.
- Daily-driven for weeks: the search feature branch stack has been developed on top of this branch.

## Known limitations

- no-mesh tests relying on `.interconnected` domains in CoreDNS won't work correctly in local executions (especially for the operator not in the cluster)
- tests relying on SRV DNS resolution will fail locally - kube-forwarding-proxy doesn't support SRV requests yet

## Proof of Work

EVG PR patch [6a543f17](https://spruce.mongodb.com/version/6a543f17291ab0000721fc92): 518/519 tasks green. All three devcontainer local-kind e2e tasks pass:

- `e2e_devc_search_connectivity_tool_rs` ✅
- `e2e_devc_search_connectivity_tool_mc_rs` ✅
- `e2e_devc_om8_ops_manager_pod_spec` ✅

The single unrelated failure (`e2e_om80_kind_ubi / e2e_om_ops_manager_backup`) is a base-branch OM backup e2e outside this diff.
