### PR TITLE
Search: API doc & code-quality nits

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -75,10 +75,10 @@ func (p *Prometheus) GetPort() int32 {
 }
 
 type MongoDBSearchSpec struct {
-	// Optional version of MongoDB Search component (mongot). If not set, then the operator will set the most appropriate version of MongoDB Search.
+	// Version of MongoDB Search (mongot) to run. If unset, the operator picks the most appropriate version.
 	// +optional
 	Version string `json:"version"`
-	// MongoDB database connection details from which MongoDB Search will synchronize data to build indexes.
+	// Source is the MongoDB database that MongoDB Search syncs from to build its indexes.
 	// +optional
 	Source *MongoDBSource `json:"source"`
 	// Deprecated: use spec.clusters[].replicas instead; this top-level form will be removed.
@@ -94,7 +94,7 @@ type MongoDBSearchSpec struct {
 	// Deprecated: use spec.clusters[].resourceRequirements instead; this top-level form will be removed.
 	// +optional
 	ResourceRequirements *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
-	// Configure security settings of the MongoDB Search server that MongoDB database is connecting to when performing search queries.
+	// Security holds the TLS settings for the MongoDB Search server.
 	// +optional
 	Security Security `json:"security"`
 	// Configure verbosity of mongot logs. Defaults to INFO if not set.
@@ -104,8 +104,8 @@ type MongoDBSearchSpec struct {
 	// Configure prometheus metrics endpoint in mongot. If not set, the metrics endpoint will be disabled.
 	// +optional
 	Prometheus *Prometheus `json:"prometheus,omitempty"`
-	// Configure MongoDB Search's automatic generation of vector embeddings using an embedding model service.
-	// `embedding` field of mongot config is generated using the values provided here.
+	// AutoEmbedding configures MongoDB Search to generate vector embeddings automatically
+	// through an embedding model service. These values populate the `embedding` section of the mongot config.
 	// +optional
 	AutoEmbedding *EmbeddingConfig `json:"autoEmbedding,omitempty"`
 	// LoadBalancer configures how mongod/mongos connect to mongot (Managed vs Unmanaged/BYO Load Balancer).
@@ -119,10 +119,12 @@ type MongoDBSearchSpec struct {
 	// https://www.mongodb.com/docs/manual/tutorial/mongot-sizing/advanced-guidance/hardware/#jvm-heap-sizing
 	// +optional
 	JVMFlags []string `json:"jvmFlags,omitempty"`
-	// Clusters is the per-cluster distribution shape. Required for multi-cluster
-	// deployments (len > 1); when omitted, the reconciler defaults it to a single
-	// entry built from the top-level fields. Pointer-of-slice so omitted vs.
-	// empty is distinguishable.
+	// Clusters configures the deployment per Kubernetes cluster: one entry for a
+	// single cluster (clusterName optional), or one entry per cluster for
+	// multi-cluster (clusterName required, len > 1). This is the place to set
+	// replicas, resources, storage, and StatefulSet overrides.
+	// If omitted, the operator falls back to the deprecated top-level fields and
+	// runs in a single cluster.
 	// +optional
 	// +kubebuilder:validation:MaxItems=50
 	// +kubebuilder:validation:XValidation:rule="self.all(c1, self.exists_one(c2, c2.clusterName == c1.clusterName))",message="clusters[].clusterName must be unique"
@@ -133,8 +135,8 @@ type MongoDBSearchSpec struct {
 // At-most-one of MatchTags or Hosts may be set.
 // +kubebuilder:validation:XValidation:rule="!(has(self.matchTags) && has(self.hosts))",message="syncSourceSelector.matchTags and syncSourceSelector.hosts are mutually exclusive"
 type SyncSourceSelector struct {
-	// MatchTags renders into mongot's readPreferenceTags; the operator picks
-	// sync-source members whose replSetConfig tags match.
+	// MatchTags selects which sync-source mongods to read from by their replica-set tags.
+	// The operator passes these to mongot as readPreferenceTags.
 	// +optional
 	// +kubebuilder:validation:MaxProperties=50
 	MatchTags map[string]string `json:"matchTags,omitempty"`
@@ -148,7 +150,8 @@ type SyncSourceSelector struct {
 
 // ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
 // when len(spec.clusters) > 1; optional in the single-cluster case.
-// All other fields override the corresponding top-level value when set; nil/omitted inherits.
+// Each other field, when set, applies to this cluster; when unset, it falls back to
+// the matching top-level default.
 type ClusterSpec struct {
 	// ClusterName is the Kubernetes cluster name. Required and immutable
 	// when len(spec.clusters) > 1; optional in the single-cluster case.
@@ -161,8 +164,7 @@ type ClusterSpec struct {
 	// For ReplicaSet sources this is the total; for sharded sources it is per shard.
 	// When Replicas > 1, a load balancer (spec.loadBalancer) is required to distribute
 	// traffic across mongot instances.
-	// 0 is allowed so operators (and operator-driven test harnesses) can take mongot
-	// offline cleanly via the CR — the StatefulSet scales to 0; the MongoDBSearch CR stays.
+	// Set to 0 to take mongot offline: the StatefulSet scales to 0 while the MongoDBSearch CR stays.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
@@ -231,20 +233,27 @@ type UnmanagedLBConfig struct {
 }
 
 type EmbeddingConfig struct {
+	// ProviderEndpoint is the URL of the embedding model service.
 	ProviderEndpoint string `json:"providerEndpoint,omitempty"`
-	// EmbeddingModelAPIKeySecret would have the name of the secret that has two keys
-	// query-key and indexing-key for embedding model's API keys.
+	// EmbeddingModelAPIKeySecret references a Secret holding the embedding model's API keys.
+	// The Secret must contain two keys: query-key and indexing-key.
 	// +kubebuilder:validation:Required
 	EmbeddingModelAPIKeySecret corev1.LocalObjectReference `json:"embeddingModelAPIKeySecret"`
 }
 
 type MongoDBSource struct {
+	// MongoDBResourceRef points to an operator-managed MongoDB resource to sync from.
+	// Mutually exclusive with External.
 	// +optional
 	MongoDBResourceRef *userv1.MongoDBResourceRef `json:"mongodbResourceRef,omitempty"`
+	// ExternalMongoDBSource describes a MongoDB deployment the operator does not manage.
+	// Mutually exclusive with MongoDBResourceRef.
 	// +optional
 	ExternalMongoDBSource *ExternalMongoDBSource `json:"external,omitempty"`
+	// PasswordSecretRef references the Secret holding the sync-source user's password.
 	// +optional
 	PasswordSecretRef *userv1.SecretKeyRef `json:"passwordSecretRef,omitempty"`
+	// Username is the sync-source user mongot authenticates as. Defaults to search-sync-source.
 	// +optional
 	Username *string `json:"username,omitempty"`
 	// X509 configures x509 client certificate authentication for the sync source connection.
@@ -316,6 +325,7 @@ type ExternalMongodTLS struct {
 }
 
 type Security struct {
+	// TLS configures TLS for the MongoDB Search server.
 	// +optional
 	TLS *TLS `json:"tls,omitempty"`
 }

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -20,25 +20,25 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
-// ShardNamePlaceholder is the placeholder used in endpoint templates for sharded clusters
-const ShardNamePlaceholder = "{shardName}"
-
-// ClusterNamePlaceholder is substituted with spec.clusters[i].ClusterName when
-// resolving spec.loadBalancer.managed.externalHostname for cluster i in
-// multi-cluster MongoDBSearch deployments. The Envoy reconciler substitutes the
-// member cluster name so per-cluster SNI hostnames stay distinct.
-const ClusterNamePlaceholder = "{clusterName}"
-
-// ClusterIndexPlaceholder is substituted with the stable cluster-index for
-// spec.clusters[i]. The index is monotonic and never reused on remove/re-add
-// (see api/v1/search/cluster_index.go).
-const ClusterIndexPlaceholder = "{clusterIndex}"
-
-// LabelResourceOwner is the label key used to identify the MongoDBSearch CR that
-// owns a resource. Used as part of GetOwnerLabels for StateStore ConfigMap selection.
-const LabelResourceOwner = "mongodb.com/v1.mongodbSearchResourceOwner"
-
 const (
+	// ShardNamePlaceholder is the placeholder used in endpoint templates for sharded clusters
+	ShardNamePlaceholder = "{shardName}"
+
+	// ClusterNamePlaceholder is substituted with spec.clusters[i].ClusterName when
+	// resolving spec.loadBalancer.managed.externalHostname for cluster i in
+	// multi-cluster MongoDBSearch deployments. The Envoy reconciler substitutes the
+	// member cluster name so per-cluster SNI hostnames stay distinct.
+	ClusterNamePlaceholder = "{clusterName}"
+
+	// ClusterIndexPlaceholder is substituted with the stable cluster-index for
+	// spec.clusters[i]. The index is monotonic and never reused on remove/re-add
+	// (see api/mongodb/v1/search/cluster_index.go).
+	ClusterIndexPlaceholder = "{clusterIndex}"
+
+	// LabelResourceOwner is the label key used to identify the MongoDBSearch CR that
+	// owns a resource. Used as part of GetOwnerLabels for StateStore ConfigMap selection.
+	LabelResourceOwner = "mongodb.com/v1.mongodbSearchResourceOwner"
+
 	MongotDefaultWireprotoPort      int32 = 27027
 	MongotDefaultGrpcPort           int32 = 27028
 	MongotDefaultPrometheusPort     int32 = 9946
@@ -81,37 +81,17 @@ type MongoDBSearchSpec struct {
 	// MongoDB database connection details from which MongoDB Search will synchronize data to build indexes.
 	// +optional
 	Source *MongoDBSource `json:"source"`
-	// Deprecated: In multi-cluster deployments, prefer spec.clusters[].replicas. When
-	// spec.clusters is omitted, this value auto-promotes into spec.clusters[0].replicas.
-	// Setting both spec.replicas and spec.clusters at the same time is rejected by admission.
-	// Replicas is the number of mongot pods to deploy.
-	// For ReplicaSet source: the number of mongot pods in total.
-	// For Sharded source: the number mongot pods per shard.
-	// When Replicas > 1, a load balancer configuration (spec.loadBalancer)
-	// is required to distribute traffic across mongot instances.
-	// 0 is allowed so operators (and operator-driven test harnesses) can
-	// take mongot offline cleanly via the CR — the StatefulSet is scaled
-	// to 0 by the reconciler; the MongoDBSearch CR itself stays around.
+	// Deprecated: use spec.clusters[].replicas instead; this top-level form will be removed.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
-	// Deprecated: In multi-cluster deployments, prefer spec.clusters[].statefulSet. When
-	// spec.clusters is omitted, this value auto-promotes into spec.clusters[0].statefulSet.
-	// Setting both spec.statefulSet and spec.clusters at the same time is rejected by admission.
-	// StatefulSetSpec which the operator will apply to the MongoDB Search StatefulSet at the end of the reconcile loop. Use to provide necessary customizations,
-	// which aren't exposed as fields in the MongoDBSearch.spec.
+	// Deprecated: use spec.clusters[].statefulSet instead; this top-level form will be removed.
 	// +optional
 	StatefulSetConfiguration *v1.StatefulSetConfiguration `json:"statefulSet,omitempty"`
-	// Deprecated: In multi-cluster deployments, prefer spec.clusters[].persistence. When
-	// spec.clusters is omitted, this value auto-promotes into spec.clusters[0].persistence.
-	// Setting both spec.persistence and spec.clusters at the same time is rejected by admission.
-	// Configure MongoDB Search's persistent volume. If not defined, the operator will request 10GB of storage.
+	// Deprecated: use spec.clusters[].persistence instead; this top-level form will be removed.
 	// +optional
 	Persistence *v1.Persistence `json:"persistence,omitempty"`
-	// Deprecated: In multi-cluster deployments, prefer spec.clusters[].resourceRequirements. When
-	// spec.clusters is omitted, this value auto-promotes into spec.clusters[0].resourceRequirements.
-	// Setting both spec.resourceRequirements and spec.clusters at the same time is rejected by admission.
-	// Configure resource requests and limits for the MongoDB Search pods.
+	// Deprecated: use spec.clusters[].resourceRequirements instead; this top-level form will be removed.
 	// +optional
 	ResourceRequirements *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
 	// Configure security settings of the MongoDB Search server that MongoDB database is connecting to when performing search queries.
@@ -167,27 +147,33 @@ type SyncSourceSelector struct {
 }
 
 // ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-// when len(spec.clusters) > 1; optional in the single-cluster degenerate case.
+// when len(spec.clusters) > 1; optional in the single-cluster case.
 // All other fields override the corresponding top-level value when set; nil/omitted inherits.
 type ClusterSpec struct {
 	// ClusterName is the Kubernetes cluster name. Required and immutable
-	// when len(spec.clusters) > 1; optional in the single-cluster degenerate case.
-	// MaxLength bounds the per-element cost contributed to the parent
-	// clusters[] uniqueness CEL rule. 253 matches the DNS subdomain limit
-	// that K8s cluster names obey.
+	// when len(spec.clusters) > 1; optional in the single-cluster case.
+	// MaxLength is 253 to match the DNS subdomain limit Kubernetes cluster
+	// names obey (and to bound the clusters[] uniqueness CEL rule's per-element cost).
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
 	ClusterName string `json:"clusterName,omitempty"`
-	// Replicas overrides spec.replicas for this cluster's mongot StatefulSet.
-	// For sharded sources, this is mongot pods per shard, not total.
-	// 0 is allowed (StatefulSet scales to 0 — see spec.replicas docs).
+	// Replicas is the number of mongot pods for this cluster's StatefulSet.
+	// For ReplicaSet sources this is the total; for sharded sources it is per shard.
+	// When Replicas > 1, a load balancer (spec.loadBalancer) is required to distribute
+	// traffic across mongot instances.
+	// 0 is allowed so operators (and operator-driven test harnesses) can take mongot
+	// offline cleanly via the CR — the StatefulSet scales to 0; the MongoDBSearch CR stays.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
+	// ResourceRequirements configures resource requests and limits for this cluster's mongot pods.
 	// +optional
 	ResourceRequirements *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
+	// Persistence configures this cluster's mongot persistent volume. Defaults to 10GB if unset.
 	// +optional
 	Persistence *v1.Persistence `json:"persistence,omitempty"`
+	// StatefulSetConfiguration is applied to this cluster's mongot StatefulSet at the end of the
+	// reconcile loop, for customizations not exposed as first-class fields.
 	// +optional
 	StatefulSetConfiguration *v1.StatefulSetConfiguration `json:"statefulSet,omitempty"`
 	// +optional

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -81,17 +81,17 @@ type MongoDBSearchSpec struct {
 	// Source is the MongoDB database that MongoDB Search syncs from to build its indexes.
 	// +optional
 	Source *MongoDBSource `json:"source"`
-	// Deprecated: use spec.clusters[].replicas instead; this top-level form will be removed.
+	// Deprecated: use spec.clusters[].replicas instead; this top-level field will be removed.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
-	// Deprecated: use spec.clusters[].statefulSet instead; this top-level form will be removed.
+	// Deprecated: use spec.clusters[].statefulSet instead; this top-level field will be removed.
 	// +optional
 	StatefulSetConfiguration *v1.StatefulSetConfiguration `json:"statefulSet,omitempty"`
-	// Deprecated: use spec.clusters[].persistence instead; this top-level form will be removed.
+	// Deprecated: use spec.clusters[].persistence instead; this top-level field will be removed.
 	// +optional
 	Persistence *v1.Persistence `json:"persistence,omitempty"`
-	// Deprecated: use spec.clusters[].resourceRequirements instead; this top-level form will be removed.
+	// Deprecated: use spec.clusters[].resourceRequirements instead; this top-level field will be removed.
 	// +optional
 	ResourceRequirements *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
 	// Security holds the TLS settings for the MongoDB Search server.
@@ -155,8 +155,7 @@ type SyncSourceSelector struct {
 type ClusterSpec struct {
 	// ClusterName is the Kubernetes cluster name. Required and immutable
 	// when len(spec.clusters) > 1; optional in the single-cluster case.
-	// MaxLength is 253 to match the DNS subdomain limit Kubernetes cluster
-	// names obey (and to bound the clusters[] uniqueness CEL rule's per-element cost).
+	// MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
 	ClusterName string `json:"clusterName,omitempty"`

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -336,7 +336,7 @@ func validateX509AuthConfig(s *MongoDBSearch) v1.ValidationResult {
 }
 
 // validateClustersClusterNameNonEmpty rejects an empty spec.clusters[i].clusterName
-// when len(spec.clusters) > 1. The single-cluster degenerate case (len <= 1) keeps
+// when len(spec.clusters) > 1. The single-cluster case (len <= 1) keeps
 // allowing an empty clusterName. Uniqueness is the next validator's job; the dedicated
 // "is required" message fires here so a two-empty-names spec surfaces the actionable
 // hint instead of "duplicate".
@@ -593,7 +593,7 @@ func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
 // validateMCRejectsUnmanagedLB rejects multi-cluster MongoDBSearch with
 // spec.loadBalancer.unmanaged set. Q3-MC / Q4-MC topologies are deferred
 // post-GA per spec §4.4 and §B0.2; multi-cluster at GA requires managed LB.
-// Single-cluster (and the degenerate single-entry spec.clusters case) keep
+// Single-cluster (and the single-entry spec.clusters case) keep
 // using unmanaged LB without change.
 func validateMCRejectsUnmanagedLB(s *MongoDBSearch) v1.ValidationResult {
 	if s.Spec.Clusters == nil || len(*s.Spec.Clusters) <= 1 {

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -267,7 +267,7 @@ func TestValidateClustersUniqueClusterName(t *testing.T) {
 			errorContains: "duplicate",
 		},
 		{
-			// Empty names are reserved for the single-cluster degenerate case;
+			// Empty names are reserved for the single-cluster case;
 			// two empty names is still a duplicate.
 			name:          "two empty names",
 			clusters:      []ClusterSpec{{}, {}},

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -195,7 +195,7 @@ type clusterWorkItem struct {
 // buildClusterWorkList expands spec.clusters[] into the per-cluster work units
 // the reconciler will iterate over. Membership rules:
 //   - len(memberClusterClientsMap) == 0 → single-cluster install; one work item with ClusterName="" and ClusterIndex=0.
-//   - len(spec.clusters) == 0 → single-cluster degenerate; one work item with ClusterName="" and ClusterIndex=0.
+//   - len(spec.clusters) == 0 → single-cluster (empty spec.clusters); one work item with ClusterName="" and ClusterIndex=0.
 //   - otherwise → one work item per spec.clusters[i]. ClusterIndex is resolved from
 //     mapping; -1 if the cluster is not yet in the mapping (first reconcile race).
 func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.MongoDBSearch, mapping map[string]int) []clusterWorkItem {

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -750,7 +750,7 @@ func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 	memberARaw := fake.NewClientBuilder().Build()
 	r := newMongoDBSearchEnvoyReconciler(centralRaw, "envoy:latest", map[string]client.Client{"a": memberARaw})
 
-	// Single-cluster degenerate: Client must be the central client.
+	// Single-cluster: Client must be the central client.
 	singleSearch := &searchv1.MongoDBSearch{}
 	wl := r.buildClusterWorkList(singleSearch, nil)
 	require.Len(t, wl, 1)
@@ -777,7 +777,7 @@ func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 func TestLoadBalancerNamesForCluster_IndexBased(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
 
-	// Index 0 (single-cluster degenerate path).
+	// Index 0 (single-cluster path).
 	assert.Equal(t, "mdb-search-search-lb-0-0", search.LoadBalancerDeploymentNameForCluster(0))
 	assert.Equal(t, "mdb-search-search-lb-0-0-config", search.LoadBalancerConfigMapNameForCluster(0))
 

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3315,7 +3315,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 }
 
 // Empty GetShardNames() yields an empty work list. The reconciler must not fail
-// noisily on the degenerate case; the preflight step is a no-op and reconcile
+// noisily on the empty-shard-names case; the preflight step is a no-op and reconcile
 // should reach an OK terminal state with no per-shard resources created.
 // (Production-shaped sources never return empty
 // — this is a defensive boundary check.)
@@ -3334,7 +3334,7 @@ func TestReconcileSharded_EmptyShardNames(t *testing.T) {
 	})
 
 	// emptyShardedSource implements SearchSourceShardedDeployment but reports
-	// zero shards — the degenerate case.
+	// zero shards — the empty boundary case.
 	src := &mockShardedSource{shardNames: nil}
 	central := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(search).Build())
 


### PR DESCRIPTION
Comment/doc-only cleanup of the MongoDBSearch API types. No behavior change.

- Trim deprecated top-level field docs to redirects
- Simplify field descriptions; drop "degenerate" jargon
- Unify const declarations