### PR TITLE
Search: default anti-affinity for mongot pods

### DIFF
--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -612,7 +612,7 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 									"app": search.LoadBalancerDeploymentNameForCluster(clusterIndex),
 								},
 							},
-							TopologyKey: "kubernetes.io/hostname",
+							TopologyKey: util.DefaultAntiAffinityTopologyKey,
 						},
 					},
 				},

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -143,6 +143,10 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, clusterName,
 				podtemplatespec.WithPodLabels(labels),
 				podtemplatespec.WithVolumes(volumes),
 				podtemplatespec.WithServiceAccount(util.MongoDBServiceAccount),
+				// Default: spread this StatefulSet's mongot pods across hosts (preferred, not
+				// required). A clusters[].statefulSet affinity override replaces this term.
+				podtemplatespec.WithAffinity(labels[appLabelKey], appLabelKey, 100),
+				podtemplatespec.WithTopologyKey(util.DefaultAntiAffinityTopologyKey, 0),
 				podtemplatespec.WithContainer(MongotContainerName, mongodbSearchContainer(mdbSearch, perCluster, volumeMounts, searchImage, usePerPodConfig)),
 			),
 		),

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -8,11 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct"
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 func TestCreateSearchStatefulSetFunc_JVMFlags(t *testing.T) {
@@ -205,6 +209,67 @@ func TestCreateSearchResourceRequirements(t *testing.T) {
 				"expected memory %s, got %s", tc.expectedMemory.String(), result.Requests.Memory().String())
 		})
 	}
+}
+
+func TestCreateSearchStatefulSetFunc_DefaultAntiAffinity(t *testing.T) {
+	search := newTestMongoDBSearch("test-search", "default")
+	labels := map[string]string{appLabelKey: "test-search-svc"}
+
+	stsMod, err := CreateSearchStatefulSetFunc(search, "", "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+	require.NoError(t, err)
+	sts := statefulset.New(stsMod)
+
+	affinity := sts.Spec.Template.Spec.Affinity
+	require.NotNil(t, affinity)
+	require.NotNil(t, affinity.PodAntiAffinity)
+
+	// The affinity should be preferred, not required
+	assert.Empty(t, affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	terms := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, terms, 1)
+	assert.Equal(t, int32(100), terms[0].Weight)
+	assert.Equal(t, util.DefaultAntiAffinityTopologyKey, terms[0].PodAffinityTerm.TopologyKey)
+	require.NotNil(t, terms[0].PodAffinityTerm.LabelSelector)
+	// Selects this StatefulSet's own pods, so the term spreads them across hosts.
+	assert.Equal(t, map[string]string{appLabelKey: "test-search-svc"}, terms[0].PodAffinityTerm.LabelSelector.MatchLabels)
+}
+
+func TestCreateSearchStatefulSetFunc_StatefulSetOverrideReplacesAntiAffinity(t *testing.T) {
+	customAntiAffinity := &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+			TopologyKey:   "topology.kubernetes.io/zone",
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"custom": "selector"}},
+		}},
+	}
+	search := newTestMongoDBSearch("test-search", "default", func(s *searchv1.MongoDBSearch) {
+		s.Spec.Clusters = &[]searchv1.ClusterSpec{{
+			ClusterName: "cluster-1",
+			StatefulSetConfiguration: &v1.StatefulSetConfiguration{
+				SpecWrapper: v1.StatefulSetSpecWrapper{
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{PodAntiAffinity: customAntiAffinity},
+							},
+						},
+					},
+				},
+			},
+		}}
+	})
+	labels := map[string]string{appLabelKey: "test-search-svc"}
+
+	stsMod, err := CreateSearchStatefulSetFunc(search, "cluster-1", "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+	require.NoError(t, err)
+	sts := statefulset.New(stsMod)
+
+	pa := sts.Spec.Template.Spec.Affinity.PodAntiAffinity
+	require.NotNil(t, pa)
+	// The override's PodAntiAffinity replaces the default term wholesale.
+	assert.Empty(t, pa.PreferredDuringSchedulingIgnoredDuringExecution)
+	require.Len(t, pa.RequiredDuringSchedulingIgnoredDuringExecution, 1)
+	assert.Equal(t, "topology.kubernetes.io/zone", pa.RequiredDuringSchedulingIgnoredDuringExecution[0].TopologyKey)
+	assert.Equal(t, map[string]string{"custom": "selector"}, pa.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels)
 }
 
 type containerInfo struct {


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1048

## Chain of upstream PRs as of 2026-06-03

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * **PR #1168 (THIS ONE)**:
      `search/ga-base` ← `search/jben/mongot-antiaffinity`

<!-- end git-machete generated -->

Spread a StatefulSet's mongot pods across hosts by default (preferred, weight 100, `kubernetes.io/hostname`) — matching every other MongoDB workload. Overridable via `clusters[].statefulSet`.