### PR TITLE
[KUBE-10] Use dynamic envoy config for CDS/LDS

### DIFF
--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -24,76 +25,45 @@ import (
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	upstreamhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
 )
 
-// buildEnvoyConfigJSON builds the Envoy bootstrap configuration using
-// go-control-plane protobuf types and marshals it to JSON.
-func buildEnvoyConfigJSON(routes []envoyRoute, tlsEnabled bool, caKeyName string) (string, error) {
-	config, err := buildEnvoyBootstrapConfig(routes, tlsEnabled, caKeyName)
-	if err != nil {
-		return "", fmt.Errorf("failed to build Envoy bootstrap config: %w", err)
-	}
-
-	marshaler := protojson.MarshalOptions{
-		UseProtoNames: true, // snake_case field names (matches Envoy expectations)
-		Indent:        "  ",
-	}
-	data, err := marshaler.Marshal(config)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal Envoy config to JSON: %w", err)
-	}
-
-	return string(data), nil
-}
-
-// buildEnvoyBootstrapConfig constructs the full Envoy bootstrap protobuf.
-func buildEnvoyBootstrapConfig(routes []envoyRoute, tlsEnabled bool, caKeyName string) (*bootstrapv3.Bootstrap, error) {
-	filterChains := make([]*listenerv3.FilterChain, 0, len(routes))
-	clusters := make([]*clusterv3.Cluster, 0, len(routes))
-
-	for _, route := range routes {
-		fc, err := buildFilterChain(route, tlsEnabled, caKeyName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build filter chain for route %s: %w", route.Name, err)
-		}
-		filterChains = append(filterChains, fc)
-
-		cl, err := buildCluster(route, tlsEnabled, caKeyName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build cluster for route %s: %w", route.Name, err)
-		}
-		clusters = append(clusters, cl)
-	}
-
-	var listenerFilters []*listenerv3.ListenerFilter
-	if tlsEnabled {
-		tlsInspectorCfg, err := anypb.New(&tlsinspectorv3.TlsInspector{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal TLS inspector config: %w", err)
-		}
-		listenerFilters = []*listenerv3.ListenerFilter{
-			{
-				Name: wellknown.TLSInspector,
-				ConfigType: &listenerv3.ListenerFilter_TypedConfig{
-					TypedConfig: tlsInspectorCfg,
-				},
-			},
-		}
-	}
-
+// buildBootstrapJSON returns the static Envoy bootstrap config JSON.
+// This config points Envoy at filesystem-based CDS/LDS for dynamic resource
+// discovery and does not contain any static_resources. bootstrap config json
+// is stable across shard add/remove operations — only CDS/LDS files change.
+func buildBootstrapJSON() (string, error) {
 	runtimeStruct, err := structpb.NewStruct(map[string]interface{}{
 		"overload": map[string]interface{}{
 			"global_downstream_max_connections": 50000,
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to build runtime struct: %w", err)
+		return "", fmt.Errorf("failed to build runtime struct: %w", err)
 	}
 
-	return &bootstrapv3.Bootstrap{
+	pathConfigSource := func(path string) *corev3.ConfigSource {
+		return &corev3.ConfigSource{
+			ConfigSourceSpecifier: &corev3.ConfigSource_PathConfigSource{
+				PathConfigSource: &corev3.PathConfigSource{
+					Path: path,
+					WatchedDirectory: &corev3.WatchedDirectory{
+						Path: envoyConfigPath,
+					},
+				},
+			},
+		}
+	}
+
+	bootstrap := &bootstrapv3.Bootstrap{
+		Node: &corev3.Node{
+			// id is the envoy node identifier to identify a specific enovy instance from xDS management server
+			Id:      "envoy-search-proxy",
+			Cluster: "search-proxy",
+		},
 		Admin: &bootstrapv3.Admin{
 			Address: socketAddress("0.0.0.0", uint32(EnvoyAdminPort)),
 			// enable just some endpoints because it's recommended to not enable all the admin endpoints by default.
@@ -104,16 +74,9 @@ func buildEnvoyBootstrapConfig(routes []envoyRoute, tlsEnabled bool, caKeyName s
 				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/logging"}},
 			},
 		},
-		StaticResources: &bootstrapv3.Bootstrap_StaticResources{
-			Listeners: []*listenerv3.Listener{
-				{
-					Name:            "mongod_listener",
-					Address:         socketAddress("0.0.0.0", uint32(searchv1.EnvoyDefaultProxyPort)),
-					ListenerFilters: listenerFilters,
-					FilterChains:    filterChains,
-				},
-			},
-			Clusters: clusters,
+		DynamicResources: &bootstrapv3.Bootstrap_DynamicResources{
+			CdsConfig: pathConfigSource(envoyConfigPath + "/cds.json"),
+			LdsConfig: pathConfigSource(envoyConfigPath + "/lds.json"),
 		},
 		LayeredRuntime: &bootstrapv3.LayeredRuntime{
 			Layers: []*bootstrapv3.RuntimeLayer{
@@ -125,7 +88,94 @@ func buildEnvoyBootstrapConfig(routes []envoyRoute, tlsEnabled bool, caKeyName s
 				},
 			},
 		},
-	}, nil
+	}
+
+	return marshalJSON(bootstrap)
+}
+
+// buildCDSJSON builds the CDS (Cluster Discovery Service) DiscoveryResponse JSON containing all upstream clusters.
+// Each route produces one cluster pointing to a mongot group's headless service.
+func buildCDSJSON(routes []envoyRoute, tlsEnabled bool, caKeyName string) (string, error) {
+	resources := make([]*anypb.Any, 0, len(routes))
+	for _, route := range routes {
+		cluster, err := buildCluster(route, tlsEnabled, caKeyName)
+		if err != nil {
+			return "", fmt.Errorf("failed to build cluster for route %s: %w", route.Name, err)
+		}
+		clusterAny, err := anypb.New(cluster)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal cluster %s to Any: %w", route.Name, err)
+		}
+		resources = append(resources, clusterAny)
+	}
+
+	resp := &discoveryv3.DiscoveryResponse{
+		Resources: resources,
+		TypeUrl:   "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+	}
+
+	return marshalJSON(resp)
+}
+
+// buildLDSJSON builds the LDS (Listener Discovery Service) DiscoveryResponse JSON containing the listener.
+// The listener has one filter chain per route (per shard or single RS).
+func buildLDSJSON(routes []envoyRoute, tlsEnabled bool, caKeyName string) (string, error) {
+	filterChains := make([]*listenerv3.FilterChain, 0, len(routes))
+	for _, route := range routes {
+		fc, err := buildFilterChain(route, tlsEnabled, caKeyName)
+		if err != nil {
+			return "", fmt.Errorf("failed to build filter chain for route %s: %w", route.Name, err)
+		}
+		filterChains = append(filterChains, fc)
+	}
+
+	var listenerFilters []*listenerv3.ListenerFilter
+	if tlsEnabled {
+		tlsInspectorCfg, err := anypb.New(&tlsinspectorv3.TlsInspector{})
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal TLS inspector config: %w", err)
+		}
+		listenerFilters = []*listenerv3.ListenerFilter{
+			{
+				Name: wellknown.TLSInspector,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{
+					TypedConfig: tlsInspectorCfg,
+				},
+			},
+		}
+	}
+
+	listener := &listenerv3.Listener{
+		Name:            "mongod_listener",
+		Address:         socketAddress("0.0.0.0", uint32(searchv1.EnvoyDefaultProxyPort)),
+		ListenerFilters: listenerFilters,
+		FilterChains:    filterChains,
+	}
+
+	listenerAny, err := anypb.New(listener)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal listener to Any: %w", err)
+	}
+
+	resp := &discoveryv3.DiscoveryResponse{
+		Resources: []*anypb.Any{listenerAny},
+		TypeUrl:   "type.googleapis.com/envoy.config.listener.v3.Listener",
+	}
+
+	return marshalJSON(resp)
+}
+
+// marshalJSON marshals a protobuf message to JSON with Envoy-compatible options.
+func marshalJSON(msg proto.Message) (string, error) {
+	marshaler := protojson.MarshalOptions{
+		UseProtoNames: true, // snake_case field names (matches Envoy expectations)
+		Indent:        "  ",
+	}
+	data, err := marshaler.Marshal(msg)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal config to JSON: %w", err)
+	}
+	return string(data), nil
 }
 
 // socketAddress builds an Envoy Address with a TCP socket.

--- a/controllers/operator/envoy_config_builder_test.go
+++ b/controllers/operator/envoy_config_builder_test.go
@@ -11,7 +11,9 @@ import (
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
 )
@@ -38,18 +40,25 @@ func unmarshalBootstrap(t *testing.T, jsonStr string) *bootstrapv3.Bootstrap {
 	return bootstrap
 }
 
-func TestBuildEnvoyConfigJSON_OutputIsValidJSON(t *testing.T) {
-	result, err := buildEnvoyConfigJSON([]envoyRoute{testRoute("mdb-sh-0")}, false, testCAKeyName())
-	require.NoError(t, err)
-	assert.True(t, json.Valid([]byte(result)), "output should be valid JSON")
+func unmarshalDiscoveryResponse(t *testing.T, jsonStr string) *discoveryv3.DiscoveryResponse {
+	t.Helper()
+	resp := &discoveryv3.DiscoveryResponse{}
+	err := protojson.Unmarshal([]byte(jsonStr), resp)
+	require.NoError(t, err, "failed to unmarshal DiscoveryResponse")
+	return resp
 }
 
-func TestBuildEnvoyConfigJSON_SingleShard_NoTLS(t *testing.T) {
-	route := testRoute("mdb-sh-0")
-	result, err := buildEnvoyConfigJSON([]envoyRoute{route}, false, testCAKeyName())
+func TestBuildBootstrapJSON(t *testing.T) {
+	result, err := buildBootstrapJSON()
 	require.NoError(t, err)
+	assert.True(t, json.Valid([]byte(result)))
 
 	bootstrap := unmarshalBootstrap(t, result)
+
+	// Node (required for xDS subscriptions)
+	require.NotNil(t, bootstrap.Node)
+	assert.Equal(t, "envoy-search-proxy", bootstrap.Node.Id)
+	assert.Equal(t, "search-proxy", bootstrap.Node.Cluster)
 
 	// Admin
 	require.NotNil(t, bootstrap.Admin)
@@ -57,29 +66,49 @@ func TestBuildEnvoyConfigJSON_SingleShard_NoTLS(t *testing.T) {
 	assert.Equal(t, "0.0.0.0", adminAddr.GetAddress())
 	assert.Equal(t, uint32(EnvoyAdminPort), adminAddr.GetPortValue())
 
-	// Static resources
-	require.NotNil(t, bootstrap.StaticResources)
-	require.Len(t, bootstrap.StaticResources.Listeners, 1)
-	listener := bootstrap.StaticResources.Listeners[0]
-	assert.Equal(t, "mongod_listener", listener.Name)
-	assert.Equal(t, uint32(searchv1.EnvoyDefaultProxyPort), listener.Address.GetSocketAddress().GetPortValue())
+	// No static resources
+	assert.Nil(t, bootstrap.StaticResources)
 
-	// No TLS Inspector when TLS is disabled
-	assert.Empty(t, listener.ListenerFilters, "no TLS Inspector when TLS disabled")
+	// Dynamic resources with filesystem xDS
+	require.NotNil(t, bootstrap.DynamicResources)
+	require.NotNil(t, bootstrap.DynamicResources.CdsConfig)
+	require.NotNil(t, bootstrap.DynamicResources.LdsConfig)
 
-	// Filter chains
-	require.Len(t, listener.FilterChains, 1)
-	fc := listener.FilterChains[0]
-	assert.Nil(t, fc.FilterChainMatch, "no SNI match when TLS disabled (default filter chain)")
-	assert.Nil(t, fc.TransportSocket, "no TLS transport socket when TLS disabled")
+	cdsSrc := bootstrap.DynamicResources.CdsConfig.GetPathConfigSource()
+	require.NotNil(t, cdsSrc)
+	assert.Equal(t, "/etc/envoy/cds.json", cdsSrc.Path)
+	require.NotNil(t, cdsSrc.WatchedDirectory)
+	assert.Equal(t, "/etc/envoy", cdsSrc.WatchedDirectory.Path)
 
-	// Clusters
-	require.Len(t, bootstrap.StaticResources.Clusters, 1)
-	cluster := bootstrap.StaticResources.Clusters[0]
+	ldsSrc := bootstrap.DynamicResources.LdsConfig.GetPathConfigSource()
+	require.NotNil(t, ldsSrc)
+	assert.Equal(t, "/etc/envoy/lds.json", ldsSrc.Path)
+	require.NotNil(t, ldsSrc.WatchedDirectory)
+	assert.Equal(t, "/etc/envoy", ldsSrc.WatchedDirectory.Path)
+
+	// Layered runtime
+	require.NotNil(t, bootstrap.LayeredRuntime)
+	require.Len(t, bootstrap.LayeredRuntime.Layers, 1)
+	assert.Equal(t, "static_layer", bootstrap.LayeredRuntime.Layers[0].Name)
+}
+
+func TestBuildCDSJSON_SingleShard_NoTLS(t *testing.T) {
+	route := testRoute("mdb-sh-0")
+	result, err := buildCDSJSON([]envoyRoute{route}, false, testCAKeyName())
+	require.NoError(t, err)
+	assert.True(t, json.Valid([]byte(result)))
+
+	resp := unmarshalDiscoveryResponse(t, result)
+	assert.Equal(t, "type.googleapis.com/envoy.config.cluster.v3.Cluster", resp.TypeUrl)
+	require.Len(t, resp.Resources, 1)
+
+	cluster := &clusterv3.Cluster{}
+	err = resp.Resources[0].UnmarshalTo(cluster)
+	require.NoError(t, err)
 	assert.Equal(t, "mongot_mdb_sh_0_cluster", cluster.Name)
 	assert.Equal(t, clusterv3.Cluster_STRICT_DNS, cluster.GetType())
 	assert.Equal(t, clusterv3.Cluster_ROUND_ROBIN, cluster.LbPolicy)
-	assert.Nil(t, cluster.TransportSocket, "no TLS transport socket when TLS disabled")
+	assert.Nil(t, cluster.TransportSocket, "no TLS when disabled")
 
 	// Endpoint
 	require.Len(t, cluster.LoadAssignment.Endpoints, 1)
@@ -91,178 +120,176 @@ func TestBuildEnvoyConfigJSON_SingleShard_NoTLS(t *testing.T) {
 	// Circuit breakers
 	require.NotNil(t, cluster.CircuitBreakers)
 	require.Len(t, cluster.CircuitBreakers.Thresholds, 1)
-	thresh := cluster.CircuitBreakers.Thresholds[0]
-	assert.Equal(t, corev3.RoutingPriority_DEFAULT, thresh.Priority)
-	assert.Equal(t, uint32(1024), thresh.MaxConnections.GetValue())
+	assert.Equal(t, corev3.RoutingPriority_DEFAULT, cluster.CircuitBreakers.Thresholds[0].Priority)
+	assert.Equal(t, uint32(1024), cluster.CircuitBreakers.Thresholds[0].MaxConnections.GetValue())
 
 	// TCP keepalive
 	require.NotNil(t, cluster.UpstreamConnectionOptions)
 	require.NotNil(t, cluster.UpstreamConnectionOptions.TcpKeepalive)
 	assert.Equal(t, uint32(10), cluster.UpstreamConnectionOptions.TcpKeepalive.KeepaliveTime.GetValue())
-
-	// LayeredRuntime
-	require.NotNil(t, bootstrap.LayeredRuntime)
-	require.Len(t, bootstrap.LayeredRuntime.Layers, 1)
-	assert.Equal(t, "static_layer", bootstrap.LayeredRuntime.Layers[0].Name)
 }
 
-func TestBuildEnvoyConfigJSON_SingleShard_WithTLS(t *testing.T) {
+func TestBuildCDSJSON_SingleShard_WithTLS(t *testing.T) {
 	route := testRoute("mdb-sh-0")
-	caKeyName := testCAKeyName()
-	result, err := buildEnvoyConfigJSON([]envoyRoute{route}, true, caKeyName)
+	result, err := buildCDSJSON([]envoyRoute{route}, true, testCAKeyName())
 	require.NoError(t, err)
 
-	bootstrap := unmarshalBootstrap(t, result)
+	resp := unmarshalDiscoveryResponse(t, result)
+	require.Len(t, resp.Resources, 1)
 
-	// Filter chain has downstream TLS
-	fc := bootstrap.StaticResources.Listeners[0].FilterChains[0]
-	require.NotNil(t, fc.TransportSocket, "TLS transport socket should be present")
-
-	downstreamTLS := &tlsv3.DownstreamTlsContext{}
-	err = fc.TransportSocket.GetTypedConfig().UnmarshalTo(downstreamTLS)
+	cluster := &clusterv3.Cluster{}
+	err = resp.Resources[0].UnmarshalTo(cluster)
 	require.NoError(t, err)
-
-	assert.True(t, downstreamTLS.RequireClientCertificate.GetValue())
-	assert.Equal(t, tlsv3.TlsParameters_TLSv1_3, downstreamTLS.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion)
-	assert.Equal(t, tlsv3.TlsParameters_TLSv1_3, downstreamTLS.CommonTlsContext.TlsParams.TlsMaximumProtocolVersion)
-	assert.Equal(t, []string{"h2"}, downstreamTLS.CommonTlsContext.AlpnProtocols)
-
-	require.Len(t, downstreamTLS.CommonTlsContext.TlsCertificates, 1)
-	cert := downstreamTLS.CommonTlsContext.TlsCertificates[0]
-	assert.Equal(t, envoyServerCertPath+"/tls.crt", cert.CertificateChain.GetFilename())
-	assert.Equal(t, envoyServerCertPath+"/tls.key", cert.PrivateKey.GetFilename())
-
-	valCtx := downstreamTLS.CommonTlsContext.GetValidationContext()
-	require.NotNil(t, valCtx)
-	assert.Equal(t, envoyCACertPath+"/"+caKeyName, valCtx.TrustedCa.GetFilename())
-
-	// Cluster has upstream TLS
-	cluster := bootstrap.StaticResources.Clusters[0]
-	require.NotNil(t, cluster.TransportSocket, "upstream TLS transport socket should be present")
+	require.NotNil(t, cluster.TransportSocket, "upstream TLS should be present")
 
 	upstreamTLS := &tlsv3.UpstreamTlsContext{}
 	err = cluster.TransportSocket.GetTypedConfig().UnmarshalTo(upstreamTLS)
 	require.NoError(t, err)
-
 	assert.Equal(t, route.UpstreamHosts[0], upstreamTLS.Sni)
 	assert.Equal(t, []string{"h2"}, upstreamTLS.CommonTlsContext.AlpnProtocols)
-
-	require.Len(t, upstreamTLS.CommonTlsContext.TlsCertificates, 1)
-	clientCert := upstreamTLS.CommonTlsContext.TlsCertificates[0]
-	assert.Equal(t, envoyClientCertPath+"/tls.crt", clientCert.CertificateChain.GetFilename())
-	assert.Equal(t, envoyClientCertPath+"/tls.key", clientCert.PrivateKey.GetFilename())
 }
 
-func TestBuildEnvoyConfigJSON_MultipleShards_WithTLS(t *testing.T) {
+func TestBuildCDSJSON_MultipleShards(t *testing.T) {
+	routes := []envoyRoute{
+		{Name: "mdb-sh-0", NameSafe: "mdb_sh_0", SNIHostname: "s0.ns.svc.cluster.local", UpstreamHosts: []string{"m0.ns.svc.cluster.local"}, UpstreamPort: 27028},
+		{Name: "mdb-sh-1", NameSafe: "mdb_sh_1", SNIHostname: "s1.ns.svc.cluster.local", UpstreamHosts: []string{"m1.ns.svc.cluster.local"}, UpstreamPort: 27028},
+	}
+	result, err := buildCDSJSON(routes, false, testCAKeyName())
+	require.NoError(t, err)
+
+	resp := unmarshalDiscoveryResponse(t, result)
+	require.Len(t, resp.Resources, 2)
+
+	for i, route := range routes {
+		cluster := &clusterv3.Cluster{}
+		err = resp.Resources[i].UnmarshalTo(cluster)
+		require.NoError(t, err)
+		assert.Equal(t, "mongot_"+route.NameSafe+"_cluster", cluster.Name)
+	}
+}
+
+func TestBuildLDSJSON_SingleShard_NoTLS(t *testing.T) {
+	route := testRoute("mdb-sh-0")
+	result, err := buildLDSJSON([]envoyRoute{route}, false, testCAKeyName())
+	require.NoError(t, err)
+	assert.True(t, json.Valid([]byte(result)))
+
+	resp := unmarshalDiscoveryResponse(t, result)
+	assert.Equal(t, "type.googleapis.com/envoy.config.listener.v3.Listener", resp.TypeUrl)
+	require.Len(t, resp.Resources, 1)
+
+	listener := &listenerv3.Listener{}
+	err = resp.Resources[0].UnmarshalTo(listener)
+	require.NoError(t, err)
+	assert.Equal(t, "mongod_listener", listener.Name)
+	assert.Equal(t, uint32(searchv1.EnvoyDefaultProxyPort), listener.Address.GetSocketAddress().GetPortValue())
+	assert.Empty(t, listener.ListenerFilters, "no TLS Inspector when TLS disabled")
+	require.Len(t, listener.FilterChains, 1)
+	assert.Nil(t, listener.FilterChains[0].FilterChainMatch, "no SNI match when TLS disabled")
+}
+
+func TestBuildLDSJSON_SingleShard_WithTLS(t *testing.T) {
+	route := testRoute("mdb-sh-0")
+	result, err := buildLDSJSON([]envoyRoute{route}, true, testCAKeyName())
+	require.NoError(t, err)
+
+	resp := unmarshalDiscoveryResponse(t, result)
+	require.Len(t, resp.Resources, 1)
+
+	listener := &listenerv3.Listener{}
+	err = resp.Resources[0].UnmarshalTo(listener)
+	require.NoError(t, err)
+
+	// TLS Inspector present
+	require.Len(t, listener.ListenerFilters, 1)
+	assert.Contains(t, listener.ListenerFilters[0].Name, "tls_inspector")
+
+	// Filter chain has downstream TLS and SNI match
+	require.Len(t, listener.FilterChains, 1)
+	fc := listener.FilterChains[0]
+	require.NotNil(t, fc.FilterChainMatch)
+	assert.Equal(t, []string{route.SNIHostname}, fc.FilterChainMatch.ServerNames)
+	require.NotNil(t, fc.TransportSocket)
+
+	downstreamTLS := &tlsv3.DownstreamTlsContext{}
+	err = fc.TransportSocket.GetTypedConfig().UnmarshalTo(downstreamTLS)
+	require.NoError(t, err)
+	assert.True(t, downstreamTLS.RequireClientCertificate.GetValue())
+	assert.Equal(t, tlsv3.TlsParameters_TLSv1_3, downstreamTLS.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion)
+}
+
+func TestBuildLDSJSON_MultipleShards_WithTLS(t *testing.T) {
 	routes := []envoyRoute{
 		{Name: "mdb-sh-0", NameSafe: "mdb_sh_0", SNIHostname: "shard0.ns.svc.cluster.local", UpstreamHosts: []string{"mongot0.ns.svc.cluster.local"}, UpstreamPort: 27028},
 		{Name: "mdb-sh-1", NameSafe: "mdb_sh_1", SNIHostname: "shard1.ns.svc.cluster.local", UpstreamHosts: []string{"mongot1.ns.svc.cluster.local"}, UpstreamPort: 27028},
 		{Name: "mdb-sh-2", NameSafe: "mdb_sh_2", SNIHostname: "shard2.ns.svc.cluster.local", UpstreamHosts: []string{"mongot2.ns.svc.cluster.local"}, UpstreamPort: 27028},
 	}
 
-	// Sharded clusters always require TLS for SNI-based routing
-	result, err := buildEnvoyConfigJSON(routes, true, testCAKeyName())
+	result, err := buildLDSJSON(routes, true, testCAKeyName())
 	require.NoError(t, err)
 
-	bootstrap := unmarshalBootstrap(t, result)
+	resp := unmarshalDiscoveryResponse(t, result)
+	listener := &listenerv3.Listener{}
+	err = resp.Resources[0].UnmarshalTo(listener)
+	require.NoError(t, err)
 
-	// TLS Inspector present
-	require.Len(t, bootstrap.StaticResources.Listeners[0].ListenerFilters, 1)
-	assert.Contains(t, bootstrap.StaticResources.Listeners[0].ListenerFilters[0].Name, "tls_inspector")
-
-	require.Len(t, bootstrap.StaticResources.Listeners[0].FilterChains, 3)
-	require.Len(t, bootstrap.StaticResources.Clusters, 3)
+	require.Len(t, listener.ListenerFilters, 1)
+	assert.Contains(t, listener.ListenerFilters[0].Name, "tls_inspector")
+	require.Len(t, listener.FilterChains, 3)
 
 	for i, route := range routes {
-		fc := bootstrap.StaticResources.Listeners[0].FilterChains[i]
+		fc := listener.FilterChains[i]
 		require.NotNil(t, fc.FilterChainMatch)
 		assert.Equal(t, []string{route.SNIHostname}, fc.FilterChainMatch.ServerNames)
 		assert.NotNil(t, fc.TransportSocket, "downstream TLS should be present")
-
-		cluster := bootstrap.StaticResources.Clusters[i]
-		expectedName := "mongot_" + route.NameSafe + "_cluster"
-		assert.Equal(t, expectedName, cluster.Name)
-		assert.NotNil(t, cluster.TransportSocket, "upstream TLS should be present")
-
-		ep := cluster.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint()
-		assert.Equal(t, route.UpstreamHosts[0], ep.Address.GetSocketAddress().GetAddress())
 	}
 }
 
-func TestBuildEnvoyConfigJSON_ReplicaSet_NoTLS(t *testing.T) {
+func TestBuildLDSJSON_ReplicaSet_NoTLS(t *testing.T) {
 	route := envoyRoute{
-		Name:          "rs",
-		NameSafe:      "rs",
+		Name: "rs", NameSafe: "rs",
 		SNIHostname:   "mdb-search-search-proxy-svc.test-ns.svc.cluster.local",
 		UpstreamHosts: []string{"mdb-search-search-svc.test-ns.svc.cluster.local"},
 		UpstreamPort:  27028,
 	}
 
-	result, err := buildEnvoyConfigJSON([]envoyRoute{route}, false, testCAKeyName())
+	result, err := buildLDSJSON([]envoyRoute{route}, false, testCAKeyName())
 	require.NoError(t, err)
 
-	bootstrap := unmarshalBootstrap(t, result)
+	resp := unmarshalDiscoveryResponse(t, result)
+	listener := &listenerv3.Listener{}
+	err = resp.Resources[0].UnmarshalTo(listener)
+	require.NoError(t, err)
 
-	listener := bootstrap.StaticResources.Listeners[0]
-
-	// No TLS Inspector for non-TLS RS
-	assert.Empty(t, listener.ListenerFilters, "no TLS Inspector for non-TLS ReplicaSet")
-
-	// Single default filter chain (no SNI match)
+	assert.Empty(t, listener.ListenerFilters, "no TLS Inspector for non-TLS RS")
 	require.Len(t, listener.FilterChains, 1)
-	fc := listener.FilterChains[0]
-	assert.Nil(t, fc.FilterChainMatch, "no SNI match for non-TLS ReplicaSet")
-	assert.Nil(t, fc.TransportSocket, "no downstream TLS for non-TLS ReplicaSet")
+	assert.Nil(t, listener.FilterChains[0].FilterChainMatch, "no SNI match for non-TLS RS")
+	assert.Nil(t, listener.FilterChains[0].TransportSocket, "no downstream TLS for non-TLS RS")
+}
 
-	// Single cluster
-	require.Len(t, bootstrap.StaticResources.Clusters, 1)
-	cluster := bootstrap.StaticResources.Clusters[0]
+func TestBuildCDSJSON_ReplicaSet_NoTLS(t *testing.T) {
+	route := envoyRoute{
+		Name: "rs", NameSafe: "rs",
+		SNIHostname:   "mdb-search-search-proxy-svc.test-ns.svc.cluster.local",
+		UpstreamHosts: []string{"mdb-search-search-svc.test-ns.svc.cluster.local"},
+		UpstreamPort:  27028,
+	}
+
+	result, err := buildCDSJSON([]envoyRoute{route}, false, testCAKeyName())
+	require.NoError(t, err)
+
+	resp := unmarshalDiscoveryResponse(t, result)
+	require.Len(t, resp.Resources, 1)
+
+	cluster := &clusterv3.Cluster{}
+	err = resp.Resources[0].UnmarshalTo(cluster)
+	require.NoError(t, err)
 	assert.Equal(t, "mongot_rs_cluster", cluster.Name)
-	assert.Nil(t, cluster.TransportSocket, "no upstream TLS for non-TLS ReplicaSet")
+	assert.Nil(t, cluster.TransportSocket, "no upstream TLS for non-TLS RS")
 
 	ep := cluster.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint()
 	assert.Equal(t, route.UpstreamHosts[0], ep.Address.GetSocketAddress().GetAddress())
 	assert.Equal(t, uint32(route.UpstreamPort), ep.Address.GetSocketAddress().GetPortValue())
-}
-
-func TestBuildEnvoyConfigJSON_ReplicaSet_WithTLS(t *testing.T) {
-	route := envoyRoute{
-		Name:          "rs",
-		NameSafe:      "rs",
-		SNIHostname:   "mdb-search-search-proxy-svc.test-ns.svc.cluster.local",
-		UpstreamHosts: []string{"mdb-search-search-svc.test-ns.svc.cluster.local"},
-		UpstreamPort:  27028,
-	}
-
-	result, err := buildEnvoyConfigJSON([]envoyRoute{route}, true, testCAKeyName())
-	require.NoError(t, err)
-
-	bootstrap := unmarshalBootstrap(t, result)
-
-	listener := bootstrap.StaticResources.Listeners[0]
-
-	// TLS Inspector present for TLS RS
-	require.Len(t, listener.ListenerFilters, 1)
-	assert.Contains(t, listener.ListenerFilters[0].Name, "tls_inspector")
-
-	// Single filter chain with SNI match
-	require.Len(t, listener.FilterChains, 1)
-	fc := listener.FilterChains[0]
-	require.NotNil(t, fc.FilterChainMatch)
-	assert.Equal(t, []string{route.SNIHostname}, fc.FilterChainMatch.ServerNames)
-	assert.NotNil(t, fc.TransportSocket, "downstream TLS present for TLS ReplicaSet")
-
-	// Single cluster with upstream TLS
-	require.Len(t, bootstrap.StaticResources.Clusters, 1)
-	cluster := bootstrap.StaticResources.Clusters[0]
-	assert.Equal(t, "mongot_rs_cluster", cluster.Name)
-	assert.NotNil(t, cluster.TransportSocket, "upstream TLS present for TLS ReplicaSet")
-
-	// Verify upstream TLS SNI
-	upstreamTLS := &tlsv3.UpstreamTlsContext{}
-	err = cluster.TransportSocket.GetTypedConfig().UnmarshalTo(upstreamTLS)
-	require.NoError(t, err)
-	assert.Equal(t, route.UpstreamHosts[0], upstreamTLS.Sni)
 }
 
 func TestBuildFilterChain_NoTLS_NoSNIMatch(t *testing.T) {
@@ -285,21 +312,27 @@ func TestBuildFilterChain_WithTLS_HasSNIMatch(t *testing.T) {
 	assert.NotNil(t, chain.TransportSocket, "transport socket should be present with TLS")
 }
 
-func TestBuildBootstrapConfig_NoTLS_NoTLSInspector(t *testing.T) {
+func TestBuildLDSJSON_NoTLS_NoTLSInspector(t *testing.T) {
 	route := testRoute("test-shard")
-	bootstrap, err := buildEnvoyBootstrapConfig([]envoyRoute{route}, false, testCAKeyName())
+	result, err := buildLDSJSON([]envoyRoute{route}, false, testCAKeyName())
 	require.NoError(t, err)
 
-	listener := bootstrap.StaticResources.Listeners[0]
+	resp := unmarshalDiscoveryResponse(t, result)
+	listener := &listenerv3.Listener{}
+	err = resp.Resources[0].UnmarshalTo(listener)
+	require.NoError(t, err)
 	assert.Empty(t, listener.ListenerFilters, "no listener filters when TLS disabled")
 }
 
-func TestBuildBootstrapConfig_WithTLS_HasTLSInspector(t *testing.T) {
+func TestBuildLDSJSON_WithTLS_HasTLSInspector(t *testing.T) {
 	route := testRoute("test-shard")
-	bootstrap, err := buildEnvoyBootstrapConfig([]envoyRoute{route}, true, testCAKeyName())
+	result, err := buildLDSJSON([]envoyRoute{route}, true, testCAKeyName())
 	require.NoError(t, err)
 
-	listener := bootstrap.StaticResources.Listeners[0]
+	resp := unmarshalDiscoveryResponse(t, result)
+	listener := &listenerv3.Listener{}
+	err = resp.Resources[0].UnmarshalTo(listener)
+	require.NoError(t, err)
 	require.Len(t, listener.ListenerFilters, 1)
 	assert.Contains(t, listener.ListenerFilters[0].Name, "tls_inspector")
 }

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -245,15 +245,26 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 		return workflow.Pending("No routes to configure for load balancer (cluster=%q)", clusterName)
 	}
 
+	// Generate Envoy config files: static bootstrap + dynamic CDS/LDS
 	caKeyName := caKeyNameFromTLSConfig(tlsCfg)
-	envoyJSON, err := buildEnvoyConfigJSON(routes, tlsEnabled, caKeyName)
+	bootstrapJSON, err := buildBootstrapJSON()
 	if err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
-	if err := r.ensureConfigMap(ctx, search, envoyJSON, clusterName, clusterIndex, c, log); err != nil {
+	cdsJSON, err := buildCDSJSON(routes, tlsEnabled, caKeyName)
+	if err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
-	if err := r.ensureDeployment(ctx, search, envoyJSON, clusterName, clusterIndex, c, tlsCfg, log); err != nil {
+	ldsJSON, err := buildLDSJSON(routes, tlsEnabled, caKeyName)
+	if err != nil {
+		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
+	}
+
+	if err := r.ensureConfigMap(ctx, search, bootstrapJSON, cdsJSON, ldsJSON, clusterName, clusterIndex, c, log); err != nil {
+		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
+	}
+	// Ensure Deployment (hash only bootstrap — CDS/LDS are hot-reloaded by Envoy via filesystem xDS)
+	if err := r.ensureDeployment(ctx, search, bootstrapJSON, clusterName, clusterIndex, c, tlsCfg, log); err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 	return workflow.OK()
@@ -438,16 +449,15 @@ func buildReplicaSetRouteForCluster(search *searchv1.MongoDBSearch, clusterIndex
 	}
 }
 
-// ensureConfigMap creates or updates the Envoy ConfigMap in the cluster
-// indicated by clusterName ("" = central cluster, single-cluster path).
-// clusterIndex is used for resource naming; clusterName is used for client
-// lookup and labels.
+// ensureConfigMap creates or updates the Envoy ConfigMap with three files:
+// bootstrap.json (static), cds.json (dynamic clusters), and lds.json (dynamic listener).
+// Kubernetes ConfigMap updates are atomic (symlink swap), so all files update together.
 //
 // Cross-cluster ownership note: Kubernetes garbage collection does not span
 // clusters, so we only set an OwnerReference when writing into the central
 // cluster (clusterName == ""). Cleanup of member-cluster objects is handled
 // explicitly in deleteEnvoyResources.
-func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, envoyJSON, clusterName string, clusterIndex int, c kubernetesClient.Client, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, cdsJSON, ldsJSON, clusterName string, clusterIndex int, c kubernetesClient.Client, log *zap.SugaredLogger) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      search.LoadBalancerConfigMapNameForCluster(clusterIndex),
@@ -457,7 +467,11 @@ func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, sear
 
 	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
 		cm.Labels = envoyLabelsForCluster(search, clusterName, clusterIndex)
-		cm.Data = map[string]string{"envoy.json": envoyJSON}
+		cm.Data = map[string]string{
+			"bootstrap.json": bootstrapJSON,
+			"cds.json":       cdsJSON,
+			"lds.json":       ldsJSON,
+		}
 		if clusterName == "" {
 			return controllerutil.SetOwnerReference(search, cm, c.Scheme())
 		}
@@ -471,12 +485,13 @@ func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, sear
 	return nil
 }
 
-// ensureDeployment creates or updates the Envoy Deployment in the cluster
-// indicated by clusterName ("" = central cluster, single-cluster path).
-// clusterIndex is used for resource naming; clusterName is used for labels.
-// See ensureConfigMap for the cross-cluster ownership rule.
-func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, envoyJSON, clusterName string, clusterIndex int, c kubernetesClient.Client, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
-	configHash := fmt.Sprintf("%x", sha256.Sum256([]byte(envoyJSON)))
+// ensureDeployment creates or updates the Envoy Deployment.
+// The config hash is computed from bootstrapJSON only — CDS/LDS changes are
+// hot-reloaded by Envoy via filesystem xDS and do not require a pod restart.
+//
+// Cross-cluster ownership note: see ensureConfigMap.
+func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, clusterName string, clusterIndex int, c kubernetesClient.Client, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
+	configHash := fmt.Sprintf("%x", sha256.Sum256([]byte(bootstrapJSON)))
 	replicas := envoyReplicas(search)
 	labels := envoyLabelsForCluster(search, clusterName, clusterIndex)
 	podLabels := envoyPodLabelsForCluster(search, clusterIndex)
@@ -637,7 +652,7 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 				//     (not ``source``) on purpose to not confuse some log parsing
 				//     utilities, e.g. lnav.
 				Args: []string{
-					"-c", "/etc/envoy/envoy.json",
+					"-c", "/etc/envoy/bootstrap.json",
 					"--log-level", "info",
 					"--log-format", `{"time":"%Y-%m-%dT%H:%M:%S.%e%z","level":"%l","logger":"%n","thread":%t,"loc":"%g:%#","message":"%j"}`,
 				},

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -844,13 +844,15 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
 	// cluster "a" is at index 0 in the mapping.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "a", 0, r.memberClusterClientsMap["a"], zap.S()))
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "a", 0, r.memberClusterClientsMap["a"], zap.S()))
 
 	// Member A has the ConfigMap named with index 0.
 	cmA := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cmA))
-	assert.Equal(t, `{"x":1}`, cmA.Data["envoy.json"])
+	assert.Equal(t, `{"bootstrap":1}`, cmA.Data["bootstrap.json"])
+	assert.Equal(t, `{"cds":1}`, cmA.Data["cds.json"])
+	assert.Equal(t, `{"lds":1}`, cmA.Data["lds.json"])
 	// Cluster name label stamped (name-keyed for cross-cluster enqueue).
 	assert.Equal(t, "a", cmA.Labels[khandler.MongoDBSearchClusterNameLabel])
 	assert.Equal(t, "mdb-search", cmA.Labels[khandler.MongoDBSearchOwnerNameLabel])
@@ -875,7 +877,7 @@ func TestEnsureConfigMap_SingleCluster_WritesToCentralWithOwnerRef(t *testing.T)
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
 	}
 	// Single-cluster uses index 0.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "", 0, r.kubeClient, zap.S()))
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "", 0, r.kubeClient, zap.S()))
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, central.Get(context.Background(),
@@ -897,7 +899,7 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
 	}
 	// cluster "a" is at index 0.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"x":1}`, "a", 0, r.memberClusterClientsMap["a"], zap.S()))
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "a", 0, r.memberClusterClientsMap["a"], zap.S()))
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),

--- a/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
@@ -310,7 +310,7 @@ def verify_per_cluster_envoy_sni(
     helper: MCSearchDeploymentHelper,
     member_cluster_clients: List[MultiClusterClient],
 ) -> None:
-    """Each per-cluster Envoy ConfigMap's envoy.json references exactly its
+    """Each per-cluster Envoy ConfigMap's lds.json references exactly its
     cluster-local proxy-svc FQDN in SNI server_names — no cross-cluster leakage.
 
     Lifts ``q2_mc_rs_steady.test_per_cluster_envoy_sni_observed``.
@@ -321,19 +321,19 @@ def verify_per_cluster_envoy_sni(
         expected_fqdn = _expected_proxy_svc_fqdn(mdbs_resource_name, cluster_idx, namespace)
 
         cm = mcc.core_v1_api().read_namespaced_config_map(name=cm_name, namespace=namespace)
-        envoy_json = (cm.data or {}).get("envoy.json")
-        assert envoy_json, f"envoy.json missing in ConfigMap {cm_name} ({mcc.cluster_name})"
+        lds_json = (cm.data or {}).get("lds.json")
+        assert lds_json, f"lds.json missing in ConfigMap {cm_name} ({mcc.cluster_name})"
 
-        envoy_cfg = json.loads(envoy_json)
+        lds_cfg = json.loads(lds_json)
         sni_names: List[str] = []
-        for listener in envoy_cfg.get("static_resources", {}).get("listeners", []):
-            for fc in listener.get("filter_chains", []):
+        for resource in lds_cfg.get("resources", []):
+            for fc in resource.get("filter_chains", []):
                 fcm = fc.get("filter_chain_match", {}) or {}
                 sni_names.extend(fcm.get("server_names", []) or [])
 
         assert expected_fqdn in sni_names, (
             f"[{mcc.cluster_name}] expected SNI server_name {expected_fqdn!r} "
-            f"in envoy.json filter_chain_match.server_names, got {sni_names}"
+            f"in lds.json filter_chain_match.server_names, got {sni_names}"
         )
 
         # Defensive: no OTHER cluster's proxy-svc FQDN should appear.
@@ -344,10 +344,10 @@ def verify_per_cluster_envoy_sni(
             other_fqdn = _expected_proxy_svc_fqdn(mdbs_resource_name, other_idx, namespace)
             assert other_fqdn not in sni_names, (
                 f"[{mcc.cluster_name}] foreign SNI {other_fqdn!r} present in "
-                f"envoy.json server_names — per-cluster Envoy must only match its own FQDN"
+                f"lds.json server_names — per-cluster Envoy must only match its own FQDN"
             )
 
-        logger.info(f"[{mcc.cluster_name}] envoy.json SNI server_names={sni_names} (expected match: {expected_fqdn})")
+        logger.info(f"[{mcc.cluster_name}] lds.json SNI server_names={sni_names} (expected match: {expected_fqdn})")
 
 
 # ---------------------------------------------------------------------------

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -734,7 +734,7 @@ def test_per_cluster_envoy_sni_observed(
     helper: MCSearchDeploymentHelper,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    """Each per-cluster Envoy ConfigMap's envoy.json must reference exactly the
+    """Each per-cluster Envoy ConfigMap's lds.json must reference exactly the
     cluster-local proxy-svc FQDN in its SNI server_names — no cross-cluster leakage.
     """
     for mcc in member_cluster_clients:
@@ -743,22 +743,22 @@ def test_per_cluster_envoy_sni_observed(
         expected_fqdn = _expected_proxy_svc_fqdn(MDBS_RESOURCE_NAME, cluster_idx, namespace)
 
         cm = mcc.core_v1_api().read_namespaced_config_map(name=cm_name, namespace=namespace)
-        envoy_json = (cm.data or {}).get("envoy.json")
-        assert envoy_json, f"envoy.json missing in ConfigMap {cm_name} ({mcc.cluster_name})"
+        lds_json = (cm.data or {}).get("lds.json")
+        assert lds_json, f"lds.json missing in ConfigMap {cm_name} ({mcc.cluster_name})"
 
         # Parse and walk filter_chains[].filter_chain_match.server_names[]
         # for the per-cluster FQDN. Avoids substring false-positives from
         # the upstream-host references that share the namespace prefix.
-        envoy_cfg = json.loads(envoy_json)
+        lds_cfg = json.loads(lds_json)
         sni_names: List[str] = []
-        for listener in envoy_cfg.get("static_resources", {}).get("listeners", []):
-            for fc in listener.get("filter_chains", []):
+        for resource in lds_cfg.get("resources", []):
+            for fc in resource.get("filter_chains", []):
                 fcm = fc.get("filter_chain_match", {}) or {}
                 sni_names.extend(fcm.get("server_names", []) or [])
 
         assert expected_fqdn in sni_names, (
             f"[{mcc.cluster_name}] expected SNI server_name {expected_fqdn!r} "
-            f"in envoy.json filter_chain_match.server_names, got {sni_names}"
+            f"in lds.json filter_chain_match.server_names, got {sni_names}"
         )
 
         # Defensive: no OTHER cluster's proxy-svc FQDN should appear.
@@ -769,10 +769,10 @@ def test_per_cluster_envoy_sni_observed(
             other_fqdn = _expected_proxy_svc_fqdn(MDBS_RESOURCE_NAME, other_idx, namespace)
             assert other_fqdn not in sni_names, (
                 f"[{mcc.cluster_name}] foreign SNI {other_fqdn!r} present in "
-                f"envoy.json server_names — per-cluster Envoy must only match its own FQDN"
+                f"lds.json server_names — per-cluster Envoy must only match its own FQDN"
             )
 
-        logger.info(f"[{mcc.cluster_name}] envoy.json SNI server_names={sni_names} (expected match: {expected_fqdn})")
+        logger.info(f"[{mcc.cluster_name}] lds.json SNI server_names={sni_names} (expected match: {expected_fqdn})")
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1080

## Chain of upstream PRs as of 2026-06-01

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1080:
      `search/ga-base` ← `lsierant/KUBE-17-connectivity-tool`

      * **PR #1169 (THIS ONE)**:
        `lsierant/KUBE-17-connectivity-tool` ← `search/dynamic-cds-lds-config`

<!-- end git-machete generated -->

## Summary
In the current implementation we had a static file as envoy config and provided that file to the envoy pods. Every time something changed in that file because let's a shard was added or removed, the envoy pod had to be restarted to pick up the new config. We would like to minimize the envoy pod restarts to reduce disruptions to search queries.

To improve this we are using filesystem xDS, which means only bootstrap related configs (bootstrap config) are provided at the start to envoy. The bootstrap config also has paths to the cluster config (`cds.json`) and listeners config (`lds.json`) where clusters and listeners are configured.

```
bootstrap := &bootstrapv3.Bootstrap{
		Node: &corev3.Node{
			Id:      "envoy-search-proxy",
			Cluster: "search-proxy",
		},
		Admin: &bootstrapv3.Admin{
			Address: socketAddress("0.0.0.0", uint32(envoyAdminPort)),
		},
		DynamicResources: &bootstrapv3.Bootstrap_DynamicResources{
			CdsConfig: pathConfigSource(envoyConfigPath + "/cds.json"),
			LdsConfig: pathConfigSource(envoyConfigPath + "/lds.json"),
		},
```

 Having the configs defined in this way if a shard is added or removed, cluster and listeners config will change that envoy will hot reload them without restart.

## Proof of Work

E2E will be part of another PR.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
