### PR TITLE
KUBE-75: treat null in additionalMongodConfig as field removal

### DIFF
--- a/changelog/20260601_fix_additional_mongod_config_null_field_removal.md
+++ b/changelog/20260601_fix_additional_mongod_config_null_field_removal.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-06-01
+---
+
+* **MongoDB**: Fixed a bug where setting a field to `null` in `additionalMongodConfig` to remove it from a deployment did not take effect. The field would either be ignored or reappear on the next reconciliation.

--- a/pkg/util/maputil/mapmerge.go
+++ b/pkg/util/maputil/mapmerge.go
@@ -31,6 +31,11 @@ func MergeMaps(dst, src map[string]interface{}) {
 				dstMap := dst[key].(map[string]interface{})
 				MergeMaps(dstMap, t)
 			}
+		case nil:
+			// nil means the caller wants this field removed; delete it from the
+			// destination so it is not sent to OM as "verbosity": null, which
+			// would either reintroduce the field or cause type confusion.
+			delete(dst, key)
 		default:
 			{
 				dst[key] = castValue(dst[key], t)

--- a/pkg/util/maputil/mapmerge.go
+++ b/pkg/util/maputil/mapmerge.go
@@ -32,9 +32,6 @@ func MergeMaps(dst, src map[string]interface{}) {
 				MergeMaps(dstMap, t)
 			}
 		case nil:
-			// nil means the caller wants this field removed; delete it from the
-			// destination so it is not sent to OM as "verbosity": null, which
-			// would either reintroduce the field or cause type confusion.
 			delete(dst, key)
 		default:
 			{

--- a/pkg/util/maputil/mapmerge_test.go
+++ b/pkg/util/maputil/mapmerge_test.go
@@ -58,6 +58,40 @@ func TestMergeMaps(t *testing.T) {
 		src["nestedMap"].(map[string]interface{})["newkey"] = 80
 		assert.Empty(t, ReadMapValueAsInterface(dst, "nestedMap", "newkey"))
 	})
+	t.Run("Nil src value deletes key from dst", func(t *testing.T) {
+		dst := map[string]interface{}{
+			"systemLog": map[string]interface{}{
+				"verbosity": 4,
+				"logAppend": true,
+			},
+		}
+		src := map[string]interface{}{
+			"systemLog": map[string]interface{}{
+				"verbosity": nil,
+				"logAppend": true,
+			},
+		}
+		MergeMaps(dst, src)
+		_, hasVerbosity := dst["systemLog"].(map[string]interface{})["verbosity"]
+		assert.False(t, hasVerbosity, "nil src value must remove the key from dst")
+		assert.Equal(t, true, dst["systemLog"].(map[string]interface{})["logAppend"])
+	})
+	t.Run("Nil src value is no-op when key already absent from dst", func(t *testing.T) {
+		dst := map[string]interface{}{
+			"systemLog": map[string]interface{}{
+				"logAppend": true,
+			},
+		}
+		src := map[string]interface{}{
+			"systemLog": map[string]interface{}{
+				"verbosity": nil,
+				"logAppend": true,
+			},
+		}
+		MergeMaps(dst, src)
+		_, hasVerbosity := dst["systemLog"].(map[string]interface{})["verbosity"]
+		assert.False(t, hasVerbosity, "nil src value must leave key absent when it was not in dst")
+	})
 	t.Run("Fails if destination is not map", func(t *testing.T) {
 		dst := map[string]interface{}{"nestedMap": "foo"}
 		src := mapForTest()

--- a/pkg/util/maputil/maputil.go
+++ b/pkg/util/maputil/maputil.go
@@ -100,8 +100,6 @@ func traverse(currentValue interface{}, currentPath []string) []string {
 			return allPaths
 		}
 	case nil:
-		// nil means the caller wants this field removed; treat it as absent so
-		// RemoveFieldsBasedOnDesiredAndPrevious will include it in itemsToRemove.
 		return []string{}
 	default:
 		{

--- a/pkg/util/maputil/maputil.go
+++ b/pkg/util/maputil/maputil.go
@@ -99,6 +99,10 @@ func traverse(currentValue interface{}, currentPath []string) []string {
 			}
 			return allPaths
 		}
+	case nil:
+		// nil means the caller wants this field removed; treat it as absent so
+		// RemoveFieldsBasedOnDesiredAndPrevious will include it in itemsToRemove.
+		return []string{}
 	default:
 		{
 			// We found the "terminal" node in the map - need to dump the current path

--- a/pkg/util/maputil/maputil_test.go
+++ b/pkg/util/maputil/maputil_test.go
@@ -78,3 +78,34 @@ func TestRemoveFieldsBasedOnDesiredAndPrevious(t *testing.T) {
 	actual := RemoveFieldsBasedOnDesiredAndPrevious(p, spec, prev)
 	assert.Equal(t, expected, actual, "three was set previously, and so should have been removed.")
 }
+
+func TestRemoveFieldsBasedOnDesiredAndPrevious_NilValueMeansRemove(t *testing.T) {
+	// Simulates setting additionalMongodConfig.systemLog.verbosity to null in the CR.
+	// Kubernetes preserves the null in the stored spec, so the desired map has verbosity: nil.
+	// nil must be treated as "absent" so that RemoveFieldsBasedOnDesiredAndPrevious removes it.
+	current := map[string]interface{}{
+		"systemLog": map[string]interface{}{
+			"verbosity": 4,
+			"logAppend": true,
+		},
+	}
+	desired := map[string]interface{}{
+		"systemLog": map[string]interface{}{
+			"verbosity": nil,
+			"logAppend": true,
+		},
+	}
+	prev := map[string]interface{}{
+		"systemLog": map[string]interface{}{
+			"verbosity": 4,
+			"logAppend": true,
+		},
+	}
+	expected := map[string]interface{}{
+		"systemLog": map[string]interface{}{
+			"logAppend": true,
+		},
+	}
+	actual := RemoveFieldsBasedOnDesiredAndPrevious(current, desired, prev)
+	assert.Equal(t, expected, actual, "verbosity: nil in the desired map should remove the field")
+}


### PR DESCRIPTION
> [!NOTE]
> This PR is split out from the work in #1155, which bundled several independent multi-cluster and MongoDB fixes. That work is being broken into granular, separately reviewable PRs; this one carries the `additionalMongodConfig` field-removal fix only.

# Summary

Setting a field to `null` in `additionalMongodConfig` to remove it from a deployment did not take effect — the field was either ignored or reappeared on the next reconciliation. The root cause is that `nil` map values were not treated as "remove this field":

- `maputil.traverse` now treats `nil` as absent, so `RemoveFieldsBasedOnDesiredAndPrevious` includes the field in `itemsToRemove`.
- `MergeMaps` now deletes keys whose source value is `nil` instead of forwarding `"field": null` to Ops Manager.

Previously a `null` override was dropped or re-introduced; now it reliably removes the field from the deployment.

## Proof of Work

- `pkg/util/maputil/maputil_test.go` — `TestRemoveFieldsBasedOnDesiredAndPrevious_NilValueMeansRemove`
- `pkg/util/maputil/mapmerge_test.go` — `TestMergeMaps` nil-deletes-key and nil-is-no-op-when-absent cases

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?