### PR TITLE
KUBE-75: identify multi-cluster StatefulSets by annotation instead of cross-cluster ownerReference

### DIFF
--- a/changelog/20260601_fix_multicluster_statefulset_owner_reference_annotation.md
+++ b/changelog/20260601_fix_multicluster_statefulset_owner_reference_annotation.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-06-01
+---
+
+* **MongoDBOpsManager**, **MongoDB**, **MongoDBMultiCluster**: Fixed a bug in multi-cluster mode where `StatefulSet` resources created in remote member clusters carried `ownerReferences` pointing to the Custom Resource in the central cluster, causing the Kubernetes garbage collector to delete them as orphans. Member-cluster StatefulSets now carry the `MongoDBMultiResource` annotation instead, which the operator uses to map them back to their parent Custom Resource.

--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/certs"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct/scalers/interfaces"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
+	"github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/podtemplatespec"
@@ -483,13 +484,22 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 	mongodbAgentVolumeMounts = append(mongodbAgentVolumeMounts, acVersionMount)
 	podSecurityContext, _ := podtemplatespec.WithDefaultSecurityContextsModifications()
 
+	// ownerRefs is nil in multi-cluster mode: the MongoDBOpsManager CR only exists in the
+	// central cluster, and a cross-cluster ownerReference causes the Kubernetes garbage
+	// collector to delete this StatefulSet as an orphan. Cleanup in multi-cluster mode is
+	// handled through explicit label-based deletion instead.
+	ownerRefs := kube.BaseOwnerReference(&opsManager)
+	if opsManager.Spec.AppDB.IsMultiCluster() {
+		ownerRefs = nil
+	}
+
 	sts := statefulset.New(
 		statefulset.WithName(opsManager.Spec.AppDB.NameForCluster(scaler.MemberClusterNum())),
 		statefulset.WithNamespace(opsManager.Spec.AppDB.GetNamespace()),
 		statefulset.WithServiceName(opsManager.Spec.AppDB.HeadlessServiceNameForCluster(scaler.MemberClusterNum())),
 		statefulset.WithReplicas(scale.ReplicasThisReconciliation(scaler)),
 		statefulset.WithUpdateStrategyType(updateStrategyType),
-		statefulset.WithOwnerReference(kube.BaseOwnerReference(&opsManager)),
+		statefulset.WithOwnerReference(ownerRefs),
 		dataVolumeClaim,
 		logVolumeClaim,
 		singleModeVolumeClaim,
@@ -535,6 +545,11 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 		if clusterSpecItem.StatefulSetConfiguration != nil {
 			sts.Spec = merge.StatefulSetSpecs(sts.Spec, clusterSpecItem.StatefulSetConfiguration.SpecWrapper.Spec)
 		}
+
+		// The MongoDBMultiResourceAnnotation replaces ownerReferences in multi-cluster mode:
+		// watch predicates and the OM connection factory use it to map StatefulSets back to
+		// their parent CR. Merge to preserve any annotations set by earlier modifiers.
+		sts.Annotations = merge.StringToStringMap(sts.Annotations, handler.MultiClusterStatefulSetAnnotations(opsManager.Name))
 	}
 	return sts, nil
 }

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -13,6 +13,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct/scalers"
+	"github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
@@ -93,6 +94,44 @@ func TestAppDBMultiClusterPerClusterStatefulSetOverride(t *testing.T) {
 	assert.NotNil(t, stsB.Spec.Replicas)
 	assert.Equal(t, int32(1), *stsB.Spec.Replicas)
 	assert.NotEmpty(t, stsB.Spec.ServiceName)
+}
+
+// TestAppDbStatefulSet_MultiClusterIdentity verifies that in multi-cluster mode the AppDB
+// StatefulSet carries no ownerReference (preventing cross-cluster GC orphan deletion) and
+// does carry MongoDBMultiResourceAnnotation (so watch predicates and the OM connection
+// factory can map the StatefulSet back to its parent MongoDBOpsManager CR).
+func TestAppDbStatefulSet_MultiClusterIdentity(t *testing.T) {
+	clusterSpecList := mdbv1.ClusterSpecList{
+		{ClusterName: "cluster-a", Members: 1},
+		{ClusterName: "cluster-b", Members: 1},
+	}
+
+	t.Run("multi-cluster mode: no ownerReferences, annotation set", func(t *testing.T) {
+		om := omv1.NewOpsManagerBuilderDefault().
+			SetAppDBTopology(omv1.ClusterTopologyMultiCluster).
+			SetAppDBClusterSpecList(clusterSpecList).
+			Build()
+
+		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "cluster-a", 0, nil), appsv1.OnDeleteStatefulSetStrategyType, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, sts.OwnerReferences,
+			"StatefulSet in a remote member cluster must not carry an ownerReference pointing to the MongoDBOpsManager CR")
+		assert.Equal(t, om.Name, sts.Annotations[handler.MongoDBMultiResourceAnnotation],
+			"StatefulSet must carry MongoDBMultiResourceAnnotation so watch predicates and the OM connection factory can map it back to its parent CR")
+	})
+
+	t.Run("single-cluster mode: ownerReference set, no multi-cluster annotation", func(t *testing.T) {
+		om := omv1.NewOpsManagerBuilderDefault().Build()
+
+		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil), appsv1.OnDeleteStatefulSetStrategyType, nil)
+		assert.NoError(t, err)
+		assert.Len(t, sts.OwnerReferences, 1,
+			"StatefulSet in single-cluster mode must carry an ownerReference so Kubernetes GC can clean it up")
+		assert.Empty(t, sts.Annotations[handler.MongoDBMultiResourceAnnotation],
+			"StatefulSet in single-cluster mode must not carry MongoDBMultiResourceAnnotation")
+	})
 }
 
 func TestResourceRequirements(t *testing.T) {

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -18,6 +18,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/agents"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/certs"
+	"github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/persistentvolumeclaim"
@@ -188,6 +189,9 @@ func ReplicaSetOptions(additionalOpts ...func(options *DatabaseStatefulSetOption
 			stsSpec = &appsv1.StatefulSetSpec{Template: *mdb.Spec.PodSpec.PodTemplateWrapper.PodTemplate}
 		}
 
+		// ReplicaSetOptions is used exclusively by the single-cluster MongoDB controller.
+		// OwnerReference is always set: the CR and the StatefulSet live in the same cluster
+		// so Kubernetes GC can clean up the StatefulSet automatically when the CR is deleted.
 		opts := DatabaseStatefulSetOptions{
 			Replicas:                scale.ReplicasThisReconciliation(&mdb),
 			Name:                    mdb.Name,
@@ -235,12 +239,21 @@ func shardedOptions(cfg shardedOptionCfg, additionalOpts ...func(options *Databa
 		podSpec = mdbv1.MongoDbPodSpec{Persistence: clusterComponentSpec.PodSpec.Persistence}
 	}
 
+	// ownerRefs is nil in multi-cluster mode: the MongoDBShardedCluster CR only exists in the
+	// central cluster, and a cross-cluster ownerReference causes the Kubernetes garbage
+	// collector to delete this StatefulSet as an orphan. Cleanup in multi-cluster mode is
+	// handled through explicit label-based deletion instead.
+	ownerRefs := kube.BaseOwnerReference(&cfg.mdb)
+	if cfg.mdb.Spec.IsMultiCluster() {
+		ownerRefs = nil
+	}
+
 	opts := DatabaseStatefulSetOptions{
 		Name:                    cfg.rsName,
 		ServiceName:             cfg.serviceName,
 		PodSpec:                 NewDefaultPodSpecWrapper(podSpec),
 		ServicePort:             cfg.componentSpec.GetAdditionalMongodConfig().GetPortOrDefault(),
-		OwnerReference:          kube.BaseOwnerReference(&cfg.mdb),
+		OwnerReference:          ownerRefs,
 		AgentConfig:             cfg.componentSpec.GetAgentConfig(),
 		StatefulSetSpecOverride: statefulSetSpecOverride,
 		Labels:                  cfg.mdb.Labels,
@@ -250,6 +263,10 @@ func shardedOptions(cfg shardedOptionCfg, additionalOpts ...func(options *Databa
 	}
 
 	if cfg.mdb.Spec.IsMultiCluster() {
+		// The MongoDBMultiResourceAnnotation replaces ownerReferences in multi-cluster mode:
+		// watch predicates and the OM connection factory use it to map StatefulSets back to
+		// their parent CR.
+		opts.Annotations = handler.MultiClusterStatefulSetAnnotations(cfg.mdb.Name)
 		opts.HostNameOverrideConfigmapName = cfg.mdb.GetHostNameOverrideConfigmapName()
 	}
 	for _, opt := range additionalOpts {

--- a/controllers/operator/construct/multicluster/multicluster_replicaset.go
+++ b/controllers/operator/construct/multicluster/multicluster_replicaset.go
@@ -19,6 +19,14 @@ func MultiClusterReplicaSetOptions(additionalOpts ...func(options *construct.Dat
 		if mdbm.Spec.StatefulSetConfiguration != nil {
 			stsSpec = mdbm.Spec.StatefulSetConfiguration.SpecWrapper.Spec
 		}
+		// OwnerReference is always nil: MongoDBMultiCluster resources are always deployed in
+		// multi-cluster mode. The CR only exists in the central cluster, and a cross-cluster
+		// ownerReference causes the Kubernetes garbage collector to delete this StatefulSet as
+		// an orphan. Cleanup is handled through explicit label-based deletion instead.
+		//
+		// Annotations carries MongoDBMultiResourceAnnotation, which replaces ownerReferences:
+		// watch predicates and the OM connection factory use it to map StatefulSets back to
+		// their parent CR.
 		opts := construct.DatabaseStatefulSetOptions{
 			Name:                          mdbm.Name,
 			ServicePort:                   mdbm.Spec.GetAdditionalMongodConfig().GetPortOrDefault(),
@@ -26,10 +34,12 @@ func MultiClusterReplicaSetOptions(additionalOpts ...func(options *construct.Dat
 			AgentConfig:                   &mdbm.Spec.Agent,
 			PodSpec:                       construct.NewDefaultPodSpecWrapper(*mdbv1.NewMongoDbPodSpec()),
 			Labels:                        mdbm.GetOwnerLabels(),
+			OwnerReference:                nil,
 			MultiClusterMode:              true,
 			HostNameOverrideConfigmapName: mdbm.GetHostNameOverrideConfigmapName(),
 			StatefulSetSpecOverride:       &stsSpec,
 			StsType:                       construct.MultiReplicaSet,
+			Annotations:                   handler.MultiClusterStatefulSetAnnotations(mdbm.Name),
 		}
 		for _, opt := range additionalOpts {
 			opt(&opts)
@@ -64,20 +74,8 @@ func WithStsOverride(stsOverride *appsv1.StatefulSetSpec) func(options *construc
 	}
 }
 
-func WithAnnotations(resourceName string) func(options *construct.DatabaseStatefulSetOptions) {
-	return func(options *construct.DatabaseStatefulSetOptions) {
-		options.Annotations = statefulSetAnnotations(resourceName)
-	}
-}
-
 func statefulSetName(mdbmName string, clusterNum int) string {
 	return fmt.Sprintf("%s-%d", mdbmName, clusterNum)
-}
-
-func statefulSetAnnotations(mdbmName string) map[string]string {
-	return map[string]string{
-		handler.MongoDBMultiResourceAnnotation: mdbmName,
-	}
 }
 
 func PodLabel(mdbmName string) map[string]string {

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -515,7 +515,6 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(ctx context.Cont
 			mconstruct.WithClusterNum(clusterNum),
 			Replicas(replicasThisReconciliation),
 			mconstruct.WithStsOverride(&stsOverride),
-			mconstruct.WithAnnotations(mrs.Name),
 			mconstruct.WithServiceName(mrs.MultiHeadlessServiceName(clusterNum)),
 			PodEnvVars(newPodVars(conn, projectConfig, mrs.Spec.LogLevel)),
 			CurrentAgentAuthMechanism(currentAgentAuthMode),
@@ -1169,11 +1168,15 @@ func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imag
 		}
 	}
 
-	// register watcher across member clusters
-	for k, v := range memberClustersMap {
-		err := c.Watch(source.Kind[client.Object](v.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
+	// In multi-cluster mode, watch StatefulSet status changes in each member cluster and
+	// enqueue a reconciliation request for the owning MongoDBMultiCluster CR.
+	// The MongoDBMultiResourceAnnotation on each StatefulSet carries the CR name (set in
+	// MultiClusterReplicaSetOptions); EnqueueRequestForOwnerMultiCluster reads it to build
+	// the request.
+	for clusterName, memberCluster := range memberClustersMap {
+		err = c.Watch(source.Kind[client.Object](memberCluster.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
 		if err != nil {
-			return xerrors.Errorf("failed to set Watch on member cluster: %s, err: %w", k, err)
+			return xerrors.Errorf("failed to set StatefulSet watch on member cluster %s: %w", clusterName, err)
 		}
 	}
 

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/dns"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/images"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/annotations"
@@ -984,6 +985,19 @@ func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClu
 			zap.S().Errorf("Failed to watch for vault secret changes: %v", err)
 		}
 	}
+	// In multi-cluster mode, watch AppDB StatefulSet status changes in each member cluster
+	// and enqueue a reconciliation request for the owning MongoDBOpsManager CR.
+	// The MongoDBMultiResourceAnnotation on each StatefulSet carries the CR name (set in
+	// AppDbStatefulSet); EnqueueRequestForOwnerMultiCluster reads it to build the request.
+	// This mirrors the equivalent watch registered in the MongoDBMultiCluster and
+	// MongoDBShardedCluster controllers.
+	for clusterName, memberCluster := range memberClustersMap {
+		err = c.Watch(source.Kind[client.Object](memberCluster.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
+		if err != nil {
+			return xerrors.Errorf("failed to set AppDB StatefulSet watch on member cluster %s: %w", clusterName, err)
+		}
+	}
+
 	zap.S().Infof("Registered controller %s", util.MongoDbOpsManagerController)
 	return nil
 }

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/dns"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/images"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/annotations"
@@ -1856,6 +1857,18 @@ func AddShardedClusterController(ctx context.Context, mgr manager.Manager, image
 		})))
 	if err != nil {
 		return err
+	}
+
+	// In multi-cluster mode, watch StatefulSet status changes in each member cluster and
+	// enqueue a reconciliation request for the owning MongoDBShardedCluster CR.
+	// The MongoDBMultiResourceAnnotation on each StatefulSet carries the CR name (set in
+	// shardedOptions); EnqueueRequestForOwnerMultiCluster reads it to build the request.
+	// This mirrors the equivalent watch registered in the MongoDBMultiCluster controller.
+	for clusterName, memberCluster := range memberClustersMap {
+		err = c.Watch(source.Kind[client.Object](memberCluster.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
+		if err != nil {
+			return xerrors.Errorf("failed to set StatefulSet watch on member cluster %s: %w", clusterName, err)
+		}
 	}
 
 	zap.S().Infof("Registered controller %s", util.MongoDbShardedClusterController)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set.py
@@ -103,6 +103,35 @@ def test_statefulset_is_created_across_multiple_clusters(
 
 
 @pytest.mark.e2e_multi_cluster_replica_set
+def test_statefulsets_multi_cluster_identity(
+    mongodb_multi: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Regression test: multi-cluster StatefulSets must carry no ownerReferences and must
+    carry the MongoDBMultiResource annotation.
+
+    No ownerReferences: a cross-cluster ownerReference points to a CR that does not exist
+    in the member cluster. The Kubernetes GC treats the StatefulSet as an orphan and deletes
+    it immediately, causing an infinite create-delete reconciliation loop. Cleanup on CR
+    deletion is handled through explicit label-based deletion instead.
+
+    MongoDBMultiResource annotation: replaces ownerReferences as the identifier that watch
+    predicates and the OM connection factory use to map StatefulSets back to their parent CR."""
+    statefulsets = mongodb_multi.read_statefulsets(member_cluster_clients)
+    for cluster_name, sts in statefulsets.items():
+        owner_refs = sts.metadata.owner_references
+        assert not owner_refs, (
+            f"StatefulSet {sts.metadata.name} in cluster {cluster_name} must have no "
+            f"ownerReferences in multi-cluster mode, but got: {owner_refs}"
+        )
+        annotation_value = (sts.metadata.annotations or {}).get("MongoDBMultiResource")
+        assert annotation_value == mongodb_multi.name, (
+            f"StatefulSet {sts.metadata.name} in cluster {cluster_name} must carry "
+            f"annotation 'MongoDBMultiResource={mongodb_multi.name}', but got: {annotation_value!r}"
+        )
+
+
+@pytest.mark.e2e_multi_cluster_replica_set
 def test_pvc_not_created(
     mongodb_multi: MongoDBMulti,
     member_cluster_clients: List[MultiClusterClient],

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb.py
@@ -118,6 +118,35 @@ def test_create_om(ops_manager: MongoDBOpsManager, appdb_member_cluster_names: l
 
 
 @mark.e2e_multi_cluster_appdb
+def test_appdb_statefulsets_multi_cluster_identity(
+    ops_manager: MongoDBOpsManager,
+    appdb_member_cluster_names: list[str],
+):
+    """Regression test: AppDB StatefulSets in member clusters must carry no ownerReferences
+    and must carry the MongoDBMultiResource annotation.
+
+    No ownerReferences: a cross-cluster ownerReference points to the MongoDBOpsManager CR
+    that only exists in the central cluster. The Kubernetes GC treats the StatefulSet as an
+    orphan and deletes it immediately, causing an infinite create-delete reconciliation loop.
+    Cleanup on CR deletion is handled through explicit label-based deletion instead.
+
+    MongoDBMultiResource annotation: replaces ownerReferences as the identifier that watch
+    predicates and the OM connection factory use to map StatefulSets back to their parent CR."""
+    for cluster_name in appdb_member_cluster_names:
+        sts = ops_manager.read_appdb_statefulset(member_cluster_name=cluster_name)
+        owner_refs = sts.metadata.owner_references
+        assert not owner_refs, (
+            f"AppDB StatefulSet {sts.metadata.name} in cluster {cluster_name} must have no "
+            f"ownerReferences in multi-cluster mode, but got: {owner_refs}"
+        )
+        annotation_value = (sts.metadata.annotations or {}).get("MongoDBMultiResource")
+        assert annotation_value == ops_manager.name, (
+            f"AppDB StatefulSet {sts.metadata.name} in cluster {cluster_name} must carry "
+            f"annotation 'MongoDBMultiResource={ops_manager.name}', but got: {annotation_value!r}"
+        )
+
+
+@mark.e2e_multi_cluster_appdb
 def test_scale_up_one_cluster(ops_manager: MongoDBOpsManager, appdb_member_cluster_names):
     ops_manager.load()
     ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = appdb_cluster_spec_list_with_overrides(

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest.py
@@ -4,7 +4,7 @@ from kubetester.mongodb import MongoDB
 from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
-from tests.conftest import get_member_cluster_names
+from tests.conftest import get_member_cluster_clients, get_member_cluster_names
 from tests.multicluster.conftest import cluster_spec_list
 
 MDB_RESOURCE_NAME = "sh"
@@ -39,3 +39,30 @@ def test_create(sharded_cluster: MongoDB, custom_mdb_version: str, issuer_ca_con
 @mark.e2e_multi_cluster_sharded_simplest
 def test_sharded_cluster(sharded_cluster: MongoDB):
     sharded_cluster.assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@mark.e2e_multi_cluster_sharded_simplest
+def test_statefulsets_multi_cluster_identity(namespace: str):
+    """Regression test: sharded cluster StatefulSets in member clusters must carry no
+    ownerReferences and must carry the MongoDBMultiResource annotation.
+
+    No ownerReferences: a cross-cluster ownerReference points to the MongoDBShardedCluster
+    CR that only exists in the central cluster. The Kubernetes GC treats the StatefulSet as
+    an orphan and deletes it immediately, causing an infinite create-delete reconciliation loop.
+    Cleanup on CR deletion is handled through explicit label-based deletion instead.
+
+    MongoDBMultiResource annotation: replaces ownerReferences as the identifier that watch
+    predicates and the OM connection factory use to map StatefulSets back to their parent CR."""
+    for mcc in get_member_cluster_clients():
+        sts_list = mcc.list_namespaced_stateful_sets(namespace)
+        for sts in sts_list.items:
+            owner_refs = sts.metadata.owner_references
+            assert not owner_refs, (
+                f"StatefulSet {sts.metadata.name} in cluster {mcc.cluster_name} must have no "
+                f"ownerReferences in multi-cluster mode, but got: {owner_refs}"
+            )
+            annotation_value = (sts.metadata.annotations or {}).get("MongoDBMultiResource")
+            assert annotation_value == MDB_RESOURCE_NAME, (
+                f"StatefulSet {sts.metadata.name} in cluster {mcc.cluster_name} must carry "
+                f"annotation 'MongoDBMultiResource={MDB_RESOURCE_NAME}', but got: {annotation_value!r}"
+            )

--- a/pkg/handler/enqueue_owner_multi.go
+++ b/pkg/handler/enqueue_owner_multi.go
@@ -13,6 +13,16 @@ import (
 
 const MongoDBMultiResourceAnnotation = "MongoDBMultiResource"
 
+// MultiClusterStatefulSetAnnotations returns the annotations that must be set on a
+// StatefulSet deployed in multi-cluster mode. MongoDBMultiResourceAnnotation replaces
+// ownerReferences as the identifier that watch predicates and the OM connection factory
+// use to map the StatefulSet back to its parent CR.
+func MultiClusterStatefulSetAnnotations(crName string) map[string]string {
+	return map[string]string{
+		MongoDBMultiResourceAnnotation: crName,
+	}
+}
+
 var _ handler.EventHandler = &EnqueueRequestForOwnerMultiCluster{}
 
 // EnqueueRequestForOwnerMultiCluster implements the EventHandler interface for multi-cluster callbacks.


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1172

## Chain of upstream PRs as of 2026-06-01

* PR #1172:
  `master` ← `KUBE-75/fix-cross-cluster-owner-references`

  * **PR #1173 (THIS ONE)**:
    `KUBE-75/fix-cross-cluster-owner-references` ← `KUBE-75/add-multicluster-statefulset-annotations`

<!-- end git-machete generated -->

# Summary

This PR is split out from the work in #1155, which bundled several independent multi-cluster and MongoDB fixes. That work is being broken into granular, separately reviewable PRs.

**This is the top of a 2-PR stack — it is based on #1172** (`KUBE-75/fix-cross-cluster-owner-references`). Review/merge that one first; this PR's diff is scoped to the StatefulSet identity change only.

Member-cluster StatefulSets previously carried an `ownerReference` to the CR in the central cluster. Because that owner does not exist in the member cluster, the Kubernetes garbage collector deleted the StatefulSet as an orphan, causing an infinite create-delete reconciliation loop. The StatefulSet ownerReference removal must travel **with** its replacement identity mechanism (otherwise owner resolution panics), so it is kept separate from the non-StatefulSet removals in the base PR.

Member-cluster StatefulSets (AppDB, replica set / sharded components, and MongoDBMultiCluster) now carry no `ownerReference` and instead carry the `MongoDBMultiResource` annotation. Watch predicates and the OM connection factory use the annotation to map a StatefulSet back to its parent CR. The OpsManager, sharded, and multi-replicaset controllers register a StatefulSet watch in each member cluster that enqueues the owning CR via the annotation.

## Proof of Work

- `controllers/operator/construct/appdb_construction_test.go` — `TestAppDbStatefulSet_MultiClusterIdentity` (multi-cluster: no ownerRefs + annotation set; single-cluster: ownerRef set, no annotation)
- `controllers/operator/...` unit suite incl. `TestMultiClusterShardedSetRace` (owner resolution via annotation)
- e2e identity assertions: `multi_cluster_replica_set.py`, `multicluster_appdb/multicluster_appdb.py`, `multicluster_shardedcluster/multi_cluster_sharded_simplest.py`

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?