### PR TITLE
chore: gofumpt-format datastoreconfig.go to fix lint_repo

### DIFF
--- a/controllers/om/backup/datastoreconfig.go
+++ b/controllers/om/backup/datastoreconfig.go
@@ -1,6 +1,5 @@
 package backup
 
-
 type DataStoreConfigResponse struct {
 	DataStoreConfigs []DataStoreConfig `json:"results"`
 }


### PR DESCRIPTION
# Summary

#1153 enabled the golangci-lint formatter command (`golangci-lint fmt`, which runs **gofumpt**) as the `golangci-lint-fmt` pre-commit hook. gofumpt flags a stray double blank line after the `package backup` clause in `controllers/om/backup/datastoreconfig.go` — present since 2022 and never caught by plain `gofmt`.

Because `golangci-lint-fmt` rewrites the file, `scripts/evergreen/check_precommit.sh` detects a diff and fails the `lint_repo` task on `master` and on **every branch cut from it**. This removes the extra blank line so the formatter is a no-op.

Previously: `lint_repo` red on every PR (`golangci-lint-fmt` reformats `datastoreconfig.go`). Now: formatter is clean, `lint_repo` passes.

## Proof of Work

```
$ pre-commit run golangci-lint-fmt --all-files
golangci-lint-fmt........................................................Passed
```

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? — N/A, `skip-changelog` (formatting-only, no user-facing change)