### PR TITLE
test: support custom kind images and detect compliance

### DIFF
--- a/.evergreen-mco.yml
+++ b/.evergreen-mco.yml
@@ -1,176 +1,83 @@
-buildvariants:
-- display_tasks:
-  - execution_tasks: []
-    name: e2e_mco_tests
-  name: e2e_mco_tests
-  tasks:
-  - name: e2e_mco_task_group
-task_groups:
-- max_hosts: -1
-  name: e2e_mco_task_group
-  setup_group:
-  - func: clone
-  - func: download_kube_tools
-  - func: setup_building_host
-  setup_task:
-  - func: cleanup_exec_environment
-  - func: configure_docker_auth
-  - func: setup_kubernetes_environment
-  tasks:
-  - feature_compatibility_version
-  - prometheus
-  - replica_set
-  - replica_set_arbiter
-  - replica_set_change_version
-  - replica_set_connection_string_options
-  - replica_set_cross_namespace_deploy
-  - replica_set_custom_persistent_volume
-  - replica_set_custom_role
-  - replica_set_enterprise_upgrade_4_5
-  - replica_set_enterprise_upgrade_5_6
-  - replica_set_enterprise_upgrade_6_7
-  - replica_set_enterprise_upgrade_7_8
-  - replica_set_mongod_config
-  - replica_set_mongod_port_change_with_arbiters
-  - replica_set_mongod_readiness
-  - replica_set_mount_connection_string
-  - replica_set_operator_upgrade
-  - replica_set_recovery
-  - replica_set_remove_user
-  - replica_set_scale
-  - replica_set_scale_down
-  - replica_set_tls
-  - replica_set_tls_recreate_mdbc
-  - replica_set_tls_rotate
-  - replica_set_tls_rotate_delete_sts
-  - replica_set_tls_upgrade
-  - replica_set_x509
-  - statefulset_arbitrary_config
-  - statefulset_arbitrary_config_update
-  teardown_group:
-  - func: prune_docker_resources
-  teardown_task:
-  - func: upload_e2e_logs_gotest
-  - func: teardown_kubernetes_environment
-tasks:
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: feature_compatibility_version
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: prometheus
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_arbiter
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_change_version
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_connection_string_options
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_cross_namespace_deploy
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_custom_persistent_volume
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_custom_role
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_enterprise_upgrade_4_5
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_enterprise_upgrade_5_6
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_enterprise_upgrade_6_7
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_enterprise_upgrade_7_8
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_mongod_config
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_mongod_port_change_with_arbiters
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_mongod_readiness
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_mount_connection_string
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_operator_upgrade
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_recovery
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_remove_user
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_scale
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_scale_down
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_tls
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_tls_recreate_mdbc
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_tls_rotate
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_tls_rotate_delete_sts
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_tls_upgrade
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: replica_set_x509
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: statefulset_arbitrary_config
-- commands:
-  - func: e2e_test
-    retry_on_failure: true
-  name: statefulset_arbitrary_config_update
-
+Cannot find python venv in /Users/jose.vazquez/mongodb/mongodb-kubernetes
+total 89288
+drwxr-xr-x 81 jose.vazquez staff     2592 Jun  1 18:02 .
+drwxr-xr-x 52 jose.vazquez staff     1664 May  5 10:13 ..
+drwxr-xr-x  3 jose.vazquez staff       96 Apr 16 18:02 .claude
+drwxr-xr-x 10 jose.vazquez staff      320 May 26 16:03 .devbox
+-rw-r--r--  1 jose.vazquez staff     1048 Apr  8 10:21 .dockerignore
+-rw-r--r--  1 jose.vazquez staff      223 Feb  3 14:15 .editorconfig
+-rw-r--r--  1 jose.vazquez staff    30676 May 21 15:39 .evergreen-functions.yml
+-rw-r--r--  1 jose.vazquez staff       74 Jun  1 18:04 .evergreen-mco.yml
+-rw-r--r--  1 jose.vazquez staff      860 Feb  3 14:15 .evergreen-periodic-builds.yaml
+-rw-r--r--  1 jose.vazquez staff    13641 May  5 14:31 .evergreen-release.yml
+-rw-r--r--  1 jose.vazquez staff     7000 May 29 09:54 .evergreen-snippets.yml
+-rw-r--r--  1 jose.vazquez staff    33033 Jun  1 15:31 .evergreen-tasks.yml
+-rw-r--r--  1 jose.vazquez staff    74642 May 29 09:54 .evergreen.yml
+-rw-r--r--  1 jose.vazquez staff      108 Feb  3 14:15 .flake8
+drwxr-xr-x  4 jose.vazquez staff      128 Apr 22 17:22 .generated
+drwxr-xr-x 21 jose.vazquez staff      672 Jun  1 18:04 .git
+drwxr-xr-x  4 jose.vazquez staff      128 Apr  8 10:21 .githooks
+drwxr-xr-x  9 jose.vazquez staff      288 May 21 15:40 .github
+-rw-r--r--  1 jose.vazquez staff     2473 May 29 09:54 .gitignore
+-rw-r--r--  1 jose.vazquez staff        0 Feb  3 14:15 .gitmodules
+-rw-r--r--  1 jose.vazquez staff     6386 May 29 09:54 .golangci.yml
+drwxr-xr-x 10 jose.vazquez staff      320 May  5 14:31 .idea
+drwxr-xr-x  7 jose.vazquez staff      224 Feb 13 11:12 .mck-devbox
+-rw-------  1 jose.vazquez staff     4771 Jun  1 18:02 .pre-commit-config.yaml
+-rw-r--r--  1 jose.vazquez staff      219 Feb  3 14:15 .pylintrc
+-rw-r--r--  1 jose.vazquez staff       13 Feb  3 14:15 .rsyncignore
+-rw-r--r--  1 jose.vazquez staff       38 Feb  3 14:15 .rsyncinclude
+drwxr-xr-x  5 jose.vazquez staff      160 May  5 14:31 .run
+-rw-r--r--  1 jose.vazquez staff      186 Apr  8 10:21 .shellcheckrc
+-rw-------  1 jose.vazquez staff       14 Jun  1 18:02 .tool-versions
+drwxr-xr-x  7 jose.vazquez staff      224 Feb 10 09:48 .venv
+drwxr-xr-x  3 jose.vazquez staff       96 Feb  6 17:15 .vscode
+-rw-r--r--  1 jose.vazquez staff    10229 Feb  3 14:15 Apache License
+-rw-r--r--  1 jose.vazquez staff     2779 Apr 22 10:16 CONTRIBUTING.md
+-rw-r--r--  1 jose.vazquez staff     3993 Apr 22 11:39 EVERGREEN.md
+-rw-r--r--  1 jose.vazquez staff     1418 Feb  3 14:15 LICENSE-MCK
+-rw-r--r--  1 jose.vazquez staff    12229 Jun  1 18:02 LICENSE-THIRD-PARTY
+-rw-r--r--  1 jose.vazquez staff    16177 Jun  1 17:30 Makefile
+-rw-r--r--  1 jose.vazquez staff     1276 Jun  1 15:31 PROJECT
+-rw-r--r--  1 jose.vazquez staff     5014 Feb  3 14:15 README.md
+-rw-r--r--  1 jose.vazquez staff     7336 Feb  3 14:15 RELEASE_NOTES.md
+-rw-r--r--  1 jose.vazquez staff    71535 Feb  3 14:15 RELEASE_NOTES_MEKO.md
+-rw-r--r--  1 jose.vazquez staff      501 Feb  3 14:15 SECURITY.md
+drwxr-xr-x  3 jose.vazquez staff       96 Jun  1 15:31 api
+drwxr-xr-x  4 jose.vazquez staff      128 May  7 17:45 bin
+-rw-r--r--  1 jose.vazquez staff    13548 May  5 14:31 build_info.json
+-rw-r--r--  1 jose.vazquez staff      905 May 26 16:17 build_info_agent.json
+drwxr-xr-x 53 jose.vazquez staff     1696 Jun  1 15:31 changelog
+drwxr-xr-x  4 jose.vazquez staff      128 May 29 09:54 cmd
+drwxr-xr-x 10 jose.vazquez staff      320 Feb  3 14:15 config
+drwxr-xr-x  5 jose.vazquez staff      160 Feb  3 14:15 controllers
+drwxr-xr-x  5 jose.vazquez staff      160 Feb  3 14:15 deploy
+-rw-r--r--  1 jose.vazquez staff     1746 Apr 22 17:55 devbox-init.shell
+-rw-r--r--  1 jose.vazquez staff      749 May 26 11:15 devbox.json
+-rw-r--r--  1 jose.vazquez staff    27847 May 26 11:16 devbox.lock
+drwxr-xr-x 14 jose.vazquez staff      448 Feb 13 11:25 docker
+drwxr-xr-x  8 jose.vazquez staff      256 Apr 22 10:16 docs
+-rwxr-xr-x  1 jose.vazquez staff    11231 Apr 22 11:39 generate_ssdlc_report.py
+-rwxr-xr-x  1 jose.vazquez staff     2553 Feb  3 14:15 generate_ssdlc_report_test.py
+-rw-r--r--  1 jose.vazquez staff     7173 Jun  1 15:31 go.mod
+-rw-r--r--  1 jose.vazquez staff    41407 Jun  1 15:31 go.sum
+drwxr-xr-x  3 jose.vazquez staff       96 Feb  3 14:15 hack
+drwxr-xr-x  9 jose.vazquez staff      288 Jun  1 15:31 helm_chart
+drwxr-xr-x  3 jose.vazquez staff       96 May 29 09:54 internal
+-rw-r--r--  1 jose.vazquez staff      266 Jun  1 17:30 kubernetes-versions.json
+drwxr-xr-x  3 jose.vazquez staff       96 Jun  1 18:02 lib
+-rw-r--r--  1 jose.vazquez staff    13406 Jun  1 18:02 licenses_full.csv
+-rw-r--r--  1 jose.vazquez staff     1119 Feb 10 16:33 licenses_stderr
+-rw-r--r--  1 jose.vazquez staff    24259 Jun  1 15:31 main.go
+drwxr-xr-x 14 jose.vazquez staff      448 Feb  3 14:15 mongodb-community-operator
+-rwxr-xr-x  1 jose.vazquez staff 90783874 May  7 14:52 mongodb-kubernetes
+-rw-r--r--  1 jose.vazquez staff    53401 May 20 17:55 mongodb-kubernetes-1.8.1.tgz
+drwxr-xr-x  6 jose.vazquez staff      192 Jun  1 18:02 multi_cluster
+drwxr-xr-x 25 jose.vazquez staff      800 May 29 09:54 pkg
+drwxr-xr-x 19 jose.vazquez staff      608 Jun  1 15:31 public
+-rw-r--r--  1 jose.vazquez staff      265 May  5 14:31 pyproject.toml
+-rw-r--r--  1 jose.vazquez staff    10345 Jun  1 15:31 release.json
+-rw-r--r--  1 jose.vazquez staff     1324 Jun  1 15:31 requirements.txt
+drwxr-xr-x 23 jose.vazquez staff      736 Jun  1 18:02 scripts
+drwxr-xr-x 17 jose.vazquez staff      544 May 28 09:53 tmp
+-rw-r--r--  1 jose.vazquez staff      309 May 29 09:54 tools.go

--- a/.evergreen-mco.yml
+++ b/.evergreen-mco.yml
@@ -1,83 +1,176 @@
-Cannot find python venv in /Users/jose.vazquez/mongodb/mongodb-kubernetes
-total 89288
-drwxr-xr-x 81 jose.vazquez staff     2592 Jun  1 18:02 .
-drwxr-xr-x 52 jose.vazquez staff     1664 May  5 10:13 ..
-drwxr-xr-x  3 jose.vazquez staff       96 Apr 16 18:02 .claude
-drwxr-xr-x 10 jose.vazquez staff      320 May 26 16:03 .devbox
--rw-r--r--  1 jose.vazquez staff     1048 Apr  8 10:21 .dockerignore
--rw-r--r--  1 jose.vazquez staff      223 Feb  3 14:15 .editorconfig
--rw-r--r--  1 jose.vazquez staff    30676 May 21 15:39 .evergreen-functions.yml
--rw-r--r--  1 jose.vazquez staff       74 Jun  1 18:04 .evergreen-mco.yml
--rw-r--r--  1 jose.vazquez staff      860 Feb  3 14:15 .evergreen-periodic-builds.yaml
--rw-r--r--  1 jose.vazquez staff    13641 May  5 14:31 .evergreen-release.yml
--rw-r--r--  1 jose.vazquez staff     7000 May 29 09:54 .evergreen-snippets.yml
--rw-r--r--  1 jose.vazquez staff    33033 Jun  1 15:31 .evergreen-tasks.yml
--rw-r--r--  1 jose.vazquez staff    74642 May 29 09:54 .evergreen.yml
--rw-r--r--  1 jose.vazquez staff      108 Feb  3 14:15 .flake8
-drwxr-xr-x  4 jose.vazquez staff      128 Apr 22 17:22 .generated
-drwxr-xr-x 21 jose.vazquez staff      672 Jun  1 18:04 .git
-drwxr-xr-x  4 jose.vazquez staff      128 Apr  8 10:21 .githooks
-drwxr-xr-x  9 jose.vazquez staff      288 May 21 15:40 .github
--rw-r--r--  1 jose.vazquez staff     2473 May 29 09:54 .gitignore
--rw-r--r--  1 jose.vazquez staff        0 Feb  3 14:15 .gitmodules
--rw-r--r--  1 jose.vazquez staff     6386 May 29 09:54 .golangci.yml
-drwxr-xr-x 10 jose.vazquez staff      320 May  5 14:31 .idea
-drwxr-xr-x  7 jose.vazquez staff      224 Feb 13 11:12 .mck-devbox
--rw-------  1 jose.vazquez staff     4771 Jun  1 18:02 .pre-commit-config.yaml
--rw-r--r--  1 jose.vazquez staff      219 Feb  3 14:15 .pylintrc
--rw-r--r--  1 jose.vazquez staff       13 Feb  3 14:15 .rsyncignore
--rw-r--r--  1 jose.vazquez staff       38 Feb  3 14:15 .rsyncinclude
-drwxr-xr-x  5 jose.vazquez staff      160 May  5 14:31 .run
--rw-r--r--  1 jose.vazquez staff      186 Apr  8 10:21 .shellcheckrc
--rw-------  1 jose.vazquez staff       14 Jun  1 18:02 .tool-versions
-drwxr-xr-x  7 jose.vazquez staff      224 Feb 10 09:48 .venv
-drwxr-xr-x  3 jose.vazquez staff       96 Feb  6 17:15 .vscode
--rw-r--r--  1 jose.vazquez staff    10229 Feb  3 14:15 Apache License
--rw-r--r--  1 jose.vazquez staff     2779 Apr 22 10:16 CONTRIBUTING.md
--rw-r--r--  1 jose.vazquez staff     3993 Apr 22 11:39 EVERGREEN.md
--rw-r--r--  1 jose.vazquez staff     1418 Feb  3 14:15 LICENSE-MCK
--rw-r--r--  1 jose.vazquez staff    12229 Jun  1 18:02 LICENSE-THIRD-PARTY
--rw-r--r--  1 jose.vazquez staff    16177 Jun  1 17:30 Makefile
--rw-r--r--  1 jose.vazquez staff     1276 Jun  1 15:31 PROJECT
--rw-r--r--  1 jose.vazquez staff     5014 Feb  3 14:15 README.md
--rw-r--r--  1 jose.vazquez staff     7336 Feb  3 14:15 RELEASE_NOTES.md
--rw-r--r--  1 jose.vazquez staff    71535 Feb  3 14:15 RELEASE_NOTES_MEKO.md
--rw-r--r--  1 jose.vazquez staff      501 Feb  3 14:15 SECURITY.md
-drwxr-xr-x  3 jose.vazquez staff       96 Jun  1 15:31 api
-drwxr-xr-x  4 jose.vazquez staff      128 May  7 17:45 bin
--rw-r--r--  1 jose.vazquez staff    13548 May  5 14:31 build_info.json
--rw-r--r--  1 jose.vazquez staff      905 May 26 16:17 build_info_agent.json
-drwxr-xr-x 53 jose.vazquez staff     1696 Jun  1 15:31 changelog
-drwxr-xr-x  4 jose.vazquez staff      128 May 29 09:54 cmd
-drwxr-xr-x 10 jose.vazquez staff      320 Feb  3 14:15 config
-drwxr-xr-x  5 jose.vazquez staff      160 Feb  3 14:15 controllers
-drwxr-xr-x  5 jose.vazquez staff      160 Feb  3 14:15 deploy
--rw-r--r--  1 jose.vazquez staff     1746 Apr 22 17:55 devbox-init.shell
--rw-r--r--  1 jose.vazquez staff      749 May 26 11:15 devbox.json
--rw-r--r--  1 jose.vazquez staff    27847 May 26 11:16 devbox.lock
-drwxr-xr-x 14 jose.vazquez staff      448 Feb 13 11:25 docker
-drwxr-xr-x  8 jose.vazquez staff      256 Apr 22 10:16 docs
--rwxr-xr-x  1 jose.vazquez staff    11231 Apr 22 11:39 generate_ssdlc_report.py
--rwxr-xr-x  1 jose.vazquez staff     2553 Feb  3 14:15 generate_ssdlc_report_test.py
--rw-r--r--  1 jose.vazquez staff     7173 Jun  1 15:31 go.mod
--rw-r--r--  1 jose.vazquez staff    41407 Jun  1 15:31 go.sum
-drwxr-xr-x  3 jose.vazquez staff       96 Feb  3 14:15 hack
-drwxr-xr-x  9 jose.vazquez staff      288 Jun  1 15:31 helm_chart
-drwxr-xr-x  3 jose.vazquez staff       96 May 29 09:54 internal
--rw-r--r--  1 jose.vazquez staff      266 Jun  1 17:30 kubernetes-versions.json
-drwxr-xr-x  3 jose.vazquez staff       96 Jun  1 18:02 lib
--rw-r--r--  1 jose.vazquez staff    13406 Jun  1 18:02 licenses_full.csv
--rw-r--r--  1 jose.vazquez staff     1119 Feb 10 16:33 licenses_stderr
--rw-r--r--  1 jose.vazquez staff    24259 Jun  1 15:31 main.go
-drwxr-xr-x 14 jose.vazquez staff      448 Feb  3 14:15 mongodb-community-operator
--rwxr-xr-x  1 jose.vazquez staff 90783874 May  7 14:52 mongodb-kubernetes
--rw-r--r--  1 jose.vazquez staff    53401 May 20 17:55 mongodb-kubernetes-1.8.1.tgz
-drwxr-xr-x  6 jose.vazquez staff      192 Jun  1 18:02 multi_cluster
-drwxr-xr-x 25 jose.vazquez staff      800 May 29 09:54 pkg
-drwxr-xr-x 19 jose.vazquez staff      608 Jun  1 15:31 public
--rw-r--r--  1 jose.vazquez staff      265 May  5 14:31 pyproject.toml
--rw-r--r--  1 jose.vazquez staff    10345 Jun  1 15:31 release.json
--rw-r--r--  1 jose.vazquez staff     1324 Jun  1 15:31 requirements.txt
-drwxr-xr-x 23 jose.vazquez staff      736 Jun  1 18:02 scripts
-drwxr-xr-x 17 jose.vazquez staff      544 May 28 09:53 tmp
--rw-r--r--  1 jose.vazquez staff      309 May 29 09:54 tools.go
+buildvariants:
+- display_tasks:
+  - execution_tasks: []
+    name: e2e_mco_tests
+  name: e2e_mco_tests
+  tasks:
+  - name: e2e_mco_task_group
+task_groups:
+- max_hosts: -1
+  name: e2e_mco_task_group
+  setup_group:
+  - func: clone
+  - func: download_kube_tools
+  - func: setup_building_host
+  setup_task:
+  - func: cleanup_exec_environment
+  - func: configure_docker_auth
+  - func: setup_kubernetes_environment
+  tasks:
+  - feature_compatibility_version
+  - prometheus
+  - replica_set
+  - replica_set_arbiter
+  - replica_set_change_version
+  - replica_set_connection_string_options
+  - replica_set_cross_namespace_deploy
+  - replica_set_custom_persistent_volume
+  - replica_set_custom_role
+  - replica_set_enterprise_upgrade_4_5
+  - replica_set_enterprise_upgrade_5_6
+  - replica_set_enterprise_upgrade_6_7
+  - replica_set_enterprise_upgrade_7_8
+  - replica_set_mongod_config
+  - replica_set_mongod_port_change_with_arbiters
+  - replica_set_mongod_readiness
+  - replica_set_mount_connection_string
+  - replica_set_operator_upgrade
+  - replica_set_recovery
+  - replica_set_remove_user
+  - replica_set_scale
+  - replica_set_scale_down
+  - replica_set_tls
+  - replica_set_tls_recreate_mdbc
+  - replica_set_tls_rotate
+  - replica_set_tls_rotate_delete_sts
+  - replica_set_tls_upgrade
+  - replica_set_x509
+  - statefulset_arbitrary_config
+  - statefulset_arbitrary_config_update
+  teardown_group:
+  - func: prune_docker_resources
+  teardown_task:
+  - func: upload_e2e_logs_gotest
+  - func: teardown_kubernetes_environment
+tasks:
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: feature_compatibility_version
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: prometheus
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_arbiter
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_change_version
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_connection_string_options
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_cross_namespace_deploy
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_custom_persistent_volume
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_custom_role
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_enterprise_upgrade_4_5
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_enterprise_upgrade_5_6
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_enterprise_upgrade_6_7
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_enterprise_upgrade_7_8
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_mongod_config
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_mongod_port_change_with_arbiters
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_mongod_readiness
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_mount_connection_string
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_operator_upgrade
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_recovery
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_remove_user
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_scale
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_scale_down
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_tls
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_tls_recreate_mdbc
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_tls_rotate
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_tls_rotate_delete_sts
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_tls_upgrade
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: replica_set_x509
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: statefulset_arbitrary_config
+- commands:
+  - func: e2e_test
+    retry_on_failure: true
+  name: statefulset_arbitrary_config_update
+

--- a/.github/workflows/check-kubernetes-versions.yml
+++ b/.github/workflows/check-kubernetes-versions.yml
@@ -1,0 +1,54 @@
+name: Check Kubernetes Versions
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC
+  workflow_dispatch:
+    inputs:
+      operator_release_date:
+        description: 'Override OPERATOR_RELEASE_DATE (YYYY-MM-DD). Leave blank to use today.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  check-kubernetes-versions:
+    name: Check Kubernetes Versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check Kubernetes versions
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          OPERATOR_RELEASE_DATE: ${{ inputs.operator_release_date }}
+        run: scripts/check-kube-versions.sh
+
+  failure-alert:
+    name: Slack Alert on Failure
+    runs-on: ubuntu-latest
+    needs:
+      - check-kubernetes-versions
+    if: >-
+      always() &&
+      needs.check-kubernetes-versions.result == 'failure' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK}" ]; then
+            echo "SLACK_WEBHOOK not set, skipping notification"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG="❌ *Kubernetes Versions Check Failed* | ${{ github.repository }}\nTrigger: ${{ github.event_name }}\n<${RUN_URL}|View Failing Logs>"
+          curl -s -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"${MSG}\"}" \
+            "${SLACK_WEBHOOK}"

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,10 @@ cert:
 recreate-e2e-multicluster-kind:
 	scripts/dev/recreate_kind_clusters.sh
 
+.PHONY: check-kubernetes-versions
+check-kubernetes-versions:
+	scripts/check-kube-versions.sh
+
 ####################################
 ## operator-sdk provided Makefile ##
 ####################################

--- a/kubernetes-versions.json
+++ b/kubernetes-versions.json
@@ -1,13 +1,13 @@
 {
   "kubernetes": {
-    "min": "1.33.7",
-    "max": "1.35.0"
+    "min": "1.34.3",
+    "max": "1.36.1"
   },
   "openshift": "4.21",
   "kind": {
     "images": {
       "min": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node",
-      "max": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node"
+      "max": "ghcr.io/mongodb/kindest-node"
     }
   }
 }

--- a/kubernetes-versions.json
+++ b/kubernetes-versions.json
@@ -7,7 +7,7 @@
   "kind": {
     "images": {
       "min": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node",
-      "max": "ghcr.io/mongodb/kindest-node"
+      "max": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node"
     }
   }
 }

--- a/kubernetes-versions.json
+++ b/kubernetes-versions.json
@@ -3,5 +3,11 @@
     "min": "1.33.7",
     "max": "1.35.0"
   },
-  "openshift": "4.21"
+  "openshift": "4.21",
+  "kind": {
+    "images": {
+      "min": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node",
+      "max": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node"
+    }
+  }
 }

--- a/scripts/check-kube-versions.sh
+++ b/scripts/check-kube-versions.sh
@@ -21,7 +21,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONFIG_FILE="${CONFIG_FILE:-${PROJECT_ROOT}/kubernetes-versions.json}"
 OPERATOR_RELEASE_DATE="${OPERATOR_RELEASE_DATE:-$(date +%Y-%m-%d)}"
-BUFFER_MONTHS=1
+NEW_VERSION_BUFFER_DAYS=30
+EOL_BUFFER_DAYS=30
 
 # API Endpoints
 K8S_API="https://endoflife.date/api/kubernetes.json"
@@ -55,14 +56,14 @@ main() {
     info "--------------------------------------------------------"
     info "Checking Support Policy Compliance"
     display "Operator Release Date: ${OPERATOR_RELEASE_DATE}"
-    display "Buffer: ${BUFFER_MONTHS} months"
+    display "New Version Buffer: ${NEW_VERSION_BUFFER_DAYS} days | EOL Buffer: ${EOL_BUFFER_DAYS} days"
     info "--------------------------------------------------------"
 
     check_dependencies
     validate_config
 
-    THRESHOLD_DATE=$(calc_date "${OPERATOR_RELEASE_DATE}" "-${BUFFER_MONTHS}")
-    EOL_THRESHOLD_DATE=$(calc_date "${OPERATOR_RELEASE_DATE}" "+${BUFFER_MONTHS}")
+    THRESHOLD_DATE=$(calc_date "${OPERATOR_RELEASE_DATE}" "-${NEW_VERSION_BUFFER_DAYS}")
+    EOL_THRESHOLD_DATE=$(calc_date "${OPERATOR_RELEASE_DATE}" "+${EOL_BUFFER_DAYS}")
 
     display "Policy Cutoff (New Versions): Releases before ${THRESHOLD_DATE} must be supported."
     display ""
@@ -97,7 +98,7 @@ main() {
     check_k8s_range "${k8s_min}" "${k8s_max}" || true
     check_ocp_single "${ocp_ver}" || true
 
-    if [ ${EXIT_CODE} -eq 0 ]; then
+    if [ "${EXIT_CODE}" -eq 0 ]; then
         display ""
         success "All version checks passed!"
     else
@@ -113,7 +114,7 @@ main() {
     OUTPUT_FD=0
 
     # Send to Slack if there are issues
-    if [ ${EXIT_CODE} -ne 0 ]; then
+    if [ "${EXIT_CODE}" -ne 0 ]; then
         send_to_slack "${output_file}"
     fi
 
@@ -122,7 +123,7 @@ main() {
         rm -f "${output_file}"
     fi
 
-    exit ${EXIT_CODE}
+    exit "${EXIT_CODE}"
 }
 
 # Check dependencies
@@ -135,7 +136,7 @@ check_dependencies() {
         fi
     done
 
-    if [ ${#missing_deps[@]} -gt 0 ]; then
+    if [ "${#missing_deps[@]}" -gt 0 ]; then
         error "Missing required dependencies: ${missing_deps[*]}"
         exit 1
     fi
@@ -181,7 +182,7 @@ send_to_slack() {
     fi
 
     echo "Sending version check results to Slack..." >&2
-    º"${slack_script}" < "${output_file}" || {
+    cat "${output_file}" | "${slack_script}" || {
         echo "Warning: Failed to send message to Slack" >&2
         return 0
     }
@@ -358,29 +359,24 @@ normalize_version() {
     echo "${version}" | cut -d. -f1,2
 }
 
-# Calculate date with month offset
+# Calculate date with day offset (e.g. "-45" or "+45")
 calc_date() {
     local date_str="$1"
-    local months="$2"
+    local days="$2"
 
     # Detect BSD (macOS) vs GNU date
-    if date -v+1m >/dev/null 2>&1; then
+    if date -v+1d >/dev/null 2>&1; then
         # BSD date (macOS)
-        if [[ ${months} =~ ^- ]]; then
-            # Negative months: remove minus sign and use -v-${abs}m
-            local abs_months="${months#-}"
-            date -v-"${abs_months}m" -j -f "%Y-%m-%d" "${date_str}" +%Y-%m-%d
-        elif [[ ${months} =~ ^\+ ]]; then
-            # Positive months: remove plus sign and use -v+${abs}m
-            local abs_months="${months#+}"
-            date -v+"${abs_months}m" -j -f "%Y-%m-%d" "${date_str}" +%Y-%m-%d
+        if [[ ${days} =~ ^- ]]; then
+            local abs="${days#-}"
+            date -v-"${abs}d" -j -f "%Y-%m-%d" "${date_str}" +%Y-%m-%d
         else
-            # No sign prefix, assume positive
-            date -v+"${months}m" -j -f "%Y-%m-%d" "${date_str}" +%Y-%m-%d
+            local abs="${days#+}"
+            date -v+"${abs}d" -j -f "%Y-%m-%d" "${date_str}" +%Y-%m-%d
         fi
     else
         # GNU date (Linux)
-        date -d "${date_str} ${months} months" +%Y-%m-%d
+        date -d "${date_str} ${days} days" +%Y-%m-%d
     fi
 }
 
@@ -417,8 +413,8 @@ success() {
 
 # Helper function to write plain text to output file
 write_to_file() {
-    if [ ${OUTPUT_FD} -gt 0 ]; then
-        echo "$1" >&${OUTPUT_FD}
+    if [ "${OUTPUT_FD}" -gt 0 ]; then
+        echo "$1" >&"${OUTPUT_FD}"
     fi
 }
 

--- a/scripts/check-kube-versions.sh
+++ b/scripts/check-kube-versions.sh
@@ -182,7 +182,7 @@ send_to_slack() {
     fi
 
     echo "Sending version check results to Slack..." >&2
-    cat "${output_file}" | "${slack_script}" || {
+    "${slack_script}" < "${output_file}" || {
         echo "Warning: Failed to send message to Slack" >&2
         return 0
     }

--- a/scripts/dev/setup_kind_cluster.sh
+++ b/scripts/dev/setup_kind_cluster.sh
@@ -57,19 +57,14 @@ shift "$((OPTIND - 1))"
 
 kubeconfig_path="${HOME}/.kube/${cluster_name}"
 
-# create a cluster with the local registry enabled in containerd
-registry="docker.io"
-if [[ "${RUNNING_IN_EVG:-false}" == "true" ]]; then
-  registry="268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors"
-fi
-
 metallb_version="v0.13.7"
 metrics_server_version="v0.7.2"
 
+# local registry
 reg_name='kind-registry'
 reg_port='5000'
-kube_max_version=$(jq -r '.kubernetes.max' kubernetes-versions.json)
-kind_image="${registry}/kindest/node:v${kube_max_version}"
+# kind image source
+kind_image="${KIND_NODE_IMAGE:-$(scripts/get-kind-image.sh max)}"
 
 kind_delete_cluster() {
   kind delete cluster --name "${cluster_name}" || true

--- a/scripts/get-kind-image.sh
+++ b/scripts/get-kind-image.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2026 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Returns the full kind node image ref for the min or max Kubernetes version.
+# Usage: ./scripts/get-kind-image.sh [min|max]
+# Example output: ghcr.io/mongodb/kindest-node:v1.36.1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VERSION_FILE="${VERSION_FILE:-${REPO_ROOT}/kubernetes-versions.json}"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 [min|max]" >&2
+    exit 1
+fi
+
+VERSION_TYPE="${1}"
+
+if [ "${VERSION_TYPE}" != "min" ] && [ "${VERSION_TYPE}" != "max" ]; then
+    echo "Error: version type must be 'min' or 'max'" >&2
+    exit 1
+fi
+
+if [ ! -f "${VERSION_FILE}" ]; then
+    echo "Error: version file not found: ${VERSION_FILE}" >&2
+    exit 1
+fi
+
+VERSION=$(jq -r ".kubernetes.${VERSION_TYPE}" "${VERSION_FILE}")
+IMAGE=$(jq -r ".kind.images.${VERSION_TYPE}" "${VERSION_FILE}")
+
+if [ -z "${VERSION}" ] || [ "${VERSION}" == "null" ]; then
+    echo "Error: could not read kubernetes.${VERSION_TYPE} from ${VERSION_FILE}" >&2
+    exit 1
+fi
+
+if [ -z "${IMAGE}" ] || [ "${IMAGE}" == "null" ]; then
+    echo "Error: could not read kind.images.${VERSION_TYPE} from ${VERSION_FILE}" >&2
+    exit 1
+fi
+
+echo "${IMAGE}:v${VERSION}"


### PR DESCRIPTION
# Summary

The official kindest/node image for Kubernetes 1.36.1 is not yet published, so we build and host it at:

`ghcr.io/mongodb/kindest-node`

We also add `kind.images.min/max` to `kubernetes-versions.json` to customize the kind test images.

A workflow to check the policy was respected has been added.

The current Kubernetes versions were out of policy so they were bumped.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
