### PR TITLE
test(search): comprehensive simulated-MC tests + sharded mongot bootstrap resilience

### DIFF
--- a/api/mongodb/v1/search/cluster_index_test.go
+++ b/api/mongodb/v1/search/cluster_index_test.go
@@ -87,6 +87,15 @@ func TestAssignClusterIndices(t *testing.T) {
 			current:  []ClusterSpec{{ClusterName: "us-east", ClusterIndex: pin(5)}, {ClusterName: "us-west"}},
 			want:     map[string]int{"us-east": 5, "us-west": 6},
 		},
+		{
+			// Two distinct names pinning the same index: AssignClusterIndices keeps
+			// both at that index (it keys on name, not index). Uniqueness across
+			// clusterIndex values is a CRD CEL rule enforced at admission, not here.
+			name:     "duplicate pinned index across distinct names: both kept (CEL enforces uniqueness at admission)",
+			existing: map[string]int{},
+			current:  []ClusterSpec{{ClusterName: "us-east", ClusterIndex: pin(5)}, {ClusterName: "us-west", ClusterIndex: pin(5)}},
+			want:     map[string]int{"us-east": 5, "us-west": 5},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -96,6 +96,36 @@ func resolveClusterMapping(
 	return state.ClusterMapping, nil
 }
 
+// prepareSearchForReconcile runs the shared pre-reconcile gate for both search
+// reconcilers. ValidateSpec runs on the UN-NARROWED spec first: simulated-MC narrows
+// spec.clusters[] via LocalizeToCluster, after which the MC validators short-circuit on
+// len(clusters) <= 1 and would silently accept misconfigured MC specs.
+// writeStatus routes validation failures to the caller's own status surface. Returns
+// skip=true when the caller should stop reconciling (validation failed, or this operator
+// does not own the CR). The operatorClusterName mode discriminator lives only here.
+func prepareSearchForReconcile(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	operatorClusterName string,
+	writeStatus func(workflow.Status) (reconcile.Result, error),
+	log *zap.SugaredLogger,
+) (skip bool, res reconcile.Result, err error) {
+	if vErr := search.ValidateSpec(); vErr != nil {
+		r, e := writeStatus(workflow.Invalid("%s", vErr.Error()))
+		return true, r, e
+	}
+	if operatorClusterName != "" {
+		if vErr := search.ValidateSimulatedMCClusterIndices(); vErr != nil {
+			r, e := writeStatus(workflow.Invalid("%s", vErr.Error()))
+			return true, r, e
+		}
+		if !search.LocalizeToCluster(operatorClusterName) {
+			return true, reconcile.Result{}, nil
+		}
+	}
+	return false, reconcile.Result{}, nil
+}
+
 type MongoDBSearchReconciler struct {
 	kubeClient           kubernetesClient.Client
 	watch                *watch.ResourceWatcher
@@ -136,26 +166,11 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		return result, err
 	}
 
-	// Validate the UN-NARROWED spec first. Simulated-MC narrows spec.clusters[] to a
-	// 1-element slice via LocalizeToCluster below; after narrowing the MC validators
-	// (e.g., validateMCExternalHostnamePlaceholders, validateMCRejectsUnmanagedLB)
-	// short-circuit on len(clusters) <= 1 and silently accept misconfigured MC specs.
-	// The reconcile helper still calls ValidateSpec defensively but only sees the
-	// narrowed spec — this top-level call is the source of truth for MC-shape rules.
-	if err := mdbSearch.ValidateSpec(); err != nil {
-		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Invalid("%s", err.Error()), log)
-	}
-
-	// Simulated-MC operators require every spec.clusters[] entry to pin a ClusterIndex.
-	// Runs on the un-narrowed spec (before LocalizeToCluster) so it sees all clusters.
-	if r.operatorClusterName != "" {
-		if err := mdbSearch.ValidateSimulatedMCClusterIndices(); err != nil {
-			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Invalid("%s", err.Error()), log)
-		}
-	}
-
-	if r.operatorClusterName != "" && !mdbSearch.LocalizeToCluster(r.operatorClusterName) {
-		return reconcile.Result{}, nil
+	if skip, result, err := prepareSearchForReconcile(ctx, mdbSearch, r.operatorClusterName,
+		func(st workflow.Status) (reconcile.Result, error) {
+			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, st, log)
+		}, log); skip {
+		return result, err
 	}
 
 	clusterMapping, err := resolveClusterMapping(ctx, r.kubeClient, mdbSearch, log)

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -1013,6 +1013,10 @@ func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
 		require.NoError(t, c.Get(ctx, req.NamespacedName, got))
 		require.Equal(t, status.PhaseFailed, got.Status.Phase,
 			"missing clusterIndex must surface as Failed phase, got %q (msg=%q)", got.Status.Phase, got.Status.Message)
+		// workflow.Invalid capitalizes the first char, so match on the stable substring.
+		assert.Contains(t, got.Status.Message,
+			"multi-cluster mode requires clusterIndex on every spec.clusters[] entry (missing on",
+			"failure must come from ValidateSimulatedMCClusterIndices")
 	})
 
 	t.Run("empty clusters is Invalid", func(t *testing.T) {

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -1000,23 +1000,6 @@ func TestReconcile_SimulatedMC_ShardedSource_NoMatchSilentNoOp(t *testing.T) {
 		"state ConfigMap must not be created in sharded no-match path")
 }
 
-// MC validators run on the UN-narrowed spec — confirm that an invalid spec surfaces as PhaseFailed at the reconciler level. Validator content is covered by TestValidateSpec_MCShardedSource.
-func TestReconcile_SimulatedMC_ShardedSource_ValidationRunsPreLocalization(t *testing.T) {
-	ctx := context.Background()
-	search := newSimulatedMCShardedMongoDBSearch("mdb-search", mock.TestNamespace)
-	search.Spec.LoadBalancer.Managed.ExternalHostname = "{clusterName}.lb.example.com:443" // missing {shardName}
-
-	reconciler, c := newSimulatedMCSearchReconciler(t, "cluster-a", search)
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
-	_, err := reconciler.Reconcile(ctx, req)
-	require.NoError(t, err, "workflow.Invalid returns nil error; assert via Status")
-
-	got := &searchv1.MongoDBSearch{}
-	require.NoError(t, c.Get(ctx, req.NamespacedName, got))
-	require.Equal(t, status.PhaseFailed, got.Status.Phase,
-		"invalid-spec must surface as Failed phase, got %q (msg=%q)", got.Status.Phase, got.Status.Message)
-}
-
 // Simulated-MC enforces ClusterIndex on every spec.clusters[] entry. Both empty-clusters
 // and a nil-ClusterIndex entry must surface as Invalid (Failed phase) before LocalizeToCluster.
 func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -725,6 +725,17 @@ func driveSearchReconcileToRunning(
 	return got
 }
 
+// readSimulatedMCStateMapping decodes the persisted clusterName->index mapping from the {name}-state ConfigMap.
+func readSimulatedMCStateMapping(ctx context.Context, t *testing.T, c client.Client, search *searchv1.MongoDBSearch) map[string]int {
+	t.Helper()
+	stateCM := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name + "-state", Namespace: search.Namespace}, stateCM),
+		"state ConfigMap must exist in simulated-MC mode")
+	var state SearchDeploymentState
+	require.NoError(t, decodeStateJSON(stateCM, &state))
+	return state.ClusterMapping
+}
+
 // newSimulatedMCMongoDBSearch: baseline RS fixture with 2 ClusterIndex-pinned spec.clusters entries for simulated-MC reconcile tests.
 func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
 	clusters := []searchv1.ClusterSpec{
@@ -747,49 +758,59 @@ func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch
 	}
 }
 
-// Simulated-MC mode: only the local-cluster entry gets resources; the other cluster's resources MUST NOT appear.
+// Simulated-MC mode: only the local-cluster entry gets resources at its pinned ClusterIndex; the other cluster's resources MUST NOT appear. The non-zero-pin row guards that RS naming follows the pinned index, not array position 0 (which equals the pin after localization).
 func TestReconcile_SimulatedMC_ProjectedReconcilesLocalOnly(t *testing.T) {
-	ctx := context.Background()
-	search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+	cases := []struct {
+		name        string
+		opCluster   string
+		pinClusterB *int32 // override (*spec.Clusters)[1].ClusterIndex when non-nil
+		wantIdx     int
+		wrongIdx    int
+	}{
+		{name: "default_pins_cluster_a_index_0", opCluster: "cluster-a", pinClusterB: nil, wantIdx: 0, wrongIdx: 1},
+		{name: "cluster_b_pinned_to_index_7", opCluster: "cluster-b", pinClusterB: ptr.To(int32(7)), wantIdx: 7, wrongIdx: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+			if tc.pinClusterB != nil {
+				(*search.Spec.Clusters)[1].ClusterIndex = tc.pinClusterB
+			}
 
-	reconciler, c := newSimulatedMCSearchReconciler(t, "cluster-a", search)
+			reconciler, c := newSimulatedMCSearchReconciler(t, tc.opCluster, search)
 
-	got := driveSearchReconcileToRunning(ctx, t, reconciler, c, search, 3)
+			got := driveSearchReconcileToRunning(ctx, t, reconciler, c, search, 5)
 
-	// cluster-a's resources (index 0) must exist on the central (= operator's) client.
-	stsA := &appsv1.StatefulSet{}
-	require.NoError(t, c.Get(ctx, search.StatefulSetNamespacedNameForCluster(0), stsA),
-		"STS for cluster-a (index 0) must exist")
-	cmA := &corev1.ConfigMap{}
-	require.NoError(t, c.Get(ctx, search.MongotConfigConfigMapNameForCluster(0), cmA),
-		"mongot ConfigMap for cluster-a must exist")
-	proxyA := &corev1.Service{}
-	require.NoError(t, c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(0), proxyA),
-		"proxy Service for cluster-a must exist")
+			// Local cluster's resources must exist at the PINNED index on the operator's client.
+			sts := &appsv1.StatefulSet{}
+			require.NoError(t, c.Get(ctx, search.StatefulSetNamespacedNameForCluster(tc.wantIdx), sts),
+				"STS at pinned index %d must exist", tc.wantIdx)
+			cm := &corev1.ConfigMap{}
+			require.NoError(t, c.Get(ctx, search.MongotConfigConfigMapNameForCluster(tc.wantIdx), cm),
+				"mongot ConfigMap at pinned index %d must exist", tc.wantIdx)
+			proxy := &corev1.Service{}
+			require.NoError(t, c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.wantIdx), proxy),
+				"proxy Service at pinned index %d must exist", tc.wantIdx)
 
-	// cluster-b's resources (index 1) MUST NOT exist — this operator never wrote them.
-	stsB := &appsv1.StatefulSet{}
-	err := c.Get(ctx, search.StatefulSetNamespacedNameForCluster(1), stsB)
-	assert.True(t, apiErrors.IsNotFound(err), "STS for cluster-b (index 1) must NOT exist; got err=%v", err)
-	cmB := &corev1.ConfigMap{}
-	err = c.Get(ctx, search.MongotConfigConfigMapNameForCluster(1), cmB)
-	assert.True(t, apiErrors.IsNotFound(err), "mongot ConfigMap for cluster-b must NOT exist; got err=%v", err)
-	proxyB := &corev1.Service{}
-	err = c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(1), proxyB)
-	assert.True(t, apiErrors.IsNotFound(err), "proxy Service for cluster-b must NOT exist; got err=%v", err)
+			// The other cluster's index MUST be untouched — this operator never wrote it.
+			err := c.Get(ctx, search.StatefulSetNamespacedNameForCluster(tc.wrongIdx), &appsv1.StatefulSet{})
+			assert.True(t, apiErrors.IsNotFound(err), "STS at index %d must NOT exist; got err=%v", tc.wrongIdx, err)
+			err = c.Get(ctx, search.MongotConfigConfigMapNameForCluster(tc.wrongIdx), &corev1.ConfigMap{})
+			assert.True(t, apiErrors.IsNotFound(err), "mongot ConfigMap at index %d must NOT exist; got err=%v", tc.wrongIdx, err)
+			err = c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.wrongIdx), &corev1.Service{})
+			assert.True(t, apiErrors.IsNotFound(err), "proxy Service at index %d must NOT exist; got err=%v", tc.wrongIdx, err)
 
-	// The {search-name}-state ConfigMap IS used in simulated-MC mode now —
-	// LocalizeToCluster narrows spec.clusters[] to the local entry before the
-	// state-CM load, so the persisted mapping carries only this cluster's entry.
-	stateCM := &corev1.ConfigMap{}
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name + "-state", Namespace: search.Namespace}, stateCM),
-		"state ConfigMap must be created in simulated-MC mode")
+			// LocalizeToCluster narrows spec.clusters[] to the local entry BEFORE the state-CM
+			// write, so the persisted mapping carries ONLY this operator's cluster at its pin.
+			assert.Equal(t, map[string]int{tc.opCluster: tc.wantIdx},
+				readSimulatedMCStateMapping(ctx, t, c, search),
+				"persisted mapping must contain only the localized cluster at its pinned index")
 
-	// Status phase must reflect a normal reconcile outcome (Running or Pending,
-	// depending on STS-readiness timing) — anything else (Failed/Invalid) signals
-	// a regression in the projection path.
-	assert.Contains(t, []status.Phase{status.PhaseRunning, status.PhasePending}, got.Status.Phase,
-		"projected reconcile should land on Running or Pending; got %q (msg=%q)", got.Status.Phase, got.Status.Message)
+			require.Equal(t, status.PhaseRunning, got.Status.Phase,
+				"projected reconcile must reach Running; got %q (msg=%q)", got.Status.Phase, got.Status.Message)
+		})
+	}
 }
 
 // Simulated-MC: operator not in spec.clusters[] returns Result{}, nil and mutates nothing.
@@ -936,8 +957,14 @@ func TestReconcile_SimulatedMC_ShardedSource_ProjectedReconcilesLocalOnly(t *tes
 			err := c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.wrongIdx), wrongProxy)
 			assert.True(t, apiErrors.IsNotFound(err), "cluster-level proxy Service at idx %d must NOT exist; err=%v", tc.wrongIdx, err)
 
-			assert.Contains(t, []status.Phase{status.PhaseRunning, status.PhasePending}, got.Status.Phase,
-				"projected sharded reconcile should land Running or Pending; got %q (msg=%q)", got.Status.Phase, got.Status.Message)
+			// Localization narrows to the local entry before the state-CM write, so the
+			// persisted mapping carries only this operator's cluster at its pinned index.
+			assert.Equal(t, map[string]int{tc.opCluster: tc.wantIdx},
+				readSimulatedMCStateMapping(ctx, t, c, search),
+				"persisted mapping must contain only the localized cluster at its pinned index")
+
+			require.Equal(t, status.PhaseRunning, got.Status.Phase,
+				"projected sharded reconcile must reach Running; got %q (msg=%q)", got.Status.Phase, got.Status.Message)
 		})
 	}
 }

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -108,23 +108,13 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 		return result, err
 	}
 
-	// Validate the UN-NARROWED spec first (see mongodbsearch_controller.go::Reconcile
-	// for the rationale). Failures surface on /status/loadBalancer so the Envoy
-	// sub-status stays authoritative for LB shape errors.
-	if err := mdbSearch.ValidateSpec(); err != nil {
-		return r.updateLBStatus(ctx, mdbSearch, workflow.Invalid("%s", err.Error()), log)
-	}
-
-	// Simulated-MC operators require every spec.clusters[] entry to pin a ClusterIndex.
-	// Runs on the un-narrowed spec (before LocalizeToCluster) so it sees all clusters.
-	if r.operatorClusterName != "" {
-		if err := mdbSearch.ValidateSimulatedMCClusterIndices(); err != nil {
-			return r.updateLBStatus(ctx, mdbSearch, workflow.Invalid("%s", err.Error()), log)
-		}
-	}
-
-	if r.operatorClusterName != "" && !mdbSearch.LocalizeToCluster(r.operatorClusterName) {
-		return reconcile.Result{}, nil
+	// Envoy validation failures surface on /status/loadBalancer so the Envoy sub-status
+	// stays authoritative for LB shape errors.
+	if skip, result, err := prepareSearchForReconcile(ctx, mdbSearch, r.operatorClusterName,
+		func(st workflow.Status) (reconcile.Result, error) {
+			return r.updateLBStatus(ctx, mdbSearch, st, log)
+		}, log); skip {
+		return result, err
 	}
 
 	// TODO: can we find a better cleanup mechanism, and optimize the watching of the loadbalancer field by this controller ?

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -1488,6 +1488,197 @@ func TestDeleteEnvoyResources_SkipsUnregisteredCluster(t *testing.T) {
 	}, zap.S())
 }
 
+// Cross-cluster worst-of aggregation: with the FAILING cluster ordered FIRST,
+// the top-level LB phase must still be Failed. Ordering the failure first is the
+// discriminator — a "worstPhase = last-seen-phase" regression would compute OK
+// (cluster b succeeds) and downgrade to Pending. Only proper worst-of
+// accumulation across clusters keeps it Failed. The single-cluster
+// TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed cannot cover this.
+func TestEnvoyReconcile_MultiCluster_FailedFirstThenOK_AggregatesFailed(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
+			},
+			// "a" first so the Failed phase is seen before the OK phase.
+			Clusters: &[]searchv1.ClusterSpec{{ClusterName: "a"}, {ClusterName: "b"}},
+		},
+	}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"a": 0, "b": 1})
+
+	// Cluster "a" rejects every write → Failed; cluster "b" succeeds → OK.
+	memberA := failingWriteClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA, "b": memberB}, "")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	require.NotNil(t, patched.Status.LoadBalancer)
+	assert.Equal(t, status.PhaseFailed, patched.Status.LoadBalancer.Phase,
+		"a Failed + b OK must aggregate to top-level Failed regardless of cluster order")
+}
+
+// --- simulated-MC Reconcile() coverage (operatorClusterName != "") ------------
+
+// Simulated-MC: when the operator's cluster is NOT listed in spec.clusters[],
+// LocalizeToCluster returns false and Reconcile is a silent no-op — no Envoy
+// resources created anywhere, LB status untouched.
+func TestEnvoyReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+
+	idx0, idx1 := int32(0), int32(1)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
+			},
+			// Both entries pinned so ValidateSimulatedMCClusterIndices passes and the
+			// no-op is attributable to LocalizeToCluster (not validation).
+			Clusters: &[]searchv1.ClusterSpec{
+				{ClusterName: "cluster-a", ClusterIndex: &idx0},
+				{ClusterName: "cluster-b", ClusterIndex: &idx1},
+			},
+		},
+	}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+
+	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-c")
+
+	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
+
+	// No Envoy Deployment / ConfigMap at any index on the central client.
+	for _, i := range []int{0, 1, 2} {
+		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(i), Namespace: "ns"}, &appsv1.Deployment{})),
+			"Envoy Deployment at index %d must not exist", i)
+		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+			types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(i), Namespace: "ns"}, &corev1.ConfigMap{})),
+			"Envoy ConfigMap at index %d must not exist", i)
+	}
+
+	// LB status untouched: the no-op returns before any status patch.
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	assert.Nil(t, patched.Status.LoadBalancer, "no-match reconcile must not write loadBalancer status")
+}
+
+// Simulated-MC: a spec.clusters[] entry missing its ClusterIndex must fail
+// validation BEFORE LocalizeToCluster, surfacing on status.loadBalancer with the
+// exact ValidateSimulatedMCClusterIndices message.
+func TestEnvoyReconcile_SimulatedMC_MissingClusterIndex_Invalid(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+
+	idx0 := int32(0)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
+			},
+			Clusters: &[]searchv1.ClusterSpec{
+				{ClusterName: "cluster-a", ClusterIndex: &idx0},
+				{ClusterName: "cluster-b"}, // missing ClusterIndex
+			},
+		},
+	}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-a")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err, "workflow.Invalid returns nil error; assert via status.loadBalancer")
+
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	require.NotNil(t, patched.Status.LoadBalancer, "Envoy controller must write loadBalancer status on validation failure")
+	assert.Equal(t, status.PhaseFailed, patched.Status.LoadBalancer.Phase,
+		"missing clusterIndex must surface as Failed on loadBalancer status")
+	// workflow.Invalid capitalizes the first char, so match on the stable substring.
+	assert.Contains(t, patched.Status.LoadBalancer.Message,
+		"multi-cluster mode requires clusterIndex on every spec.clusters[] entry (missing on",
+		"message must come from ValidateSimulatedMCClusterIndices")
+}
+
+// Simulated-MC dual-index fix through the FULL Envoy Reconcile: operator's
+// cluster is pinned to a NON-ZERO index (7), memberClusterClientsMap is empty
+// (so the work item falls back to kubeClient), state CM carries {cluster-b:7}.
+// The Envoy Deployment + ConfigMap must render at the index-7 name, nothing at 0.
+func TestEnvoyReconcile_SimulatedMC_Match_RendersAtPinnedIndex(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+
+	idx0, idx7 := int32(0), int32(7)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
+			},
+			Clusters: &[]searchv1.ClusterSpec{
+				{ClusterName: "cluster-a", ClusterIndex: &idx0},
+				{ClusterName: "cluster-b", ClusterIndex: &idx7},
+			},
+		},
+	}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"cluster-b": 7})
+
+	// memberClusterClientsMap empty: simulated-MC falls back to kubeClient (= central).
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-b")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	require.NotNil(t, patched.Status.LoadBalancer)
+	assert.Equal(t, status.PhaseRunning, patched.Status.LoadBalancer.Phase,
+		"pinned-index reconcile should succeed; got msg=%q", patched.Status.LoadBalancer.Message)
+
+	// Resources rendered at the pinned index 7 on the central (kubeClient) client.
+	require.NoError(t, central.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(7), Namespace: "ns"}, &appsv1.Deployment{}),
+		"Envoy Deployment must render at pinned index 7")
+	require.NoError(t, central.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(7), Namespace: "ns"}, &corev1.ConfigMap{}),
+		"Envoy ConfigMap must render at pinned index 7")
+
+	// Nothing at index 0 — the array-position index must not leak through.
+	assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, &appsv1.Deployment{})),
+		"no Envoy Deployment may render at array-position index 0")
+	assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, &corev1.ConfigMap{})),
+		"no Envoy ConfigMap may render at array-position index 0")
+}
+
 // failingWriteClient wraps a client.Client and rejects every write so we can
 // simulate a per-cluster Failed status without needing a real envtest.
 type failingWriteClient struct {

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -16,18 +16,26 @@ parameters here.
 
 from __future__ import annotations
 
+import json
 import os
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 import kubernetes
+import yaml
+from kubernetes.client.rest import ApiException
 from kubetester import create_or_update_secret, read_secret, try_load
+from kubetester.kubetester import KubernetesTester
 from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
 from kubetester.mongodb_user import MongoDBUser
 from kubetester.multicluster_client import MultiClusterClient
 from kubetester.operator import Operator
 from pytest import fixture
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import search_resource_names
+from tests.common.search.search_tester import SearchTester
+from tests.conftest import get_issuer_ca_filepath
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -150,3 +158,191 @@ def _build_user(
         resource["spec"]["passwordSecretKeyRef"]["name"] = f"{name}-password"
     resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
     return resource
+
+
+# ---------------------------------------------------------------------------
+# Comprehensive happy-path helpers (shared by RS + sharded variants)
+# ---------------------------------------------------------------------------
+
+
+def assert_per_cluster_count(per_cluster: List, expected: int = 2) -> None:
+    """Vacuous-green guard: every per-cluster loop test must iterate `expected`
+    clusters. Without this a fixture that silently yields 0 entries makes the
+    loop body never run, so the test passes while asserting nothing.
+    """
+    assert len(per_cluster) == expected, (
+        f"expected {expected} per-cluster entries to iterate, got {len(per_cluster)}; "
+        f"a per-cluster loop test over fewer clusters would be vacuously green"
+    )
+
+
+def assert_foreign_resources_absent(
+    mcc: MultiClusterClient,
+    mdbs_name: str,
+    foreign_idx: int,
+    namespace: str,
+    *,
+    sharded: bool = False,
+    shard_names: List[str] | None = None,
+) -> None:
+    """Assert THIS cluster's client cannot see the OTHER cluster's index-suffixed
+    Search resources — proves the per-operator LocalizeToCluster projection only
+    materialises its own slice (no cross-cluster fan-out leak).
+
+    Every read must raise 404 (IsNotFound). A read that SUCCEEDS fails the test;
+    any non-404 ApiException is re-raised (don't mask RBAC/connectivity errors as
+    "absent").
+    """
+
+    def _assert_404(read_fn: Callable[[], object], what: str) -> None:
+        try:
+            read_fn()
+        except ApiException as exc:
+            if exc.status == 404:
+                return
+            raise
+        raise AssertionError(
+            f"[{mcc.cluster_name}] foreign resource {what} (idx={foreign_idx}) is present "
+            f"but must NOT exist on this cluster — LocalizeToCluster must only materialise the local slice"
+        )
+
+    apps = mcc.apps_v1_api()
+    if sharded:
+        assert shard_names, "sharded=True requires shard_names"
+        for shard_name in shard_names:
+            sts = search_resource_names.shard_statefulset_name(mdbs_name, shard_name, foreign_idx)
+            svc = search_resource_names.shard_service_name(mdbs_name, shard_name, foreign_idx)
+            proxy = search_resource_names.shard_proxy_service_name(mdbs_name, shard_name, foreign_idx)
+            cm = search_resource_names.shard_configmap_name(mdbs_name, shard_name, foreign_idx)
+            _assert_404(lambda n=sts: mcc.read_namespaced_stateful_set(n, namespace), f"STS {sts}")
+            _assert_404(lambda n=svc: mcc.read_namespaced_service(n, namespace), f"Service {svc}")
+            _assert_404(lambda n=proxy: mcc.read_namespaced_service(n, namespace), f"proxy Service {proxy}")
+            _assert_404(lambda n=cm: mcc.read_namespaced_config_map(n, namespace), f"mongot CM {cm}")
+    else:
+        sts = f"{mdbs_name}-search-{foreign_idx}"
+        svc = f"{mdbs_name}-search-{foreign_idx}-svc"
+        proxy = f"{mdbs_name}-search-{foreign_idx}-proxy-svc"
+        cm = f"{mdbs_name}-search-{foreign_idx}-config"
+        _assert_404(lambda: mcc.read_namespaced_stateful_set(sts, namespace), f"STS {sts}")
+        _assert_404(lambda: mcc.read_namespaced_service(svc, namespace), f"Service {svc}")
+        _assert_404(lambda: mcc.read_namespaced_service(proxy, namespace), f"proxy Service {proxy}")
+        _assert_404(lambda: mcc.read_namespaced_config_map(cm, namespace), f"mongot CM {cm}")
+
+    foreign_envoy = search_resource_names.lb_deployment_name(mdbs_name, foreign_idx)
+    _assert_404(
+        lambda: apps.read_namespaced_deployment(name=foreign_envoy, namespace=namespace),
+        f"Envoy Deployment {foreign_envoy}",
+    )
+    logger.info(f"[{mcc.cluster_name}] confirmed foreign idx={foreign_idx} Search resources absent")
+
+
+def read_mongod_set_parameter(
+    pod_name: str,
+    namespace: str,
+    api_client: kubernetes.client.ApiClient,
+) -> Dict[str, object]:
+    """Read /data/automation-mongod.conf inside a mongod pod and return the parsed
+    `setParameter` map. Caller chooses the api_client (member cluster). Generalized
+    from q2_mc_rs_steady._read_mongod_set_parameter — only valid for mongod pods
+    (mongos is stateless and has no automation-mongod.conf; use getParameter there).
+    """
+    raw = KubernetesTester.run_command_in_pod_container(
+        pod_name,
+        namespace,
+        ["cat", "/data/automation-mongod.conf"],
+        api_client=api_client,
+    )
+    parsed = yaml.safe_load(raw) or {}
+    return parsed.get("setParameter", {}) or {}
+
+
+def assert_mongot_host_on_disk(
+    mdb,
+    expected_by_idx: Dict[int, str],
+    member_clients: List[MultiClusterClient],
+    *,
+    pod_name_for_idx: Callable[[object, int], str] | None = None,
+    timeout: int = 300,
+) -> None:
+    """Poll each cluster's first mongod pod and confirm both `mongotHost` and
+    `searchIndexManagementHostAndPort` resolve to `expected_by_idx[cluster_index]`.
+
+    Reads the on-disk /data/automation-mongod.conf so this verifies the AC patch
+    landed AND was applied by the agent. `pod_name_for_idx(mdb, idx)` selects the
+    pod to inspect (defaults to the RS first-member name `{mdb.name}-{idx}-0`).
+    `expected_by_idx` is an explicit cluster_index -> endpoint map so callers can
+    encode either per-cluster locality (RS) or single-path collapse (sharded).
+    """
+    if pod_name_for_idx is None:
+
+        def pod_name_for_idx(m, idx):
+            return f"{m.name}-{idx}-0"
+
+    def check() -> tuple:
+        all_correct = True
+        msgs: List[str] = []
+        for mcc in member_clients:
+            cluster_idx = _idx(mcc)
+            pod_name = pod_name_for_idx(mdb, cluster_idx)
+            expected = expected_by_idx[cluster_idx]
+            try:
+                params = read_mongod_set_parameter(pod_name, mdb.namespace, mcc.api_client)
+                got_host = params.get("mongotHost", "")
+                got_idx_mgmt = params.get("searchIndexManagementHostAndPort", "")
+                if got_host != expected:
+                    all_correct = False
+                    msgs.append(f"[{mcc.cluster_name}] {pod_name}: mongotHost={got_host!r} expected={expected!r}")
+                elif got_idx_mgmt != expected:
+                    all_correct = False
+                    msgs.append(
+                        f"[{mcc.cluster_name}] {pod_name}: searchIndexManagementHostAndPort="
+                        f"{got_idx_mgmt!r} expected={expected!r}"
+                    )
+                else:
+                    msgs.append(f"[{mcc.cluster_name}] {pod_name}: mongotHost={expected} OK")
+            except Exception as exc:
+                all_correct = False
+                msgs.append(f"[{mcc.cluster_name}] {pod_name}: error reading conf: {exc}")
+        return all_correct, "\n".join(msgs)
+
+    run_periodically(check, timeout=timeout, sleep_time=10, msg="per-cluster mongotHost on disk")
+
+
+def per_cluster_search_tester(
+    host: str,
+    username: str,
+    password: str,
+    *,
+    direct: bool = True,
+) -> SearchTester:
+    """SearchTester pinned to a single cluster's mongod/mongos `host` (`name:port`).
+
+    `direct=True` sets directConnection=true so RS topology discovery does not
+    silently follow back to the primary — the connected pod serves the query.
+    `$search` is a read aggregation any node can serve, so readPreference=
+    secondaryPreferred lets a secondary answer. TLS + the issuer CA are always on
+    (the source runs requireTLS).
+    """
+    opts = "directConnection=true&readPreference=secondaryPreferred&" if direct else ""
+    conn_str = f"mongodb://{username}:{password}@{host}/?{opts}authSource=admin"
+    return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
+
+
+def read_state_configmap_mapping(
+    mcc: MultiClusterClient,
+    mdbs_name: str,
+    namespace: str,
+) -> Dict[str, int]:
+    """Read the `{mdbs_name}-state` ConfigMap on `mcc`'s cluster and return its
+    `clusterMapping` dict. In simulated-MC mode each operator narrows spec.clusters[]
+    to its own slice (LocalizeToCluster) before persisting, so this map is LOCAL —
+    it contains only this cluster's entry, written to this member cluster's etcd.
+    """
+    cm = mcc.read_namespaced_config_map(f"{mdbs_name}-state", namespace)
+    raw = (cm.data or {}).get("state")
+    assert raw, (
+        f"[{mcc.cluster_name}] state ConfigMap {mdbs_name}-state missing 'state' key; "
+        f"got keys {list((cm.data or {}).keys())}"
+    )
+    state = json.loads(raw)
+    return state.get("clusterMapping") or {}

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -62,8 +62,11 @@ SOURCE_CERT_PREFIX = "clustercert"
 
 
 @fixture(scope="module")
-def tools_pod(namespace: str) -> mongodb_tools_pod.ToolsPod:
-    return mongodb_tools_pod.get_tools_pod(namespace)
+def tools_pod(namespace: str, member_cluster_clients: List[MultiClusterClient]) -> mongodb_tools_pod.ToolsPod:
+    # Run the tools pod in a mesh-joined member cluster so it can resolve the
+    # cross-cluster RS/mongos member-service DNS. The central operator cluster has
+    # no istio sidecar, so a tools pod there gets "no such host" on member services.
+    return mongodb_tools_pod.get_tools_pod(namespace, api_client=member_cluster_clients[0].api_client)
 
 
 # ---------------------------------------------------------------------------

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_basic.py
@@ -8,11 +8,13 @@ import os
 from typing import List, Tuple
 
 import kubernetes
+import pymongo.errors
 from kubernetes.client import CoreV1Api
 from kubetester import create_or_update_configmap, create_or_update_secret, read_secret, try_load
 from kubetester.certs import create_tls_certs
 from kubetester.certs_mongodb_multi import create_multi_cluster_mongodb_tls_certs
 from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
 from kubetester.mongodb_multi import MongoDBMulti
 from kubetester.mongodb_search import MongoDBSearch
 from kubetester.mongodb_user import MongoDBUser
@@ -22,12 +24,16 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
 from tests.common.search import search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
 from tests.common.search.sharded_search_helper import create_issuer_ca
+from tests.conftest import get_issuer_ca_filepath
 from tests.multicluster.conftest import cluster_spec_list
 from tests.multicluster_search.conftest import (
     ADMIN_USER_NAME,
     ADMIN_USER_PASSWORD,
     ENVOY_LB_REPLICAS,
+    ENVOY_PROXY_PORT,
     MDBS_TLS_CERT_PREFIX,
     MONGOT_USER_NAME,
     MONGOT_USER_PASSWORD,
@@ -38,6 +44,11 @@ from tests.multicluster_search.conftest import (
     _idx,
     _install_simulated_operator,
     _replicate_mongot_user_password_to_members,
+    assert_foreign_resources_absent,
+    assert_mongot_host_on_disk,
+    assert_per_cluster_count,
+    per_cluster_search_tester,
+    read_state_configmap_mapping,
 )
 
 logger = test_logger.get_test_logger(__name__)
@@ -51,6 +62,11 @@ MDBS_RESOURCE_NAME = "mdb-mc-sim-search"
 
 MEMBERS_PER_CLUSTER: List[int | None] = [3, 3]
 MONGOT_REPLICAS_PER_CLUSTER = 3
+
+# Generous index-ready timeout to account for cross-cluster mesh latency during sync.
+SEARCH_INDEX_READY_TIMEOUT = 300
+# mongot may still be in INITIAL_SYNC briefly after the index reports READY.
+SEARCH_QUERY_RETRY_TIMEOUT = 90
 
 # --- TLS-everywhere constants ----------------------------------------------
 # CA ConfigMap (used by MongoDBMulti.spec.security.tls.ca — key: ca-pem/mms-ca.crt).
@@ -433,6 +449,7 @@ def test_replicate_tls_to_members(
 def test_search_running_per_cluster(
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
+    assert_per_cluster_count(per_cluster_mdbs_search)
     for _mcc, mdbs in per_cluster_mdbs_search:
         mdbs.update()
     for mcc, mdbs in per_cluster_mdbs_search:
@@ -445,6 +462,7 @@ def test_per_cluster_resources_exist(
     namespace: str,
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
+    assert_per_cluster_count(per_cluster_mdbs_search)
     for mcc, _mdbs in per_cluster_mdbs_search:
         idx = _idx(mcc)
         sts_name = f"{MDBS_RESOURCE_NAME}-search-{idx}"
@@ -478,7 +496,229 @@ def test_status_per_cluster_local_only(
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
     """No cross-cluster status awareness in simulated-MC mode; each cluster's CR view reports its own phase."""
+    assert_per_cluster_count(per_cluster_mdbs_search)
     for mcc, mdbs in per_cluster_mdbs_search:
         mdbs.load()
         phase = mdbs.get_status_phase()
         assert phase == Phase.Running, f"[{mcc.cluster_name}] MongoDBSearch {mdbs.name} phase={phase}, expected Running"
+
+
+# ---------------------------------------------------------------------------
+# Per-cluster mongotHost locality (the unique value of the LocalizeToCluster topology)
+# ---------------------------------------------------------------------------
+
+
+def _expected_mongot_host_by_idx(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> dict:
+    """cluster_index -> THAT cluster's LOCAL Envoy proxy-svc FQDN:port.
+
+    Each entry is the cluster's own proxy svc — NOT a single shared cluster's — so
+    a regression that funnels every mongod through one cluster's Envoy is caught.
+    """
+    return {
+        _idx(mcc): (
+            f"{search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, _idx(mcc))}:{ENVOY_PROXY_PORT}"
+        )
+        for mcc in member_cluster_clients
+    }
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_patch_per_cluster_mongot_host(
+    namespace: str,
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Patch the OM automation config so each cluster's mongods use THEIR OWN cluster-local
+    Envoy proxy-svc FQDN for mongotHost + searchIndexManagementHostAndPort.
+
+    MongoDBMultiCluster does not expose per-cluster additionalMongodConfig, so (exactly
+    as q2_mc_rs_steady) the per-process AC keys are set directly. Leaving them out of the
+    CR spec ensures subsequent operator reconciles never clobber this per-cluster locality.
+    """
+    member_cluster_clients = member_cluster_clients[:2]
+    expected_by_idx = _expected_mongot_host_by_idx(namespace, member_cluster_clients)
+    logger.info(f"per-cluster mongotHost map: {expected_by_idx}")
+
+    om_tester = mdb.get_om_tester()
+    ac_path = f"/groups/{om_tester.context.project_id}/automationConfig"
+    ac = om_tester.om_request("get", ac_path).json()
+
+    process_prefix = f"{mdb.name}-"
+    patched_processes: List[str] = []
+    for process in ac.get("processes", []):
+        process_name = process.get("name", "")
+        if not process_name.startswith(process_prefix):
+            continue
+        try:
+            cluster_idx = int(process_name[len(process_prefix) :].split("-")[0])
+        except ValueError:
+            continue
+        if cluster_idx not in expected_by_idx:
+            continue
+
+        mongot_host = expected_by_idx[cluster_idx]
+        set_parameter = process.setdefault("args2_6", {}).setdefault("setParameter", {})
+        set_parameter["mongotHost"] = mongot_host
+        set_parameter["searchIndexManagementHostAndPort"] = mongot_host
+        patched_processes.append(f"{process_name}->{mongot_host}")
+
+    assert patched_processes, (
+        f"no AC processes matched prefix {process_prefix!r}; "
+        f"AC contained {[p.get('name') for p in ac.get('processes', [])]}"
+    )
+    logger.info(f"patched {len(patched_processes)} processes: {patched_processes}")
+
+    ac["version"] = ac.get("version", 0) + 1
+    om_tester.om_request("put", ac_path, json_object=ac)
+    logger.info(f"PUT automation config v{ac['version']} with per-cluster mongotHost")
+
+    # Block until every mongod applies the new goal version — setParameter changes restart processes.
+    om_tester.wait_agents_ready(timeout=900)
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_per_cluster_mongot_host_observed(
+    namespace: str,
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """On-disk read-back: each cluster's first mongod must show ITS OWN cluster-local
+    proxy-svc FQDN in mongotHost + searchIndexManagementHostAndPort. Proves per-cluster
+    locality landed AND was applied by the agent (not just accepted by OM REST).
+    """
+    member_cluster_clients = member_cluster_clients[:2]
+    expected_by_idx = _expected_mongot_host_by_idx(namespace, member_cluster_clients)
+    assert_mongot_host_on_disk(mdb, expected_by_idx, member_cluster_clients)
+
+
+# ---------------------------------------------------------------------------
+# Data plane: seed data + $search index (once on source RS) + per-cluster query
+# ---------------------------------------------------------------------------
+
+
+def _source_rs_search_tester(mdb: MongoDBMulti, username: str, password: str) -> SearchTester:
+    """SearchTester pointed at the source MongoDBMulti RS via mesh DNS, using
+    ?replicaSet=... so the driver discovers the primary for writes (restore + index).
+    """
+    seed_host = f"{mdb.name}-0-0-svc.{mdb.namespace}.svc.cluster.local:27017"
+    conn_str = f"mongodb://{username}:{password}@{seed_host}/?replicaSet={mdb.name}&authSource=admin"
+    return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
+    """mongorestore sample_mflix into the source RS (a single logical RS; every
+    per-cluster mongot syncs from it, so one restore feeds both clusters' mongots).
+    """
+    tester = _source_rs_search_tester(mdb, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    tester.mongorestore_from_url(
+        archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
+        ns_include="sample_mflix.*",
+        tools_pod=tools_pod,
+    )
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_create_search_index(mdb: MongoDBMulti):
+    """Create the $search index ONCE against the source RS — mongot replication
+    propagates it to every per-cluster mongot. (Per-cluster applies to the QUERY, not
+    the index: creating it N times via direct connections would be redundant.)
+    """
+    tester = _source_rs_search_tester(mdb, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+    movies.create_search_index()
+    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_per_cluster_search_query(
+    namespace: str,
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """$search direct-connected to EACH cluster's own mongod — proves each cluster's
+    independent mongod -> local-Envoy -> local-mongot path returns rows. This is the
+    unique value of the per-operator LocalizeToCluster topology: not just the cluster
+    currently holding the primary, but every cluster's local data path.
+    """
+    member_cluster_clients = member_cluster_clients[:2]
+    assert_per_cluster_count(member_cluster_clients)
+
+    for mcc in member_cluster_clients:
+        cluster_index = _idx(mcc)
+        pod_host = f"{mdb.name}-{cluster_index}-0-svc.{mdb.namespace}.svc.cluster.local:27017"
+        tester = per_cluster_search_tester(pod_host, USER_NAME, USER_PASSWORD, direct=True)
+        movies = SampleMoviesSearchHelper(search_tester=tester)
+
+        def execute_search(_ci: int = cluster_index) -> tuple:
+            try:
+                results = movies.text_search_movies("Star Wars")
+                count = len(results)
+                if count > 0:
+                    titles = [r.get("title") for r in results[:5]]
+                    logger.info(f"cluster_index={_ci}: $search returned {count} results: {titles}")
+                    return True, f"cluster_index={_ci}: $search returned {count} results"
+                return False, f"cluster_index={_ci}: $search returned no results"
+            except pymongo.errors.PyMongoError as exc:
+                return False, f"cluster_index={_ci}: $search error: {exc}"
+
+        run_periodically(
+            execute_search,
+            timeout=SEARCH_QUERY_RETRY_TIMEOUT,
+            sleep_time=5,
+            msg=f"cluster_index={cluster_index}: $search via local mongod",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-cluster isolation + persisted state
+# ---------------------------------------------------------------------------
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_cross_cluster_isolation_absence(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Each cluster must NOT contain the OTHER cluster's index-suffixed Search resources.
+    Confirms each simulated operator only materialises its own LocalizeToCluster slice.
+    """
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    indices = [_idx(mcc) for mcc, _ in per_cluster_mdbs_search]
+    for mcc, _mdbs in per_cluster_mdbs_search:
+        this_idx = _idx(mcc)
+        for foreign_idx in indices:
+            if foreign_idx == this_idx:
+                continue
+            assert_foreign_resources_absent(mcc, MDBS_RESOURCE_NAME, foreign_idx, namespace)
+
+
+@mark.e2e_search_simulated_mc_basic
+def test_state_configmap_mapping_persisted(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Each cluster's `{mdbs}-state` ConfigMap pins clusterMapping[thisCluster]==thisIndex.
+
+    Simulated-MC narrows spec.clusters[] to the local slice (LocalizeToCluster) before
+    persisting, so the mapping is LOCAL: it holds this cluster's entry only and must NOT
+    leak the foreign cluster's name. This is the per-cluster index-pinning source of truth.
+    """
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    names = {mcc.cluster_name for mcc, _ in per_cluster_mdbs_search}
+    for mcc, _mdbs in per_cluster_mdbs_search:
+        mapping = read_state_configmap_mapping(mcc, MDBS_RESOURCE_NAME, namespace)
+        assert mapping.get(mcc.cluster_name) == _idx(mcc), (
+            f"[{mcc.cluster_name}] state clusterMapping[{mcc.cluster_name!r}]={mapping.get(mcc.cluster_name)!r}, "
+            f"want {_idx(mcc)}"
+        )
+        foreign = names - {mcc.cluster_name}
+        for other in foreign:
+            assert other not in mapping, (
+                f"[{mcc.cluster_name}] state clusterMapping leaked foreign cluster {other!r}: {mapping} — "
+                f"simulated-MC operators persist a LOCAL-only mapping"
+            )
+        logger.info(f"[{mcc.cluster_name}] persisted local clusterMapping={mapping}")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded_basic.py
@@ -51,6 +51,9 @@ from tests.multicluster_search.conftest import (
     _idx,
     _install_simulated_operator,
     _replicate_mongot_user_password_to_members,
+    assert_foreign_resources_absent,
+    assert_per_cluster_count,
+    read_state_configmap_mapping,
 )
 
 logger = test_logger.get_test_logger(__name__)
@@ -542,6 +545,7 @@ def test_search_cr_reaches_running_per_cluster(
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
     """Same CR applied to each member; each simulated operator stamps Running on its own slice."""
+    assert_per_cluster_count(per_cluster_mdbs_search)
     for _mcc, mdbs in per_cluster_mdbs_search:
         mdbs.update()
     for mcc, mdbs in per_cluster_mdbs_search:
@@ -555,6 +559,7 @@ def test_per_cluster_sharded_resources_exist(
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
     """Each member materialises its own (cluster, shard) mongot STS/Svc/CM/proxy + per-cluster Envoy LB."""
+    assert_per_cluster_count(per_cluster_mdbs_search)
     for mcc, _mdbs in per_cluster_mdbs_search:
         ci = _idx(mcc)
         for shard_idx in range(SHARD_COUNT):
@@ -591,6 +596,7 @@ def test_status_per_cluster_local_only(
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
     """No cross-cluster status awareness in simulated-MC mode; each cluster reports its own slice's phase."""
+    assert_per_cluster_count(per_cluster_mdbs_search)
     for mcc, mdbs in per_cluster_mdbs_search:
         mdbs.load()
         phase = mdbs.get_status_phase()
@@ -643,8 +649,18 @@ def test_per_cluster_search_query(
     namespace: str,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    """$search via each cluster's local mongos — proves both clusters' Envoy + per-shard mongot data path returns rows."""
+    """$search via each cluster's local mongos.
+
+    Honesty note: this exercises ONLY cluster-0's data path. In MC sharded mode both
+    mongos share a single spec.mongos.additionalMongodConfig (one mongotHost value), so
+    each cluster's mongos routes mongot traffic to cluster-0's Envoy via Istio east-west.
+    Querying through each cluster's mongos therefore proves per-cluster mongos
+    connectivity, but the per-shard mongot data path that actually serves the rows is
+    cluster-0's — cluster-1's per-shard mongots are not exercised by these queries.
+    test_mongos_mongot_host_single_path makes this single-path reality explicit on disk.
+    """
     member_cluster_clients = member_cluster_clients[:2]
+    assert_per_cluster_count(member_cluster_clients)
     for mcc in member_cluster_clients:
         cluster_index = _idx(mcc)
         tester = _per_cluster_mongos_search_tester(namespace, cluster_index, USER_NAME, USER_PASSWORD)
@@ -668,3 +684,102 @@ def test_per_cluster_search_query(
             sleep_time=5,
             msg=f"cluster_index={cluster_index}: $search via local mongos",
         )
+
+
+# ---------------------------------------------------------------------------
+# Single-path read-back + cross-cluster isolation + persisted state
+# ---------------------------------------------------------------------------
+
+
+@mark.e2e_search_simulated_mc_sharded_basic
+def test_mongos_mongot_host_single_path(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Read-back proving the single-path reality: BOTH clusters' mongos report mongotHost
+    pointing at cluster-0's Envoy proxy endpoint.
+
+    MC sharded mongos share one spec.mongos.additionalMongodConfig, so the operator stamps
+    the same cluster-0 mongotHost on every mongos. We read it via `getParameter` over each
+    cluster's local mongos (directConnection) rather than the on-disk automation-mongod.conf
+    because mongos is stateless and has no automation-mongod.conf. expected_by_idx is
+    {0: ep0, 1: ep0} — the explicit assertion that cluster-1's mongos is NOT cluster-local.
+    """
+    member_cluster_clients = member_cluster_clients[:2]
+    assert_per_cluster_count(member_cluster_clients)
+
+    cluster0_endpoint = (
+        f"{search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, 0)}:{ENVOY_PROXY_PORT}"
+    )
+    expected_by_idx = {_idx(mcc): cluster0_endpoint for mcc in member_cluster_clients}
+
+    for mcc in member_cluster_clients:
+        ci = _idx(mcc)
+        tester = _per_cluster_mongos_search_tester(namespace, ci, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+        params = tester.client.admin.command(
+            {"getParameter": 1, "mongotHost": 1, "searchIndexManagementHostAndPort": 1}
+        )
+        got_host = params.get("mongotHost", "")
+        got_idx_mgmt = params.get("searchIndexManagementHostAndPort", "")
+        assert got_host == expected_by_idx[ci], (
+            f"[{mcc.cluster_name}] mongos mongotHost={got_host!r}, expected cluster-0 endpoint "
+            f"{expected_by_idx[ci]!r} (both mongos share one additionalMongodConfig → single path)"
+        )
+        assert got_idx_mgmt == expected_by_idx[ci], (
+            f"[{mcc.cluster_name}] mongos searchIndexManagementHostAndPort={got_idx_mgmt!r}, "
+            f"expected cluster-0 endpoint {expected_by_idx[ci]!r}"
+        )
+        logger.info(f"[{mcc.cluster_name}] mongos mongotHost={got_host} (cluster-0 single-path confirmed)")
+
+
+@mark.e2e_search_simulated_mc_sharded_basic
+def test_cross_cluster_isolation_absence(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Each cluster must NOT contain the OTHER cluster's per-(cluster,shard) Search resources.
+    Confirms each simulated operator only materialises its own LocalizeToCluster slice.
+    """
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    shard_names = [f"{MDB_RESOURCE_NAME}-{shard_idx}" for shard_idx in range(SHARD_COUNT)]
+    indices = [_idx(mcc) for mcc, _ in per_cluster_mdbs_search]
+    for mcc, _mdbs in per_cluster_mdbs_search:
+        this_idx = _idx(mcc)
+        for foreign_idx in indices:
+            if foreign_idx == this_idx:
+                continue
+            assert_foreign_resources_absent(
+                mcc,
+                MDBS_RESOURCE_NAME,
+                foreign_idx,
+                namespace,
+                sharded=True,
+                shard_names=shard_names,
+            )
+
+
+@mark.e2e_search_simulated_mc_sharded_basic
+def test_state_configmap_mapping_persisted(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Each cluster's `{mdbs}-state` ConfigMap pins clusterMapping[thisCluster]==thisIndex.
+
+    Simulated-MC narrows spec.clusters[] to the local slice (LocalizeToCluster) before
+    persisting, so the mapping is LOCAL: it holds this cluster's entry only and must NOT
+    leak the foreign cluster's name. This is the per-cluster index-pinning source of truth.
+    """
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    names = {mcc.cluster_name for mcc, _ in per_cluster_mdbs_search}
+    for mcc, _mdbs in per_cluster_mdbs_search:
+        mapping = read_state_configmap_mapping(mcc, MDBS_RESOURCE_NAME, namespace)
+        assert mapping.get(mcc.cluster_name) == _idx(mcc), (
+            f"[{mcc.cluster_name}] state clusterMapping[{mcc.cluster_name!r}]={mapping.get(mcc.cluster_name)!r}, "
+            f"want {_idx(mcc)}"
+        )
+        for other in names - {mcc.cluster_name}:
+            assert other not in mapping, (
+                f"[{mcc.cluster_name}] state clusterMapping leaked foreign cluster {other!r}: {mapping} — "
+                f"simulated-MC operators persist a LOCAL-only mapping"
+            )
+        logger.info(f"[{mcc.cluster_name}] persisted local clusterMapping={mapping}")


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1126

## Chain of upstream PRs as of 2026-06-03

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1126:
      `search/ga-base` ← `search/simulated-mc`

      * **PR #1177 (THIS ONE)**:
        `search/simulated-mc` ← `search/simulated-mc-comprehensive-tests`

<!-- end git-machete generated -->

## Summary

Stacked on top of #1126 (`search/simulated-mc`). Elevates the simulated-multi-cluster MongoDBSearch tests from basic/scaffold to **comprehensive**, and fixes a startup-timing race in the sharded path that the new coverage exposes.

Three reviewable commits:

1. **`test(search)`: comprehensive Go unit tests** — full-`Reconcile()` coverage for the Envoy reconciler in simulated-MC mode (no-match silent no-op; missing-`clusterIndex` Invalid with message pin; renders at the *resolved* pinned index, not spec-array position); a Failed-first multi-cluster worst-of-phase aggregation test (mutation-verified); message pin on the main-controller enforcement subtest; `AssignClusterIndices` last-write-wins row.
2. **`test(search)`: comprehensive simulated-MC e2e** — RS now proves the **per-cluster data plane** end to end (per-process automation-config `mongotHost` → each cluster's LOCAL Envoy, on-disk locality read-back, `$search` index on the source, real `$search` through each cluster's own mongod). Cross-cluster resource-isolation (absence) assertions, state-ConfigMap mapping persistence, and `len`-guards against vacuous-green loops. Sharded: corrected the per-cluster `$search` docstring (mongos share one `additionalMongodConfig` → only cluster-0's data path is exercised) + a `getParameter` read-back making that explicit; isolation + state-CM + guards. Shared helpers extracted to `conftest.py`.
3. **`fix(search)`: retry mongot bootstrap on simulated-MC sharded source** — on the sharded path mongot dials mongos over TLS at startup; when the cross-cluster Istio mTLS mesh hasn't converged, the handshake is terminated far-side, mongot exits 1, and Kubernetes CrashLoopBackOffs it (5-min backoff), consuming the readiness window. Wraps the existing mongot command in a bounded shell retry loop so a transient bootstrap failure no longer trips the crashloop trap. **Gated to simulated-MC + sharded only** — central-MC and single-cluster StatefulSets are byte-identical; no ga-base-owned file touched.

## Notes for review

- No assertions were weakened to make anything pass. Three Go cases that are unreachable through `Reconcile()` (the `-1`→Pending sentinel + Pending-aggregation legs — `resolveClusterMapping` persists the mapping before `buildClusterWorkList`, so every entry is always mapped) were **not faked**; that branch looks vestigial and is flagged for a possible follow-up cleanup.
- The sharded `$search` single-path limitation is structural (MC sharded mongos share one config), documented rather than worked around.

## Verification

- `go build ./...` clean; `go test ./controllers/operator/ ./controllers/searchcontroller/ ./api/mongodb/v1/search/` all `ok` (uncached).
- `py_compile` clean on all touched test files.
- E2E validated in CI (this patch).

## Tickets

KUBE-32
