### PR TITLE
[KUBE-96] Add `connection_keepalive` setting in envoy config

### DIFF
--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -241,6 +241,10 @@ func buildFilterChain(route envoyRoute, tlsEnabled bool, caKeyName string) (*lis
 		Http2ProtocolOptions: &corev3.Http2ProtocolOptions{
 			InitialConnectionWindowSize: wrapperspb.UInt32(1048576),
 			InitialStreamWindowSize:     wrapperspb.UInt32(1048576),
+			ConnectionKeepalive: &corev3.KeepaliveSettings{
+				Interval: durationpb.New(60 * time.Second),
+				Timeout:  durationpb.New(10 * time.Second),
+			},
 		},
 		StreamIdleTimeout: durationpb.New(300 * time.Second),
 		RequestTimeout:    durationpb.New(300 * time.Second),
@@ -305,6 +309,10 @@ func buildCluster(route envoyRoute, tlsEnabled bool, caKeyName string) (*cluster
 					Http2ProtocolOptions: &corev3.Http2ProtocolOptions{
 						InitialConnectionWindowSize: wrapperspb.UInt32(1048576),
 						InitialStreamWindowSize:     wrapperspb.UInt32(1048576),
+						ConnectionKeepalive: &corev3.KeepaliveSettings{
+							Interval: durationpb.New(60 * time.Second),
+							Timeout:  durationpb.New(10 * time.Second),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
# Summary

Apple had started testing search with external mongodb and while doing the test they encountered a problem where the queries from mongod to mongot errored out with below message if no queries were sent for ~6 minutes or in other words if the connection was idle for ~6 minutes.

```
MongoServerError: Error connecting to Search Index Management service.
```

They had very simple setup where they installed operator and search resource on EKS and the MongoDB was being installed externally. To expose the MCK managed load balancer to the outside they were creating a K8s service of type `LoadBalancer`, which resulted in an AWS NLB getting created. And the DNS of that AWS NLB is what was being configured in mongod config for the mongod -> mognot communication.

Looking at the error message it felt like the connection is being dropped by the AWS NLB if the TCP connection is idle for more than ~6 minutes and after further investigation we saw that the default timeout for aws NLB is 350s which means that if the TCP connection is idle for more than 350 seconds, AWS NBL would drop that TCP connection and that's what was happening.

This PR fixes that problem and to fix that, we have changed the envoy config (upstream as well as downstream) to make sure that envoy sends the PING frame every 60s in the TCP connection and if the PING frame is sent on the TCP connection every 60s, AWS NLB would not see this TCP connection as idle and would not close the connection. Which would result into the issue getting fixed.


The change just configure the envoy to send the PING frames which shouldn't affect the mongod connection behaviour at all.

## Proof of Work

Manually tested in local setup as well with apple.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
