### PR TITLE
CLOUDP-407997: Add release promote

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -60,7 +60,7 @@ github.com/prometheus/procfs,v0.16.1,https://github.com/prometheus/procfs/blob/v
 github.com/r3labs/diff/v3,v3.0.2,https://github.com/r3labs/diff/blob/v3.0.2/LICENSE,MPL-2.0
 github.com/ryanuber/go-glob,v1.0.0,https://github.com/ryanuber/go-glob/blob/v1.0.0/LICENSE,MIT
 github.com/spf13/cast,v1.10.0,https://github.com/spf13/cast/blob/v1.10.0/LICENSE,MIT
-github.com/spf13/pflag,v1.0.9,https://github.com/spf13/pflag/blob/v1.0.9/LICENSE,BSD-3-Clause
+github.com/spf13/pflag,v1.0.10,https://github.com/spf13/pflag/blob/v1.0.10/LICENSE,BSD-3-Clause
 github.com/stretchr/objx,v0.5.3,https://github.com/stretchr/objx/blob/v0.5.3/LICENSE,MIT
 github.com/stretchr/testify/assert,v1.11.1,https://github.com/stretchr/testify/blob/v1.11.1/LICENSE,MIT
 github.com/vmihailenco/msgpack/v5,v5.4.1,https://github.com/vmihailenco/msgpack/blob/v5.4.1/LICENSE,BSD-2-Clause

--- a/cmd/kubectl-mongodb/LICENSE-THIRD-PARTY
+++ b/cmd/kubectl-mongodb/LICENSE-THIRD-PARTY
@@ -19,7 +19,7 @@ github.com/modern-go/reflect2,v1.0.2,https://github.com/modern-go/reflect2/blob/
 github.com/munnerz/goautoneg,v0.0.0-20191010083416-a7dc8b61c822,https://github.com/munnerz/goautoneg/blob/a7dc8b61c822/LICENSE,BSD-3-Clause
 github.com/pkg/errors,v0.9.1,https://github.com/pkg/errors/blob/v0.9.1/LICENSE,BSD-2-Clause
 github.com/spf13/cobra,v1.10.2,https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt,Apache-2.0
-github.com/spf13/pflag,v1.0.9,https://github.com/spf13/pflag/blob/v1.0.9/LICENSE,BSD-3-Clause
+github.com/spf13/pflag,v1.0.10,https://github.com/spf13/pflag/blob/v1.0.10/LICENSE,BSD-3-Clause
 github.com/x448/float16,v0.8.4,https://github.com/x448/float16/blob/v0.8.4/LICENSE,MIT
 go.yaml.in/yaml/v2,v2.4.2,https://github.com/yaml/go-yaml/blob/v2.4.2/LICENSE,Apache-2.0
 google.golang.org/protobuf,v1.36.11,https://github.com/protocolbuffers/protobuf-go/blob/v1.36.11/LICENSE,BSD-3-Clause

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -77,16 +77,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -127,12 +127,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.1"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.2"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.9.1
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.9.2
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.9.0
+  replaces: mongodb-kubernetes.v1.9.1
   version: 0.0.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0
+	github.com/google/go-containerregistry v0.21.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.8
@@ -59,8 +60,11 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
+	github.com/docker/cli v29.4.0+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
@@ -91,7 +95,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -104,6 +108,8 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -111,7 +117,9 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
+github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -26,6 +28,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
+github.com/docker/cli v29.4.0+incompatible h1:+IjXULMetlvWJiuSI0Nbor36lcJ5BTcVpUmB21KBoVM=
+github.com/docker/cli v29.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
+github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
@@ -97,6 +103,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-containerregistry v0.21.5 h1:KTJG9Pn/jC0VdZR6ctV3/jcN+q6/Iqlx0sTVz3ywZlM=
+github.com/google/go-containerregistry v0.21.5/go.mod h1:ySvMuiWg+dOsRW0Hw8GYwfMwBlNRTmpYBFJPlkco5zU=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -148,8 +156,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -196,6 +204,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
@@ -220,12 +232,15 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
+github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
-github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -239,6 +254,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
+github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.9.1
+version: 1.9.2
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.9.1
+  version: 1.9.2
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.9.1
+  version: 1.9.2
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -146,11 +146,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.9.1
+  version: 1.9.2
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.9.1
+  version: 1.9.2
 
 ## Ops Manager
 opsManager:
@@ -158,7 +158,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.9.1
+  version: 1.9.2
 
 agent:
   name: mongodb-agent

--- a/internal/ci/cli/release.go
+++ b/internal/ci/cli/release.go
@@ -1,0 +1,15 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func newReleaseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "release",
+		Short: "Release automation commands",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newReleasePromoteCmd())
+	return cmd
+}

--- a/internal/ci/cli/release_promote.go
+++ b/internal/ci/cli/release_promote.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 
@@ -54,9 +55,15 @@ func newReleasePromoteCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 
-	_ = cmd.MarkFlagRequired("image")
-	_ = cmd.MarkFlagRequired("commit")
-	_ = cmd.MarkFlagRequired("version")
+	MustNotErr(cmd.MarkFlagRequired("image"))
+	MustNotErr(cmd.MarkFlagRequired("commit"))
+	MustNotErr(cmd.MarkFlagRequired("version"))
 
 	return cmd
+}
+
+func MustNotErr(err error) {
+	if err != nil {
+		log.Fatalf("fatal error: %v", err)
+	}
 }

--- a/internal/ci/cli/release_promote.go
+++ b/internal/ci/cli/release_promote.go
@@ -23,23 +23,25 @@ func newReleasePromoteCmd() *cobra.Command {
 		Use:   "promote",
 		Short: "Promote a candidate image by applying promoted-latest and promoted-{commit}-{version} tags",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			promoter := release.NewOCIPromoter(registryURL, repo)
-			tags, err := release.Promote(release.PromoteInputs{
+			client := release.NewRegistryClient(registryURL)
+			tags, err := client.Promote(release.PromoteInputs{
 				Image:   image,
 				Commit:  commit,
 				Version: version,
+				Repo:    repo,
 				DryRun:  dryRun,
-			}, promoter)
+			})
 			if err != nil {
 				return err
 			}
 			for _, tag := range tags {
+				var line string
 				if dryRun {
-					_, err = fmt.Fprintf(cmd.OutOrStdout(), "dry-run: would copy %s → %s/%s:%s\n", image, registryURL, repo, tag)
+					line = fmt.Sprintf("dry-run: would copy %s → %s/%s:%s\n", image, registryURL, repo, tag)
 				} else {
-					_, err = fmt.Fprintf(cmd.OutOrStdout(), "promoted: %s/%s:%s\n", registryURL, repo, tag)
+					line = fmt.Sprintf("promoted: %s/%s:%s\n", registryURL, repo, tag)
 				}
-				if err != nil {
+				if _, err := fmt.Fprint(cmd.OutOrStdout(), line); err != nil {
 					return err
 				}
 			}
@@ -52,7 +54,6 @@ func newReleasePromoteCmd() *cobra.Command {
 	cmd.Flags().StringVar(&version, "version", "", "version to encode in the promoted tag (required)")
 	cmd.Flags().StringVar(&registryURL, "registry", "https://quay.io", "target OCI registry base URL")
 	cmd.Flags().StringVar(&repo, "repo", "mongodb/mongodb-kubernetes-operator", "target image repository")
-
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 
 	MustNotErr(cmd.MarkFlagRequired("image"))

--- a/internal/ci/cli/release_promote.go
+++ b/internal/ci/cli/release_promote.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mongodb/mongodb-kubernetes/internal/ci/release"
+)
+
+func newReleasePromoteCmd() *cobra.Command {
+	var (
+		image       string
+		commit      string
+		version     string
+		registryURL string
+		repo        string
+		dryRun      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "promote",
+		Short: "Promote a candidate image by applying promoted-latest and promoted-{commit}-{version} tags",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			promoter := release.NewOCIPromoter(registryURL, repo)
+			tags, err := release.Promote(release.PromoteInputs{
+				Image:   image,
+				Commit:  commit,
+				Version: version,
+				DryRun:  dryRun,
+			}, promoter)
+			if err != nil {
+				return err
+			}
+			for _, tag := range tags {
+				if dryRun {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "dry-run: would copy %s → %s/%s:%s\n", image, registryURL, repo, tag)
+				} else {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "promoted: %s/%s:%s\n", registryURL, repo, tag)
+				}
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&image, "image", "", "source image reference to promote (required)")
+	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to encode in the promoted tag (required)")
+	cmd.Flags().StringVar(&version, "version", "", "version to encode in the promoted tag (required)")
+	cmd.Flags().StringVar(&registryURL, "registry", "https://quay.io", "target OCI registry base URL")
+	cmd.Flags().StringVar(&repo, "repo", "mongodb/mongodb-kubernetes-operator", "target image repository")
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+
+	_ = cmd.MarkFlagRequired("image")
+	_ = cmd.MarkFlagRequired("commit")
+	_ = cmd.MarkFlagRequired("version")
+
+	return cmd
+}

--- a/internal/ci/cli/root.go
+++ b/internal/ci/cli/root.go
@@ -27,6 +27,7 @@ func NewRoot() *cobra.Command {
 	}
 
 	root.AddCommand(newVersionCmd())
+	root.AddCommand(newReleaseCmd())
 
 	return root
 }

--- a/internal/ci/release/promote.go
+++ b/internal/ci/release/promote.go
@@ -3,11 +3,6 @@ package release
 import (
 	"errors"
 	"fmt"
-	"strings"
-
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 const PromotedTagPrefix = "promoted-"
@@ -17,14 +12,8 @@ func PromotedTagFor(commit, version string) string {
 	return PromotedTagPrefix + commit + "-" + version
 }
 
-// promotedLatestTag returns the rolling tag for the most recently promoted candidate.
 func promotedLatestTag() string {
 	return PromotedTagPrefix + "latest"
-}
-
-// Promoter copies a source image to one or more tags in the target registry.
-type Promoter interface {
-	CopyWithTags(srcRef string, tags []string) error
 }
 
 // PromoteInputs are the parameters for a promote operation.
@@ -32,12 +21,11 @@ type PromoteInputs struct {
 	Image   string // source image reference (required)
 	Commit  string // commit SHA for the promoted tag name (required)
 	Version string // version for the promoted tag name (required)
-	DryRun  bool   // if true, return the tags that would be applied without copying
+	Repo    string // target repository under the registry host (required)
+	DryRun  bool
 }
 
-// Promote copies the source image to promoted-{commit}-{version} and promoted-latest,
-// and returns the list of tags that were applied.
-func Promote(inputs PromoteInputs, promoter Promoter) ([]string, error) {
+func promote(inputs PromoteInputs, t Transport) ([]string, error) {
 	if inputs.Image == "" {
 		return nil, errors.New("image is required")
 	}
@@ -47,6 +35,9 @@ func Promote(inputs PromoteInputs, promoter Promoter) ([]string, error) {
 	if inputs.Version == "" {
 		return nil, errors.New("version is required")
 	}
+	if inputs.Repo == "" {
+		return nil, errors.New("repo is required")
+	}
 
 	tags := []string{
 		PromotedTagFor(inputs.Commit, inputs.Version),
@@ -55,52 +46,8 @@ func Promote(inputs PromoteInputs, promoter Promoter) ([]string, error) {
 	if inputs.DryRun {
 		return tags, nil
 	}
-	if err := promoter.CopyWithTags(inputs.Image, tags); err != nil {
+	if err := t.CopyWithTags(inputs.Image, inputs.Repo, tags); err != nil {
 		return nil, fmt.Errorf("promote %s: %w", inputs.Image, err)
 	}
 	return tags, nil
-}
-
-// gcrPromoter implements Promoter via google/go-containerregistry.
-type gcrPromoter struct {
-	host     string
-	repo     string
-	insecure bool
-}
-
-// NewOCIPromoter returns a Promoter that copies images into the given registry+repo.
-func NewOCIPromoter(baseURL, repo string) Promoter {
-	insecure := strings.HasPrefix(baseURL, "http://")
-	host := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
-	return &gcrPromoter{host: host, repo: repo, insecure: insecure}
-}
-
-func (p *gcrPromoter) CopyWithTags(srcRef string, tags []string) error {
-	src, err := name.ParseReference(srcRef, p.nameOpts()...)
-	if err != nil {
-		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
-	}
-
-	desc, err := remote.Get(src, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err != nil {
-		return fmt.Errorf("get %s: %w", srcRef, err)
-	}
-
-	for _, tag := range tags {
-		dst, err := name.NewTag(fmt.Sprintf("%s/%s:%s", p.host, p.repo, tag), p.nameOpts()...)
-		if err != nil {
-			return fmt.Errorf("parse target tag %s: %w", tag, err)
-		}
-		if err := remote.Tag(dst, desc, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-			return fmt.Errorf("tag %s: %w", tag, err)
-		}
-	}
-	return nil
-}
-
-func (p *gcrPromoter) nameOpts() []name.Option {
-	if p.insecure {
-		return []name.Option{name.Insecure}
-	}
-	return nil
 }

--- a/internal/ci/release/promote.go
+++ b/internal/ci/release/promote.go
@@ -1,0 +1,106 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const PromotedTagPrefix = "promoted-"
+
+// PromotedTagFor constructs the immutable tag for a specific commit+version candidate.
+func PromotedTagFor(commit, version string) string {
+	return PromotedTagPrefix + commit + "-" + version
+}
+
+// promotedLatestTag returns the rolling tag for the most recently promoted candidate.
+func promotedLatestTag() string {
+	return PromotedTagPrefix + "latest"
+}
+
+// Promoter copies a source image to one or more tags in the target registry.
+type Promoter interface {
+	CopyWithTags(srcRef string, tags []string) error
+}
+
+// PromoteInputs are the parameters for a promote operation.
+type PromoteInputs struct {
+	Image   string // source image reference (required)
+	Commit  string // commit SHA for the promoted tag name (required)
+	Version string // version for the promoted tag name (required)
+	DryRun  bool   // if true, return the tags that would be applied without copying
+}
+
+// Promote copies the source image to promoted-{commit}-{version} and promoted-latest,
+// and returns the list of tags that were applied.
+func Promote(inputs PromoteInputs, promoter Promoter) ([]string, error) {
+	if inputs.Image == "" {
+		return nil, errors.New("image is required")
+	}
+	if inputs.Commit == "" {
+		return nil, errors.New("commit is required")
+	}
+	if inputs.Version == "" {
+		return nil, errors.New("version is required")
+	}
+
+	tags := []string{
+		PromotedTagFor(inputs.Commit, inputs.Version),
+		promotedLatestTag(),
+	}
+	if inputs.DryRun {
+		return tags, nil
+	}
+	if err := promoter.CopyWithTags(inputs.Image, tags); err != nil {
+		return nil, fmt.Errorf("promote %s: %w", inputs.Image, err)
+	}
+	return tags, nil
+}
+
+// gcrPromoter implements Promoter via google/go-containerregistry.
+type gcrPromoter struct {
+	host     string
+	repo     string
+	insecure bool
+}
+
+// NewOCIPromoter returns a Promoter that copies images into the given registry+repo.
+func NewOCIPromoter(baseURL, repo string) Promoter {
+	insecure := strings.HasPrefix(baseURL, "http://")
+	host := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+	return &gcrPromoter{host: host, repo: repo, insecure: insecure}
+}
+
+func (p *gcrPromoter) CopyWithTags(srcRef string, tags []string) error {
+	src, err := name.ParseReference(srcRef, p.nameOpts()...)
+	if err != nil {
+		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+
+	desc, err := remote.Get(src, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("get %s: %w", srcRef, err)
+	}
+
+	for _, tag := range tags {
+		dst, err := name.NewTag(fmt.Sprintf("%s/%s:%s", p.host, p.repo, tag), p.nameOpts()...)
+		if err != nil {
+			return fmt.Errorf("parse target tag %s: %w", tag, err)
+		}
+		if err := remote.Tag(dst, desc, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+			return fmt.Errorf("tag %s: %w", tag, err)
+		}
+	}
+	return nil
+}
+
+func (p *gcrPromoter) nameOpts() []name.Option {
+	if p.insecure {
+		return []name.Option{name.Insecure}
+	}
+	return nil
+}

--- a/internal/ci/release/promote_test.go
+++ b/internal/ci/release/promote_test.go
@@ -1,0 +1,102 @@
+package release
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestPromote(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const repo = "myorg/myimage"
+
+	// push a source "nightly" image
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	srcDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("image digest: %v", err)
+	}
+	srcRef := fmt.Sprintf("%s/%s:nightly-abc1234", host, repo)
+	ref, err := name.ParseReference(srcRef, name.Insecure)
+	if err != nil {
+		t.Fatalf("parse ref: %v", err)
+	}
+	if err := remote.Write(ref, img); err != nil {
+		t.Fatalf("push source: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		inputs  PromoteInputs
+		wantErr string
+	}{
+		{
+			name:   "happy path",
+			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0"},
+		},
+		{
+			name:    "image required",
+			inputs:  PromoteInputs{Commit: "abc1234", Version: "1.9.0"},
+			wantErr: "image",
+		},
+		{
+			name:    "commit required",
+			inputs:  PromoteInputs{Image: srcRef, Version: "1.9.0"},
+			wantErr: "commit",
+		},
+		{
+			name:    "version required",
+			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234"},
+			wantErr: "version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promoter := NewOCIPromoter(srv.URL, repo)
+			tags, err := Promote(tt.inputs, promoter)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// both promoted tags must point to the same digest as the source
+			for _, tag := range tags {
+				ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, tag), name.Insecure)
+				if err != nil {
+					t.Errorf("parse tag %s: %v", tag, err)
+					continue
+				}
+				desc, err := remote.Get(ref)
+				if err != nil {
+					t.Errorf("tag %s not found after promote: %v", tag, err)
+					continue
+				}
+				if desc.Digest.String() != srcDigest.String() {
+					t.Errorf("tag %s: digest got %q, want %q", tag, desc.Digest, srcDigest)
+				}
+			}
+		})
+	}
+}

--- a/internal/ci/release/promote_test.go
+++ b/internal/ci/release/promote_test.go
@@ -19,23 +19,8 @@ func TestPromote(t *testing.T) {
 	host := strings.TrimPrefix(srv.URL, "http://")
 	const repo = "myorg/myimage"
 
-	// push a source "nightly" image
-	img, err := random.Image(1024, 1)
-	if err != nil {
-		t.Fatalf("random image: %v", err)
-	}
-	srcDigest, err := img.Digest()
-	if err != nil {
-		t.Fatalf("image digest: %v", err)
-	}
 	srcRef := fmt.Sprintf("%s/%s:nightly-abc1234", host, repo)
-	ref, err := name.ParseReference(srcRef, name.Insecure)
-	if err != nil {
-		t.Fatalf("parse ref: %v", err)
-	}
-	if err := remote.Write(ref, img); err != nil {
-		t.Fatalf("push source: %v", err)
-	}
+	srcDigest := pushImage(t, srcRef, name.Insecure)
 
 	tests := []struct {
 		name    string
@@ -44,36 +29,38 @@ func TestPromote(t *testing.T) {
 	}{
 		{
 			name:   "happy path",
-			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0"},
+			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo},
 		},
 		{
 			name:    "image required",
-			inputs:  PromoteInputs{Commit: "abc1234", Version: "1.9.0"},
+			inputs:  PromoteInputs{Commit: "abc1234", Version: "1.9.0", Repo: repo},
 			wantErr: "image",
 		},
 		{
 			name:    "commit required",
-			inputs:  PromoteInputs{Image: srcRef, Version: "1.9.0"},
+			inputs:  PromoteInputs{Image: srcRef, Version: "1.9.0", Repo: repo},
 			wantErr: "commit",
 		},
 		{
 			name:    "version required",
-			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234"},
+			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234", Repo: repo},
 			wantErr: "version",
+		},
+		{
+			name:    "repo required",
+			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0"},
+			wantErr: "repo",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			promoter := NewOCIPromoter(srv.URL, repo)
-			tags, err := Promote(tt.inputs, promoter)
+			client := NewRegistryClient(srv.URL)
+			tags, err := client.Promote(tt.inputs)
 
 			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
-				}
-				if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
 				}
 				return
 			}
@@ -81,7 +68,6 @@ func TestPromote(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			// both promoted tags must point to the same digest as the source
 			for _, tag := range tags {
 				ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, tag), name.Insecure)
 				if err != nil {
@@ -93,10 +79,31 @@ func TestPromote(t *testing.T) {
 					t.Errorf("tag %s not found after promote: %v", tag, err)
 					continue
 				}
-				if desc.Digest.String() != srcDigest.String() {
+				if desc.Digest.String() != srcDigest {
 					t.Errorf("tag %s: digest got %q, want %q", tag, desc.Digest, srcDigest)
 				}
 			}
 		})
 	}
+}
+
+// pushImage pushes a random image to the given reference and returns its digest string.
+func pushImage(t *testing.T, ref string, opts ...name.Option) string {
+	t.Helper()
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	d, err := img.Digest()
+	if err != nil {
+		t.Fatalf("image digest: %v", err)
+	}
+	r, err := name.ParseReference(ref, opts...)
+	if err != nil {
+		t.Fatalf("parse ref %s: %v", ref, err)
+	}
+	if err := remote.Write(r, img); err != nil {
+		t.Fatalf("push %s: %v", ref, err)
+	}
+	return d.String()
 }

--- a/internal/ci/release/registry.go
+++ b/internal/ci/release/registry.go
@@ -1,0 +1,89 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// Transport is the low-level OCI interface. The default implementation talks to
+// a real registry via go-containerregistry; tests can substitute a fake.
+type Transport interface {
+	// CopyWithTags copies srcRef to dstRepo under each of the given tags.
+	CopyWithTags(srcRef string, dstRepo string, tags []string) error
+}
+
+// RegistryClient performs release operations against an OCI registry.
+type RegistryClient struct {
+	host      string
+	insecure  bool
+	transport Transport
+}
+
+// Option configures a RegistryClient.
+type Option func(*RegistryClient)
+
+// WithTransport overrides the default GCR transport. Intended for testing.
+func WithTransport(t Transport) Option {
+	return func(c *RegistryClient) {
+		c.transport = t
+	}
+}
+
+// NewRegistryClient returns a RegistryClient for the given registry base URL.
+// By default it uses the real GCR transport authenticated via DefaultKeychain.
+// Pass WithTransport to override, e.g. in tests.
+func NewRegistryClient(baseURL string, opts ...Option) *RegistryClient {
+	insecure := strings.HasPrefix(baseURL, "http://")
+	host := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+	c := &RegistryClient{host: host, insecure: insecure}
+	for _, o := range opts {
+		o(c)
+	}
+	if c.transport == nil {
+		c.transport = &gcrTransport{host: host, insecure: insecure}
+	}
+	return c
+}
+
+// Promote copies the source image to promoted-{commit}-{version} and promoted-latest.
+func (c *RegistryClient) Promote(inputs PromoteInputs) ([]string, error) {
+	return promote(inputs, c.transport)
+}
+
+// gcrTransport implements Transport via google/go-containerregistry.
+type gcrTransport struct {
+	host     string
+	insecure bool
+}
+
+func (t *gcrTransport) CopyWithTags(srcRef string, dstRepo string, tags []string) error {
+	src, err := name.ParseReference(srcRef, t.nameOpts()...)
+	if err != nil {
+		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+	desc, err := remote.Get(src, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("get %s: %w", srcRef, err)
+	}
+	for _, tag := range tags {
+		dst, err := name.NewTag(fmt.Sprintf("%s/%s:%s", t.host, dstRepo, tag), t.nameOpts()...)
+		if err != nil {
+			return fmt.Errorf("parse target tag %s: %w", tag, err)
+		}
+		if err := remote.Tag(dst, desc, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+			return fmt.Errorf("tag %s: %w", tag, err)
+		}
+	}
+	return nil
+}
+
+func (t *gcrTransport) nameOpts() []name.Option {
+	if t.insecure {
+		return []name.Option{name.Insecure}
+	}
+	return nil
+}

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -344,7 +344,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -403,16 +403,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -339,7 +339,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -392,16 +392,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -440,12 +440,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.1"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.2"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -344,7 +344,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -400,16 +400,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.17.0.tgz"
   },
-  "mongodbOperator": "1.9.1",
-  "initDatabaseVersion": "1.9.1",
-  "initOpsManagerVersion": "1.9.1",
-  "databaseImageVersion": "1.9.1",
+  "mongodbOperator": "1.9.2",
+  "initDatabaseVersion": "1.9.2",
+  "initOpsManagerVersion": "1.9.2",
+  "databaseImageVersion": "1.9.2",
   "agentVersion": "108.0.12.8846-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -97,7 +97,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"
@@ -294,7 +295,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"
@@ -317,7 +319,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"
@@ -340,7 +343,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"


### PR DESCRIPTION
# Summary

Adds `mckctl release promote` the first real release automation step.

This command copies the tested staging image to the release candidate registry, marking it as promotable for release day. This action **must** only be run after all merge tests passed.

Dry-run mode prints what would be promoted without making any changes. Full verification always runs regardless of dry-run.

## Proof of Work

`internal/ci/release/promote_test.go` covers the promote logic with unit tests. 

Manual testing:
```shell
mcktli release promote --dry-run --version # <version> prints the would-be promote commands without touching the registry.
```

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
