### PR TITLE
KUBE-36: steady-state search availability smoke (on the KUBE-17/26 harness)

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1408,6 +1408,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_availability_smoke
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_connectivity_tool_mc_rs
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -903,6 +903,7 @@ task_groups:
       - e2e_search_connectivity_tool
       - e2e_search_connectivity_tool_sharded
       - e2e_search_cds_hot_reload
+      - e2e_search_availability_smoke
     <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.

--- a/docker/mongodb-kubernetes-tests/tests/search/README.md
+++ b/docker/mongodb-kubernetes-tests/tests/search/README.md
@@ -1,0 +1,52 @@
+# Search e2e tests
+
+End-to-end tests for MongoDB Search (`MongoDBSearch`). Single-cluster suites live
+here under `tests/search/`; shared helpers live under `tests/common/search/`.
+
+## Availability tests
+
+Availability tests assert search stays queryable while something happens to the
+deployment (steady state, a pod restart, a config change, a connection drain).
+They share the harness in `tests/common/search/`:
+
+- `connectivity.py` — `SearchConnectivityTool` (one-shot + paging `$search`, with
+  cache-buster queries so a result isn't served stale from mongot's cache) and
+  `ConnectivityVerdict`; plus disruption primitives (`delete_pods`,
+  `hard_kill_pods_by_label`, `wait_for_mongot_statefulset_drained`,
+  `patch_mongot_readiness_probe_to_false`, `paging_baseline_and_fault`).
+- `background_availability_tester.py` — `SearchAvailabilityBackgroundTester`
+  (background load loop; `wait_for_operations`, `verdict`) plus `assert_no_outage`
+  (uninterrupted availability) and `assert_outage_detected` (a fault surfaced).
+- `bootstrap_test_mixins.py` — deployment step mixins (`InstallOperatorTests`,
+  `MongoDBRsDeploymentTests`, `SearchDeploymentTests`, `SearchSampleDataAndIndexTests`)
+  and `SearchE2EFixtures`, configured via `MongoDBRsDeploymentConfig` /
+  `SearchDeploymentConfig`.
+
+### Pattern
+
+Compose the deployment mixins, then run the tester:
+
+```python
+class TestInstallOperator(InstallOperatorTests): ...
+class TestSearchWithReplicaSet(SearchDeploymentTests, MongoDBRsDeploymentTests): ...
+class TestSearchSampleDataAndIndex(SearchSampleDataAndIndexTests, SearchE2EFixtures): ...
+
+class TestSteadyStateAvailability(SearchE2EFixtures):
+    def test_steady_state_availability(self, mdb):
+        tool = SearchConnectivityTool(self._user_tester(mdb))
+        with SearchAvailabilityBackgroundTester(tool, mode="paging") as bg:
+            bg.wait_for_operations(30)        # steady state; or: trigger a fault here
+        assert_no_outage(bg.verdict)          # or assert_outage_detected(...) for faults
+```
+
+`search_availability_smoke.py` (marker `e2e_search_availability_smoke`) is the
+steady-state baseline. A disruption scenario is the same shape with a real
+`delete_pods(...)` / drain call inside the `with` block before the verdict.
+
+## Conventions
+
+- Markers `e2e_search_*`; single-cluster context `e2e_mdb_kind_ubi_cloudqa`
+  (+ om80 / openshift mirrors).
+- GA scope is external mongod sources behind the managed Envoy LB.
+- Each test is written for a specific Evergreen context — verify the active
+  context before running locally.

--- a/docker/mongodb-kubernetes-tests/tests/search/search_availability_smoke.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_availability_smoke.py
@@ -1,0 +1,77 @@
+"""Acceptance smoke: steady-state search availability (single-cluster RS).
+
+Consumes the availability harness (`SearchAvailabilityBackgroundTester` +
+`SearchConnectivityTool`) and the deployment mixins from `tests/common/search`.
+Deploys an external-source replica set with the managed Envoy LB, seeds
+sample_mflix + an index, then runs a background `$search` load and asserts no
+outage under steady state (no disruption). Disruption scenarios extend this by
+injecting a fault between starting the tester and taking the verdict.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tests import test_logger
+from tests.common.search.background_availability_tester import (
+    SearchAvailabilityBackgroundTester,
+    assert_no_outage,
+)
+from tests.common.search.bootstrap_test_mixins import (
+    InstallOperatorTests,
+    MongoDBDeploymentConfig,
+    MongoDBRsDeploymentTests,
+    SampleDataAndIndexConfig,
+    SearchDeploymentConfig,
+    SearchRsDeploymentTests,
+    SearchSampleDataAndIndexTests,
+)
+from tests.common.search.connectivity import SearchConnectivityTool
+from tests.common.search.rs_search_helper import rs_search_tester
+from tests.conftest import get_namespace
+
+logger = test_logger.get_test_logger(__name__)
+
+pytestmark = pytest.mark.e2e_search_availability_smoke
+
+NAMESPACE = get_namespace()
+MDB = MongoDBDeploymentConfig(mdb_resource_name="mdb-rs-avail")
+SEARCH = SearchDeploymentConfig()
+
+# paging-mode operations to observe across the steady-state window
+STEADY_STATE_OPERATIONS = 30
+
+
+class TestInstallOperator(InstallOperatorTests):
+    pass
+
+
+class TestMongoDBDeployment(MongoDBRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSearchDeployment(SearchRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSampleData(SearchSampleDataAndIndexTests):
+    sample_config = SampleDataAndIndexConfig()
+
+    def admin_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.admin_user_name, MDB.admin_user_password)
+
+    def user_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password)
+
+
+class TestSteadyStateAvailability:
+    def test_steady_state_availability(self, namespace: str):
+        tool = SearchConnectivityTool(
+            rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password)
+        )
+        with SearchAvailabilityBackgroundTester(tool, mode="paging") as bg:
+            bg.wait_for_operations(STEADY_STATE_OPERATIONS)
+        assert_no_outage(bg.verdict)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_availability_smoke.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_availability_smoke.py
@@ -12,10 +12,7 @@ from __future__ import annotations
 
 import pytest
 from tests import test_logger
-from tests.common.search.background_availability_tester import (
-    SearchAvailabilityBackgroundTester,
-    assert_no_outage,
-)
+from tests.common.search.background_availability_tester import SearchAvailabilityBackgroundTester, assert_no_outage
 from tests.common.search.bootstrap_test_mixins import (
     InstallOperatorTests,
     MongoDBDeploymentConfig,


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1080

## Chain of upstream PRs as of 2026-06-03

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1080:
      `search/ga-base` ← `lsierant/KUBE-17-connectivity-tool`

      * **PR #1181 (THIS ONE)**:
        `lsierant/KUBE-17-connectivity-tool` ← `search/ga-base-KUBE-36-availability-scaffolding`

<!-- end git-machete generated -->

[skip-ci]

# Summary

Stacked on the KUBE-17/26 search availability harness (PR #1080). KUBE-36's deliverable is the steady-state availability acceptance test: prove `$search` stays continuously queryable on the single-cluster external-source RS + managed Envoy LB topology, using the shared harness rather than a local copy.

This branch is based on `lsierant/KUBE-17-connectivity-tool` (#1080) and adds only:

| File | What |
|---|---|
| `tests/search/search_availability_smoke.py` | Composes the deployment mixins (`InstallOperatorTests` / `MongoDBRsDeploymentTests` / `SearchDeploymentTests` / `SearchSampleDataAndIndexTests`) then runs `SearchAvailabilityBackgroundTester` + `SearchConnectivityTool` under steady-state load and asserts `assert_no_outage`. Marker `e2e_search_availability_smoke`. |
| `tests/search/README.md` | Documents the availability-test pattern over #1080's harness (KUBE-36 acceptance item). |
| `.evergreen-tasks.yml` / `.evergreen.yml` | Registers `e2e_search_availability_smoke` alongside the other search availability tasks. |

An earlier revision shipped a standalone availability runner; that duplicated #1080's `SearchAvailabilityBackgroundTester` / `connectivity.py` / `bootstrap_test_mixins`, so it was dropped in favor of consuming the harness. #1080 is canonical and merges first; this rebases onto it.

## Proof of Work

- e2e: `e2e_search_availability_smoke` **passed locally** on the #1080-based stack (single-cluster kind, cloud-qa) — `17 passed, 1 skipped` (test_create_ops_manager skipped on Cloud Manager), including `TestSteadyStateAvailability::test_steady_state_availability` (`assert_no_outage` over a background `$search` load).
- Imports resolve against #1080's harness modules; `black`/`isort`/`py_compile` clean.
- Stays **draft** (stacked on an internal feature branch).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? (skip-changelog label — test-only)