### PR TITLE
fix: remove redundant update_standalone causing pre-commit infinite loop

### DIFF
--- a/scripts/evergreen/release/helm_files_handler.py
+++ b/scripts/evergreen/release/helm_files_handler.py
@@ -66,30 +66,3 @@ def get_value_in_yaml_file(yaml_file_path: str, key: str):
         doc = yaml.load(fd)
 
     return get_value_in_doc(doc, key)
-
-
-def update_standalone_installer(yaml_file_path: str, version: str):
-    """
-    Updates a bundle of manifests with the correct image version for
-    the operator deployment.
-    """
-    yaml = ruamel.yaml.YAML()
-
-    yaml.explicit_start = True  # Ensure explicit `---` in the output
-    yaml.indent(mapping=2, sequence=4, offset=2)  # Align with tab width produced by Helm
-    yaml.preserve_quotes = True  # Preserve original quotes in the YAML file
-    yaml.width = 4096  # Set a very large line width to prevent inconsistent line wrapping
-
-    with open(yaml_file_path, "r") as fd:
-        data = list(yaml.load_all(fd))  # Convert the generator to a list
-
-    for doc in data:
-        # We're only interested in the Deployments of the operator, where
-        # we change the image version to the one provided in the release.
-        if doc["kind"] == "Deployment":
-            full_image = doc["spec"]["template"]["spec"]["containers"][0]["image"]
-            image = full_image.rsplit(":", 1)[0]
-            doc["spec"]["template"]["spec"]["containers"][0]["image"] = image + ":" + version
-
-    with open(yaml_file_path, "w") as fd:
-        yaml.dump_all(data, fd)

--- a/scripts/evergreen/release/update_helm_values_files.py
+++ b/scripts/evergreen/release/update_helm_values_files.py
@@ -12,13 +12,7 @@ import sys
 from typing import List
 
 from agent_matrix import get_supported_version_for_image
-from helm_files_handler import (
-    get_value_in_yaml_file,
-    set_value_in_yaml_file,
-    update_all_helm_values_files,
-    update_standalone_installer,
-)
-from packaging.version import Version
+from helm_files_handler import get_value_in_yaml_file, set_value_in_yaml_file, update_all_helm_values_files
 
 RELEASE_JSON_TO_HELM_KEY = {
     "mongodbOperator": "operator",
@@ -51,20 +45,9 @@ def main() -> int:
             update_all_helm_values_files(RELEASE_JSON_TO_HELM_KEY[k], release[k])
 
     update_helm_charts(operator_version, release)
-    update_standalone(operator_version)
     update_cluster_service_version(operator_version)
 
     return 0
-
-
-def update_standalone(operator_version):
-    file_paths = [
-        "public/mongodb-kubernetes.yaml",
-        "public/mongodb-kubernetes-openshift.yaml",
-        "public/mongodb-kubernetes-multi-cluster.yaml",
-    ]
-    for file_path in file_paths:
-        update_standalone_installer(file_path, operator_version)
 
 
 def update_helm_charts(operator_version, release):


### PR DESCRIPTION
## Summary

This PR is required for #473.

`update-values-yaml` and `generate-standalone-yaml` are sequential pre-commit hooks that both write to `public/mongodb-kubernetes.yaml` (and the openshift/multi-cluster variants), causing an infinite modification loop that prevents pre-commit from ever converging.

**Root cause:** `update_helm_values_files.py` called `update_standalone_installer()` on the public standalone YAMLs to patch the operator image version. That function uses `ruamel.yaml` with `yaml.indent(mapping=2, sequence=4, offset=2)`, which reformats YAML sequence items with 2 extra spaces of offset. The `generate-standalone-yaml` hook (which runs immediately after) regenerates those same files via `helm template -f helm_chart/values.yaml`, producing helm's native sequence format — undoing the ruamel reformatting. Both hooks detected file modifications on every run.

**Why `update_standalone_installer` was redundant:** `helm_chart/templates/operator.yaml` embeds the operator image version directly from `{{ .Values.operator.version }}`. Since `update-values-yaml` writes the new version into `helm_chart/values.yaml` first, `generate-standalone-yaml`'s `helm template` call already produces public YAMLs with the correct version — no separate patching step is needed.

**Fix:** Remove `update_standalone()` and its now-dead `update_standalone_installer` helper. `update_helm_values_files.py` is only ever invoked via the `update-values-yaml` pre-commit hook, which is always followed by `generate-standalone-yaml`.

## Proof of Work

Running `pre-commit run --all-files` now converges cleanly on every invocation — both `update-values-yaml` and `generate-standalone-yaml` report `Passed` with no file modifications.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details