### PR TITLE
CLOUDP-403367: Rename OperatorConfig multiCluster.clusterClientTimeout to memberClusterClientTimeout

### DIFF
--- a/api/operator/v1/operatorconfig_types.go
+++ b/api/operator/v1/operatorconfig_types.go
@@ -56,12 +56,12 @@ type ProxyConfig struct {
 
 // MultiClusterConfig contains multi-cluster configuration settings.
 type MultiClusterConfig struct {
-	// ClusterClientTimeout is the timeout in seconds for connecting to a member
+	// MemberClusterClientTimeout is the timeout in seconds for connecting to a member
 	// cluster's Kubernetes API server.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=10
-	ClusterClientTimeout int `json:"clusterClientTimeout,omitempty"`
+	MemberClusterClientTimeout int `json:"memberClusterClientTimeout,omitempty"`
 }
 
 // AutomaticRecoveryConfig controls automatic recovery of resources with broken automation configuration.

--- a/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
@@ -137,10 +137,10 @@ spec:
               multiCluster:
                 description: MultiCluster contains multi-cluster configuration.
                 properties:
-                  clusterClientTimeout:
+                  memberClusterClientTimeout:
                     default: 10
                     description: |-
-                      ClusterClientTimeout is the timeout in seconds for connecting to a member
+                      MemberClusterClientTimeout is the timeout in seconds for connecting to a member
                       cluster's Kubernetes API server.
                     minimum: 1
                     type: integer

--- a/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
+++ b/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
@@ -137,10 +137,10 @@ spec:
               multiCluster:
                 description: MultiCluster contains multi-cluster configuration.
                 properties:
-                  clusterClientTimeout:
+                  memberClusterClientTimeout:
                     default: 10
                     description: |-
-                      ClusterClientTimeout is the timeout in seconds for connecting to a member
+                      MemberClusterClientTimeout is the timeout in seconds for connecting to a member
                       cluster's Kubernetes API server.
                     minimum: 1
                     type: integer

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -7704,10 +7704,10 @@ spec:
               multiCluster:
                 description: MultiCluster contains multi-cluster configuration.
                 properties:
-                  clusterClientTimeout:
+                  memberClusterClientTimeout:
                     default: 10
                     description: |-
-                      ClusterClientTimeout is the timeout in seconds for connecting to a member
+                      MemberClusterClientTimeout is the timeout in seconds for connecting to a member
                       cluster's Kubernetes API server.
                     minimum: 1
                     type: integer


### PR DESCRIPTION
# Summary

Renames `spec.multiCluster.clusterClientTimeout` to `spec.multiCluster.memberClusterClientTimeout` in the `OperatorConfig` CRD to better reflect that the timeout applies specifically to member cluster API server connections.


## Proof of Work

N/A

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
