### PR TITLE
CLOUDP-411215: Wire OperatorConfig into operator startup

### DIFF
--- a/config/rbac/operator-roles-base.yaml
+++ b/config/rbac/operator-roles-base.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -22,6 +22,7 @@ from tests import test_logger
 OPERATOR_CRDS = (
     "mongodb.mongodb.com",
     "mongodbusers.mongodb.com",
+    "operatorconfigs.operator.mongodb.com",
     "opsmanagers.mongodb.com",
 )
 

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
@@ -13,6 +13,9 @@ def ops_manager_and_mongodb_crds():
     """Installs OM and MDB CRDs only (we need to do this manually as Helm 3 doesn't support templating for CRDs"""
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_mongodb.yaml")
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_opsmanagers.yaml")
+    create_or_replace_from_yaml(
+        client.api_client.ApiClient(), "helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml"
+    )
 
 
 @fixture(scope="module")
@@ -35,6 +38,9 @@ def operator_only_ops_manager_and_mongodb(
 def mongodb_crds():
     """Installs OM and MDB CRDs only (we need to do this manually as Helm 3 doesn't support templating for CRDs"""
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_mongodb.yaml")
+    create_or_replace_from_yaml(
+        client.api_client.ApiClient(), "helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml"
+    )
 
 
 @fixture(scope="module")
@@ -65,9 +71,10 @@ def test_install_operator_ops_manager_and_mongodb_only(
 @pytest.mark.e2e_operator_partial_crd
 def test_only_ops_manager_and_mongodb_crds_exist():
     operator_crds = list_operator_crds()
-    assert len(operator_crds) == 2
+    assert len(operator_crds) == 3
     assert operator_crds[0].metadata.name == "mongodb.mongodb.com"
-    assert operator_crds[1].metadata.name == "opsmanagers.mongodb.com"
+    assert operator_crds[1].metadata.name == "operatorconfigs.operator.mongodb.com"
+    assert operator_crds[2].metadata.name == "opsmanagers.mongodb.com"
 
 
 @pytest.mark.e2e_operator_partial_crd
@@ -84,5 +91,6 @@ def test_install_operator_mongodb_only(operator_only_mongodb: Operator):
 @pytest.mark.e2e_operator_partial_crd
 def test_only_mongodb_and_users_crds_exists():
     operator_crds = list_operator_crds()
-    assert len(operator_crds) == 1
+    assert len(operator_crds) == 2
     assert operator_crds[0].metadata.name == "mongodb.mongodb.com"
+    assert operator_crds[1].metadata.name == "operatorconfigs.operator.mongodb.com"

--- a/helm_chart/templates/operator-roles-base.yaml
+++ b/helm_chart/templates/operator-roles-base.yaml
@@ -92,6 +92,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 {{- if eq $roleScope "ClusterRole" }}
   - apiGroups:
       - ''

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -52,6 +53,7 @@ import (
 	mcoConstruct "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/controllers/construct" //nolint:depguard
 	"github.com/mongodb/mongodb-kubernetes/pkg/images"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
+	"github.com/mongodb/mongodb-kubernetes/pkg/operatorconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/pprof"
 	"github.com/mongodb/mongodb-kubernetes/pkg/telemetry"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
@@ -131,6 +133,8 @@ func run() error {
 	}
 
 	ctx := signals.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	operator.OmUpdateChannel = make(chan event.GenericEvent)
 
 	klog.InitFlags(nil)
@@ -158,6 +162,8 @@ func run() error {
 
 	// Get a config to talk to the apiserver
 	cfg := ctrl.GetConfigOrDie()
+
+	operatorConfigName := env.ReadOrDefault(util.OperatorConfigNameEnv, util.DefaultOperatorConfigName)
 
 	log.Debugf("Setting up tracing with ID: %s, Parent ID: %s, Endpoint: %s", traceIDHex, spanIDHex, endpoint)
 	ctx, tp, err := telemetry.SetupTracingFromParent(ctx, traceIDHex, spanIDHex, endpoint)
@@ -194,6 +200,19 @@ func run() error {
 		}
 	}
 
+	// Restrict the OperatorConfig informer to the single named instance in the operator's own
+	// namespace. Without this, a change to any OperatorConfig in any watched namespace would
+	// trigger a restart.
+	managerOptions.Cache.ByObject = map[client.Object]cache.ByObject{
+		&operatorv1.OperatorConfig{}: {
+			Namespaces: map[string]cache.Config{
+				currentNamespace: {
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", operatorConfigName),
+				},
+			},
+		},
+	}
+
 	if isInLocalMode() {
 		// managerOptions.MetricsBindAddress = "127.0.0.1:8180"
 		managerOptions.Metrics = metricsServer.Options{
@@ -209,7 +228,17 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	// TODO(m1kola): use operatorCfg to configure controllers as settings are migrated from env vars
+	_, err = operatorconfig.Load(ctx, mgr.GetAPIReader(), currentNamespace, operatorConfigName)
+	if err != nil {
+		return fmt.Errorf("loading OperatorConfig: %w", err)
+	}
+
 	log.Info("Registering Components.")
+
+	if err := mgr.Add(operatorconfig.NewWatcher(mgr.GetCache(), cancel)); err != nil {
+		return err
+	}
 
 	// Setup Scheme for all resources
 	if err := apiv1.AddToScheme(scheme); err != nil {

--- a/pkg/kubectl-mongodb/common/common.go
+++ b/pkg/kubectl-mongodb/common/common.go
@@ -396,6 +396,11 @@ func getCentralRules() []rbacv1.PolicyRule {
 			},
 			APIGroups: []string{"mongodbcommunity.mongodb.com"},
 		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			Resources: []string{"operatorconfigs"},
+			APIGroups: []string{"operator.mongodb.com"},
+		},
 	}
 }
 

--- a/pkg/operatorconfig/operatorconfig.go
+++ b/pkg/operatorconfig/operatorconfig.go
@@ -1,0 +1,39 @@
+package operatorconfig
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+)
+
+// Load fetches the OperatorConfig CR with the given name from the given namespace.
+// If no CR exists, a fully-defaulted config is returned with an empty ResourceVersion.
+func Load(ctx context.Context, c client.Reader, namespace, name string) (operatorv1.OperatorConfig, error) {
+	var cfg operatorv1.OperatorConfig
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &cfg)
+	if apierrors.IsNotFound(err) {
+		return withDefaults(operatorv1.OperatorConfig{}), nil
+	}
+	if err != nil {
+		return operatorv1.OperatorConfig{}, fmt.Errorf("getting OperatorConfig %q in namespace %q: %w", name, namespace, err)
+	}
+	return withDefaults(cfg), nil
+}
+
+// withDefaults fills in Go-side defaults that mirror the CRD schema markers.
+// Required when constructing a spec without the API server's defaulting webhook.
+func withDefaults(cfg operatorv1.OperatorConfig) operatorv1.OperatorConfig {
+	if cfg.Spec.DefaultArchitecture == "" {
+		cfg.Spec.DefaultArchitecture = operatorv1.ArchitectureNonStatic
+	}
+	if cfg.Spec.MaxConcurrentReconciles == 0 {
+		cfg.Spec.MaxConcurrentReconciles = 1
+	}
+	return cfg
+}

--- a/pkg/operatorconfig/operatorconfig_test.go
+++ b/pkg/operatorconfig/operatorconfig_test.go
@@ -1,0 +1,75 @@
+package operatorconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+const testNamespace = "test-ns"
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = operatorv1.AddToScheme(s)
+	return s
+}
+
+func TestLoad_AbsentCR(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ResourceVersion)
+	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
+	assert.Equal(t, 1, cfg.Spec.MaxConcurrentReconciles)
+}
+
+func TestLoad_PresentCR(t *testing.T) {
+	cr := &operatorv1.OperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.DefaultOperatorConfigName,
+			Namespace: testNamespace,
+		},
+		Spec: operatorv1.OperatorConfigSpec{
+			MaxConcurrentReconciles: 4,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+	cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, cfg.Spec.MaxConcurrentReconciles)
+	// DefaultArchitecture was omitted in the CR; withDefaults fills it in
+	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
+	assert.NotEmpty(t, cfg.ResourceVersion)
+}
+
+func TestLoad_ClientError(t *testing.T) {
+	c := &failingClient{fake.NewClientBuilder().WithScheme(testScheme()).Build()}
+
+	_, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.Error(t, err)
+}
+
+// failingClient wraps a fake client and forces Get to return a non-NotFound error.
+type failingClient struct {
+	client.Client
+}
+
+func (f *failingClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return fmt.Errorf("simulated API server failure")
+}

--- a/pkg/operatorconfig/watcher.go
+++ b/pkg/operatorconfig/watcher.go
@@ -1,0 +1,85 @@
+package operatorconfig
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+)
+
+// +kubebuilder:rbac:groups=operator.mongodb.com,resources=operatorconfigs,verbs=get;list;watch,namespace=placeholder
+
+// Watcher watches the single OperatorConfig instance scoped by the manager cache (see
+// ByObject in main.go) and initiates a graceful shutdown when the CR is created, its spec
+// changes, or it is deleted, so the operator can restart and reload its configuration.
+type Watcher struct {
+	cache        cache.Cache
+	cancel       context.CancelFunc
+	shutdownOnce sync.Once
+	synced       atomic.Bool
+}
+
+func NewWatcher(c cache.Cache, cancel context.CancelFunc) *Watcher {
+	return &Watcher{
+		cache:  c,
+		cancel: cancel,
+	}
+}
+
+func (w *Watcher) Start(ctx context.Context) error {
+	informer, err := w.cache.GetInformer(ctx, &operatorv1.OperatorConfig{})
+	if err != nil {
+		return err
+	}
+	reg, err := informer.AddEventHandler(w.newEventHandler())
+	if err != nil {
+		return err
+	}
+
+	// Wait until this registration's initial object replay is complete before marking
+	// the watcher as synced. Until then, AddFunc calls are suppressed (initial sync
+	// replay). informer.HasSynced() is not suitable here — it reflects the informer's
+	// global state, which is already true when Start() runs.
+	if !toolscache.WaitForCacheSync(ctx.Done(), reg.HasSynced) {
+		return nil
+	}
+	w.synced.Store(true)
+
+	<-ctx.Done()
+	return nil
+}
+
+func (w *Watcher) newEventHandler() toolscache.ResourceEventHandlerFuncs {
+	return toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(_ any) {
+			if w.synced.Load() {
+				w.shutdownOnce.Do(func() {
+					zap.S().Info("OperatorConfig created - initiating graceful shutdown for config load")
+					w.cancel()
+				})
+			}
+		},
+		UpdateFunc: func(old, new any) {
+			oldObj, newObj := old.(metav1.Object), new.(metav1.Object)
+			if newObj.GetGeneration() != oldObj.GetGeneration() {
+				w.shutdownOnce.Do(func() {
+					zap.S().Info("OperatorConfig changed - initiating graceful shutdown for config reload")
+					w.cancel()
+				})
+			}
+		},
+		DeleteFunc: func(_ any) {
+			w.shutdownOnce.Do(func() {
+				zap.S().Info("OperatorConfig deleted - initiating graceful shutdown to revert to defaults")
+				w.cancel()
+			})
+		},
+	}
+}

--- a/pkg/operatorconfig/watcher_test.go
+++ b/pkg/operatorconfig/watcher_test.go
@@ -1,0 +1,72 @@
+package operatorconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+)
+
+func TestWatcher_Add(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		synced       bool
+		expectCancel bool
+	}{
+		{name: "creation after cache sync triggers restart", synced: true, expectCancel: true},
+		{name: "creation during initial cache sync is ignored", synced: false, expectCancel: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cancelled := make(chan struct{}, 1)
+			w := &Watcher{cancel: func() { cancelled <- struct{}{} }}
+			w.synced.Store(tc.synced)
+			handler := w.newEventHandler()
+			handler.AddFunc(&operatorv1.OperatorConfig{})
+
+			if tc.expectCancel {
+				assert.Len(t, cancelled, 1)
+			} else {
+				assert.Empty(t, cancelled)
+			}
+		})
+	}
+}
+
+func TestWatcher_Update(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		oldGen       int64
+		newGen       int64
+		expectCancel bool
+	}{
+		{name: "generation changed triggers restart", oldGen: 1, newGen: 2, expectCancel: true},
+		{name: "unchanged generation does not trigger restart", oldGen: 1, newGen: 1, expectCancel: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cancelled := make(chan struct{}, 1)
+			w := &Watcher{cancel: func() { cancelled <- struct{}{} }}
+			handler := w.newEventHandler()
+
+			oldObj := &operatorv1.OperatorConfig{ObjectMeta: metav1.ObjectMeta{Generation: tc.oldGen}}
+			newObj := &operatorv1.OperatorConfig{ObjectMeta: metav1.ObjectMeta{Generation: tc.newGen}}
+			handler.UpdateFunc(oldObj, newObj)
+
+			if tc.expectCancel {
+				assert.Len(t, cancelled, 1)
+			} else {
+				assert.Empty(t, cancelled)
+			}
+		})
+	}
+}
+
+func TestWatcher_Delete(t *testing.T) {
+	cancelled := make(chan struct{}, 1)
+	w := &Watcher{cancel: func() { cancelled <- struct{}{} }}
+	handler := w.newEventHandler()
+	handler.DeleteFunc(&operatorv1.OperatorConfig{})
+	assert.Len(t, cancelled, 1)
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -161,6 +161,10 @@ const (
 	OIDC                              = "OIDC"
 	MinimumScramSha256MdbVersion      = "4.0.0"
 
+	// OperatorConfig variables
+	OperatorConfigNameEnv     = "MDB_OPERATOR_CONFIG_NAME"
+	DefaultOperatorConfigName = "operator-config"
+
 	// pprof variables
 	OperatorPprofEnabledEnv  = "MDB_OPERATOR_PPROF_ENABLED"
 	OperatorPprofPortEnv     = "MDB_OPERATOR_PPROF_PORT"

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
@@ -52,6 +52,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - operator.mongodb.com
+  resources:
+  - operatorconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
@@ -37,6 +37,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - operator.mongodb.com
+  resources:
+  - operatorconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - secrets


### PR DESCRIPTION
# Summary

Infrastructure PR to begin consuming the `OperatorConfig` CRD that was added in #1182.

- `pkg/operatorconfig` — new package with `Load()` (reads the CR, falls back to defaults when absent) (CR name is `operator-config`, overridable via `MDB_OPERATOR_CONFIG_NAME` for non-standard deployments).
- `controllers/operatorconfig` — new reconciler that watches `OperatorConfig` and triggers a graceful manager shutdown when the CR changes or gets deleted, allowing the pod to restart and pick up the new config/defaults.
- `main.go` — loads `OperatorConfig` early in startup (before the manager is created) and registers the reconciler unconditionally (not gated by `--watch-resource` like other CRDs).

What's next

Individual settings will be migrated from env vars to OperatorConfig in follow-up PRs.

## Proof of Work

Tests from the base branch should still pass.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
