### PR TITLE
Add configurable priorityClassName to the operator Helm chart

### DIFF
--- a/changelog/20260608_feature_add_priorityclassname_to_the_operator_helm_chart.md
+++ b/changelog/20260608_feature_add_priorityclassname_to_the_operator_helm_chart.md
@@ -1,0 +1,6 @@
+---
+kind: feature
+date: 2026-06-08
+---
+
+* **Helm Chart**: Added a new `operator.priorityClassName` field that can be used to set the `priorityClassName` of the Operator deployment through the Helm Chart. This allows the Operator pod to be scheduled on clusters where pod priority and preemption are enforced.

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -299,6 +299,9 @@ spec:
         {{- end }}
 
 {{- with .Values.operator }}
+  {{- with .priorityClassName }}
+      priorityClassName: {{ . }}
+  {{- end }}
   {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_chart/tests/operator_priority_class_test.yaml
+++ b/helm_chart/tests/operator_priority_class_test.yaml
@@ -1,0 +1,24 @@
+suite: test operator priorityClassName setting for values.yaml
+templates:
+  - operator.yaml
+tests:
+  - it: priorityClassName is not set by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: priorityClassName is set when provided
+    set:
+      operator.priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+  - it: priorityClassName is set when provided for multi-cluster deployment
+    values:
+      - ../values-multi-cluster.yaml
+    set:
+      operator.priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -33,6 +33,9 @@ operator:
 
   affinity: {}
 
+  # PriorityClass name to assign to the operator pod. Leave empty to not set any priorityClassName.
+  priorityClassName: ''
+
   # operator cpu requests and limits
   resources:
     requests:


### PR DESCRIPTION
# Summary

On clusters where pod priority and preemption are enforced, the operator pod can become unschedulable because its `Deployment` does not expose a `priorityClassName`, making the operator unusable on large environments.

This PR adds an `operator.priorityClassName` Helm value that sets `priorityClassName` on the operator Deployment pod template, following the same conditional rendering pattern as the existing `nodeSelector`, `affinity` and `tolerations` values. It is omitted when left empty (the default), so existing installations are unaffected.

Fixes #609

## Proof of Work

`helm template` renders the field only when the value is set:

```console
$ helm template helm_chart --set operator.priorityClassName=high-priority | grep priorityClassName
      priorityClassName: high-priority
```

A new `helm_chart/tests/operator_priority_class_test.yaml` suite covers the default-absent, set, and multi-cluster cases. All chart tests pass with `helm unittest helm_chart`.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
