### PR TITLE
KUBE-38: config-change + TLS-rotation search availability e2e [skip-ci]

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1428,6 +1428,16 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_availability_config_change
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_search_availability_tls_rotation
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_cds_hot_reload
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -909,6 +909,8 @@ task_groups:
       - e2e_search_availability_infra
       - e2e_search_availability_upgrade
       - e2e_search_availability_upgrade_operator
+      - e2e_search_availability_config_change
+      - e2e_search_availability_tls_rotation
     <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.

--- a/docker/mongodb-kubernetes-tests/tests/search/README.md
+++ b/docker/mongodb-kubernetes-tests/tests/search/README.md
@@ -29,6 +29,8 @@ sub-check** that force-drains past the buffer to prove the cursor fault is obser
 | `search_availability_infra.py` | `e2e_search_availability_infra` | node drain (cordon + evict), operator restart |
 | `search_availability_upgrade_dataplane.py` | `e2e_search_availability_upgrade` | mongot version upgrade (`spec.version`), envoy image upgrade (`MDB_ENVOY_IMAGE`, CI-only) |
 | `search_availability_upgrade_operator.py` | `e2e_search_availability_upgrade_operator` | operator-version upgrade (released → dev) on managed LB, CI-only: no-image-bump gratuitous-roll measurement, then default-image-bump |
+| `search_availability_config_change.py` | `e2e_search_availability_config_change` | mongot `resourceRequirements` change (rolls mongot StatefulSet), envoy `resourceRequirements` change (rolls managed-LB Deployment); each touches only its own group |
+| `search_availability_tls_rotation.py` | `e2e_search_availability_tls_rotation` | search-server TLS cert rotation (`spec.security.tls.certsSecretPrefix` → freshly-issued prefix; rolls mongot + envoy onto the new cert) |
 
 The operator-version upgrade suite deploys on the **latest released operator** (single-cluster
 managed Envoy LB shipped in MCK 1.8.0) and upgrades to this build — the real customer chart-upgrade
@@ -58,6 +60,9 @@ shared bootstrap test-class chain, then runs its scenarios with a steady-state g
 | envoy image upgrade | blip → recover | ride-through or transient drop → reopen | n/a (CI-only) |
 | operator default-image-bump | blip → recover | ride-through or transient drop → reopen | n/a (CI-only) |
 | operator no-image-bump | continuous | continuous (control plane off the data path) | n/a (measures gratuitous rolls) |
+| mongot resource change | blip → recover | ride-through or transient drop → reopen | n/a (one-shot transition; envoy untouched) |
+| envoy resource change | blip → recover | ride-through or transient drop → reopen | n/a (one-shot transition; mongot untouched) |
+| TLS cert rotation | blip → recover | ride-through or transient drop → reopen | n/a (one-shot transition; rolls both) |
 
 Assertions check availability *properties*, never exact operation counts. The roll cursor cells
 assert the open cursor serves *fresh* pages after recovery (succeeded grows past a post-recovery

--- a/docker/mongodb-kubernetes-tests/tests/search/search_availability_config_change.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_availability_config_change.py
@@ -1,0 +1,193 @@
+"""Search availability across MongoDBSearch config changes that roll a pod group.
+
+Two pod-spec resource changes on one deployment, each driven through the MongoDBSearch CR:
+a mongot ``spec.clusters[].resourceRequirements`` change (rolls the mongot StatefulSet) and an
+envoy ``spec.loadBalancer.managed.resourceRequirements`` change (rolls the managed-LB Deployment).
+Each runs a background-tester window across the roll and asserts post-recovery progress (the open
+cursor serves fresh pages after the roll), emitting a per-run roll count and recovery time, and
+asserts the change touched only its own group. Both reconcile a CR field, so they run anywhere.
+Version/image upgrades live in search_availability_upgrade_dataplane.py; TLS-cert rotation in
+search_availability_tls_rotation.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from tests import test_logger
+from tests.common.search import search_resource_names
+from tests.common.search.background_availability_tester import SearchAvailabilityBackgroundTester, assert_no_outage
+from tests.common.search.bootstrap_test_mixins import (
+    InstallOperatorTests,
+    MongoDBDeploymentConfig,
+    MongoDBRsDeploymentTests,
+    SampleDataAndIndexConfig,
+    SearchDeploymentConfig,
+    SearchRsDeploymentTests,
+    SearchSampleDataAndIndexTests,
+)
+from tests.common.search.connectivity import SearchConnectivityTool, wait_for_all_pods_replaced
+from tests.common.search.rs_search_helper import rs_search_tester
+from tests.common.search.search_deployment_helper import SearchDeploymentHelper
+from tests.common.search.upgrade_availability import assert_rolled_through as _assert_rolled_through
+from tests.common.search.upgrade_availability import pod_uids as _pod_uids
+from tests.common.search.upgrade_availability import roll_count as _roll_count
+from tests.conftest import get_namespace
+
+logger = test_logger.get_test_logger(__name__)
+
+pytestmark = pytest.mark.e2e_search_availability_config_change
+
+NAMESPACE = get_namespace()
+MDB = MongoDBDeploymentConfig(mdb_resource_name="mdb-rs-avail-cfg")
+SEARCH = SearchDeploymentConfig()
+MDBS_NAME = MDB.mdb_resource_name
+MONGOT_SELECTOR = f"app={search_resource_names.mongot_service_name_for_cluster(MDBS_NAME)}"
+ENVOY_DEPLOYMENT = search_resource_names.lb_deployment_name(MDBS_NAME)
+ENVOY_SELECTOR = f"app={ENVOY_DEPLOYMENT}"
+
+BASELINE_OPS = 30
+POST_EVENT_OPS = 15
+
+# Sustained-outage ceiling for a managed-LB ride-through; the surviving replica serves through a
+# one-at-a-time roll, so the real value is small. Fails a pathological run.
+DISRUPTION_BOUND_S = 60.0
+
+# Resource bumps that differ from the bootstrap defaults (mongot_cpu=1/mongot_memory=2Gi), so the
+# operator sees a real pod-spec change and rolls the group. Kept small to stay within node capacity.
+_MONGOT_RESOURCES = {"requests": {"cpu": "150m", "memory": "256Mi"}, "limits": {"cpu": "600m", "memory": "640Mi"}}
+
+
+# --- shared helpers -------------------------------------------------------
+
+
+def _emit_metric(path: str, *, rolls_mongot: int, rolls_envoy: int, recovery_s: float, disruption_s: float) -> None:
+    """One greppable SEARCH_CONFIG_METRIC line per path; the roll/disruption stories cite it from the log."""
+    logger.info(
+        f"SEARCH_CONFIG_METRIC path={path} rolls_mongot={rolls_mongot} rolls_envoy={rolls_envoy} "
+        f"recovery_s={recovery_s:.1f} disruption_s={disruption_s:.1f}"
+    )
+
+
+def _user_tool(namespace: str) -> SearchConnectivityTool:
+    """A fresh tool (own pymongo client) per call — never share one across concurrent testers."""
+    return SearchConnectivityTool(rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password))
+
+
+def _load_mdbs(namespace: str) -> MongoDBSearch:
+    helper = SearchDeploymentHelper(
+        namespace=namespace,
+        mdb_resource_name=MDB.mdb_resource_name,
+        mdbs_resource_name=MDBS_NAME,
+        ca_configmap_name=MDB.ca_configmap_name,
+    )
+    return helper.mdbs_for_ext_rs_source(
+        MDB.mongot_user_name,
+        members=MDB.rs_members,
+        lb_mode="Managed",
+        clusters=[{"replicas": SEARCH.mongot_replicas}],
+    )
+
+
+def _assert_steady(namespace: str) -> None:
+    """Recovery/steady-state gate: a clean window on both query types (fresh client per tester)."""
+    _user_tool(namespace).wait_for_sentinel_indexed(timeout=300)
+    for mode in ("oneshot", "paging"):
+        with SearchAvailabilityBackgroundTester(_user_tool(namespace), mode=mode, interval_seconds=0.1) as bg:
+            bg.wait_for_operations(BASELINE_OPS)
+        assert_no_outage(bg.verdict)
+
+
+# --- deploy chain (once per file) -----------------------------------------
+
+
+class TestInstallOperator(InstallOperatorTests):
+    pass
+
+
+class TestMongoDBDeployment(MongoDBRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSearchDeployment(SearchRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSampleData(SearchSampleDataAndIndexTests):
+    sample_config = SampleDataAndIndexConfig()
+
+    def admin_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.admin_user_name, MDB.admin_user_password)
+
+    def user_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password)
+
+
+# --- scenario: mongot resourceRequirements change (CR spec.clusters[].resourceRequirements) ---
+
+
+class TestMongotResourceChange:
+    def test_steady_state_before(self, namespace: str):
+        _assert_steady(namespace)
+
+    def test_mongot_resource_change_availability(self, namespace: str):
+        """Set spec.clusters[0].resourceRequirements: the mongot StatefulSet rolls one pod at a time,
+        the surviving replica serves new queries, and the open cursor serves fresh pages after recovery.
+        A mongot-only change must leave envoy untouched."""
+        oneshot = SearchAvailabilityBackgroundTester(_user_tool(namespace), mode="oneshot", interval_seconds=0.2)
+        paging = SearchAvailabilityBackgroundTester(
+            _user_tool(namespace), mode="paging", paging_batch_size=5, paging_reset_every=50_000, interval_seconds=0.05
+        )
+        with oneshot, paging:
+            oneshot.wait_for_operations(BASELINE_OPS)
+            paging.wait_for_operations(BASELINE_OPS)
+            mongot_before = _pod_uids(namespace, MONGOT_SELECTOR)
+            envoy_before = _pod_uids(namespace, ENVOY_SELECTOR)
+            mdbs = _load_mdbs(namespace)
+            mdbs.load()
+            mdbs["spec"]["clusters"][0]["resourceRequirements"] = _MONGOT_RESOURCES
+            t0 = time.monotonic()
+            mdbs.update()
+            wait_for_all_pods_replaced(namespace, mongot_before)
+            mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+            recovery_s = time.monotonic() - t0
+            ok_at_recovery = paging.succeeded_count  # snapshot once pods are Ready again
+            oneshot.wait_for_operations(POST_EVENT_OPS)
+            paging.wait_for_operations(POST_EVENT_OPS)
+            ok_after = paging.succeeded_count
+        disruption_s = paging.max_consecutive_failure * paging.interval_seconds
+        rolls_mongot = _roll_count(namespace, MONGOT_SELECTOR, mongot_before)
+        rolls_envoy = _roll_count(namespace, ENVOY_SELECTOR, envoy_before)
+        logger.info(f"mongot-resources oneshot verdict: {oneshot.verdict.as_dict()}")
+        _emit_metric(
+            "mongot-resources",
+            rolls_mongot=rolls_mongot,
+            rolls_envoy=rolls_envoy,
+            recovery_s=recovery_s,
+            disruption_s=disruption_s,
+        )
+        assert (
+            rolls_mongot >= SEARCH.mongot_replicas
+        ), f"expected all {SEARCH.mongot_replicas} mongot to roll, got {rolls_mongot}"
+        assert (
+            rolls_envoy == 0
+        ), f"a mongot resource change must not disturb envoy, but {rolls_envoy} envoy pod(s) rolled"
+        _assert_rolled_through(
+            paging.verdict,
+            ok_at_recovery,
+            ok_after,
+            "mongot-resources",
+            disruption_s=disruption_s,
+            bound_s=DISRUPTION_BOUND_S,
+        )
+        _assert_steady(namespace)
+
+    def test_recovers_to_steady_state(self, namespace: str):
+        _assert_steady(namespace)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_availability_config_change.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_availability_config_change.py
@@ -29,7 +29,11 @@ from tests.common.search.bootstrap_test_mixins import (
     SearchRsDeploymentTests,
     SearchSampleDataAndIndexTests,
 )
-from tests.common.search.connectivity import SearchConnectivityTool, wait_for_all_pods_replaced
+from tests.common.search.connectivity import (
+    SearchConnectivityTool,
+    wait_for_all_pods_replaced,
+    wait_for_pods_by_label_replaced,
+)
 from tests.common.search.rs_search_helper import rs_search_tester
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.upgrade_availability import assert_rolled_through as _assert_rolled_through
@@ -59,6 +63,7 @@ DISRUPTION_BOUND_S = 60.0
 # Resource bumps that differ from the bootstrap defaults (mongot_cpu=1/mongot_memory=2Gi), so the
 # operator sees a real pod-spec change and rolls the group. Kept small to stay within node capacity.
 _MONGOT_RESOURCES = {"requests": {"cpu": "150m", "memory": "256Mi"}, "limits": {"cpu": "600m", "memory": "640Mi"}}
+_ENVOY_RESOURCES = {"requests": {"cpu": "150m", "memory": "192Mi"}, "limits": {"cpu": "600m", "memory": "640Mi"}}
 
 
 # --- shared helpers -------------------------------------------------------
@@ -184,6 +189,65 @@ class TestMongotResourceChange:
             ok_at_recovery,
             ok_after,
             "mongot-resources",
+            disruption_s=disruption_s,
+            bound_s=DISRUPTION_BOUND_S,
+        )
+        _assert_steady(namespace)
+
+    def test_recovers_to_steady_state(self, namespace: str):
+        _assert_steady(namespace)
+
+
+# --- scenario: envoy resourceRequirements change (CR spec.loadBalancer.managed.resourceRequirements) ---
+
+
+class TestEnvoyResourceChange:
+    def test_steady_state_before(self, namespace: str):
+        _assert_steady(namespace)
+
+    def test_envoy_resource_change_availability(self, namespace: str):
+        """Set spec.loadBalancer.managed.resourceRequirements: the operator rolls the managed-LB
+        Deployment, a surviving envoy replica serves new queries, and the open cursor serves fresh
+        pages after recovery. An envoy-only change must leave mongot untouched."""
+        oneshot = SearchAvailabilityBackgroundTester(_user_tool(namespace), mode="oneshot", interval_seconds=0.2)
+        paging = SearchAvailabilityBackgroundTester(
+            _user_tool(namespace), mode="paging", paging_batch_size=5, paging_reset_every=50_000, interval_seconds=0.05
+        )
+        with oneshot, paging:
+            oneshot.wait_for_operations(BASELINE_OPS)
+            paging.wait_for_operations(BASELINE_OPS)
+            mongot_before = _pod_uids(namespace, MONGOT_SELECTOR)
+            envoy_before = _pod_uids(namespace, ENVOY_SELECTOR)
+            mdbs = _load_mdbs(namespace)
+            mdbs.load()
+            mdbs["spec"]["loadBalancer"]["managed"]["resourceRequirements"] = _ENVOY_RESOURCES
+            t0 = time.monotonic()
+            mdbs.update()
+            wait_for_pods_by_label_replaced(namespace, ENVOY_SELECTOR, envoy_before, expected=SEARCH.envoy_lb_replicas)
+            mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+            recovery_s = time.monotonic() - t0
+            ok_at_recovery = paging.succeeded_count  # snapshot once pods are Ready again
+            oneshot.wait_for_operations(POST_EVENT_OPS)
+            paging.wait_for_operations(POST_EVENT_OPS)
+            ok_after = paging.succeeded_count
+        disruption_s = paging.max_consecutive_failure * paging.interval_seconds
+        rolls_mongot = _roll_count(namespace, MONGOT_SELECTOR, mongot_before)
+        rolls_envoy = _roll_count(namespace, ENVOY_SELECTOR, envoy_before)
+        logger.info(f"envoy-resources oneshot verdict: {oneshot.verdict.as_dict()}")
+        _emit_metric(
+            "envoy-resources",
+            rolls_mongot=rolls_mongot,
+            rolls_envoy=rolls_envoy,
+            recovery_s=recovery_s,
+            disruption_s=disruption_s,
+        )
+        assert rolls_envoy >= 1, f"expected envoy to roll, but rolls_envoy={rolls_envoy}"
+        assert rolls_mongot == 0, f"an envoy resource change must not disturb mongot, but {rolls_mongot} rolled"
+        _assert_rolled_through(
+            paging.verdict,
+            ok_at_recovery,
+            ok_after,
+            "envoy-resources",
             disruption_s=disruption_s,
             bound_s=DISRUPTION_BOUND_S,
         )

--- a/docker/mongodb-kubernetes-tests/tests/search/search_availability_tls_rotation.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_availability_tls_rotation.py
@@ -1,0 +1,208 @@
+"""Search availability across a search-server TLS cert rotation.
+
+Rotates the MongoDBSearch server cert under sustained query load: the deployment starts with the
+harness-default TLS (``certsSecretPrefix=certs``), a fresh LB + search cert is issued under a new
+prefix, and the CR's ``spec.security.tls.certsSecretPrefix`` is pointed at it. Both mongot and envoy
+carry the server cert, so both roll onto the new material; the background tester window asserts the
+open cursor serves fresh pages after recovery. The mongod source stays ``searchTLSMode: requireTLS``
+throughout, so this is a rotation, not an off->on enable (that needs a non-TLS bootstrap variant).
+Resource-spec changes live in search_availability_config_change.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from tests import test_logger
+from tests.common.search import search_resource_names
+from tests.common.search.background_availability_tester import SearchAvailabilityBackgroundTester, assert_no_outage
+from tests.common.search.bootstrap_test_mixins import (
+    InstallOperatorTests,
+    MongoDBDeploymentConfig,
+    MongoDBRsDeploymentTests,
+    SampleDataAndIndexConfig,
+    SearchDeploymentConfig,
+    SearchRsDeploymentTests,
+    SearchSampleDataAndIndexTests,
+)
+from tests.common.search.connectivity import (
+    SearchConnectivityTool,
+    wait_for_all_pods_replaced,
+    wait_for_pods_by_label_replaced,
+)
+from tests.common.search.rs_search_helper import create_rs_lb_certificates, create_rs_search_tls_cert, rs_search_tester
+from tests.common.search.search_deployment_helper import SearchDeploymentHelper, ensure_search_issuer
+from tests.common.search.upgrade_availability import assert_rolled_through as _assert_rolled_through
+from tests.common.search.upgrade_availability import pod_uids as _pod_uids
+from tests.common.search.upgrade_availability import roll_count as _roll_count
+from tests.conftest import get_namespace
+
+logger = test_logger.get_test_logger(__name__)
+
+pytestmark = pytest.mark.e2e_search_availability_tls_rotation
+
+NAMESPACE = get_namespace()
+MDB = MongoDBDeploymentConfig(mdb_resource_name="mdb-rs-avail-tls")
+SEARCH = SearchDeploymentConfig()
+MDBS_NAME = MDB.mdb_resource_name
+MONGOT_SELECTOR = f"app={search_resource_names.mongot_service_name_for_cluster(MDBS_NAME)}"
+ENVOY_DEPLOYMENT = search_resource_names.lb_deployment_name(MDBS_NAME)
+ENVOY_SELECTOR = f"app={ENVOY_DEPLOYMENT}"
+
+BASELINE_OPS = 30
+POST_EVENT_OPS = 15
+
+# Sustained-outage ceiling for a managed-LB ride-through; the surviving replica serves through a
+# one-at-a-time roll, so the real value is small. Fails a pathological run.
+DISRUPTION_BOUND_S = 60.0
+
+# New cert-secret prefix to rotate onto (the bootstrap deploys with SearchDeploymentConfig.tls_cert_prefix).
+_ROTATED_PREFIX = "certs-rot"
+
+
+# --- shared helpers -------------------------------------------------------
+
+
+def _emit_metric(path: str, *, rolls_mongot: int, rolls_envoy: int, recovery_s: float, disruption_s: float) -> None:
+    """One greppable SEARCH_CONFIG_METRIC line per path; the roll/disruption stories cite it from the log."""
+    logger.info(
+        f"SEARCH_CONFIG_METRIC path={path} rolls_mongot={rolls_mongot} rolls_envoy={rolls_envoy} "
+        f"recovery_s={recovery_s:.1f} disruption_s={disruption_s:.1f}"
+    )
+
+
+def _user_tool(namespace: str) -> SearchConnectivityTool:
+    """A fresh tool (own pymongo client) per call — never share one across concurrent testers."""
+    return SearchConnectivityTool(rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password))
+
+
+def _load_mdbs(namespace: str) -> MongoDBSearch:
+    helper = SearchDeploymentHelper(
+        namespace=namespace,
+        mdb_resource_name=MDB.mdb_resource_name,
+        mdbs_resource_name=MDBS_NAME,
+        ca_configmap_name=MDB.ca_configmap_name,
+    )
+    return helper.mdbs_for_ext_rs_source(
+        MDB.mongot_user_name,
+        members=MDB.rs_members,
+        lb_mode="Managed",
+        clusters=[{"replicas": SEARCH.mongot_replicas}],
+    )
+
+
+def _assert_steady(namespace: str) -> None:
+    """Recovery/steady-state gate: a clean window on both query types (fresh client per tester)."""
+    _user_tool(namespace).wait_for_sentinel_indexed(timeout=300)
+    for mode in ("oneshot", "paging"):
+        with SearchAvailabilityBackgroundTester(_user_tool(namespace), mode=mode, interval_seconds=0.1) as bg:
+            bg.wait_for_operations(BASELINE_OPS)
+        assert_no_outage(bg.verdict)
+
+
+# --- deploy chain (once per file) -----------------------------------------
+
+
+class TestInstallOperator(InstallOperatorTests):
+    pass
+
+
+class TestMongoDBDeployment(MongoDBRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSearchDeployment(SearchRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSampleData(SearchSampleDataAndIndexTests):
+    sample_config = SampleDataAndIndexConfig()
+
+    def admin_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.admin_user_name, MDB.admin_user_password)
+
+    def user_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password)
+
+
+# --- scenario: search-server TLS cert rotation (CR spec.security.tls.certsSecretPrefix) ---
+
+
+class TestRotateSearchTLSCert:
+    def test_steady_state_before(self, namespace: str):
+        _assert_steady(namespace)
+
+    def test_issue_rotated_certs(self, namespace: str):
+        """Issue a fresh LB + search cert under the new prefix, mirroring the bootstrap's TLS step.
+        The index-0 headless-svc SAN matches the RS mongot StatefulSet the operator deploys."""
+        issuer = ensure_search_issuer(namespace)
+        create_rs_lb_certificates(namespace, issuer, MDBS_NAME, _ROTATED_PREFIX)
+        indexed_svc = search_resource_names.mongot_service_name_for_cluster(MDBS_NAME)
+        create_rs_search_tls_cert(
+            namespace,
+            issuer,
+            MDBS_NAME,
+            _ROTATED_PREFIX,
+            extra_domains=[f"{indexed_svc}.{namespace}.svc.cluster.local"],
+        )
+
+    def test_tls_rotation_availability(self, namespace: str):
+        """Point certsSecretPrefix at the rotated cert: both mongot (StatefulSet) and envoy (managed-LB
+        Deployment) carry the server cert, so both roll onto the new material while the surviving
+        replica of each serves new queries and the open cursor serves fresh pages after recovery."""
+        oneshot = SearchAvailabilityBackgroundTester(_user_tool(namespace), mode="oneshot", interval_seconds=0.2)
+        paging = SearchAvailabilityBackgroundTester(
+            _user_tool(namespace), mode="paging", paging_batch_size=5, paging_reset_every=50_000, interval_seconds=0.05
+        )
+        with oneshot, paging:
+            oneshot.wait_for_operations(BASELINE_OPS)
+            paging.wait_for_operations(BASELINE_OPS)
+            mongot_before = _pod_uids(namespace, MONGOT_SELECTOR)
+            envoy_before = _pod_uids(namespace, ENVOY_SELECTOR)
+            mdbs = _load_mdbs(namespace)
+            mdbs.load()
+            mdbs["spec"]["security"]["tls"]["certsSecretPrefix"] = _ROTATED_PREFIX
+            t0 = time.monotonic()
+            mdbs.update()
+            wait_for_all_pods_replaced(namespace, mongot_before)
+            wait_for_pods_by_label_replaced(namespace, ENVOY_SELECTOR, envoy_before, expected=SEARCH.envoy_lb_replicas)
+            mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+            recovery_s = time.monotonic() - t0
+            ok_at_recovery = paging.succeeded_count  # snapshot once pods are Ready again
+            oneshot.wait_for_operations(POST_EVENT_OPS)
+            paging.wait_for_operations(POST_EVENT_OPS)
+            ok_after = paging.succeeded_count
+        disruption_s = paging.max_consecutive_failure * paging.interval_seconds
+        rolls_mongot = _roll_count(namespace, MONGOT_SELECTOR, mongot_before)
+        rolls_envoy = _roll_count(namespace, ENVOY_SELECTOR, envoy_before)
+        logger.info(f"tls-rotation oneshot verdict: {oneshot.verdict.as_dict()}")
+        _emit_metric(
+            "tls-rotation",
+            rolls_mongot=rolls_mongot,
+            rolls_envoy=rolls_envoy,
+            recovery_s=recovery_s,
+            disruption_s=disruption_s,
+        )
+        assert (
+            rolls_mongot >= SEARCH.mongot_replicas
+        ), f"expected all {SEARCH.mongot_replicas} mongot to roll onto the new cert, got {rolls_mongot}"
+        assert rolls_envoy >= 1, f"expected envoy to roll onto the new cert, but rolls_envoy={rolls_envoy}"
+        _assert_rolled_through(
+            paging.verdict,
+            ok_at_recovery,
+            ok_after,
+            "tls-rotation",
+            disruption_s=disruption_s,
+            bound_s=DISRUPTION_BOUND_S,
+        )
+        _assert_steady(namespace)
+
+    def test_recovers_to_steady_state(self, namespace: str):
+        _assert_steady(namespace)


### PR DESCRIPTION
[skip-ci] KUBE-38: e2e coverage for MongoDB $search availability across CR config changes.

# Summary

Adds e2e tests asserting that `$search` stays available under sustained query load while MongoDBSearch CR config changes trigger a rolling reconcile, consuming the availability harness (background query tester + connectivity primitives + managed-LB bootstrap deploy) from the parent branches. Two grouped suites:

| Suite (marker) | Config changes |
|---|---|
| `search_availability_config_change.py` (`e2e_search_availability_config_change`) | mongot `spec.clusters[].resourceRequirements` (rolls the mongot StatefulSet); envoy `spec.loadBalancer.managed.resourceRequirements` (rolls the managed-LB Deployment) |
| `search_availability_tls_rotation.py` (`e2e_search_availability_tls_rotation`) | search-server TLS cert rotation — fresh LB + search certs issued under a new prefix, applied via `spec.security.tls.certsSecretPrefix` (rolls mongot + envoy onto the new cert) |

Each suite runs a continuous paging + oneshot background tester across the change, counts mongot/envoy pod rolls, measures recovery/disruption, and asserts availability *properties* — a new query blips and recovers within a disruption bound; an open cursor serves fresh pages after recovery — never exact operation counts. A `SEARCH_CONFIG_METRIC` log line per path carries the roll counts plus recovery/disruption numbers. The resource-change suite additionally asserts group isolation: a mongot change leaves envoy untouched and vice versa.

# Proof of Work

Validated locally against a kind cluster (single-cluster managed LB, cloud-qa) — both markers green:

- `e2e_search_availability_config_change` — 22 passed, 1 skipped; mongot-resources roll (rolls_mongot=2, rolls_envoy=0), envoy-resources roll (rolls_mongot=0, rolls_envoy=2), disruption ≤ 0.1s.
- `e2e_search_availability_tls_rotation` — 20 passed, 1 skipped; cert rotation rolled both groups (rolls_mongot=2, rolls_envoy=2), disruption 0.1s.
- The single skip per run is the in-cluster Ops Manager bring-up, skipped under Cloud Manager.
- Changed test files are `black`/`isort`/`flake8` clean under the repo-pinned versions; both suites collect.

## Notes for reviewer

The TLS scenario is a cert *rotation*, not an off→on enable: the mongod source is `searchTLSMode: requireTLS` throughout (and `mdbs_for_ext_rs_source` always sets `spec.security.tls`), so an off→on toggle would need a dedicated non-TLS bootstrap variant — out of scope here, left as a follow-up. Rotating `certsSecretPrefix` stays inside the supported topology and still rolls both the mongot and envoy cert mounts.

# Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? — `skip-changelog` (test-only, no customer-facing change)
