### PR TITLE
CLOUDP-411215: Add OperatorConfig multiCluster.memberClusterRequiredHealthyStreak

### DIFF
--- a/api/operator/v1/operatorconfig_types.go
+++ b/api/operator/v1/operatorconfig_types.go
@@ -62,6 +62,15 @@ type MultiClusterConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=10
 	MemberClusterClientTimeout int `json:"memberClusterClientTimeout,omitempty"`
+
+	// MemberClusterRequiredHealthyStreak is the number of consecutive successful health
+	// checks required before a previously failed member cluster is considered recovered
+	// and its failed-cluster annotation is removed. Only relevant when automatic failover
+	// is disabled.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:default=5
+	MemberClusterRequiredHealthyStreak int `json:"memberClusterRequiredHealthyStreak,omitempty"`
 }
 
 // AutomaticRecoveryConfig controls automatic recovery of resources with broken automation configuration.

--- a/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
@@ -144,6 +144,15 @@ spec:
                       cluster's Kubernetes API server.
                     minimum: 1
                     type: integer
+                  memberClusterRequiredHealthyStreak:
+                    default: 5
+                    description: |-
+                      MemberClusterRequiredHealthyStreak is the number of consecutive successful health
+                      checks required before a previously failed member cluster is considered recovered
+                      and its failed-cluster annotation is removed. Only relevant when automatic failover
+                      is disabled.
+                    minimum: 1
+                    type: integer
                 type: object
               proxy:
                 description: Proxy contains proxy environment variable propagation

--- a/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
+++ b/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
@@ -144,6 +144,15 @@ spec:
                       cluster's Kubernetes API server.
                     minimum: 1
                     type: integer
+                  memberClusterRequiredHealthyStreak:
+                    default: 5
+                    description: |-
+                      MemberClusterRequiredHealthyStreak is the number of consecutive successful health
+                      checks required before a previously failed member cluster is considered recovered
+                      and its failed-cluster annotation is removed. Only relevant when automatic failover
+                      is disabled.
+                    minimum: 1
+                    type: integer
                 type: object
               proxy:
                 description: Proxy contains proxy environment variable propagation

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -7711,6 +7711,15 @@ spec:
                       cluster's Kubernetes API server.
                     minimum: 1
                     type: integer
+                  memberClusterRequiredHealthyStreak:
+                    default: 5
+                    description: |-
+                      MemberClusterRequiredHealthyStreak is the number of consecutive successful health
+                      checks required before a previously failed member cluster is considered recovered
+                      and its failed-cluster annotation is removed. Only relevant when automatic failover
+                      is disabled.
+                    minimum: 1
+                    type: integer
                 type: object
               proxy:
                 description: Proxy contains proxy environment variable propagation


### PR DESCRIPTION
## Summary

Adds `.spec.multiCluster.memberClusterRequiredHealthyStreak` to the `OperatorConfig` CRD — the number of consecutive successful health checks required before a failed member cluster's annotation is cleared, allowing automatic recovery without manual intervention when failover is disabled.

Replaces `multiCluster.memberClusterRequiredHealthyStreak` (Helm) / `MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK` (env var). Default: `5`.

Covers the new setting introduced in #1156.

## Proof of Work

N/A - existing tests should pass

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details