### PR TITLE
CLOUDP-411215: Replace MDB_MAX_CONCURRENT_RECONCILES with OperatorConfig

### DIFF
--- a/changelog/20260609_breaking_maxconcurrentreconciles_moved_to_operatorconfig.md
+++ b/changelog/20260609_breaking_maxconcurrentreconciles_moved_to_operatorconfig.md
@@ -1,0 +1,6 @@
+---
+kind: breaking
+date: 2026-06-09
+---
+
+* **Operator**: The `operator.maxConcurrentReconciles` Helm value and the `MDB_MAX_CONCURRENT_RECONCILES` environment variable have been removed. Configure the maximum number of concurrent reconciliations per controller using `.spec.maxConcurrentReconciles` in the `OperatorConfig` CR instead. The default value remains `1`. Users who previously set this value must create or update their `OperatorConfig` resource before upgrading to MCK 2.0.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -72,16 +72,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -117,12 +117,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.2"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_2_0_0
+              value: "quay.io/mongodb/mongodb-kubernetes-database:2.0.0"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_2_0_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:2.0.0"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_2_0_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:2.0.0"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -96,8 +96,7 @@ spec:
               value: 'true'
             - name: MDB_WEBHOOK_REGISTER_CONFIGURATION
               value: "false"
-            - name: MDB_MAX_CONCURRENT_RECONCILES
-              value: "1"
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.8.2
+    containerImage: quay.io/mongodb/mongodb-kubernetes:2.0.0
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.8.1
+  replaces: mongodb-kubernetes.v1.8.2
   version: 0.0.0

--- a/config/rbac/operator-roles-base.yaml
+++ b/config/rbac/operator-roles-base.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -1115,10 +1115,10 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileOMCAConfigMap(ctx context.Con
 
 // AddMultiReplicaSetController creates a new MongoDbMultiReplicaset Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClustersMap map[string]cluster.Cluster) error {
+func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClustersMap map[string]cluster.Cluster, maxConcurrentReconciles int) error {
 	// Create a new controller
 	reconciler := newMultiClusterReplicaSetReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, om.NewOpsManagerConnection, multicluster.ClustersMapToClientMap(memberClustersMap))
-	c, err := controller.New(util.MongoDbMultiClusterController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	c, err := controller.New(util.MongoDbMultiClusterController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -941,9 +941,9 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 	return create.OpsManagerInKubernetes(ctx, memberCluster, opsManager, sts, log)
 }
 
-func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClustersMap map[string]cluster.Cluster, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string) error {
+func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClustersMap map[string]cluster.Cluster, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string, maxConcurrentReconciles int) error {
 	reconciler := NewOpsManagerReconciler(ctx, mgr.GetClient(), multicluster.ClustersMapToClientMap(memberClustersMap), imageUrls, initDatabaseVersion, initOpsManagerImageVersion, om.NewOpsManagerConnection, &api.DefaultInitializer{}, api.NewOmAdmin)
-	c, err := controller.New(util.MongoDbOpsManagerController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	c, err := controller.New(util.MongoDbOpsManagerController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -55,7 +55,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	util_int "github.com/mongodb/mongodb-kubernetes/pkg/util/int"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
@@ -628,10 +627,10 @@ func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(ctx context.Context
 
 // AddReplicaSetController creates a new MongoDbReplicaset Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string) error {
+func AddReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, maxConcurrentReconciles int) error {
 	// Create a new controller
 	reconciler := newReplicaSetReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, om.NewOpsManagerConnection)
-	c, err := controller.New(util.MongoDbReplicaSetController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	c, err := controller.New(util.MongoDbReplicaSetController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -24,8 +24,6 @@ import (
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1" //nolint:depguard
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
 
 type MongoDBSearchReconciler struct {
@@ -156,7 +154,7 @@ func mdbcSearchIndexBuilder(rawObj client.Object) []string {
 	return []string{resourceRef.Namespace + "/" + resourceRef.Name}
 }
 
-func AddMongoDBSearchController(ctx context.Context, mgr manager.Manager, operatorSearchConfig searchcontroller.OperatorSearchConfig) error {
+func AddMongoDBSearchController(ctx context.Context, mgr manager.Manager, operatorSearchConfig searchcontroller.OperatorSearchConfig, maxConcurrentReconciles int) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, mdbcSearchIndexBuilder); err != nil {
 		return err
 	}
@@ -164,7 +162,7 @@ func AddMongoDBSearchController(ctx context.Context, mgr manager.Manager, operat
 	r := newMongoDBSearchReconciler(kubernetesClient.NewClient(mgr.GetClient()), operatorSearchConfig)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&searchv1.MongoDBSearch{}).
 		Watches(&mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}).
 		Watches(&mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch}).

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -464,7 +464,7 @@ func envoyPodLabels(search *searchv1.MongoDBSearch) map[string]string {
 }
 
 // Controller Registration
-func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, defaultEnvoyImage string) error {
+func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, defaultEnvoyImage string, maxConcurrentReconciles int) error {
 	// NOTE: The field index for MongoDBSearchIndexFieldName is already registered
 	// by AddMongoDBSearchController. Do not register it again here.
 
@@ -472,7 +472,7 @@ func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, d
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("mongodbsearchenvoy").
-		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&searchv1.MongoDBSearch{}).
 		Watches(&mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}).
 		Watches(&mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch}).

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -1782,10 +1782,10 @@ func logDiffOfProcessNames(acProcesses []string, healthyProcesses []string, log 
 	}
 }
 
-func AddShardedClusterController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClustersMap map[string]cluster.Cluster, backupEnableDelay time.Duration) error {
+func AddShardedClusterController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClustersMap map[string]cluster.Cluster, backupEnableDelay time.Duration, maxConcurrentReconciles int) error {
 	// Create a new controller
 	reconciler := newShardedClusterReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, multicluster.ClustersMapToClientMap(memberClustersMap), om.NewOpsManagerConnection, backupEnableDelay)
-	options := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)} // nolint:forbidigo
+	options := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles}
 	c, err := controller.New(util.MongoDbShardedClusterController, mgr, options)
 	if err != nil {
 		return err

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
 	"github.com/mongodb/mongodb-kubernetes/pkg/vault"
 	"github.com/mongodb/mongodb-kubernetes/pkg/vault/vaultwatcher"
@@ -51,10 +50,10 @@ import (
 
 // AddStandaloneController creates a new MongoDbStandalone Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddStandaloneController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string) error {
+func AddStandaloneController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, maxConcurrentReconciles int) error {
 	// Create a new controller
 	reconciler := newStandaloneReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, om.NewOpsManagerConnection)
-	c, err := controller.New(util.MongoDbStandaloneController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	c, err := controller.New(util.MongoDbStandaloneController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/controllers/operator/mongodbuser_controller.go
+++ b/controllers/operator/mongodbuser_controller.go
@@ -36,7 +36,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/stringutil"
 )
 
@@ -302,9 +301,9 @@ func (r *MongoDBUserReconciler) updateConnectionStringSecret(ctx context.Context
 	return secret.CreateOrUpdate(ctx, r.SecretClient, connectionStringSecret)
 }
 
-func AddMongoDBUserController(ctx context.Context, mgr manager.Manager, memberClustersMap map[string]cluster.Cluster, backupEnableDelay time.Duration) error {
+func AddMongoDBUserController(ctx context.Context, mgr manager.Manager, memberClustersMap map[string]cluster.Cluster, backupEnableDelay time.Duration, maxConcurrentReconciles int) error {
 	reconciler := newMongoDBUserReconciler(ctx, mgr.GetClient(), om.NewOpsManagerConnection, multicluster.ClustersMapToClientMap(memberClustersMap), backupEnableDelay)
-	c, err := controller.New(util.MongoDbUserController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	c, err := controller.New(util.MongoDbUserController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/controllers/operatorconfig/reconciler.go
+++ b/controllers/operatorconfig/reconciler.go
@@ -1,0 +1,55 @@
+package operatorconfig
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+)
+
+// +kubebuilder:rbac:groups=operator.mongodb.com,resources=operatorconfigs,verbs=get;list;watch,namespace=placeholder
+
+type Reconciler struct {
+	client                client.Client
+	cancel                context.CancelFunc
+	loadedResourceVersion string
+	shutdownOnce          sync.Once
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	var cfg operatorv1.OperatorConfig
+	if err := r.client.Get(ctx, req.NamespacedName, &cfg); err != nil {
+		if apierrors.IsNotFound(err) && r.loadedResourceVersion != "" {
+			zap.S().Info("OperatorConfig deleted — initiating graceful shutdown to revert to defaults")
+			r.shutdownOnce.Do(r.cancel)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	if cfg.ResourceVersion == r.loadedResourceVersion {
+		return reconcile.Result{}, nil
+	}
+	zap.S().Info("OperatorConfig changed — initiating graceful shutdown for config reload")
+	r.shutdownOnce.Do(r.cancel)
+	return reconcile.Result{}, nil
+}
+
+func AddOperatorConfigController(mgr manager.Manager, cancel context.CancelFunc, loadedResourceVersion string) error {
+	r := &Reconciler{
+		client:                mgr.GetClient(),
+		cancel:                cancel,
+		loadedResourceVersion: loadedResourceVersion,
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("operatorconfig").
+		For(&operatorv1.OperatorConfig{}).
+		Complete(r)
+}

--- a/controllers/operatorconfig/reconciler_test.go
+++ b/controllers/operatorconfig/reconciler_test.go
@@ -1,0 +1,116 @@
+package operatorconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+)
+
+const (
+	operatorNamespace = "operator-ns"
+	configName        = "operator-config"
+	loadedRV          = "1000"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = operatorv1.AddToScheme(s)
+	return s
+}
+
+func configKey() types.NamespacedName {
+	return types.NamespacedName{Name: configName, Namespace: operatorNamespace}
+}
+
+// newReconciler builds a Reconciler and returns a channel that receives a value when cancel is called.
+func newReconciler(c *fake.ClientBuilder, rv string) (*Reconciler, <-chan struct{}) {
+	cancelled := make(chan struct{}, 1)
+	r := &Reconciler{
+		client:                c.Build(),
+		cancel:                func() { cancelled <- struct{}{} },
+		loadedResourceVersion: rv,
+	}
+	return r, cancelled
+}
+
+func TestReconcile(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		crRV         string
+		expectCancel bool
+	}{
+		{
+			name:         "unchanged ResourceVersion does not trigger restart",
+			crRV:         loadedRV,
+			expectCancel: false,
+		},
+		{
+			name:         "changed ResourceVersion triggers restart",
+			crRV:         "1001",
+			expectCancel: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := &operatorv1.OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            configName,
+					Namespace:       operatorNamespace,
+					ResourceVersion: tc.crRV,
+				},
+			}
+			r, cancelled := newReconciler(fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr), loadedRV)
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: configKey()})
+
+			require.NoError(t, err)
+			if tc.expectCancel {
+				assert.Len(t, cancelled, 1)
+			} else {
+				assert.Empty(t, cancelled)
+			}
+		})
+	}
+}
+
+func TestReconcile_Deletion(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		loadedRV     string
+		expectCancel bool
+	}{
+		{
+			name:         "deletion after CR existed at startup triggers restart",
+			loadedRV:     loadedRV,
+			expectCancel: true,
+		},
+		{
+			name:         "deletion when no CR existed at startup is a no-op",
+			loadedRV:     "",
+			expectCancel: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// No CR in the fake client — simulates a deleted or never-existing object.
+			r, cancelled := newReconciler(fake.NewClientBuilder().WithScheme(testScheme()), tc.loadedRV)
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: configKey()})
+
+			require.NoError(t, err)
+			if tc.expectCancel {
+				assert.Len(t, cancelled, 1)
+			} else {
+				assert.Empty(t, cancelled)
+			}
+		})
+	}
+}

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -22,6 +22,7 @@ from tests import test_logger
 OPERATOR_CRDS = (
     "mongodb.mongodb.com",
     "mongodbusers.mongodb.com",
+    "operatorconfigs.operator.mongodb.com",
     "opsmanagers.mongodb.com",
 )
 

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
@@ -13,6 +13,9 @@ def ops_manager_and_mongodb_crds():
     """Installs OM and MDB CRDs only (we need to do this manually as Helm 3 doesn't support templating for CRDs"""
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_mongodb.yaml")
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_opsmanagers.yaml")
+    create_or_replace_from_yaml(
+        client.api_client.ApiClient(), "helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml"
+    )
 
 
 @fixture(scope="module")
@@ -35,6 +38,9 @@ def operator_only_ops_manager_and_mongodb(
 def mongodb_crds():
     """Installs OM and MDB CRDs only (we need to do this manually as Helm 3 doesn't support templating for CRDs"""
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_mongodb.yaml")
+    create_or_replace_from_yaml(
+        client.api_client.ApiClient(), "helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml"
+    )
 
 
 @fixture(scope="module")
@@ -65,9 +71,10 @@ def test_install_operator_ops_manager_and_mongodb_only(
 @pytest.mark.e2e_operator_partial_crd
 def test_only_ops_manager_and_mongodb_crds_exist():
     operator_crds = list_operator_crds()
-    assert len(operator_crds) == 2
+    assert len(operator_crds) == 3
     assert operator_crds[0].metadata.name == "mongodb.mongodb.com"
-    assert operator_crds[1].metadata.name == "opsmanagers.mongodb.com"
+    assert operator_crds[1].metadata.name == "operatorconfigs.operator.mongodb.com"
+    assert operator_crds[2].metadata.name == "opsmanagers.mongodb.com"
 
 
 @pytest.mark.e2e_operator_partial_crd
@@ -84,5 +91,6 @@ def test_install_operator_mongodb_only(operator_only_mongodb: Operator):
 @pytest.mark.e2e_operator_partial_crd
 def test_only_mongodb_and_users_crds_exists():
     operator_crds = list_operator_crds()
-    assert len(operator_crds) == 1
+    assert len(operator_crds) == 2
     assert operator_crds[0].metadata.name == "mongodb.mongodb.com"
+    assert operator_crds[1].metadata.name == "operatorconfigs.operator.mongodb.com"

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.8.2
+version: 2.0.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/templates/operator-roles-base.yaml
+++ b/helm_chart/templates/operator-roles-base.yaml
@@ -92,6 +92,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 {{- if eq $roleScope "ClusterRole" }}
   - apiGroups:
       - ''

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -212,10 +212,7 @@ spec:
             - name: MDB_WEBHOOK_NAME
               value: {{ .Values.operator.webhook.name | quote }}
     {{- end }}
-    {{- if .Values.operator.maxConcurrentReconciles }}
-            - name: MDB_MAX_CONCURRENT_RECONCILES
-              value: "{{ .Values.operator.maxConcurrentReconciles }}"
-    {{- end }}
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.8.2
+  version: 2.0.0
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.8.2
+  version: 2.0.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -122,11 +122,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.8.2
+  version: 2.0.0
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.8.2
+  version: 2.0.0
 
 ## Ops Manager
 opsManager:
@@ -134,7 +134,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.8.2
+  version: 2.0.0
 
 agent:
   name: mongodb-agent

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -48,15 +48,6 @@ operator:
 
   securityContext: {}
 
-  # Control how many reconciles can be performed in parallel.
-  # It sets MaxConcurrentReconciles https://pkg.go.dev/github.com/kubernetes-sigs/controller-runtime/pkg/controller#Options).
-  # Increasing the number of concurrent reconciles will decrease the time needed to reconcile all watched resources.
-  # But it might result in increased load on Ops Manager API, K8S API server and will require allocating more cpu and memory for the operator deployment.
-  #
-  # This setting works independently for all watched CRD types, so setting doesn't mean the operator will use only 4 workers in total, but
-  # each CRD type (MongoDB, MongoDBMultiCluster, MongoDBOpsManager, MongoDBUser) will be reconciled with 4 workers, making it
-  # 4*4=20 workers in total. Memory usage depends on the actual number of resources reconciles in parallel and is not allocated upfront.
-  maxConcurrentReconciles: 1
 
   # Create operator service account and roles
   # if false, then operator RBAC will not be provided by the chart

--- a/main.go
+++ b/main.go
@@ -297,27 +297,27 @@ func run() error {
 
 	// Setup all Controllers
 	if slices.Contains(crds, mongoDBCRDPlural) {
-		if err := setupMongoDBCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap, backupEnableDelay); err != nil {
+		if err := setupMongoDBCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap, backupEnableDelay, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
 	if slices.Contains(crds, mongoDBOpsManagerCRDPlural) {
-		if err := setupMongoDBOpsManagerCRD(ctx, mgr, memberClusterObjectsMap, imageUrls, initDatabaseNonStaticImageVersion, initOpsManagerImageVersion); err != nil {
+		if err := setupMongoDBOpsManagerCRD(ctx, mgr, memberClusterObjectsMap, imageUrls, initDatabaseNonStaticImageVersion, initOpsManagerImageVersion, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
 	if slices.Contains(crds, mongoDBUserCRDPlural) {
-		if err := setupMongoDBUserCRD(ctx, mgr, memberClusterObjectsMap, backupEnableDelay); err != nil {
+		if err := setupMongoDBUserCRD(ctx, mgr, memberClusterObjectsMap, backupEnableDelay, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
 	if slices.Contains(crds, mongoDBMultiClusterCRDPlural) {
-		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap); err != nil {
+		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
 	if slices.Contains(crds, mongoDBSearchCRDPlural) {
-		if err := setupMongoDBSearchCRD(ctx, mgr); err != nil {
+		if err := setupMongoDBSearchCRD(ctx, mgr, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
@@ -398,14 +398,14 @@ func shutdownTracerProvider(signalCtx context.Context, tp *sdktrace.TracerProvid
 	}
 }
 
-func setupMongoDBCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClusterObjectsMap map[string]runtime_cluster.Cluster, backupEnableDelay time.Duration) error {
-	if err := operator.AddStandaloneController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage); err != nil {
+func setupMongoDBCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClusterObjectsMap map[string]runtime_cluster.Cluster, backupEnableDelay time.Duration, maxConcurrentReconciles int) error {
+	if err := operator.AddStandaloneController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, maxConcurrentReconciles); err != nil {
 		return err
 	}
-	if err := operator.AddReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage); err != nil {
+	if err := operator.AddReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, maxConcurrentReconciles); err != nil {
 		return err
 	}
-	if err := operator.AddShardedClusterController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap, backupEnableDelay); err != nil {
+	if err := operator.AddShardedClusterController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap, backupEnableDelay, maxConcurrentReconciles); err != nil {
 		return err
 	}
 	return ctrl.NewWebhookManagedBy(mgr).For(&mdbv1.MongoDB{}).
@@ -413,8 +413,8 @@ func setupMongoDBCRD(ctx context.Context, mgr manager.Manager, imageUrls images.
 		Complete()
 }
 
-func setupMongoDBOpsManagerCRD(ctx context.Context, mgr manager.Manager, memberClusterObjectsMap map[string]runtime_cluster.Cluster, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string) error {
-	if err := operator.AddOpsManagerController(ctx, mgr, memberClusterObjectsMap, imageUrls, initDatabaseVersion, initOpsManagerImageVersion); err != nil {
+func setupMongoDBOpsManagerCRD(ctx context.Context, mgr manager.Manager, memberClusterObjectsMap map[string]runtime_cluster.Cluster, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string, maxConcurrentReconciles int) error {
+	if err := operator.AddOpsManagerController(ctx, mgr, memberClusterObjectsMap, imageUrls, initDatabaseVersion, initOpsManagerImageVersion, maxConcurrentReconciles); err != nil {
 		return err
 	}
 	return ctrl.NewWebhookManagedBy(mgr).For(&omv1.MongoDBOpsManager{}).
@@ -422,12 +422,12 @@ func setupMongoDBOpsManagerCRD(ctx context.Context, mgr manager.Manager, memberC
 		Complete()
 }
 
-func setupMongoDBUserCRD(ctx context.Context, mgr manager.Manager, memberClusterObjectsMap map[string]runtime_cluster.Cluster, backupEnableDelay time.Duration) error {
-	return operator.AddMongoDBUserController(ctx, mgr, memberClusterObjectsMap, backupEnableDelay)
+func setupMongoDBUserCRD(ctx context.Context, mgr manager.Manager, memberClusterObjectsMap map[string]runtime_cluster.Cluster, backupEnableDelay time.Duration, maxConcurrentReconciles int) error {
+	return operator.AddMongoDBUserController(ctx, mgr, memberClusterObjectsMap, backupEnableDelay, maxConcurrentReconciles)
 }
 
-func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClusterObjectsMap map[string]runtime_cluster.Cluster) error {
-	if err := operator.AddMultiReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap); err != nil {
+func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, memberClusterObjectsMap map[string]runtime_cluster.Cluster, maxConcurrentReconciles int) error {
+	if err := operator.AddMultiReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, memberClusterObjectsMap, maxConcurrentReconciles); err != nil {
 		return err
 	}
 	return ctrl.NewWebhookManagedBy(mgr).For(&mdbmultiv1.MongoDBMultiCluster{}).
@@ -435,19 +435,19 @@ func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, image
 		Complete()
 }
 
-func setupMongoDBSearchCRD(ctx context.Context, mgr manager.Manager) error {
+func setupMongoDBSearchCRD(ctx context.Context, mgr manager.Manager, maxConcurrentReconciles int) error {
 	if err := operator.AddMongoDBSearchController(ctx, mgr, searchcontroller.OperatorSearchConfig{
 		SearchRepo:    env.ReadOrPanic(util.SearchRepoURLEnv),
 		SearchName:    env.ReadOrPanic(util.SearchNameEnv),
 		SearchVersion: env.ReadOrPanic(util.SearchVersionEnv),
-	}); err != nil {
+	}, maxConcurrentReconciles); err != nil {
 		return err
 	}
 
 	// We cannot use ReadOrPanic here because this variable is only needed when Search is used with a managed load
 	// balancer
 	envoyImage := env.ReadOrDefault(util.EnvoyImageEnv, "")
-	if err := operator.AddMongoDBSearchEnvoyController(ctx, mgr, envoyImage); err != nil {
+	if err := operator.AddMongoDBSearchEnvoyController(ctx, mgr, envoyImage, maxConcurrentReconciles); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -46,12 +47,14 @@ import (
 	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct"
+	operatorconfigcontroller "github.com/mongodb/mongodb-kubernetes/controllers/operatorconfig"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mcov1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1"                       //nolint:depguard
 	mcoController "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/controllers"          //nolint:depguard
 	mcoConstruct "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/controllers/construct" //nolint:depguard
 	"github.com/mongodb/mongodb-kubernetes/pkg/images"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
+	"github.com/mongodb/mongodb-kubernetes/pkg/operatorconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/pprof"
 	"github.com/mongodb/mongodb-kubernetes/pkg/telemetry"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
@@ -131,6 +134,8 @@ func run() error {
 	}
 
 	ctx := signals.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	operator.OmUpdateChannel = make(chan event.GenericEvent)
 
 	klog.InitFlags(nil)
@@ -158,6 +163,16 @@ func run() error {
 
 	// Get a config to talk to the apiserver
 	cfg := ctrl.GetConfigOrDie()
+
+	bootstrapClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("creating bootstrap client: %w", err)
+	}
+	operatorConfigName := env.ReadOrDefault(util.OperatorConfigNameEnv, util.DefaultOperatorConfigName)
+	operatorCfg, err := operatorconfig.Load(ctx, bootstrapClient, currentNamespace, operatorConfigName)
+	if err != nil {
+		return fmt.Errorf("loading OperatorConfig: %w", err)
+	}
 
 	log.Debugf("Setting up tracing with ID: %s, Parent ID: %s, Endpoint: %s", traceIDHex, spanIDHex, endpoint)
 	ctx, tp, err := telemetry.SetupTracingFromParent(ctx, traceIDHex, spanIDHex, endpoint)
@@ -194,6 +209,16 @@ func run() error {
 		}
 	}
 
+	managerOptions.Cache.ByObject = map[client.Object]cache.ByObject{
+		&operatorv1.OperatorConfig{}: {
+			Namespaces: map[string]cache.Config{
+				currentNamespace: {
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", operatorConfigName),
+				},
+			},
+		},
+	}
+
 	if isInLocalMode() {
 		// managerOptions.MetricsBindAddress = "127.0.0.1:8180"
 		managerOptions.Metrics = metricsServer.Options{
@@ -210,6 +235,10 @@ func run() error {
 		return err
 	}
 	log.Info("Registering Components.")
+
+	if err := operatorconfigcontroller.AddOperatorConfigController(mgr, cancel, operatorCfg.ResourceVersion); err != nil {
+		return err
+	}
 
 	// Setup Scheme for all resources
 	if err := apiv1.AddToScheme(scheme); err != nil {

--- a/pkg/kubectl-mongodb/common/common.go
+++ b/pkg/kubectl-mongodb/common/common.go
@@ -396,6 +396,11 @@ func getCentralRules() []rbacv1.PolicyRule {
 			},
 			APIGroups: []string{"mongodbcommunity.mongodb.com"},
 		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			Resources: []string{"operatorconfigs"},
+			APIGroups: []string{"operator.mongodb.com"},
+		},
 	}
 }
 

--- a/pkg/operatorconfig/operatorconfig.go
+++ b/pkg/operatorconfig/operatorconfig.go
@@ -1,0 +1,39 @@
+package operatorconfig
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+)
+
+// Load fetches the OperatorConfig CR with the given name from the given namespace.
+// If no CR exists, a fully-defaulted config is returned with an empty ResourceVersion.
+func Load(ctx context.Context, c client.Client, namespace, name string) (operatorv1.OperatorConfig, error) {
+	var cfg operatorv1.OperatorConfig
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &cfg)
+	if apierrors.IsNotFound(err) {
+		return withDefaults(operatorv1.OperatorConfig{}), nil
+	}
+	if err != nil {
+		return operatorv1.OperatorConfig{}, fmt.Errorf("getting OperatorConfig %q in namespace %q: %w", name, namespace, err)
+	}
+	return withDefaults(cfg), nil
+}
+
+// withDefaults fills in Go-side defaults that mirror the CRD schema markers.
+// Required when constructing a spec without the API server's defaulting webhook.
+func withDefaults(cfg operatorv1.OperatorConfig) operatorv1.OperatorConfig {
+	if cfg.Spec.DefaultArchitecture == "" {
+		cfg.Spec.DefaultArchitecture = operatorv1.ArchitectureNonStatic
+	}
+	if cfg.Spec.MaxConcurrentReconciles == 0 {
+		cfg.Spec.MaxConcurrentReconciles = 1
+	}
+	return cfg
+}

--- a/pkg/operatorconfig/operatorconfig_test.go
+++ b/pkg/operatorconfig/operatorconfig_test.go
@@ -1,0 +1,75 @@
+package operatorconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+const testNamespace = "test-ns"
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = operatorv1.AddToScheme(s)
+	return s
+}
+
+func TestLoad_AbsentCR(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ResourceVersion)
+	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
+	assert.Equal(t, 1, cfg.Spec.MaxConcurrentReconciles)
+}
+
+func TestLoad_PresentCR(t *testing.T) {
+	cr := &operatorv1.OperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.DefaultOperatorConfigName,
+			Namespace: testNamespace,
+		},
+		Spec: operatorv1.OperatorConfigSpec{
+			MaxConcurrentReconciles: 4,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+	cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, cfg.Spec.MaxConcurrentReconciles)
+	// DefaultArchitecture was omitted in the CR; withDefaults fills it in
+	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
+	assert.NotEmpty(t, cfg.ResourceVersion)
+}
+
+func TestLoad_ClientError(t *testing.T) {
+	c := &failingClient{fake.NewClientBuilder().WithScheme(testScheme()).Build()}
+
+	_, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.Error(t, err)
+}
+
+// failingClient wraps a fake client and forces Get to return a non-NotFound error.
+type failingClient struct {
+	client.Client
+}
+
+func (f *failingClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return fmt.Errorf("simulated API server failure")
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -161,6 +161,10 @@ const (
 	OIDC                              = "OIDC"
 	MinimumScramSha256MdbVersion      = "4.0.0"
 
+	// OperatorConfig variables
+	OperatorConfigNameEnv     = "MDB_OPERATOR_CONFIG_NAME"
+	DefaultOperatorConfigName = "operator-config"
+
 	// pprof variables
 	OperatorPprofEnabledEnv  = "MDB_OPERATOR_PPROF_ENABLED"
 	OperatorPprofPortEnv     = "MDB_OPERATOR_PPROF_PORT"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -217,8 +217,6 @@ const (
 	MdbWebhookPortEnv                  = "MDB_WEBHOOK_PORT"
 	MdbWebhookNameEnv                  = "MDB_WEBHOOK_NAME"
 
-	MaxConcurrentReconcilesEnv = "MDB_MAX_CONCURRENT_RECONCILES"
-
 	// Search environment variables
 	SearchRepoURLEnv = "MDB_SEARCH_REPO_URL"
 	SearchNameEnv    = "MDB_SEARCH_NAME"

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -413,8 +413,7 @@ spec:
               value: quay.io/mongodb
             - name: PERFORM_FAILOVER
               value: 'true'
-            - name: MDB_MAX_CONCURRENT_RECONCILES
-              value: "1"
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -340,7 +340,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -391,16 +391,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -409,8 +409,7 @@ spec:
               value: quay.io/mongodb
             - name: PERFORM_FAILOVER
               value: 'true'
-            - name: MDB_MAX_CONCURRENT_RECONCILES
-              value: "1"
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -337,7 +337,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -387,16 +387,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -430,12 +430,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.8.2"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_8_2
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.8.2"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_2_0_0
+              value: "quay.io/mongodb/mongodb-kubernetes-database:2.0.0"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_2_0_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:2.0.0"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_2_0_0
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:2.0.0"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -80,6 +80,14 @@ rules:
       - opsmanagers/status
       - mongodbmulticluster/status
       - mongodbsearch/status
+  - apiGroups:
+      - operator.mongodb.com
+    resources:
+      - operatorconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -340,7 +340,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.8.2"
+          image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -388,16 +388,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: DATABASE_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.8.2"
+              value: "2.0.0"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -410,8 +410,7 @@ spec:
               value: quay.io/mongodb
             - name: PERFORM_FAILOVER
               value: 'true'
-            - name: MDB_MAX_CONCURRENT_RECONCILES
-              value: "1"
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
@@ -52,6 +52,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - operator.mongodb.com
+  resources:
+  - operatorconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
@@ -37,6 +37,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - operator.mongodb.com
+  resources:
+  - operatorconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.15.0.tgz"
   },
-  "mongodbOperator": "1.8.2",
-  "initDatabaseVersion": "1.8.2",
-  "initOpsManagerVersion": "1.8.2",
-  "databaseImageVersion": "1.8.2",
+  "mongodbOperator": "2.0.0",
+  "initDatabaseVersion": "2.0.0",
+  "initOpsManagerVersion": "2.0.0",
+  "databaseImageVersion": "2.0.0",
   "agentVersion": "108.0.12.8846-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -94,7 +94,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "2.0.0"
       ],
       "variants": [
         "ubi"
@@ -285,7 +286,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "2.0.0"
       ],
       "variants": [
         "ubi"
@@ -306,7 +308,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "2.0.0"
       ],
       "variants": [
         "ubi"
@@ -327,7 +330,8 @@
         "1.7.0",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "2.0.0"
       ],
       "variants": [
         "ubi"


### PR DESCRIPTION
Includes https://github.com/mongodb/mongodb-kubernetes/pull/1198 which needs to be merged first.

## Summary

Part of the Installation UX epic (CLOUDP-260547). `maxConcurrentReconciles`
is the first operator-level setting moved from env-var / Helm-value
configuration to the `OperatorConfig` CRD.

The `MDB_MAX_CONCURRENT_RECONCILES` environment variable and the
`operator.maxConcurrentReconciles` Helm value are removed. The operator now
reads `.spec.maxConcurrentReconciles` from the `OperatorConfig` CR at
startup. When no `OperatorConfig` CR is present the default value of `1` is
applied automatically, preserving existing behaviour for users who do not
create an `OperatorConfig` resource.

A migration guide for users upgrading from MCK 1.x will be provided
separately as part of the MCK 2.0 release.

## Proof of Work

- `go build ./...` clean
- `go test ./controllers/operator/... ./pkg/operatorconfig/...` all pass
- Existing E2Es are unaffected (no test references to removed Helm value or env var)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
      (Migration guide will be prepared separately as part of MCK 2.0 docs.)
- [x] Have you added changelog file?