### PR TITLE
KUBE-103: Make Search autoEmbedding API-key secret optional for internal VoyageAI

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -145,8 +145,12 @@ type EmbeddingConfig struct {
 	ProviderEndpoint string `json:"providerEndpoint,omitempty"`
 	// EmbeddingModelAPIKeySecret would have the name of the secret that has two keys
 	// query-key and indexing-key for embedding model's API keys.
-	// +kubebuilder:validation:Required
-	EmbeddingModelAPIKeySecret corev1.LocalObjectReference `json:"embeddingModelAPIKeySecret"`
+	// It may be omitted only when ProviderEndpoint points to the Kubernetes Service
+	// exposing the self-hosted Voyage AI embedding model managed by this operator. For any
+	// other endpoint the secret remains required; the operator validates this at
+	// reconcile time.
+	// +optional
+	EmbeddingModelAPIKeySecret corev1.LocalObjectReference `json:"embeddingModelAPIKeySecret,omitempty"`
 }
 
 type MongoDBSource struct {

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -65,6 +65,10 @@ spec:
                     description: |-
                       EmbeddingModelAPIKeySecret would have the name of the secret that has two keys
                       query-key and indexing-key for embedding model's API keys.
+                      It may be omitted only when ProviderEndpoint points to the Kubernetes Service
+                      exposing the self-hosted Voyage AI embedding model managed by this operator. For any
+                      other endpoint the secret remains required; the operator validates this at
+                      reconcile time.
                     properties:
                       name:
                         default: ""
@@ -79,8 +83,6 @@ spec:
                     x-kubernetes-map-type: atomic
                   providerEndpoint:
                     type: string
-                required:
-                - embeddingModelAPIKeySecret
                 type: object
               jvmFlags:
                 description: |-

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -681,6 +681,11 @@ const (
 	appLabelKey           = "app"
 	shardLabelKey         = "shard"
 	proxyServiceComponent = "search-proxy"
+
+	nameLabelKey       = "app.kubernetes.io/name"
+	managedByLabelKey  = "app.kubernetes.io/managed-by"
+	voyageAILabelValue = "voyageai"
+	operatorLabelValue = "mongodb-kubernetes-operator"
 )
 
 // buildHeadlessService builds a headless Service for a reconcile unit. All topology-specific
@@ -916,8 +921,8 @@ func (r *MongoDBSearchReconcileHelper) isInternalVoyageAIEndpoint(ctx context.Co
 		return false, xerrors.Errorf("failed to resolve embedding provider Service %s/%s: %w", svcNamespace, svcName, err)
 	}
 
-	return svc.Labels["app.kubernetes.io/name"] == "voyageai" &&
-		svc.Labels["app.kubernetes.io/managed-by"] == "mongodb-kubernetes-operator", nil
+	return svc.Labels[nameLabelKey] == voyageAILabelValue &&
+		svc.Labels[managedByLabelKey] == operatorLabelValue, nil
 }
 
 // setupMongotContainerArgsForFakeAPIKeys writes placeholder embedding key files

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -789,18 +791,36 @@ func validateSearchVesionForEmbedding(version string, log *zap.SugaredLogger) er
 // ensureEmbeddingConfig returns the mongot config and stateful set modification function based on the values provided in the search CR, it
 // also returns the hash of the secret that has the embedding API keys so that if the keys are changed the search pod is automatically restarted.
 func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(ctx context.Context, log *zap.SugaredLogger) (mongot.Modification, statefulset.Modification, error) {
-	if r.mdbSearch.Spec.AutoEmbedding == nil {
+	ae := r.mdbSearch.Spec.AutoEmbedding
+	if ae == nil {
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
 
-	// If AutoEmbedding is not nil, it's safe to assume that EmbeddingModelAPIKeySecret would be provided because we have marked it
-	// a required field.
-	apiKeySecretHash, err := ensureEmbeddingAPIKeySecret(ctx, r.client, client.ObjectKey{
-		Name:      r.mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name,
-		Namespace: r.mdbSearch.Namespace,
-	})
-	if err != nil {
-		return nil, nil, err
+	// The API key secret is optional only when the provider endpoint refers to an
+	// in-cluster VoyageAI service (ai.mongodb.com), which authenticates at the
+	// network layer rather than via API keys. For any external provider it is required.
+	// The endpoint detection (a Service lookup) only matters when no secret is given,
+	// so it is skipped when one is — keeping the secret path free of Service lookups.
+	hasAPIKeySecret := ae.EmbeddingModelAPIKeySecret.Name != ""
+
+	apiKeySecretHash := ""
+	if hasAPIKeySecret {
+		var err error
+		apiKeySecretHash, err = ensureEmbeddingAPIKeySecret(ctx, r.client, client.ObjectKey{
+			Name:      ae.EmbeddingModelAPIKeySecret.Name,
+			Namespace: r.mdbSearch.Namespace,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		internal, err := r.isInternalVoyageAIEndpoint(ctx, ae.ProviderEndpoint)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !internal {
+			return nil, nil, xerrors.Errorf("spec.autoEmbedding.embeddingModelAPIKeySecret is required unless spec.autoEmbedding.providerEndpoint refers to an in-cluster VoyageAI service")
+		}
 	}
 
 	_, version := r.searchImageAndVersion()
@@ -811,6 +831,9 @@ func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(ctx context.Context
 	autoEmbeddingViewWriterTrue := true
 	mongotModification := func(config *mongot.Config) {
 		config.Embedding = &mongot.EmbeddingConfig{
+			// mongot mandates the key files at bootstrap even when the provider ignores
+			// them, so the paths are always set. For the internal VoyageAI case the
+			// operator writes placeholder files (see below).
 			IndexingKeyFile: fmt.Sprintf("%s/%s", embeddingKeyFilePath, indexingKeyName),
 			QueryKeyFile:    fmt.Sprintf("%s/%s", embeddingKeyFilePath, queryKeyName),
 		}
@@ -819,16 +842,29 @@ func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(ctx context.Context
 		// Once we start supporting multiple mongot instances, we need to figure this out and then set here.
 		config.Embedding.IsAutoEmbeddingViewWriter = &autoEmbeddingViewWriterTrue
 
-		if r.mdbSearch.Spec.AutoEmbedding.ProviderEndpoint != "" {
-			config.Embedding.ProviderEndpoint = r.mdbSearch.Spec.AutoEmbedding.ProviderEndpoint
+		if ae.ProviderEndpoint != "" {
+			config.Embedding.ProviderEndpoint = ae.ProviderEndpoint
 		}
 	}
-	readOnlyByOwnerPermission := int32(400)
-	apiKeyVolume := statefulset.CreateVolumeFromSecret(embeddingKeyVolumeName, r.mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name, statefulset.WithSecretDefaultMode(&readOnlyByOwnerPermission))
-	apiKeyVolumeMount := statefulset.CreateVolumeMount(embeddingKeyVolumeName, apiKeysTempVolumeMount, statefulset.WithReadOnly(true))
 
 	emptyDirVolume := statefulset.CreateVolumeFromEmptyDir(apiKeysTempVolumeName)
 	emptyDirVolumeMount := statefulset.CreateVolumeMount(apiKeysTempVolumeName, embeddingKeyFilePath)
+
+	if !hasAPIKeySecret {
+		// Internal VoyageAI endpoint: no user secret. The in-cluster VoyageAI server
+		// authenticates at the network layer and ignores API keys, but mongot still
+		// requires the key files to exist. Write placeholder files into the emptyDir.
+		stsModification := statefulset.WithPodSpecTemplate(podtemplatespec.Apply(
+			podtemplatespec.WithVolume(emptyDirVolume),
+			podtemplatespec.WithVolumeMounts(MongotContainerName, emptyDirVolumeMount),
+			podtemplatespec.WithContainer(MongotContainerName, setupMongotContainerArgsForFakeAPIKeys()),
+		))
+		return mongotModification, stsModification, nil
+	}
+
+	readOnlyByOwnerPermission := int32(400)
+	apiKeyVolume := statefulset.CreateVolumeFromSecret(embeddingKeyVolumeName, ae.EmbeddingModelAPIKeySecret.Name, statefulset.WithSecretDefaultMode(&readOnlyByOwnerPermission))
+	apiKeyVolumeMount := statefulset.CreateVolumeMount(embeddingKeyVolumeName, apiKeysTempVolumeMount, statefulset.WithReadOnly(true))
 
 	stsModification := statefulset.WithPodSpecTemplate(podtemplatespec.Apply(
 		podtemplatespec.WithVolume(apiKeyVolume),
@@ -841,6 +877,63 @@ func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(ctx context.Context
 		}),
 	))
 	return mongotModification, stsModification, nil
+}
+
+// isInternalVoyageAIEndpoint reports whether the given provider endpoint URL points
+// at an in-cluster VoyageAI Service (ai.mongodb.com) managed by this operator. The
+// host is parsed into a Service name/namespace (<svc>[.<ns>[.svc...]]) and the
+// backing Service is checked for the VoyageAI operator labels. A non-cluster host,
+// a missing Service, or a Service without those labels is treated as external.
+func (r *MongoDBSearchReconcileHelper) isInternalVoyageAIEndpoint(ctx context.Context, endpoint string) (bool, error) {
+	if endpoint == "" {
+		return false, nil
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Hostname() == "" {
+		return false, nil
+	}
+	host := u.Hostname()
+	if net.ParseIP(host) != nil {
+		return false, nil
+	}
+
+	// The host is assumed to be cluster-internal Service DNS of the form
+	// <svc>[.<ns>[.svc[.cluster.local]]]. A bare name resolves to this resource's
+	// namespace. External hostnames (e.g. api.voyageai.com) fall through to the
+	// Service lookup below and are rejected as not-found / not VoyageAI-labelled.
+	parts := strings.Split(host, ".")
+	svcName := parts[0]
+	svcNamespace := r.mdbSearch.Namespace
+	if len(parts) >= 2 {
+		svcNamespace = parts[1]
+	}
+
+	svc := &corev1.Service{}
+	if err := r.client.Get(ctx, client.ObjectKey{Name: svcName, Namespace: svcNamespace}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, xerrors.Errorf("failed to resolve embedding provider Service %s/%s: %w", svcNamespace, svcName, err)
+	}
+
+	return svc.Labels["app.kubernetes.io/name"] == "voyageai" &&
+		svc.Labels["app.kubernetes.io/managed-by"] == "mongodb-kubernetes-operator", nil
+}
+
+// setupMongotContainerArgsForFakeAPIKeys writes placeholder embedding key files
+// for the internal-VoyageAI case. The in-cluster VoyageAI server ignores API keys
+// (it authenticates at the network layer), but mongot fails to bootstrap unless the
+// key files exist, so the operator fabricates them with 0400 permissions.
+func setupMongotContainerArgsForFakeAPIKeys() container.Modification {
+	return prependCommand(fakeAPIKeysCommand(embeddingKeyFilePath))
+}
+
+func fakeAPIKeysCommand(destFilePath string) string {
+	return fmt.Sprintf(`
+printf 'internal' > %[1]s/%[2]s
+printf 'internal' > %[1]s/%[3]s
+chmod 0400 %[1]s/%[2]s %[1]s/%[3]s
+`, destFilePath, queryKeyName, indexingKeyName)
 }
 
 func setupMongotContainerArgsForAPIKeys() container.Modification {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -568,6 +568,95 @@ func TestEnsureEmbeddingConfig_APIKeySecretAndProviderEndpont(t *testing.T) {
 	assert.Equal(t, expectedMongotConfig.Embedding, conf.Embedding)
 }
 
+func voyageAIService(name, namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "voyageai",
+				"app.kubernetes.io/managed-by": "mongodb-kubernetes-operator",
+			},
+		},
+	}
+}
+
+func TestEnsureEmbeddingConfig_InternalVoyageAI_NoSecretRequired(t *testing.T) {
+	ctx := context.TODO()
+	endpoint := "http://voyage-embedding-svc.mongodb.svc.cluster.local:8080/embeddings"
+	search := newTestMongoDBSearch("mdb-search", "mongodb", func(s *searchv1.MongoDBSearch) {
+		s.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{ProviderEndpoint: endpoint} // no API key secret
+	})
+	// The Service backing the endpoint is an operator-managed VoyageAI service.
+	fakeClient := newTestFakeClient(search, voyageAIService("voyage-embedding-svc", "mongodb"))
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{SearchVersion: "0.60.0"})
+
+	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
+	require.NoError(t, err)
+
+	// mongot config: endpoint set, and key file paths set (mongot requires them);
+	// the operator fabricates the files since the VoyageAI server ignores the keys.
+	conf := &mongot.Config{}
+	mongotModif(conf)
+	require.NotNil(t, conf.Embedding)
+	assert.Equal(t, endpoint, conf.Embedding.ProviderEndpoint)
+	assert.Equal(t, fmt.Sprintf("%s/%s", embeddingKeyFilePath, indexingKeyName), conf.Embedding.IndexingKeyFile)
+	assert.Equal(t, fmt.Sprintf("%s/%s", embeddingKeyFilePath, queryKeyName), conf.Embedding.QueryKeyFile)
+	assert.True(t, *conf.Embedding.IsAutoEmbeddingViewWriter)
+
+	// Only the emptyDir is mounted (no user secret volume), and the container writes
+	// placeholder key files.
+	sts := &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: MongotContainerName, Args: []string{"-c", "exec mongot"}}}, Volumes: []corev1.Volume{},
+	}}}}
+	stsModif(sts)
+	volNames := map[string]bool{}
+	for _, v := range sts.Spec.Template.Spec.Volumes {
+		volNames[v.Name] = true
+	}
+	assert.True(t, volNames[apiKeysTempVolumeName], "emptyDir for key files should be mounted")
+	assert.False(t, volNames[embeddingKeyVolumeName], "no user secret volume should be mounted")
+	assert.Contains(t, sts.Spec.Template.Spec.Containers[0].Args[1], queryKeyName)
+	assert.Contains(t, sts.Spec.Template.Spec.Containers[0].Args[1], "chmod 0400")
+}
+
+// Without an API key secret, the secret is required for any endpoint that is not
+// an in-cluster VoyageAI service: external hosts, in-cluster non-VoyageAI Services,
+// and an empty endpoint all error.
+func TestEnsureEmbeddingConfig_SecretRequiredForNonInternal(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		endpoint string
+		objects  []client.Object // extra objects, e.g. a non-VoyageAI Service at the endpoint host
+	}{
+		{
+			name:     "external endpoint",
+			endpoint: "https://api.voyageai.com/v1/embeddings",
+		},
+		{
+			name:     "in-cluster non-VoyageAI service",
+			endpoint: "http://some-svc.mongodb.svc.cluster.local:8080/embeddings",
+			objects:  []client.Object{&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "some-svc", Namespace: "mongodb"}}},
+		},
+		{
+			name:     "empty endpoint",
+			endpoint: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("mdb-search", "mongodb", func(s *searchv1.MongoDBSearch) {
+				s.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{ProviderEndpoint: tc.endpoint}
+			})
+			fakeClient := newTestFakeClient(append([]client.Object{search}, tc.objects...)...)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{SearchVersion: "0.60.0"})
+
+			_, _, err := helper.ensureEmbeddingConfig(context.TODO(), nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "embeddingModelAPIKeySecret is required")
+		})
+	}
+}
+
 func TestEnsureEmbeddingConfig_WOAutoEmbedding(t *testing.T) {
 	mongotCMWithoutEmbedding := `healthCheck:
   address: ""

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -65,6 +65,10 @@ spec:
                     description: |-
                       EmbeddingModelAPIKeySecret would have the name of the secret that has two keys
                       query-key and indexing-key for embedding model's API keys.
+                      It may be omitted only when ProviderEndpoint points to the Kubernetes Service
+                      exposing the self-hosted Voyage AI embedding model managed by this operator. For any
+                      other endpoint the secret remains required; the operator validates this at
+                      reconcile time.
                     properties:
                       name:
                         default: ""
@@ -79,8 +83,6 @@ spec:
                     x-kubernetes-map-type: atomic
                   providerEndpoint:
                     type: string
-                required:
-                - embeddingModelAPIKeySecret
                 type: object
               jvmFlags:
                 description: |-

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4087,6 +4087,10 @@ spec:
                     description: |-
                       EmbeddingModelAPIKeySecret would have the name of the secret that has two keys
                       query-key and indexing-key for embedding model's API keys.
+                      It may be omitted only when ProviderEndpoint points to the Kubernetes Service
+                      exposing the self-hosted Voyage AI embedding model managed by this operator. For any
+                      other endpoint the secret remains required; the operator validates this at
+                      reconcile time.
                     properties:
                       name:
                         default: ""
@@ -4101,8 +4105,6 @@ spec:
                     x-kubernetes-map-type: atomic
                   providerEndpoint:
                     type: string
-                required:
-                - embeddingModelAPIKeySecret
                 type: object
               jvmFlags:
                 description: |-


### PR DESCRIPTION
# Summary

The embeddingModelAPIKeySecret is now optional when providerEndpoint resolves to an in-cluster VoyageAI Service (verified by operator labels); external
providers still require it. mongot mandates the key files at bootstrap, so the operator fabricates placeholder files for the internal case. Regenerated CRDs.

## Proof of Work

Unit Test were addded

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
