### PR TITLE
Switch pre-commit to golangci-lint-full for whole-project linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,7 +120,7 @@ linters:
         path: ^pkg\/util\/env
       - linters:
           - forbidigo
-        path: ^main.go$
+        path: (^|/)main\.go$
       - linters:
           - forbidigo
         path: ^mongodb-community-operator\/cmd\/(readiness|versionhook)\/main\.go$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,7 +160,10 @@ repos:
   - repo: https://github.com/golangci/golangci-lint
     rev: v2.1.0
     hooks:
-      - id: golangci-lint
+      # golangci-lint-full (not golangci-lint) runs on the entire module rather than only
+      # files changed since HEAD, so linters that need whole-program analysis (e.g. unused,
+      # staticcheck) see the full codebase and pre-existing violations are not silently skipped.
+      - id: golangci-lint-full
         args: [--timeout=10m]
         language_version: 1.26.4
       - id: golangci-lint-fmt

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -54,11 +54,11 @@ const (
 	indexingKeyName = "indexing-key"
 	queryKeyName    = "query-key"
 
-	apiKeysTempVolumeName = "api-keys-config"
+	apiKeysTempVolumeName = "api-keys-config" //nolint:gosec // volume name, not a credential
 	// To overcome the strict requirement of api keys having 0400 permission we mount the api keys
 	// to a temp location apiKeysTempVolumeMount and then copy it to correct location embeddingKeyFilePath,
 	// changing the permission to 0400.
-	apiKeysTempVolumeMount = "/tmp/auto-embedding-api-keys"
+	apiKeysTempVolumeMount = "/tmp/auto-embedding-api-keys" //nolint:gosec // mount path, not a credential
 
 	// is the minimum search image version that is required to enable the auto embeddings for vector search
 	minSearchImageVersionForEmbedding = "0.60.0"
@@ -758,10 +758,10 @@ func ensureEmbeddingAPIKeySecret(ctx context.Context, client secret.Getter, secr
 	}
 
 	if _, ok := data[indexingKeyName]; !ok {
-		return "", fmt.Errorf(`Required key "%s" is not present in the Secret %s/%s`, indexingKeyName, secretObj.Namespace, secretObj.Name)
+		return "", fmt.Errorf(`required key "%s" is not present in the Secret %s/%s`, indexingKeyName, secretObj.Namespace, secretObj.Name)
 	}
 	if _, ok := data[queryKeyName]; !ok {
-		return "", fmt.Errorf(`Required key "%s" is not present in the Secret %s/%s`, queryKeyName, secretObj.Namespace, secretObj.Name)
+		return "", fmt.Errorf(`required key "%s" is not present in the Secret %s/%s`, queryKeyName, secretObj.Namespace, secretObj.Name)
 	}
 
 	d, err := json.Marshal(data)
@@ -896,11 +896,11 @@ type x509AuthResource struct {
 }
 
 func (x *x509AuthResource) TLSSecretNamespacedName() types.NamespacedName {
-	return x.MongoDBSearch.X509ClientCertSecret()
+	return x.X509ClientCertSecret()
 }
 
 func (x *x509AuthResource) TLSOperatorSecretNamespacedName() types.NamespacedName {
-	return x.MongoDBSearch.X509OperatorManagedSecret()
+	return x.X509OperatorManagedSecret()
 }
 
 // ensureX509ClientCertConfig processes x509 client certificate configuration for the sync source in case of mongot to mongod communication.
@@ -1005,12 +1005,12 @@ type perShardTLSResource struct {
 
 // TLSSecretNamespacedName returns the per-shard source secret name.
 func (p *perShardTLSResource) TLSSecretNamespacedName() types.NamespacedName {
-	return p.MongoDBSearch.TLSSecretForShard(p.shardName)
+	return p.TLSSecretForShard(p.shardName)
 }
 
 // TLSOperatorSecretNamespacedName returns the per-shard operator-managed secret name.
 func (p *perShardTLSResource) TLSOperatorSecretNamespacedName() types.NamespacedName {
-	return p.MongoDBSearch.TLSOperatorSecretForShard(p.shardName)
+	return p.TLSOperatorSecretForShard(p.shardName)
 }
 
 func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context) (mongot.Modification, statefulset.Modification) {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -713,7 +713,7 @@ func TestValidateSearchResource(t *testing.T) {
 				},
 			},
 			errAssertion: assert.Error,
-			errMsg:       fmt.Sprintf("Required key \"%s\" is not present in the Secret mongodb/%s", indexingKeyName, testApiKeySecretName),
+			errMsg:       fmt.Sprintf("required key \"%s\" is not present in the Secret mongodb/%s", indexingKeyName, testApiKeySecretName),
 		},
 		{
 			apiKeySecret: &corev1.Secret{
@@ -726,7 +726,7 @@ func TestValidateSearchResource(t *testing.T) {
 				},
 			},
 			errAssertion: assert.Error,
-			errMsg:       fmt.Sprintf("Required key \"%s\" is not present in the Secret mongodb/%s", queryKeyName, testApiKeySecretName),
+			errMsg:       fmt.Sprintf("required key \"%s\" is not present in the Secret mongodb/%s", queryKeyName, testApiKeySecretName),
 		},
 		{
 			apiKeySecret: &corev1.Secret{
@@ -2238,7 +2238,7 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 		}
 	}
 	require.NotNil(t, x509Volume, "x509-client-cert volume should exist")
-	assert.Equal(t, "test-search-x509-client-cert", x509Volume.VolumeSource.Secret.SecretName)
+	assert.Equal(t, "test-search-x509-client-cert", x509Volume.Secret.SecretName)
 
 	// Verify x509 volume mount on mongot container
 	mongotContainer := sts.Spec.Template.Spec.Containers[0]
@@ -2309,7 +2309,7 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 		}
 	}
 	require.NotNil(t, keyPasswordVolume, "x509-key-password volume should exist")
-	assert.Equal(t, "x509-cert", keyPasswordVolume.VolumeSource.Secret.SecretName)
+	assert.Equal(t, "x509-cert", keyPasswordVolume.Secret.SecretName)
 
 	mongotContainer := sts.Spec.Template.Spec.Containers[0]
 	var keyPasswordMount *corev1.VolumeMount

--- a/controllers/searchcontroller/sharded_external_search_source_test.go
+++ b/controllers/searchcontroller/sharded_external_search_source_test.go
@@ -371,7 +371,7 @@ func TestShardedExternalSearchSource_TLSConfig(t *testing.T) {
 		assert.NotNil(t, tlsConfig)
 		assert.Equal(t, "ca.crt", tlsConfig.CAFileName)
 		assert.Equal(t, "ca", tlsConfig.CAVolume.Name)
-		assert.Equal(t, "top-level-ca-secret", tlsConfig.CAVolume.VolumeSource.Secret.SecretName)
+		assert.Equal(t, "top-level-ca-secret", tlsConfig.CAVolume.Secret.SecretName)
 		assert.NotNil(t, tlsConfig.ResourcesToWatch)
 	})
 
@@ -390,6 +390,6 @@ func TestShardedExternalSearchSource_TLSConfig(t *testing.T) {
 		tlsConfig := src.TLSConfig()
 
 		assert.NotNil(t, tlsConfig)
-		assert.Equal(t, "ca-secret", tlsConfig.CAVolume.VolumeSource.Secret.SecretName)
+		assert.Equal(t, "ca-secret", tlsConfig.CAVolume.Secret.SecretName)
 	})
 }

--- a/internal/ci/runner/runner.go
+++ b/internal/ci/runner/runner.go
@@ -34,10 +34,10 @@ func New(dryRun bool, workDir string) *Runner {
 // Exec runs a command for its side effects, honoring DryRun.
 func (r *Runner) Exec(ctx context.Context, name string, args ...string) error {
 	if r.DryRun {
-		fmt.Fprintf(r.LogOut, "[dry-run] would run: %s\n", format(name, args))
+		_, _ = fmt.Fprintf(r.LogOut, "[dry-run] would run: %s\n", format(name, args))
 		return nil
 	}
-	fmt.Fprintf(r.LogOut, "→ %s\n", format(name, args))
+	_, _ = fmt.Fprintf(r.LogOut, "→ %s\n", format(name, args))
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = r.WorkDir
 	cmd.Stdout = r.Stdout

--- a/mongodb-community-operator/controllers/construct/mongodbstatefulset.go
+++ b/mongodb-community-operator/controllers/construct/mongodbstatefulset.go
@@ -121,8 +121,6 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 
 	hooksVolume := corev1.Volume{}
 	scriptsVolume := corev1.Volume{}
-	upgradeInitContainer := podtemplatespec.NOOP()
-	readinessInitContainer := podtemplatespec.NOOP()
 
 	// tmp volume is required by the mongodb-agent and mongod
 	tmpVolume := statefulset.CreateVolumeFromEmptyDir("tmp")
@@ -154,8 +152,8 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 
 	mongodVolumeMounts = append(mongodVolumeMounts, hooksVolumeMount)
 	mongodbAgentVolumeMounts = append(mongodbAgentVolumeMounts, scriptsVolumeMount)
-	upgradeInitContainer = podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount}, versionUpgradeHookImage))
-	readinessInitContainer = podtemplatespec.WithInitContainer(ReadinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount}, readinessProbeImage))
+	upgradeInitContainer := podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount}, versionUpgradeHookImage))
+	readinessInitContainer := podtemplatespec.WithInitContainer(ReadinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount}, readinessProbeImage))
 
 	dataVolumeClaim := statefulset.NOOP()
 	logVolumeClaim := statefulset.NOOP()
@@ -299,20 +297,6 @@ func mongodbAgentContainer(automationConfigSecretName string, volumeMounts []cor
 				Value: agentHealthStatusFilePathValue,
 			},
 		),
-	)
-}
-
-func mongodbAgentUtilitiesContainer(volumeMounts []corev1.VolumeMount, initDatabaseImage string) container.Modification {
-	_, containerSecurityContext := podtemplatespec.WithDefaultSecurityContextsModifications()
-	return container.Apply(
-		container.WithName(util.AgentContainerUtilitiesName),
-		container.WithImage(initDatabaseImage),
-		container.WithImagePullPolicy(corev1.PullAlways),
-		container.WithResourceRequirements(resourcerequirements.Defaults()),
-		container.WithVolumeMounts(volumeMounts),
-		container.WithCommand([]string{"bash", "-c", "touch /tmp/agent-utilities-holder_marker && tail -F -n0 /tmp/agent-utilities-holder_marker"}),
-		container.WithArgs([]string{""}),
-		containerSecurityContext,
 	)
 }
 

--- a/mongodb-community-operator/test/e2e/mongodbtests/mongodbtests.go
+++ b/mongodb-community-operator/test/e2e/mongodbtests/mongodbtests.go
@@ -708,6 +708,7 @@ func StatefulSetContainerConditionIsTrue(ctx context.Context, mdb *mdbv1.MongoDB
 		existingContainer := container.GetByName(containerName, sts.Spec.Template.Spec.Containers)
 		if existingContainer == nil {
 			t.Fatalf(`No container found with name "%s" in StatefulSet pod template`, containerName)
+			return
 		}
 
 		if !condition(*existingContainer) {

--- a/scripts/dev/prepare-multi-cluster/main.go
+++ b/scripts/dev/prepare-multi-cluster/main.go
@@ -33,6 +33,7 @@ const (
 	multiClusterSecretName = "test-pod-multi-cluster-config" //nolint:gosec
 	imageRegistriesSecret  = "image-registries-secret"
 	kubernetesServiceName  = "kubernetes"
+	clusterTypeKind        = "kind"
 )
 
 func main() {
@@ -76,7 +77,7 @@ func main() {
 
 	// Phase 1: KIND kubeconfig overrides
 	var kindKubeconfig string
-	if cfg.clusterType == "kind" {
+	if cfg.clusterType == clusterTypeKind {
 		fmt.Println("Phase 1: Overriding kubeconfig API servers for KIND clusters")
 		kindKubeconfig = overrideKindKubeconfig(ctx, cfg, clients, allClusters, collectErrorFor("kind-override"))
 	}
@@ -115,7 +116,7 @@ func main() {
 	go func() {
 		defer phase3wg.Done()
 		kubeconfigPath := cfg.kubeconfigPath
-		if cfg.clusterType == "kind" && kindKubeconfig != "" {
+		if cfg.clusterType == clusterTypeKind && kindKubeconfig != "" {
 			kubeconfigPath = kindKubeconfig
 		}
 		createKubeconfigSecret(ctx, clients[cfg.testPodCluster], cfg.testPodCluster, cfg.namespace, kubeconfigPath, collectErrorFor(cfg.testPodCluster))
@@ -159,8 +160,8 @@ func main() {
 	createMultiClusterConfigSecret(ctx, clients[cfg.testPodCluster], cfg, tokens, collectErrorFor(cfg.testPodCluster))
 
 	// Clean up KIND temp kubeconfig
-	if cfg.clusterType == "kind" && kindKubeconfig != "" {
-		os.Remove(kindKubeconfig)
+	if cfg.clusterType == clusterTypeKind && kindKubeconfig != "" {
+		_ = os.Remove(kindKubeconfig)
 	}
 
 	// Phase 6: Extract config files locally (parallel)
@@ -365,7 +366,10 @@ func overrideKindKubeconfig(ctx context.Context, cfg config, clients map[string]
 		return ""
 	}
 	tmpPath := tmpFile.Name()
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		collectError(err, "failed to close temp kubeconfig")
+		return ""
+	}
 
 	if err := clientcmd.WriteToFile(*kubeConfig, tmpPath); err != nil {
 		collectError(err, "failed to write temp kubeconfig")
@@ -800,7 +804,7 @@ func writeConfigFile(dir, name string, data []byte, collectError func(error, str
 
 	// The typed API returns already-decoded data, no base64 step needed.
 	filePath := filepath.Join(dir, name)
-	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
 		collectError(err, fmt.Sprintf("failed to write config file %s", filePath))
 	}
 }
@@ -819,7 +823,7 @@ func setupKubectlMongodb(cfg config) error {
 		if err != nil {
 			return fmt.Errorf("failed to read pre-compiled binary: %v", err)
 		}
-		return os.WriteFile(cfg.kubeconfigCreatorPath, data, 0o755)
+		return os.WriteFile(cfg.kubeconfigCreatorPath, data, 0o755) //nolint:gosec // executable binary requires world-executable permissions
 	}
 
 	// Build from source
@@ -835,7 +839,7 @@ func setupKubectlMongodb(cfg config) error {
 	}
 	env = append(env, fmt.Sprintf("GOOS=%s", goos), fmt.Sprintf("GOARCH=%s", goarch))
 
-	cmd := exec.Command("go", "build", "-o", cfg.kubeconfigCreatorPath, "main.go")
+	cmd := exec.Command("go", "build", "-o", cfg.kubeconfigCreatorPath, "main.go") //nolint:gosec // developer script, inputs are trusted CLI config
 	cmd.Dir = cmdDir
 	cmd.Env = env
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
# Summary

Currently we:
1. We have code which violates our linter config and it never gets reported because we only run a linter on new files.
2. Because we only run linter on new files, some of the linters get silently disabled (such as `unused`, `staticcheck`).

Here we switch pre-commit from `golangci-lint` to `golangci-lint-full` and fix all violations surfaced by the full scan.

## Proof of Work

Existing tests pass. `golangci-lint-full` passes clean via pre-commit.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details