### PR TITLE
Add forbidigo rule for k8s.io/utils/env

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,9 @@ linters:
         - pattern: env\.(Read.*?|EnsureVar|MergeWithOverride)
           pkg: github.com/mongodb/mongodb-kubernetes/pkg/util/env
           msg: "Using this env package here is prohibited. Please work with environment variables in the main package."
+        - pattern: env\.Get.*
+          pkg: k8s.io/utils/env
+          msg: "Reading environment variables here is prohibited. Please read environment variables in the main package."
       # Rules with the `pkg` depend on it
       analyze-types: true
     staticcheck:

--- a/pkg/util/architectures/static.go
+++ b/pkg/util/architectures/static.go
@@ -57,7 +57,7 @@ func IsRunningStaticArchitecture(annotations map[string]string) bool {
 		}
 	}
 
-	operatorEnv := env.GetString(DefaultEnvArchitecture, string(NonStatic))
+	operatorEnv := env.GetString(DefaultEnvArchitecture, string(NonStatic)) //nolint:forbidigo
 	return operatorEnv == string(Static)
 }
 


### PR DESCRIPTION
# Summary

`k8s.io/utils/env.GetString` (and other `Get*` functions) were not covered by our forbidigo config, allowing env reads to slip through the lint check. This adds the missing rule and suppresses the one existing violation with `nolint` until it is properly refactored.

## Proof of Work

Pre-commit `golangci-lint-full` now flags the violation and passes with the `nolint` suppression in place.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title? — no ticket needed
- [x] Have you checked whether your jira ticket required DOCSP changes? — no DOCSP ticket needed
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed