### PR TITLE
Fix a panic in sharded mdb controller when `deploymentstate.status` is `nil`

### DIFF
--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -794,6 +794,9 @@ func (r *ShardedClusterReconcileHelper) initializeStateStore(ctx context.Context
 		}
 	} else {
 		r.deploymentState = state
+		if r.deploymentState.Status == nil {
+			r.deploymentState.Status = &mdbv1.MongoDbStatus{}
+		}
 		if r.deploymentState.Status.SizeStatusInClusters == nil {
 			r.deploymentState.Status.SizeStatusInClusters = &mdbstatus.MongodbShardedSizeStatusInClusters{}
 		}


### PR DESCRIPTION
# Summary

While initializing the state store we read the state from `configmap` and then tried to deserialize that to a Go type. If the state in the configmap didn't have the `deploymentState.status` populated or if it was nil, in that case the below code resulted into a panic

```
if r.deploymentState.Status.SizeStatusInClusters == nil {
``` 

This might happen when as part of a reconciliation somehow only deploymentState was persisted and not status. 

## Proof of Work

I was able to reproduce this as part of testing [this PR](https://github.com/mongodb/mongodb-kubernetes/pull/1216), after this fix, it worked fine.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
