### PR TITLE
KUBE-108: Fix(appdb): clear stale PVC resize status after successful resize

### DIFF
--- a/changelog/20260610_fix_appdb_stale_pvc_resize_status_after_successful_resize.md
+++ b/changelog/20260610_fix_appdb_stale_pvc_resize_status_after_successful_resize.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-06-10
+---
+
+* **OpsManager AppDB**: Fixed an issue where the `status.applicationDatabase.pvc` field in the `MongoDBOpsManager` CRD retained a stale `PVC Resize - STS has been orphaned` phase indefinitely after a PVC resize completed successfully. The AppDB was healthy and fully operational, but the misleading status entry required manual intervention to clear.

--- a/changelog/20260610_fix_appdb_stale_pvc_resize_status_after_successful_resize.md
+++ b/changelog/20260610_fix_appdb_stale_pvc_resize_status_after_successful_resize.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-06-10
 ---
 
-* **OpsManager AppDB**: Fixed an issue where the `status.applicationDatabase.pvc` field in the `MongoDBOpsManager` CRD retained a stale `PVC Resize - STS has been orphaned` phase indefinitely after a PVC resize completed successfully. The AppDB was healthy and fully operational, but the misleading status entry required manual intervention to clear.
+* **OpsManager AppDB**: Fixed an issue where the `status.applicationDatabase.pvc` field in the `MongoDBOpsManager` CRD retained a stale `PVC Resize - STS has been orphaned` phase indefinitely after a PVC resize completed successfully.

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -734,7 +734,7 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 
 	log.Infof("Finished reconciliation for AppDB ReplicaSet!")
 
-	return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...))
+	return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...), status.NewPVCsStatusOptionEmptyStatus())
 }
 
 func (r *ReconcileAppDbReplicaSet) blockNonEmptyClusterSpecItemRemoval(appDBSpec omv1.AppDBSpec) error {

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -1659,15 +1659,8 @@ func TestAppDB_PVCStatusClearedAfterSuccessfulResize(t *testing.T) {
 			require.NoError(t, fakeClient.SubResource("status").Update(ctx, &updatedPVC))
 		}
 
-		// Reconcile 2: PVCs done; the STS is orphaned and recreated; status shows PhaseSTSOrphaned.
-		reconciler, err = newAppDbReconciler(ctx, fakeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
-		require.NoError(t, err)
-		_, err = reconciler.ReconcileAppDB(ctx, opsManager)
-		require.NoError(t, err)
-		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: opsManager.Name, Namespace: opsManager.Namespace}, opsManager))
-		require.Equal(t, pvc.PhaseSTSOrphaned, opsManager.Status.AppDbStatus.PVCs[0].Phase)
-
-		// Reconcile 3: no resize needed; the status should be fully cleared.
+		// Reconcile 2: PVCs done; the STS is orphaned and recreated. The reconcile completes
+		// successfully, so the final updateStatus clears the stale PVC entry in the same pass.
 		reconciler, err = newAppDbReconciler(ctx, fakeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
 		require.NoError(t, err)
 		_, err = reconciler.ReconcileAppDB(ctx, opsManager)
@@ -1675,6 +1668,6 @@ func TestAppDB_PVCStatusClearedAfterSuccessfulResize(t *testing.T) {
 		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: opsManager.Name, Namespace: opsManager.Namespace}, opsManager))
 
 		assert.Nil(t, opsManager.Status.AppDbStatus.PVCs,
-			"PVC status must be cleared after a successful resize; fix: add NewPVCsStatusOptionEmptyStatus() to the final updateStatus call in ReconcileAppDB")
+			"PVC status must be cleared after a successful resize")
 	})
 }

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
+	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status/pvc"
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/agents"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/connectionstring"
@@ -1594,4 +1596,85 @@ func TestClearTLSParams(t *testing.T) {
 			assert.Equal(t, tt.expectedOutput, tt.input)
 		})
 	}
+}
+
+// TestAppDB_PVCStatusClearedAfterSuccessfulResize is a regression test for KUBE-108.
+// After a PVC resize completes, the AppDB controller must clear the stale PVC status
+// from the CRD. Without the fix, the PhaseSTSOrphaned entry persists indefinitely.
+func TestAppDB_PVCStatusClearedAfterSuccessfulResize(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		builder := DefaultOpsManagerBuilder().SetAppDbMembers(3)
+		opsManager := builder.Build()
+
+		fakeClient, omConnectionFactory := mock.NewDefaultFakeClient()
+		createRunningAppDB(ctx, t, 3, fakeClient, opsManager, omConnectionFactory)
+
+		// Create the PVCs that Kubernetes would generate for the AppDB StatefulSet.
+		// VolumeClaimTemplate name is "data" (AppDBSpec.DataVolumeName()), STS name is "<om-name>-db".
+		stsName := opsManager.Spec.AppDB.Name()
+		initialStorage := resource.MustParse("16G")
+		newStorage := resource.MustParse("50G")
+
+		var pvcs []corev1.PersistentVolumeClaim
+		for i := 0; i < 3; i++ {
+			p := corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("data-%s-%d", stsName, i),
+					Namespace: opsManager.Namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: initialStorage},
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{corev1.ResourceStorage: initialStorage},
+				},
+			}
+			require.NoError(t, fakeClient.Create(ctx, &p))
+			pvcs = append(pvcs, p)
+		}
+
+		// Trigger a resize by increasing the storage in the AppDB spec.
+		opsManager.Spec.AppDB.PodSpec.Persistence = &v1.Persistence{
+			SingleConfig: &v1.PersistenceConfig{Storage: "50G"},
+		}
+		require.NoError(t, fakeClient.Update(ctx, opsManager))
+
+		// Reconcile 1: resize detected; PVCs are patched but storage has not propagated yet.
+		reconciler, err := newAppDbReconciler(ctx, fakeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+		require.NoError(t, err)
+		_, err = reconciler.ReconcileAppDB(ctx, opsManager)
+		require.NoError(t, err)
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: opsManager.Name, Namespace: opsManager.Namespace}, opsManager))
+		require.Equal(t, pvc.PhasePVCResize, opsManager.Status.AppDbStatus.PVCs[0].Phase)
+
+		// Simulate Kubernetes completing the PVC resize (update status.Capacity on each PVC).
+		for i := range pvcs {
+			var updatedPVC corev1.PersistentVolumeClaim
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: pvcs[i].Name, Namespace: pvcs[i].Namespace}, &updatedPVC))
+			updatedPVC.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: newStorage}
+			updatedPVC.Spec.Resources.Requests[corev1.ResourceStorage] = newStorage
+			require.NoError(t, fakeClient.SubResource("status").Update(ctx, &updatedPVC))
+		}
+
+		// Reconcile 2: PVCs done; the STS is orphaned and recreated; status shows PhaseSTSOrphaned.
+		reconciler, err = newAppDbReconciler(ctx, fakeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+		require.NoError(t, err)
+		_, err = reconciler.ReconcileAppDB(ctx, opsManager)
+		require.NoError(t, err)
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: opsManager.Name, Namespace: opsManager.Namespace}, opsManager))
+		require.Equal(t, pvc.PhaseSTSOrphaned, opsManager.Status.AppDbStatus.PVCs[0].Phase)
+
+		// Reconcile 3: no resize needed; the status should be fully cleared.
+		reconciler, err = newAppDbReconciler(ctx, fakeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+		require.NoError(t, err)
+		_, err = reconciler.ReconcileAppDB(ctx, opsManager)
+		require.NoError(t, err)
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: opsManager.Name, Namespace: opsManager.Namespace}, opsManager))
+
+		assert.Nil(t, opsManager.Status.AppDbStatus.PVCs,
+			"PVC status must be cleared after a successful resize; fix: add NewPVCsStatusOptionEmptyStatus() to the final updateStatus call in ReconcileAppDB")
+	})
 }

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -881,6 +881,55 @@ func TestHandlePVCResize(t *testing.T) {
 	})
 }
 
+// TestReplicaSetReconciler_PVCStatusClearedAfterSuccessfulResize verifies that after a full PVC
+// resize cycle the reconciler clears the stale PVC status entry from the CRD status.
+// This complements TestHandlePVCResize (which only unit-tests HandlePVCResize) by going through
+// the full Reconcile path and asserting the final updateStatus call clears the field.
+func TestReplicaSetReconciler_PVCStatusClearedAfterSuccessfulResize(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		podSpec := newDefaultPodSpec()
+		podSpec.Persistence = &v1.Persistence{SingleConfig: &v1.PersistenceConfig{Storage: "1Gi"}}
+		rs := DefaultReplicaSetBuilder().
+			SetPersistent(util.BooleanRef(true)).
+			SetPodSpec(&podSpec).
+			Build()
+
+		reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", rs)
+		checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
+
+		// Read the STS the reconciler created and manufacture the matching PVCs
+		// (in a real cluster the StatefulSet controller would do this automatically).
+		sts, err := kubeClient.GetStatefulSet(ctx, kube.ObjectKey(rs.Namespace, rs.Name))
+		require.NoError(t, err)
+		pvcs := createPVCs(t, sts, kubeClient)
+
+		// Trigger a resize by increasing the storage in the spec.
+		rs.Spec.PodSpec.Persistence = &v1.Persistence{SingleConfig: &v1.PersistenceConfig{Storage: "2Gi"}}
+		err = kubeClient.Update(ctx, rs)
+		require.NoError(t, err)
+
+		// Reconcile 1: resize detected; PVCs are patched but Capacity not yet updated.
+		_, err = reconciler.Reconcile(ctx, requestFromObject(rs))
+		require.NoError(t, err)
+		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(rs.Namespace, rs.Name), rs))
+		require.Equal(t, pvc.PhasePVCResize, rs.Status.PVCs[0].Phase)
+
+		// Simulate Kubernetes completing the PVC resize.
+		for i := range pvcs {
+			setPVCWithUpdatedResource(ctx, t, kubeClient, &pvcs[i])
+		}
+
+		// Reconcile 2: PVCs done; STS orphaned and recreated; reconcile completes successfully.
+		// The final updateStatus must clear the stale PVC status entry.
+		_, err = reconciler.Reconcile(ctx, requestFromObject(rs))
+		require.NoError(t, err)
+		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(rs.Namespace, rs.Name), rs))
+
+		assert.Nil(t, rs.Status.PVCs, "PVC status must be cleared after a successful resize")
+	})
+}
+
 // ===== Test for state and vault annotations handling in replicaset controller =====
 
 // TestReplicaSetAnnotations_WrittenOnSuccess verifies that lastAchievedSpec annotation is written after successful


### PR DESCRIPTION
# Summary

After a PVC resize completes on an AppDB replica set, the `status.applicationDatabase.pvc` field in the MongoDBOpsManager CRD was never cleared. The AppDB controller's final success updateStatus call was missing `NewPVCsStatusOptionEmptyStatus()`, unlike the regular `MongoDBReplicaSet` and sharded cluster controllers which already handle this correctly. As a result, the PVC Resize - STS has been orphaned phase persisted indefinitely in the CRD status even after the resize was fully complete and the AppDB was healthy.

The fix adds `status.NewPVCsStatusOptionEmptyStatus()` to the final `updateStatus` call in `ReconcileAppDB`, so the PVC status field is explicitly cleared on every successful reconcile.

## Proof of Work

A regression test `TestAppDB_PVCStatusClearedAfterSuccessfulResize` walks the full resize state machine — resize detected, PVCs resized, STS orphaned and recreated — and asserts the PVC status is nil after completion.

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
