### PR TITLE
[KUBE-125] Adopt to updated mongot config format (introduced `repilcaSet.scramAuth`)

### DIFF
--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -122,12 +122,18 @@ func buildExpectedMongotConfig(search *searchv1.MongoDBSearch, mdbc *mdbcv1.Mong
 	return mongot.Config{
 		SyncSource: mongot.ConfigSyncSource{
 			ReplicaSet: mongot.ConfigReplicaSet{
-				HostAndPort:    hostAndPorts,
-				Username:       searchv1.MongotDefaultSyncSourceUsername,
-				PasswordFile:   searchcontroller.TempSourceUserPasswordPath,
-				TLS:            ptr.To(false),
+				HostAndPort: hostAndPorts,
+				ScramAuth: &mongot.ConfigScramAuth{
+					Username:     searchv1.MongotDefaultSyncSourceUsername,
+					PasswordFile: searchcontroller.TempSourceUserPasswordPath,
+					TLS: &mongot.ScramAuthTLS{
+						Enabled: false,
+					},
+					AuthSource: ptr.To("admin"),
+				},
+			},
+			ReplicationReader: &mongot.ConfigReplicationReader{
 				ReadPreference: ptr.To("secondaryPreferred"),
-				AuthSource:     ptr.To("admin"),
 			},
 		},
 		Storage: mongot.ConfigStorage{

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1355,11 +1355,6 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 	}
 
 	mongotModification := func(config *mongot.Config) {
-		// config.SyncSource.ReplicaSet.Username = ""
-		// config.SyncSource.ReplicaSet.PasswordFile = ""
-		// we don't really HAVE TO set it to `$external`, mongot uses $external in case of x509 anyway
-		// config.SyncSource.ReplicaSet.AuthSource = ptr.To("$external")
-
 		config.SyncSource.ReplicaSet.ScramAuth = nil
 		config.SyncSource.ReplicaSet.X509 = &mongot.ConfigX509{
 			TLSCertificateKeyFile:    ptr.To(certPath),
@@ -1370,11 +1365,6 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 		}
 
 		if config.SyncSource.Router != nil {
-			// config.SyncSource.Router.Username = ""
-			// config.SyncSource.Router.PasswordFile = ""
-			// // we don't really HAVE TO set it to `$external`, mongot uses $external in case of x509 anyway
-			// config.SyncSource.Router.AuthSource = ptr.To("$external")
-
 			config.SyncSource.Router.ScramAuth = nil
 			config.SyncSource.Router.X509 = &mongot.ConfigX509{
 				TLSCertificateKeyFile:    ptr.To(certPath),

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1331,9 +1331,10 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
 
+	tlsSourceConfig := r.db.TLSConfig()
 	// in this https://docs.google.com/document/d/11xdolqdUR2Ht107AbxO5VKW658ytl6rPoJlYYc36ufE/edit?tab=t.0#heading=h.xpj7eo2nhgir document
 	// it's mentioned that tls=true is required for x509 auth.
-	if r.db.TLSConfig() == nil {
+	if tlsSourceConfig == nil {
 		return nil, nil, xerrors.New("tls must be enabled for syncSource to enable x509 auth for search resource")
 	}
 
@@ -1354,24 +1355,30 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 	}
 
 	mongotModification := func(config *mongot.Config) {
-		config.SyncSource.ReplicaSet.Username = ""
-		config.SyncSource.ReplicaSet.PasswordFile = ""
+		// config.SyncSource.ReplicaSet.Username = ""
+		// config.SyncSource.ReplicaSet.PasswordFile = ""
 		// we don't really HAVE TO set it to `$external`, mongot uses $external in case of x509 anyway
-		config.SyncSource.ReplicaSet.AuthSource = ptr.To("$external")
+		// config.SyncSource.ReplicaSet.AuthSource = ptr.To("$external")
+
+		config.SyncSource.ReplicaSet.ScramAuth = nil
 		config.SyncSource.ReplicaSet.X509 = &mongot.ConfigX509{
-			TLSCertificateKeyFile: ptr.To(certPath),
+			TLSCertificateKeyFile:    ptr.To(certPath),
+			CertificateAuthorityFile: ptr.To(tls.CAMountPath + tlsSourceConfig.CAFileName),
 		}
 		if hasKeyPassword {
 			config.SyncSource.ReplicaSet.X509.TLSCertificateKeyFilePasswordFile = ptr.To(TempX509KeyPasswordPath)
 		}
 
 		if config.SyncSource.Router != nil {
-			config.SyncSource.Router.Username = ""
-			config.SyncSource.Router.PasswordFile = ""
-			// we don't really HAVE TO set it to `$external`, mongot uses $external in case of x509 anyway
-			config.SyncSource.Router.AuthSource = ptr.To("$external")
+			// config.SyncSource.Router.Username = ""
+			// config.SyncSource.Router.PasswordFile = ""
+			// // we don't really HAVE TO set it to `$external`, mongot uses $external in case of x509 anyway
+			// config.SyncSource.Router.AuthSource = ptr.To("$external")
+
+			config.SyncSource.Router.ScramAuth = nil
 			config.SyncSource.Router.X509 = &mongot.ConfigX509{
-				TLSCertificateKeyFile: ptr.To(certPath),
+				TLSCertificateKeyFile:    ptr.To(certPath),
+				CertificateAuthorityFile: ptr.To(tls.CAMountPath + tlsSourceConfig.CAFileName),
 			}
 			if hasKeyPassword {
 				config.SyncSource.Router.X509.TLSCertificateKeyFilePasswordFile = ptr.To(TempX509KeyPasswordPath)
@@ -1442,18 +1449,23 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 	}
 
 	mongotModification := func(config *mongot.Config) {
-		config.SyncSource.ReplicaSet.TLS = ptr.To(true)
-		config.SyncSource.CertificateAuthorityFile = ptr.To(tls.CAMountPath + tlsSourceConfig.CAFileName)
+		config.SyncSource.ReplicaSet.ScramAuth.TLS = &mongot.ScramAuthTLS{
+			Enabled:                  true,
+			CertificateAuthorityFile: ptr.To(tls.CAMountPath + tlsSourceConfig.CAFileName),
+		}
 
 		// For sharded clusters, also enable TLS for the Router (mongos) connection
-		if config.SyncSource.Router != nil {
-			config.SyncSource.Router.TLS = ptr.To(true)
+		if config.SyncSource.Router != nil && config.SyncSource.Router.ScramAuth != nil {
+			config.SyncSource.Router.ScramAuth.TLS = &mongot.ScramAuthTLS{
+				Enabled:                  true,
+				CertificateAuthorityFile: ptr.To(tls.CAMountPath + tlsSourceConfig.CAFileName),
+			}
 		}
 
 		// if the gRPC server is configured to accept TLS connections then toggle mTLS as well
 		if config.Server.Grpc.TLS.Mode == mongot.ConfigTLSModeTLS {
 			config.Server.Grpc.TLS.Mode = mongot.ConfigTLSModeMTLS
-			config.Server.Grpc.TLS.CertificateAuthorityFile = config.SyncSource.CertificateAuthorityFile
+			config.Server.Grpc.TLS.CertificateAuthorityFile = ptr.To(tls.CAMountPath + tlsSourceConfig.CAFileName)
 		}
 	}
 
@@ -1481,12 +1493,18 @@ func baseMongotConfig(search *searchv1.MongoDBSearch, hostAndPorts []string) mon
 	return func(config *mongot.Config) {
 		config.SyncSource = mongot.ConfigSyncSource{
 			ReplicaSet: mongot.ConfigReplicaSet{
-				HostAndPort:    hostAndPorts,
-				Username:       search.SourceUsername(),
-				PasswordFile:   TempSourceUserPasswordPath,
-				TLS:            ptr.To(false),
+				HostAndPort: hostAndPorts,
+				ScramAuth: &mongot.ConfigScramAuth{
+					Username:     search.SourceUsername(),
+					PasswordFile: TempSourceUserPasswordPath,
+					TLS: &mongot.ScramAuthTLS{
+						Enabled: false,
+					},
+					AuthSource: ptr.To("admin"),
+				},
+			},
+			ReplicationReader: &mongot.ConfigReplicationReader{
 				ReadPreference: ptr.To("secondaryPreferred"),
-				AuthSource:     ptr.To("admin"),
 			},
 		}
 		config.Storage = mongot.ConfigStorage{
@@ -1543,10 +1561,14 @@ func wireprotoMongotMod(search *searchv1.MongoDBSearch) mongot.Modification {
 func routerMongotMod(search *searchv1.MongoDBSearch, shardedSource SearchSourceShardedDeployment) mongot.Modification {
 	return func(config *mongot.Config) {
 		config.SyncSource.Router = &mongot.ConfigRouter{
-			HostAndPort:  shardedSource.MongosHostsAndPorts(),
-			Username:     search.SourceUsername(),
-			PasswordFile: TempSourceUserPasswordPath,
-			TLS:          ptr.To(false),
+			HostAndPort: shardedSource.MongosHostsAndPorts(),
+			ScramAuth: &mongot.ConfigScramAuth{
+				Username:     search.SourceUsername(),
+				PasswordFile: TempSourceUserPasswordPath,
+				TLS: &mongot.ScramAuthTLS{
+					Enabled: false,
+				},
+			},
 		}
 	}
 }

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -1077,7 +1077,7 @@ func TestCreateShardMongotConfig(t *testing.T) {
 	mongot.Apply(baseMongotConfig(search, seeds0), routerMongotMod(search, shardedSource), featureFlagsMongotMod(search))(&config)
 
 	assert.Equal(t, []string{"my-cluster-0-0.svc:27017", "my-cluster-0-1.svc:27017", "my-cluster-0-2.svc:27017"}, config.SyncSource.ReplicaSet.HostAndPort)
-	assert.Equal(t, search.SourceUsername(), config.SyncSource.ReplicaSet.Username)
+	assert.Equal(t, search.SourceUsername(), config.SyncSource.ReplicaSet.ScramAuth.Username)
 
 	// OverloadRetrySignal defaults to true even when featureFlags is not set in CR
 	require.NotNil(t, config.FeatureFlags)
@@ -1119,27 +1119,27 @@ func TestShardedMongotConfigWithTLS(t *testing.T) {
 	config := mongot.Config{}
 	mongot.Apply(baseMongotConfig(search, seedsTLS), routerMongotMod(search, shardedSource))(&config)
 
-	require.NotNil(t, config.SyncSource.ReplicaSet.TLS)
-	assert.False(t, *config.SyncSource.ReplicaSet.TLS, "ReplicaSet TLS should initially be false")
+	require.NotNil(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.Enabled)
+	assert.False(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.Enabled, "ReplicaSet TLS should initially be false")
 	require.NotNil(t, config.SyncSource.Router)
-	require.NotNil(t, config.SyncSource.Router.TLS)
-	assert.False(t, *config.SyncSource.Router.TLS, "Router TLS should initially be false")
+	require.NotNil(t, config.SyncSource.Router.ScramAuth.TLS.Enabled)
+	assert.False(t, config.SyncSource.Router.ScramAuth.TLS.Enabled, "Router TLS should initially be false")
 
 	// Simulate what ensureEgressTlsConfig does when TLS is enabled
 	tlsSourceConfig := shardedSource.TLSConfig()
 	require.NotNil(t, tlsSourceConfig, "TLS config should not be nil")
 
 	// Apply the TLS modification (simulating ensureEgressTlsConfig behavior)
-	config.SyncSource.ReplicaSet.TLS = ptr.To(true)
-	config.SyncSource.CertificateAuthorityFile = ptr.To("/mongodb-automation/ca/" + tlsSourceConfig.CAFileName)
+	config.SyncSource.ReplicaSet.ScramAuth.TLS.Enabled = true
+	config.SyncSource.ReplicaSet.ScramAuth.TLS.CertificateAuthorityFile = ptr.To("/mongodb-automation/ca/" + tlsSourceConfig.CAFileName)
 	if config.SyncSource.Router != nil {
-		config.SyncSource.Router.TLS = ptr.To(true)
+		config.SyncSource.Router.ScramAuth.TLS.Enabled = true
 	}
 
-	assert.True(t, *config.SyncSource.ReplicaSet.TLS, "ReplicaSet TLS should be enabled")
-	require.NotNil(t, config.SyncSource.CertificateAuthorityFile)
-	assert.Equal(t, "/mongodb-automation/ca/ca-pem", *config.SyncSource.CertificateAuthorityFile)
-	assert.True(t, *config.SyncSource.Router.TLS, "Router TLS should be enabled for sharded clusters")
+	assert.True(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.Enabled, "ReplicaSet TLS should be enabled")
+	require.NotNil(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.CertificateAuthorityFile)
+	assert.Equal(t, "/mongodb-automation/ca/ca-pem", *config.SyncSource.ReplicaSet.ScramAuth.TLS.CertificateAuthorityFile)
+	assert.True(t, config.SyncSource.Router.ScramAuth.TLS.Enabled, "Router TLS should be enabled for sharded clusters")
 }
 
 func TestShardedMongotConfigWithoutTLS(t *testing.T) {
@@ -1161,12 +1161,12 @@ func TestShardedMongotConfigWithoutTLS(t *testing.T) {
 	config := mongot.Config{}
 	mongot.Apply(baseMongotConfig(search, seedsNoTLS), routerMongotMod(search, shardedSource))(&config)
 
-	require.NotNil(t, config.SyncSource.ReplicaSet.TLS)
-	assert.False(t, *config.SyncSource.ReplicaSet.TLS, "ReplicaSet TLS should be false when source has no TLS")
+	require.NotNil(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.Enabled)
+	assert.False(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.Enabled, "ReplicaSet TLS should be false when source has no TLS")
 	require.NotNil(t, config.SyncSource.Router)
-	require.NotNil(t, config.SyncSource.Router.TLS)
-	assert.False(t, *config.SyncSource.Router.TLS, "Router TLS should be false when source has no TLS")
-	assert.Nil(t, config.SyncSource.CertificateAuthorityFile)
+	require.NotNil(t, config.SyncSource.Router.ScramAuth.TLS.Enabled)
+	assert.False(t, config.SyncSource.Router.ScramAuth.TLS.Enabled, "Router TLS should be false when source has no TLS")
+	assert.Nil(t, config.SyncSource.ReplicaSet.ScramAuth.TLS.CertificateAuthorityFile)
 }
 
 // mockShardedSource is a mock implementation of ShardedSearchSourceDBResource for testing
@@ -2234,17 +2234,19 @@ func TestEnsureX509ClientCertConfig_NoopWhenNotConfigured(t *testing.T) {
 	config := &mongot.Config{
 		SyncSource: mongot.ConfigSyncSource{
 			ReplicaSet: mongot.ConfigReplicaSet{
-				Username:     "original-user",
-				PasswordFile: "/original/path",
-				AuthSource:   ptr.To("admin"),
+				ScramAuth: &mongot.ConfigScramAuth{
+					Username:     "original-user",
+					PasswordFile: "/original/path",
+					AuthSource:   ptr.To("admin"),
+				},
 			},
 		},
 	}
 	mongotMod(config)
 
-	assert.Equal(t, "original-user", config.SyncSource.ReplicaSet.Username)
-	assert.Equal(t, "/original/path", config.SyncSource.ReplicaSet.PasswordFile)
-	assert.Equal(t, "admin", *config.SyncSource.ReplicaSet.AuthSource)
+	assert.Equal(t, "original-user", config.SyncSource.ReplicaSet.ScramAuth.Username)
+	assert.Equal(t, "/original/path", config.SyncSource.ReplicaSet.ScramAuth.PasswordFile)
+	assert.Equal(t, "admin", *config.SyncSource.ReplicaSet.ScramAuth.AuthSource)
 	assert.Nil(t, config.SyncSource.ReplicaSet.X509)
 
 	sts := newBaseMongotStatefulSet()
@@ -2298,23 +2300,25 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	config := &mongot.Config{
 		SyncSource: mongot.ConfigSyncSource{
 			ReplicaSet: mongot.ConfigReplicaSet{
-				Username:     "search-sync-source",
-				PasswordFile: TempSourceUserPasswordPath,
-				AuthSource:   ptr.To("admin"),
+				ScramAuth: &mongot.ConfigScramAuth{
+					Username:     "search-sync-source",
+					PasswordFile: TempSourceUserPasswordPath,
+					AuthSource:   ptr.To("admin"),
+				},
 			},
 			Router: &mongot.ConfigRouter{
-				HostAndPort:  []string{"mongos-svc:27017"},
-				Username:     "search-sync-source",
-				PasswordFile: TempSourceUserPasswordPath,
+				HostAndPort: []string{"mongos-svc:27017"},
+				ScramAuth: &mongot.ConfigScramAuth{
+					Username:     "search-sync-source",
+					PasswordFile: TempSourceUserPasswordPath,
+				},
 			},
 		},
 	}
 	mongotMod(config)
 
-	// ReplicaSet: username/password cleared, authSource=$external, x509 cert path set
-	assert.Empty(t, config.SyncSource.ReplicaSet.Username)
-	assert.Empty(t, config.SyncSource.ReplicaSet.PasswordFile)
-	assert.Equal(t, "$external", *config.SyncSource.ReplicaSet.AuthSource)
+	// ReplicaSet: scramAuth cleared, x509 cert path set
+	assert.Nil(t, config.SyncSource.ReplicaSet.ScramAuth)
 	require.NotNil(t, config.SyncSource.ReplicaSet.X509)
 	require.NotNil(t, config.SyncSource.ReplicaSet.X509.TLSCertificateKeyFile)
 	assert.True(t, strings.HasPrefix(*config.SyncSource.ReplicaSet.X509.TLSCertificateKeyFile, X509ClientCertOperatorMountPath))
@@ -2322,9 +2326,7 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	assert.Nil(t, config.SyncSource.ReplicaSet.X509.TLSCertificateKeyFilePasswordFile)
 
 	// Router: same x509 modifications, cert path matches ReplicaSet
-	assert.Empty(t, config.SyncSource.Router.Username)
-	assert.Empty(t, config.SyncSource.Router.PasswordFile)
-	assert.Equal(t, "$external", *config.SyncSource.Router.AuthSource)
+	assert.Nil(t, config.SyncSource.Router.ScramAuth)
 	require.NotNil(t, config.SyncSource.Router.X509)
 	require.NotNil(t, config.SyncSource.Router.X509.TLSCertificateKeyFile)
 	assert.Equal(t, *config.SyncSource.ReplicaSet.X509.TLSCertificateKeyFile, *config.SyncSource.Router.X509.TLSCertificateKeyFile)
@@ -2391,8 +2393,10 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	config := &mongot.Config{
 		SyncSource: mongot.ConfigSyncSource{
 			ReplicaSet: mongot.ConfigReplicaSet{
-				Username:     "search-sync-source",
-				PasswordFile: TempSourceUserPasswordPath,
+				ScramAuth: &mongot.ConfigScramAuth{
+					Username:     "search-sync-source",
+					PasswordFile: TempSourceUserPasswordPath,
+				},
 			},
 		},
 	}

--- a/pkg/mongot/mongot_config.go
+++ b/pkg/mongot/mongot_config.go
@@ -37,31 +37,47 @@ type EmbeddingConfig struct {
 }
 
 type ConfigSyncSource struct {
-	ReplicaSet               ConfigReplicaSet `json:"replicaSet"`
-	Router                   *ConfigRouter    `json:"router,omitempty"`
-	CertificateAuthorityFile *string          `json:"caFile,omitempty"`
+	ReplicaSet        ConfigReplicaSet         `json:"replicaSet"`
+	Router            *ConfigRouter            `json:"router,omitempty"`
+	ReplicationReader *ConfigReplicationReader `json:"replicationReader,omitempty"`
+}
+
+type ConfigReplicationReader struct {
+	ReadPreference *string       `json:"readPreference,omitempty"`
+	TagSets        [][]ConfigTag `json:"tagSets,omitempty"`
+}
+
+type ConfigTag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type ConfigRouter struct {
-	HostAndPort  []string    `json:"hostAndPort"`
-	Username     string      `json:"username,omitempty"`
-	PasswordFile string      `json:"passwordFile,omitempty"`
-	TLS          *bool       `json:"tls,omitempty"`
-	AuthSource   *string     `json:"authSource,omitempty"`
-	X509         *ConfigX509 `json:"x509,omitempty"`
+	HostAndPort []string         `json:"hostAndPort"`
+	X509        *ConfigX509      `json:"x509,omitempty"`
+	ScramAuth   *ConfigScramAuth `json:"scramAuth,omitempty"`
 }
 
 type ConfigReplicaSet struct {
-	HostAndPort    []string    `json:"hostAndPort"`
-	Username       string      `json:"username,omitempty"`
-	PasswordFile   string      `json:"passwordFile,omitempty"`
-	TLS            *bool       `json:"tls,omitempty"`
-	ReadPreference *string     `json:"readPreference,omitempty"`
-	AuthSource     *string     `json:"authSource,omitempty"`
-	X509           *ConfigX509 `json:"x509,omitempty"`
+	HostAndPort []string         `json:"hostAndPort"`
+	X509        *ConfigX509      `json:"x509,omitempty"`
+	ScramAuth   *ConfigScramAuth `json:"scramAuth,omitempty"`
+}
+
+type ConfigScramAuth struct {
+	Username     string        `json:"username"`
+	PasswordFile string        `json:"passwordFile"`
+	TLS          *ScramAuthTLS `json:"tls,omitempty"`
+	AuthSource   *string       `json:"authSource,omitempty"`
+}
+
+type ScramAuthTLS struct {
+	Enabled                  bool    `json:"enabled"`
+	CertificateAuthorityFile *string `json:"caFile,omitempty"`
 }
 
 type ConfigX509 struct {
+	CertificateAuthorityFile          *string `json:"caFile,omitempty"`
 	TLSCertificateKeyFile             *string `json:"tlsCertificateKeyFile,omitempty"`
 	TLSCertificateKeyFilePasswordFile *string `json:"tlsCertificateKeyFilePasswordFile,omitempty"`
 }

--- a/scripts/dev/contexts/variables/mongodb_search_dev
+++ b/scripts/dev/contexts/variables/mongodb_search_dev
@@ -3,6 +3,6 @@
 set -Eeou pipefail
 
 # Temporary development images built from mongot master
-export MDB_SEARCH_VERSION="1.64.0-66-g7b0f85e89c" # built after x509 authn support
-export MDB_SEARCH_NAME="staging/mongodb-search"
+export MDB_SEARCH_VERSION="7df8689e40" # built on commit 7df8689e40
+export MDB_SEARCH_NAME="dev/mongot-community"
 export MDB_SEARCH_REPO_URL="268558157000.dkr.ecr.us-east-1.amazonaws.com"


### PR DESCRIPTION
# Summary

Like mentioned in this [Jira ticket](https://jira.mongodb.org/browse/CLOUDP-377241), the mongot team changes the mongot config format to move some of the fields around and they will be removed from their previous location. This means that mongot config after GA release of mongot, will have new format (mainly for `scramAuth`).

This PR makes sure that we adhere to that new format and  makes respective changes in the MCK code that generates the mongot config.

### Format changes

1. These fields
```
username: <string> // deprecated
passwordFile: <string> // deprecated
authSource: <string> // deprecated
tls: <boolean> // deprecated
```
have been moved from `syncSource.replicaSet` to `syncSource.replicaSet.scramAuth`.

2. The field `syncSource.replicaSet.readPreference` has been moved to `syncSource.replicationReader`

```
replicationReader:
      readPreference: <string>
      tagSet: list<list<string>>
```

3. The top level field `syncSource.caFile` has been moved to all the specific auth blocks under `syncSource.replicaSet.x509.caFile` and `syncSource.replicaSet.scramAuth.tls.caFile` etc.


### Important consideration

When we change MCK to adopt to/work with new config format, MCK will not work with older config format. But this is not really a problem for us because we have decided that MCK search GA release and later will only support search GA release and later. Which would mean only one format of mongot config to support. 

ToDo: Raise another PR to make search min req version for MCK GA version.


## Proof of Work

Successful CI.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
