### PR TITLE
MongoDBSearch: rename spec.clusters[].clusterName to name [skip-ci]

### DIFF
--- a/api/mongodb/v1/search/cluster_index.go
+++ b/api/mongodb/v1/search/cluster_index.go
@@ -9,9 +9,9 @@ func AssignClusterIndices(existing map[string]int, current []ClusterSpec) map[st
 	maps.Copy(result, existing)
 	for _, c := range current {
 		if c.ClusterIndex != nil {
-			result[c.ClusterName] = int(*c.ClusterIndex)
-		} else if _, ok := result[c.ClusterName]; !ok {
-			result[c.ClusterName] = 0
+			result[c.Name] = int(*c.ClusterIndex)
+		} else if _, ok := result[c.Name]; !ok {
+			result[c.Name] = 0
 		}
 	}
 	return result

--- a/api/mongodb/v1/search/cluster_index_test.go
+++ b/api/mongodb/v1/search/cluster_index_test.go
@@ -10,13 +10,13 @@ import (
 func clusterSpecsNamed(ns ...string) []ClusterSpec {
 	out := make([]ClusterSpec, 0, len(ns))
 	for _, n := range ns {
-		out = append(out, ClusterSpec{ClusterName: n})
+		out = append(out, ClusterSpec{Name: n})
 	}
 	return out
 }
 
 func pinnedSpec(name string, idx int32) ClusterSpec {
-	return ClusterSpec{ClusterName: name, ClusterIndex: ptr.To(idx)}
+	return ClusterSpec{Name: name, ClusterIndex: ptr.To(idx)}
 }
 
 func TestAssignClusterIndices(t *testing.T) {

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -136,7 +136,7 @@ type ClusterSpec struct {
 	// MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
-	ClusterName string `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 	// ClusterIndex is the stable integer in per-cluster resource names. Required on every entry
 	// of a multi-cluster spec, and even on a single entry when each member cluster runs its own
 	// operator. Changing it renames this cluster's resources, orphaning those at the old index.
@@ -880,7 +880,7 @@ func (s *MongoDBSearch) EffectiveClusterFor(clusterName string) (ClusterSpec, er
 		return ClusterSpec{}, errors.New("no clusters are configured in spec.clusters")
 	}
 	for _, c := range clusters {
-		if c.ClusterName == clusterName {
+		if c.Name == clusterName {
 			return c, nil
 		}
 	}
@@ -1158,12 +1158,12 @@ func (s *MongoDBSearch) ValidateSimulatedMCClusterIndices() error {
 	seen := make(map[int32]string, len(s.Spec.Clusters))
 	for _, c := range s.Spec.Clusters {
 		if c.ClusterIndex == nil {
-			return fmt.Errorf("running one operator per cluster requires clusterIndex on every spec.clusters[] entry (missing on %q)", c.ClusterName)
+			return fmt.Errorf("running one operator per cluster requires clusterIndex on every spec.clusters[] entry (missing on %q)", c.Name)
 		}
 		if prev, dup := seen[*c.ClusterIndex]; dup {
-			return fmt.Errorf("clusterIndex %d is set on more than one spec.clusters[] entry (%q and %q); pinned indices must be distinct", *c.ClusterIndex, prev, c.ClusterName)
+			return fmt.Errorf("clusterIndex %d is set on more than one spec.clusters[] entry (%q and %q); pinned indices must be distinct", *c.ClusterIndex, prev, c.Name)
 		}
-		seen[*c.ClusterIndex] = c.ClusterName
+		seen[*c.ClusterIndex] = c.Name
 	}
 	return nil
 }
@@ -1174,7 +1174,7 @@ func (s *MongoDBSearch) LocalizeToCluster(name string) bool {
 		return true
 	}
 	for _, c := range s.Spec.Clusters {
-		if c.ClusterName == name {
+		if c.Name == name {
 			s.Spec.Clusters = []ClusterSpec{c}
 			return true
 		}

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -97,13 +97,13 @@ type MongoDBSearchSpec struct {
 	// +optional
 	FeatureFlags *FeatureFlags `json:"featureFlags,omitempty"`
 	// Clusters configures the deployment per Kubernetes cluster: one entry for a
-	// single cluster (clusterName optional), or one entry per cluster for
-	// multi-cluster (clusterName required, len > 1). This is the place to set
+	// single cluster (name optional), or one entry per cluster for
+	// multi-cluster (name required, len > 1). This is the place to set
 	// replicas, resources, storage, and StatefulSet overrides.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=50
-	// +kubebuilder:validation:XValidation:rule="size(self) <= 1 || self.all(c1, has(c1.clusterName) && self.exists_one(c2, has(c2.clusterName) && c2.clusterName == c1.clusterName))",message="clusters[].clusterName must be set and unique when more than one cluster is specified"
+	// +kubebuilder:validation:XValidation:rule="size(self) <= 1 || self.all(c1, has(c1.name) && self.exists_one(c2, has(c2.name) && c2.name == c1.name))",message="clusters[].name must be set and unique when more than one cluster is specified"
 	// +kubebuilder:validation:XValidation:rule="self.all(c1, !has(c1.clusterIndex) || self.exists_one(c2, has(c2.clusterIndex) && c2.clusterIndex == c1.clusterIndex))",message="clusters[].clusterIndex must be unique when set"
 	// +kubebuilder:validation:XValidation:rule="size(self) <= 1 || self.all(c, has(c.clusterIndex))",message="clusters[].clusterIndex is required on every entry when more than one cluster is specified"
 	Clusters []ClusterSpec `json:"clusters"`
@@ -126,17 +126,17 @@ type SyncSourceSelector struct {
 	Hosts []string `json:"hosts,omitempty"`
 }
 
-// ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-// when len(spec.clusters) > 1; optional in the single-cluster case.
+// ClusterSpec is one entry in spec.clusters[]. The cluster name (spec.clusters[].name)
+// is required and immutable when len(spec.clusters) > 1; optional in the single-cluster case.
 // Each field, when set, applies to this cluster; when unset, the operator's
 // per-field default applies.
 type ClusterSpec struct {
-	// ClusterName is the Kubernetes cluster name. Required and immutable
+	// Name is the Kubernetes cluster name. Required and immutable
 	// when len(spec.clusters) > 1; optional in the single-cluster case.
 	// MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
-	ClusterName string `json:"clusterName,omitempty"`
+	ClusterName string `json:"name,omitempty"`
 	// ClusterIndex is the stable integer in per-cluster resource names. Required on every entry
 	// of a multi-cluster spec, and even on a single entry when each member cluster runs its own
 	// operator. Changing it renames this cluster's resources, orphaning those at the old index.

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -41,24 +41,24 @@ func TestHasMultipleReplicas(t *testing.T) {
 	assert.True(t, mk(ClusterSpec{Replicas: ptr.To(int32(2))}).HasMultipleReplicas())
 	// Any single cluster over one replica trips the load-balancer requirement.
 	assert.True(t, mk(
-		ClusterSpec{ClusterName: "a", Replicas: ptr.To(int32(1))},
-		ClusterSpec{ClusterName: "b", Replicas: ptr.To(int32(3))},
+		ClusterSpec{Name: "a", Replicas: ptr.To(int32(1))},
+		ClusterSpec{Name: "b", Replicas: ptr.To(int32(3))},
 	).HasMultipleReplicas())
 }
 
 func TestEffectiveClusters(t *testing.T) {
 	clusters := []ClusterSpec{
-		{ClusterName: "us-east", Replicas: ptr.To(int32(2))},
-		{ClusterName: "us-west", Replicas: ptr.To(int32(3))},
+		{Name: "us-east", Replicas: ptr.To(int32(2))},
+		{Name: "us-west", Replicas: ptr.To(int32(3))},
 	}
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: clusters}}
 	assert.Equal(t, clusters, s.EffectiveClusters())
 }
 
 func TestEffectiveClusterFor(t *testing.T) {
-	clusterA := ClusterSpec{ClusterName: "cluster-a"}
+	clusterA := ClusterSpec{Name: "cluster-a"}
 	resB := &corev1.ResourceRequirements{}
-	clusterB := ClusterSpec{ClusterName: "cluster-b", ResourceRequirements: resB}
+	clusterB := ClusterSpec{Name: "cluster-b", ResourceRequirements: resB}
 
 	t.Run("empty clusterName returns first entry", func(t *testing.T) {
 		s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: []ClusterSpec{clusterA, clusterB}}}
@@ -76,7 +76,7 @@ func TestEffectiveClusterFor(t *testing.T) {
 
 	t.Run("unknown clusterName returns error", func(t *testing.T) {
 		s := &MongoDBSearch{Spec: MongoDBSearchSpec{
-			Clusters: []ClusterSpec{{ClusterName: "only"}},
+			Clusters: []ClusterSpec{{Name: "only"}},
 		}}
 		got, err := s.EffectiveClusterFor("missing")
 		require.Error(t, err)
@@ -214,9 +214,9 @@ func TestGetManagedLBEndpointForCluster(t *testing.T) {
 	s := &MongoDBSearch{
 		Spec: MongoDBSearchSpec{
 			Clusters: []ClusterSpec{
-				{ClusterName: "us-east-k8s", LoadBalancer: managed("us-east.search-lb.example.com:443")},
-				{ClusterName: "eu-west-k8s", LoadBalancer: managed("eu-west.search-lb.example.com:443")},
-				{ClusterName: "ap-south-k8s"},
+				{Name: "us-east-k8s", LoadBalancer: managed("us-east.search-lb.example.com:443")},
+				{Name: "eu-west-k8s", LoadBalancer: managed("eu-west.search-lb.example.com:443")},
+				{Name: "ap-south-k8s"},
 			},
 		},
 	}
@@ -240,8 +240,8 @@ func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
 		return &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: hostname}}
 	}
 	clusters := []ClusterSpec{
-		{ClusterName: "us-east-k8s", LoadBalancer: managed("us-east-k8s.{shardName}.lb.example.com:443")},
-		{ClusterName: "eu-west-k8s", LoadBalancer: managed("eu-west-k8s.{shardName}.lb.example.com:443")},
+		{Name: "us-east-k8s", LoadBalancer: managed("us-east-k8s.{shardName}.lb.example.com:443")},
+		{Name: "eu-west-k8s", LoadBalancer: managed("eu-west-k8s.{shardName}.lb.example.com:443")},
 	}
 	shards := []string{"shard-0", "shard-1"}
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: clusters}}
@@ -249,7 +249,7 @@ func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
 	got := make(map[string]struct{})
 	for _, c := range clusters {
 		for _, sh := range shards {
-			got[s.GetManagedLBEndpointForClusterShard(c.ClusterName, sh)] = struct{}{}
+			got[s.GetManagedLBEndpointForClusterShard(c.Name, sh)] = struct{}{}
 		}
 	}
 	assert.Len(t, got, 4, "2x2 cross-product should yield 4 distinct hostnames")
@@ -269,7 +269,7 @@ func TestGetManagedLBEndpointForClusterLevel(t *testing.T) {
 		return &MongoDBSearch{
 			Spec: MongoDBSearchSpec{
 				Clusters: []ClusterSpec{
-					{ClusterName: "us-east-k8s", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tmpl}}},
+					{Name: "us-east-k8s", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tmpl}}},
 				},
 			},
 		}
@@ -317,24 +317,24 @@ func TestValidateSimulatedMCClusterIndices(t *testing.T) {
 		{
 			name: "all entries pin clusterIndex is ok",
 			clusters: []ClusterSpec{
-				{ClusterName: "us-east", ClusterIndex: ptr.To(int32(0))},
-				{ClusterName: "eu-west", ClusterIndex: ptr.To(int32(1))},
+				{Name: "us-east", ClusterIndex: ptr.To(int32(0))},
+				{Name: "eu-west", ClusterIndex: ptr.To(int32(1))},
 			},
 			wantErr: false,
 		},
 		{
 			name: "one entry missing clusterIndex is invalid",
 			clusters: []ClusterSpec{
-				{ClusterName: "us-east", ClusterIndex: ptr.To(int32(0))},
-				{ClusterName: "eu-west"},
+				{Name: "us-east", ClusterIndex: ptr.To(int32(0))},
+				{Name: "eu-west"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "duplicate clusterIndex is invalid",
 			clusters: []ClusterSpec{
-				{ClusterName: "us-east", ClusterIndex: ptr.To(int32(0))},
-				{ClusterName: "eu-west", ClusterIndex: ptr.To(int32(0))},
+				{Name: "us-east", ClusterIndex: ptr.To(int32(0))},
+				{Name: "eu-west", ClusterIndex: ptr.To(int32(0))},
 			},
 			wantErr: true,
 		},
@@ -382,8 +382,8 @@ func TestMongoDBSearch_LocalizeToCluster(t *testing.T) {
 		// LocalizeToCluster is the simulated-MC narrowing function, so clusterIndex
 		// is mandatory and must be unique on every entry.
 		return []ClusterSpec{
-			{ClusterName: "us-east", ClusterIndex: ptr.To(int32(0))},
-			{ClusterName: "us-west", ClusterIndex: ptr.To(int32(1))},
+			{Name: "us-east", ClusterIndex: ptr.To(int32(0))},
+			{Name: "us-west", ClusterIndex: ptr.To(int32(1))},
 		}
 	}
 	tests := []struct {
@@ -411,7 +411,7 @@ func TestMongoDBSearch_LocalizeToCluster(t *testing.T) {
 			require.NotNil(t, s.Spec.Clusters)
 			require.Len(t, s.Spec.Clusters, tc.wantLen)
 			if tc.wantFirst != "" {
-				assert.Equal(t, tc.wantFirst, s.Spec.Clusters[0].ClusterName)
+				assert.Equal(t, tc.wantFirst, s.Spec.Clusters[0].Name)
 			}
 		})
 	}
@@ -437,8 +437,8 @@ func TestMongoDBSearch_LocalizeToCluster(t *testing.T) {
 			s := &MongoDBSearch{Spec: MongoDBSearchSpec{
 				Source: &MongoDBSource{ExternalMongoDBSource: &ExternalMongoDBSource{ShardedCluster: sharded}},
 				Clusters: []ClusterSpec{
-					{ClusterName: "us-east", ClusterIndex: ptr.To(int32(0))},
-					{ClusterName: "us-west", ClusterIndex: ptr.To(int32(1))},
+					{Name: "us-east", ClusterIndex: ptr.To(int32(0))},
+					{Name: "us-west", ClusterIndex: ptr.To(int32(1))},
 				},
 			}}
 			s.LocalizeToCluster(tc.localize)
@@ -457,7 +457,7 @@ func TestResolveSizingForClusterShard(t *testing.T) {
 	overridePersistence := &v1.Persistence{}
 
 	cluster := ClusterSpec{
-		ClusterName:          "east",
+		Name:                 "east",
 		Replicas:             ptr.To(int32(2)),
 		ResourceRequirements: clusterRes,
 		Persistence:          clusterPersistence,
@@ -546,10 +546,10 @@ func TestResolveSizingForClusterShard(t *testing.T) {
 
 	t.Run("override in one cluster does not leak into another cluster", func(t *testing.T) {
 		s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: []ClusterSpec{
-			{ClusterName: "east", Replicas: ptr.To(int32(1)), ShardOverrides: []ShardOverride{
+			{Name: "east", Replicas: ptr.To(int32(1)), ShardOverrides: []ShardOverride{
 				{ShardNames: []string{"shard-0"}, Replicas: ptr.To(int32(4))},
 			}},
-			{ClusterName: "west", Replicas: ptr.To(int32(2))},
+			{Name: "west", Replicas: ptr.To(int32(2))},
 		}}}
 		assert.Equal(t, 4, replicasFor(t, s, "east", "shard-0"))
 		assert.Equal(t, 2, replicasFor(t, s, "west", "shard-0"))

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -466,16 +466,16 @@ func validateX509AuthConfig(s *MongoDBSearch) v1.ValidationResult {
 	return v1.ValidationSuccess()
 }
 
-// validateClustersClusterNameNonEmpty rejects an empty spec.clusters[i].clusterName.
+// validateClustersClusterNameNonEmpty rejects an empty spec.clusters[i].name.
 // The dispatch scopes this to multi-cluster specs (len > 1); the single-cluster case
-// keeps allowing an empty clusterName. Uniqueness is another validator's job; the
+// keeps allowing an empty name. Uniqueness is another validator's job; the
 // dedicated "is required" message fires here so a two-empty-names spec surfaces the
 // actionable hint instead of "duplicate".
 func validateClustersClusterNameNonEmpty(s *MongoDBSearch) v1.ValidationResult {
 	for i, c := range s.Spec.Clusters {
 		if c.ClusterName == "" {
 			return v1.ValidationError(
-				"spec.clusters[%d].clusterName is required when len(spec.clusters) > 1",
+				"spec.clusters[%d].name is required when len(spec.clusters) > 1",
 				i,
 			)
 		}
@@ -502,8 +502,8 @@ func validateClustersClusterIndexRequired(s *MongoDBSearch) v1.ValidationResult 
 	return v1.ValidationSuccess()
 }
 
-// validateClustersUniqueClusterName enforces clusterName uniqueness inside spec.clusters.
-// Empty clusterNames are skipped: validateClustersClusterNameNonEmpty owns the
+// validateClustersUniqueClusterName enforces spec.clusters[].name uniqueness.
+// Empty names are skipped: validateClustersClusterNameNonEmpty owns the
 // multi-cluster "is required" rule and surfaces the actionable message, so a
 // two-empty-names spec must not be pre-empted here with a "duplicate" error.
 func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
@@ -514,7 +514,7 @@ func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
 		}
 		if first, dup := seen[c.ClusterName]; dup {
 			return v1.ValidationError(
-				"duplicate clusterName %q in spec.clusters (entries %d and %d)",
+				"duplicate name %q in spec.clusters (entries %d and %d)",
 				c.ClusterName, first, i,
 			)
 		}

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -473,7 +473,7 @@ func validateX509AuthConfig(s *MongoDBSearch) v1.ValidationResult {
 // actionable hint instead of "duplicate".
 func validateClustersClusterNameNonEmpty(s *MongoDBSearch) v1.ValidationResult {
 	for i, c := range s.Spec.Clusters {
-		if c.ClusterName == "" {
+		if c.Name == "" {
 			return v1.ValidationError(
 				"spec.clusters[%d].name is required when len(spec.clusters) > 1",
 				i,
@@ -509,16 +509,16 @@ func validateClustersClusterIndexRequired(s *MongoDBSearch) v1.ValidationResult 
 func validateClustersUniqueClusterName(s *MongoDBSearch) v1.ValidationResult {
 	seen := make(map[string]int, len(s.Spec.Clusters))
 	for i, c := range s.Spec.Clusters {
-		if c.ClusterName == "" {
+		if c.Name == "" {
 			continue
 		}
-		if first, dup := seen[c.ClusterName]; dup {
+		if first, dup := seen[c.Name]; dup {
 			return v1.ValidationError(
 				"duplicate name %q in spec.clusters (entries %d and %d)",
-				c.ClusterName, first, i,
+				c.Name, first, i,
 			)
 		}
-		seen[c.ClusterName] = i
+		seen[c.Name] = i
 	}
 	return v1.ValidationSuccess()
 }
@@ -550,7 +550,7 @@ func validateClustersSyncSourceSelector(s *MongoDBSearch) v1.ValidationResult {
 // validateResourceName.
 func validateClustersEnvoyResourceNames(s *MongoDBSearch) v1.ValidationResult {
 	for i, c := range s.Spec.Clusters {
-		if c.ClusterName == "" {
+		if c.Name == "" {
 			continue
 		}
 		resources := []shardResourceName{
@@ -566,7 +566,7 @@ func validateClustersEnvoyResourceNames(s *MongoDBSearch) v1.ValidationResult {
 			},
 		}
 		for _, resource := range resources {
-			if err := validateResourceName(resource, s.Name, c.ClusterName); err != nil {
+			if err := validateResourceName(resource, s.Name, c.Name); err != nil {
 				return v1.ValidationError("%s", err.Error())
 			}
 		}

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -526,12 +526,12 @@ func TestValidateClustersClusterNameNonEmpty(t *testing.T) {
 		{
 			name:          "MC with empty clusterName at index 1",
 			clusters:      []ClusterSpec{pinnedSpec("us-east-k8s", 0), {ClusterName: ""}},
-			errorContains: "spec.clusters[1].clusterName is required",
+			errorContains: "spec.clusters[1].name is required",
 		},
 		{
 			name:          "MC with empty clusterName at index 0",
 			clusters:      []ClusterSpec{{ClusterName: ""}, pinnedSpec("eu-west-k8s", 1)},
-			errorContains: "spec.clusters[0].clusterName is required",
+			errorContains: "spec.clusters[0].name is required",
 		},
 		{
 			// Both names empty must surface the actionable "is required" hint, not
@@ -539,7 +539,7 @@ func TestValidateClustersClusterNameNonEmpty(t *testing.T) {
 			// non-empty rule wins regardless of validator-group ordering.
 			name:          "MC with two empty clusterNames reports is-required, not duplicate",
 			clusters:      []ClusterSpec{{ClusterName: ""}, {ClusterName: ""}},
-			errorContains: "spec.clusters[0].clusterName is required",
+			errorContains: "spec.clusters[0].name is required",
 		},
 	}
 	for _, tt := range tests {

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -233,7 +233,7 @@ func TestValidateClustersSyncSourceSelector(t *testing.T) {
 			s := &MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
 				Spec: MongoDBSearchSpec{
-					Clusters: []ClusterSpec{{ClusterName: "us-east-k8s", SyncSourceSelector: tt.selector}},
+					Clusters: []ClusterSpec{{Name: "us-east-k8s", SyncSourceSelector: tt.selector}},
 				},
 			}
 			res := validateClustersSyncSourceSelector(s)
@@ -254,10 +254,10 @@ func TestValidateClustersUniqueClusterName(t *testing.T) {
 		errorContains string
 	}{
 		{name: "single empty clusterName", clusters: []ClusterSpec{{}}},
-		{name: "two unique names", clusters: []ClusterSpec{{ClusterName: "a"}, {ClusterName: "b"}}},
+		{name: "two unique names", clusters: []ClusterSpec{{Name: "a"}, {Name: "b"}}},
 		{
 			name:          "duplicate names",
-			clusters:      []ClusterSpec{{ClusterName: "a"}, {ClusterName: "a"}},
+			clusters:      []ClusterSpec{{Name: "a"}, {Name: "a"}},
 			errorContains: "duplicate",
 		},
 		{
@@ -290,7 +290,7 @@ func TestValidateMCExternalHostnames(t *testing.T) {
 	mkSearch := func(hostnames []string, sharded bool) *MongoDBSearch {
 		clusters := make([]ClusterSpec, 0, len(hostnames))
 		for i, hn := range hostnames {
-			c := ClusterSpec{ClusterName: "cluster-" + strconv.Itoa(i)}
+			c := ClusterSpec{Name: "cluster-" + strconv.Itoa(i)}
 			if hn != "" {
 				c.LoadBalancer = managedLBWithHostname(hn)
 			}
@@ -368,7 +368,7 @@ func TestValidateExternalHostnameDNSLength(t *testing.T) {
 	mkSearch := func(hostnames []string, shardNames []string) *MongoDBSearch {
 		clusters := make([]ClusterSpec, 0, len(hostnames))
 		for i, hn := range hostnames {
-			c := ClusterSpec{ClusterName: "cluster-" + strconv.Itoa(i)}
+			c := ClusterSpec{Name: "cluster-" + strconv.Itoa(i)}
 			if hn != "" {
 				c.LoadBalancer = managedLBWithHostname(hn)
 			}
@@ -494,8 +494,8 @@ func TestValidateMCRequiresManagedLB(t *testing.T) {
 			s := &MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
 				Spec: MongoDBSearchSpec{Clusters: []ClusterSpec{
-					{ClusterName: "us-east-k8s", LoadBalancer: tt.lb},
-					{ClusterName: "eu-west-k8s", LoadBalancer: tt.lb},
+					{Name: "us-east-k8s", LoadBalancer: tt.lb},
+					{Name: "eu-west-k8s", LoadBalancer: tt.lb},
 				}},
 			}
 			res := validateMCRequiresManagedLB(s)
@@ -525,12 +525,12 @@ func TestValidateClustersClusterNameNonEmpty(t *testing.T) {
 		},
 		{
 			name:          "MC with empty clusterName at index 1",
-			clusters:      []ClusterSpec{pinnedSpec("us-east-k8s", 0), {ClusterName: ""}},
+			clusters:      []ClusterSpec{pinnedSpec("us-east-k8s", 0), {Name: ""}},
 			errorContains: "spec.clusters[1].name is required",
 		},
 		{
 			name:          "MC with empty clusterName at index 0",
-			clusters:      []ClusterSpec{{ClusterName: ""}, pinnedSpec("eu-west-k8s", 1)},
+			clusters:      []ClusterSpec{{Name: ""}, pinnedSpec("eu-west-k8s", 1)},
 			errorContains: "spec.clusters[0].name is required",
 		},
 		{
@@ -538,7 +538,7 @@ func TestValidateClustersClusterNameNonEmpty(t *testing.T) {
 			// "duplicate" — validateClustersUniqueClusterName skips empties so the
 			// non-empty rule wins regardless of validator-group ordering.
 			name:          "MC with two empty clusterNames reports is-required, not duplicate",
-			clusters:      []ClusterSpec{{ClusterName: ""}, {ClusterName: ""}},
+			clusters:      []ClusterSpec{{Name: ""}, {Name: ""}},
 			errorContains: "spec.clusters[0].name is required",
 		},
 	}
@@ -587,22 +587,22 @@ func TestValidateMCMatchTagsNonEmpty(t *testing.T) {
 		{
 			name: "MC nil matchTags inherits",
 			clusters: []ClusterSpec{
-				{ClusterName: "us-east-k8s", ClusterIndex: ptr.To(int32(0)), SyncSourceSelector: &SyncSourceSelector{Hosts: []string{"h:27017"}}},
-				{ClusterName: "eu-west-k8s", ClusterIndex: ptr.To(int32(1)), SyncSourceSelector: &SyncSourceSelector{Hosts: []string{"h:27017"}}},
+				{Name: "us-east-k8s", ClusterIndex: ptr.To(int32(0)), SyncSourceSelector: &SyncSourceSelector{Hosts: []string{"h:27017"}}},
+				{Name: "eu-west-k8s", ClusterIndex: ptr.To(int32(1)), SyncSourceSelector: &SyncSourceSelector{Hosts: []string{"h:27017"}}},
 			},
 		},
 		{
 			name: "MC populated matchTags",
 			clusters: []ClusterSpec{
-				{ClusterName: "us-east-k8s", ClusterIndex: ptr.To(int32(0)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "us-east"}}},
-				{ClusterName: "eu-west-k8s", ClusterIndex: ptr.To(int32(1)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "eu-west"}}},
+				{Name: "us-east-k8s", ClusterIndex: ptr.To(int32(0)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "us-east"}}},
+				{Name: "eu-west-k8s", ClusterIndex: ptr.To(int32(1)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "eu-west"}}},
 			},
 		},
 		{
 			name: "MC empty matchTags rejected",
 			clusters: []ClusterSpec{
-				{ClusterName: "us-east-k8s", ClusterIndex: ptr.To(int32(0)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "us-east"}}},
-				{ClusterName: "eu-west-k8s", ClusterIndex: ptr.To(int32(1)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{}}},
+				{Name: "us-east-k8s", ClusterIndex: ptr.To(int32(0)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{"region": "us-east"}}},
+				{Name: "eu-west-k8s", ClusterIndex: ptr.To(int32(1)), SyncSourceSelector: &SyncSourceSelector{MatchTags: map[string]string{}}},
 			},
 			errorContains: "spec.clusters[1].syncSourceSelector.matchTags cannot be empty",
 		},
@@ -642,7 +642,7 @@ func TestValidateClustersClusterIndexRequired(t *testing.T) {
 	}{
 		{
 			name:     "single-entry unpinned allowed",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			clusters: []ClusterSpec{{Name: "us-east-k8s"}},
 		},
 		{
 			name:     "MC all pinned distinct",
@@ -650,12 +650,12 @@ func TestValidateClustersClusterIndexRequired(t *testing.T) {
 		},
 		{
 			name:          "MC missing clusterIndex at index 0",
-			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, pinnedSpec("eu-west-k8s", 1)},
+			clusters:      []ClusterSpec{{Name: "us-east-k8s"}, pinnedSpec("eu-west-k8s", 1)},
 			errorContains: "spec.clusters[0].clusterIndex is required when len(spec.clusters) > 1",
 		},
 		{
 			name:          "MC missing clusterIndex at index 1",
-			clusters:      []ClusterSpec{pinnedSpec("us-east-k8s", 0), {ClusterName: "eu-west-k8s"}},
+			clusters:      []ClusterSpec{pinnedSpec("us-east-k8s", 0), {Name: "eu-west-k8s"}},
 			errorContains: "spec.clusters[1].clusterIndex is required when len(spec.clusters) > 1",
 		},
 		{
@@ -726,8 +726,8 @@ func TestValidateMCRequiresExternalSource(t *testing.T) {
 	mdbBad := &MongoDBSearch{
 		Spec: MongoDBSearchSpec{
 			Clusters: []ClusterSpec{
-				{ClusterName: "cluster-a"},
-				{ClusterName: "cluster-b"},
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
 			},
 		},
 	}
@@ -740,8 +740,8 @@ func TestValidateMCRequiresExternalSource(t *testing.T) {
 	mdbRS := &MongoDBSearch{
 		Spec: MongoDBSearchSpec{
 			Clusters: []ClusterSpec{
-				{ClusterName: "cluster-a"},
-				{ClusterName: "cluster-b"},
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
 			},
 			Source: &MongoDBSource{
 				ExternalMongoDBSource: &ExternalMongoDBSource{
@@ -755,8 +755,8 @@ func TestValidateMCRequiresExternalSource(t *testing.T) {
 	mdbSharded := &MongoDBSearch{
 		Spec: MongoDBSearchSpec{
 			Clusters: []ClusterSpec{
-				{ClusterName: "cluster-a"},
-				{ClusterName: "cluster-b"},
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
 			},
 			Source: &MongoDBSource{
 				ExternalMongoDBSource: &ExternalMongoDBSource{
@@ -785,34 +785,34 @@ func TestValidateLBConfig(t *testing.T) {
 	}{
 		{
 			name:     "no LB anywhere ok",
-			clusters: []ClusterSpec{{ClusterName: "a"}, {ClusterName: "b"}},
+			clusters: []ClusterSpec{{Name: "a"}, {Name: "b"}},
 		},
 		{
 			name:     "managed everywhere ok",
-			clusters: []ClusterSpec{{ClusterName: "a", LoadBalancer: managed}, {ClusterName: "b", LoadBalancer: managed}},
+			clusters: []ClusterSpec{{Name: "a", LoadBalancer: managed}, {Name: "b", LoadBalancer: managed}},
 		},
 		{
 			name:     "unmanaged everywhere ok",
-			clusters: []ClusterSpec{{ClusterName: "a", LoadBalancer: unmanaged}, {ClusterName: "b", LoadBalancer: unmanaged}},
+			clusters: []ClusterSpec{{Name: "a", LoadBalancer: unmanaged}, {Name: "b", LoadBalancer: unmanaged}},
 		},
 		{
 			name:          "neither managed nor unmanaged rejected",
-			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: &LoadBalancerConfig{}}},
+			clusters:      []ClusterSpec{{Name: "a", LoadBalancer: &LoadBalancerConfig{}}},
 			errorContains: "exactly one of 'managed' or 'unmanaged'",
 		},
 		{
 			name:          "both managed and unmanaged rejected",
-			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}, Unmanaged: &UnmanagedLBConfig{Endpoint: "e:443"}}}},
+			clusters:      []ClusterSpec{{Name: "a", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}, Unmanaged: &UnmanagedLBConfig{Endpoint: "e:443"}}}},
 			errorContains: "mutually exclusive",
 		},
 		{
 			name:          "partial presence rejected",
-			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: managed}, {ClusterName: "b"}},
+			clusters:      []ClusterSpec{{Name: "a", LoadBalancer: managed}, {Name: "b"}},
 			errorContains: "every cluster or on none",
 		},
 		{
 			name:          "mixed modes rejected",
-			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: managed}, {ClusterName: "b", LoadBalancer: unmanaged}},
+			clusters:      []ClusterSpec{{Name: "a", LoadBalancer: managed}, {Name: "b", LoadBalancer: unmanaged}},
 			errorContains: "cannot be mixed",
 		},
 	}
@@ -870,7 +870,7 @@ func TestValidateClustersEnvoyResourceNames(t *testing.T) {
 			if tt.clusterNames != nil {
 				clusters := make([]ClusterSpec, 0, len(tt.clusterNames))
 				for _, cn := range tt.clusterNames {
-					clusters = append(clusters, ClusterSpec{ClusterName: cn})
+					clusters = append(clusters, ClusterSpec{Name: cn})
 				}
 				s.Spec.Clusters = clusters
 			}
@@ -1086,8 +1086,8 @@ func TestValidateShardOverrides(t *testing.T) {
 	t.Run("same shard overridden in different clusters is allowed", func(t *testing.T) {
 		s := newSearch("my-search", []ExternalShardConfig{shard("shard-0")}, "", false, false)
 		s.Spec.Clusters = []ClusterSpec{
-			{ClusterName: "east", ShardOverrides: []ShardOverride{{ShardNames: []string{"shard-0"}}}},
-			{ClusterName: "west", ShardOverrides: []ShardOverride{{ShardNames: []string{"shard-0"}}}},
+			{Name: "east", ShardOverrides: []ShardOverride{{ShardNames: []string{"shard-0"}}}},
+			{Name: "west", ShardOverrides: []ShardOverride{{ShardNames: []string{"shard-0"}}}},
 		}
 		assert.Equal(t, v1.SuccessLevel, validateShardOverrides(s).Level)
 	})

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -89,13 +89,13 @@ spec:
               clusters:
                 description: |-
                   Clusters configures the deployment per Kubernetes cluster: one entry for a
-                  single cluster (clusterName optional), or one entry per cluster for
-                  multi-cluster (clusterName required, len > 1). This is the place to set
+                  single cluster (name optional), or one entry per cluster for
+                  multi-cluster (name required, len > 1). This is the place to set
                   replicas, resources, storage, and StatefulSet overrides.
                 items:
                   description: |-
-                    ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-                    when len(spec.clusters) > 1; optional in the single-cluster case.
+                    ClusterSpec is one entry in spec.clusters[]. The cluster name (spec.clusters[].name)
+                    is required and immutable when len(spec.clusters) > 1; optional in the single-cluster case.
                     Each field, when set, applies to this cluster; when unset, the operator's
                     per-field default applies.
                   properties:
@@ -108,13 +108,6 @@ spec:
                       maximum: 999
                       minimum: 0
                       type: integer
-                    clusterName:
-                      description: |-
-                        ClusterName is the Kubernetes cluster name. Required and immutable
-                        when len(spec.clusters) > 1; optional in the single-cluster case.
-                        MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
-                      maxLength: 253
-                      type: string
                     jvmFlags:
                       description: JVMFlags sets the `--jvm-flags` option for this
                         cluster's mongot pods.
@@ -276,6 +269,13 @@ spec:
                       - message: exactly one of managed or unmanaged must be set
                         rule: (has(self.managed) && !has(self.unmanaged)) || (!has(self.managed)
                           && has(self.unmanaged))
+                    name:
+                      description: |-
+                        Name is the Kubernetes cluster name. Required and immutable
+                        when len(spec.clusters) > 1; optional in the single-cluster case.
+                        MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
+                      maxLength: 253
+                      type: string
                     persistence:
                       description: Persistence configures this cluster's mongot persistent
                         volume. Defaults to 10GB if unset.
@@ -620,10 +620,10 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-validations:
-                - message: clusters[].clusterName must be set and unique when more
-                    than one cluster is specified
-                  rule: size(self) <= 1 || self.all(c1, has(c1.clusterName) && self.exists_one(c2,
-                    has(c2.clusterName) && c2.clusterName == c1.clusterName))
+                - message: clusters[].name must be set and unique when more than one
+                    cluster is specified
+                  rule: size(self) <= 1 || self.all(c1, has(c1.name) && self.exists_one(c2,
+                    has(c2.name) && c2.name == c1.name))
                 - message: clusters[].clusterIndex must be unique when set
                   rule: self.all(c1, !has(c1.clusterIndex) || self.exists_one(c2,
                     has(c2.clusterIndex) && c2.clusterIndex == c1.clusterIndex))

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -466,7 +466,7 @@ func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
 // pinnedCluster builds a spec.clusters[] entry with an explicit clusterIndex
 // (required on every entry of a multi-cluster spec).
 func pinnedCluster(name string, idx int32) searchv1.ClusterSpec {
-	return searchv1.ClusterSpec{ClusterName: name, ClusterIndex: ptr.To(idx)}
+	return searchv1.ClusterSpec{Name: name, ClusterIndex: ptr.To(idx)}
 }
 
 // setupStateCMTest's fixture must be MC-valid (external source + managed LB) so
@@ -481,7 +481,7 @@ func setupStateCMTest(t *testing.T, clusters ...searchv1.ClusterSpec) (*MongoDBS
 	}
 	for i := range clusters {
 		clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
-			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].ClusterName)},
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].Name)},
 		}
 	}
 	search.Spec.Clusters = clusters
@@ -518,7 +518,7 @@ func updateSearchClusters(t *testing.T, ctx context.Context, c client.Client, na
 	// matching setupStateCMTest so add/remove updates stay MC-valid.
 	for i := range clusters {
 		clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
-			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].ClusterName)},
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].Name)},
 		}
 	}
 	latest.Spec.Clusters = clusters
@@ -602,11 +602,11 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 	}
 	search.Spec.Clusters = []searchv1.ClusterSpec{
 		{
-			ClusterName: "us-east", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+			Name: "us-east", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
 			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-east.example.com"}},
 		},
 		{
-			ClusterName: "us-west", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+			Name: "us-west", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
 			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-west.example.com"}},
 		},
 	}
@@ -758,11 +758,11 @@ func assertSearchOwnerLabels(t *testing.T, search *searchv1.MongoDBSearch, clust
 func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
 	clusters := []searchv1.ClusterSpec{
 		{
-			ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+			Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
 			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"}},
 		},
 		{
-			ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+			Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
 			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"}},
 		},
 	}
@@ -909,11 +909,11 @@ func newSimulatedMCShardedMongoDBSearch(name, namespace string) *searchv1.MongoD
 	// {shardName}. prefix is required for cluster-level form derivation.
 	clusters := []searchv1.ClusterSpec{
 		{
-			ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+			Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
 			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-a.example.com"}},
 		},
 		{
-			ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+			Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
 			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-b.example.com"}},
 		},
 	}
@@ -1060,7 +1060,7 @@ func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
 		// Single-entry unpinned passes ValidateSpec (MC validators skip at len==1), so the
 		// failure is attributable to the sim-MC gate requiring the pin even on one entry.
 		search.Spec.Clusters = []searchv1.ClusterSpec{
-			{ClusterName: "cluster-a", Replicas: ptr.To(int32(1))},
+			{Name: "cluster-a", Replicas: ptr.To(int32(1))},
 		}
 
 		reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-a", search)
@@ -1133,7 +1133,7 @@ func TestMongoDBSearchReconcile_ResolveClusterMappingFailure_Failed(t *testing.T
 	search.Spec.Clusters = []searchv1.ClusterSpec{pinnedCluster("us-east", 0), pinnedCluster("us-west", 1)}
 	for i := range search.Spec.Clusters {
 		search.Spec.Clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
-			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", search.Spec.Clusters[i].ClusterName)},
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", search.Spec.Clusters[i].Name)},
 		}
 	}
 
@@ -1171,7 +1171,7 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+					Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.example.com",
@@ -1179,7 +1179,7 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 					},
 				},
 				{
-					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+					Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.example.com",

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -237,11 +237,11 @@ func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.Mon
 	}
 	work := make([]clusterWorkItem, 0, len(search.Spec.Clusters))
 	for _, c := range search.Spec.Clusters {
-		idx, ok := mapping[c.ClusterName]
+		idx, ok := mapping[c.Name]
 		if !ok {
 			idx = -1
 		}
-		work = append(work, clusterWorkItem{ClusterName: c.ClusterName, ClusterIndex: idx, Client: r.clientForCluster(c.ClusterName)})
+		work = append(work, clusterWorkItem{ClusterName: c.Name, ClusterIndex: idx, Client: r.clientForCluster(c.Name)})
 	}
 	return work
 }

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -141,7 +141,7 @@ func TestBuildReplicaSetRouteForCluster_PerClusterHostnames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cs := make([]searchv1.ClusterSpec, 0, len(clusterNames))
 			for i, n := range clusterNames {
-				c := searchv1.ClusterSpec{ClusterName: n}
+				c := searchv1.ClusterSpec{Name: n}
 				if tt.endpoints != nil {
 					c.LoadBalancer = &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoints[i]},
@@ -158,15 +158,15 @@ func TestBuildReplicaSetRouteForCluster_PerClusterHostnames(t *testing.T) {
 			search.Spec.Clusters = cs
 
 			for i, c := range cs {
-				route := buildReplicaSetRouteForCluster(search, i, c.ClusterName)
+				route := buildReplicaSetRouteForCluster(search, i, c.Name)
 				assert.Equal(t, tt.expectedSNIs[i], route.SNIHostname,
-					"cluster %d (%s)", i, c.ClusterName)
+					"cluster %d (%s)", i, c.Name)
 				assert.Equal(t, "rs", route.Name)
-				assert.Equal(t, c.ClusterName, route.ClusterID)
+				assert.Equal(t, c.Name, route.ClusterID)
 				expectedUpstream := fmt.Sprintf("mdb-search-search-%d-svc.test-ns.svc.cluster.local", i)
-				require.Len(t, route.UpstreamHosts, 1, "cluster %d (%s) UpstreamHosts length", i, c.ClusterName)
+				require.Len(t, route.UpstreamHosts, 1, "cluster %d (%s) UpstreamHosts length", i, c.Name)
 				assert.Equal(t, expectedUpstream, route.UpstreamHosts[0],
-					"cluster %d (%s) UpstreamHosts[0]", i, c.ClusterName)
+					"cluster %d (%s) UpstreamHosts[0]", i, c.Name)
 			}
 		})
 	}
@@ -457,13 +457,13 @@ func TestBuildRoutesForCluster_RS_PerClusterHostname(t *testing.T) {
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "us-east-k8s", Replicas: &one,
+					Name: "us-east-k8s", Replicas: &one,
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-east.example.com"},
 					},
 				},
 				{
-					ClusterName: "eu-west-k8s", Replicas: &one,
+					Name: "eu-west-k8s", Replicas: &one,
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-eu-west.example.com"},
 					},
@@ -485,7 +485,7 @@ func TestBuildRoutesForCluster_RS_NoTemplateUsesPerClusterProxySvcFQDN(t *testin
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "us-east-k8s", Replicas: &one},
+				{Name: "us-east-k8s", Replicas: &one},
 			},
 		},
 	}
@@ -539,7 +539,7 @@ func TestBuildRoutesForCluster_Sharded_PerClusterShardSNI(t *testing.T) {
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "us-east-k8s", Replicas: &one,
+					Name: "us-east-k8s", Replicas: &one,
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "mongot-us-east-{shardName}.example.com",
@@ -547,7 +547,7 @@ func TestBuildRoutesForCluster_Sharded_PerClusterShardSNI(t *testing.T) {
 					},
 				},
 				{
-					ClusterName: "eu-west-k8s", Replicas: &one,
+					Name: "eu-west-k8s", Replicas: &one,
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "mongot-eu-west-{shardName}.example.com",
@@ -599,8 +599,8 @@ func TestBuildShardRoutes_MC_ClusterLevel_NoExternalHostname(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "cluster-a"},
-				{ClusterName: "cluster-b"},
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
 			},
 		},
 	}
@@ -647,7 +647,7 @@ func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "cluster-a",
+					Name: "cluster-a",
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.cluster-a.search.example.com:443",
@@ -655,7 +655,7 @@ func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 					},
 				},
 				{
-					ClusterName: "cluster-b",
+					Name: "cluster-b",
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.cluster-b.search.example.com:443",
@@ -747,8 +747,8 @@ func TestEnvoyFilterChain_PerClusterSNI(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "us-east-k8s", Replicas: &one},
-				{ClusterName: "eu-west-k8s", Replicas: &one},
+				{Name: "us-east-k8s", Replicas: &one},
+				{Name: "eu-west-k8s", Replicas: &one},
 			},
 		},
 	}
@@ -839,8 +839,8 @@ func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 	mcSearch := &searchv1.MongoDBSearch{
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "a", ClusterIndex: ptr.To(int32(0))},
-				{ClusterName: "unknown", ClusterIndex: ptr.To(int32(1))},
+				{Name: "a", ClusterIndex: ptr.To(int32(0))},
+				{Name: "unknown", ClusterIndex: ptr.To(int32(1))},
 			},
 		},
 	}
@@ -1019,8 +1019,8 @@ func TestBuildClusterWorkList_MultiCluster_OneItemPerSpecEntry(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "a"},
-				{ClusterName: "b"},
+				{Name: "a"},
+				{Name: "b"},
 			},
 		},
 	}
@@ -1040,7 +1040,7 @@ func TestBuildClusterWorkList_MissingFromMapping_SentinelIndex(t *testing.T) {
 	}, "")
 	search := &searchv1.MongoDBSearch{
 		Spec: searchv1.MongoDBSearchSpec{
-			Clusters: []searchv1.ClusterSpec{{ClusterName: "a"}},
+			Clusters: []searchv1.ClusterSpec{{Name: "a"}},
 		},
 	}
 	// Empty mapping simulates first reconcile before main controller writes state.
@@ -1058,7 +1058,7 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 		Spec: searchv1.MongoDBSearchSpec{
 			Source: &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
 			Clusters: []searchv1.ClusterSpec{{
-				ClusterName:  "missing-cluster",
+				Name:         "missing-cluster",
 				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-missing-cluster.example.com"}},
 			}},
 		},
@@ -1090,7 +1090,7 @@ func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{{
-				ClusterName: "a",
+				Name: "a",
 				LoadBalancer: &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
 				},
@@ -1126,7 +1126,7 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{{
-				ClusterName:  "a",
+				Name:         "a",
 				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
 			}},
 		},
@@ -1190,13 +1190,13 @@ func TestReconcile_WorstOfPhase_Aggregated(t *testing.T) {
 			},
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "a", ClusterIndex: ptr.To(int32(0)),
+					Name: "a", ClusterIndex: ptr.To(int32(0)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
 					},
 				},
 				{
-					ClusterName: "missing", ClusterIndex: ptr.To(int32(1)),
+					Name: "missing", ClusterIndex: ptr.To(int32(1)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-missing.example.com"},
 					},
@@ -1248,7 +1248,7 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 				},
 			},
 			Clusters: []searchv1.ClusterSpec{{
-				ClusterName: "a",
+				Name: "a",
 				LoadBalancer: &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
 				},
@@ -1297,13 +1297,13 @@ func TestReconcile_NoStateCM_ClustersPending(t *testing.T) {
 			},
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)),
+					Name: "cluster-a", ClusterIndex: ptr.To(int32(0)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"},
 					},
 				},
 				{
-					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)),
+					Name: "cluster-b", ClusterIndex: ptr.To(int32(1)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"},
 					},
@@ -1350,13 +1350,13 @@ func TestReconcile_UsesIndicesFromStateMapping(t *testing.T) {
 			},
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(5)),
+					Name: "cluster-a", ClusterIndex: ptr.To(int32(5)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com", Replicas: ptr.To(int32(2))},
 					},
 				},
 				{
-					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(7)),
+					Name: "cluster-b", ClusterIndex: ptr.To(int32(7)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com", Replicas: ptr.To(int32(4))},
 					},
@@ -1425,7 +1425,7 @@ func TestReconcile_StableIndexAcrossClusterRemovals(t *testing.T) {
 		clusters := make([]searchv1.ClusterSpec, 0, len(clusterNames))
 		for i, n := range clusterNames {
 			cs := searchv1.ClusterSpec{
-				ClusterName: n,
+				Name: n,
 				LoadBalancer: &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{
 						ExternalHostname: fmt.Sprintf("mongot-%s.example.com", n),
@@ -1591,7 +1591,7 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 				},
 			},
 			Clusters: []searchv1.ClusterSpec{{
-				ClusterName:  "cluster-a",
+				Name:         "cluster-a",
 				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com"}},
 			}},
 		},
@@ -1630,7 +1630,7 @@ func newMCEnvoySearch(name, namespace, uid string, clusters ...searchv1.ClusterS
 	for i := range clusters {
 		if clusters[i].LoadBalancer == nil {
 			clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].ClusterName)},
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].Name)},
 			}
 		}
 	}
@@ -1670,7 +1670,7 @@ func TestBuildClusterWorkList_SimulatedMC_UsesProjectedIndex(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "kind-e2e-cluster-2", ClusterIndex: ptr.To(int32(1))},
+				{Name: "kind-e2e-cluster-2", ClusterIndex: ptr.To(int32(1))},
 			},
 		},
 	}
@@ -1686,7 +1686,7 @@ func TestBuildReplicaSetRouteForCluster_ResolvedIndexNotArrayPos(t *testing.T) {
 	// SNI is the cluster's literal LB hostname; the resolved index (7), not the array
 	// position (0), must drive the per-cluster mongot Service name in UpstreamHosts.
 	clusters := []searchv1.ClusterSpec{{
-		ClusterName:  "eu-west-k8s",
+		Name:         "eu-west-k8s",
 		LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-eu-west-k8s.apps.example.com"}},
 	}}
 	search := &searchv1.MongoDBSearch{
@@ -1707,7 +1707,7 @@ func TestBuildRoutesForCluster_SimulatedMC_Sharded_PerShardSNIUsesProjectedIndex
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName:  "kind-e2e-cluster-2",
+					Name:         "kind-e2e-cluster-2",
 					ClusterIndex: ptr.To(int32(1)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
@@ -1794,7 +1794,7 @@ func TestEnvoyReconcile_LBCleanup_ReadableState_DeletesAcrossMapping(t *testing.
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
-			Clusters: []searchv1.ClusterSpec{{ClusterName: "cluster-a"}},
+			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a"}},
 		},
 		// LB previously managed → status present; spec no longer managed → cleanup branch.
 		Status: searchv1.MongoDBSearchStatus{LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}},
@@ -1826,7 +1826,7 @@ func TestEnvoyReconcile_LBCleanup_StateLoadError_CentralOnlyFallback(t *testing.
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
-			Clusters: []searchv1.ClusterSpec{{ClusterName: "cluster-a"}},
+			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a"}},
 		},
 		Status: searchv1.MongoDBSearchStatus{LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}},
 	}
@@ -1955,7 +1955,7 @@ func TestEnvoyReconcile_SimulatedMC_MissingClusterIndex_Invalid(t *testing.T) {
 
 	// Single entry, no pin — built via the generic MC helper because
 	// newSimulatedMCEnvoySearch can only produce pinned entries.
-	search := newMCEnvoySearch("mdb-search", "ns", "", searchv1.ClusterSpec{ClusterName: "cluster-a"})
+	search := newMCEnvoySearch("mdb-search", "ns", "", searchv1.ClusterSpec{Name: "cluster-a"})
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 
 	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-a")
@@ -2073,7 +2073,7 @@ func TestReconcileForCluster_SimulatedMC_ShardedSource_RendersToProvidedClient(t
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{{
-				ClusterName:  "kind-e2e-cluster-1",
+				Name:         "kind-e2e-cluster-1",
 				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.kind-e2e-cluster-1.example.com"}},
 			}},
 		},
@@ -2108,7 +2108,7 @@ func TestBuildRoutesForCluster_LBResolvedByName_NotSpecPosition(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 			Spec: searchv1.MongoDBSearchSpec{
 				Clusters: []searchv1.ClusterSpec{
-					{ClusterName: "cluster-b", LoadBalancer: managed("mongot-b.example.com")},
+					{Name: "cluster-b", LoadBalancer: managed("mongot-b.example.com")},
 				},
 			},
 		}
@@ -2122,8 +2122,8 @@ func TestBuildRoutesForCluster_LBResolvedByName_NotSpecPosition(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 			Spec: searchv1.MongoDBSearchSpec{
 				Clusters: []searchv1.ClusterSpec{
-					{ClusterName: "cluster-b", LoadBalancer: managed("mongot-b.example.com")},
-					{ClusterName: "cluster-a", LoadBalancer: managed("mongot-a.example.com")},
+					{Name: "cluster-b", LoadBalancer: managed("mongot-b.example.com")},
+					{Name: "cluster-a", LoadBalancer: managed("mongot-a.example.com")},
 				},
 			},
 		}
@@ -2152,7 +2152,7 @@ func TestReconcile_LBConfigSurvivesClusterRemoval(t *testing.T) {
 			},
 			Clusters: []searchv1.ClusterSpec{
 				{
-					ClusterName: "cluster-b",
+					Name: "cluster-b",
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "mongot-b.example.com",

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -290,7 +290,7 @@ func (r *MongoDBSearchReconcileHelper) buildRSWorkList() []rsWorkItem {
 	clusters := r.mdbSearch.Spec.Clusters
 	work := make([]rsWorkItem, 0, len(clusters))
 	for _, c := range clusters {
-		work = append(work, rsWorkItem{ClusterName: c.ClusterName, ClusterIndex: r.state.ClusterMapping[c.ClusterName]})
+		work = append(work, rsWorkItem{ClusterName: c.Name, ClusterIndex: r.state.ClusterMapping[c.Name]})
 	}
 	return work
 }

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -1633,12 +1633,12 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 						},
 					},
 					Clusters: []searchv1.ClusterSpec{
-						{ClusterName: "us-east-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
+						{Name: "us-east-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
 							Managed: &searchv1.ManagedLBConfig{
 								ExternalHostname: "{shardName}.us-east-k8s.search.example.com:443",
 							},
 						}},
-						{ClusterName: "eu-west-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
+						{Name: "eu-west-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
 							Managed: &searchv1.ManagedLBConfig{
 								ExternalHostname: "{shardName}.eu-west-k8s.search.example.com:443",
 							},
@@ -1691,7 +1691,7 @@ func TestGetMongosConfigParametersForSharded_PersistedIndexNotSpecPosition(t *te
 				MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "test-mdb"},
 			},
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{
+				{Name: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.b.example.com:443"},
 				}},
 			},
@@ -2796,8 +2796,8 @@ func (f *fakeExternalSource) ResourceType() mdbv1.ResourceType {
 func TestBuildReplicaSetPlan_PerClusterUnitsForMC(t *testing.T) {
 	mdb := newTestMongoDBSearch("mdb-search", "ns")
 	mdb.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", Replicas: ptr.To(int32(2))},
-		{ClusterName: "cluster-b", Replicas: ptr.To(int32(2))},
+		{Name: "cluster-a", Replicas: ptr.To(int32(2))},
+		{Name: "cluster-b", Replicas: ptr.To(int32(2))},
 	}
 	mdb.Spec.Source = &searchv1.MongoDBSource{
 		ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
@@ -2850,8 +2850,8 @@ func TestBuildReplicaSetPlan_SingleClusterUsesIndexZeroNames(t *testing.T) {
 func TestReconcilePlan_UsesPerClusterClient(t *testing.T) {
 	mdb := newTestMongoDBSearch("mdb-search", "ns")
 	mdb.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", Replicas: ptr.To(int32(2))},
-		{ClusterName: "cluster-b", Replicas: ptr.To(int32(2))},
+		{Name: "cluster-a", Replicas: ptr.To(int32(2))},
+		{Name: "cluster-b", Replicas: ptr.To(int32(2))},
 	}
 	mdb.Spec.Source = &searchv1.MongoDBSource{
 		ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
@@ -2922,10 +2922,10 @@ func TestBuildShardedPlan_PerClusterShardUnitsForMC(t *testing.T) {
 	// must start with {shardName}. so the operator can derive the cluster-level
 	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
@@ -2987,10 +2987,10 @@ func TestReconcileShardedMC_FanOutUsesPerClusterClient(t *testing.T) {
 	// must start with {shardName}. so the operator can derive the cluster-level
 	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
@@ -3108,10 +3108,10 @@ func TestReconcileShardedMC_AllUnitsAppliedBeforeReadinessCheck(t *testing.T) {
 	// must start with {shardName}. so the operator can derive the cluster-level
 	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
@@ -3232,10 +3232,10 @@ func newMCShardedFixture(t *testing.T) *mcShardedFixture {
 	// must start with {shardName}. so the operator can derive the cluster-level
 	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+		{Name: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
@@ -3404,8 +3404,8 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns", func(s *searchv1.MongoDBSearch) {
 		s.UID = "search-uid"
 		s.Spec.Clusters = []searchv1.ClusterSpec{
-			{ClusterName: "cluster-a", LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
-			{ClusterName: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
+			{Name: "cluster-a", LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
+			{Name: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
 		}
 	})
 
@@ -3795,7 +3795,7 @@ func TestReconcileShardedMC_ShardOverrideReplicas(t *testing.T) {
 	fx := newMCShardedFixture(t)
 	fx.search.Spec.Clusters = []searchv1.ClusterSpec{
 		{
-			ClusterName:  "cluster-a",
+			Name:         "cluster-a",
 			ClusterIndex: ptr.To(int32(0)),
 			Replicas:     ptr.To(int32(1)),
 			LoadBalancer: fx.search.Spec.Clusters[0].LoadBalancer,
@@ -3805,7 +3805,7 @@ func TestReconcileShardedMC_ShardOverrideReplicas(t *testing.T) {
 			},
 		},
 		{
-			ClusterName:  "cluster-b",
+			Name:         "cluster-b",
 			ClusterIndex: ptr.To(int32(1)),
 			Replicas:     ptr.To(int32(3)),
 			LoadBalancer: fx.search.Spec.Clusters[1].LoadBalancer,

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -266,7 +266,7 @@ func TestCreateSearchStatefulSetFunc_StatefulSetOverrideReplacesAntiAffinity(t *
 	}
 	search := newTestMongoDBSearch("test-search", "default", func(s *searchv1.MongoDBSearch) {
 		s.Spec.Clusters = []searchv1.ClusterSpec{{
-			ClusterName: "cluster-1",
+			Name: "cluster-1",
 			StatefulSetConfiguration: &v1.StatefulSetConfiguration{
 				SpecWrapper: v1.StatefulSetSpecWrapper{
 					Spec: appsv1.StatefulSetSpec{

--- a/controllers/searchcontroller/secrets_presence.go
+++ b/controllers/searchcontroller/secrets_presence.go
@@ -49,7 +49,7 @@ func CheckSecretsPresence(
 		// TLS certs) must be probed at that index, not 0.
 		idx := 0
 		if cs := search.Spec.Clusters; len(cs) == 1 {
-			if v, ok := clusterMapping[cs[0].ClusterName]; ok {
+			if v, ok := clusterMapping[cs[0].Name]; ok {
 				idx = v
 			} else if pinned := cs[0].ClusterIndex; pinned != nil {
 				idx = int(*pinned)

--- a/controllers/searchcontroller/secrets_presence_test.go
+++ b/controllers/searchcontroller/secrets_presence_test.go
@@ -206,7 +206,7 @@ func TestCheckSecretsPresence_SingleClusterSharded_CentralIncludesPerShardCerts(
 func TestCheckSecretsPresence_SimulatedMC_UsesMappedIndex(t *testing.T) {
 	newPinnedSearch := func() *searchv1.MongoDBSearch {
 		s := mcShardedTLSSearch(t, "s", "ns", "shard-0")
-		s.Spec.Clusters = []searchv1.ClusterSpec{{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(7))}}
+		s.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-b", ClusterIndex: ptr.To(int32(7))}}
 		return s
 	}
 	mapping := map[string]int{"cluster-b": 7}

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
@@ -340,7 +340,7 @@ class SearchDeploymentTests:
 
 
 class SearchRsDeploymentTests(SearchDeploymentTests):
-    """SC ReplicaSet search deploy. SC = one cluster entry, no clusterName (index 0)."""
+    """SC ReplicaSet search deploy. SC = one cluster entry, no name (index 0)."""
 
     def search_clusters(self) -> list:
         return [

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
@@ -119,7 +119,7 @@ class SearchRsMcDeploymentTests(SearchDeploymentTests):
     def search_clusters(self) -> list:
         return [
             {
-                "clusterName": cluster_name,
+                "name": cluster_name,
                 "clusterIndex": i,
                 "replicas": self.search_config.mongot_replicas,
                 "resourceRequirements": self.search_config.mongot_resource_requirements(),
@@ -351,7 +351,7 @@ class SearchShardedMcDeploymentTests(SearchShardedDeploymentTests):
     def search_clusters(self) -> list:
         return [
             {
-                "clusterName": name,
+                "name": name,
                 "clusterIndex": i,
                 "replicas": self.search_config.mongot_replicas,
                 "resourceRequirements": self.search_config.mongot_resource_requirements(),

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
@@ -391,7 +391,7 @@ class SearchDeploymentHelper:
         """Create MongoDBSearch with an external RS source.
 
         ``clusters`` (mutually exclusive with ``replicas``) writes spec.clusters;
-        a single entry with no clusterName models a single-cluster RS at index 0.
+        a single entry with no name models a single-cluster RS at index 0.
         """
         resource = MongoDBSearch.from_yaml(
             yaml_fixture("search-minimal.yaml"),

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -275,7 +275,7 @@ def build_per_cluster_search_crs(
 
     clusters_spec = [
         {
-            "clusterName": mcc.cluster_name,
+            "name": mcc.cluster_name,
             "clusterIndex": _idx(mcc),
             "replicas": mongot_replicas,
             "loadBalancer": {

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -264,12 +264,16 @@ def build_per_cluster_search_crs(
     member_cluster_clients: List[MultiClusterClient],
     mdbs_resource_name: str,
     mongot_replicas: int,
-    external_hostname_template: str,
+    external_hostname_for_cluster: Callable[[int], str],
     source_external: dict,
 ) -> List[Tuple[MultiClusterClient, MongoDBSearch]]:
     """Build the SAME MongoDBSearch CR (spec.clusters lists all clusters) against each
     member's API; each simulated operator projects to its own slice. `source_external`
     carries the variant-specific spec.source.external block (hostAndPorts vs shardedCluster).
+
+    `external_hostname_for_cluster(cluster_index)` returns that cluster's literal managed-LB
+    externalHostname; #1238 moved the LB under spec.clusters[] and dropped the per-cluster
+    hostname placeholder, so each cluster needs a distinct literal (validation rejects duplicates).
     """
     results: List[Tuple[MultiClusterClient, MongoDBSearch]] = []
 
@@ -281,7 +285,7 @@ def build_per_cluster_search_crs(
             "loadBalancer": {
                 "managed": {
                     "replicas": ENVOY_LB_REPLICAS,
-                    "externalHostname": external_hostname_template.replace("{clusterIndex}", str(_idx(mcc))),
+                    "externalHostname": external_hostname_for_cluster(_idx(mcc)),
                 },
             },
         }

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -216,21 +216,24 @@ def mdbs(
         "tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX},
     }
 
-    resource["spec"]["clusters"] = [
-        {
-            "name": mcc.cluster_name,
-            "clusterIndex": mcc.cluster_index,
-            "replicas": MONGOT_REPLICAS_PER_CLUSTER,
-            "loadBalancer": {
-                "managed": {
-                    "externalHostname": search_resource_names.mc_proxy_svc_fqdn(
-                        MDBS_RESOURCE_NAME, namespace, _idx(mcc)
-                    ),
+    clusters = []
+    for mcc in member_cluster_clients:
+        assert mcc.cluster_index is not None, f"cluster_index unset on {mcc.cluster_name!r}"
+        clusters.append(
+            {
+                "name": mcc.cluster_name,
+                "clusterIndex": mcc.cluster_index,
+                "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+                "loadBalancer": {
+                    "managed": {
+                        "externalHostname": search_resource_names.mc_proxy_svc_fqdn(
+                            MDBS_RESOURCE_NAME, namespace, _idx(mcc)
+                        ),
+                    },
                 },
-            },
-        }
-        for mcc in member_cluster_clients
-    ]
+            }
+        )
+    resource["spec"]["clusters"] = clusters
 
     resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
     try_load(resource)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -218,7 +218,7 @@ def mdbs(
 
     resource["spec"]["clusters"] = [
         {
-            "clusterName": mcc.cluster_name,
+            "name": mcc.cluster_name,
             "clusterIndex": mcc.cluster_index,
             "replicas": MONGOT_REPLICAS_PER_CLUSTER,
             "loadBalancer": {

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -226,7 +226,7 @@ def mdbs(
 
     resource["spec"]["clusters"] = [
         {
-            "clusterName": mcc.cluster_name,
+            "name": mcc.cluster_name,
             "clusterIndex": mcc.cluster_index,
             "replicas": MONGOT_REPLICAS_PER_CLUSTER,
             "loadBalancer": {

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -224,21 +224,24 @@ def mdbs(
         "tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX},
     }
 
-    resource["spec"]["clusters"] = [
-        {
-            "name": mcc.cluster_name,
-            "clusterIndex": mcc.cluster_index,
-            "replicas": MONGOT_REPLICAS_PER_CLUSTER,
-            "loadBalancer": {
-                "managed": {
-                    "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
-                        MDBS_RESOURCE_NAME, namespace, _idx(mcc)
-                    ),
+    clusters = []
+    for mcc in member_cluster_clients:
+        assert mcc.cluster_index is not None, f"cluster_index unset on {mcc.cluster_name!r}"
+        clusters.append(
+            {
+                "name": mcc.cluster_name,
+                "clusterIndex": mcc.cluster_index,
+                "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+                "loadBalancer": {
+                    "managed": {
+                        "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
+                            MDBS_RESOURCE_NAME, namespace, _idx(mcc)
+                        ),
+                    },
                 },
-            },
-        }
-        for mcc in member_cluster_clients
-    ]
+            }
+        )
+    resource["spec"]["clusters"] = clusters
 
     resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
     try_load(resource)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_rs.py
@@ -132,7 +132,7 @@ class TestSearchConnectivityToolMC:
                 mdbs.load()
                 clusters = [dict(c) for c in original_clusters]
                 for entry in clusters:
-                    if entry["clusterName"] == outage_mcc.cluster_name:
+                    if entry["name"] == outage_mcc.cluster_name:
                         entry["replicas"] = 0
                 mdbs["spec"]["clusters"] = clusters
                 mdbs.update()
@@ -250,7 +250,7 @@ class TestSearchConnectivityToolMC:
                 mdbs.load()
                 clusters = [dict(c) for c in original_clusters]
                 for entry in clusters:
-                    if entry["clusterName"] == outage_mcc.cluster_name:
+                    if entry["name"] == outage_mcc.cluster_name:
                         entry["replicas"] = 0
                 mdbs["spec"]["clusters"] = clusters
                 mdbs.update()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
@@ -176,7 +176,7 @@ class TestSearchConnectivityToolMcSharded:
             mdbs.load()
             clusters = [dict(c) for c in original_clusters]
             for entry in clusters:
-                if entry["clusterName"] == faulted_name:
+                if entry["name"] == faulted_name:
                     entry["replicas"] = 0
             mdbs["spec"]["clusters"] = clusters
             mdbs.update()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
@@ -166,7 +166,9 @@ def per_cluster_mdbs_search(
         member_cluster_clients,
         MDBS_RESOURCE_NAME,
         MONGOT_REPLICAS_PER_CLUSTER,
-        f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-proxy-svc.{namespace}.svc.cluster.local",
+        # Per-cluster literal: the cluster's own proxy-svc FQDN (distinct per clusterIndex),
+        # mirroring q2_mc_rs_steady.
+        lambda idx: search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, idx),
         {
             "hostAndPorts": seeds,
             "tls": {"ca": {"name": ca_configmap}},

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
@@ -265,9 +265,10 @@ def per_cluster_mdbs_search(
         member_cluster_clients,
         MDBS_RESOURCE_NAME,
         MONGOT_REPLICAS_PER_CLUSTER,
-        # Per-cluster, per-shard externalHostname template — operator
-        # substitutes {clusterIndex} and {shardName} per resource.
-        f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local",
+        # Per-cluster literal with the clusterIndex baked in (distinct per cluster); the
+        # {shardName} placeholder is retained for the operator to resolve per shard,
+        # mirroring q3_mc_sharded_external_mtls.
+        lambda idx: search_resource_names.shard_proxy_svc_hostname_template(MDBS_RESOURCE_NAME, namespace, idx),
         {
             "shardedCluster": {
                 "router": {"hosts": router_hosts},

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -89,13 +89,13 @@ spec:
               clusters:
                 description: |-
                   Clusters configures the deployment per Kubernetes cluster: one entry for a
-                  single cluster (clusterName optional), or one entry per cluster for
-                  multi-cluster (clusterName required, len > 1). This is the place to set
+                  single cluster (name optional), or one entry per cluster for
+                  multi-cluster (name required, len > 1). This is the place to set
                   replicas, resources, storage, and StatefulSet overrides.
                 items:
                   description: |-
-                    ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-                    when len(spec.clusters) > 1; optional in the single-cluster case.
+                    ClusterSpec is one entry in spec.clusters[]. The cluster name (spec.clusters[].name)
+                    is required and immutable when len(spec.clusters) > 1; optional in the single-cluster case.
                     Each field, when set, applies to this cluster; when unset, the operator's
                     per-field default applies.
                   properties:
@@ -108,13 +108,6 @@ spec:
                       maximum: 999
                       minimum: 0
                       type: integer
-                    clusterName:
-                      description: |-
-                        ClusterName is the Kubernetes cluster name. Required and immutable
-                        when len(spec.clusters) > 1; optional in the single-cluster case.
-                        MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
-                      maxLength: 253
-                      type: string
                     jvmFlags:
                       description: JVMFlags sets the `--jvm-flags` option for this
                         cluster's mongot pods.
@@ -276,6 +269,13 @@ spec:
                       - message: exactly one of managed or unmanaged must be set
                         rule: (has(self.managed) && !has(self.unmanaged)) || (!has(self.managed)
                           && has(self.unmanaged))
+                    name:
+                      description: |-
+                        Name is the Kubernetes cluster name. Required and immutable
+                        when len(spec.clusters) > 1; optional in the single-cluster case.
+                        MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
+                      maxLength: 253
+                      type: string
                     persistence:
                       description: Persistence configures this cluster's mongot persistent
                         volume. Defaults to 10GB if unset.
@@ -620,10 +620,10 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-validations:
-                - message: clusters[].clusterName must be set and unique when more
-                    than one cluster is specified
-                  rule: size(self) <= 1 || self.all(c1, has(c1.clusterName) && self.exists_one(c2,
-                    has(c2.clusterName) && c2.clusterName == c1.clusterName))
+                - message: clusters[].name must be set and unique when more than one
+                    cluster is specified
+                  rule: size(self) <= 1 || self.all(c1, has(c1.name) && self.exists_one(c2,
+                    has(c2.name) && c2.name == c1.name))
                 - message: clusters[].clusterIndex must be unique when set
                   rule: self.all(c1, !has(c1.clusterIndex) || self.exists_one(c2,
                     has(c2.clusterIndex) && c2.clusterIndex == c1.clusterIndex))

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4113,13 +4113,13 @@ spec:
               clusters:
                 description: |-
                   Clusters configures the deployment per Kubernetes cluster: one entry for a
-                  single cluster (clusterName optional), or one entry per cluster for
-                  multi-cluster (clusterName required, len > 1). This is the place to set
+                  single cluster (name optional), or one entry per cluster for
+                  multi-cluster (name required, len > 1). This is the place to set
                   replicas, resources, storage, and StatefulSet overrides.
                 items:
                   description: |-
-                    ClusterSpec is one entry in spec.clusters[]. ClusterName is required and immutable
-                    when len(spec.clusters) > 1; optional in the single-cluster case.
+                    ClusterSpec is one entry in spec.clusters[]. The cluster name (spec.clusters[].name)
+                    is required and immutable when len(spec.clusters) > 1; optional in the single-cluster case.
                     Each field, when set, applies to this cluster; when unset, the operator's
                     per-field default applies.
                   properties:
@@ -4132,13 +4132,6 @@ spec:
                       maximum: 999
                       minimum: 0
                       type: integer
-                    clusterName:
-                      description: |-
-                        ClusterName is the Kubernetes cluster name. Required and immutable
-                        when len(spec.clusters) > 1; optional in the single-cluster case.
-                        MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
-                      maxLength: 253
-                      type: string
                     jvmFlags:
                       description: JVMFlags sets the `--jvm-flags` option for this
                         cluster's mongot pods.
@@ -4300,6 +4293,13 @@ spec:
                       - message: exactly one of managed or unmanaged must be set
                         rule: (has(self.managed) && !has(self.unmanaged)) || (!has(self.managed)
                           && has(self.unmanaged))
+                    name:
+                      description: |-
+                        Name is the Kubernetes cluster name. Required and immutable
+                        when len(spec.clusters) > 1; optional in the single-cluster case.
+                        MaxLength is 253 — the DNS subdomain limit Kubernetes cluster names follow.
+                      maxLength: 253
+                      type: string
                     persistence:
                       description: Persistence configures this cluster's mongot persistent
                         volume. Defaults to 10GB if unset.
@@ -4644,10 +4644,10 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-validations:
-                - message: clusters[].clusterName must be set and unique when more
-                    than one cluster is specified
-                  rule: size(self) <= 1 || self.all(c1, has(c1.clusterName) && self.exists_one(c2,
-                    has(c2.clusterName) && c2.clusterName == c1.clusterName))
+                - message: clusters[].name must be set and unique when more than one
+                    cluster is specified
+                  rule: size(self) <= 1 || self.all(c1, has(c1.name) && self.exists_one(c2,
+                    has(c2.name) && c2.name == c1.name))
                 - message: clusters[].clusterIndex must be unique when set
                   rule: self.all(c1, !has(c1.clusterIndex) || self.exists_one(c2,
                     has(c2.clusterIndex) && c2.clusterIndex == c1.clusterIndex))


### PR DESCRIPTION
> **Rebased & taken over — updated 2026-06-22.** The original author is out; I took over this stack. Both #1224 (shardOverrides) and #1238 (per-cluster loadBalancer) have now **merged into `search/ga-base`**, so this is the final PR of the stack and targets `search/ga-base` directly. It carries the `clusterName`→`name` rename plus the simulated-MC e2e fixture migration to per-cluster `loadBalancer`. Content is unchanged from the previously-green full multi-cluster + load-balancer e2e validation (byte-identical tree, just reparented). **The `name` rename is breaking post-GA — please confirm the `name` vs `clusterName` decision before merge.**

**Update (rebased onto rewritten ga-base):** `search/ga-base` was force-rewritten (per-cluster LB + shardOverrides re-landed as a squashed "KUBE-120: finalize API" + the #1262 CI fix). This PR was rebased onto the new ga-base; the rename commits applied clean, and the sim-MC fixture migration was reconciled with #1262 (kept only the non-redundant deltas — the `name` rename + the per-cluster callable). Rename verified complete (Go field + JSON tag + CRD all `name`); build + search unit suites green; zero CRD drift.

**Update (review follow-up):** addressed @viveksinghggits's nits — the Go field `ClusterSpec.ClusterName` is renamed to `Name` too (not just the JSON tag), and its doc comment fixed; the generated CRD is unchanged (JSON tag was already `name`). Also fixed two pre-existing lint failures surfaced on CI (a gofmt reformat and two Python `ty` `int | None` call-site narrowings) — neither related to the rename. Unit-covered; no e2e behavior change.

# Summary

Renames the per-cluster identifier field `spec.clusters[].clusterName` → `spec.clusters[].name`. This is the user-facing key on each `clusters[]` entry; the rename flows through the Go API types, the generated CRD/CEL validation, and all unit + e2e tests. No behavior change — purely the API surface.

Note: this makes MongoDBSearch the only CRD using `name` for the per-cluster key (AppDB / sharded / OM use `clusterName`). This is intentional for the MongoDBSearch `spec.clusters[]` API but is breaking post-GA, so it should be confirmed before merge.

## Proof of Work

- Unit suites for `api/mongodb/v1/search`, `controllers/searchcontroller`, and `controllers/operator` pass; `make manifests` produces zero CRD drift.
- The full multi-cluster + LB e2e suite (q2/q3 MC, simulated-MC RS + sharded, managed/unmanaged per-cluster-LB) is green on the rebased stack.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details




