### PR TITLE
[KUBE-126] Add support for password encrypted keyfile for gRPC connections to mongot

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1287,10 +1287,21 @@ func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Contex
 		return nil, nil, err
 	}
 
+	// Check if the user-provided TLS secret contains an optional key password
+	hasKeyPassword := false
+	userProvidedTLSSecret := tlsResource.TLSSecretNamespacedName()
+	_, keyPasswordErr := secret.ReadKey(ctx, kubeClient, GrpcKeyPasswordSecretKey, userProvidedTLSSecret)
+	if keyPasswordErr == nil {
+		hasKeyPassword = true
+	}
+
 	mongotModification := func(config *mongot.Config) {
 		certPath := tls.OperatorSecretMountPath + certFileName
 		config.Server.Grpc.TLS.Mode = mongot.ConfigTLSModeTLS
 		config.Server.Grpc.TLS.CertificateKeyFile = ptr.To(certPath)
+		if hasKeyPassword {
+			config.Server.Grpc.TLS.CertificateKeyFilePasswordFile = ptr.To(TempGrpcKeyPasswordPath)
+		}
 		if config.Server.Wireproto != nil {
 			config.Server.Wireproto.TLS.Mode = mongot.ConfigTLSModeTLS
 			config.Server.Wireproto.TLS.CertificateKeyFile = ptr.To(certPath)
@@ -1300,11 +1311,27 @@ func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Contex
 	tlsSecret := tlsResource.TLSOperatorSecretNamespacedName()
 	tlsVolume := statefulset.CreateVolumeFromSecret("tls", tlsSecret.Name)
 	tlsVolumeMount := statefulset.CreateVolumeMount("tls", tls.OperatorSecretMountPath, statefulset.WithReadOnly(true))
+
+	volumeMounts := []corev1.VolumeMount{tlsVolumeMount}
+	volumes := []podtemplatespec.Modification{podtemplatespec.WithVolume(tlsVolume)}
+	var containerMods []container.Modification
+
+	if hasKeyPassword {
+		keyPasswordVolume := statefulset.CreateVolumeFromSecret("grpc-key-password", userProvidedTLSSecret.Name)
+		keyPasswordVolumeMount := statefulset.CreateVolumeMount("grpc-key-password", GrpcKeyPasswordMountPath,
+			statefulset.WithReadOnly(true), statefulset.WithSubPath(GrpcKeyPasswordSecretKey))
+
+		volumeMounts = append(volumeMounts, keyPasswordVolumeMount)
+		volumes = append(volumes, podtemplatespec.WithVolume(keyPasswordVolume))
+		containerMods = append(containerMods, prependCommand(sensitiveFilePermissionsWorkaround(GrpcKeyPasswordMountPath, TempGrpcKeyPasswordPath, "0600")))
+	}
+
+	containerMods = append(containerMods, container.WithVolumeMounts(volumeMounts))
+
 	statefulsetModification := statefulset.WithPodSpecTemplate(podtemplatespec.Apply(
-		podtemplatespec.WithVolume(tlsVolume),
-		podtemplatespec.WithContainer(MongotContainerName, container.Apply(
-			container.WithVolumeMounts([]corev1.VolumeMount{tlsVolumeMount}),
-		)),
+		append(volumes, podtemplatespec.WithContainer(MongotContainerName, container.Apply(
+			containerMods...,
+		)))...,
 	))
 
 	return mongotModification, statefulsetModification, nil

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -52,6 +52,10 @@ const (
 	// The original is mounted read-only from a ConfigMap; we copy it to /tmp so that
 	// sed can replace the server-name placeholder with the actual pod hostname.
 	TempMongotConfigPath = tempVolumePath + "/" + MongotConfigFilename
+
+	GrpcKeyPasswordMountPath = "/mongot/grpc-key-password"           // #nosec G101 -- path, not a password
+	TempGrpcKeyPasswordPath  = tempVolumePath + "/grpc-key-password" // #nosec G101 -- path, not a password
+	GrpcKeyPasswordSecretKey = "tls.keyFilePassword"                 // #nosec G101 -- secret key name, not a password
 )
 
 // SearchSourceDBResource is an object wrapping a MongoDBCommunity object

--- a/docker/mongodb-kubernetes-tests/tests/common/search/tls_utils.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/tls_utils.py
@@ -1,0 +1,36 @@
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    Encoding,
+    PrivateFormat,
+    load_pem_private_key,
+)
+from kubetester import read_secret, update_secret
+from tests import test_logger
+
+logger = test_logger.get_test_logger(__name__)
+
+
+def encrypt_tls_key_with_password(namespace: str, secret_name: str, password: str):
+    """Encrypts the private key in a TLS secret with a password.
+
+    Reads the secret, encrypts tls.key with the given password, and updates
+    the secret with the encrypted key and a tls.keyFilePassword entry
+    containing the password."""
+    secret_data = read_secret(namespace, secret_name)
+
+    private_key = load_pem_private_key(secret_data["tls.key"].encode(), password=None)
+    encrypted_key_pem = private_key.private_bytes(
+        encoding=Encoding.PEM,
+        format=PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=BestAvailableEncryption(password.encode()),
+    )
+
+    update_secret(
+        namespace,
+        secret_name,
+        data={
+            "tls.key": encrypted_key_pem.decode(),
+            "tls.keyFilePassword": password,
+        },
+    )
+    logger.info(f"Encrypted private key in secret {secret_name} with password")

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_tls.py
@@ -13,6 +13,7 @@ from tests.common.search import movies_search_helper, search_resource_names
 from tests.common.search.replicaset_search_helper import verify_rs_mongod_parameters
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.search_tester import SearchTester
+from tests.common.search.tls_utils import encrypt_tls_key_with_password
 from tests.conftest import get_default_operator, get_issuer_ca_filepath
 from tests.search.om_deployment import get_ops_manager
 
@@ -31,6 +32,9 @@ USER_PASSWORD = f"{USER_NAME}-password"
 
 # MongoDBSearch TLS configuration -- convention: {name}-search-cert
 MDBS_TLS_SECRET_NAME = search_resource_names.mongot_tls_cert_name(MDB_RESOURCE_NAME)
+
+# Password used to encrypt the gRPC server certificate private key
+GRPC_KEY_PASSWORD = "test-grpc-key-password"
 
 
 @fixture(scope="function")
@@ -116,6 +120,10 @@ def test_install_tls_secrets_and_configmaps(namespace: str, mdb: MongoDB, mdbs: 
         ],
         secret_name=MDBS_TLS_SECRET_NAME,
     )
+
+    # Encrypt the gRPC server certificate key with a password to verify
+    # that mongot can handle password-protected keys via tls.keyFilePassword
+    encrypt_tls_key_with_password(namespace, MDBS_TLS_SECRET_NAME, GRPC_KEY_PASSWORD)
 
 
 @mark.e2e_search_enterprise_tls

--- a/docker/mongodb-kubernetes-tests/tests/search/search_mongot_replicaset_x509_auth.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_mongot_replicaset_x509_auth.py
@@ -1,10 +1,4 @@
-from cryptography.hazmat.primitives.serialization import (
-    BestAvailableEncryption,
-    Encoding,
-    PrivateFormat,
-    load_pem_private_key,
-)
-from kubetester import create_or_update_secret, read_secret, try_load, update_secret
+from kubetester import create_or_update_secret, try_load
 from kubetester.certs import create_agent_tls_certs, create_tls_certs, create_x509_mongodb_tls_certs, generate_cert
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
@@ -18,6 +12,7 @@ from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import movies_search_helper, search_resource_names
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.search_tester import SearchTester
+from tests.common.search.tls_utils import encrypt_tls_key_with_password
 from tests.conftest import get_default_operator, get_issuer_ca_filepath
 from tests.search.om_deployment import get_ops_manager
 
@@ -44,30 +39,6 @@ X509_CLIENT_CERT_CN = "mongot-sync-source"
 X509_AUTH_KEY_PASSWORD = "test-x509-key-password"
 
 
-def encrypt_x509_key_with_password(namespace: str, secret_name: str, password: str):
-    """Encrypts the private key in a TLS secret with a password.
-
-    Reads the cert-manager-generated secret, encrypts tls.key with the given
-    password, and updates the secret with the encrypted key and a
-    tls.keyFilePassword entry containing the password."""
-    secret_data = read_secret(namespace, secret_name)
-
-    private_key = load_pem_private_key(secret_data["tls.key"].encode(), password=None)
-    encrypted_key_pem = private_key.private_bytes(
-        encoding=Encoding.PEM,
-        format=PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=BestAvailableEncryption(password.encode()),
-    )
-
-    update_secret(
-        namespace,
-        secret_name,
-        data={
-            "tls.key": encrypted_key_pem.decode(),
-            "tls.keyFilePassword": password,
-        },
-    )
-    logger.info(f"Encrypted private key in secret {secret_name} with password")
 
 
 def get_x509_subject_dn(namespace: str) -> str:
@@ -223,7 +194,7 @@ def test_install_tls_secrets_and_configmaps(namespace: str, mdb: MongoDB, mdbs: 
 
     # Encrypt the x509 client cert private key with a password to test
     # that mongot can handle password-protected keys via tls.keyFilePassword
-    encrypt_x509_key_with_password(namespace, X509_CLIENT_CERT_SECRET_NAME, X509_AUTH_KEY_PASSWORD)
+    encrypt_tls_key_with_password(namespace, X509_CLIENT_CERT_SECRET_NAME, X509_AUTH_KEY_PASSWORD)
 
 
 @mark.e2e_search_mongot_replicaset_x509_auth

--- a/pkg/mongot/mongot_config.go
+++ b/pkg/mongot/mongot_config.go
@@ -122,9 +122,10 @@ type ConfigWireprotoTLS struct {
 }
 
 type ConfigGrpcTLS struct {
-	Mode                     ConfigTLSMode `json:"mode"`
-	CertificateKeyFile       *string       `json:"certificateKeyFile,omitempty"`
-	CertificateAuthorityFile *string       `json:"caFile,omitempty"`
+	Mode                           ConfigTLSMode `json:"mode"`
+	CertificateKeyFile             *string       `json:"certificateKeyFile,omitempty"`
+	CertificateKeyFilePasswordFile *string       `json:"certificateKeyFilePasswordFile,omitempty"`
+	CertificateAuthorityFile       *string       `json:"caFile,omitempty"`
 }
 
 type ConfigMetrics struct {


### PR DESCRIPTION
# Summary

The mongot upstream recently added support password encrypted keyfile for gRPC connections at mongot side. This is how the mongot config looks like before 

```
server:
  grpc:
     address: <string>
     tls:
        mode: <string>
        certificateKeyFile: <string>
        caFile: <string>
```

now it has been change to 

```
server:
  grpc:
     address: <string>
     tls:
        mode: <string>
        certificateKeyFile: <string>
        certificateKeyFilePasswordFile: <string>
        caFile: <string>
```

This PR adds support so that if users want they can provide password for their keyfile, if it's encrypted. To provide the password they are just going to provide the tls secret like they used and they just have to provide another key in that secret named `tls.keyFilePassword`. If this key is provided in the secret configured in the search resource at `spec.security.tls.certificateKeySecretRef` or `spec.security.tls.certsSecretPrefix`, we mount that to the pod and update the mongot config with the password. 

In E2E the secret M`DBS_TLS_SECRET_NAME` initially just has `tls.key` and `tls.crt`. When we call `encrypt_tls_key_with_password`, it encrypted `tls.key` and updated `tls.key` with encrypted data. and also adds a new secret field `tls.keyFilePassword`. Once operator sees that the referred secret has `tls.keyFilePassword` it adds `certificateKeyFilePasswordFile` in the mongot config.
this is how the mongot config looks like

```
data:
  config.yml: |
    server:
      grpc:
        address: 0.0.0.0:27028
        tls:
          caFile: /var/lib/tls/ca/ca-pem
          certificateKeyFile: /var/lib/tls/server/2228e2769c3866c988c27cd04a9d9fb288de3b031efa7cb2882c918c564935a9.pem
          certificateKeyFilePasswordFile: /tmp/grpc-key-password
          mode: mTLS
    storage:
....
```

## Proof of Work

E2E will part of next PR.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
