### PR TITLE
KUBE-120: Move MongoDBSearch loadBalancer under clusters[] and resolve it by cluster name

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -239,8 +239,7 @@ type LoadBalancerConfig struct {
 type ManagedLBConfig struct {
 	// ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
 	// For sharded clusters, may contain a {shardName} placeholder.
-	// In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-	// SNI hostnames stay distinct.
+	// In multi-cluster deployments, every cluster's hostname must be distinct.
 	// Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
 	// +optional
 	ExternalHostname string `json:"externalHostname,omitempty"`
@@ -434,7 +433,7 @@ type MongoDBSearchStatus struct {
 	Version       string           `json:"version,omitempty"`
 	Warnings      []status.Warning `json:"warnings,omitempty"`
 	// LoadBalancer reports the state of the operator-managed load balancer.
-	// Only populated when spec.loadBalancer.managed is set.
+	// Only populated when spec.clusters[].loadBalancer.managed is set.
 	// +optional
 	LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
 }

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -3,7 +3,6 @@ package search
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,17 +24,6 @@ import (
 const (
 	// ShardNamePlaceholder is the placeholder used in endpoint templates for sharded clusters
 	ShardNamePlaceholder = "{shardName}"
-
-	// ClusterNamePlaceholder is substituted with spec.clusters[i].ClusterName when
-	// resolving spec.loadBalancer.managed.externalHostname for cluster i in
-	// multi-cluster MongoDBSearch deployments. The Envoy reconciler substitutes the
-	// member cluster name so per-cluster SNI hostnames stay distinct.
-	ClusterNamePlaceholder = "{clusterName}"
-
-	// ClusterIndexPlaceholder is substituted with the stable cluster-index for
-	// spec.clusters[i]. The index is taken verbatim from the user pin; the persisted
-	// mapping retains removed clusters' entries (see cluster_index.go).
-	ClusterIndexPlaceholder = "{clusterIndex}"
 
 	// LabelResourceOwner is the label key used to identify the MongoDBSearch CR that
 	// owns a resource. Used as part of GetOwnerLabels for StateStore ConfigMap selection.
@@ -103,12 +91,6 @@ type MongoDBSearchSpec struct {
 	// through an embedding model service. These values populate the `embedding` section of the mongot config.
 	// +optional
 	AutoEmbedding *EmbeddingConfig `json:"autoEmbedding,omitempty"`
-	// LoadBalancer configures how mongod/mongos connect to mongot (Managed vs Unmanaged/BYO Load Balancer).
-	// Top-level spec.loadBalancer.managed.* serves as the default for every entry in spec.clusters;
-	// per-cluster overrides deep-merge into this template (see spec.clusters[].loadBalancer.managed).
-	// spec.loadBalancer.unmanaged is top-level only — there is no per-cluster form.
-	// +optional
-	LoadBalancer *LoadBalancerConfig `json:"loadBalancer,omitempty"`
 	// FeatureFlags configures mongot feature flags. When a flag is set to true in the CR,
 	// it is rendered into the mongot config YAML. When omitted or false, the flag is not
 	// included in mongot config and mongot uses its built-in defaults.
@@ -164,8 +146,8 @@ type ClusterSpec struct {
 	ClusterIndex *int32 `json:"clusterIndex,omitempty"`
 	// Replicas is the number of mongot pods for this cluster's StatefulSet.
 	// For ReplicaSet sources this is the total; for sharded sources it is per shard.
-	// When Replicas > 1, a load balancer (spec.loadBalancer) is required to distribute
-	// traffic across mongot instances.
+	// When Replicas > 1, a load balancer (spec.clusters[].loadBalancer) is required to
+	// distribute traffic across mongot instances.
 	// Set to 0 to take mongot offline: the StatefulSet scales to 0 while the MongoDBSearch CR stays.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
@@ -182,7 +164,9 @@ type ClusterSpec struct {
 	StatefulSetConfiguration *v1.StatefulSetConfiguration `json:"statefulSet,omitempty"`
 	// +optional
 	SyncSourceSelector *SyncSourceSelector `json:"syncSourceSelector,omitempty"`
-	// LoadBalancer per-cluster override; deep-merged into spec.loadBalancer.managed.
+	// LoadBalancer configures how mongod/mongos connect to this cluster's mongot
+	// (managed Envoy or user-provided). Every cluster must agree on the mode:
+	// either all clusters set managed, all set unmanaged, or none set loadBalancer.
 	// +optional
 	LoadBalancer *LoadBalancerConfig `json:"loadBalancer,omitempty"`
 	// JVMFlags sets the `--jvm-flags` option for this cluster's mongot pods.
@@ -538,8 +522,8 @@ func (s *MongoDBSearch) updateLoadBalancerStatus(phase status.Phase, statusOptio
 // GetMinMongotReadyReplicasForRouting returns the minimum number of ready mongot
 // replicas required to consider a mongot group ready for envoy to route real traffic to a shard's mongot group.
 func (s *MongoDBSearch) GetMinMongotReadyReplicasForRouting() int32 {
-	if s.IsLBModeManaged() && s.Spec.LoadBalancer.Managed.MinMongotReadyReplicas != nil {
-		return *s.Spec.LoadBalancer.Managed.MinMongotReadyReplicas
+	if lb := s.firstClusterLB(); lb != nil && lb.Managed != nil && lb.Managed.MinMongotReadyReplicas != nil {
+		return *lb.Managed.MinMongotReadyReplicas
 	}
 	return 1
 }
@@ -785,31 +769,54 @@ func (s *MongoDBSearch) GetPrometheus() *Prometheus {
 	return s.Spec.Prometheus
 }
 
+// lbForClusterIndex returns spec.clusters[i].loadBalancer, or nil when i is out
+// of range or the cluster does not set one.
+func (s *MongoDBSearch) lbForClusterIndex(i int) *LoadBalancerConfig {
+	if i < 0 || i >= len(s.Spec.Clusters) {
+		return nil
+	}
+	return s.Spec.Clusters[i].LoadBalancer
+}
+
+// firstClusterLB returns the first cluster's loadBalancer. Validation enforces
+// that every cluster sets the same mode (or none sets one), so the first entry
+// answers deployment-wide mode questions.
+func (s *MongoDBSearch) firstClusterLB() *LoadBalancerConfig {
+	return s.lbForClusterIndex(0)
+}
+
 func (s *MongoDBSearch) IsLBModeUnmanaged() bool {
-	return s.Spec.LoadBalancer != nil && s.Spec.LoadBalancer.Unmanaged != nil
+	lb := s.firstClusterLB()
+	return lb != nil && lb.Unmanaged != nil
 }
 
 // IsReplicaSetUnmanagedLB returns true if this is a ReplicaSet with unmanaged LB configuration.
 // An endpoint with a template placeholder ({shardName}) is NOT considered a ReplicaSet endpoint.
 func (s *MongoDBSearch) IsReplicaSetUnmanagedLB() bool {
 	return s.IsLBModeUnmanaged() &&
-		s.Spec.LoadBalancer.Unmanaged.Endpoint != "" &&
+		s.firstClusterLB().Unmanaged.Endpoint != "" &&
 		!s.HasEndpointTemplate()
 }
 
-func (s *MongoDBSearch) GetReplicaSetUnmanagedLBEndpoint() string {
-	if !s.IsReplicaSetUnmanagedLB() {
+// GetUnmanagedLBEndpointForCluster returns spec.clusters[i].loadBalancer.unmanaged.endpoint,
+// or "" when cluster i does not configure an unmanaged LB.
+func (s *MongoDBSearch) GetUnmanagedLBEndpointForCluster(i int) string {
+	lb := s.lbForClusterIndex(i)
+	if lb == nil || lb.Unmanaged == nil {
 		return ""
 	}
-	return s.Spec.LoadBalancer.Unmanaged.Endpoint
+	return lb.Unmanaged.Endpoint
 }
 
-// HasEndpointTemplate returns true if the unmanaged endpoint contains the {shardName} template placeholder.
+// HasEndpointTemplate returns true if the unmanaged endpoint contains the {shardName}
+// template placeholder. Validation enforces that every cluster's endpoint has the same
+// shape (templated or not), so the first cluster answers for the deployment.
 func (s *MongoDBSearch) HasEndpointTemplate() bool {
-	if s.Spec.LoadBalancer == nil || s.Spec.LoadBalancer.Unmanaged == nil {
+	lb := s.firstClusterLB()
+	if lb == nil || lb.Unmanaged == nil {
 		return false
 	}
-	return strings.Contains(s.Spec.LoadBalancer.Unmanaged.Endpoint, ShardNamePlaceholder)
+	return strings.Contains(lb.Unmanaged.Endpoint, ShardNamePlaceholder)
 }
 
 // IsShardedUnmanagedLB returns true if this is a sharded unmanaged LB configuration
@@ -826,19 +833,19 @@ func (s *MongoDBSearch) IsShardedEndpoint() bool {
 	if s.IsShardedUnmanagedLB() {
 		return true
 	}
-	if s.IsLBModeManaged() && strings.Contains(s.Spec.LoadBalancer.Managed.ExternalHostname, ShardNamePlaceholder) {
+	if s.IsLBModeManaged() && strings.Contains(s.firstClusterLB().Managed.ExternalHostname, ShardNamePlaceholder) {
 		return true
 	}
 	return false
 }
 
-// GetEndpointForShard returns the endpoint for a specific shard by substituting
-// the {shardName} placeholder in the endpoint template.
-func (s *MongoDBSearch) GetEndpointForShard(shardName string) string {
+// GetEndpointForClusterShard returns cluster i's unmanaged endpoint for a specific
+// shard by substituting the {shardName} placeholder.
+func (s *MongoDBSearch) GetEndpointForClusterShard(i int, shardName string) string {
 	if !s.IsShardedUnmanagedLB() {
 		return ""
 	}
-	return strings.ReplaceAll(s.Spec.LoadBalancer.Unmanaged.Endpoint, ShardNamePlaceholder, shardName)
+	return strings.ReplaceAll(s.GetUnmanagedLBEndpointForCluster(i), ShardNamePlaceholder, shardName)
 }
 
 // EffectiveClusters returns the per-cluster distribution slice the reconcile
@@ -980,96 +987,54 @@ func (s *MongoDBSearch) MongotConfigMapForClusterShard(clusterIndex int, shardNa
 }
 
 func (s *MongoDBSearch) IsLBModeManaged() bool {
-	return s.Spec.LoadBalancer != nil && s.Spec.LoadBalancer.Managed != nil
+	lb := s.firstClusterLB()
+	return lb != nil && lb.Managed != nil
 }
 
-// GetManagedLBDeploymentConfig returns the user-provided Envoy Deployment override, or nil.
-func (s *MongoDBSearch) GetManagedLBDeploymentConfig() *v1.DeploymentConfiguration {
-	if s.IsLBModeManaged() {
-		return s.Spec.LoadBalancer.Managed.Deployment
+// GetManagedLBForCluster returns spec.clusters[i].loadBalancer.managed, or nil
+// when cluster i does not configure a managed LB.
+func (s *MongoDBSearch) GetManagedLBForCluster(i int) *ManagedLBConfig {
+	lb := s.lbForClusterIndex(i)
+	if lb == nil {
+		return nil
 	}
-	return nil
+	return lb.Managed
 }
 
-// GetManagedLBResourceRequirements returns user-specified Envoy resource requirements, or nil.
-func (s *MongoDBSearch) GetManagedLBResourceRequirements() *corev1.ResourceRequirements {
-	if s.IsLBModeManaged() {
-		return s.Spec.LoadBalancer.Managed.ResourceRequirements
-	}
-	return nil
-}
-
-// GetManagedLBRetryPolicy returns user-specified Envoy retry policy, or nil.
-func (s *MongoDBSearch) GetManagedLBRetryPolicy() *EnvoyRetryPolicy {
-	if s.IsLBModeManaged() {
-		return s.Spec.LoadBalancer.Managed.RetryPolicy
-	}
-	return nil
-}
-
-// GetManagedLBEndpoint returns the external hostname from spec.loadBalancer.managed.externalHostname
-// when managed LB is configured. Returns "" otherwise.
-func (s *MongoDBSearch) GetManagedLBEndpoint() string {
-	if !s.IsLBModeManaged() {
+// GetManagedLBEndpointForCluster returns cluster i's externalHostname.
+// {shardName} may remain in the result; use GetManagedLBEndpointForClusterShard
+// when it needs resolving. Returns "" when cluster i has no managed LB.
+func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
+	cfg := s.GetManagedLBForCluster(i)
+	if cfg == nil {
 		return ""
 	}
-	return s.Spec.LoadBalancer.Managed.ExternalHostname
+	return cfg.ExternalHostname
 }
 
-// GetManagedLBEndpointForShard returns the external hostname for a specific shard by substituting
-// the {shardName} template in spec.loadBalancer.managed.externalHostname (no cluster placeholders).
-// Returns "" if managed LB is not configured or externalHostname is empty.
-func (s *MongoDBSearch) GetManagedLBEndpointForShard(shardName string) string {
-	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
-		return ""
-	}
-	return strings.ReplaceAll(s.Spec.LoadBalancer.Managed.ExternalHostname, ShardNamePlaceholder, shardName)
-}
-
-// GetManagedLBEndpointForCluster resolves {clusterName} and {clusterIndex} in the
-// externalHostname template from the caller's resolved index and name. Returns "" when
-// managed LB is not configured; use GetManagedLBEndpointForClusterShard to also resolve {shardName}.
-func (s *MongoDBSearch) GetManagedLBEndpointForCluster(clusterIndex int, clusterName string) string {
-	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
-		return ""
-	}
-	out := s.Spec.LoadBalancer.Managed.ExternalHostname
-	out = strings.ReplaceAll(out, ClusterNamePlaceholder, clusterName)
-	out = strings.ReplaceAll(out, ClusterIndexPlaceholder, strconv.Itoa(clusterIndex))
-	return out
-}
-
-// GetManagedLBEndpointForClusterShard returns the externalHostname template with
-// {clusterName}, {clusterIndex}, and {shardName} all resolved for the
-// (cluster, shard) pair. Used for sharded multi-cluster MongoDBSearch
-// deployments. Returns "" when managed LB is not configured.
-func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(clusterIndex int, clusterName, shardName string) string {
-	out := s.GetManagedLBEndpointForCluster(clusterIndex, clusterName)
+// GetManagedLBEndpointForClusterShard returns cluster i's externalHostname with
+// {shardName} resolved. Used for sharded MongoDBSearch deployments.
+func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(i int, shardName string) string {
+	out := s.GetManagedLBEndpointForCluster(i)
 	if out == "" {
 		return ""
 	}
 	return strings.ReplaceAll(out, ShardNamePlaceholder, shardName)
 }
 
-// GetManagedLBEndpointForClusterLevel returns the mongos-facing endpoint: externalHostname
-// with the leading "{shardName}." stripped. Returns "" when not derivable so the caller falls back to the proxy Service FQDN.
-func (s *MongoDBSearch) GetManagedLBEndpointForClusterLevel(clusterIndex int, clusterName string) string {
-	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+// GetManagedLBEndpointForClusterLevel derives the mongos-facing endpoint by stripping
+// the leading "{shardName}." from cluster i's externalHostname. Returns "" when not
+// derivable; callers fall back to the cluster-level proxy Service FQDN.
+func (s *MongoDBSearch) GetManagedLBEndpointForClusterLevel(i int) string {
+	tmpl := s.GetManagedLBEndpointForCluster(i)
+	if tmpl == "" {
 		return ""
 	}
-	tmpl := s.Spec.LoadBalancer.Managed.ExternalHostname
 	trimmed := strings.TrimPrefix(tmpl, ShardNamePlaceholder+".")
 	if strings.Contains(trimmed, ShardNamePlaceholder) {
 		return ""
 	}
-	// Empty clusterName (operator-managed sharded mongos passes "") would substitute to a
-	// blank label and emit a malformed ".host"; return "" so the caller falls back to the proxy FQDN.
-	if clusterName == "" && strings.Contains(trimmed, ClusterNamePlaceholder) {
-		return ""
-	}
-	out := strings.ReplaceAll(trimmed, ClusterNamePlaceholder, clusterName)
-	out = strings.ReplaceAll(out, ClusterIndexPlaceholder, strconv.Itoa(clusterIndex))
-	return out
+	return trimmed
 }
 
 // IsLoadBalancerReady returns true if managed LB is not configured,

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -769,20 +769,14 @@ func (s *MongoDBSearch) GetPrometheus() *Prometheus {
 	return s.Spec.Prometheus
 }
 
-// lbForClusterIndex returns spec.clusters[i].loadBalancer, or nil when i is out
-// of range or the cluster does not set one.
-func (s *MongoDBSearch) lbForClusterIndex(i int) *LoadBalancerConfig {
-	if i < 0 || i >= len(s.Spec.Clusters) {
-		return nil
-	}
-	return s.Spec.Clusters[i].LoadBalancer
-}
-
 // firstClusterLB returns the first cluster's loadBalancer. Validation enforces
 // that every cluster sets the same mode (or none sets one), so the first entry
 // answers deployment-wide mode questions.
 func (s *MongoDBSearch) firstClusterLB() *LoadBalancerConfig {
-	return s.lbForClusterIndex(0)
+	if len(s.Spec.Clusters) == 0 {
+		return nil
+	}
+	return s.Spec.Clusters[0].LoadBalancer
 }
 
 func (s *MongoDBSearch) IsLBModeUnmanaged() bool {
@@ -798,25 +792,21 @@ func (s *MongoDBSearch) IsReplicaSetUnmanagedLB() bool {
 		!s.HasEndpointTemplate()
 }
 
-// GetUnmanagedLBEndpointForCluster returns spec.clusters[i].loadBalancer.unmanaged.endpoint,
-// or "" when cluster i does not configure an unmanaged LB.
-func (s *MongoDBSearch) GetUnmanagedLBEndpointForCluster(i int) string {
-	lb := s.lbForClusterIndex(i)
+// GetUnmanagedLBEndpoint returns the unmanaged endpoint, or "" when no
+// unmanaged LB is configured. Unmanaged LB is single-cluster-only
+// (validateMCRequiresManagedLB), so the first cluster is the only one.
+func (s *MongoDBSearch) GetUnmanagedLBEndpoint() string {
+	lb := s.firstClusterLB()
 	if lb == nil || lb.Unmanaged == nil {
 		return ""
 	}
 	return lb.Unmanaged.Endpoint
 }
 
-// HasEndpointTemplate returns true if the unmanaged endpoint contains the {shardName}
-// template placeholder. Validation enforces that every cluster's endpoint has the same
-// shape (templated or not), so the first cluster answers for the deployment.
+// HasEndpointTemplate returns true if the unmanaged endpoint contains the
+// {shardName} template placeholder.
 func (s *MongoDBSearch) HasEndpointTemplate() bool {
-	lb := s.firstClusterLB()
-	if lb == nil || lb.Unmanaged == nil {
-		return false
-	}
-	return strings.Contains(lb.Unmanaged.Endpoint, ShardNamePlaceholder)
+	return strings.Contains(s.GetUnmanagedLBEndpoint(), ShardNamePlaceholder)
 }
 
 // IsShardedUnmanagedLB returns true if this is a sharded unmanaged LB configuration
@@ -825,27 +815,13 @@ func (s *MongoDBSearch) IsShardedUnmanagedLB() bool {
 	return s.IsLBModeUnmanaged() && s.HasEndpointTemplate()
 }
 
-// IsShardedEndpoint returns true if the LB configuration uses a sharded endpoint pattern
-// (either unmanaged with {shardName} template, or managed with {shardName} in hostname).
-// This is a hint that the MongoDBSearch targets a sharded cluster, though the
-// authoritative check is the type assertion on SearchSourceShardedDeployment at the controller level.
-func (s *MongoDBSearch) IsShardedEndpoint() bool {
-	if s.IsShardedUnmanagedLB() {
-		return true
-	}
-	if s.IsLBModeManaged() && strings.Contains(s.firstClusterLB().Managed.ExternalHostname, ShardNamePlaceholder) {
-		return true
-	}
-	return false
-}
-
-// GetEndpointForClusterShard returns cluster i's unmanaged endpoint for a specific
-// shard by substituting the {shardName} placeholder.
-func (s *MongoDBSearch) GetEndpointForClusterShard(i int, shardName string) string {
+// GetEndpointForShard returns the unmanaged endpoint for a specific shard by
+// substituting the {shardName} placeholder.
+func (s *MongoDBSearch) GetEndpointForShard(shardName string) string {
 	if !s.IsShardedUnmanagedLB() {
 		return ""
 	}
-	return strings.ReplaceAll(s.GetUnmanagedLBEndpointForCluster(i), ShardNamePlaceholder, shardName)
+	return strings.ReplaceAll(s.GetUnmanagedLBEndpoint(), ShardNamePlaceholder, shardName)
 }
 
 // EffectiveClusters returns the per-cluster distribution slice the reconcile
@@ -991,31 +967,35 @@ func (s *MongoDBSearch) IsLBModeManaged() bool {
 	return lb != nil && lb.Managed != nil
 }
 
-// GetManagedLBForCluster returns spec.clusters[i].loadBalancer.managed, or nil
-// when cluster i does not configure a managed LB.
-func (s *MongoDBSearch) GetManagedLBForCluster(i int) *ManagedLBConfig {
-	lb := s.lbForClusterIndex(i)
-	if lb == nil {
+// GetManagedLBForCluster returns the named cluster's loadBalancer.managed, or
+// nil when the cluster is unknown or has no managed LB. An empty clusterName
+// means the first cluster (single-cluster installs). Resolution is by name:
+// controllers thread cluster indices from the persisted ClusterMapping, which
+// outlives spec positions, so an index must never be used to look up spec
+// entries (it is for resource naming only).
+func (s *MongoDBSearch) GetManagedLBForCluster(clusterName string) *ManagedLBConfig {
+	c, err := s.EffectiveClusterFor(clusterName)
+	if err != nil || c.LoadBalancer == nil {
 		return nil
 	}
-	return lb.Managed
+	return c.LoadBalancer.Managed
 }
 
-// GetManagedLBEndpointForCluster returns cluster i's externalHostname.
+// GetManagedLBEndpointForCluster returns the named cluster's externalHostname.
 // {shardName} may remain in the result; use GetManagedLBEndpointForClusterShard
-// when it needs resolving. Returns "" when cluster i has no managed LB.
-func (s *MongoDBSearch) GetManagedLBEndpointForCluster(i int) string {
-	cfg := s.GetManagedLBForCluster(i)
+// when it needs resolving. Returns "" when the cluster has no managed LB.
+func (s *MongoDBSearch) GetManagedLBEndpointForCluster(clusterName string) string {
+	cfg := s.GetManagedLBForCluster(clusterName)
 	if cfg == nil {
 		return ""
 	}
 	return cfg.ExternalHostname
 }
 
-// GetManagedLBEndpointForClusterShard returns cluster i's externalHostname with
-// {shardName} resolved. Used for sharded MongoDBSearch deployments.
-func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(i int, shardName string) string {
-	out := s.GetManagedLBEndpointForCluster(i)
+// GetManagedLBEndpointForClusterShard returns the named cluster's externalHostname
+// with {shardName} resolved. Used for sharded MongoDBSearch deployments.
+func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(clusterName, shardName string) string {
+	out := s.GetManagedLBEndpointForCluster(clusterName)
 	if out == "" {
 		return ""
 	}
@@ -1023,10 +1003,10 @@ func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(i int, shardName str
 }
 
 // GetManagedLBEndpointForClusterLevel derives the mongos-facing endpoint by stripping
-// the leading "{shardName}." from cluster i's externalHostname. Returns "" when not
-// derivable; callers fall back to the cluster-level proxy Service FQDN.
-func (s *MongoDBSearch) GetManagedLBEndpointForClusterLevel(i int) string {
-	tmpl := s.GetManagedLBEndpointForCluster(i)
+// the leading "{shardName}." from the named cluster's externalHostname. Returns ""
+// when not derivable; callers fall back to the cluster-level proxy Service FQDN.
+func (s *MongoDBSearch) GetManagedLBEndpointForClusterLevel(clusterName string) string {
+	tmpl := s.GetManagedLBEndpointForCluster(clusterName)
 	if tmpl == "" {
 		return ""
 	}

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -220,18 +220,19 @@ func TestGetManagedLBEndpointForCluster(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "us-east.search-lb.example.com:443", s.GetManagedLBEndpointForCluster(0))
-	assert.Equal(t, "eu-west.search-lb.example.com:443", s.GetManagedLBEndpointForCluster(1))
-	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(2), "cluster without LB")
-	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(5), "out-of-range index")
+	assert.Equal(t, "us-east.search-lb.example.com:443", s.GetManagedLBEndpointForCluster("us-east-k8s"))
+	assert.Equal(t, "eu-west.search-lb.example.com:443", s.GetManagedLBEndpointForCluster("eu-west-k8s"))
+	assert.Equal(t, "us-east.search-lb.example.com:443", s.GetManagedLBEndpointForCluster(""), "empty name means first cluster")
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster("ap-south-k8s"), "cluster without LB")
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster("unknown"), "unknown cluster name")
 }
 
 func TestGetManagedLBEndpointForCluster_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(""))
 
 	s.Spec.Clusters = []ClusterSpec{{LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: ""}}}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(""))
 }
 
 func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
@@ -246,9 +247,9 @@ func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: clusters}}
 
 	got := make(map[string]struct{})
-	for i := range clusters {
+	for _, c := range clusters {
 		for _, sh := range shards {
-			got[s.GetManagedLBEndpointForClusterShard(i, sh)] = struct{}{}
+			got[s.GetManagedLBEndpointForClusterShard(c.ClusterName, sh)] = struct{}{}
 		}
 	}
 	assert.Len(t, got, 4, "2x2 cross-product should yield 4 distinct hostnames")
@@ -260,7 +261,7 @@ func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
 
 func TestGetManagedLBEndpointForClusterShard_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard(0, "shard-0"))
+	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard("", "shard-0"))
 }
 
 func TestGetManagedLBEndpointForClusterLevel(t *testing.T) {
@@ -287,14 +288,14 @@ func TestGetManagedLBEndpointForClusterLevel(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, mk(tc.template).GetManagedLBEndpointForClusterLevel(0))
+			assert.Equal(t, tc.want, mk(tc.template).GetManagedLBEndpointForClusterLevel("us-east-k8s"))
 		})
 	}
 }
 
 func TestGetManagedLBEndpointForClusterLevel_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForClusterLevel(0))
+	assert.Equal(t, "", s.GetManagedLBEndpointForClusterLevel(""))
 }
 
 func TestValidateSimulatedMCClusterIndices(t *testing.T) {

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -169,7 +169,7 @@ func TestIsLoadBalancerReady(t *testing.T) {
 			name: "managed LB, status nil",
 			search: MongoDBSearch{
 				Spec: MongoDBSearchSpec{
-					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}},
+					Clusters: []ClusterSpec{{LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}}}},
 				},
 			},
 			expected: false,
@@ -178,7 +178,7 @@ func TestIsLoadBalancerReady(t *testing.T) {
 			name: "managed LB, status Running",
 			search: MongoDBSearch{
 				Spec: MongoDBSearchSpec{
-					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}},
+					Clusters: []ClusterSpec{{LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}}}},
 				},
 				Status: MongoDBSearchStatus{
 					LoadBalancer: &LoadBalancerStatus{Phase: status.PhaseRunning},
@@ -190,7 +190,7 @@ func TestIsLoadBalancerReady(t *testing.T) {
 			name: "managed LB, status Pending",
 			search: MongoDBSearch{
 				Spec: MongoDBSearchSpec{
-					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}},
+					Clusters: []ClusterSpec{{LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}}}},
 				},
 				Status: MongoDBSearchStatus{
 					LoadBalancer: &LoadBalancerStatus{Phase: status.PhasePending},
@@ -208,98 +208,47 @@ func TestIsLoadBalancerReady(t *testing.T) {
 }
 
 func TestGetManagedLBEndpointForCluster(t *testing.T) {
-	tests := []struct {
-		name         string
-		template     string
-		clusterIndex int
-		clusterName  string
-		want         string
-	}{
-		{
-			name:         "clusterName substitution first cluster",
-			template:     "{clusterName}.search-lb.example.com:443",
-			clusterIndex: 0,
-			clusterName:  "us-east-k8s",
-			want:         "us-east-k8s.search-lb.example.com:443",
-		},
-		{
-			name:         "clusterIndex substitution second cluster",
-			template:     "search-{clusterIndex}.lb.example.com:443",
-			clusterIndex: 1,
-			clusterName:  "eu-west-k8s",
-			want:         "search-1.lb.example.com:443",
-		},
-		{
-			name:         "both placeholders present",
-			template:     "{clusterName}-{clusterIndex}.lb.example.com:443",
-			clusterIndex: 1,
-			clusterName:  "eu-west-k8s",
-			want:         "eu-west-k8s-1.lb.example.com:443",
-		},
-		{
-			name:         "no placeholders left untouched",
-			template:     "static.lb.example.com:443",
-			clusterIndex: 0,
-			clusterName:  "us-east-k8s",
-			want:         "static.lb.example.com:443",
-		},
-		{
-			name:         "empty clusterName with only {clusterIndex} still renders",
-			template:     "search-{clusterIndex}.lb.example.com:443",
-			clusterIndex: 0,
-			clusterName:  "",
-			want:         "search-0.lb.example.com:443",
-		},
-		{
-			name:         "resolved index 7 renders verbatim",
-			template:     "mongot-{clusterIndex}.example.com",
-			clusterIndex: 7,
-			clusterName:  "us-east",
-			want:         "mongot-7.example.com",
-		},
-		{
-			name:         "resolved index 0 renders verbatim",
-			template:     "mongot-{clusterIndex}.example.com",
-			clusterIndex: 0,
-			clusterName:  "us-east",
-			want:         "mongot-0.example.com",
+	managed := func(hostname string) *LoadBalancerConfig {
+		return &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: hostname}}
+	}
+	s := &MongoDBSearch{
+		Spec: MongoDBSearchSpec{
+			Clusters: []ClusterSpec{
+				{ClusterName: "us-east-k8s", LoadBalancer: managed("us-east.search-lb.example.com:443")},
+				{ClusterName: "eu-west-k8s", LoadBalancer: managed("eu-west.search-lb.example.com:443")},
+				{ClusterName: "ap-south-k8s"},
+			},
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			s := &MongoDBSearch{
-				Spec: MongoDBSearchSpec{
-					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tc.template}},
-				},
-			}
-			assert.Equal(t, tc.want, s.GetManagedLBEndpointForCluster(tc.clusterIndex, tc.clusterName))
-		})
-	}
+	assert.Equal(t, "us-east.search-lb.example.com:443", s.GetManagedLBEndpointForCluster(0))
+	assert.Equal(t, "eu-west.search-lb.example.com:443", s.GetManagedLBEndpointForCluster(1))
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(2), "cluster without LB")
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(5), "out-of-range index")
 }
 
 func TestGetManagedLBEndpointForCluster_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0, "us-east-k8s"))
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
 
-	s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: ""}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0, "us-east-k8s"))
+	s.Spec.Clusters = []ClusterSpec{{LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: ""}}}}
+	assert.Equal(t, "", s.GetManagedLBEndpointForCluster(0))
 }
 
 func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
-	template := "{clusterName}.{shardName}.lb.example.com:443"
-	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
-	shards := []string{"shard-0", "shard-1"}
-	s := &MongoDBSearch{
-		Spec: MongoDBSearchSpec{
-			LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
-			Clusters:     clusters,
-		},
+	managed := func(hostname string) *LoadBalancerConfig {
+		return &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: hostname}}
 	}
+	clusters := []ClusterSpec{
+		{ClusterName: "us-east-k8s", LoadBalancer: managed("us-east-k8s.{shardName}.lb.example.com:443")},
+		{ClusterName: "eu-west-k8s", LoadBalancer: managed("eu-west-k8s.{shardName}.lb.example.com:443")},
+	}
+	shards := []string{"shard-0", "shard-1"}
+	s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: clusters}}
 
 	got := make(map[string]struct{})
 	for i := range clusters {
 		for _, sh := range shards {
-			got[s.GetManagedLBEndpointForClusterShard(i, clusters[i].ClusterName, sh)] = struct{}{}
+			got[s.GetManagedLBEndpointForClusterShard(i, sh)] = struct{}{}
 		}
 	}
 	assert.Len(t, got, 4, "2x2 cross-product should yield 4 distinct hostnames")
@@ -309,64 +258,43 @@ func TestGetManagedLBEndpointForClusterShard_CrossProduct(t *testing.T) {
 	assert.Contains(t, got, "eu-west-k8s.shard-1.lb.example.com:443")
 }
 
-func TestGetManagedLBEndpointForClusterShard_ClusterIndex(t *testing.T) {
-	template := "search-{clusterIndex}.{shardName}.lb.example.com:443"
-	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
-	s := &MongoDBSearch{
-		Spec: MongoDBSearchSpec{
-			LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
-			Clusters:     clusters,
-		},
-	}
-	assert.Equal(t, "search-0.shard-a.lb.example.com:443", s.GetManagedLBEndpointForClusterShard(0, "us-east-k8s", "shard-a"))
-	assert.Equal(t, "search-1.shard-b.lb.example.com:443", s.GetManagedLBEndpointForClusterShard(1, "eu-west-k8s", "shard-b"))
-}
-
 func TestGetManagedLBEndpointForClusterShard_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard(0, "us-east-k8s", "shard-0"))
+	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard(0, "shard-0"))
 }
 
 func TestGetManagedLBEndpointForClusterLevel(t *testing.T) {
 	mk := func(tmpl string) *MongoDBSearch {
 		return &MongoDBSearch{
 			Spec: MongoDBSearchSpec{
-				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tmpl}},
+				Clusters: []ClusterSpec{
+					{ClusterName: "us-east-k8s", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tmpl}}},
+				},
 			},
 		}
 	}
 	tests := []struct {
-		name         string
-		template     string
-		clusterIndex int
-		clusterName  string
-		want         string
+		name     string
+		template string
+		want     string
 	}{
-		{"strip prefix, resolve clusterName", "{shardName}.{clusterName}.search.example.com", 0, "us-east-k8s", "us-east-k8s.search.example.com"},
-		{"strip prefix, resolve clusterIndex", "{shardName}.search-{clusterIndex}.example.com", 1, "eu-west-k8s", "search-1.example.com"},
-		{"strip prefix, single-cluster sharded shape (no cluster placeholders)", "{shardName}.search.example.com", 0, "us-east-k8s", "search.example.com"},
+		{"strip leading shardName prefix", "{shardName}.us-east.search.example.com", "us-east.search.example.com"},
+		{"no shardName returned as-is", "us-east.search.example.com", "us-east.search.example.com"},
 		// {shardName} as a name component (not a leading prefix) is not derivable to a
 		// single cluster-level hostname; expect "" so the caller falls back to the
 		// cluster-level proxy Service FQDN.
-		{"shardName as name component returns empty", "search-{clusterIndex}-{shardName}-proxy.example.com", 0, "us-east-k8s", ""},
-		// {clusterName} with an empty name (operator-managed sharded mongos path)
-		// is unresolvable; return "" so the caller falls back to the proxy-svc FQDN
-		// rather than emitting a malformed ".search.example.com".
-		{"empty clusterName with {clusterName} placeholder returns empty", "{shardName}.{clusterName}.search.example.com", 0, "", ""},
-		// {clusterIndex} with an empty name still resolves — 0 is well-formed.
-		{"empty clusterName with only {clusterIndex} resolves", "{shardName}.search-{clusterIndex}.example.com", 0, "", "search-0.example.com"},
-		{"cluster-level strips prefix and renders resolved index 7", "{shardName}.search-{clusterIndex}.lb.example.com:443", 7, "us-east", "search-7.lb.example.com:443"},
+		{"shardName as name component returns empty", "search-{shardName}-proxy.example.com", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, mk(tc.template).GetManagedLBEndpointForClusterLevel(tc.clusterIndex, tc.clusterName))
+			assert.Equal(t, tc.want, mk(tc.template).GetManagedLBEndpointForClusterLevel(0))
 		})
 	}
 }
 
 func TestGetManagedLBEndpointForClusterLevel_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForClusterLevel(0, "us-east-k8s"))
+	assert.Equal(t, "", s.GetManagedLBEndpointForClusterLevel(0))
 }
 
 func TestValidateSimulatedMCClusterIndices(t *testing.T) {

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -222,8 +222,11 @@ func validateManagedLBExternalHostname(s *MongoDBSearch) v1.ValidationResult {
 	if !s.IsExternalMongoDBSource() {
 		return v1.ValidationSuccess()
 	}
-	for i := range s.Spec.Clusters {
-		if cfg := s.GetManagedLBForCluster(i); cfg != nil && cfg.ExternalHostname == "" {
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
+			continue
+		}
+		if c.LoadBalancer.Managed.ExternalHostname == "" {
 			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.externalHostname must be specified when using managed load balancer with an external MongoDB source", i)
 		}
 	}
@@ -606,8 +609,11 @@ func validateMCExternalHostnames(s *MongoDBSearch) v1.ValidationResult {
 		return v1.ValidationSuccess()
 	}
 	seen := make(map[string]int, len(s.Spec.Clusters))
-	for i := range s.Spec.Clusters {
-		tmpl := s.GetManagedLBEndpointForCluster(i)
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
+			continue
+		}
+		tmpl := c.LoadBalancer.Managed.ExternalHostname
 		if tmpl == "" {
 			continue
 		}
@@ -673,8 +679,11 @@ func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
 
 	// Iterate the cross-product. len(shardNames) == 0 runs a single pass per
 	// cluster with no shard substitution.
-	for i := range s.Spec.Clusters {
-		base := s.GetManagedLBEndpointForCluster(i)
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
+			continue
+		}
+		base := c.LoadBalancer.Managed.ExternalHostname
 		if base == "" {
 			continue
 		}

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -107,12 +107,13 @@ func multiClusterValidators() []func(*MongoDBSearch) v1.ValidationResult {
 		validateMCRequiresExternalSource,
 		validateMCRequiresManagedLB,
 		validateMCMatchTagsNonEmpty,
-		validateMCExternalHostnamePlaceholders,
+		validateMCExternalHostnames,
 	}
 }
 
 // managedLBValidators run only when a managed load balancer is configured
-// (IsLBModeManaged). The dispatch guarantees spec.loadBalancer.managed != nil.
+// (IsLBModeManaged, keyed on the first cluster). validateLBConfig enforces that
+// every cluster sets the same mode, so members may assume managed everywhere.
 func managedLBValidators() []func(*MongoDBSearch) v1.ValidationResult {
 	return []func(*MongoDBSearch) v1.ValidationResult{
 		validateManagedLBExternalHostname,
@@ -121,7 +122,8 @@ func managedLBValidators() []func(*MongoDBSearch) v1.ValidationResult {
 }
 
 // unmanagedLBValidators run only when an unmanaged load balancer is configured
-// (IsLBModeUnmanaged). The dispatch guarantees spec.loadBalancer.unmanaged != nil.
+// (IsLBModeUnmanaged, keyed on the first cluster). validateLBConfig enforces that
+// every cluster sets the same mode, so members may assume unmanaged everywhere.
 func unmanagedLBValidators() []func(*MongoDBSearch) v1.ValidationResult {
 	return []func(*MongoDBSearch) v1.ValidationResult{
 		validateUnmanagedLBConfig,
@@ -145,51 +147,86 @@ func validateClustersNonEmpty(s *MongoDBSearch) v1.ValidationResult {
 // across the replicas. It depends only on spec fields, so it lives in the
 // spec-validation tier.
 func validateMultipleReplicasRequireLB(s *MongoDBSearch) v1.ValidationResult {
-	if max := s.MaxReplicasAcrossClusters(); max > 1 && s.Spec.LoadBalancer == nil {
-		return v1.ValidationError(
-			"multiple mongot replicas (%d) require load balancer configuration; "+
-				"please configure load balancing in spec.loadBalancer.",
-			max,
-		)
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer != nil {
+			continue
+		}
+		max := c.ReplicasOrDefault()
+		for _, o := range c.ShardOverrides {
+			if o.Replicas != nil && int(*o.Replicas) > max {
+				max = int(*o.Replicas)
+			}
+		}
+		if max > 1 {
+			return v1.ValidationError(
+				"multiple mongot replicas (%d) require load balancer configuration; "+
+					"please configure load balancing in spec.clusters[%d].loadBalancer.",
+				max, i,
+			)
+		}
 	}
 	return v1.ValidationSuccess()
 }
 
+// validateLBConfig enforces the per-cluster load balancer rules:
+//   - each entry sets exactly one of managed or unmanaged (the XValidation marker
+//     on LoadBalancerConfig enforces this at the CRD level; this check provides
+//     the same guarantee at the controller level);
+//   - clusters agree on presence: all set loadBalancer, or none do;
+//   - clusters agree on mode: managed and unmanaged cannot be mixed.
 func validateLBConfig(s *MongoDBSearch) v1.ValidationResult {
-	if s.Spec.LoadBalancer == nil {
-		// LB config is optional
+	withLB, managedCount, unmanagedCount := 0, 0, 0
+	for i, c := range s.Spec.Clusters {
+		lb := c.LoadBalancer
+		if lb == nil {
+			continue
+		}
+		withLB++
+		if lb.Managed == nil && lb.Unmanaged == nil {
+			return v1.ValidationError("spec.clusters[%d].loadBalancer must have exactly one of 'managed' or 'unmanaged' set", i)
+		}
+		if lb.Managed != nil && lb.Unmanaged != nil {
+			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed and spec.clusters[%d].loadBalancer.unmanaged are mutually exclusive", i, i)
+		}
+		if lb.Managed != nil {
+			managedCount++
+		} else {
+			unmanagedCount++
+		}
+	}
+	if withLB > 0 && withLB != len(s.Spec.Clusters) {
+		return v1.ValidationError("spec.clusters[].loadBalancer must be set on every cluster or on none; %d of %d clusters set it", withLB, len(s.Spec.Clusters))
+	}
+	if managedCount > 0 && unmanagedCount > 0 {
+		return v1.ValidationError("spec.clusters[].loadBalancer mode must be the same on every cluster; managed and unmanaged cannot be mixed")
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateUnmanagedLBConfig validates that every cluster's unmanaged LB specifies an endpoint.
+func validateUnmanagedLBConfig(s *MongoDBSearch) v1.ValidationResult {
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Unmanaged == nil {
+			continue
+		}
+		if c.LoadBalancer.Unmanaged.Endpoint == "" {
+			return v1.ValidationError("spec.clusters[%d].loadBalancer.unmanaged.endpoint must be specified when spec.clusters[%d].loadBalancer.unmanaged is configured", i, i)
+		}
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateManagedLBExternalHostname validates that every cluster sets externalHostname when
+// using managed LB with an external MongoDB source (Rule 5: Envoy needs the hostname for SNI matching).
+func validateManagedLBExternalHostname(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsExternalMongoDBSource() {
 		return v1.ValidationSuccess()
 	}
-
-	// Exactly one of managed or unmanaged must be set.
-	// The XValidation marker on LoadBalancerConfig enforces this at the CRD level;
-	// this check provides the same guarantee at the controller level.
-	if s.Spec.LoadBalancer.Managed == nil && s.Spec.LoadBalancer.Unmanaged == nil {
-		return v1.ValidationError("spec.loadBalancer must have exactly one of 'managed' or 'unmanaged' set")
+	for i := range s.Spec.Clusters {
+		if cfg := s.GetManagedLBForCluster(i); cfg != nil && cfg.ExternalHostname == "" {
+			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.externalHostname must be specified when using managed load balancer with an external MongoDB source", i)
+		}
 	}
-	if s.Spec.LoadBalancer.Managed != nil && s.Spec.LoadBalancer.Unmanaged != nil {
-		return v1.ValidationError("spec.loadBalancer.managed and spec.loadBalancer.unmanaged are mutually exclusive")
-	}
-
-	return v1.ValidationSuccess()
-}
-
-// validateUnmanagedLBConfig validates that an endpoint is specified when unmanaged LB is configured.
-func validateUnmanagedLBConfig(s *MongoDBSearch) v1.ValidationResult {
-	if s.Spec.LoadBalancer.Unmanaged.Endpoint == "" {
-		return v1.ValidationError("spec.loadBalancer.unmanaged.endpoint must be specified when spec.loadBalancer.unmanaged is configured")
-	}
-
-	return v1.ValidationSuccess()
-}
-
-// validateManagedLBExternalHostname validates that externalHostname is set when using managed LB
-// with an external MongoDB source (Rule 5: Envoy needs the hostname for SNI matching).
-func validateManagedLBExternalHostname(s *MongoDBSearch) v1.ValidationResult {
-	if s.IsExternalMongoDBSource() && s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
-		return v1.ValidationError("spec.loadBalancer.managed.externalHostname must be specified when using managed load balancer with an external MongoDB source")
-	}
-
 	return v1.ValidationSuccess()
 }
 
@@ -199,42 +236,47 @@ func isPlaceholderOnly(endpoint string) bool {
 	return strings.TrimSpace(strings.ReplaceAll(endpoint, ShardNamePlaceholder, "")) == ""
 }
 
-// validateUnmanagedEndpointTemplate validates the unmanaged endpoint template against the source
-// topology. For an external sharded source the endpoint must be a per-shard template: it must
-// contain at least one {shardName} placeholder (Rule 6) and more than just the placeholder. For
-// every other source (ReplicaSet) the endpoint must not contain a {shardName} placeholder, since
-// the template makes no sense for a ReplicaSet (Rule 8).
+// validateUnmanagedEndpointTemplate validates each cluster's unmanaged endpoint template against
+// the source topology. For an external sharded source the endpoint must be a per-shard template:
+// it must contain at least one {shardName} placeholder (Rule 6) and more than just the placeholder.
+// For every other source (ReplicaSet) the endpoint must not contain a {shardName} placeholder,
+// since the template makes no sense for a ReplicaSet (Rule 8).
 func validateUnmanagedEndpointTemplate(s *MongoDBSearch) v1.ValidationResult {
-	endpoint := s.Spec.LoadBalancer.Unmanaged.Endpoint
-	hasTemplate := s.HasEndpointTemplate()
-
-	// External sharded: the declared shard set means each shard needs its own
-	// endpoint, so the template is required and must carry more than the placeholder.
-	if s.IsExternalSourceSharded() {
-		if !hasTemplate {
-			return v1.ValidationError("spec.loadBalancer.unmanaged.endpoint must contain at least one %s placeholder to differentiate between shards", ShardNamePlaceholder)
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Unmanaged == nil {
+			continue
 		}
-		if isPlaceholderOnly(endpoint) {
-			return v1.ValidationError("spec.loadBalancer.unmanaged.endpoint must contain more than just the %s placeholder", ShardNamePlaceholder)
+		endpoint := c.LoadBalancer.Unmanaged.Endpoint
+		hasTemplate := strings.Contains(endpoint, ShardNamePlaceholder)
+		path := fmt.Sprintf("spec.clusters[%d].loadBalancer.unmanaged.endpoint", i)
+
+		// External sharded: the declared shard set means each shard needs its own
+		// endpoint, so the template is required and must carry more than the placeholder.
+		if s.IsExternalSourceSharded() {
+			if !hasTemplate {
+				return v1.ValidationError("%s must contain at least one %s placeholder to differentiate between shards", path, ShardNamePlaceholder)
+			}
+			if isPlaceholderOnly(endpoint) {
+				return v1.ValidationError("%s must contain more than just the %s placeholder", path, ShardNamePlaceholder)
+			}
+			continue
 		}
-		return v1.ValidationSuccess()
-	}
 
-	// External ReplicaSet: a single mongot fleet, so a {shardName} template is meaningless.
-	if s.IsExternalMongoDBSource() {
-		if hasTemplate {
-			return v1.ValidationError("spec.loadBalancer.unmanaged.endpoint must not contain a %s placeholder for ReplicaSet deployments", ShardNamePlaceholder)
+		// External ReplicaSet: a single mongot fleet, so a {shardName} template is meaningless.
+		if s.IsExternalMongoDBSource() {
+			if hasTemplate {
+				return v1.ValidationError("%s must not contain a %s placeholder for ReplicaSet deployments", path, ShardNamePlaceholder)
+			}
+			continue
 		}
-		return v1.ValidationSuccess()
-	}
 
-	// Operator-managed source: sharded-ness is only known at reconcile time, so we
-	// neither require nor forbid the template, but a templated endpoint must carry
-	// more than the placeholder.
-	if hasTemplate && isPlaceholderOnly(endpoint) {
-		return v1.ValidationError("spec.loadBalancer.unmanaged.endpoint must contain more than just the %s placeholder", ShardNamePlaceholder)
+		// Operator-managed source: sharded-ness is only known at reconcile time, so we
+		// neither require nor forbid the template, but a templated endpoint must carry
+		// more than the placeholder.
+		if hasTemplate && isPlaceholderOnly(endpoint) {
+			return v1.ValidationError("%s must contain more than just the %s placeholder", path, ShardNamePlaceholder)
+		}
 	}
-
 	return v1.ValidationSuccess()
 }
 
@@ -550,32 +592,38 @@ func ValidateShardNameRFC1123(shardName string) error {
 	return nil
 }
 
-// validateMCExternalHostnamePlaceholders enforces, for multi-cluster specs:
-//   - When managed LB is in use, externalHostname must contain {clusterName} or
-//     {clusterIndex} so each cluster's resolved hostname is distinct.
-//   - When the source is external sharded, externalHostname must additionally
-//     contain {shardName} so the cluster-level form is derivable.
+// validateMCExternalHostnames enforces, for multi-cluster specs with a managed LB:
+//   - every cluster's externalHostname must be distinct, so per-cluster SNI
+//     hostnames don't collide;
+//   - when the source is external sharded, each hostname must contain {shardName}
+//     so the per-shard form is derivable.
 //
 // The dispatch scopes this to multi-cluster (len > 1); the LB-mode check stays
 // inline because this group is not LB-mode-scoped (it also runs for unmanaged MC,
 // where there is nothing to validate).
-func validateMCExternalHostnamePlaceholders(s *MongoDBSearch) v1.ValidationResult {
-	if !s.IsLBModeManaged() || s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
+func validateMCExternalHostnames(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsLBModeManaged() {
 		return v1.ValidationSuccess()
 	}
-	tmpl := s.Spec.LoadBalancer.Managed.ExternalHostname
-	hasCluster := strings.Contains(tmpl, ClusterNamePlaceholder) || strings.Contains(tmpl, ClusterIndexPlaceholder)
-	if !hasCluster {
-		return v1.ValidationError(
-			"spec.loadBalancer.managed.externalHostname must contain %s or %s when len(spec.clusters) > 1",
-			ClusterNamePlaceholder, ClusterIndexPlaceholder,
-		)
-	}
-	if s.IsExternalSourceSharded() && !strings.Contains(tmpl, ShardNamePlaceholder) {
-		return v1.ValidationError(
-			"spec.loadBalancer.managed.externalHostname must contain %s for multi-cluster sharded deployments",
-			ShardNamePlaceholder,
-		)
+	seen := make(map[string]int, len(s.Spec.Clusters))
+	for i := range s.Spec.Clusters {
+		tmpl := s.GetManagedLBEndpointForCluster(i)
+		if tmpl == "" {
+			continue
+		}
+		if first, dup := seen[tmpl]; dup {
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed.externalHostname %q is also used by spec.clusters[%d]; every cluster needs a distinct hostname",
+				i, tmpl, first,
+			)
+		}
+		seen[tmpl] = i
+		if s.IsExternalSourceSharded() && !strings.Contains(tmpl, ShardNamePlaceholder) {
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed.externalHostname must contain %s for multi-cluster sharded deployments",
+				i, ShardNamePlaceholder,
+			)
+		}
 	}
 	return v1.ValidationSuccess()
 }
@@ -587,10 +635,6 @@ func validateMCExternalHostnamePlaceholders(s *MongoDBSearch) v1.ValidationResul
 // entire string is the host. Iterates spec.clusters[] (always >= 1) x
 // spec.source.external.shardedCluster.shards[] (may be empty).
 func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
-	if s.Spec.LoadBalancer.Managed.ExternalHostname == "" {
-		return v1.ValidationSuccess()
-	}
-
 	var shardNames []string
 	if s.IsExternalSourceSharded() {
 		for _, sh := range s.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards {
@@ -598,31 +642,29 @@ func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
 		}
 	}
 
-	check := func(host string) v1.ValidationResult {
+	check := func(clusterIdx int, host string) v1.ValidationResult {
+		path := fmt.Sprintf("spec.clusters[%d].loadBalancer.managed.externalHostname", clusterIdx)
 		h := host
 		if idx := strings.LastIndex(h, ":"); idx >= 0 {
 			h = h[:idx]
 		}
 		if len(h) == 0 {
-			return v1.ValidationError(
-				"spec.loadBalancer.managed.externalHostname resolves to an empty host: %q",
-				host,
-			)
+			return v1.ValidationError("%s resolves to an empty host: %q", path, host)
 		}
 		// IsDNS1123Subdomain caps the FQDN at 253 chars and enforces the
 		// overall regex, but does *not* enforce the per-label 63-char limit.
 		// Walk the labels separately so a single oversized cluster/shard label trips here.
 		if errs := validation.IsDNS1123Subdomain(h); len(errs) > 0 {
 			return v1.ValidationError(
-				"spec.loadBalancer.managed.externalHostname resolves to an invalid DNS subdomain %q: %s",
-				h, strings.Join(errs, ", "),
+				"%s resolves to an invalid DNS subdomain %q: %s",
+				path, h, strings.Join(errs, ", "),
 			)
 		}
 		for _, label := range strings.Split(h, ".") {
 			if errs := validation.IsDNS1123Label(label); len(errs) > 0 {
 				return v1.ValidationError(
-					"spec.loadBalancer.managed.externalHostname resolves to an invalid DNS subdomain %q: label %q: %s",
-					h, label, strings.Join(errs, ", "),
+					"%s resolves to an invalid DNS subdomain %q: label %q: %s",
+					path, h, label, strings.Join(errs, ", "),
 				)
 			}
 		}
@@ -631,22 +673,19 @@ func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
 
 	// Iterate the cross-product. len(shardNames) == 0 runs a single pass per
 	// cluster with no shard substitution.
-	for i, c := range s.Spec.Clusters {
-		// Pinned ClusterIndex when set, else the array position — reachable only for
-		// single-entry specs under pinned-only; spec validation can't read the state CM.
-		idx := i
-		if c.ClusterIndex != nil {
-			idx = int(*c.ClusterIndex)
+	for i := range s.Spec.Clusters {
+		base := s.GetManagedLBEndpointForCluster(i)
+		if base == "" {
+			continue
 		}
-		base := s.GetManagedLBEndpointForCluster(idx, c.ClusterName)
 		if len(shardNames) == 0 {
-			if res := check(base); res.Level == v1.ErrorLevel {
+			if res := check(i, base); res.Level == v1.ErrorLevel {
 				return res
 			}
 			continue
 		}
 		for _, sn := range shardNames {
-			if res := check(strings.ReplaceAll(base, ShardNamePlaceholder, sn)); res.Level == v1.ErrorLevel {
+			if res := check(i, strings.ReplaceAll(base, ShardNamePlaceholder, sn)); res.Level == v1.ErrorLevel {
 				return res
 			}
 		}
@@ -655,20 +694,24 @@ func validateExternalHostnameDNSLength(s *MongoDBSearch) v1.ValidationResult {
 }
 
 // validateMCRequiresManagedLB enforces that a multi-cluster MongoDBSearch uses
-// spec.loadBalancer.managed. Multi-cluster at GA requires Envoy (managed LB), so
-// both a missing load balancer and an unmanaged one are rejected when there is
-// more than one cluster. The dispatch scopes this to multi-cluster (len > 1);
-// single-cluster keeps using no-LB / unmanaged LB.
+// a managed load balancer on every cluster. Multi-cluster at GA requires Envoy
+// (managed LB), so both a missing load balancer and an unmanaged one are rejected
+// when there is more than one cluster. The dispatch scopes this to multi-cluster
+// (len > 1); single-cluster keeps using no-LB / unmanaged LB.
 func validateMCRequiresManagedLB(s *MongoDBSearch) v1.ValidationResult {
-	if s.Spec.LoadBalancer == nil {
-		return v1.ValidationError(
-			"multi-cluster MongoDBSearch requires a managed load balancer (spec.loadBalancer.managed) at the moment; none is configured",
-		)
-	}
-	if s.Spec.LoadBalancer.Unmanaged != nil {
-		return v1.ValidationError(
-			"multi-cluster MongoDBSearch requires a managed load balancer (spec.loadBalancer.managed) at the moment; spec.loadBalancer.unmanaged is not supported for multi-cluster",
-		)
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil {
+			return v1.ValidationError(
+				"multi-cluster MongoDBSearch requires a managed load balancer (spec.clusters[%d].loadBalancer.managed) at the moment; none is configured",
+				i,
+			)
+		}
+		if c.LoadBalancer.Unmanaged != nil {
+			return v1.ValidationError(
+				"multi-cluster MongoDBSearch requires a managed load balancer at the moment; spec.clusters[%d].loadBalancer.unmanaged is not supported for multi-cluster",
+				i,
+			)
+		}
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -146,24 +146,15 @@ func validateClustersNonEmpty(s *MongoDBSearch) v1.ValidationResult {
 // mongot replica in any cluster without a load balancer to distribute traffic
 // across the replicas. It depends only on spec fields, so it lives in the
 // spec-validation tier.
+// validateLBConfig (all-or-none) runs first, so LB presence is uniform across
+// clusters and checking the first cluster covers them all.
 func validateMultipleReplicasRequireLB(s *MongoDBSearch) v1.ValidationResult {
-	for i, c := range s.Spec.Clusters {
-		if c.LoadBalancer != nil {
-			continue
-		}
-		max := c.ReplicasOrDefault()
-		for _, o := range c.ShardOverrides {
-			if o.Replicas != nil && int(*o.Replicas) > max {
-				max = int(*o.Replicas)
-			}
-		}
-		if max > 1 {
-			return v1.ValidationError(
-				"multiple mongot replicas (%d) require load balancer configuration; "+
-					"please configure load balancing in spec.clusters[%d].loadBalancer.",
-				max, i,
-			)
-		}
+	if max := s.MaxReplicasAcrossClusters(); max > 1 && s.firstClusterLB() == nil {
+		return v1.ValidationError(
+			"multiple mongot replicas (%d) require load balancer configuration; "+
+				"please configure load balancing in spec.clusters[].loadBalancer.",
+			max,
+		)
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -89,10 +89,10 @@ func TestValidateShardNames(t *testing.T) {
 			name: "valid MC Proxy Service at borderline with single-digit max index",
 			search: func() *MongoDBSearch {
 				s := newSearch(strings.Repeat("a", 20), []ExternalShardConfig{shard(strings.Repeat("s", 23))}, "", false, true)
-				s.Spec.LoadBalancer.Managed.ExternalHostname = "{shardName}.{clusterName}.example.com"
 				clusters := make([]ClusterSpec, 10)
 				for i := range clusters {
 					clusters[i] = pinnedSpec("c"+strconv.Itoa(i), int32(i))
+					clusters[i].LoadBalancer = managedLBWithHostname("{shardName}.c" + strconv.Itoa(i) + ".example.com")
 				}
 				s.Spec.Clusters = clusters
 				return s
@@ -104,10 +104,10 @@ func TestValidateShardNames(t *testing.T) {
 			name: "invalid MC Proxy Service overshoots at two-digit max index",
 			search: func() *MongoDBSearch {
 				s := newSearch(strings.Repeat("a", 20), []ExternalShardConfig{shard(strings.Repeat("s", 23))}, "", false, true)
-				s.Spec.LoadBalancer.Managed.ExternalHostname = "{shardName}.{clusterName}.example.com"
 				clusters := make([]ClusterSpec, 11)
 				for i := range clusters {
 					clusters[i] = pinnedSpec("c"+strconv.Itoa(i), int32(i))
+					clusters[i].LoadBalancer = managedLBWithHostname("{shardName}.c" + strconv.Itoa(i) + ".example.com")
 				}
 				s.Spec.Clusters = clusters
 				return s
@@ -286,16 +286,19 @@ func TestValidateClustersUniqueClusterName(t *testing.T) {
 	}
 }
 
-func TestValidateMCExternalHostnamePlaceholders(t *testing.T) {
-	mkSearch := func(template string, clusters []ClusterSpec, sharded bool) *MongoDBSearch {
+func TestValidateMCExternalHostnames(t *testing.T) {
+	mkSearch := func(hostnames []string, sharded bool) *MongoDBSearch {
+		clusters := make([]ClusterSpec, 0, len(hostnames))
+		for i, hn := range hostnames {
+			c := ClusterSpec{ClusterName: "cluster-" + strconv.Itoa(i)}
+			if hn != "" {
+				c.LoadBalancer = managedLBWithHostname(hn)
+			}
+			clusters = append(clusters, c)
+		}
 		s := &MongoDBSearch{
 			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-			Spec: MongoDBSearchSpec{
-				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
-			},
-		}
-		if clusters != nil {
-			s.Spec.Clusters = clusters
+			Spec:       MongoDBSearchSpec{Clusters: clusters},
 		}
 		if sharded {
 			s.Spec.Source = &MongoDBSource{
@@ -312,60 +315,45 @@ func TestValidateMCExternalHostnamePlaceholders(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		template      string
-		clusters      []ClusterSpec
+		hostnames     []string
 		sharded       bool
 		errorContains string
 	}{
 		{
-			name:     "MC RS with clusterName placeholder",
-			template: "{clusterName}.lb.example.com:443",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			name:      "MC RS with distinct hostnames",
+			hostnames: []string{"us-east.lb.example.com:443", "eu-west.lb.example.com:443"},
 		},
 		{
-			name:     "MC RS with clusterIndex placeholder",
-			template: "search-{clusterIndex}.lb.example.com:443",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			name:          "MC RS with duplicate hostnames rejected",
+			hostnames:     []string{"static.lb.example.com:443", "static.lb.example.com:443"},
+			errorContains: "distinct hostname",
 		},
 		{
-			name:          "MC RS missing both cluster placeholders",
-			template:      "static.lb.example.com:443",
-			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
-			errorContains: "{clusterName}",
+			name:      "MC sharded with shardName in each hostname",
+			hostnames: []string{"{shardName}.us-east.lb.example.com:443", "{shardName}.eu-west.lb.example.com:443"},
+			sharded:   true,
 		},
 		{
-			name:     "MC sharded starts with shardName",
-			template: "{shardName}.{clusterName}.lb.example.com:443",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
-			sharded:  true,
-		},
-		{
-			name:          "MC sharded missing shardName",
-			template:      "{clusterName}.lb.example.com:443",
-			clusters:      []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			name:          "MC sharded missing shardName rejected",
+			hostnames:     []string{"us-east.lb.example.com:443", "eu-west.lb.example.com:443"},
 			sharded:       true,
 			errorContains: "{shardName}",
 		},
 		{
-			name:     "MC sharded shardName as name component is allowed",
-			template: "search-{clusterIndex}-{shardName}-proxy.lb.example.com:443",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
-			sharded:  true,
+			name:      "MC sharded shardName as name component is allowed",
+			hostnames: []string{"search-us-east-{shardName}-proxy.lb.example.com:443", "search-eu-west-{shardName}-proxy.lb.example.com:443"},
+			sharded:   true,
 		},
 		{
-			name:     "no managed LB returns success",
-			template: "",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			name:      "no managed LB returns success",
+			hostnames: []string{"", ""},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := mkSearch(tt.template, tt.clusters, tt.sharded)
-			if tt.template == "" {
-				s.Spec.LoadBalancer = nil
-			}
-			res := validateMCExternalHostnamePlaceholders(s)
+			s := mkSearch(tt.hostnames, tt.sharded)
+			res := validateMCExternalHostnames(s)
 			if tt.errorContains != "" {
 				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
 				assert.Contains(t, res.Msg, tt.errorContains)
@@ -377,15 +365,18 @@ func TestValidateMCExternalHostnamePlaceholders(t *testing.T) {
 }
 
 func TestValidateExternalHostnameDNSLength(t *testing.T) {
-	mkSearch := func(template string, clusters []ClusterSpec, shardNames []string) *MongoDBSearch {
+	mkSearch := func(hostnames []string, shardNames []string) *MongoDBSearch {
+		clusters := make([]ClusterSpec, 0, len(hostnames))
+		for i, hn := range hostnames {
+			c := ClusterSpec{ClusterName: "cluster-" + strconv.Itoa(i)}
+			if hn != "" {
+				c.LoadBalancer = managedLBWithHostname(hn)
+			}
+			clusters = append(clusters, c)
+		}
 		s := &MongoDBSearch{
 			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-			Spec: MongoDBSearchSpec{
-				LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: template}},
-			},
-		}
-		if clusters != nil {
-			s.Spec.Clusters = clusters
+			Spec:       MongoDBSearchSpec{Clusters: clusters},
 		}
 		if shardNames != nil {
 			shards := make([]ExternalShardConfig, 0, len(shardNames))
@@ -407,80 +398,62 @@ func TestValidateExternalHostnameDNSLength(t *testing.T) {
 	// Build a > 63-char label.
 	longLabel := strings.Repeat("a", 64)
 
-	// Build a > 253-char total host: 4 labels of 60 chars each separated by dots = 4*60 + 3 = 243 (<253),
-	// so use longer labels to overflow. 5 labels of 60 chars: 5*60 + 4 = 304 > 253.
-	longClusterLabel := strings.Repeat("c", 60)
-
 	tests := []struct {
 		name          string
-		template      string
-		clusters      []ClusterSpec
+		hostnames     []string
 		shardNames    []string
 		errorContains string
 	}{
 		{
-			name:     "short hostname RS single-cluster passes",
-			template: "search.lb.example.com:443",
-			clusters: []ClusterSpec{{}},
+			name:      "short hostname RS single-cluster passes",
+			hostnames: []string{"search.lb.example.com:443"},
 		},
 		{
-			name:     "short hostname MC RS passes",
-			template: "{clusterName}.search-lb.example.com:443",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			name:      "short hostname MC RS passes",
+			hostnames: []string{"us-east.search-lb.example.com:443", "eu-west.search-lb.example.com:443"},
 		},
 		{
 			name:       "short hostname MC sharded passes",
-			template:   "{clusterName}.{shardName}.lb.example.com:443",
-			clusters:   []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			hostnames:  []string{"us-east.{shardName}.lb.example.com:443", "eu-west.{shardName}.lb.example.com:443"},
 			shardNames: []string{"shard-0", "shard-1"},
 		},
 		{
-			name:          "DNS label > 63 after substitution rejected",
-			template:      "{clusterName}.lb.example.com:443",
-			clusters:      []ClusterSpec{{ClusterName: longLabel}, {ClusterName: "ok"}},
+			name:          "DNS label > 63 rejected",
+			hostnames:     []string{longLabel + ".lb.example.com:443", "ok.lb.example.com:443"},
 			errorContains: "invalid DNS subdomain",
 		},
 		{
-			// Each label fits 63, but the FQDN exceeds 253 after substitution.
-			// 4 x 60-char labels + 4 dots = 244; plus "{clusterName}." (60+1=61) and tail (suffix) bring it well over 253.
-			name:     "FQDN > 253 after cross-product rejected",
-			template: "{clusterName}." + strings.Repeat("a", 60) + "." + strings.Repeat("b", 60) + "." + strings.Repeat("c", 60) + "." + strings.Repeat("d", 60) + ".lb.example.com:443",
-			clusters: []ClusterSpec{
-				{ClusterName: longClusterLabel},
-				{ClusterName: "ok"},
-			},
+			// Each label fits 63, but the FQDN exceeds 253.
+			// 5 x 60-char labels + 4 dots = 304 > 253.
+			name:          "FQDN > 253 rejected",
+			hostnames:     []string{strings.Repeat("c", 60) + "." + strings.Repeat("a", 60) + "." + strings.Repeat("b", 60) + "." + strings.Repeat("c", 60) + "." + strings.Repeat("d", 60) + ".lb.example.com:443"},
 			errorContains: "invalid DNS subdomain",
 		},
 		{
-			name:     "single-entry clusters substitutes and validates",
-			template: "{clusterName}.lb.example.com:443",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}},
+			name:       "shard substitution validates each resolved hostname",
+			hostnames:  []string{"{shardName}.lb.example.com:443"},
+			shardNames: []string{"shard-0"},
 		},
 		{
 			name:          "empty host after port-stripping rejected",
-			template:      ":443",
-			clusters:      []ClusterSpec{{}},
+			hostnames:     []string{":443"},
 			errorContains: "empty host",
 		},
 		{
-			name:     "no port present validates whole string as host",
-			template: "{clusterName}.lb.example.com",
-			clusters: []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}},
+			name:      "no port present validates whole string as host",
+			hostnames: []string{"us-east.lb.example.com", "eu-west.lb.example.com"},
 		},
 		{
-			// 62-char label + {clusterIndex}: pinned index 70 renders a 64-char label
-			// (overflow), array position 0 would render 63 (valid). Single entry, so the
-			// validator only overflows if it honors the pinned ClusterIndex, not position 0.
-			name:          "pinned clusterIndex (not array position) drives DNS-label overflow",
-			template:      strings.Repeat("a", 62) + "{clusterIndex}.lb.example.com:443",
-			clusters:      []ClusterSpec{pinnedSpec("us-east-k8s", 70)},
+			name:          "oversized shard label rejected after substitution",
+			hostnames:     []string{"{shardName}.lb.example.com:443"},
+			shardNames:    []string{longLabel},
 			errorContains: "invalid DNS subdomain",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := mkSearch(tt.template, tt.clusters, tt.shardNames)
+			s := mkSearch(tt.hostnames, tt.shardNames)
 			res := validateExternalHostnameDNSLength(s)
 			if tt.errorContains != "" {
 				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
@@ -496,7 +469,6 @@ func TestValidateExternalHostnameDNSLength(t *testing.T) {
 // dispatch scopes this validator to multi-cluster specs, so only the LB shape
 // matters here. Both no-LB and unmanaged-LB are rejected; managed is accepted.
 func TestValidateMCRequiresManagedLB(t *testing.T) {
-	clusters := []ClusterSpec{{ClusterName: "us-east-k8s"}, {ClusterName: "eu-west-k8s"}}
 	tests := []struct {
 		name          string
 		lb            *LoadBalancerConfig
@@ -504,24 +476,27 @@ func TestValidateMCRequiresManagedLB(t *testing.T) {
 	}{
 		{
 			name: "MC + managed LB allowed",
-			lb:   &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{clusterName}.lb.example.com:443"}},
+			lb:   &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "lb.example.com:443"}},
 		},
 		{
 			name:          "MC + no LB rejected",
 			lb:            nil,
-			errorContains: "requires a managed load balancer (spec.loadBalancer.managed) at the moment; none is configured",
+			errorContains: "requires a managed load balancer (spec.clusters[0].loadBalancer.managed) at the moment; none is configured",
 		},
 		{
 			name:          "MC + unmanaged LB rejected",
 			lb:            &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: "lb.example.com:443"}},
-			errorContains: "spec.loadBalancer.unmanaged is not supported for multi-cluster",
+			errorContains: "spec.clusters[0].loadBalancer.unmanaged is not supported for multi-cluster",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: clusters, LoadBalancer: tt.lb},
+				Spec: MongoDBSearchSpec{Clusters: []ClusterSpec{
+					{ClusterName: "us-east-k8s", LoadBalancer: tt.lb},
+					{ClusterName: "eu-west-k8s", LoadBalancer: tt.lb},
+				}},
 			}
 			res := validateMCRequiresManagedLB(s)
 			if tt.errorContains != "" {
@@ -580,7 +555,9 @@ func TestValidateClustersClusterNameNonEmpty(t *testing.T) {
 				s.Spec.Source = &MongoDBSource{
 					ExternalMongoDBSource: &ExternalMongoDBSource{HostAndPorts: []string{"h:27017"}},
 				}
-				s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{clusterName}.lb.example.com:443"}}
+				for i := range s.Spec.Clusters {
+					s.Spec.Clusters[i].LoadBalancer = managedLBWithHostname("c" + strconv.Itoa(i) + ".lb.example.com:443")
+				}
 			}
 			err := s.ValidateSpec()
 			if tt.errorContains != "" {
@@ -642,7 +619,9 @@ func TestValidateMCMatchTagsNonEmpty(t *testing.T) {
 				s.Spec.Source = &MongoDBSource{
 					ExternalMongoDBSource: &ExternalMongoDBSource{HostAndPorts: []string{"h:27017"}},
 				}
-				s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{clusterName}.lb.example.com:443"}}
+				for i := range s.Spec.Clusters {
+					s.Spec.Clusters[i].LoadBalancer = managedLBWithHostname("c" + strconv.Itoa(i) + ".lb.example.com:443")
+				}
 			}
 			err := s.ValidateSpec()
 			if tt.errorContains != "" {
@@ -687,17 +666,21 @@ func TestValidateClustersClusterIndexRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			clusters := append([]ClusterSpec(nil), tt.clusters...)
 			s := &MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: tt.clusters},
+				Spec:       MongoDBSearchSpec{Clusters: clusters},
 			}
-			// Multi-cluster specs need an external source + managed LB so the
-			// clusterIndex check is the rule under test, not the MC source/LB checks.
-			if len(tt.clusters) > 1 {
+			// Multi-cluster specs need an external source + managed LB on every
+			// cluster so the clusterIndex check is the rule under test, not the MC
+			// source/LB checks.
+			if len(clusters) > 1 {
 				s.Spec.Source = &MongoDBSource{
 					ExternalMongoDBSource: &ExternalMongoDBSource{HostAndPorts: []string{"h:27017"}},
 				}
-				s.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{clusterName}.lb.example.com:443"}}
+				for i := range clusters {
+					clusters[i].LoadBalancer = managedLBWithHostname("c" + strconv.Itoa(i) + ".lb.example.com:443")
+				}
 			}
 			err := s.ValidateSpec()
 			if tt.errorContains != "" {
@@ -708,6 +691,11 @@ func TestValidateClustersClusterIndexRequired(t *testing.T) {
 			}
 		})
 	}
+}
+
+// managedLBWithHostname is a shorthand for a per-cluster managed LB entry.
+func managedLBWithHostname(hostname string) *LoadBalancerConfig {
+	return &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: hostname}}
 }
 
 func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTLS, isLBManaged bool) *MongoDBSearch {
@@ -729,7 +717,7 @@ func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTL
 		search.Spec.Security.TLS = &TLS{CertsSecretPrefix: tlsPrefix}
 	}
 	if isLBManaged {
-		search.Spec.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{}}
+		search.Spec.Clusters[0].LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{}}
 	}
 	return search
 }
@@ -783,6 +771,66 @@ func TestValidateMCRequiresExternalSource(t *testing.T) {
 		},
 	}
 	assert.Equal(t, v1.SuccessLevel, validateMCRequiresExternalSource(mdbSharded).Level, "MC sharded source must be accepted")
+}
+
+// TestValidateLBConfig covers the per-cluster LB shape rules: exactly one of
+// managed/unmanaged per entry, all-or-none presence, and no mode mixing.
+func TestValidateLBConfig(t *testing.T) {
+	managed := &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "lb.example.com:443"}}
+	unmanaged := &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: "lb.example.com:443"}}
+	tests := []struct {
+		name          string
+		clusters      []ClusterSpec
+		errorContains string
+	}{
+		{
+			name:     "no LB anywhere ok",
+			clusters: []ClusterSpec{{ClusterName: "a"}, {ClusterName: "b"}},
+		},
+		{
+			name:     "managed everywhere ok",
+			clusters: []ClusterSpec{{ClusterName: "a", LoadBalancer: managed}, {ClusterName: "b", LoadBalancer: managed}},
+		},
+		{
+			name:     "unmanaged everywhere ok",
+			clusters: []ClusterSpec{{ClusterName: "a", LoadBalancer: unmanaged}, {ClusterName: "b", LoadBalancer: unmanaged}},
+		},
+		{
+			name:          "neither managed nor unmanaged rejected",
+			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: &LoadBalancerConfig{}}},
+			errorContains: "exactly one of 'managed' or 'unmanaged'",
+		},
+		{
+			name:          "both managed and unmanaged rejected",
+			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}, Unmanaged: &UnmanagedLBConfig{Endpoint: "e:443"}}}},
+			errorContains: "mutually exclusive",
+		},
+		{
+			name:          "partial presence rejected",
+			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: managed}, {ClusterName: "b"}},
+			errorContains: "every cluster or on none",
+		},
+		{
+			name:          "mixed modes rejected",
+			clusters:      []ClusterSpec{{ClusterName: "a", LoadBalancer: managed}, {ClusterName: "b", LoadBalancer: unmanaged}},
+			errorContains: "cannot be mixed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Spec:       MongoDBSearchSpec{Clusters: tt.clusters},
+			}
+			res := validateLBConfig(s)
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level)
+			}
+		})
+	}
 }
 
 // TestValidateClustersEnvoyResourceNames is the admission check for the
@@ -894,9 +942,15 @@ func TestValidateMultipleReplicasRequireLB(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			clusters := tt.clusters
+			for i := range clusters {
+				if tt.lb != nil {
+					clusters[i].LoadBalancer = tt.lb
+				}
+			}
 			s := &MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-				Spec:       MongoDBSearchSpec{Clusters: tt.clusters, LoadBalancer: tt.lb},
+				Spec:       MongoDBSearchSpec{Clusters: clusters},
 			}
 			res := validateMultipleReplicasRequireLB(s)
 			if tt.errorContains != "" {
@@ -964,8 +1018,10 @@ func TestValidateUnmanagedEndpointTemplate(t *testing.T) {
 			s := &MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
 				Spec: MongoDBSearchSpec{
-					Source:       tt.source,
-					LoadBalancer: &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: tt.endpoint}},
+					Source: tt.source,
+					Clusters: []ClusterSpec{
+						{LoadBalancer: &LoadBalancerConfig{Unmanaged: &UnmanagedLBConfig{Endpoint: tt.endpoint}}},
+					},
 				},
 			}
 			res := validateUnmanagedEndpointTemplate(s)

--- a/api/mongodb/v1/search/zz_generated.deepcopy.go
+++ b/api/mongodb/v1/search/zz_generated.deepcopy.go
@@ -425,11 +425,6 @@ func (in *MongoDBSearchSpec) DeepCopyInto(out *MongoDBSearchSpec) {
 		*out = new(EmbeddingConfig)
 		**out = **in
 	}
-	if in.LoadBalancer != nil {
-		in, out := &in.LoadBalancer, &out.LoadBalancer
-		*out = new(LoadBalancerConfig)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.FeatureFlags != nil {
 		in, out := &in.FeatureFlags, &out.FeatureFlags
 		*out = new(FeatureFlags)

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -122,8 +122,10 @@ spec:
                         type: string
                       type: array
                     loadBalancer:
-                      description: LoadBalancer per-cluster override; deep-merged
-                        into spec.loadBalancer.managed.
+                      description: |-
+                        LoadBalancer configures how mongod/mongos connect to this cluster's mongot
+                        (managed Envoy or user-provided). Every cluster must agree on the mode:
+                        either all clusters set managed, all set unmanaged, or none set loadBalancer.
                       properties:
                         managed:
                           description: Managed configures an operator-managed Envoy
@@ -327,8 +329,8 @@ spec:
                       description: |-
                         Replicas is the number of mongot pods for this cluster's StatefulSet.
                         For ReplicaSet sources this is the total; for sharded sources it is per shard.
-                        When Replicas > 1, a load balancer (spec.loadBalancer) is required to distribute
-                        traffic across mongot instances.
+                        When Replicas > 1, a load balancer (spec.clusters[].loadBalancer) is required to
+                        distribute traffic across mongot instances.
                         Set to 0 to take mongot offline: the StatefulSet scales to 0 while the MongoDBSearch CR stays.
                       format: int32
                       minimum: 0
@@ -643,162 +645,6 @@ spec:
                       gRPC RESOURCE_EXHAUSTED status codes. Defaults to true.
                     type: boolean
                 type: object
-              loadBalancer:
-                description: |-
-                  LoadBalancer configures how mongod/mongos connect to mongot (Managed vs Unmanaged/BYO Load Balancer).
-                  Top-level spec.loadBalancer.managed.* serves as the default for every entry in spec.clusters;
-                  per-cluster overrides deep-merge into this template (see spec.clusters[].loadBalancer.managed).
-                  spec.loadBalancer.unmanaged is top-level only — there is no per-cluster form.
-                properties:
-                  managed:
-                    description: Managed configures an operator-managed Envoy load
-                      balancer.
-                    properties:
-                      deployment:
-                        description: |-
-                          Deployment holds optional overrides merged into the operator-created Envoy Deployment.
-                          Follows the same convention as spec.statefulSet on MongoDB resources.
-                        properties:
-                          metadata:
-                            description: DeploymentMetadataWrapper is a wrapper around
-                              Labels and Annotations
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          spec:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                        required:
-                        - spec
-                        type: object
-                      externalHostname:
-                        description: |-
-                          ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
-                          For sharded clusters, may contain a {shardName} placeholder.
-                          In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-                          SNI hostnames stay distinct.
-                          Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
-                        type: string
-                      minMongotReadyReplicas:
-                        description: |-
-                          MinMongotReadyReplicas is the minimum number of ready mongot replicas in a group
-                          before this mongot group can be considered ready and envoy routes real traffic to it.
-                          Until this threshold is met, traffic for that shard is forwarded to a healthy mongot group with the
-                          routed_from_another_shard header (returning empty results).
-                          Defaults to 1 if not specified.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      replicas:
-                        description: |-
-                          Replicas is the number of Envoy proxy pods to deploy.
-                          Defaults to 1 if not specified.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      resourceRequirements:
-                        description: |-
-                          ResourceRequirements for the Envoy container.
-                          When not set, defaults to requests: {cpu: 100m, memory: 128Mi}, limits: {cpu: 500m, memory: 512Mi}.
-                        properties:
-                          claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
-                            items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
-                                  type: string
-                                request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                            type: object
-                        type: object
-                      retryPolicy:
-                        description: |-
-                          RetryPolicy configures Envoy retry behavior for individual gRPC streams to upstream mongot clusters.
-                          When not set, retries are enabled with sensible defaults (2 retries, 60s per-try timeout).
-                        properties:
-                          numRetries:
-                            description: |-
-                              NumRetries is the maximum number of retries per request.
-                              Defaults to 2 if not specified (3 total attempts including the original).
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          perTryTimeout:
-                            description: |-
-                              PerTryTimeout is the timeout for each retry attempt (including the original).
-                              Specified as a Go duration string (e.g., "60s", "30s").
-                              Defaults to "60s" if not specified.
-                            type: string
-                        type: object
-                    type: object
-                  unmanaged:
-                    description: Unmanaged configures a user-provided (BYO) L7 load
-                      balancer.
-                    properties:
-                      endpoint:
-                        description: |-
-                          Endpoint is the full host:port of the BYO load balancer written into mongod config.
-                          For sharded clusters, must contain a {shardName} placeholder.
-                        type: string
-                    type: object
-                type: object
-                x-kubernetes-validations:
-                - message: exactly one of managed or unmanaged must be set
-                  rule: (has(self.managed) && !has(self.unmanaged)) || (!has(self.managed)
-                    && has(self.unmanaged))
               logLevel:
                 description: Configure verbosity of mongot logs. Defaults to INFO
                   if not set.

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -159,8 +159,7 @@ spec:
                               description: |-
                                 ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
                                 For sharded clusters, may contain a {shardName} placeholder.
-                                In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-                                SNI hostnames stay distinct.
+                                In multi-cluster deployments, every cluster's hostname must be distinct.
                                 Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
                               type: string
                             minMongotReadyReplicas:
@@ -864,7 +863,7 @@ spec:
               loadBalancer:
                 description: |-
                   LoadBalancer reports the state of the operator-managed load balancer.
-                  Only populated when spec.loadBalancer.managed is set.
+                  Only populated when spec.clusters[].loadBalancer.managed is set.
                 properties:
                   message:
                     type: string

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -901,9 +901,13 @@ func TestReconcile_SimulatedMC_RePinUpdatesMappingAndNames(t *testing.T) {
 }
 
 func newSimulatedMCShardedMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
+	// Each cluster gets its own externalHostname (distinct per cluster); the
+	// {shardName}. prefix is required for cluster-level form derivation.
 	clusters := []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1))},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1))},
+		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-a.example.com"}}},
+		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-b.example.com"}}},
 	}
 	return &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -917,13 +921,6 @@ func newSimulatedMCShardedMongoDBSearch(name, namespace string) *searchv1.MongoD
 							{ShardName: "sh-1", Hosts: []string{"sh-1-a.example:27017"}},
 						},
 					},
-				},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					// {shardName}. prefix is required for cluster-level form derivation;
-					// {clusterName} satisfies validateMCExternalHostnamePlaceholders.
-					ExternalHostname: "{shardName}.{clusterName}.example.com",
 				},
 			},
 			Security: searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "certs"}},

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -479,8 +479,10 @@ func setupStateCMTest(t *testing.T, clusters ...searchv1.ClusterSpec) (*MongoDBS
 			HostAndPorts: []string{"mdb-0.mdb.svc:27017", "mdb-1.mdb.svc:27017"},
 		},
 	}
-	search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-		Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
+	for i := range clusters {
+		clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].ClusterName)},
+		}
 	}
 	search.Spec.Clusters = clusters
 	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
@@ -512,6 +514,13 @@ func updateSearchClusters(t *testing.T, ctx context.Context, c client.Client, na
 	t.Helper()
 	latest := &searchv1.MongoDBSearch{}
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: name, Namespace: mock.TestNamespace}, latest))
+	// Stamp the per-cluster managed LB every cluster needs to pass MC validation,
+	// matching setupStateCMTest so add/remove updates stay MC-valid.
+	for i := range clusters {
+		clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].ClusterName)},
+		}
+	}
 	latest.Spec.Clusters = clusters
 	require.NoError(t, c.Update(ctx, latest))
 }
@@ -589,12 +598,17 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 					HostAndPorts: []string{"mdb-0.mdb.svc:27017", "mdb-1.mdb.svc:27017"},
 				},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"}},
 		},
 	}
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "us-east", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1))},
-		{ClusterName: "us-west", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1))},
+		{
+			ClusterName: "us-east", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-east.example.com"}},
+		},
+		{
+			ClusterName: "us-west", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-west.example.com"}},
+		},
 	}
 
 	eastClient := mock.NewEmptyFakeClientBuilder().Build()
@@ -743,8 +757,10 @@ func assertSearchOwnerLabels(t *testing.T, search *searchv1.MongoDBSearch, clust
 
 func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
 	clusters := []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1))},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1))},
+		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"}}},
+		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"}}},
 	}
 	return &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -753,9 +769,6 @@ func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch
 				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
 					HostAndPorts: []string{"mdb-0.mdb.svc:27017", "mdb-1.mdb.svc:27017"},
 				},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
 			},
 			Clusters: clusters,
 		},
@@ -1083,11 +1096,9 @@ func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
 
 	t.Run("empty clusters is Invalid", func(t *testing.T) {
 		search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+		// Empty clusters means there is no per-cluster loadBalancer either, so the
+		// failure is attributable to the clusters check, not the LB validators.
 		search.Spec.Clusters = []searchv1.ClusterSpec{}
-		// Use a placeholder-free hostname so the failure is attributable to the
-		// clusters checks, not the DNS-length validator rejecting an unsubstituted
-		// {clusterName} literal.
-		search.Spec.LoadBalancer.Managed.ExternalHostname = "mongot.example.com"
 
 		reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-a", search)
 		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
@@ -1114,10 +1125,12 @@ func TestMongoDBSearchReconcile_ResolveClusterMappingFailure_Failed(t *testing.T
 	search.Spec.Source = &searchv1.MongoDBSource{
 		ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mdb-0.mdb.svc:27017"}},
 	}
-	search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-		Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
-	}
 	search.Spec.Clusters = []searchv1.ClusterSpec{pinnedCluster("us-east", 0), pinnedCluster("us-west", 1)}
+	for i := range search.Spec.Clusters {
+		search.Spec.Clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", search.Spec.Clusters[i].ClusterName)},
+		}
+	}
 
 	base := mock.NewEmptyFakeClientBuilder().WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 	// failingWriteClient rejects the state-CM write that resolveClusterMapping
@@ -1152,8 +1165,22 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 		},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1))},
-				{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1))},
+				{
+					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.example.com",
+						},
+					},
+				},
+				{
+					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.example.com",
+						},
+					},
+				},
 			},
 			Source: &searchv1.MongoDBSource{
 				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
@@ -1165,11 +1192,6 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 							{ShardName: "sh-2", Hosts: []string{"sh-2-a.example:27017"}},
 						},
 					},
-				},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "{shardName}.mdb-search-search-{clusterIndex}-proxy-svc.example.com",
 				},
 			},
 			Security: searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "certs"}},

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -276,7 +276,11 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	if err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
-	ldsJSON, err := buildLDSJSON(routes, tlsEnabled, caKeyName, search.GetManagedLBRetryPolicy())
+	var retryPolicy *searchv1.EnvoyRetryPolicy
+	if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil {
+		retryPolicy = cfg.RetryPolicy
+	}
+	ldsJSON, err := buildLDSJSON(routes, tlsEnabled, caKeyName, retryPolicy)
 	if err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
@@ -530,7 +534,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 	if err != nil {
 		return err
 	}
-	replicas := envoyReplicas(search)
+	replicas := envoyReplicas(search, clusterIndex)
 	labels := envoyLabelsForCluster(search, clusterName, clusterIndex)
 	podLabels := envoyPodLabelsForCluster(search, clusterIndex)
 	tlsEnabled := search.IsTLSConfigured()
@@ -538,7 +542,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 	if err != nil {
 		return err
 	}
-	resources := envoyResourceRequirements(search)
+	resources := envoyResourceRequirements(search, clusterIndex)
 	managedSecurityContext := env.ReadBoolOrDefault(podtemplatespec.ManagedSecurityContextEnv, false) // nolint:forbidigo
 
 	dep := &appsv1.Deployment{
@@ -568,10 +572,10 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 		}
 
 		// Apply user deployment configuration override
-		if depCfg := search.GetManagedLBDeploymentConfig(); depCfg != nil {
-			dep.Spec = merge.DeploymentSpecs(dep.Spec, depCfg.SpecWrapper.Spec)
-			dep.Labels = merge.StringToStringMap(dep.Labels, depCfg.MetadataWrapper.Labels)
-			dep.Annotations = merge.StringToStringMap(dep.Annotations, depCfg.MetadataWrapper.Annotations)
+		if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil && cfg.Deployment != nil {
+			dep.Spec = merge.DeploymentSpecs(dep.Spec, cfg.Deployment.SpecWrapper.Spec)
+			dep.Labels = merge.StringToStringMap(dep.Labels, cfg.Deployment.MetadataWrapper.Labels)
+			dep.Annotations = merge.StringToStringMap(dep.Annotations, cfg.Deployment.MetadataWrapper.Annotations)
 		}
 
 		if clusterName == "" {
@@ -745,11 +749,11 @@ func (r *MongoDBSearchEnvoyReconciler) envoyContainerImage() (string, error) {
 	return r.defaultEnvoyImage, nil
 }
 
-// envoyResourceRequirements returns user-specified resource requirements
+// envoyResourceRequirements returns the cluster's resource requirements
 // or the defaults (100m/128Mi requests, 500m/512Mi limits).
-func envoyResourceRequirements(search *searchv1.MongoDBSearch) corev1.ResourceRequirements {
-	if reqs := search.GetManagedLBResourceRequirements(); reqs != nil {
-		return *reqs
+func envoyResourceRequirements(search *searchv1.MongoDBSearch, clusterIndex int) corev1.ResourceRequirements {
+	if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil && cfg.ResourceRequirements != nil {
+		return *cfg.ResourceRequirements
 	}
 	return defaultEnvoyResourceRequirements()
 }
@@ -789,11 +793,11 @@ func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, c
 	return labels
 }
 
-// envoyReplicas returns the desired Envoy replica count.
-// Uses spec.loadBalancer.managed.replicas if set, otherwise defaults to 1.
-func envoyReplicas(search *searchv1.MongoDBSearch) int32 {
-	if cfg := search.Spec.LoadBalancer; cfg != nil && cfg.Managed != nil && cfg.Managed.Replicas != nil {
-		return *cfg.Managed.Replicas
+// envoyReplicas returns the cluster's desired Envoy replica count.
+// Uses spec.clusters[].loadBalancer.managed.replicas if set, otherwise defaults to 1.
+func envoyReplicas(search *searchv1.MongoDBSearch, clusterIndex int) int32 {
+	if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil && cfg.Replicas != nil {
+		return *cfg.Replicas
 	}
 	return envoyReplicasDefault
 }

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -247,8 +247,11 @@ func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.Mon
 }
 
 // reconcileForCluster runs the ConfigMap + Deployment ensure for one cluster's
-// work item. routingReadyMongotGroups is the state-CM switch — shards not listed
-// get fallback routing. Returns a workflow.Status describing the per-cluster outcome.
+// work item. clusterName resolves the cluster's LB config and is used for log
+// context; clusterIndex is used for resource naming ONLY (it comes from the
+// persisted ClusterMapping, which outlives spec positions). routingReadyMongotGroups
+// is the state-CM switch — shards not listed get fallback routing.
+// Returns a workflow.Status describing the per-cluster outcome.
 func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	ctx context.Context,
 	search *searchv1.MongoDBSearch,
@@ -276,9 +279,10 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	if err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
+	managedLB := search.GetManagedLBForCluster(clusterName)
 	var retryPolicy *searchv1.EnvoyRetryPolicy
-	if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil {
-		retryPolicy = cfg.RetryPolicy
+	if managedLB != nil {
+		retryPolicy = managedLB.RetryPolicy
 	}
 	ldsJSON, err := buildLDSJSON(routes, tlsEnabled, caKeyName, retryPolicy)
 	if err != nil {
@@ -289,7 +293,7 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 	// Ensure Deployment (hash only bootstrap — CDS/LDS are hot-reloaded by Envoy via filesystem xDS)
-	if err := r.ensureDeployment(ctx, search, bootstrapJSON, clusterName, clusterIndex, c, tlsCfg, log); err != nil {
+	if err := r.ensureDeployment(ctx, search, bootstrapJSON, clusterName, clusterIndex, managedLB, c, tlsCfg, log); err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 	return workflow.OK()
@@ -387,7 +391,7 @@ func buildShardRoutes(search *searchv1.MongoDBSearch, shardNames []string, clust
 		upstreamFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", mongotServiceName, namespace)
 
 		sniHostname := fmt.Sprintf("%s.%s.svc.cluster.local", sniServiceName, namespace)
-		if endpoint := search.GetManagedLBEndpointForClusterShard(clusterIndex, clusterName, shardName); endpoint != "" {
+		if endpoint := search.GetManagedLBEndpointForClusterShard(clusterName, shardName); endpoint != "" {
 			sniHostname = endpoint
 		}
 
@@ -424,7 +428,7 @@ func buildShardRoutes(search *searchv1.MongoDBSearch, shardNames []string, clust
 	// the user supplied a managed-LB externalHostname (with {shardName}. prefix stripped).
 	clusterLevelSvcName := search.ProxyServiceNamespacedNameForCluster(clusterIndex).Name
 	clusterLevelSNI := fmt.Sprintf("%s.%s.svc.cluster.local", clusterLevelSvcName, namespace)
-	if endpoint := search.GetManagedLBEndpointForClusterLevel(clusterIndex, clusterName); endpoint != "" {
+	if endpoint := search.GetManagedLBEndpointForClusterLevel(clusterName); endpoint != "" {
 		clusterLevelSNI = endpoint
 	}
 
@@ -463,7 +467,7 @@ func buildReplicaSetRouteForCluster(search *searchv1.MongoDBSearch, clusterIndex
 
 	sniServiceName := search.ProxyServiceNamespacedNameForCluster(clusterIndex).Name
 	sniHostname := fmt.Sprintf("%s.%s.svc.cluster.local", sniServiceName, namespace)
-	if endpoint := search.GetManagedLBEndpointForCluster(clusterIndex, clusterName); endpoint != "" {
+	if endpoint := search.GetManagedLBEndpointForCluster(clusterName); endpoint != "" {
 		sniHostname = endpoint
 	}
 
@@ -529,12 +533,12 @@ func envoyConfigHash(configJSON string) (string, error) {
 // hot-reloaded by Envoy via filesystem xDS and do not require a pod restart.
 //
 // Cross-cluster ownership note: see ensureConfigMap.
-func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, clusterName string, clusterIndex int, c kubernetesClient.Client, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, clusterName string, clusterIndex int, managedLB *searchv1.ManagedLBConfig, c kubernetesClient.Client, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
 	configHash, err := envoyConfigHash(bootstrapJSON)
 	if err != nil {
 		return err
 	}
-	replicas := envoyReplicas(search, clusterIndex)
+	replicas := envoyReplicas(managedLB)
 	labels := envoyLabelsForCluster(search, clusterName, clusterIndex)
 	podLabels := envoyPodLabelsForCluster(search, clusterIndex)
 	tlsEnabled := search.IsTLSConfigured()
@@ -542,7 +546,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 	if err != nil {
 		return err
 	}
-	resources := envoyResourceRequirements(search, clusterIndex)
+	resources := envoyResourceRequirements(managedLB)
 	managedSecurityContext := env.ReadBoolOrDefault(podtemplatespec.ManagedSecurityContextEnv, false) // nolint:forbidigo
 
 	dep := &appsv1.Deployment{
@@ -572,10 +576,10 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 		}
 
 		// Apply user deployment configuration override
-		if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil && cfg.Deployment != nil {
-			dep.Spec = merge.DeploymentSpecs(dep.Spec, cfg.Deployment.SpecWrapper.Spec)
-			dep.Labels = merge.StringToStringMap(dep.Labels, cfg.Deployment.MetadataWrapper.Labels)
-			dep.Annotations = merge.StringToStringMap(dep.Annotations, cfg.Deployment.MetadataWrapper.Annotations)
+		if managedLB != nil && managedLB.Deployment != nil {
+			dep.Spec = merge.DeploymentSpecs(dep.Spec, managedLB.Deployment.SpecWrapper.Spec)
+			dep.Labels = merge.StringToStringMap(dep.Labels, managedLB.Deployment.MetadataWrapper.Labels)
+			dep.Annotations = merge.StringToStringMap(dep.Annotations, managedLB.Deployment.MetadataWrapper.Annotations)
 		}
 
 		if clusterName == "" {
@@ -751,9 +755,9 @@ func (r *MongoDBSearchEnvoyReconciler) envoyContainerImage() (string, error) {
 
 // envoyResourceRequirements returns the cluster's resource requirements
 // or the defaults (100m/128Mi requests, 500m/512Mi limits).
-func envoyResourceRequirements(search *searchv1.MongoDBSearch, clusterIndex int) corev1.ResourceRequirements {
-	if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil && cfg.ResourceRequirements != nil {
-		return *cfg.ResourceRequirements
+func envoyResourceRequirements(managedLB *searchv1.ManagedLBConfig) corev1.ResourceRequirements {
+	if managedLB != nil && managedLB.ResourceRequirements != nil {
+		return *managedLB.ResourceRequirements
 	}
 	return defaultEnvoyResourceRequirements()
 }
@@ -795,9 +799,9 @@ func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, c
 
 // envoyReplicas returns the cluster's desired Envoy replica count.
 // Uses spec.clusters[].loadBalancer.managed.replicas if set, otherwise defaults to 1.
-func envoyReplicas(search *searchv1.MongoDBSearch, clusterIndex int) int32 {
-	if cfg := search.GetManagedLBForCluster(clusterIndex); cfg != nil && cfg.Replicas != nil {
-		return *cfg.Replicas
+func envoyReplicas(managedLB *searchv1.ManagedLBConfig) int32 {
+	if managedLB != nil && managedLB.Replicas != nil {
+		return *managedLB.Replicas
 	}
 	return envoyReplicasDefault
 }

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -240,7 +240,7 @@ func TestBuildEnvoyPodSpec_DefaultResources(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 	}
-	resources := envoyResourceRequirements(search, 0)
+	resources := envoyResourceRequirements(search.GetManagedLBForCluster(""))
 	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	assert.Len(t, podSpec.Containers, 1)
@@ -275,7 +275,7 @@ func TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 	}
-	resources := envoyResourceRequirements(search, 0)
+	resources := envoyResourceRequirements(search.GetManagedLBForCluster(""))
 
 	cases := []struct {
 		name           string
@@ -350,7 +350,7 @@ func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 	}
 
 	// Build the base pod spec as the controller would
-	resources := envoyResourceRequirements(search, 0)
+	resources := envoyResourceRequirements(search.GetManagedLBForCluster(""))
 	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	// Verify base spec has no tolerations
@@ -429,7 +429,7 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	}
 
 	// Build base with resourceRequirements (200m)
-	resources := envoyResourceRequirements(search, 0)
+	resources := envoyResourceRequirements(search.GetManagedLBForCluster(""))
 	assert.Equal(t, resource.MustParse("200m"), resources.Requests[corev1.ResourceCPU])
 
 	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
@@ -892,7 +892,7 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 
 func TestEnvoyReplicas_DefaultsTo1(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-	assert.Equal(t, int32(1), envoyReplicas(search, 0))
+	assert.Equal(t, int32(1), envoyReplicas(search.GetManagedLBForCluster("")))
 }
 
 // envoyTestScheme returns a runtime.Scheme registered for the types ensureDeployment/
@@ -1150,7 +1150,7 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 	} {
 		search.Spec.Clusters[0].LoadBalancer.Managed.Replicas = tc.lbReplicas
 		// cluster "a" is at index 0.
-		require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, "a", 0, r.clientForCluster("a"), nil, zap.S()))
+		require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, "a", 0, search.GetManagedLBForCluster("a"), r.clientForCluster("a"), nil, zap.S()))
 
 		dep := &appsv1.Deployment{}
 		require.NoError(t, memberA.Get(context.Background(),

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -89,9 +89,11 @@ func TestBuildReplicaSetRoute(t *testing.T) {
 				},
 			}
 			if tt.endpoint != "" {
-				search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint},
-				}
+				search.Spec.Clusters = []searchv1.ClusterSpec{{
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint},
+					},
+				}}
 			}
 
 			route := buildReplicaSetRouteForCluster(search, 0, "")
@@ -106,54 +108,47 @@ func TestBuildReplicaSetRoute(t *testing.T) {
 	}
 }
 
-func TestBuildReplicaSetRouteForCluster_PerClusterPlaceholders(t *testing.T) {
-	clusters := []searchv1.ClusterSpec{
-		{ClusterName: "kind-e2e-cluster-1"},
-		{ClusterName: "kind-e2e-cluster-2"},
-	}
+func TestBuildReplicaSetRouteForCluster_PerClusterHostnames(t *testing.T) {
+	clusterNames := []string{"kind-e2e-cluster-1", "kind-e2e-cluster-2"}
 
 	tests := []struct {
 		name         string
-		endpoint     string
+		endpoints    []string
 		expectedSNIs []string
 	}{
 		{
-			name:     "no endpoint: per-cluster proxy-svc FQDN",
-			endpoint: "",
+			name:      "no endpoint: per-cluster proxy-svc FQDN",
+			endpoints: nil,
 			expectedSNIs: []string{
 				"mdb-search-search-0-proxy-svc.test-ns.svc.cluster.local",
 				"mdb-search-search-1-proxy-svc.test-ns.svc.cluster.local",
 			},
 		},
 		{
-			name:     "{clusterIndex} placeholder substitutes per cluster",
-			endpoint: "mdb-search-search-{clusterIndex}-proxy-svc.test-ns.svc.cluster.local",
-			expectedSNIs: []string{
-				"mdb-search-search-0-proxy-svc.test-ns.svc.cluster.local",
-				"mdb-search-search-1-proxy-svc.test-ns.svc.cluster.local",
+			name: "per-cluster literal hostnames",
+			endpoints: []string{
+				"us-east.lb.example.com:443",
+				"eu-west.lb.example.com:443",
 			},
-		},
-		{
-			name:     "{clusterName} placeholder substitutes per cluster",
-			endpoint: "mongot-{clusterName}.apps.example.com",
 			expectedSNIs: []string{
-				"mongot-kind-e2e-cluster-1.apps.example.com",
-				"mongot-kind-e2e-cluster-2.apps.example.com",
-			},
-		},
-		{
-			name:     "{clusterName} and {clusterIndex} both substituted",
-			endpoint: "{clusterName}-{clusterIndex}.apps.example.com",
-			expectedSNIs: []string{
-				"kind-e2e-cluster-1-0.apps.example.com",
-				"kind-e2e-cluster-2-1.apps.example.com",
+				"us-east.lb.example.com:443",
+				"eu-west.lb.example.com:443",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := append([]searchv1.ClusterSpec{}, clusters...)
+			cs := make([]searchv1.ClusterSpec, 0, len(clusterNames))
+			for i, n := range clusterNames {
+				c := searchv1.ClusterSpec{ClusterName: n}
+				if tt.endpoints != nil {
+					c.LoadBalancer = &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoints[i]},
+					}
+				}
+				cs = append(cs, c)
+			}
 			search := &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mdb-search",
@@ -161,11 +156,6 @@ func TestBuildReplicaSetRouteForCluster_PerClusterPlaceholders(t *testing.T) {
 				},
 			}
 			search.Spec.Clusters = cs
-			if tt.endpoint != "" {
-				search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint},
-				}
-			}
 
 			for i, c := range cs {
 				route := buildReplicaSetRouteForCluster(search, i, c.ClusterName)
@@ -222,9 +212,11 @@ func TestBuildShardRoutes(t *testing.T) {
 				},
 			}
 			if tt.endpoint != "" {
-				search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint},
-				}
+				search.Spec.Clusters = []searchv1.ClusterSpec{{
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint},
+					},
+				}}
 			}
 
 			routes := buildShardRoutes(search, shardNames, 0, "", nil)
@@ -248,7 +240,7 @@ func TestBuildEnvoyPodSpec_DefaultResources(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 	}
-	resources := envoyResourceRequirements(search)
+	resources := envoyResourceRequirements(search, 0)
 	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	assert.Len(t, podSpec.Containers, 1)
@@ -283,7 +275,7 @@ func TestBuildEnvoyPodSpec_ConfigMapVolumePerCluster(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 	}
-	resources := envoyResourceRequirements(search)
+	resources := envoyResourceRequirements(search, 0)
 
 	cases := []struct {
 		name           string
@@ -330,33 +322,35 @@ func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					Deployment: &v1.DeploymentConfiguration{
-						SpecWrapper: v1.DeploymentSpecWrapper{
-							Spec: appsv1.DeploymentSpec{
-								Template: corev1.PodTemplateSpec{
-									Spec: corev1.PodSpec{
-										Tolerations: []corev1.Toleration{
-											{Key: "dedicated", Value: "search", Effect: corev1.TaintEffectNoSchedule},
+			Clusters: []searchv1.ClusterSpec{{
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{
+						Deployment: &v1.DeploymentConfiguration{
+							SpecWrapper: v1.DeploymentSpecWrapper{
+								Spec: appsv1.DeploymentSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Tolerations: []corev1.Toleration{
+												{Key: "dedicated", Value: "search", Effect: corev1.TaintEffectNoSchedule},
+											},
+											NodeSelector: map[string]string{"node-type": "search"},
 										},
-										NodeSelector: map[string]string{"node-type": "search"},
 									},
 								},
 							},
-						},
-						MetadataWrapper: v1.DeploymentMetadataWrapper{
-							Labels:      map[string]string{"custom-label": "value"},
-							Annotations: map[string]string{"custom-annotation": "value"},
+							MetadataWrapper: v1.DeploymentMetadataWrapper{
+								Labels:      map[string]string{"custom-label": "value"},
+								Annotations: map[string]string{"custom-annotation": "value"},
+							},
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
 	// Build the base pod spec as the controller would
-	resources := envoyResourceRequirements(search)
+	resources := envoyResourceRequirements(search, 0)
 	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
 
 	// Verify base spec has no tolerations
@@ -375,7 +369,7 @@ func TestBuildEnvoyPodSpec_WithDeploymentConfigurationOverride(t *testing.T) {
 		},
 	}
 
-	depCfg := search.Spec.LoadBalancer.Managed.Deployment
+	depCfg := search.Spec.Clusters[0].LoadBalancer.Managed.Deployment
 	dep.Spec = merge.DeploymentSpecs(dep.Spec, depCfg.SpecWrapper.Spec)
 	dep.Labels = merge.StringToStringMap(dep.Labels, depCfg.MetadataWrapper.Labels)
 	dep.Annotations = merge.StringToStringMap(dep.Annotations, depCfg.MetadataWrapper.Annotations)
@@ -400,24 +394,26 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ResourceRequirements: &corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("200m"),
+			Clusters: []searchv1.ClusterSpec{{
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{
+						ResourceRequirements: &corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("200m"),
+							},
 						},
-					},
-					Deployment: &v1.DeploymentConfiguration{
-						SpecWrapper: v1.DeploymentSpecWrapper{
-							Spec: appsv1.DeploymentSpec{
-								Template: corev1.PodTemplateSpec{
-									Spec: corev1.PodSpec{
-										Containers: []corev1.Container{
-											{
-												Name: "envoy",
-												Resources: corev1.ResourceRequirements{
-													Requests: corev1.ResourceList{
-														corev1.ResourceCPU: resource.MustParse("500m"),
+						Deployment: &v1.DeploymentConfiguration{
+							SpecWrapper: v1.DeploymentSpecWrapper{
+								Spec: appsv1.DeploymentSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "envoy",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("500m"),
+														},
 													},
 												},
 											},
@@ -428,12 +424,12 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
 	// Build base with resourceRequirements (200m)
-	resources := envoyResourceRequirements(search)
+	resources := envoyResourceRequirements(search, 0)
 	assert.Equal(t, resource.MustParse("200m"), resources.Requests[corev1.ResourceCPU])
 
 	podSpec := buildEnvoyPodSpec(search, 0, nil, false, "envoy:latest", resources, false)
@@ -445,7 +441,7 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	}
 
 	// Apply deployment override
-	depCfg := search.Spec.LoadBalancer.Managed.Deployment
+	depCfg := search.Spec.Clusters[0].LoadBalancer.Managed.Deployment
 	dep.Spec = merge.DeploymentSpecs(dep.Spec, depCfg.SpecWrapper.Spec)
 
 	// deployment override wins (500m)
@@ -454,18 +450,23 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 
 // --- per-cluster route renderer tests -----------------------------------------
 
-func TestBuildRoutesForCluster_RS_TemplateSubstitutesClusterName(t *testing.T) {
+func TestBuildRoutesForCluster_RS_PerClusterHostname(t *testing.T) {
 	one := int32(1)
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "us-east-k8s", Replicas: &one},
-				{ClusterName: "eu-west-k8s", Replicas: &one},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "mongot-{clusterName}.example.com",
+				{
+					ClusterName: "us-east-k8s", Replicas: &one,
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-east.example.com"},
+					},
+				},
+				{
+					ClusterName: "eu-west-k8s", Replicas: &one,
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-eu-west.example.com"},
+					},
 				},
 			},
 		},
@@ -475,7 +476,7 @@ func TestBuildRoutesForCluster_RS_TemplateSubstitutesClusterName(t *testing.T) {
 	require.Len(t, routes, 1)
 	assert.Equal(t, "rs", routes[0].Name)
 	assert.Equal(t, "us-east-k8s", routes[0].ClusterID)
-	assert.Equal(t, "mongot-us-east-k8s.example.com", routes[0].SNIHostname)
+	assert.Equal(t, "mongot-us-east.example.com", routes[0].SNIHostname)
 }
 
 func TestBuildRoutesForCluster_RS_NoTemplateUsesPerClusterProxySvcFQDN(t *testing.T) {
@@ -537,13 +538,21 @@ func TestBuildRoutesForCluster_Sharded_PerClusterShardSNI(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "us-east-k8s", Replicas: &one},
-				{ClusterName: "eu-west-k8s", Replicas: &one},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					// Both placeholders present — must substitute both.
-					ExternalHostname: "mongot-{clusterName}-{shardName}.example.com",
+				{
+					ClusterName: "us-east-k8s", Replicas: &one,
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "mongot-us-east-{shardName}.example.com",
+						},
+					},
+				},
+				{
+					ClusterName: "eu-west-k8s", Replicas: &one,
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "mongot-eu-west-{shardName}.example.com",
+						},
+					},
 				},
 			},
 		},
@@ -557,12 +566,12 @@ func TestBuildRoutesForCluster_Sharded_PerClusterShardSNI(t *testing.T) {
 	require.Len(t, east, 3)
 	require.Len(t, west, 3)
 
-	// Per-(cluster, shard) SNI emitted with both substitutions.
+	// Per-(cluster, shard) SNI emitted with the per-cluster hostname and {shardName} substituted.
 	assert.Equal(t, "us-east-k8s", east[0].ClusterID)
-	assert.Equal(t, "mongot-us-east-k8s-mdb-sh-0.example.com", east[0].SNIHostname)
-	assert.Equal(t, "mongot-us-east-k8s-mdb-sh-1.example.com", east[1].SNIHostname)
-	assert.Equal(t, "mongot-eu-west-k8s-mdb-sh-0.example.com", west[0].SNIHostname)
-	assert.Equal(t, "mongot-eu-west-k8s-mdb-sh-1.example.com", west[1].SNIHostname)
+	assert.Equal(t, "mongot-us-east-mdb-sh-0.example.com", east[0].SNIHostname)
+	assert.Equal(t, "mongot-us-east-mdb-sh-1.example.com", east[1].SNIHostname)
+	assert.Equal(t, "mongot-eu-west-mdb-sh-0.example.com", west[0].SNIHostname)
+	assert.Equal(t, "mongot-eu-west-mdb-sh-1.example.com", west[1].SNIHostname)
 
 	// Last route in each cluster is the cluster-level route.
 	assert.Equal(t, "cluster-level", east[2].Name)
@@ -627,22 +636,31 @@ func TestBuildShardRoutes_MC_ClusterLevel_NoExternalHostname(t *testing.T) {
 	}
 }
 
-// TestBuildShardRoutes_MC_ClusterLevel_ManagedLB asserts that with a managed-LB
-// externalHostname of "{shardName}.{clusterName}.search.example.com:443", the
-// per-shard SNIs resolve per-shard and the cluster-level SNI strips the
-// "{shardName}." prefix to produce "{clusterName}.search.example.com:443".
+// TestBuildShardRoutes_MC_ClusterLevel_ManagedLB asserts that with a per-cluster
+// managed-LB externalHostname of "{shardName}.cluster-b.search.example.com:443",
+// the per-shard SNIs resolve per-shard and the cluster-level SNI strips the
+// "{shardName}." prefix to produce "cluster-b.search.example.com:443".
 func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 	shardNames := []string{"mdb-sh-0", "mdb-sh-1", "mdb-sh-2"}
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "cluster-a"},
-				{ClusterName: "cluster-b"},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "{shardName}.{clusterName}.search.example.com:443",
+				{
+					ClusterName: "cluster-a",
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "{shardName}.cluster-a.search.example.com:443",
+						},
+					},
+				},
+				{
+					ClusterName: "cluster-b",
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "{shardName}.cluster-b.search.example.com:443",
+						},
+					},
 				},
 			},
 		},
@@ -652,7 +670,7 @@ func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 
 	require.Len(t, routes, 4)
 
-	// Per-shard SNIs must resolve both {clusterName} and {shardName}.
+	// Per-shard SNIs must resolve {shardName} against cluster-b's own hostname.
 	for i, shardName := range shardNames {
 		expected := fmt.Sprintf("%s.cluster-b.search.example.com:443", shardName)
 		assert.Equal(t, expected, routes[i].SNIHostname, "per-shard SNI mismatch for shard %s", shardName)
@@ -874,7 +892,7 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 
 func TestEnvoyReplicas_DefaultsTo1(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-	assert.Equal(t, int32(1), envoyReplicas(search))
+	assert.Equal(t, int32(1), envoyReplicas(search, 0))
 }
 
 // envoyTestScheme returns a runtime.Scheme registered for the types ensureDeployment/
@@ -1069,10 +1087,12 @@ func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
-			},
-			Clusters: []searchv1.ClusterSpec{{ClusterName: "a"}},
+			Clusters: []searchv1.ClusterSpec{{
+				ClusterName: "a",
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
+				},
+			}},
 		},
 	}
 
@@ -1103,8 +1123,10 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
-			Clusters:     []searchv1.ClusterSpec{{ClusterName: "a"}},
+			Clusters: []searchv1.ClusterSpec{{
+				ClusterName:  "a",
+				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			}},
 		},
 	}
 	for _, tc := range []struct {
@@ -1124,7 +1146,7 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 			expectedDeplReplicas: 4,
 		},
 	} {
-		search.Spec.LoadBalancer.Managed.Replicas = tc.lbReplicas
+		search.Spec.Clusters[0].LoadBalancer.Managed.Replicas = tc.lbReplicas
 		// cluster "a" is at index 0.
 		require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, "a", 0, r.clientForCluster("a"), nil, zap.S()))
 
@@ -1164,14 +1186,19 @@ func TestReconcile_WorstOfPhase_Aggregated(t *testing.T) {
 					HostAndPorts: []string{"mongo-0:27017"},
 				},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "mongot-{clusterName}.example.com",
-				},
-			},
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "a", ClusterIndex: ptr.To(int32(0))},
-				{ClusterName: "missing", ClusterIndex: ptr.To(int32(1))},
+				{
+					ClusterName: "a", ClusterIndex: ptr.To(int32(0)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
+					},
+				},
+				{
+					ClusterName: "missing", ClusterIndex: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-missing.example.com"},
+					},
+				},
 			},
 		},
 	}
@@ -1218,12 +1245,12 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 					HostAndPorts: []string{"mongo-0:27017"},
 				},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "mongot-{clusterName}.example.com",
+			Clusters: []searchv1.ClusterSpec{{
+				ClusterName: "a",
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
 				},
-			},
-			Clusters: []searchv1.ClusterSpec{{ClusterName: "a"}},
+			}},
 		},
 	}
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
@@ -1266,14 +1293,19 @@ func TestReconcile_NoStateCM_ClustersPending(t *testing.T) {
 					HostAndPorts: []string{"mongo-0:27017"},
 				},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "mongot-{clusterName}.example.com",
-				},
-			},
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0))},
-				{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1))},
+				{
+					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"},
+					},
+				},
+				{
+					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"},
+					},
+				},
 			},
 		},
 	}
@@ -1314,14 +1346,19 @@ func TestReconcile_UsesIndicesFromStateMapping(t *testing.T) {
 					HostAndPorts: []string{"mongo-0:27017"},
 				},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "mongot-{clusterName}.example.com",
-				},
-			},
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(5))},
-				{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(7))},
+				{
+					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(5)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"},
+					},
+				},
+				{
+					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(7)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"},
+					},
+				},
 			},
 		},
 	}
@@ -1379,7 +1416,14 @@ func TestReconcile_StableIndexAcrossClusterRemovals(t *testing.T) {
 	mkSearch := func(clusterNames ...string) *searchv1.MongoDBSearch {
 		clusters := make([]searchv1.ClusterSpec, 0, len(clusterNames))
 		for i, n := range clusterNames {
-			cs := searchv1.ClusterSpec{ClusterName: n}
+			cs := searchv1.ClusterSpec{
+				ClusterName: n,
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{
+						ExternalHostname: fmt.Sprintf("mongot-%s.example.com", n),
+					},
+				},
+			}
 			// clusterIndex is required only for multi-cluster (len > 1) specs.
 			if len(clusterNames) > 1 {
 				cs.ClusterIndex = ptr.To(int32(i))
@@ -1392,11 +1436,6 @@ func TestReconcile_StableIndexAcrossClusterRemovals(t *testing.T) {
 				Source: &searchv1.MongoDBSource{
 					ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
 						HostAndPorts: []string{"mongo-0:27017"},
-					},
-				},
-				LoadBalancer: &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{
-						ExternalHostname: "mongot-{clusterName}.example.com",
 					},
 				},
 				Clusters: clusters,
@@ -1591,19 +1630,17 @@ func newMCEnvoySearch(name, namespace, uid string, clusters ...searchv1.ClusterS
 }
 
 func newSimulatedMCEnvoySearch(name, namespace string, clusterBIndex int32) *searchv1.MongoDBSearch {
+	clusterA := pinnedCluster("cluster-a", 0)
+	clusterA.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"}}
+	clusterB := pinnedCluster("cluster-b", clusterBIndex)
+	clusterB.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"}}
 	return &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source: &searchv1.MongoDBSource{
 				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
-			},
-			Clusters: []searchv1.ClusterSpec{
-				pinnedCluster("cluster-a", 0),
-				pinnedCluster("cluster-b", clusterBIndex),
-			},
+			Clusters: []searchv1.ClusterSpec{clusterA, clusterB},
 		},
 	}
 }
@@ -1987,9 +2024,11 @@ func TestEnvoyReconcile_ValidationFailure_NoLBConfigured_NoLBStatusWrite(t *test
 	scheme := envoyTestScheme(t)
 
 	// Removing the LB from the fully-pinned 2-cluster fixture makes ValidateSpec fail
-	// (multi-cluster requires spec.loadBalancer.managed) on a CR with no LB surface.
+	// (multi-cluster requires spec.clusters[].loadBalancer.managed) on a CR with no LB surface.
 	search := newSimulatedMCEnvoySearch("mdb-search", "ns", 1)
-	search.Spec.LoadBalancer = nil
+	for i := range search.Spec.Clusters {
+		search.Spec.Clusters[i].LoadBalancer = nil
+	}
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 
 	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-a")

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -1056,9 +1056,11 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			Source:       &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"}},
-			Clusters:     []searchv1.ClusterSpec{{ClusterName: "missing-cluster"}},
+			Source: &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
+			Clusters: []searchv1.ClusterSpec{{
+				ClusterName:  "missing-cluster",
+				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-missing-cluster.example.com"}},
+			}},
 		},
 	}
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
@@ -1350,13 +1352,13 @@ func TestReconcile_UsesIndicesFromStateMapping(t *testing.T) {
 				{
 					ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(5)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"},
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com", Replicas: ptr.To(int32(2))},
 					},
 				},
 				{
 					ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(7)),
 					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"},
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com", Replicas: ptr.To(int32(4))},
 					},
 				},
 			},
@@ -1377,18 +1379,24 @@ func TestReconcile_UsesIndicesFromStateMapping(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// cluster-a (index 5) — resources must use index 5.
+	// cluster-a (index 5) — resources must use index 5, config must be cluster-a's.
+	depA := &appsv1.Deployment{}
 	require.NoError(t, memberA.Get(ctx,
-		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(5), Namespace: "ns"}, &appsv1.Deployment{}),
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(5), Namespace: "ns"}, depA),
 		"Envoy Deployment for cluster-a must use index 5")
+	require.NotNil(t, depA.Spec.Replicas)
+	assert.Equal(t, int32(2), *depA.Spec.Replicas, "cluster-a's Deployment must carry cluster-a's LB replicas")
 	require.NoError(t, memberA.Get(ctx,
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(5), Namespace: "ns"}, &corev1.ConfigMap{}),
 		"Envoy ConfigMap for cluster-a must use index 5")
 
-	// cluster-b (index 7) — resources must use index 7.
+	// cluster-b (index 7) — resources must use index 7, config must be cluster-b's.
+	depB := &appsv1.Deployment{}
 	require.NoError(t, memberB.Get(ctx,
-		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(7), Namespace: "ns"}, &appsv1.Deployment{}),
+		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(7), Namespace: "ns"}, depB),
 		"Envoy Deployment for cluster-b must use index 7")
+	require.NotNil(t, depB.Spec.Replicas)
+	assert.Equal(t, int32(4), *depB.Spec.Replicas, "cluster-b's Deployment must carry cluster-b's LB replicas")
 	require.NoError(t, memberB.Get(ctx,
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(7), Namespace: "ns"}, &corev1.ConfigMap{}),
 		"Envoy ConfigMap for cluster-b must use index 7")
@@ -1582,8 +1590,10 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 					},
 				},
 			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com"}},
-			Clusters:     []searchv1.ClusterSpec{{ClusterName: "cluster-a"}},
+			Clusters: []searchv1.ClusterSpec{{
+				ClusterName:  "cluster-a",
+				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com"}},
+			}},
 		},
 	}
 
@@ -1615,14 +1625,20 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 
 // --- simulated-MC envoy tests carried over from search/ga-base (ported to clusterWorkItem + routingReadyMongotGroups signatures) ---
 func newMCEnvoySearch(name, namespace, uid string, clusters ...searchv1.ClusterSpec) *searchv1.MongoDBSearch {
+	// Give each cluster its own literal managed-LB hostname (the {clusterName}
+	// placeholder was removed; per-cluster hostnames must be distinct).
+	for i := range clusters {
+		if clusters[i].LoadBalancer == nil {
+			clusters[i].LoadBalancer = &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: fmt.Sprintf("mongot-%s.example.com", clusters[i].ClusterName)},
+			}
+		}
+	}
 	return &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(uid)},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source: &searchv1.MongoDBSource{
 				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"},
 			},
 			Clusters: clusters,
 		},
@@ -1667,19 +1683,21 @@ func TestBuildClusterWorkList_SimulatedMC_UsesProjectedIndex(t *testing.T) {
 
 func TestBuildReplicaSetRouteForCluster_ResolvedIndexNotArrayPos(t *testing.T) {
 	// Spec narrowed to one cluster (array position 0), but reconciled at pinned index 7.
-	clusters := []searchv1.ClusterSpec{{ClusterName: "eu-west-k8s"}}
+	// SNI is the cluster's literal LB hostname; the resolved index (7), not the array
+	// position (0), must drive the per-cluster mongot Service name in UpstreamHosts.
+	clusters := []searchv1.ClusterSpec{{
+		ClusterName:  "eu-west-k8s",
+		LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-eu-west-k8s.apps.example.com"}},
+	}}
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: clusters,
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterIndex}-{clusterName}.apps.example.com"},
-			},
 		},
 	}
 
 	route := buildReplicaSetRouteForCluster(search, 7, "eu-west-k8s")
-	assert.Equal(t, "mongot-7-eu-west-k8s.apps.example.com", route.SNIHostname)
+	assert.Equal(t, "mongot-eu-west-k8s.apps.example.com", route.SNIHostname)
 	assert.Equal(t, "mdb-search-search-7-svc.test-ns.svc.cluster.local", route.UpstreamHosts[0])
 }
 
@@ -1687,13 +1705,16 @@ func TestBuildRoutesForCluster_SimulatedMC_Sharded_PerShardSNIUsesProjectedIndex
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{
-					ExternalHostname: "{clusterIndex}-{shardName}.example.com",
-				},
-			},
 			Clusters: []searchv1.ClusterSpec{
-				{ClusterName: "kind-e2e-cluster-2", ClusterIndex: ptr.To(int32(1))},
+				{
+					ClusterName:  "kind-e2e-cluster-2",
+					ClusterIndex: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "c1-{shardName}.example.com",
+						},
+					},
+				},
 			},
 			Source: &searchv1.MongoDBSource{
 				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
@@ -1721,10 +1742,10 @@ func TestBuildRoutesForCluster_SimulatedMC_Sharded_PerShardSNIUsesProjectedIndex
 	require.Contains(t, byName, "sh-1")
 	require.Contains(t, byName, "cluster-level")
 
-	assert.Equal(t, "1-sh-0.example.com", byName["sh-0"].SNIHostname,
-		"per-shard SNI must resolve {clusterIndex}=1 via the pinned ClusterSpec.ClusterIndex")
-	assert.Equal(t, "1-sh-1.example.com", byName["sh-1"].SNIHostname,
-		"per-shard SNI must resolve {clusterIndex}=1 via the pinned ClusterSpec.ClusterIndex")
+	assert.Equal(t, "c1-sh-0.example.com", byName["sh-0"].SNIHostname,
+		"per-shard SNI must substitute {shardName} into the cluster's own LB hostname")
+	assert.Equal(t, "c1-sh-1.example.com", byName["sh-1"].SNIHostname,
+		"per-shard SNI must substitute {shardName} into the cluster's own LB hostname")
 	// Cluster-level route's SNI must be fully resolved (no literal placeholders).
 	clusterLevel := byName["cluster-level"]
 	assert.NotContains(t, clusterLevel.SNIHostname, "{")
@@ -2051,10 +2072,10 @@ func TestReconcileForCluster_SimulatedMC_ShardedSource_RendersToProvidedClient(t
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.{clusterName}.example.com"},
-			},
-			Clusters: []searchv1.ClusterSpec{{ClusterName: "kind-e2e-cluster-1"}},
+			Clusters: []searchv1.ClusterSpec{{
+				ClusterName:  "kind-e2e-cluster-1",
+				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.kind-e2e-cluster-1.example.com"}},
+			}},
 		},
 	}
 	source := &mockShardedSourceForEnvoy{shardNames: []string{"sh-0", "sh-1"}}
@@ -2074,4 +2095,87 @@ func TestReconcileForCluster_SimulatedMC_ShardedSource_RendersToProvidedClient(t
 	require.NoError(t, central.Get(context.Background(),
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm),
 		"Envoy ConfigMap must land on r.kubeClient for the projected cluster index")
+}
+
+func TestBuildRoutesForCluster_LBResolvedByName_NotSpecPosition(t *testing.T) {
+	managed := func(hostname string) *searchv1.LoadBalancerConfig {
+		return &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: hostname}}
+	}
+
+	t.Run("cluster removal: survivor keeps its persisted index", func(t *testing.T) {
+		// [cluster-a, cluster-b] -> [cluster-b]; cluster-b keeps persisted index 1.
+		search := &searchv1.MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+			Spec: searchv1.MongoDBSearchSpec{
+				Clusters: []searchv1.ClusterSpec{
+					{ClusterName: "cluster-b", LoadBalancer: managed("mongot-b.example.com")},
+				},
+			},
+		}
+		route := buildReplicaSetRouteForCluster(search, 1, "cluster-b")
+		assert.Equal(t, "mongot-b.example.com", route.SNIHostname)
+	})
+
+	t.Run("spec reorder: mapping is stable, positions are not", func(t *testing.T) {
+		// [cluster-a, cluster-b] -> [cluster-b, cluster-a]; mapping stays a=0, b=1.
+		search := &searchv1.MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+			Spec: searchv1.MongoDBSearchSpec{
+				Clusters: []searchv1.ClusterSpec{
+					{ClusterName: "cluster-b", LoadBalancer: managed("mongot-b.example.com")},
+					{ClusterName: "cluster-a", LoadBalancer: managed("mongot-a.example.com")},
+				},
+			},
+		}
+		routeA := buildReplicaSetRouteForCluster(search, 0, "cluster-a")
+		assert.Equal(t, "mongot-a.example.com", routeA.SNIHostname)
+		routeB := buildReplicaSetRouteForCluster(search, 1, "cluster-b")
+		assert.Equal(t, "mongot-b.example.com", routeB.SNIHostname)
+	})
+}
+
+// TestReconcile_LBConfigSurvivesClusterRemoval covers the same bug at reconcile
+// level for the rest of the LB config: after [cluster-a, cluster-b] ->
+// [cluster-b], the surviving cluster's Envoy Deployment must keep its
+// configured replica count even though its persisted index (1) no longer
+// matches its spec position (0).
+func TestReconcile_LBConfigSurvivesClusterRemoval(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
+			Clusters: []searchv1.ClusterSpec{
+				{
+					ClusterName: "cluster-b",
+					LoadBalancer: &searchv1.LoadBalancerConfig{
+						Managed: &searchv1.ManagedLBConfig{
+							ExternalHostname: "mongot-b.example.com",
+							Replicas:         ptr.To(int32(3)),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	// cluster-a was removed from the spec; its index is never reused.
+	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", map[string]int{"cluster-a": 0, "cluster-b": 1}, nil)
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"cluster-b": memberB}, "")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	dep := &appsv1.Deployment{}
+	require.NoError(t, memberB.Get(ctx, types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}, dep))
+	require.NotNil(t, dep.Spec.Replicas)
+	assert.Equal(t, int32(3), *dep.Spec.Replicas,
+		"cluster-b's Envoy must keep its configured replica count after cluster-a is removed")
 }

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -1018,11 +1018,11 @@ func (r *ShardedClusterReconcileHelper) logAllScalers(log *zap.SugaredLogger) {
 // 1. Per-shard mongod search parameters (when unmanaged or managed LB is configured)
 // 2. Mongos search parameters (always, when a MongoDBSearch resource exists)
 //
-// For sharded clusters with unmanaged LB (spec.loadBalancer.unmanaged):
-//   - spec.loadBalancer.unmanaged.endpoint contains a template with {shardName} placeholder
+// For sharded clusters with unmanaged LB (spec.clusters[].loadBalancer.unmanaged):
+//   - the unmanaged endpoint contains a template with {shardName} placeholder
 //   - Each shard resolves its endpoint by substituting {shardName} with the actual shard name
 //
-// For sharded clusters with managed LB (spec.loadBalancer.managed):
+// For sharded clusters with managed LB (spec.clusters[].loadBalancer.managed):
 //   - Each shard's mongod points to the operator-managed envoy proxy service
 //
 // For mongos (always configured when MongoDBSearch exists):

--- a/controllers/searchcontroller/enterprise_search_source_test.go
+++ b/controllers/searchcontroller/enterprise_search_source_test.go
@@ -323,13 +323,12 @@ func newShardedUnmanagedLBSearch(name, namespace, mdbName string, endpointTempla
 			Namespace: namespace,
 		},
 		Spec: searchv1.MongoDBSearchSpec{
-			Clusters: []searchv1.ClusterSpec{{Replicas: ptr.To(int32(1))}},
+			Clusters: []searchv1.ClusterSpec{{Replicas: ptr.To(int32(1)), LoadBalancer: lb}},
 			Source: &searchv1.MongoDBSource{
 				MongoDBResourceRef: &userv1.MongoDBResourceRef{
 					Name: mdbName,
 				},
 			},
-			LoadBalancer: lb,
 		},
 	}
 }

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1825,7 +1825,7 @@ func GetMongodConfigParameters(search *searchv1.MongoDBSearch, clusterDomain str
 // per-cluster mongotHost via spec.shardOverrides on the source MongoDB.
 func mongotEndpointForShard(search *searchv1.MongoDBSearch, shardName string, clusterDomain string) string {
 	if search.IsShardedUnmanagedLB() {
-		return search.GetEndpointForShard(shardName)
+		return search.GetEndpointForClusterShard(0, shardName)
 	}
 	if search.IsLBModeManaged() {
 		return proxyServiceHostAndPortForShard(search, 0, shardName, clusterDomain)
@@ -1903,7 +1903,7 @@ func buildSearchSetParameters(mongotEndpoint string, tlsMode automationconfig.TL
 // For no LB (single mongot), the first pod's headless FQDN is returned (pod-0.svc).
 func mongotHostAndPort(search *searchv1.MongoDBSearch, clusterDomain string) string {
 	if search.IsReplicaSetUnmanagedLB() {
-		return search.GetReplicaSetUnmanagedLBEndpoint()
+		return search.GetUnmanagedLBEndpointForCluster(0)
 	}
 	port := search.GetEffectiveMongotPort()
 	if search.IsLBModeManaged() {
@@ -1965,7 +1965,7 @@ func (r *MongoDBSearchReconcileHelper) ValidateSearchImageVersion(version string
 // external sources are fully covered at spec-validation time by
 // validateUnmanagedEndpointTemplate, and the no-load-balancer case is covered by
 // validateMultipleReplicasRequireLB. Without this check a mismatched endpoint is
-// silently ignored (see GetEndpointForShard / mongotHostAndPort) and all mongot
+// silently ignored (see GetEndpointForClusterShard / mongotHostAndPort) and all mongot
 // traffic pins to pod 0, defeating the load balancer the user configured.
 func (r *MongoDBSearchReconcileHelper) ValidateMultipleReplicasUnmanagedLBTopology() error {
 	if !r.mdbSearch.HasMultipleReplicas() || !r.mdbSearch.IsLBModeUnmanaged() {
@@ -1980,7 +1980,7 @@ func (r *MongoDBSearchReconcileHelper) ValidateMultipleReplicasUnmanagedLBTopolo
 	if _, ok := r.db.(SearchSourceShardedDeployment); ok {
 		if !r.mdbSearch.IsShardedUnmanagedLB() {
 			return xerrors.Errorf(
-				"spec.loadBalancer.unmanaged.endpoint must contain a %s placeholder for a sharded source with multiple mongot replicas; "+
+				"spec.clusters[].loadBalancer.unmanaged.endpoint must contain a %s placeholder for a sharded source with multiple mongot replicas; "+
 					"without it the endpoint cannot differentiate shards and traffic pins to a single mongot",
 				searchv1.ShardNamePlaceholder,
 			)
@@ -1990,7 +1990,7 @@ func (r *MongoDBSearchReconcileHelper) ValidateMultipleReplicasUnmanagedLBTopolo
 
 	if !r.mdbSearch.IsReplicaSetUnmanagedLB() {
 		return xerrors.Errorf(
-			"spec.loadBalancer.unmanaged.endpoint must not contain a %s placeholder for a replica set source with multiple mongot replicas",
+			"spec.clusters[].loadBalancer.unmanaged.endpoint must not contain a %s placeholder for a replica set source with multiple mongot replicas",
 			searchv1.ShardNamePlaceholder,
 		)
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1825,7 +1825,7 @@ func GetMongodConfigParameters(search *searchv1.MongoDBSearch, clusterDomain str
 // per-cluster mongotHost via spec.shardOverrides on the source MongoDB.
 func mongotEndpointForShard(search *searchv1.MongoDBSearch, shardName string, clusterDomain string) string {
 	if search.IsShardedUnmanagedLB() {
-		return search.GetEndpointForClusterShard(0, shardName)
+		return search.GetEndpointForShard(shardName)
 	}
 	if search.IsLBModeManaged() {
 		return proxyServiceHostAndPortForShard(search, 0, shardName, clusterDomain)
@@ -1845,9 +1845,11 @@ func GetMongodConfigParametersForShard(search *searchv1.MongoDBSearch, shardName
 // GetMongosConfigParametersForSharded picks the mongos→mongot endpoint by topology. No-LB targets the
 // first shard's per-shard proxy svc FQDN (the only sharded mongot hostname per-shard cert SANs cover);
 // the cluster-level Service would route to the same pod but isn't in SANs.
+// clusterIndex (from the persisted ClusterMapping) is for resource naming only;
+// clusterName resolves the cluster's LB config (empty = first cluster).
 func GetMongosConfigParametersForSharded(search *searchv1.MongoDBSearch, clusterIndex int, clusterName string, shardNames []string, clusterDomain string) map[string]any {
 	var endpoint string
-	// Three branches: explicit unmanaged LB, no spec.loadBalancer (pre-MVP
+	// Three branches: explicit unmanaged LB, no loadBalancer (pre-MVP
 	// single-cluster shape), and managed LB. The TD lists no-LB as RS-only at
 	// GA, so case B should die when admission tightens; kept for now to avoid
 	// regressing pre-MVP.
@@ -1868,7 +1870,7 @@ func GetMongosConfigParametersForSharded(search *searchv1.MongoDBSearch, cluster
 // the cluster-level proxy Service in-cluster FQDN.
 func mongotEndpointForClusterLevel(search *searchv1.MongoDBSearch, clusterIndex int, clusterName string, clusterDomain string) string {
 	if search.IsLBModeManaged() {
-		if endpoint := search.GetManagedLBEndpointForClusterLevel(clusterIndex, clusterName); endpoint != "" {
+		if endpoint := search.GetManagedLBEndpointForClusterLevel(clusterName); endpoint != "" {
 			return endpoint
 		}
 	}
@@ -1903,7 +1905,7 @@ func buildSearchSetParameters(mongotEndpoint string, tlsMode automationconfig.TL
 // For no LB (single mongot), the first pod's headless FQDN is returned (pod-0.svc).
 func mongotHostAndPort(search *searchv1.MongoDBSearch, clusterDomain string) string {
 	if search.IsReplicaSetUnmanagedLB() {
-		return search.GetUnmanagedLBEndpointForCluster(0)
+		return search.GetUnmanagedLBEndpoint()
 	}
 	port := search.GetEffectiveMongotPort()
 	if search.IsLBModeManaged() {
@@ -1965,7 +1967,7 @@ func (r *MongoDBSearchReconcileHelper) ValidateSearchImageVersion(version string
 // external sources are fully covered at spec-validation time by
 // validateUnmanagedEndpointTemplate, and the no-load-balancer case is covered by
 // validateMultipleReplicasRequireLB. Without this check a mismatched endpoint is
-// silently ignored (see GetEndpointForClusterShard / mongotHostAndPort) and all mongot
+// silently ignored (see GetEndpointForShard / mongotHostAndPort) and all mongot
 // traffic pins to pod 0, defeating the load balancer the user configured.
 func (r *MongoDBSearchReconcileHelper) ValidateMultipleReplicasUnmanagedLBTopology() error {
 	if !r.mdbSearch.HasMultipleReplicas() || !r.mdbSearch.IsLBModeUnmanaged() {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -1698,7 +1698,7 @@ func TestGetMongosConfigParametersForSharded_PersistedIndexNotSpecPosition(t *te
 		},
 	}
 
-	config := GetMongosConfigParametersForSharded(search, 1, []string{"test-mdb-0"}, "cluster.local")
+	config := GetMongosConfigParametersForSharded(search, 1, "cluster-b", []string{"test-mdb-0"}, "cluster.local")
 	setParameter, ok := config["setParameter"].(map[string]any)
 	require.True(t, ok, "setParameter should be a map")
 	assert.Equal(t, "b.example.com:443", setParameter["mongotHost"],
@@ -1842,7 +1842,7 @@ func TestEndpointTemplateSubstitution(t *testing.T) {
 			assert.True(t, search.IsShardedUnmanagedLB())
 			assert.False(t, search.IsReplicaSetUnmanagedLB())
 
-			endpoint := search.GetEndpointForClusterShard(0, tc.shardName)
+			endpoint := search.GetEndpointForShard(tc.shardName)
 			assert.Equal(t, tc.expectedEndpoint, endpoint)
 		})
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -252,9 +252,11 @@ func TestGetMongodConfigParameters_ManagedLB(t *testing.T) {
 			Namespace: "test",
 		},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{
-				Managed: &searchv1.ManagedLBConfig{},
-			},
+			Clusters: []searchv1.ClusterSpec{{
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{},
+				},
+			}},
 		},
 	}
 
@@ -330,7 +332,7 @@ func TestBuildProxyService_ManagedLB_NotReady(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 		},
 		// No status.loadBalancer → IsLoadBalancerReady() = false
 	}
@@ -346,7 +348,7 @@ func TestBuildProxyService_ManagedLB_Ready(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 		},
 		Status: searchv1.MongoDBSearchStatus{
 			LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning},
@@ -365,7 +367,7 @@ func TestBuildProxyServiceForShard_ManagedLB_NotReady(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 		},
 	}
 	unit := newTestShardUnit(search, "shard-0")
@@ -379,7 +381,7 @@ func TestBuildProxyServiceForShard_ManagedLB_Ready(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 		},
 		Status: searchv1.MongoDBSearchStatus{
 			LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning},
@@ -397,7 +399,7 @@ func TestBuildProxyService_ManagedLB_Ready_PerCluster(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 		},
 		Status: searchv1.MongoDBSearchStatus{
 			LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning},
@@ -420,7 +422,7 @@ func TestBuildProxyService_ManagedLB_Ready_SingleCluster(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 		},
 		Status: searchv1.MongoDBSearchStatus{
 			LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning},
@@ -1095,9 +1097,11 @@ func TestGetMongodConfigParametersForShard(t *testing.T) {
 							Name: "test-mdb",
 						},
 					},
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
-					},
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{
+							Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
+						},
+					}},
 				},
 			},
 			shardName:      "test-mdb-0",
@@ -1118,9 +1122,11 @@ func TestGetMongodConfigParametersForShard(t *testing.T) {
 							Name: "test-mdb",
 						},
 					},
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
-					},
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{
+							Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
+						},
+					}},
 				},
 			},
 			shardName:      "test-mdb-1",
@@ -1150,7 +1156,7 @@ func TestGetMongodConfigParametersForShard(t *testing.T) {
 
 func TestCreateShardMongotConfig(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
 		}
 	})
@@ -1190,7 +1196,7 @@ func TestCreateShardMongotConfig(t *testing.T) {
 
 func TestShardedMongotConfigWithTLS(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
 		}
 	})
@@ -1235,7 +1241,7 @@ func TestShardedMongotConfigWithTLS(t *testing.T) {
 
 func TestShardedMongotConfigWithoutTLS(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
 		}
 	})
@@ -1350,7 +1356,7 @@ func TestValidateManagedLBShardedTLS(t *testing.T) {
 		{
 			name: "non-sharded source, managed LB, no TLS - ok",
 			search: newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{},
 				}
 			}),
@@ -1364,7 +1370,7 @@ func TestValidateManagedLBShardedTLS(t *testing.T) {
 		{
 			name: "sharded source, managed LB, TLS configured - ok",
 			search: newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{},
 				}
 				s.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "prefix"}
@@ -1374,7 +1380,7 @@ func TestValidateManagedLBShardedTLS(t *testing.T) {
 		{
 			name: "sharded source, managed LB, no TLS - error",
 			search: newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{},
 				}
 			}),
@@ -1384,7 +1390,7 @@ func TestValidateManagedLBShardedTLS(t *testing.T) {
 		{
 			name: "sharded source, unmanaged LB, no TLS - ok",
 			search: newTestMongoDBSearch("test-search", "test", func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb.example.com:27028"},
 				}
 			}),
@@ -1424,7 +1430,7 @@ func TestValidateMultipleReplicasUnmanagedLBTopology(t *testing.T) {
 	}
 	withUnmanaged := func(endpoint string) func(*searchv1.MongoDBSearch) {
 		return func(s *searchv1.MongoDBSearch) {
-			s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+			s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 				Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: endpoint},
 			}
 		}
@@ -1466,7 +1472,7 @@ func TestValidateMultipleReplicasUnmanagedLBTopology(t *testing.T) {
 		{
 			name: "multiple replicas, managed LB - ok",
 			search: newTestMongoDBSearch("test-search", "test", multiReplica, func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
 			}),
 			source: &mockShardedSource{shardNames: []string{"shard-0"}},
 		},
@@ -1538,7 +1544,9 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 							Name: "test-mdb",
 						},
 					},
-					LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+					}},
 				},
 			},
 			shardNames:    []string{"test-mdb-0", "test-mdb-1"},
@@ -1558,9 +1566,11 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 							Name: "test-mdb",
 						},
 					},
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
-					},
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{
+							Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
+						},
+					}},
 				},
 			},
 			shardNames:    []string{"test-mdb-0", "test-mdb-1"},
@@ -1595,11 +1605,13 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 							Name: "test-mdb",
 						},
 					},
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Managed: &searchv1.ManagedLBConfig{
-							ExternalHostname: "{shardName}.search.example.com:443",
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{
+							Managed: &searchv1.ManagedLBConfig{
+								ExternalHostname: "{shardName}.search.example.com:443",
+							},
 						},
-					},
+					}},
 				},
 			},
 			shardNames:    []string{"test-mdb-0", "test-mdb-1"},
@@ -1608,7 +1620,7 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 			expectedHost: "search.example.com:443",
 		},
 		{
-			name: "MC managed LB - cluster-level form resolves {clusterName} for clusterIndex>0",
+			name: "MC managed LB - cluster-level form uses cluster's own externalHostname for clusterIndex>0",
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-search",
@@ -1620,14 +1632,17 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 							Name: "test-mdb",
 						},
 					},
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Managed: &searchv1.ManagedLBConfig{
-							ExternalHostname: "{shardName}.{clusterName}.search.example.com:443",
-						},
-					},
 					Clusters: []searchv1.ClusterSpec{
-						{ClusterName: "us-east-k8s"},
-						{ClusterName: "eu-west-k8s"},
+						{ClusterName: "us-east-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
+							Managed: &searchv1.ManagedLBConfig{
+								ExternalHostname: "{shardName}.us-east-k8s.search.example.com:443",
+							},
+						}},
+						{ClusterName: "eu-west-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
+							Managed: &searchv1.ManagedLBConfig{
+								ExternalHostname: "{shardName}.eu-west-k8s.search.example.com:443",
+							},
+						}},
 					},
 				},
 			},
@@ -1635,7 +1650,7 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 			clusterName:   "eu-west-k8s",
 			shardNames:    []string{"test-mdb-0", "test-mdb-1"},
 			clusterDomain: "cluster.local",
-			// Strip "{shardName}." then resolve {clusterName} from the supplied clusterName.
+			// Strip "{shardName}." from spec.clusters[1]'s own externalHostname.
 			expectedHost: "eu-west-k8s.search.example.com:443",
 		},
 	}
@@ -1681,7 +1696,7 @@ func TestMongotHostAndPort_ReplicaSet(t *testing.T) {
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 				Spec: searchv1.MongoDBSearchSpec{
-					LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+					Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 				},
 			},
 			expectedHost: "test-search-0-proxy-svc.ns.svc.cluster.local:27028",
@@ -1691,9 +1706,11 @@ func TestMongotHostAndPort_ReplicaSet(t *testing.T) {
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 				Spec: searchv1.MongoDBSearchSpec{
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "my-lb.example.com:27028"},
-					},
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{
+							Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "my-lb.example.com:27028"},
+						},
+					}},
 				},
 			},
 			expectedHost: "my-lb.example.com:27028",
@@ -1728,7 +1745,7 @@ func TestMongotEndpointForShard(t *testing.T) {
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 				Spec: searchv1.MongoDBSearchSpec{
-					LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}},
+					Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
 				},
 			},
 			shardName:    "shard-0",
@@ -1739,9 +1756,11 @@ func TestMongotEndpointForShard(t *testing.T) {
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
 				Spec: searchv1.MongoDBSearchSpec{
-					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
-					},
+					Clusters: []searchv1.ClusterSpec{{
+						LoadBalancer: &searchv1.LoadBalancerConfig{
+							Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
+						},
+					}},
 				},
 			},
 			shardName:    "shard-0",
@@ -1787,7 +1806,7 @@ func TestEndpointTemplateSubstitution(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			search := newTestMongoDBSearch("test-search", "default", func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: tc.endpointTemplate},
 				}
 			})
@@ -1796,7 +1815,7 @@ func TestEndpointTemplateSubstitution(t *testing.T) {
 			assert.True(t, search.IsShardedUnmanagedLB())
 			assert.False(t, search.IsReplicaSetUnmanagedLB())
 
-			endpoint := search.GetEndpointForShard(tc.shardName)
+			endpoint := search.GetEndpointForClusterShard(0, tc.shardName)
 			assert.Equal(t, tc.expectedEndpoint, endpoint)
 		})
 	}
@@ -1904,7 +1923,7 @@ func TestValidateEndpointTemplate(t *testing.T) {
 						},
 					},
 				}
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: tc.endpoint},
 				}
 			})
@@ -2623,7 +2642,7 @@ func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 func TestCleanupStaleShardResources(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
 		s.UID = "search-uid"
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
+		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
 	})
 
 	proxySvc := func(shard string, owned bool) *corev1.Service {
@@ -2854,9 +2873,16 @@ func TestReconcilePlan_UsesPerClusterClient(t *testing.T) {
 // cluster-level proxy Service per cluster.
 func TestBuildShardedPlan_PerClusterShardUnitsForMC(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns")
+	// MC requires managed LB; sharded + managed-LB requires TLS. ExternalHostname
+	// must start with {shardName}. so the operator can derive the cluster-level
+	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0))},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1))},
+		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+		}}},
+		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+		}}},
 	}
 
 	shardedSource := &mockShardedSource{
@@ -2912,9 +2938,16 @@ func TestBuildShardedPlan_PerClusterShardUnitsForMC(t *testing.T) {
 // cluster. Central client receives nothing.
 func TestReconcileShardedMC_FanOutUsesPerClusterClient(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns")
+	// MC requires managed LB; sharded + managed-LB requires TLS. ExternalHostname
+	// must start with {shardName}. so the operator can derive the cluster-level
+	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0))},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1))},
+		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+		}}},
+		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+		}}},
 	}
 
 	shardedSource := &mockShardedSource{
@@ -3026,9 +3059,16 @@ func TestReconcileShardedMC_FanOutUsesPerClusterClient(t *testing.T) {
 // none of them can become Ready under a fake client.
 func TestReconcileShardedMC_AllUnitsAppliedBeforeReadinessCheck(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns")
+	// MC requires managed LB; sharded + managed-LB requires TLS. ExternalHostname
+	// must start with {shardName}. so the operator can derive the cluster-level
+	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0))},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1))},
+		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+		}}},
+		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+		}}},
 	}
 	search.Spec.Source = &searchv1.MongoDBSource{
 		ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
@@ -3040,14 +3080,6 @@ func TestReconcileShardedMC_AllUnitsAppliedBeforeReadinessCheck(t *testing.T) {
 					{ShardName: "sh-2", Hosts: []string{"sh-2-a.example:27017"}},
 				},
 			},
-		},
-	}
-	// MC requires managed LB; sharded + managed-LB requires TLS. ExternalHostname
-	// must start with {shardName}. so the operator can derive the cluster-level
-	// form (M2 validator).
-	search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-		Managed: &searchv1.ManagedLBConfig{
-			ExternalHostname: "{shardName}.mdb-search-search-{clusterIndex}-proxy-svc.ns.svc.cluster.local",
 		},
 	}
 	search.Spec.Security = searchv1.Security{
@@ -3151,9 +3183,16 @@ type mcShardedFixture struct {
 func newMCShardedFixture(t *testing.T) *mcShardedFixture {
 	t.Helper()
 	search := newTestMongoDBSearch("mdb-search", "ns")
+	// MC requires managed LB; sharded + managed-LB requires TLS. ExternalHostname
+	// must start with {shardName}. so the operator can derive the cluster-level
+	// form, and must be distinct per cluster.
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0))},
-		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1))},
+		{ClusterName: "cluster-a", ClusterIndex: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+		}}},
+		{ClusterName: "cluster-b", ClusterIndex: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+		}}},
 	}
 	search.Spec.Source = &searchv1.MongoDBSource{
 		ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
@@ -3165,11 +3204,6 @@ func newMCShardedFixture(t *testing.T) *mcShardedFixture {
 					{ShardName: "sh-2", Hosts: []string{"sh-2-a.example:27017"}},
 				},
 			},
-		},
-	}
-	search.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
-		Managed: &searchv1.ManagedLBConfig{
-			ExternalHostname: "{shardName}.mdb-search-search-{clusterIndex}-proxy-svc.ns.svc.cluster.local",
 		},
 	}
 	search.Spec.Security = searchv1.Security{
@@ -3324,10 +3358,9 @@ func TestReconcileShardedMC_MissingMemberClusterClient(t *testing.T) {
 func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns", func(s *searchv1.MongoDBSearch) {
 		s.UID = "search-uid"
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
 		s.Spec.Clusters = []searchv1.ClusterSpec{
-			{ClusterName: "cluster-a"},
-			{ClusterName: "cluster-b"},
+			{ClusterName: "cluster-a", LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
+			{ClusterName: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
 		}
 	})
 
@@ -3518,7 +3551,7 @@ func TestReconcileSharded_RoutingSwitchOneWay(t *testing.T) {
 				},
 			},
 		}
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Managed: &searchv1.ManagedLBConfig{
 				ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 			},
@@ -3596,7 +3629,7 @@ func TestReconcileSharded_SwitchErrorsAggregatedAcrossUnits(t *testing.T) {
 				},
 			},
 		}
-		s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Managed: &searchv1.ManagedLBConfig{
 				ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 			},
@@ -3720,6 +3753,7 @@ func TestReconcileShardedMC_ShardOverrideReplicas(t *testing.T) {
 			ClusterName:  "cluster-a",
 			ClusterIndex: ptr.To(int32(0)),
 			Replicas:     ptr.To(int32(1)),
+			LoadBalancer: fx.search.Spec.Clusters[0].LoadBalancer,
 			ShardOverrides: []searchv1.ShardOverride{
 				// One entry, two shards: both must pick up the override.
 				{ShardNames: []string{"sh-0", "sh-1"}, Replicas: ptr.To(int32(2))},
@@ -3729,6 +3763,7 @@ func TestReconcileShardedMC_ShardOverrideReplicas(t *testing.T) {
 			ClusterName:  "cluster-b",
 			ClusterIndex: ptr.To(int32(1)),
 			Replicas:     ptr.To(int32(3)),
+			LoadBalancer: fx.search.Spec.Clusters[1].LoadBalancer,
 			ShardOverrides: []searchv1.ShardOverride{
 				// Explicit 0 takes this shard's mongot offline.
 				{ShardNames: []string{"sh-2"}, Replicas: ptr.To(int32(0))},

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -1678,6 +1678,33 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 	}
 }
 
+// TestGetMongosConfigParametersForSharded_PersistedIndexNotSpecPosition: the
+// clusterIndex callers pass comes from the persisted ClusterMapping, which
+// outlives spec positions (indices are never reused on remove/re-add). The
+// endpoint must still resolve to the named cluster's externalHostname.
+// Scenario: [cluster-a, cluster-b] -> [cluster-b]; cluster-b keeps index 1.
+func TestGetMongosConfigParametersForSharded_PersistedIndexNotSpecPosition(t *testing.T) {
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-search", Namespace: "test-ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "test-mdb"},
+			},
+			Clusters: []searchv1.ClusterSpec{
+				{ClusterName: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.b.example.com:443"},
+				}},
+			},
+		},
+	}
+
+	config := GetMongosConfigParametersForSharded(search, 1, []string{"test-mdb-0"}, "cluster.local")
+	setParameter, ok := config["setParameter"].(map[string]any)
+	require.True(t, ok, "setParameter should be a map")
+	assert.Equal(t, "b.example.com:443", setParameter["mongotHost"],
+		"mongos must get cluster-b's externalHostname even though its persisted index (1) is not its spec position (0)")
+}
+
 func TestMongotHostAndPort_ReplicaSet(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/controllers/searchcontroller/mongodbsearch_validation_test.go
+++ b/controllers/searchcontroller/mongodbsearch_validation_test.go
@@ -39,7 +39,7 @@ func TestValidateLBConfig(t *testing.T) {
 		{
 			name: "Valid: managed LB",
 			modify: func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{},
 				}
 			},
@@ -48,7 +48,7 @@ func TestValidateLBConfig(t *testing.T) {
 		{
 			name: "Valid: unmanaged LB with endpoint",
 			modify: func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb.example.com:27028"},
 				}
 			},
@@ -57,7 +57,7 @@ func TestValidateLBConfig(t *testing.T) {
 		{
 			name: "Invalid: both managed and unmanaged",
 			modify: func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed:   &searchv1.ManagedLBConfig{},
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb.example.com:27028"},
 				}
@@ -68,7 +68,7 @@ func TestValidateLBConfig(t *testing.T) {
 		{
 			name: "Invalid: neither managed nor unmanaged",
 			modify: func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{}
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{}
 			},
 			expectError:   true,
 			errorContains: "exactly one",
@@ -76,7 +76,7 @@ func TestValidateLBConfig(t *testing.T) {
 		{
 			name: "Invalid: unmanaged without endpoint",
 			modify: func(s *searchv1.MongoDBSearch) {
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{},
 				}
 			},
@@ -91,7 +91,7 @@ func TestValidateLBConfig(t *testing.T) {
 						HostAndPorts: []string{"host:27017"},
 					},
 				}
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{},
 				}
 			},
@@ -106,7 +106,7 @@ func TestValidateLBConfig(t *testing.T) {
 						HostAndPorts: []string{"host:27017"},
 					},
 				}
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "lb.example.com"},
 				}
 			},
@@ -116,7 +116,7 @@ func TestValidateLBConfig(t *testing.T) {
 			name: "Valid: unmanaged LB with shardName template and sharded source",
 			modify: func(s *searchv1.MongoDBSearch) {
 				s.Spec.Source = newExternalShardedSource()
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
 				}
 			},
@@ -126,7 +126,7 @@ func TestValidateLBConfig(t *testing.T) {
 			name: "Invalid: sharded unmanaged endpoint is only template placeholder",
 			modify: func(s *searchv1.MongoDBSearch) {
 				s.Spec.Source = newExternalShardedSource()
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "{shardName}"},
 				}
 			},
@@ -137,7 +137,7 @@ func TestValidateLBConfig(t *testing.T) {
 			name: "Invalid: sharded unmanaged endpoint without shardName template",
 			modify: func(s *searchv1.MongoDBSearch) {
 				s.Spec.Source = newExternalShardedSource()
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb.example.com:27028"},
 				}
 			},
@@ -152,7 +152,7 @@ func TestValidateLBConfig(t *testing.T) {
 						HostAndPorts: []string{"host:27017"},
 					},
 				}
-				s.Spec.LoadBalancer = &searchv1.LoadBalancerConfig{
+				s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 					Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "lb-{shardName}.example.com:27028"},
 				}
 			},

--- a/controllers/searchcontroller/sharded_internal_search_source.go
+++ b/controllers/searchcontroller/sharded_internal_search_source.go
@@ -117,5 +117,5 @@ func (r *ShardedInternalSearchSource) GetUnmanagedLBEndpointForShard(shardName s
 	if r.search == nil || !r.search.IsShardedUnmanagedLB() {
 		return ""
 	}
-	return r.search.GetEndpointForClusterShard(0, shardName)
+	return r.search.GetEndpointForShard(shardName)
 }

--- a/controllers/searchcontroller/sharded_internal_search_source.go
+++ b/controllers/searchcontroller/sharded_internal_search_source.go
@@ -117,5 +117,5 @@ func (r *ShardedInternalSearchSource) GetUnmanagedLBEndpointForShard(shardName s
 	if r.search == nil || !r.search.IsShardedUnmanagedLB() {
 		return ""
 	}
-	return r.search.GetEndpointForShard(shardName)
+	return r.search.GetEndpointForClusterShard(0, shardName)
 }

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -76,9 +76,9 @@ class MongoDBSearch(MongoDB, CustomObject):
             return None
 
     def is_lb_mode_managed(self) -> bool:
-        """Returns True if spec.loadBalancer.managed is set."""
+        """Returns True if any cluster entry has spec.clusters[].loadBalancer.managed set."""
         try:
-            return "managed" in self["spec"]["loadBalancer"]
+            return any("managed" in (c.get("loadBalancer") or {}) for c in self["spec"]["clusters"])
         except KeyError:
             return False
 

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
@@ -601,8 +601,8 @@ class SearchShardedDeploymentTests(SearchDeploymentTests):
         for i, cluster in enumerate(clusters):
             cluster["loadBalancer"] = {
                 "managed": {
-                    "externalHostname": (
-                        f"{mdbs_name}-search-{i}-{{shardName}}-proxy-svc.{self.namespace}.svc.cluster.local"
+                    "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
+                        mdbs_name, self.namespace, i
                     ),
                 },
             }

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
@@ -597,14 +597,16 @@ class SearchShardedDeploymentTests(SearchDeploymentTests):
             },
         }
         resource["spec"]["security"] = {"tls": {"certsSecretPrefix": self.search_config.tls_cert_prefix}}
-        resource["spec"]["loadBalancer"] = {
-            "managed": {
-                "externalHostname": (
-                    f"{mdbs_name}-search-{{clusterIndex}}-{{shardName}}-proxy-svc.{self.namespace}.svc.cluster.local"
-                ),
-            },
-        }
-        resource["spec"]["clusters"] = self.search_clusters()
+        clusters = self.search_clusters()
+        for i, cluster in enumerate(clusters):
+            cluster["loadBalancer"] = {
+                "managed": {
+                    "externalHostname": (
+                        f"{mdbs_name}-search-{i}-{{shardName}}-proxy-svc.{self.namespace}.svc.cluster.local"
+                    ),
+                },
+            }
+        resource["spec"]["clusters"] = clusters
         return resource
 
     def deploy_lb_certificates(self) -> None:

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
@@ -155,12 +155,14 @@ class SearchRsMcDeploymentTests(SearchDeploymentTests):
             },
         }
         resource["spec"]["security"] = {"tls": {"certsSecretPrefix": self.search_config.tls_cert_prefix}}
-        resource["spec"]["loadBalancer"] = {
-            "managed": {
-                "externalHostname": f"{mdbs_name}-search-{{clusterIndex}}-proxy-svc.{self.namespace}.svc.cluster.local",
-            },
-        }
-        resource["spec"]["clusters"] = self.search_clusters()
+        clusters = self.search_clusters()
+        for i, cluster in enumerate(clusters):
+            cluster["loadBalancer"] = {
+                "managed": {
+                    "externalHostname": f"{mdbs_name}-search-{i}-proxy-svc.{self.namespace}.svc.cluster.local",
+                },
+            }
+        resource["spec"]["clusters"] = clusters
         return resource
 
     def deploy_lb_certificates(self) -> None:

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
@@ -159,7 +159,7 @@ class SearchRsMcDeploymentTests(SearchDeploymentTests):
         for i, cluster in enumerate(clusters):
             cluster["loadBalancer"] = {
                 "managed": {
-                    "externalHostname": f"{mdbs_name}-search-{i}-proxy-svc.{self.namespace}.svc.cluster.local",
+                    "externalHostname": search_resource_names.mc_proxy_svc_fqdn(mdbs_name, self.namespace, i),
                 },
             }
         resource["spec"]["clusters"] = clusters

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins_mc.py
@@ -128,8 +128,8 @@ class SearchRsMcDeploymentTests(SearchDeploymentTests):
         ]
 
     def build_mdbs(self) -> MongoDBSearch:
-        # MC source: MongoDBMulti per-pod FQDNs; managed externalHostname uses the
-        # {clusterIndex} template so per-cluster cert SANs, AC mongotHost, and Envoy
+        # MC source: MongoDBMulti per-pod FQDNs; each cluster's managed externalHostname
+        # carries its own index so per-cluster cert SANs, AC mongotHost, and Envoy
         # SNI all resolve to the same per-cluster proxy-svc FQDN.
         mdbs_name = self.effective_mdbs_resource_name()
         resource = MongoDBSearch.from_yaml(

--- a/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
@@ -56,6 +56,23 @@ def _resolve_cluster_index(helper: Optional[MCSearchDeploymentHelper], mcc: Mult
 
 
 # ---------------------------------------------------------------------------
+# Internal naming mirrors — track ``pkg/handler/names_search.go``.
+# ---------------------------------------------------------------------------
+
+
+def _per_cluster_mongot_config_name(mdbs_name: str, cluster_index: int) -> str:
+    return f"{mdbs_name}-search-{cluster_index}-config"
+
+
+def _per_cluster_envoy_deployment_name(mdbs_name: str, cluster_index: int) -> str:
+    return f"{mdbs_name}-search-lb-0-{cluster_index}"
+
+
+def _per_cluster_envoy_configmap_name(mdbs_name: str, cluster_index: int) -> str:
+    return f"{mdbs_name}-search-lb-0-{cluster_index}-config"
+
+
+# ---------------------------------------------------------------------------
 # Cert + secret bring-up.
 # ---------------------------------------------------------------------------
 
@@ -382,6 +399,7 @@ def verify_per_cluster_envoy_sni(
                 f"in lds.json filter_chain_match.server_names, got {sni_names}"
             )
 
+            # Defensive: no OTHER cluster's proxy-svc FQDN should appear.
             for other in member_cluster_clients:
                 if other.cluster_name == mcc.cluster_name:
                     continue

--- a/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
@@ -56,23 +56,6 @@ def _resolve_cluster_index(helper: Optional[MCSearchDeploymentHelper], mcc: Mult
 
 
 # ---------------------------------------------------------------------------
-# Internal naming mirrors — track ``pkg/handler/names_search.go``.
-# ---------------------------------------------------------------------------
-
-
-def _per_cluster_mongot_config_name(mdbs_name: str, cluster_index: int) -> str:
-    return f"{mdbs_name}-search-{cluster_index}-config"
-
-
-def _per_cluster_envoy_deployment_name(mdbs_name: str, cluster_index: int) -> str:
-    return f"{mdbs_name}-search-lb-0-{cluster_index}"
-
-
-def _per_cluster_envoy_configmap_name(mdbs_name: str, cluster_index: int) -> str:
-    return f"{mdbs_name}-search-lb-0-{cluster_index}-config"
-
-
-# ---------------------------------------------------------------------------
 # Cert + secret bring-up.
 # ---------------------------------------------------------------------------
 

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
@@ -176,21 +176,6 @@ class SearchDeploymentHelper:
             },
         }
 
-        lb = None
-        if lb_mode or lb_endpoint:
-            lb = {}
-            if lb_mode == "Managed":
-                external_hostname = (
-                    f"{self.mdbs_resource_name}-search-0-{{shardName}}-proxy-svc" f".{self.namespace}.svc.cluster.local"
-                )
-                lb["managed"] = {"externalHostname": external_hostname}
-            if lb_endpoint:
-                if "unmanaged" not in lb:
-                    lb["unmanaged"] = {}
-                lb["unmanaged"]["endpoint"] = lb_endpoint
-            elif lb_mode == "Unmanaged":
-                lb["unmanaged"] = {}
-
         if replicas is not None:
             resource["spec"]["clusters"] = [{"replicas": replicas}]
 
@@ -199,9 +184,20 @@ class SearchDeploymentHelper:
             clusters[0]["shardOverrides"] = shard_overrides
             resource["spec"]["clusters"] = clusters
 
-        if lb is not None:
+        if lb_mode or lb_endpoint:
             clusters = resource["spec"].get("clusters") or [{}]
-            for cluster in clusters:
+            for i, cluster in enumerate(clusters):
+                lb = {}
+                if lb_mode == "Managed":
+                    lb["managed"] = {
+                        "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
+                            self.mdbs_resource_name, self.namespace, i
+                        )
+                    }
+                if lb_endpoint:
+                    lb["unmanaged"] = {"endpoint": lb_endpoint}
+                elif lb_mode == "Unmanaged":
+                    lb["unmanaged"] = {}
                 cluster["loadBalancer"] = lb
             resource["spec"]["clusters"] = clusters
 
@@ -427,25 +423,24 @@ class SearchDeploymentHelper:
             "tls": {"certsSecretPrefix": self.tls_cert_prefix},
         }
 
-        lb = None
-        if lb_mode:
-            if lb_mode == "Managed":
-                external_hostname = (
-                    f"{self.mdbs_resource_name}-search-0-proxy-svc" f".{self.namespace}.svc.cluster.local"
-                )
-                lb = {"managed": {"externalHostname": external_hostname}}
-            elif lb_mode == "Unmanaged":
-                lb = {"unmanaged": {}}
-
         if clusters is not None:
             resource["spec"]["clusters"] = clusters
         elif replicas is not None:
             resource["spec"]["clusters"] = [{"replicas": replicas}]
 
-        if lb is not None:
+        if lb_mode:
             clusters_spec = resource["spec"].get("clusters") or [{}]
-            for cluster in clusters_spec:
-                cluster["loadBalancer"] = lb
+            for i, cluster in enumerate(clusters_spec):
+                if lb_mode == "Managed":
+                    cluster["loadBalancer"] = {
+                        "managed": {
+                            "externalHostname": search_resource_names.mc_proxy_svc_fqdn(
+                                self.mdbs_resource_name, self.namespace, i
+                            )
+                        }
+                    }
+                elif lb_mode == "Unmanaged":
+                    cluster["loadBalancer"] = {"unmanaged": {}}
             resource["spec"]["clusters"] = clusters_spec
 
         return resource

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
@@ -176,6 +176,7 @@ class SearchDeploymentHelper:
             },
         }
 
+        lb = None
         if lb_mode or lb_endpoint:
             lb = {}
             if lb_mode == "Managed":
@@ -189,7 +190,6 @@ class SearchDeploymentHelper:
                 lb["unmanaged"]["endpoint"] = lb_endpoint
             elif lb_mode == "Unmanaged":
                 lb["unmanaged"] = {}
-            resource["spec"]["loadBalancer"] = lb
 
         if replicas is not None:
             resource["spec"]["clusters"] = [{"replicas": replicas}]
@@ -197,6 +197,12 @@ class SearchDeploymentHelper:
         if shard_overrides is not None:
             clusters = resource["spec"].get("clusters") or [{}]
             clusters[0]["shardOverrides"] = shard_overrides
+            resource["spec"]["clusters"] = clusters
+
+        if lb is not None:
+            clusters = resource["spec"].get("clusters") or [{}]
+            for cluster in clusters:
+                cluster["loadBalancer"] = lb
             resource["spec"]["clusters"] = clusters
 
         return resource
@@ -421,19 +427,26 @@ class SearchDeploymentHelper:
             "tls": {"certsSecretPrefix": self.tls_cert_prefix},
         }
 
+        lb = None
         if lb_mode:
             if lb_mode == "Managed":
                 external_hostname = (
                     f"{self.mdbs_resource_name}-search-0-proxy-svc" f".{self.namespace}.svc.cluster.local"
                 )
-                resource["spec"]["loadBalancer"] = {"managed": {"externalHostname": external_hostname}}
+                lb = {"managed": {"externalHostname": external_hostname}}
             elif lb_mode == "Unmanaged":
-                resource["spec"]["loadBalancer"] = {"unmanaged": {}}
+                lb = {"unmanaged": {}}
 
         if clusters is not None:
             resource["spec"]["clusters"] = clusters
         elif replicas is not None:
             resource["spec"]["clusters"] = [{"replicas": replicas}]
+
+        if lb is not None:
+            clusters_spec = resource["spec"].get("clusters") or [{}]
+            for cluster in clusters_spec:
+                cluster["loadBalancer"] = lb
+            resource["spec"]["clusters"] = clusters_spec
 
         return resource
 

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -173,6 +173,12 @@ def mc_proxy_svc_fqdn(search_name: str, namespace: str, cluster_index: int) -> s
     return f"{mc_proxy_svc_name(search_name, cluster_index)}.{namespace}.svc.cluster.local"
 
 
+def shard_proxy_svc_hostname_template(search_name: str, namespace: str, cluster_index: int = 0) -> str:
+    """externalHostname for a sharded managed LB: the per-shard proxy-svc FQDN
+    with the {shardName} placeholder kept for the operator to resolve."""
+    return f"{search_name}-search-{cluster_index}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local"
+
+
 # ============================================================================
 # Managed load balancer resources
 # ============================================================================

--- a/docker/mongodb-kubernetes-tests/tests/common/search/sharded_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/sharded_search_helper.py
@@ -674,10 +674,10 @@ def patch_envoy_deployment_configuration(
 ):
     """Patch the MongoDBSearch CR with a deployment override and wait for Running.
 
-    Preserves any existing fields under spec.loadBalancer.managed.
+    Preserves any existing fields under spec.clusters[0].loadBalancer.managed.
     """
     mdbs.load()
-    mdbs["spec"]["loadBalancer"].setdefault("managed", {})["deployment"] = deployment_config
+    mdbs["spec"]["clusters"][0]["loadBalancer"].setdefault("managed", {})["deployment"] = deployment_config
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=timeout)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/fixtures/search-q2-mc-rs-search.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/fixtures/search-q2-mc-rs-search.yaml
@@ -5,8 +5,7 @@ metadata:
   name: mdb-mc-rs-ext-lb-search
 spec:
   logLevel: DEBUG
-  # clusters is always populated by the test harness before apply (one entry per member cluster)
+  # clusters is always populated by the test harness before apply
+  # (one entry per member cluster, each with its own loadBalancer)
   clusters:
     - {}
-  loadBalancer:
-    managed: {}

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -182,8 +182,8 @@ def mdbs(
     """MongoDBSearch over external MongoDBMulti source, MC topology.
 
     spec.source.external.hostAndPorts is the same top-level seed list rendered to
-    every cluster's mongot ConfigMap. spec.loadBalancer.managed.externalHostname
-    uses {clusterIndex} so all three per-cluster names (cert SANs, AC mongotHost,
+    every cluster's mongot ConfigMap. Each cluster's loadBalancer.managed.externalHostname
+    carries its own index so all three per-cluster names (cert SANs, AC mongotHost,
     Envoy SNI) resolve to the same per-cluster proxy-svc FQDN.
     """
     resource = MongoDBSearch.from_yaml(
@@ -210,16 +210,17 @@ def mdbs(
         "tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX},
     }
 
-    resource["spec"]["loadBalancer"] = {
-        "managed": {
-            "externalHostname": (
-                f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-proxy-svc.{namespace}.svc.cluster.local"
-            ),
-        },
-    }
-
     resource["spec"]["clusters"] = [
-        {"clusterName": mcc.cluster_name, "clusterIndex": mcc.cluster_index, "replicas": MONGOT_REPLICAS_PER_CLUSTER}
+        {
+            "clusterName": mcc.cluster_name,
+            "clusterIndex": mcc.cluster_index,
+            "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+            "loadBalancer": {
+                "managed": {
+                    "externalHostname": f"{MDBS_RESOURCE_NAME}-search-{mcc.cluster_index}-proxy-svc.{namespace}.svc.cluster.local",
+                },
+            },
+        }
         for mcc in member_cluster_clients
     ]
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -795,7 +795,7 @@ def test_per_cluster_envoy_sni_observed(
             if other.cluster_name == mcc.cluster_name:
                 continue
             other_idx = helper.cluster_index(other.cluster_name)
-            other_fqdn = _expected_proxy_svc_fqdn(MDBS_RESOURCE_NAME, other_idx, namespace)
+            other_fqdn = search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, other_idx)
             assert other_fqdn not in sni_names, (
                 f"[{mcc.cluster_name}] foreign SNI {other_fqdn!r} present in "
                 f"lds.json server_names — per-cluster Envoy must only match its own FQDN"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -217,7 +217,9 @@ def mdbs(
             "replicas": MONGOT_REPLICAS_PER_CLUSTER,
             "loadBalancer": {
                 "managed": {
-                    "externalHostname": f"{MDBS_RESOURCE_NAME}-search-{mcc.cluster_index}-proxy-svc.{namespace}.svc.cluster.local",
+                    "externalHostname": search_resource_names.mc_proxy_svc_fqdn(
+                        MDBS_RESOURCE_NAME, namespace, mcc.cluster_index
+                    ),
                 },
             },
         }
@@ -474,11 +476,6 @@ def _per_cluster_envoy_deployment_name(mdbs_name: str, cluster_index: int) -> st
 def _per_cluster_envoy_configmap_name(mdbs_name: str, cluster_index: int) -> str:
     """Mirror LoadBalancerConfigMapNameForCluster: `{name}-search-lb-0-{clusterIndex}-config`."""
     return f"{mdbs_name}-search-lb-0-{cluster_index}-config"
-
-
-def _expected_proxy_svc_fqdn(mdbs_name: str, cluster_index: int, namespace: str) -> str:
-    """Per-cluster proxy-svc FQDN (no port) — matches GetManagedLBEndpointForCluster output."""
-    return f"{mdbs_name}-search-{cluster_index}-proxy-svc.{namespace}.svc.cluster.local"
 
 
 def _read_mongod_set_parameter(
@@ -772,7 +769,7 @@ def test_per_cluster_envoy_sni_observed(
     for mcc in member_cluster_clients:
         cluster_idx = helper.cluster_index(mcc.cluster_name)
         cm_name = _per_cluster_envoy_configmap_name(MDBS_RESOURCE_NAME, cluster_idx)
-        expected_fqdn = _expected_proxy_svc_fqdn(MDBS_RESOURCE_NAME, cluster_idx, namespace)
+        expected_fqdn = search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, cluster_idx)
 
         cm = mcc.core_v1_api().read_namespaced_config_map(name=cm_name, namespace=namespace)
         lds_json = (cm.data or {}).get("lds.json")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -218,16 +218,19 @@ def mdbs(
         "tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX},
     }
 
-    resource["spec"]["loadBalancer"] = {
-        "managed": {
-            "externalHostname": (
-                f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local"
-            ),
-        },
-    }
-
     resource["spec"]["clusters"] = [
-        {"clusterName": mcc.cluster_name, "clusterIndex": mcc.cluster_index, "replicas": MONGOT_REPLICAS_PER_CLUSTER}
+        {
+            "clusterName": mcc.cluster_name,
+            "clusterIndex": mcc.cluster_index,
+            "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+            "loadBalancer": {
+                "managed": {
+                    "externalHostname": (
+                        f"{MDBS_RESOURCE_NAME}-search-{mcc.cluster_index}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local"
+                    ),
+                },
+            },
+        }
         for mcc in member_cluster_clients
     ]
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -225,8 +225,8 @@ def mdbs(
             "replicas": MONGOT_REPLICAS_PER_CLUSTER,
             "loadBalancer": {
                 "managed": {
-                    "externalHostname": (
-                        f"{MDBS_RESOURCE_NAME}-search-{mcc.cluster_index}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local"
+                    "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
+                        MDBS_RESOURCE_NAME, namespace, mcc.cluster_index
                     ),
                 },
             },

--- a/docker/mongodb-kubernetes-tests/tests/search/fixtures/search-rs-managed-lb.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/search/fixtures/search-rs-managed-lb.yaml
@@ -10,13 +10,13 @@ spec:
   security:
     tls:
       certsSecretPrefix: certs
-  loadBalancer:
-    managed: {}
   clusters:
     - # Cap mongot at 1 CPU so a multi-replica search deployment + RS + envoy
       # fit on a single-host kind cluster without CPU starvation. Operator
       # default is 2 CPU / 4Gi memory.
       replicas: 2
+      loadBalancer:
+        managed: {}
       resourceRequirements:
         requests:
           cpu: "500m"

--- a/docker/mongodb-kubernetes-tests/tests/search/fixtures/search-sharded-external-lb.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/search/fixtures/search-sharded-external-lb.yaml
@@ -13,10 +13,10 @@ spec:
       # Secret naming pattern: {prefix}-{shardName}-search-cert
       # e.g., certs-mdb-sh-0-search-cert, certs-mdb-sh-1-search-cert
       certsSecretPrefix: certs
-  loadBalancer:
-    unmanaged:
-      # Endpoint template with {shardName} placeholder, prefixed with the MongoDBSearch name
-      # NAMESPACE placeholder is replaced with actual namespace by the test fixture
-      endpoint: "mdb-sh-search-search-0-{shardName}-proxy-svc.NAMESPACE.svc.cluster.local:27029"
   clusters:
     - replicas: 2
+      loadBalancer:
+        unmanaged:
+          # Endpoint template with {shardName} placeholder, prefixed with the MongoDBSearch name
+          # NAMESPACE placeholder is replaced with actual namespace by the test fixture
+          endpoint: "mdb-sh-search-search-0-{shardName}-proxy-svc.NAMESPACE.svc.cluster.local:27029"

--- a/docker/mongodb-kubernetes-tests/tests/search/fixtures/search-sharded-managed-lb.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/search/fixtures/search-sharded-managed-lb.yaml
@@ -13,13 +13,13 @@ spec:
       # Secret naming pattern: {prefix}-{shardName}-search-cert
       # e.g., certs-mdb-sh-0-search-cert, certs-mdb-sh-1-search-cert
       certsSecretPrefix: certs
-  loadBalancer:
-    managed: {}
   clusters:
     - # Cap each per-shard mongot at 1 CPU so a sharded search deployment
       # (multiple shards × multiple mongots + envoy) fits on a single-host
       # kind cluster without CPU starvation. Operator default is 2 CPU / 4Gi.
       replicas: 2
+      loadBalancer:
+        managed: {}
       resourceRequirements:
         requests:
           cpu: "500m"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_auto_embedding_multi_mongot.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_auto_embedding_multi_mongot.py
@@ -114,12 +114,16 @@ def mdbs(namespace: str, mdbc: MongoDBCommunity) -> MongoDBSearch:
         return resource
 
     resource["spec"]["source"] = {"passwordSecretRef": {"name": MONGOT_USER_PASSWORD_SECRET_NAME}}
-    resource["spec"]["clusters"] = [{"replicas": 2}]
-    resource["spec"]["loadBalancer"] = {
-        "unmanaged": {
-            "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+    resource["spec"]["clusters"] = [
+        {
+            "replicas": 2,
+            "loadBalancer": {
+                "unmanaged": {
+                    "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+                }
+            },
         }
-    }
+    ]
     resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
     resource["spec"]["autoEmbedding"] = {
         "embeddingModelAPIKeySecret": {"name": VOYAGE_API_KEY_SECRET_NAME},

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_multi_mongot_unmanaged_lb.py
@@ -111,12 +111,16 @@ def mdb(namespace: str, ca_configmap: str, issuer_ca_configmap: str, helper: Sea
 @fixture(scope="function")
 def mdbs(namespace: str, mdb: MongoDB, helper: SearchDeploymentHelper) -> MongoDBSearch:
     resource = helper.mdbs_for_ext_rs_source(mongot_user_name=MONGOT_USER_NAME, members=RS_MEMBERS)
-    resource["spec"]["clusters"] = [{"replicas": 2}]
-    resource["spec"]["loadBalancer"] = {
-        "unmanaged": {
-            "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+    resource["spec"]["clusters"] = [
+        {
+            "replicas": 2,
+            "loadBalancer": {
+                "unmanaged": {
+                    "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+                }
+            },
         }
-    }
+    ]
     resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
     return resource
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
@@ -387,9 +387,7 @@ def test_scale_up_to_managed_lb(mdbs: MongoDBSearch, namespace: str):
     """Scale to 2 replicas and enable managed LB. mongotHost does NOT change."""
     mdbs.load()
     external_hostname = f"{proxy_service_name(MDBS_RESOURCE_NAME)}.{namespace}.svc.cluster.local"
-    mdbs["spec"]["clusters"] = [
-        {"replicas": 2, "loadBalancer": {"managed": {"externalHostname": external_hostname}}}
-    ]
+    mdbs["spec"]["clusters"] = [{"replicas": 2, "loadBalancer": {"managed": {"externalHostname": external_hostname}}}]
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=600)
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
@@ -386,9 +386,10 @@ def test_search_query_phase1(mdb: MongoDB):
 def test_scale_up_to_managed_lb(mdbs: MongoDBSearch, namespace: str):
     """Scale to 2 replicas and enable managed LB. mongotHost does NOT change."""
     mdbs.load()
-    mdbs["spec"]["clusters"] = [{"replicas": 2}]
     external_hostname = f"{proxy_service_name(MDBS_RESOURCE_NAME)}.{namespace}.svc.cluster.local"
-    mdbs["spec"]["loadBalancer"] = {"managed": {"externalHostname": external_hostname}}
+    mdbs["spec"]["clusters"] = [
+        {"replicas": 2, "loadBalancer": {"managed": {"externalHostname": external_hostname}}}
+    ]
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=600)
 
@@ -434,10 +435,8 @@ def test_search_query_phase2(mdb: MongoDB):
 def test_scale_down_remove_lb(mdbs: MongoDBSearch):
     """Scale back to 1 replica and remove LB. mongotHost still does NOT change."""
     mdbs.load()
+    # Replacing clusters[] without loadBalancer removes the LB entirely
     mdbs["spec"]["clusters"] = [{"replicas": 1}]
-    # Remove the loadBalancer section entirely
-    if "loadBalancer" in mdbs["spec"]:
-        mdbs["spec"]["loadBalancer"] = None
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=600)
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb.py
@@ -121,12 +121,16 @@ def mdbs(namespace: str, mdb: MongoDB) -> MongoDBSearch:
         return resource
 
     resource["spec"]["source"] = {"passwordSecretRef": {"name": f"{resource.name}-{MONGOT_USER_NAME}-password"}}
-    resource["spec"]["clusters"] = [{"replicas": 2}]
-    resource["spec"]["loadBalancer"] = {
-        "unmanaged": {
-            "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+    resource["spec"]["clusters"] = [
+        {
+            "replicas": 2,
+            "loadBalancer": {
+                "unmanaged": {
+                    "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+                }
+            },
         }
-    }
+    ]
     resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
     return resource
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_multi_mongot_unmanaged_lb.py
@@ -110,15 +110,9 @@ def mdbs(namespace: str) -> MongoDBSearch:
     if try_load(resource):
         return resource
 
-    spec = resource["spec"]
-    if (
-        "loadBalancer" in spec
-        and "unmanaged" in spec["loadBalancer"]
-        and "endpoint" in spec["loadBalancer"]["unmanaged"]
-    ):
-        spec["loadBalancer"]["unmanaged"]["endpoint"] = spec["loadBalancer"]["unmanaged"]["endpoint"].replace(
-            "NAMESPACE", namespace
-        )
+    lb = resource["spec"]["clusters"][0].get("loadBalancer") or {}
+    if "unmanaged" in lb and "endpoint" in lb["unmanaged"]:
+        lb["unmanaged"]["endpoint"] = lb["unmanaged"]["endpoint"].replace("NAMESPACE", namespace)
 
     return resource
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
@@ -129,7 +129,7 @@ def create_ocp_routes_for_shards(namespace: str) -> dict[str, str]:
 
 
 def derive_lb_endpoint_template(route_hostnames: dict[str, str]) -> str:
-    """Derive the spec.loadBalancer.managed.externalHostname template from route hostnames.
+    """Derive the spec.clusters[].loadBalancer.managed.externalHostname template from route hostnames.
 
     Takes one hostname like 'mongot-mdb-sh-0-ns.apps.domain' and replaces the
     shard name with {shardName} placeholder: 'mongot-{shardName}-ns.apps.domain'.
@@ -218,7 +218,9 @@ def mdbs(namespace: str, mdb: MongoDB, helper: SearchDeploymentHelper) -> MongoD
     # The helper sets it to the in-cluster proxy-svc FQDN, but on OCP
     # mongod connects via Route hostnames instead.
     if _route_hostnames:
-        resource["spec"]["loadBalancer"]["managed"]["externalHostname"] = derive_lb_endpoint_template(_route_hostnames)
+        resource["spec"]["clusters"][0]["loadBalancer"]["managed"]["externalHostname"] = derive_lb_endpoint_template(
+            _route_hostnames
+        )
     # Shared OpenShift cluster: only 2 schedulable workers (other nodes are tainted master/infra), and this
     # test runs 4 mongot pods. CPU requests must stay low enough that 4 pods fit alongside other concurrent
     # tasks, otherwise pods go Pending with FailedScheduling. Memory drives mongot's JVM heap: -Xmx is set
@@ -248,7 +250,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running.
     apply_crds_first=True is needed on shared OCP clusters where a stale CRD
-    (missing new fields like spec.loadBalancer) may already exist."""
+    (missing new fields like spec.clusters[].loadBalancer) may already exist."""
     operator = get_default_operator(
         namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
     )

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -213,8 +213,7 @@ class TestScaleWithManagedLB:
 
     def test_enable_multi_mongot_and_managed_lb(self, mdbs: MongoDBSearch):
         mdbs.load()
-        mdbs["spec"]["clusters"] = [{"replicas": 2}]
-        mdbs["spec"]["loadBalancer"] = {"managed": {}}
+        mdbs["spec"]["clusters"] = [{"replicas": 2, "loadBalancer": {"managed": {}}}]
         mdbs.update()
 
     def test_search_running_after_scale(self, mdbs: MongoDBSearch):

--- a/docs/search/07-search-external-sharded-mongod-managed-lb/README.md
+++ b/docs/search/07-search-external-sharded-mongod-managed-lb/README.md
@@ -6,7 +6,7 @@ This guide walks you through deploying **MongoDB Search** against your **existin
 
 ### What is "Managed Envoy"?
 
-When you set `spec.loadBalancer.managed: {}` in your MongoDBSearch resource, the operator automatically:
+When you set `spec.clusters[].loadBalancer.managed: {}` in your MongoDBSearch resource, the operator automatically:
 
 1. **Deploys an Envoy proxy** - A Deployment that handles L7 (application layer) load balancing
 2. **Generates routing configuration** - SNI-based routing rules for each shard
@@ -211,7 +211,7 @@ Both must be signed by the same CA that mongod and mongot trust.
 
 #### Step 10: Create MongoDBSearch Resource
 
-Applies the MongoDBSearch CR with `loadBalancer.managed: {}` and external cluster source configuration:
+Applies the MongoDBSearch CR with `clusters[].loadBalancer.managed: {}` and external cluster source configuration:
 
 ```yaml
 apiVersion: mongodb.com/v1
@@ -221,6 +221,9 @@ metadata:
 spec:
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      loadBalancer:
+        managed:
+          externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local
   source:
     username: search-sync-source
     passwordSecretRef:
@@ -244,11 +247,9 @@ spec:
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  loadBalancer:
-    managed: {}
 ```
 
-There is no `spec.loadBalancer.unmanaged.endpoint` — the operator creates and exposes the endpoints automatically.
+There is no `spec.clusters[].loadBalancer.unmanaged.endpoint` — the operator creates and exposes the endpoints automatically.
 
 ```bash
 ./code_snippets/07_0320_create_mongodb_search_resource.sh

--- a/docs/search/07-search-external-sharded-mongod-managed-lb/code_snippets/07_0320_create_mongodb_search_resource.sh
+++ b/docs/search/07-search-external-sharded-mongod-managed-lb/code_snippets/07_0320_create_mongodb_search_resource.sh
@@ -33,13 +33,13 @@ spec:
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  # loadBalancer.managed -- operator auto-deploys
-  # and configures Envoy proxy
-  loadBalancer:
-    managed:
-      externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      # loadBalancer.managed -- operator auto-deploys
+      # and configures Envoy proxy
+      loadBalancer:
+        managed:
+          externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local
       resourceRequirements:
         limits:
           cpu: "2"

--- a/docs/search/07-search-external-sharded-mongod-managed-lb/test.sh
+++ b/docs/search/07-search-external-sharded-mongod-managed-lb/test.sh
@@ -72,7 +72,7 @@ run 07_0316a_create_mongot_tls_certificates.sh
 # Create TLS certificates for managed load balancer (Envoy)
 run 07_0316b_create_lb_tls_certificates.sh
 
-# Create MongoDBSearch with loadBalancer.managed
+# Create MongoDBSearch with clusters[].loadBalancer.managed
 # NOTE: No Envoy deployment script - the operator handles this automatically!
 run 07_0320_create_mongodb_search_resource.sh
 run_for_output 07_0325_wait_for_search_resource.sh

--- a/docs/search/09-search-sharded-mongod-managed-lb/README.md
+++ b/docs/search/09-search-sharded-mongod-managed-lb/README.md
@@ -8,7 +8,7 @@ Unlike [scenario 07](../07-search-external-sharded-mongod-managed-lb/) (external
 
 ### What is "Managed Envoy"?
 
-When you set `spec.loadBalancer.managed: {}` in your MongoDBSearch resource, the operator automatically:
+When you set `spec.clusters[].loadBalancer.managed: {}` in your MongoDBSearch resource, the operator automatically:
 
 1. **Deploys an Envoy proxy** - A Deployment that handles L7 (application layer) load balancing
 2. **Generates routing configuration** - SNI-based routing rules for each shard
@@ -83,7 +83,7 @@ In a sharded cluster, each shard has its own data. MongoDB Search deploys separa
 | Task | Your Responsibility |
 |------|---------------------|
 | MongoDB sharded cluster CR | ✅ Create the MongoDB CR (operator manages it) |
-| MongoDBSearch CR | ✅ Create with `loadBalancer.managed: {}` and `mongodbResourceRef` |
+| MongoDBSearch CR | ✅ Create with `clusters[].loadBalancer.managed: {}` and `mongodbResourceRef` |
 | TLS certificates | ✅ Create certs for mongot and LB |
 | Configure mongod search params | ❌ Operator handles this automatically |
 | Envoy deployment | ❌ Operator handles this |
@@ -285,7 +285,7 @@ Both must be signed by the same CA that mongod and mongot trust.
 
 #### Step 17: Create MongoDBSearch Resource
 
-Applies the MongoDBSearch CR with `loadBalancer.managed: {}` and `mongodbResourceRef` pointing to the MongoDB CR. Unlike the external scenario, no `source.username`, `source.passwordSecretRef`, or `source.external` block is needed — the operator infers everything from the referenced MongoDB CR:
+Applies the MongoDBSearch CR with `clusters[].loadBalancer.managed: {}` and `mongodbResourceRef` pointing to the MongoDB CR. Unlike the external scenario, no `source.username`, `source.passwordSecretRef`, or `source.external` block is needed — the operator infers everything from the referenced MongoDB CR:
 
 ```yaml
 apiVersion: mongodb.com/v1
@@ -295,14 +295,14 @@ metadata:
 spec:
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      loadBalancer:
+        managed: {}
   source:
     mongodbResourceRef:
       name: ${MDB_RESOURCE_NAME}
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  loadBalancer:
-    managed: {}
 ```
 
 ```bash

--- a/docs/search/09-search-sharded-mongod-managed-lb/code_snippets/09_0320_create_mongodb_search_resource.sh
+++ b/docs/search/09-search-sharded-mongod-managed-lb/code_snippets/09_0320_create_mongodb_search_resource.sh
@@ -14,11 +14,11 @@ spec:
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  # loadBalancer.managed -- operator automatically deploys and configures Envoy proxy
-  loadBalancer:
-    managed: {}
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      # loadBalancer.managed -- operator automatically deploys and configures Envoy proxy
+      loadBalancer:
+        managed: {}
       resourceRequirements:
         limits:
           cpu: "2"

--- a/docs/search/09-search-sharded-mongod-managed-lb/test.sh
+++ b/docs/search/09-search-sharded-mongod-managed-lb/test.sh
@@ -65,7 +65,7 @@ run 09_0316a_create_mongot_tls_certificates.sh
 # Create TLS certificates for managed load balancer (Envoy)
 run 09_0316b_create_lb_tls_certificates.sh
 
-# Create MongoDBSearch with loadBalancer.managed
+# Create MongoDBSearch with clusters[].loadBalancer.managed
 # NOTE: No Envoy deployment script - the operator handles this automatically!
 run 09_0320_create_mongodb_search_resource.sh
 run_for_output 09_0325_wait_for_search_resource.sh

--- a/docs/search/10-search-external-rs-mongod-managed-lb/README.md
+++ b/docs/search/10-search-external-rs-mongod-managed-lb/README.md
@@ -160,7 +160,7 @@ The managed Envoy proxy needs a **server certificate** (for incoming mongod conn
 
 #### Step 8: Create MongoDBSearch Resource
 
-Applies the MongoDBSearch CR with `loadBalancer.managed: {}` pointing to your external replica set:
+Applies the MongoDBSearch CR with `clusters[].loadBalancer.managed: {}` pointing to your external replica set:
 
 ```yaml
 apiVersion: mongodb.com/v1
@@ -170,6 +170,9 @@ metadata:
 spec:
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      loadBalancer:
+        managed:
+          externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local
   source:
     username: search-sync-source
     passwordSecretRef:
@@ -186,8 +189,6 @@ spec:
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  loadBalancer:
-    managed: {}
 ```
 
 ```bash

--- a/docs/search/10-search-external-rs-mongod-managed-lb/code_snippets/10_0320_create_mongodb_search_resource.sh
+++ b/docs/search/10-search-external-rs-mongod-managed-lb/code_snippets/10_0320_create_mongodb_search_resource.sh
@@ -23,11 +23,11 @@ spec:
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  loadBalancer:
-    managed:
-      externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      loadBalancer:
+        managed:
+          externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local
       resourceRequirements:
         limits:
           cpu: "2"

--- a/docs/search/10-search-external-rs-mongod-managed-lb/test.sh
+++ b/docs/search/10-search-external-rs-mongod-managed-lb/test.sh
@@ -66,7 +66,7 @@ run 10_0316a_create_mongot_tls_certificates.sh
 # Create TLS certificates for managed load balancer (Envoy)
 run 10_0316b_create_lb_tls_certificates.sh
 
-# Create MongoDBSearch with loadBalancer.managed
+# Create MongoDBSearch with clusters[].loadBalancer.managed
 # NOTE: No Envoy deployment script - the operator handles this automatically!
 run 10_0320_create_mongodb_search_resource.sh
 run_for_output 10_0325_wait_for_search_resource.sh

--- a/docs/search/11-search-rs-mongod-managed-lb/README.md
+++ b/docs/search/11-search-rs-mongod-managed-lb/README.md
@@ -8,7 +8,7 @@ The operator deploys a single mongot StatefulSet and a single LB Service for the
 
 ### What is "Managed Envoy"?
 
-When you set `spec.loadBalancer.managed: {}` in your MongoDBSearch resource, the operator automatically:
+When you set `spec.clusters[].loadBalancer.managed: {}` in your MongoDBSearch resource, the operator automatically:
 
 1. **Deploys an Envoy proxy** - A Deployment that handles L7 (application layer) load balancing
 2. **Generates routing configuration** - Routes traffic to mongot pods
@@ -67,7 +67,7 @@ graph TD
 | Task | Your Responsibility |
 |------|---------------------|
 | MongoDB replica set CR | ✅ Create the MongoDB CR (operator manages it) |
-| MongoDBSearch CR | ✅ Create with `loadBalancer.managed: {}` and `mongodbResourceRef` |
+| MongoDBSearch CR | ✅ Create with `clusters[].loadBalancer.managed: {}` and `mongodbResourceRef` |
 | TLS certificates | ✅ Create certs for mongot and LB |
 | Configure mongod search params | ❌ Operator handles this automatically |
 | Envoy deployment | ❌ Operator handles this |
@@ -269,7 +269,7 @@ Both must be signed by the same CA that mongod and mongot trust.
 
 #### Step 17: Create MongoDBSearch Resource
 
-Applies the MongoDBSearch CR with `loadBalancer.managed: {}` and `mongodbResourceRef` pointing to the MongoDB CR. Unlike the external scenario, no `source.username`, `source.passwordSecretRef`, or `source.external` block is needed — the operator infers everything from the referenced MongoDB CR:
+Applies the MongoDBSearch CR with `clusters[].loadBalancer.managed: {}` and `mongodbResourceRef` pointing to the MongoDB CR. Unlike the external scenario, no `source.username`, `source.passwordSecretRef`, or `source.external` block is needed — the operator infers everything from the referenced MongoDB CR:
 
 ```yaml
 apiVersion: mongodb.com/v1
@@ -279,14 +279,14 @@ metadata:
 spec:
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      loadBalancer:
+        managed: {}
   source:
     mongodbResourceRef:
       name: ${MDB_RESOURCE_NAME}
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  loadBalancer:
-    managed: {}
 ```
 
 ```bash

--- a/docs/search/11-search-rs-mongod-managed-lb/code_snippets/11_0320_create_mongodb_search_resource.sh
+++ b/docs/search/11-search-rs-mongod-managed-lb/code_snippets/11_0320_create_mongodb_search_resource.sh
@@ -14,11 +14,11 @@ spec:
   security:
     tls:
       certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
-  # loadBalancer.managed -- operator automatically deploys and configures Envoy proxy
-  loadBalancer:
-    managed: {}
   clusters:
     - replicas: ${MDB_MONGOT_REPLICAS}
+      # loadBalancer.managed -- operator automatically deploys and configures Envoy proxy
+      loadBalancer:
+        managed: {}
       resourceRequirements:
         limits:
           cpu: "2"

--- a/docs/search/11-search-rs-mongod-managed-lb/test.sh
+++ b/docs/search/11-search-rs-mongod-managed-lb/test.sh
@@ -65,7 +65,7 @@ run 11_0316a_create_mongot_tls_certificates.sh
 # Create TLS certificates for managed load balancer (Envoy)
 run 11_0316b_create_lb_tls_certificates.sh
 
-# Create MongoDBSearch with loadBalancer.managed
+# Create MongoDBSearch with clusters[].loadBalancer.managed
 # NOTE: No Envoy deployment script - the operator handles this automatically!
 run 11_0320_create_mongodb_search_resource.sh
 run_for_output 11_0325_wait_for_search_resource.sh

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -122,8 +122,10 @@ spec:
                         type: string
                       type: array
                     loadBalancer:
-                      description: LoadBalancer per-cluster override; deep-merged
-                        into spec.loadBalancer.managed.
+                      description: |-
+                        LoadBalancer configures how mongod/mongos connect to this cluster's mongot
+                        (managed Envoy or user-provided). Every cluster must agree on the mode:
+                        either all clusters set managed, all set unmanaged, or none set loadBalancer.
                       properties:
                         managed:
                           description: Managed configures an operator-managed Envoy
@@ -327,8 +329,8 @@ spec:
                       description: |-
                         Replicas is the number of mongot pods for this cluster's StatefulSet.
                         For ReplicaSet sources this is the total; for sharded sources it is per shard.
-                        When Replicas > 1, a load balancer (spec.loadBalancer) is required to distribute
-                        traffic across mongot instances.
+                        When Replicas > 1, a load balancer (spec.clusters[].loadBalancer) is required to
+                        distribute traffic across mongot instances.
                         Set to 0 to take mongot offline: the StatefulSet scales to 0 while the MongoDBSearch CR stays.
                       format: int32
                       minimum: 0
@@ -643,162 +645,6 @@ spec:
                       gRPC RESOURCE_EXHAUSTED status codes. Defaults to true.
                     type: boolean
                 type: object
-              loadBalancer:
-                description: |-
-                  LoadBalancer configures how mongod/mongos connect to mongot (Managed vs Unmanaged/BYO Load Balancer).
-                  Top-level spec.loadBalancer.managed.* serves as the default for every entry in spec.clusters;
-                  per-cluster overrides deep-merge into this template (see spec.clusters[].loadBalancer.managed).
-                  spec.loadBalancer.unmanaged is top-level only — there is no per-cluster form.
-                properties:
-                  managed:
-                    description: Managed configures an operator-managed Envoy load
-                      balancer.
-                    properties:
-                      deployment:
-                        description: |-
-                          Deployment holds optional overrides merged into the operator-created Envoy Deployment.
-                          Follows the same convention as spec.statefulSet on MongoDB resources.
-                        properties:
-                          metadata:
-                            description: DeploymentMetadataWrapper is a wrapper around
-                              Labels and Annotations
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          spec:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                        required:
-                        - spec
-                        type: object
-                      externalHostname:
-                        description: |-
-                          ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
-                          For sharded clusters, may contain a {shardName} placeholder.
-                          In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-                          SNI hostnames stay distinct.
-                          Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
-                        type: string
-                      minMongotReadyReplicas:
-                        description: |-
-                          MinMongotReadyReplicas is the minimum number of ready mongot replicas in a group
-                          before this mongot group can be considered ready and envoy routes real traffic to it.
-                          Until this threshold is met, traffic for that shard is forwarded to a healthy mongot group with the
-                          routed_from_another_shard header (returning empty results).
-                          Defaults to 1 if not specified.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      replicas:
-                        description: |-
-                          Replicas is the number of Envoy proxy pods to deploy.
-                          Defaults to 1 if not specified.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      resourceRequirements:
-                        description: |-
-                          ResourceRequirements for the Envoy container.
-                          When not set, defaults to requests: {cpu: 100m, memory: 128Mi}, limits: {cpu: 500m, memory: 512Mi}.
-                        properties:
-                          claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
-                            items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
-                                  type: string
-                                request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                            type: object
-                        type: object
-                      retryPolicy:
-                        description: |-
-                          RetryPolicy configures Envoy retry behavior for individual gRPC streams to upstream mongot clusters.
-                          When not set, retries are enabled with sensible defaults (2 retries, 60s per-try timeout).
-                        properties:
-                          numRetries:
-                            description: |-
-                              NumRetries is the maximum number of retries per request.
-                              Defaults to 2 if not specified (3 total attempts including the original).
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          perTryTimeout:
-                            description: |-
-                              PerTryTimeout is the timeout for each retry attempt (including the original).
-                              Specified as a Go duration string (e.g., "60s", "30s").
-                              Defaults to "60s" if not specified.
-                            type: string
-                        type: object
-                    type: object
-                  unmanaged:
-                    description: Unmanaged configures a user-provided (BYO) L7 load
-                      balancer.
-                    properties:
-                      endpoint:
-                        description: |-
-                          Endpoint is the full host:port of the BYO load balancer written into mongod config.
-                          For sharded clusters, must contain a {shardName} placeholder.
-                        type: string
-                    type: object
-                type: object
-                x-kubernetes-validations:
-                - message: exactly one of managed or unmanaged must be set
-                  rule: (has(self.managed) && !has(self.unmanaged)) || (!has(self.managed)
-                    && has(self.unmanaged))
               logLevel:
                 description: Configure verbosity of mongot logs. Defaults to INFO
                   if not set.

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -159,8 +159,7 @@ spec:
                               description: |-
                                 ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
                                 For sharded clusters, may contain a {shardName} placeholder.
-                                In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-                                SNI hostnames stay distinct.
+                                In multi-cluster deployments, every cluster's hostname must be distinct.
                                 Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
                               type: string
                             minMongotReadyReplicas:
@@ -864,7 +863,7 @@ spec:
               loadBalancer:
                 description: |-
                   LoadBalancer reports the state of the operator-managed load balancer.
-                  Only populated when spec.loadBalancer.managed is set.
+                  Only populated when spec.clusters[].loadBalancer.managed is set.
                 properties:
                   message:
                     type: string

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4146,8 +4146,10 @@ spec:
                         type: string
                       type: array
                     loadBalancer:
-                      description: LoadBalancer per-cluster override; deep-merged
-                        into spec.loadBalancer.managed.
+                      description: |-
+                        LoadBalancer configures how mongod/mongos connect to this cluster's mongot
+                        (managed Envoy or user-provided). Every cluster must agree on the mode:
+                        either all clusters set managed, all set unmanaged, or none set loadBalancer.
                       properties:
                         managed:
                           description: Managed configures an operator-managed Envoy
@@ -4351,8 +4353,8 @@ spec:
                       description: |-
                         Replicas is the number of mongot pods for this cluster's StatefulSet.
                         For ReplicaSet sources this is the total; for sharded sources it is per shard.
-                        When Replicas > 1, a load balancer (spec.loadBalancer) is required to distribute
-                        traffic across mongot instances.
+                        When Replicas > 1, a load balancer (spec.clusters[].loadBalancer) is required to
+                        distribute traffic across mongot instances.
                         Set to 0 to take mongot offline: the StatefulSet scales to 0 while the MongoDBSearch CR stays.
                       format: int32
                       minimum: 0
@@ -4667,162 +4669,6 @@ spec:
                       gRPC RESOURCE_EXHAUSTED status codes. Defaults to true.
                     type: boolean
                 type: object
-              loadBalancer:
-                description: |-
-                  LoadBalancer configures how mongod/mongos connect to mongot (Managed vs Unmanaged/BYO Load Balancer).
-                  Top-level spec.loadBalancer.managed.* serves as the default for every entry in spec.clusters;
-                  per-cluster overrides deep-merge into this template (see spec.clusters[].loadBalancer.managed).
-                  spec.loadBalancer.unmanaged is top-level only — there is no per-cluster form.
-                properties:
-                  managed:
-                    description: Managed configures an operator-managed Envoy load
-                      balancer.
-                    properties:
-                      deployment:
-                        description: |-
-                          Deployment holds optional overrides merged into the operator-created Envoy Deployment.
-                          Follows the same convention as spec.statefulSet on MongoDB resources.
-                        properties:
-                          metadata:
-                            description: DeploymentMetadataWrapper is a wrapper around
-                              Labels and Annotations
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          spec:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                        required:
-                        - spec
-                        type: object
-                      externalHostname:
-                        description: |-
-                          ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
-                          For sharded clusters, may contain a {shardName} placeholder.
-                          In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-                          SNI hostnames stay distinct.
-                          Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
-                        type: string
-                      minMongotReadyReplicas:
-                        description: |-
-                          MinMongotReadyReplicas is the minimum number of ready mongot replicas in a group
-                          before this mongot group can be considered ready and envoy routes real traffic to it.
-                          Until this threshold is met, traffic for that shard is forwarded to a healthy mongot group with the
-                          routed_from_another_shard header (returning empty results).
-                          Defaults to 1 if not specified.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      replicas:
-                        description: |-
-                          Replicas is the number of Envoy proxy pods to deploy.
-                          Defaults to 1 if not specified.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      resourceRequirements:
-                        description: |-
-                          ResourceRequirements for the Envoy container.
-                          When not set, defaults to requests: {cpu: 100m, memory: 128Mi}, limits: {cpu: 500m, memory: 512Mi}.
-                        properties:
-                          claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-                              This field is immutable. It can only be set for containers.
-                            items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
-                                  type: string
-                                request:
-                                  description: |-
-                                    Request is the name chosen for a request in the referenced claim.
-                                    If empty, everything from the claim is made available, otherwise
-                                    only the result of this request.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                            type: object
-                        type: object
-                      retryPolicy:
-                        description: |-
-                          RetryPolicy configures Envoy retry behavior for individual gRPC streams to upstream mongot clusters.
-                          When not set, retries are enabled with sensible defaults (2 retries, 60s per-try timeout).
-                        properties:
-                          numRetries:
-                            description: |-
-                              NumRetries is the maximum number of retries per request.
-                              Defaults to 2 if not specified (3 total attempts including the original).
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          perTryTimeout:
-                            description: |-
-                              PerTryTimeout is the timeout for each retry attempt (including the original).
-                              Specified as a Go duration string (e.g., "60s", "30s").
-                              Defaults to "60s" if not specified.
-                            type: string
-                        type: object
-                    type: object
-                  unmanaged:
-                    description: Unmanaged configures a user-provided (BYO) L7 load
-                      balancer.
-                    properties:
-                      endpoint:
-                        description: |-
-                          Endpoint is the full host:port of the BYO load balancer written into mongod config.
-                          For sharded clusters, must contain a {shardName} placeholder.
-                        type: string
-                    type: object
-                type: object
-                x-kubernetes-validations:
-                - message: exactly one of managed or unmanaged must be set
-                  rule: (has(self.managed) && !has(self.unmanaged)) || (!has(self.managed)
-                    && has(self.unmanaged))
               logLevel:
                 description: Configure verbosity of mongot logs. Defaults to INFO
                   if not set.

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4183,8 +4183,7 @@ spec:
                               description: |-
                                 ExternalHostname is the hostname Envoy expects for SNI matching on incoming requests.
                                 For sharded clusters, may contain a {shardName} placeholder.
-                                In multi-cluster deployments, may contain a {clusterName} placeholder so per-cluster
-                                SNI hostnames stay distinct.
+                                In multi-cluster deployments, every cluster's hostname must be distinct.
                                 Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
                               type: string
                             minMongotReadyReplicas:
@@ -4888,7 +4887,7 @@ spec:
               loadBalancer:
                 description: |-
                   LoadBalancer reports the state of the operator-managed load balancer.
-                  Only populated when spec.loadBalancer.managed is set.
+                  Only populated when spec.clusters[].loadBalancer.managed is set.
                 properties:
                   message:
                     type: string


### PR DESCRIPTION
> **Rebased & taken over — updated 2026-06-22.** The original author is out; I took over this stack. #1224 (the bottom of the stack) has now **merged into `search/ga-base`** (rebase-and-merge), so this PR was restacked directly onto current ga-base — the now-merged #1224 commits are dropped and it re-targets `search/ga-base`. This restack resolved the post-merge conflict; the per-PR diff is unchanged and was validated by the full integrated multi-cluster + load-balancer e2e suite (green).

# Summary

Moves `spec.loadBalancer` into each `spec.clusters[]` entry: every cluster carries its own LB config (`managed`/`unmanaged` mode, `externalHostname`, Envoy `replicas`, `resourceRequirements`, `retryPolicy`, deployment overrides). 

**Validation requires clusters to agree on the mode: all managed, all unmanaged, or none.** 

The `{clusterName}` hostname placeholder is gone: each cluster sets its own literal hostname, validated distinct across clusters. Controllers resolve a cluster's LB config by cluster name, so config no longer attaches to the wrong cluster when `spec.clusters[]` is reordered or an entry is removed.

Reviewer notes:

- The core contract is name vs index: cluster indices come from the persisted ClusterMapping, outlive spec positions, and are used for resource naming only; `clusterName` resolves spec config (via `EffectiveClusterFor`, empty name = first cluster for single-cluster installs). An index must never be used to look up a spec entry.
- Unmanaged LB is single-cluster-only (enforced by validation), so the per-cluster unmanaged accessors collapsed into a single `GetUnmanagedLBEndpoint`.
- Envoy sizing and overrides now flow from the resolved per-cluster `ManagedLBConfig` instead of deployment-wide spec reads.

**Most of the deleted lines are regenerated CRDs (config/crd/bases, helm_chart/crds, public/crds.yaml).**

## Proof of Work

- New unit tests pin name-based resolution in ways positional resolution cannot pass: `spec.clusters[]` ordered opposite to the persisted indices, and a removed cluster whose persisted index outlives its spec slot — covering route building, a full Envoy reconcile, and the mongos endpoint.
- Validation tests cover the per-cluster rules: all-or-none presence, no mode mixing, distinct hostnames, per-cluster DNS-length checks.
- e2e tests, fixtures and docs snippets set `loadBalancer` on cluster entries; the multi-cluster suites build per-cluster hostnames with the shared resource-name helpers.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

