### PR TITLE
KUBE-133: delete member-cluster resources when the MongoDBSearch CR is deleted

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1430,6 +1430,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_mc_search_cr_deletion
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_q3_mc_sharded_external_mtls
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1129,6 +1129,7 @@ task_groups:
       - e2e_multi_cluster_2_clusters_replica_set
       - e2e_multi_cluster_2_clusters_clusterwide
       - e2e_search_q2_mc_rs_steady
+      - e2e_mc_search_cr_deletion
       - e2e_search_q3_mc_sharded_external_mtls
       - e2e_search_connectivity_tool_mc_rs
       - e2e_search_connectivity_tool_mc_sharded

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -192,6 +193,41 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	return result, nil
 }
 
+// OnDelete implements Deleter; the ResourceEventHandler invokes it synchronously
+// when the MongoDBSearch CR is deleted. Member-cluster resources are deleted
+// explicitly only in multi-cluster mode, where owner references can't cross
+// cluster boundaries; in single-cluster deployments Kubernetes garbage
+// collection handles cleanup via owner references (same gating as the sharded
+// cluster's OnDelete).
+//
+// The sweep iterates the operator's full member-cluster client map rather than
+// the persisted ClusterMapping: the state ConfigMap is owner-ref'd to the
+// search CR and may already be GC'd when the delete event fires, and a cluster
+// recently dropped from spec.clusters may still hold resources. Owner-label
+// filtering makes clusters that never hosted this search's resources no-ops.
+//
+// There is no Ops Manager state to clean (search owns no OM project). For
+// managed replica-set sources the mongotHost setParameters self-clean on the
+// source's next reconcile: applySearchOverrides no longer injects them, and the
+// lastAchievedSpec-vs-desired diff in Process.mergeFrom removes them from the
+// automation config.
+func (r *MongoDBSearchReconciler) OnDelete(ctx context.Context, obj runtime.Object, log *zap.SugaredLogger) error {
+	search, ok := obj.(*searchv1.MongoDBSearch)
+	if !ok {
+		return xerrors.Errorf("expected *searchv1.MongoDBSearch but got %T", obj)
+	}
+
+	var err error
+	if searchcontroller.IsMultiClusterMode(search, r.memberClusterClientsMap) {
+		// db source and cluster mapping are not used by the delete sweep.
+		helper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, search, nil, r.operatorSearchConfig, r.memberClusterClientsMap, nil)
+		err = helper.OnDelete(ctx, log)
+	}
+
+	r.watch.RemoveDependentWatchedResources(search.NamespacedName())
+	return err
+}
+
 // surfaceMissingSecrets logs one entry per cluster that has gaps. The reconcile
 // loop returns RequeueAfter so the controller waits without exponential backoff
 // while the customer replicates the missing secrets.
@@ -295,11 +331,13 @@ func AddMongoDBSearchController(
 	}
 
 	ownerHandler := handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &searchv1.MongoDBSearch{}, handler.OnlyControllerOwner())
+	// ResourceEventHandler routes the CR's Delete event to r.OnDelete so
+	// member-cluster resources (not covered by owner-ref GC) are cleaned up.
 	centralWatches := []struct {
 		obj     client.Object
 		handler handler.EventHandler
 	}{
-		{&searchv1.MongoDBSearch{}, &handler.EnqueueRequestForObject{}},
+		{&searchv1.MongoDBSearch{}, &ResourceEventHandler{deleter: r}},
 		{&mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}},
 		{&mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch}},
 		{&corev1.Secret{}, &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch}},

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -193,12 +193,9 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	return result, nil
 }
 
-// OnDelete implements Deleter; the ResourceEventHandler invokes it synchronously
-// when the MongoDBSearch CR is deleted. Member-cluster resources are deleted
-// explicitly only in multi-cluster mode, where owner references can't cross
-// cluster boundaries; in single-cluster deployments Kubernetes garbage
-// collection handles cleanup via owner references (same gating as the sharded
-// cluster's OnDelete).
+// OnDelete sweeps member-cluster resources in multi-cluster mode, where owner
+// references can't cross cluster boundaries; single-cluster cleanup is left to
+// Kubernetes GC (same gating as the sharded cluster's OnDelete).
 //
 // The sweep iterates the operator's full member-cluster client map rather than
 // the persisted ClusterMapping: the state ConfigMap is owner-ref'd to the

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/mock"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1" //nolint:depguard
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
@@ -1052,6 +1053,163 @@ func TestMongoDBSearchOnDelete_StateConfigMapAlreadyGarbageCollected(t *testing.
 
 	assert.Zero(t, countSearchOwnedObjects(ctx, t, eastClient, search), "us-east must be cleaned without the state CM")
 	assert.Zero(t, countSearchOwnedObjects(ctx, t, westClient, search), "us-west must be cleaned without the state CM")
+}
+
+// watchEntriesFor counts watcher registrations whose dependent resource is owner.
+func watchEntriesFor(w *watch.ResourceWatcher, owner types.NamespacedName) int {
+	count := 0
+	for _, dependents := range w.GetWatchedResources() {
+		for _, d := range dependents {
+			if d == owner {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// Single-cluster OnDelete must NOT delete anything: resources are owner-ref'd
+// to the CR on the same cluster, so Kubernetes garbage collection owns cleanup
+// (sharded-cluster parity). Only the watch registrations are dropped.
+func TestMongoDBSearchOnDelete_SingleCluster_SkipsSweep(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+	reconciler, c := newSearchReconciler(mdbc, search)
+	checkSearchReconcileSuccessful(ctx, t, reconciler, c, search)
+
+	before := countSearchOwnedObjects(ctx, t, c, search)
+	require.Greater(t, before, 0)
+	reconciler.watch.AddWatchedResourceIfNotAdded("source-secret", search.Namespace, watch.Secret, search.NamespacedName())
+	require.NotZero(t, watchEntriesFor(reconciler.watch, search.NamespacedName()))
+
+	deleted := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, deleted))
+	require.NoError(t, c.Delete(ctx, deleted))
+	require.NoError(t, reconciler.OnDelete(ctx, deleted, zap.S()))
+
+	assert.Equal(t, before, countSearchOwnedObjects(ctx, t, c, search), "single-cluster OnDelete must not delete anything — owner-ref GC owns cleanup")
+	assert.NoError(t, c.Get(ctx, search.StatefulSetNamespacedNameForCluster(0), &appsv1.StatefulSet{}), "central mongot STS stays behind for Kubernetes GC")
+	assert.Zero(t, watchEntriesFor(reconciler.watch, search.NamespacedName()))
+}
+
+// A CR stored before spec.clusters existed keeps single-cluster semantics even
+// when the operator has member-cluster clients: its resources live on the
+// central cluster with owner refs, so OnDelete must not sweep members. Pins the
+// len(spec.Clusters) > 0 conjunct of IsMultiClusterMode at the OnDelete call
+// site.
+func TestMongoDBSearchOnDelete_LegacyCRWithoutClusters_SkipsSweep(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+	search.Spec.Clusters = nil
+
+	member := mock.NewEmptyFakeClientBuilder().Build()
+	// Name is arbitrary: the sweep matches on labels, and a legacy CR never
+	// created member-cluster resources in the first place.
+	ownedSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner-labeled-leftover",
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				componentLabelKey:                         "mongot",
+				khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	require.NoError(t, member.Create(ctx, ownedSTS))
+
+	reconciler, _ := newSearchReconcilerWithMembers(t, nil, map[string]client.Client{"us-east": member}, search)
+	require.NoError(t, reconciler.OnDelete(ctx, search, zap.S()))
+
+	assert.NoError(t, member.Get(ctx, client.ObjectKeyFromObject(ownedSTS), &appsv1.StatefulSet{}),
+		"nil spec.clusters means single-cluster semantics: no member sweep even with member clients configured")
+}
+
+// OnDelete must drop only the deleted search's entries from the watcher on both
+// controllers. Without this, events on watched secrets keep enqueuing the
+// deleted CR forever; with too much, another search's registrations are lost.
+func TestMongoDBSearchOnDelete_RemovesWatchRegistrations(t *testing.T) {
+	ctx := context.Background()
+	search := newMultiClusterExternalSearch()
+
+	memberClients := map[string]client.Client{
+		"us-east": mock.NewEmptyFakeClientBuilder().Build(),
+		"us-west": mock.NewEmptyFakeClientBuilder().Build(),
+	}
+	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
+	envoyReconciler := newMongoDBSearchEnvoyReconciler(centralClient, "envoy:test", memberClients)
+
+	otherOwner := types.NamespacedName{Name: "other-search", Namespace: search.Namespace}
+	for _, w := range []*watch.ResourceWatcher{reconciler.watch, envoyReconciler.watch} {
+		w.AddWatchedResourceIfNotAdded("source-secret", search.Namespace, watch.Secret, search.NamespacedName())
+		w.AddWatchedResourceIfNotAdded("other-secret", search.Namespace, watch.Secret, otherOwner)
+		require.Equal(t, 1, watchEntriesFor(w, search.NamespacedName()))
+	}
+
+	require.NoError(t, reconciler.OnDelete(ctx, search, zap.S()))
+	require.NoError(t, envoyReconciler.OnDelete(ctx, search, zap.S()))
+
+	for name, w := range map[string]*watch.ResourceWatcher{"search": reconciler.watch, "envoy": envoyReconciler.watch} {
+		assert.Zero(t, watchEntriesFor(w, search.NamespacedName()), "%s controller must drop the deleted search's watch registrations", name)
+		assert.Equal(t, 1, watchEntriesFor(w, otherOwner), "%s controller must keep other searches' registrations", name)
+	}
+}
+
+// A cluster dropped from spec.clusters may still hold resources when the CR is
+// deleted (the persisted mapping may already be GC'd with the state CM). Both
+// OnDelete sweeps iterate the operator's full member-client map — not
+// spec.clusters — so the dropped cluster is cleaned too.
+func TestMongoDBSearchOnDelete_SweepsClusterDroppedFromSpec(t *testing.T) {
+	ctx := context.Background()
+	search := newMultiClusterExternalSearch() // spec.clusters: us-east, us-west
+
+	euCentralClient := mock.NewEmptyFakeClientBuilder().Build()
+	memberClients := map[string]client.Client{
+		"us-east":    mock.NewEmptyFakeClientBuilder().Build(),
+		"us-west":    mock.NewEmptyFakeClientBuilder().Build(),
+		"eu-central": euCentralClient,
+	}
+
+	// Named what the MC reconcile would have created for cluster index 2,
+	// before eu-central was dropped from spec.clusters.
+	leftoverSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.StatefulSetNamespacedNameForCluster(2).Name,
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				componentLabelKey:                         "mongot",
+				khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	leftoverEnvoyDep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.LoadBalancerDeploymentNameForCluster(2),
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				componentLabelKey:                         envoyComponent,
+				khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	require.NoError(t, euCentralClient.Create(ctx, leftoverSTS))
+	require.NoError(t, euCentralClient.Create(ctx, leftoverEnvoyDep))
+
+	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
+	envoyReconciler := newMongoDBSearchEnvoyReconciler(centralClient, "envoy:test", memberClients)
+
+	require.NoError(t, reconciler.OnDelete(ctx, search, zap.S()))
+	assert.True(t, apiErrors.IsNotFound(euCentralClient.Get(ctx, client.ObjectKeyFromObject(leftoverSTS), &appsv1.StatefulSet{})),
+		"search sweep must clean the cluster dropped from spec.clusters")
+	assert.NoError(t, euCentralClient.Get(ctx, client.ObjectKeyFromObject(leftoverEnvoyDep), &appsv1.Deployment{}),
+		"Envoy resources are the Envoy controller's to sweep, not the search controller's")
+
+	require.NoError(t, envoyReconciler.OnDelete(ctx, search, zap.S()))
+	assert.True(t, apiErrors.IsNotFound(euCentralClient.Get(ctx, client.ObjectKeyFromObject(leftoverEnvoyDep), &appsv1.Deployment{})),
+		"Envoy sweep must clean the cluster dropped from spec.clusters")
 }
 
 // markAllDeploymentsAvailable mirrors MarkAllStatefulSetsAsReady for the Envoy

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -10,16 +10,19 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
@@ -644,22 +647,7 @@ func TestMongoDBSearchControllerReconcile_StateConfigMap_ReAddCluster(t *testing
 func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 	ctx := context.Background()
 
-	// MC GA requires external source (Q2); managed source + MC (Q3) is post-MVP.
-	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: mock.TestNamespace},
-		Spec: searchv1.MongoDBSearchSpec{
-			Source: &searchv1.MongoDBSource{
-				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
-					HostAndPorts: []string{"mdb-0.mdb.svc:27017", "mdb-1.mdb.svc:27017"},
-				},
-			},
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"}},
-		},
-	}
-	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{ClusterName: "us-east", Replicas: ptr.To(int32(1))},
-		{ClusterName: "us-west", Replicas: ptr.To(int32(1))},
-	}
+	search := newMultiClusterExternalSearch()
 
 	eastClient := mock.NewEmptyFakeClientBuilder().Build()
 	westClient := mock.NewEmptyFakeClientBuilder().Build()
@@ -670,31 +658,7 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 
 	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
 
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
-
-	// First reconcile creates state CM, then fans out per-cluster resources.
-	// The per-unit STS readiness gate makes the helper exit Pending as soon
-	// as one unit's STS isn't ready, so several reconciles are needed for the
-	// loop to walk every unit. Each iteration, mark STSes ready on all clients
-	// so the next pass progresses to the next unit.
-	got := &searchv1.MongoDBSearch{}
-	const maxPasses = 5
-	for i := 0; i < maxPasses; i++ {
-		_, err := reconciler.Reconcile(ctx, req)
-		require.NoError(t, err)
-		require.NoError(t, centralClient.Get(ctx, req.NamespacedName, got))
-		// The Envoy controller would normally drive LB status; we seed it so
-		// IsLoadBalancerReady() returns true once STSes are caught up.
-		if got.Status.LoadBalancer == nil {
-			got.Status.LoadBalancer = &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}
-			require.NoError(t, centralClient.Status().Update(ctx, got))
-		}
-		require.NoError(t, mock.MarkAllStatefulSetsAsReady(ctx, search.Namespace, centralClient, eastClient, westClient))
-		if got.Status.Phase == status.PhaseRunning {
-			break
-		}
-	}
-	require.Equal(t, status.PhaseRunning, got.Status.Phase, "reconciler must reach Running within %d passes", maxPasses)
+	driveSearchToRunning(ctx, t, reconciler, nil, centralClient, search, eastClient, westClient)
 
 	// State CM lives on the central client and records the mapping the helper
 	// fanned out over.
@@ -887,6 +851,207 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 			"%s: cluster-level proxy Selector must point at the LB Deployment label, got %q",
 			clusterName, svc.Spec.Selector["app"])
 	}
+}
+
+// newMultiClusterExternalSearch returns the standard 2-cluster external-RS
+// search fixture. Managed LB is mandatory for multi-cluster MongoDBSearch, so
+// it is always configured. (MC GA requires external source (Q2); managed
+// source + MC (Q3) is post-MVP.)
+func newMultiClusterExternalSearch() *searchv1.MongoDBSearch {
+	return &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: mock.TestNamespace},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+					HostAndPorts: []string{"mdb-0.mdb.svc:27017", "mdb-1.mdb.svc:27017"},
+				},
+			},
+			Clusters: []searchv1.ClusterSpec{
+				{ClusterName: "us-east", Replicas: ptr.To(int32(1))},
+				{ClusterName: "us-west", Replicas: ptr.To(int32(1))},
+			},
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{clusterName}.example.com"}},
+		},
+	}
+}
+
+// driveSearchToRunning loops Reconcile (and the Envoy reconciler when given)
+// until the search reaches Running, marking STSes ready and seeding the LB
+// status each pass, mirroring TestMongoDBSearchReconcile_Success_MultiCluster.
+func driveSearchToRunning(
+	ctx context.Context,
+	t *testing.T,
+	reconciler *MongoDBSearchReconciler,
+	envoyReconciler *MongoDBSearchEnvoyReconciler,
+	centralClient client.Client,
+	search *searchv1.MongoDBSearch,
+	memberClients ...client.Client,
+) {
+	t.Helper()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
+	got := &searchv1.MongoDBSearch{}
+	const maxPasses = 5
+	for i := 0; i < maxPasses; i++ {
+		_, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		if envoyReconciler != nil {
+			_, err = envoyReconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+		}
+		require.NoError(t, centralClient.Get(ctx, req.NamespacedName, got))
+		if search.IsLBModeManaged() && got.Status.LoadBalancer == nil {
+			got.Status.LoadBalancer = &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}
+			require.NoError(t, centralClient.Status().Update(ctx, got))
+		}
+		require.NoError(t, mock.MarkAllStatefulSetsAsReady(ctx, search.Namespace, append([]client.Client{centralClient}, memberClients...)...))
+		if got.Status.Phase == status.PhaseRunning {
+			break
+		}
+	}
+	require.Equal(t, status.PhaseRunning, got.Status.Phase, "search must reach Running within %d passes", maxPasses)
+}
+
+// countSearchOwnedObjects lists every STS / Service / ConfigMap / Deployment in
+// the search namespace on c and counts those carrying this search's owner labels.
+func countSearchOwnedObjects(ctx context.Context, t *testing.T, c client.Client, search *searchv1.MongoDBSearch) int {
+	t.Helper()
+	ownerLabels := client.MatchingLabels{
+		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+	}
+	count := 0
+	for _, list := range []client.ObjectList{&appsv1.StatefulSetList{}, &corev1.ServiceList{}, &corev1.ConfigMapList{}, &appsv1.DeploymentList{}} {
+		require.NoError(t, c.List(ctx, list, client.InNamespace(search.Namespace), ownerLabels))
+		items, err := meta.ExtractList(list)
+		require.NoError(t, err)
+		count += len(items)
+	}
+	return count
+}
+
+func TestMongoDBSearchOnDelete_MultiCluster_RemovesAllOwnedResources(t *testing.T) {
+	ctx := context.Background()
+	search := newMultiClusterExternalSearch()
+
+	eastClient := mock.NewEmptyFakeClientBuilder().Build()
+	westClient := mock.NewEmptyFakeClientBuilder().Build()
+	memberClients := map[string]client.Client{"us-east": eastClient, "us-west": westClient}
+
+	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
+	envoyReconciler := newMongoDBSearchEnvoyReconciler(centralClient, "envoy:test", memberClients)
+
+	driveSearchToRunning(ctx, t, reconciler, envoyReconciler, centralClient, search, eastClient, westClient)
+
+	// Sanity: both members hold mongot + Envoy resources before the delete.
+	require.Greater(t, countSearchOwnedObjects(ctx, t, eastClient, search), 0)
+	require.Greater(t, countSearchOwnedObjects(ctx, t, westClient, search), 0)
+	envoyDep := &appsv1.Deployment{}
+	require.NoError(t, eastClient.Get(ctx, types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: search.Namespace}, envoyDep))
+
+	// Foreign-owned look-alikes: same component labels, different owner. The
+	// sweep must not touch them.
+	foreignSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-search-mongot-0",
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				componentLabelKey:                         "mongot",
+				khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	foreignEnvoyDep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-search-search-lb-0",
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				componentLabelKey:                         envoyComponent,
+				khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	require.NoError(t, eastClient.Create(ctx, foreignSTS))
+	require.NoError(t, eastClient.Create(ctx, foreignEnvoyDep))
+
+	// Simulate the CR delete event: the CR is already gone from the API server
+	// when the watch fires, and both controllers' OnDelete receive the tombstone
+	// object carried by the Delete event.
+	deleted := &searchv1.MongoDBSearch{}
+	require.NoError(t, centralClient.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, deleted))
+	require.NoError(t, centralClient.Delete(ctx, deleted))
+	require.NoError(t, reconciler.OnDelete(ctx, deleted, zap.S()))
+	require.NoError(t, envoyReconciler.OnDelete(ctx, deleted, zap.S()))
+
+	for name, c := range map[string]client.Client{"central": centralClient, "us-east": eastClient, "us-west": westClient} {
+		assert.Zero(t, countSearchOwnedObjects(ctx, t, c, search), "no search-owned objects may remain on %s", name)
+	}
+
+	// Spot-check the per-cluster resource names are gone from their member clients.
+	for idx, mc := range map[int]client.Client{0: eastClient, 1: westClient} {
+		assert.True(t, apiErrors.IsNotFound(mc.Get(ctx, search.StatefulSetNamespacedNameForCluster(idx), &appsv1.StatefulSet{})))
+		assert.True(t, apiErrors.IsNotFound(mc.Get(ctx, search.SearchServiceNamespacedNameForCluster(idx), &corev1.Service{})))
+		assert.True(t, apiErrors.IsNotFound(mc.Get(ctx, search.ProxyServiceNamespacedNameForCluster(idx), &corev1.Service{})))
+		assert.True(t, apiErrors.IsNotFound(mc.Get(ctx, search.MongotConfigConfigMapNameForCluster(idx), &corev1.ConfigMap{})))
+		assert.True(t, apiErrors.IsNotFound(mc.Get(ctx, types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(idx), Namespace: search.Namespace}, &appsv1.Deployment{})))
+		assert.True(t, apiErrors.IsNotFound(mc.Get(ctx, types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(idx), Namespace: search.Namespace}, &corev1.ConfigMap{})))
+	}
+
+	// Foreign-owned look-alikes survive.
+	assert.NoError(t, eastClient.Get(ctx, client.ObjectKeyFromObject(foreignSTS), &appsv1.StatefulSet{}), "foreign mongot STS must survive the sweep")
+	assert.NoError(t, eastClient.Get(ctx, client.ObjectKeyFromObject(foreignEnvoyDep), &appsv1.Deployment{}), "foreign Envoy Deployment must survive the sweep")
+}
+
+func TestMongoDBSearchOnDelete_MemberClusterFailure_StillCleansOthers(t *testing.T) {
+	ctx := context.Background()
+	search := newMultiClusterExternalSearch()
+
+	eastClient := mock.NewEmptyFakeClientBuilder().Build()
+	deleteFailure := fmt.Errorf("simulated us-west delete failure")
+	westClient := interceptor.NewClient(mock.NewEmptyFakeClientBuilder().Build(), interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			return deleteFailure
+		},
+	})
+	memberClients := map[string]client.Client{"us-east": eastClient, "us-west": westClient}
+
+	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
+	driveSearchToRunning(ctx, t, reconciler, nil, centralClient, search, eastClient, westClient)
+	require.Greater(t, countSearchOwnedObjects(ctx, t, westClient, search), 0)
+
+	deleted := &searchv1.MongoDBSearch{}
+	require.NoError(t, centralClient.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, deleted))
+	err := reconciler.OnDelete(ctx, deleted, zap.S())
+
+	require.Error(t, err, "OnDelete must surface the failing member cluster")
+	assert.Contains(t, err.Error(), "us-west")
+	assert.Zero(t, countSearchOwnedObjects(ctx, t, eastClient, search), "healthy member must be fully cleaned despite the us-west failure")
+	assert.Greater(t, countSearchOwnedObjects(ctx, t, westClient, search), 0, "failing member keeps its resources (deletes are rejected)")
+}
+
+func TestMongoDBSearchOnDelete_StateConfigMapAlreadyGarbageCollected(t *testing.T) {
+	ctx := context.Background()
+	search := newMultiClusterExternalSearch()
+
+	eastClient := mock.NewEmptyFakeClientBuilder().Build()
+	westClient := mock.NewEmptyFakeClientBuilder().Build()
+	memberClients := map[string]client.Client{"us-east": eastClient, "us-west": westClient}
+
+	reconciler, centralClient := newSearchReconcilerWithMembers(t, nil, memberClients, search)
+	driveSearchToRunning(ctx, t, reconciler, nil, centralClient, search, eastClient, westClient)
+
+	// The state CM is owner-ref'd to the search CR on the central cluster, so
+	// Kubernetes GC may remove it before the delete event reaches the operator.
+	stateCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-state", Namespace: search.Namespace}}
+	require.NoError(t, centralClient.Delete(ctx, stateCM))
+
+	deleted := &searchv1.MongoDBSearch{}
+	require.NoError(t, centralClient.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, deleted))
+	require.NoError(t, reconciler.OnDelete(ctx, deleted, zap.S()))
+
+	assert.Zero(t, countSearchOwnedObjects(ctx, t, eastClient, search), "us-east must be cleaned without the state CM")
+	assert.Zero(t, countSearchOwnedObjects(ctx, t, westClient, search), "us-west must be cleaned without the state CM")
 }
 
 // markAllDeploymentsAvailable mirrors MarkAllStatefulSetsAsReady for the Envoy

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -22,7 +23,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	runtimeCluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
@@ -187,6 +188,24 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	return r.updateLBStatus(ctx, mdbSearch, workflow.OK(), log)
 }
 
+// OnDelete implements Deleter; the ResourceEventHandler invokes it synchronously
+// when the MongoDBSearch CR is deleted. Envoy Deployments/ConfigMaps on member
+// clusters aren't GC'd by Kubernetes (owner refs don't cross cluster
+// boundaries), so they are torn down explicitly, reusing the managed→unmanaged
+// teardown path. Central-cluster resources are owner-ref'd and would be GC'd
+// anyway; deleting them immediately is harmless. The CR's watched-resource
+// registrations (added by getSearchSource for managed sources) are dropped so
+// source-resource events stop enqueuing the deleted CR.
+func (r *MongoDBSearchEnvoyReconciler) OnDelete(ctx context.Context, obj runtime.Object, log *zap.SugaredLogger) error {
+	search, ok := obj.(*searchv1.MongoDBSearch)
+	if !ok {
+		return fmt.Errorf("expected *searchv1.MongoDBSearch but got %T", obj)
+	}
+	err := r.deleteAllEnvoyResources(ctx, search, log)
+	r.watch.RemoveDependentWatchedResources(search.NamespacedName())
+	return err
+}
+
 // clusterWorkItem represents one (clusterName, clusterIndex, client) unit the reconciler must process.
 // In single-cluster (no spec.clusters or empty memberClusterClientsMap) the slice
 // has one entry with ClusterName == "" and ClusterIndex == 0.
@@ -205,7 +224,7 @@ type clusterWorkItem struct {
 //   - otherwise → one work item per spec.clusters[i]. ClusterIndex is resolved from
 //     mapping; -1 if the cluster is not yet in the mapping (first reconcile race).
 func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.MongoDBSearch, mapping map[string]int) []clusterWorkItem {
-	if len(r.memberClusterClientsMap) == 0 || len(search.Spec.Clusters) == 0 {
+	if !searchcontroller.IsMultiClusterMode(search, r.memberClusterClientsMap) {
 		return []clusterWorkItem{{ClusterName: "", ClusterIndex: 0, Client: r.kubeClient}}
 	}
 	work := make([]clusterWorkItem, 0, len(search.Spec.Clusters))
@@ -870,7 +889,11 @@ func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, d
 		return err
 	}
 
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &searchv1.MongoDBSearch{}, &handler.EnqueueRequestForObject{})); err != nil {
+	// ResourceEventHandler routes the CR's Delete event to r.OnDelete so the
+	// per-cluster Envoy resources (not covered by owner-ref GC on member
+	// clusters) are cleaned up. The main search controller registers its own
+	// delete handler for the mongot resources it owns.
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &searchv1.MongoDBSearch{}, &ResourceEventHandler{deleter: r})); err != nil {
 		return err
 	}
 	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch})); err != nil {

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -22,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	runtimeCluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -146,11 +146,19 @@ func withSearchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) s
 	return withStsMetaLabels(searchOwnerLabels(search, clusterName))
 }
 
+// IsMultiClusterMode reports whether search reconciliation fans out across
+// member clusters: the operator has member-cluster clients AND the CR declares
+// spec.clusters. The single shared predicate for MC-mode decisions — keep all
+// call sites on it so they can't drift.
+func IsMultiClusterMode(search *searchv1.MongoDBSearch, memberClusterClients map[string]kubernetesClient.Client) bool {
+	return len(memberClusterClients) > 0 && len(search.Spec.Clusters) > 0
+}
+
 // clientForCluster returns the Kubernetes client for a unit's member cluster.
-// Empty clusterName / empty memberClusterClients map fall back to the central
-// client (single-cluster install). Unknown clusterName is an error.
+// Empty clusterName / single-cluster mode fall back to the central client.
+// Unknown clusterName is an error.
 func (r *MongoDBSearchReconcileHelper) clientForCluster(clusterName string) (kubernetesClient.Client, error) {
-	if clusterName == "" || len(r.memberClusterClients) == 0 {
+	if clusterName == "" || !IsMultiClusterMode(r.mdbSearch, r.memberClusterClients) {
 		return r.client, nil
 	}
 	c, ok := r.memberClusterClients[clusterName]

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3808,3 +3808,18 @@ func TestReconcileShardedMC_InterleavedStatusConverges(t *testing.T) {
 	require.NotNil(t, got.Status.LoadBalancer, "LB sub-status still present")
 	require.Equal(t, status.PhaseRunning, got.Status.LoadBalancer.Phase)
 }
+
+// IsMultiClusterMode requires BOTH member-cluster clients and spec.clusters:
+// clients without clusters is a legacy stored CR (single-cluster semantics),
+// clusters without clients is a single-cluster operator that must not fan out.
+func TestIsMultiClusterMode(t *testing.T) {
+	// The client value is irrelevant; the predicate only checks map length.
+	clients := map[string]kubernetesClient.Client{"cluster-a": nil}
+	withClusters := &searchv1.MongoDBSearch{Spec: searchv1.MongoDBSearchSpec{Clusters: []searchv1.ClusterSpec{{ClusterName: "cluster-a"}}}}
+	withoutClusters := &searchv1.MongoDBSearch{}
+
+	assert.True(t, IsMultiClusterMode(withClusters, clients))
+	assert.False(t, IsMultiClusterMode(withClusters, nil), "spec.clusters without member clients must stay single-cluster")
+	assert.False(t, IsMultiClusterMode(withoutClusters, clients), "legacy CR without spec.clusters must stay single-cluster")
+	assert.False(t, IsMultiClusterMode(withoutClusters, nil))
+}

--- a/controllers/searchcontroller/stale_sweep.go
+++ b/controllers/searchcontroller/stale_sweep.go
@@ -25,6 +25,16 @@ type staleSweepExpectations struct {
 	configMaps   map[string]bool
 }
 
+// OnDelete deletes every search-owned mongot StatefulSet, headless Service,
+// ConfigMap, and proxy Service across the central and all member clusters by
+// running the stale sweep with empty expectations. PVCs are not deleted
+// explicitly: the mongot StatefulSet sets persistentVolumeClaimRetentionPolicy
+// whenDeleted=Delete (see search_construction.go), so deleting the StatefulSet
+// reaps its PVCs — same posture as sharded MC, which doesn't delete PVCs either.
+func (r *MongoDBSearchReconcileHelper) OnDelete(ctx context.Context, log *zap.SugaredLogger) error {
+	return r.cleanupStaleResources(ctx, log, staleSweepExpectations{})
+}
+
 // cleanupStaleResources deletes search-owned mongot StatefulSets, Services, and
 // ConfigMaps (plus proxy Services in managed-LB mode) that the current reconcile
 // plan no longer expects. It runs across the central client and every member

--- a/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
@@ -352,6 +352,181 @@ def verify_per_cluster_envoy_deployment(
         logger.info(f"Envoy Deployment {envoy_deployment_name} ready in cluster {mcc.cluster_name} (idx={cluster_idx})")
 
 
+# ---------------------------------------------------------------------------
+# Per-cluster full-resource-set presence / absence.
+# ---------------------------------------------------------------------------
+
+
+def data_pvc_prefix(mdbs_resource_name: str, cluster_index: int) -> str:
+    """PVC names are ``data-<mongot-sts>-<ordinal>``; the mongot data claim is ``data``."""
+    return f"data-{search_resource_names.mongot_statefulset_name_for_cluster(mdbs_resource_name, cluster_index)}-"
+
+
+def data_pvcs_for_cluster(mcc: MultiClusterClient, mdbs_resource_name: str, cluster_index: int, namespace: str) -> List:
+    """All mongot data PVCs for a cluster index, sorted by name (one per ordinal)."""
+    pvc_prefix = data_pvc_prefix(mdbs_resource_name, cluster_index)
+    pvcs = mcc.core_v1_api().list_namespaced_persistent_volume_claim(namespace)
+    return sorted((p for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)), key=lambda p: p.metadata.name)
+
+
+def assert_cluster_search_resources_present(
+    *,
+    mcc: MultiClusterClient,
+    mdbs_resource_name: str,
+    cluster_index: int,
+    namespace: str,
+) -> None:
+    """The named cluster carries a complete, owner-labelled mongot + Envoy set."""
+    sts_name = search_resource_names.mongot_statefulset_name_for_cluster(mdbs_resource_name, cluster_index)
+    svc_name = search_resource_names.mongot_service_name_for_cluster(mdbs_resource_name, cluster_index)
+    proxy_svc_name = search_resource_names.mc_proxy_svc_name(mdbs_resource_name, cluster_index)
+    cm_name = search_resource_names.mongot_configmap_name_for_cluster(mdbs_resource_name, cluster_index)
+    envoy_deploy_name = search_resource_names.lb_deployment_name(mdbs_resource_name, cluster_index)
+    envoy_cm_name = search_resource_names.lb_configmap_name(mdbs_resource_name, cluster_index)
+
+    sts = mcc.read_namespaced_stateful_set(sts_name, namespace)
+    headless = mcc.read_namespaced_service(svc_name, namespace)
+    proxy = mcc.read_namespaced_service(proxy_svc_name, namespace)
+    cm = mcc.read_namespaced_config_map(cm_name, namespace)
+    assert_search_owner_labels(sts.metadata.labels or {}, mcc.cluster_name, f"STS {sts_name}", mdbs_resource_name)
+    assert_search_owner_labels(
+        headless.metadata.labels or {}, mcc.cluster_name, f"headless Service {svc_name}", mdbs_resource_name
+    )
+    assert_search_owner_labels(
+        proxy.metadata.labels or {}, mcc.cluster_name, f"proxy Service {proxy_svc_name}", mdbs_resource_name
+    )
+    assert_search_owner_labels(cm.metadata.labels or {}, mcc.cluster_name, f"mongot CM {cm_name}", mdbs_resource_name)
+
+    apps = mcc.apps_v1_api()
+    assert_deployment_ready_in_cluster(apps, name=envoy_deploy_name, namespace=namespace)
+    envoy_deploy = apps.read_namespaced_deployment(name=envoy_deploy_name, namespace=namespace)
+    envoy_cm = mcc.read_namespaced_config_map(envoy_cm_name, namespace)
+    assert_search_owner_labels(
+        envoy_deploy.metadata.labels or {},
+        mcc.cluster_name,
+        f"Envoy Deployment {envoy_deploy_name}",
+        mdbs_resource_name,
+    )
+    assert_search_owner_labels(
+        envoy_cm.metadata.labels or {}, mcc.cluster_name, f"Envoy CM {envoy_cm_name}", mdbs_resource_name
+    )
+
+    logger.info(
+        f"cluster {mcc.cluster_name} (idx={cluster_index}) has full search resource set: "
+        f"{sts_name}, {svc_name}, {proxy_svc_name}, {cm_name}, {envoy_deploy_name}, {envoy_cm_name}"
+    )
+
+
+def wait_for_cluster_search_resources_present(
+    *,
+    mcc: MultiClusterClient,
+    mdbs_resource_name: str,
+    cluster_index: int,
+    namespace: str,
+    timeout: int = 600,
+) -> None:
+    """Poll until the named cluster's mongot + Envoy resources have materialized."""
+
+    def check():
+        try:
+            assert_cluster_search_resources_present(
+                mcc=mcc, mdbs_resource_name=mdbs_resource_name, cluster_index=cluster_index, namespace=namespace
+            )
+            return True, f"cluster {mcc.cluster_name} (idx={cluster_index}) resources present"
+        except (kubernetes.client.ApiException, AssertionError) as exc:
+            return False, f"cluster {mcc.cluster_name} (idx={cluster_index}) not ready yet: {exc}"
+
+    run_periodically(check, timeout=timeout, sleep_time=10, msg=f"cluster {mcc.cluster_name} search resources present")
+
+
+def wait_for_cluster_search_resources_absent(
+    *,
+    mcc: MultiClusterClient,
+    mdbs_resource_name: str,
+    cluster_index: int,
+    namespace: str,
+    timeout: int = 600,
+) -> None:
+    """Poll until EVERY search-owned resource for the named cluster is gone.
+
+    Covers mongot StatefulSet, headless + proxy Services, mongot ConfigMap, the
+    backing PVCs (reaped by the StatefulSet's whenDeleted: Delete policy), and the
+    Envoy Deployment + ConfigMap. Each kind is checked independently so a partial
+    sweep surfaces the specific resource that leaked.
+    """
+    apps = mcc.apps_v1_api()
+    core = mcc.core_v1_api()
+
+    sts_name = search_resource_names.mongot_statefulset_name_for_cluster(mdbs_resource_name, cluster_index)
+    svc_name = search_resource_names.mongot_service_name_for_cluster(mdbs_resource_name, cluster_index)
+    proxy_svc_name = search_resource_names.mc_proxy_svc_name(mdbs_resource_name, cluster_index)
+    cm_name = search_resource_names.mongot_configmap_name_for_cluster(mdbs_resource_name, cluster_index)
+    envoy_deploy_name = search_resource_names.lb_deployment_name(mdbs_resource_name, cluster_index)
+    envoy_cm_name = search_resource_names.lb_configmap_name(mdbs_resource_name, cluster_index)
+    pvc_prefix = data_pvc_prefix(mdbs_resource_name, cluster_index)
+
+    def _read_gone(read_fn, name: str, kind: str):
+        try:
+            read_fn(name, namespace)
+            return False, f"{kind} {name} still exists in {mcc.cluster_name}"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"{kind} {name} deleted in {mcc.cluster_name}"
+            raise
+
+    def pvcs_gone():
+        pvcs = core.list_namespaced_persistent_volume_claim(namespace)
+        leftover = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
+        if leftover:
+            return False, f"PVC(s) for {mcc.cluster_name} still exist: {leftover}"
+        return True, f"no PVCs with prefix {pvc_prefix!r} remain in {mcc.cluster_name}"
+
+    checks = [
+        (lambda: _read_gone(apps.read_namespaced_stateful_set, sts_name, "StatefulSet"), f"StatefulSet {sts_name}"),
+        (
+            lambda: _read_gone(core.read_namespaced_service, svc_name, "headless Service"),
+            f"headless Service {svc_name}",
+        ),
+        (
+            lambda: _read_gone(core.read_namespaced_service, proxy_svc_name, "proxy Service"),
+            f"proxy Service {proxy_svc_name}",
+        ),
+        (lambda: _read_gone(core.read_namespaced_config_map, cm_name, "mongot ConfigMap"), f"mongot CM {cm_name}"),
+        (
+            lambda: _read_gone(apps.read_namespaced_deployment, envoy_deploy_name, "Envoy Deployment"),
+            f"Envoy Deployment {envoy_deploy_name}",
+        ),
+        (
+            lambda: _read_gone(core.read_namespaced_config_map, envoy_cm_name, "Envoy ConfigMap"),
+            f"Envoy CM {envoy_cm_name}",
+        ),
+        (pvcs_gone, f"PVCs {pvc_prefix}*"),
+    ]
+    for check, label in checks:
+        run_periodically(check, timeout=timeout, sleep_time=10, msg=f"{label} deletion in {mcc.cluster_name}")
+        logger.info(f"{label} confirmed deleted in {mcc.cluster_name} (idx={cluster_index})")
+
+
+def state_configmap_name(mdbs_resource_name: str) -> str:
+    """Name of the central-cluster state ConfigMap carrying the persisted ClusterMapping."""
+    return f"{mdbs_resource_name}-state"
+
+
+def read_persisted_cluster_mapping(
+    *,
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdbs_resource_name: str,
+) -> Dict[str, int]:
+    """Return the operator's persisted ClusterMapping from the ``<name>-state`` ConfigMap."""
+    state_cm_name = state_configmap_name(mdbs_resource_name)
+    core = CoreV1Api(api_client=central_cluster_client)
+    state_cm = core.read_namespaced_config_map(name=state_cm_name, namespace=namespace)
+    raw = (state_cm.data or {}).get("state")
+    assert raw, f"state ConfigMap {state_cm_name} missing 'state' key; got {list((state_cm.data or {}).keys())}"
+    return json.loads(raw).get("clusterMapping") or {}
+
+
 def _read_envoy_sni_server_names(
     mcc: MultiClusterClient,
     mdbs_resource_name: str,

--- a/docker/mongodb-kubernetes-tests/tests/common/search/sharded_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/sharded_search_helper.py
@@ -286,7 +286,7 @@ def verify_sharded_mongod_parameters(
     logger.info("All shards have correct mongod search parameters")
 
 
-def verify_text_search_query(search_tester: SearchTester):
+def verify_text_search_query(search_tester: SearchTester, timeout: int = 60):
     """Execute a text search for 'star wars' and verify results are returned."""
     movies_helper = SampleMoviesSearchHelper(search_tester)
 
@@ -305,7 +305,7 @@ def verify_text_search_query(search_tester: SearchTester):
         except pymongo.errors.PyMongoError as e:
             return False, f"Error: {e}"
 
-    run_periodically(execute_search, timeout=60, sleep_time=5, msg="search query to succeed")
+    run_periodically(execute_search, timeout=timeout, sleep_time=5, msg="search query to succeed")
     logger.info("Text search query executed successfully through mongos")
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cluster_add_remove.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cluster_add_remove.py
@@ -14,12 +14,10 @@ spans the first 2; the 3rd is the spare search cluster. The tools pod and the
 mongotHost target are pinned to member clusters (central is outside the mesh).
 """
 
-import json
 from typing import Dict, List
 
 import kubernetes
 import pymongo.errors
-from kubernetes.client import CoreV1Api
 from kubetester import create_or_update_secret, try_load
 from kubetester.certs_mongodb_multi import create_multi_cluster_mongodb_tls_certs
 from kubetester.kubetester import fixture as yaml_fixture
@@ -33,11 +31,9 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
-from tests.common.multicluster.multicluster_utils import assert_deployment_ready_in_cluster
-from tests.common.search import search_resource_names
+from tests.common.search import mc_search_helper, search_resource_names
 from tests.common.search.mc_search_helper import (
     assert_cluster_envoy_sni,
-    assert_search_owner_labels,
     assert_source_mongot_host_observed,
     build_mongodb_user,
     create_mc_lb_certificates,
@@ -64,8 +60,6 @@ SOURCE_MEMBERS_PER_CLUSTER: List[int | None] = [2, 2]
 MONGOT_REPLICAS_PER_CLUSTER = 1
 ENVOY_LB_REPLICAS = 2
 ENVOY_PROXY_PORT = 27028
-
-# Owner-label helpers/constants are imported from mc_search_helper.
 
 ADMIN_USER_NAME = "mdb-admin-user"
 ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
@@ -102,159 +96,44 @@ def _clusters_spec(cluster_names: List[str]) -> List[Dict]:
     return [{"clusterName": name, "replicas": MONGOT_REPLICAS_PER_CLUSTER} for name in cluster_names]
 
 
-def _assert_search_owner_labels(obj_labels: Dict[str, str], cluster_name: str, where: str) -> None:
-    """Bind MDBS_RESOURCE_NAME and delegate to the shared assertion."""
-    assert_search_owner_labels(obj_labels, cluster_name, where, MDBS_RESOURCE_NAME)
-
-
-def _mongot_config_name(cluster_index: int) -> str:
-    return search_resource_names.mongot_configmap_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index)
-
-
-def _envoy_deployment_name(cluster_index: int) -> str:
-    return search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_index)
-
-
-def _envoy_configmap_name(cluster_index: int) -> str:
-    return search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_index)
-
-
-def _data_pvc_prefix(cluster_index: int) -> str:
-    """PVCs are "data-<mongot-sts>-<ordinal>"; the mongot data claim is "data"."""
-    return f"data-{search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index)}-"
-
-
-def _data_pvcs_for_cluster(mcc: MultiClusterClient, cluster_index: int, namespace: str) -> List:
-    """All mongot data PVCs for a cluster index, sorted by name (one per ordinal)."""
-    pvc_prefix = _data_pvc_prefix(cluster_index)
-    pvcs = mcc.core_v1_api().list_namespaced_persistent_volume_claim(namespace)
-    return sorted((p for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)), key=lambda p: p.metadata.name)
-
-
 # =============================================================================
 # Existence / absence assertions for a cluster's full per-cluster resource set
+# (thin MDBS_RESOURCE_NAME-binding wrappers over the shared mc_search_helper
+# implementations).
 # =============================================================================
 
 
-def assert_cluster_search_resources_present(
-    mcc: MultiClusterClient,
-    cluster_index: int,
-    namespace: str,
-) -> None:
+def assert_cluster_search_resources_present(mcc: MultiClusterClient, cluster_index: int, namespace: str) -> None:
     """The named cluster carries a complete, owner-labelled mongot + Envoy set."""
-    sts_name = search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index)
-    svc_name = search_resource_names.mongot_service_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index)
-    proxy_svc_name = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, cluster_index)
-    cm_name = _mongot_config_name(cluster_index)
-    envoy_deploy_name = _envoy_deployment_name(cluster_index)
-    envoy_cm_name = _envoy_configmap_name(cluster_index)
-
-    sts = mcc.read_namespaced_stateful_set(sts_name, namespace)
-    headless = mcc.read_namespaced_service(svc_name, namespace)
-    proxy = mcc.read_namespaced_service(proxy_svc_name, namespace)
-    cm = mcc.read_namespaced_config_map(cm_name, namespace)
-    _assert_search_owner_labels(sts.metadata.labels or {}, mcc.cluster_name, f"STS {sts_name}")
-    _assert_search_owner_labels(headless.metadata.labels or {}, mcc.cluster_name, f"headless Service {svc_name}")
-    _assert_search_owner_labels(proxy.metadata.labels or {}, mcc.cluster_name, f"proxy Service {proxy_svc_name}")
-    _assert_search_owner_labels(cm.metadata.labels or {}, mcc.cluster_name, f"mongot CM {cm_name}")
-
-    apps = mcc.apps_v1_api()
-    assert_deployment_ready_in_cluster(apps, name=envoy_deploy_name, namespace=namespace)
-    envoy_deploy = apps.read_namespaced_deployment(name=envoy_deploy_name, namespace=namespace)
-    envoy_cm = mcc.read_namespaced_config_map(envoy_cm_name, namespace)
-    _assert_search_owner_labels(
-        envoy_deploy.metadata.labels or {}, mcc.cluster_name, f"Envoy Deployment {envoy_deploy_name}"
-    )
-    _assert_search_owner_labels(envoy_cm.metadata.labels or {}, mcc.cluster_name, f"Envoy CM {envoy_cm_name}")
-
-    logger.info(
-        f"cluster {mcc.cluster_name} (idx={cluster_index}) has full search resource set: "
-        f"{sts_name}, {svc_name}, {proxy_svc_name}, {cm_name}, {envoy_deploy_name}, {envoy_cm_name}"
+    mc_search_helper.assert_cluster_search_resources_present(
+        mcc=mcc, mdbs_resource_name=MDBS_RESOURCE_NAME, cluster_index=cluster_index, namespace=namespace
     )
 
 
 def wait_for_cluster_search_resources_present(
-    mcc: MultiClusterClient,
-    cluster_index: int,
-    namespace: str,
-    timeout: int = 600,
+    mcc: MultiClusterClient, cluster_index: int, namespace: str, timeout: int = 600
 ) -> None:
     """Poll until the named cluster's mongot + Envoy resources have materialized."""
-
-    def check():
-        try:
-            assert_cluster_search_resources_present(mcc, cluster_index, namespace)
-            return True, f"cluster {mcc.cluster_name} (idx={cluster_index}) resources present"
-        except (kubernetes.client.ApiException, AssertionError) as exc:
-            return False, f"cluster {mcc.cluster_name} (idx={cluster_index}) not ready yet: {exc}"
-
-    run_periodically(check, timeout=timeout, sleep_time=10, msg=f"cluster {mcc.cluster_name} search resources present")
+    mc_search_helper.wait_for_cluster_search_resources_present(
+        mcc=mcc,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        cluster_index=cluster_index,
+        namespace=namespace,
+        timeout=timeout,
+    )
 
 
 def wait_for_cluster_search_resources_absent(
-    mcc: MultiClusterClient,
-    cluster_index: int,
-    namespace: str,
-    timeout: int = 600,
+    mcc: MultiClusterClient, cluster_index: int, namespace: str, timeout: int = 600
 ) -> None:
-    """Poll until EVERY search-owned resource for the named cluster is gone.
-
-    Covers mongot StatefulSet, headless + proxy Services, mongot ConfigMap, the
-    backing PVCs (reaped by the StatefulSet's whenDeleted: Delete policy), and the
-    Envoy Deployment + ConfigMap. Each kind is checked independently so a partial
-    sweep surfaces the specific resource that leaked.
-    """
-    apps = mcc.apps_v1_api()
-    core = mcc.core_v1_api()
-
-    sts_name = search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index)
-    svc_name = search_resource_names.mongot_service_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index)
-    proxy_svc_name = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, cluster_index)
-    cm_name = _mongot_config_name(cluster_index)
-    envoy_deploy_name = _envoy_deployment_name(cluster_index)
-    envoy_cm_name = _envoy_configmap_name(cluster_index)
-    pvc_prefix = _data_pvc_prefix(cluster_index)
-
-    def _read_gone(read_fn, name: str, kind: str):
-        try:
-            read_fn(name, namespace)
-            return False, f"{kind} {name} still exists in {mcc.cluster_name}"
-        except kubernetes.client.ApiException as e:
-            if e.status == 404:
-                return True, f"{kind} {name} deleted in {mcc.cluster_name}"
-            raise
-
-    def pvcs_gone():
-        pvcs = core.list_namespaced_persistent_volume_claim(namespace)
-        leftover = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
-        if leftover:
-            return False, f"PVC(s) for {mcc.cluster_name} still exist: {leftover}"
-        return True, f"no PVCs with prefix {pvc_prefix!r} remain in {mcc.cluster_name}"
-
-    checks = [
-        (lambda: _read_gone(apps.read_namespaced_stateful_set, sts_name, "StatefulSet"), f"StatefulSet {sts_name}"),
-        (
-            lambda: _read_gone(core.read_namespaced_service, svc_name, "headless Service"),
-            f"headless Service {svc_name}",
-        ),
-        (
-            lambda: _read_gone(core.read_namespaced_service, proxy_svc_name, "proxy Service"),
-            f"proxy Service {proxy_svc_name}",
-        ),
-        (lambda: _read_gone(core.read_namespaced_config_map, cm_name, "mongot ConfigMap"), f"mongot CM {cm_name}"),
-        (
-            lambda: _read_gone(apps.read_namespaced_deployment, envoy_deploy_name, "Envoy Deployment"),
-            f"Envoy Deployment {envoy_deploy_name}",
-        ),
-        (
-            lambda: _read_gone(core.read_namespaced_config_map, envoy_cm_name, "Envoy ConfigMap"),
-            f"Envoy CM {envoy_cm_name}",
-        ),
-        (pvcs_gone, f"PVCs {pvc_prefix}*"),
-    ]
-    for check, label in checks:
-        run_periodically(check, timeout=timeout, sleep_time=10, msg=f"{label} deletion in {mcc.cluster_name}")
-        logger.info(f"{label} confirmed deleted in {mcc.cluster_name} (idx={cluster_index})")
+    """Poll until EVERY search-owned resource for the named cluster is gone."""
+    mc_search_helper.wait_for_cluster_search_resources_absent(
+        mcc=mcc,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        cluster_index=cluster_index,
+        namespace=namespace,
+        timeout=timeout,
+    )
 
 
 def read_persisted_cluster_mapping(
@@ -262,12 +141,9 @@ def read_persisted_cluster_mapping(
     central_cluster_client: kubernetes.client.ApiClient,
 ) -> Dict[str, int]:
     """Return the operator's persisted ClusterMapping from the <name>-state ConfigMap."""
-    state_cm_name = f"{MDBS_RESOURCE_NAME}-state"
-    core = CoreV1Api(api_client=central_cluster_client)
-    state_cm = core.read_namespaced_config_map(name=state_cm_name, namespace=namespace)
-    raw = (state_cm.data or {}).get("state")
-    assert raw, f"state ConfigMap {state_cm_name} missing 'state' key; got {list((state_cm.data or {}).keys())}"
-    return json.loads(raw).get("clusterMapping") or {}
+    return mc_search_helper.read_persisted_cluster_mapping(
+        namespace=namespace, central_cluster_client=central_cluster_client, mdbs_resource_name=MDBS_RESOURCE_NAME
+    )
 
 
 # =============================================================================
@@ -629,7 +505,7 @@ def test_phaseA_record_cluster1_pvc(
     """
     cluster1 = member_cluster_clients[1]
     idx = helper.cluster_index(cluster1.cluster_name)
-    pvcs = _data_pvcs_for_cluster(cluster1, idx, namespace)
+    pvcs = mc_search_helper.data_pvcs_for_cluster(cluster1, MDBS_RESOURCE_NAME, idx, namespace)
     assert pvcs, f"no mongot data PVC found for cluster {cluster1.cluster_name} (idx={idx}) to record"
     recorded_pvc["name"] = pvcs[0].metadata.name
     recorded_pvc["uid"] = pvcs[0].metadata.uid
@@ -842,7 +718,7 @@ def test_phaseD_readd_uses_original_index_and_fresh_pvc(
         f"want ORIGINAL {original_idx}; full mapping={mapping}"
     )
 
-    pvcs = _data_pvcs_for_cluster(readded, original_idx, namespace)
+    pvcs = mc_search_helper.data_pvcs_for_cluster(readded, MDBS_RESOURCE_NAME, original_idx, namespace)
     assert pvcs, f"expected a freshly-provisioned PVC for cluster {readded.cluster_name} after re-add; found none"
     new_uids = {p.metadata.uid for p in pvcs}
     assert recorded_pvc.get("uid"), "Phase A did not record the original cluster-1 PVC uid"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cr_deletion.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cr_deletion.py
@@ -631,9 +631,9 @@ def test_recreated_resources_present_per_cluster(
         central_cluster_client=central_cluster_client,
         mdbs_resource_name=MDBS_RESOURCE_NAME,
     )
-    assert mapping == {mcc.cluster_name: helper.cluster_index(mcc.cluster_name) for mcc in member_cluster_clients}, (
-        f"re-created CR must re-assign the original cluster indices, got {mapping}"
-    )
+    assert mapping == {
+        mcc.cluster_name: helper.cluster_index(mcc.cluster_name) for mcc in member_cluster_clients
+    }, f"re-created CR must re-assign the original cluster indices, got {mapping}"
 
     for mcc in member_cluster_clients:
         mc_search_helper.wait_for_cluster_search_resources_present(

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cr_deletion.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cr_deletion.py
@@ -1,42 +1,22 @@
 """Centralized-MC CR-deletion e2e for MongoDBSearch (OnDelete path).
 
 Owner references do not cross cluster boundaries, so Kubernetes GC alone cannot
-clean up the per-cluster resources a centralized MongoDBSearch fans out to its
-member clusters. The operator wires an OnDelete handler on both the search and
-Envoy controllers that explicitly sweeps every search-owned resource from every
-member cluster when the CR is deleted (mongot StatefulSet / headless Service /
-ConfigMap / proxy Service + Envoy Deployment / ConfigMap; PVCs are reaped via
-the StatefulSet's persistentVolumeClaimRetentionPolicy whenDeleted: Delete).
+clean up the per-cluster resources a centralized MongoDBSearch fans out to
+member clusters; the OnDelete sweep on both controllers does it explicitly
+(PVCs ride along via persistentVolumeClaimRetentionPolicy whenDeleted: Delete).
+Presence is asserted per kind before the delete so the absence polling cannot
+pass vacuously, and the same CR is re-created afterwards to prove the deletion
+left no wreckage blocking reinstall.
 
-Phases:
-  1. Deploy a 2-cluster external MongoDBMulti RS source (TLS+SCRAM) and a
-     MongoDBSearch spanning both clusters with a managed LB; drive to Running.
-  2. Presence guard: assert the FULL expected resource set exists per member
-     cluster (mongot kinds, proxy Svc, Envoy Deployment/CM, data PVC) plus the
-     state ConfigMap on the central cluster. Without this, phase 4's absence
-     polling could pass vacuously.
-  3. Light data-plane confidence: restore sample data, create a $search index,
-     run one query — proves the deployment being deleted was real.
-  4. DELETE the MongoDBSearch CR. Assert ZERO search-owned objects remain in
-     EACH member cluster (every kind from phase 2 including PVCs), the state CM
-     on central is GC'd (owner-ref), and the source MongoDBMulti is untouched
-     (still Running, its StatefulSets present in both clusters).
-  5. Re-create the same MongoDBSearch and drive it to Running again — a fresh
-     provision proves the deletion left no wreckage that blocks reinstall.
+Runs on the e2e_multi_cluster_2_clusters variant; the tools pod is pinned to
+member cluster 0 for consistency with the 3-cluster add/remove test (where the
+central cluster is outside the mesh).
 
-Runs on the e2e_multi_cluster_2_clusters variant (deletion semantics need no
-third cluster). On this variant the central cluster doubles as member 1, so the
-default-client tools pod would work — but it is pinned to member cluster 0 for
-consistency with the 3-cluster add/remove test where the central cluster is
-outside the mesh.
-
-The source is external, so the operator does not inject search setParameters;
-the test patches every source mongod's mongotHost via OM AC, pointing them all
-at cluster 0's proxy-svc FQDN (single stable target). That FQDN disappears with
-the sweep and reappears on re-create under the same name (cluster indices are
+The source is external, so the operator injects no search setParameters; the
+test patches every source mongod's mongotHost via OM AC at cluster 0's
+proxy-svc FQDN. That FQDN reappears on re-create under the same name (indices
 re-assigned in first-seen spec order after the state CM is GC'd), so no
-re-patching is needed — and a stale mongotHost never affects mongod health or
-the source's Running phase.
+re-patching is needed — and a stale mongotHost never affects mongod health.
 """
 
 from typing import List

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cr_deletion.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_search_cr_deletion.py
@@ -1,0 +1,664 @@
+"""Centralized-MC CR-deletion e2e for MongoDBSearch (OnDelete path).
+
+Owner references do not cross cluster boundaries, so Kubernetes GC alone cannot
+clean up the per-cluster resources a centralized MongoDBSearch fans out to its
+member clusters. The operator wires an OnDelete handler on both the search and
+Envoy controllers that explicitly sweeps every search-owned resource from every
+member cluster when the CR is deleted (mongot StatefulSet / headless Service /
+ConfigMap / proxy Service + Envoy Deployment / ConfigMap; PVCs are reaped via
+the StatefulSet's persistentVolumeClaimRetentionPolicy whenDeleted: Delete).
+
+Phases:
+  1. Deploy a 2-cluster external MongoDBMulti RS source (TLS+SCRAM) and a
+     MongoDBSearch spanning both clusters with a managed LB; drive to Running.
+  2. Presence guard: assert the FULL expected resource set exists per member
+     cluster (mongot kinds, proxy Svc, Envoy Deployment/CM, data PVC) plus the
+     state ConfigMap on the central cluster. Without this, phase 4's absence
+     polling could pass vacuously.
+  3. Light data-plane confidence: restore sample data, create a $search index,
+     run one query — proves the deployment being deleted was real.
+  4. DELETE the MongoDBSearch CR. Assert ZERO search-owned objects remain in
+     EACH member cluster (every kind from phase 2 including PVCs), the state CM
+     on central is GC'd (owner-ref), and the source MongoDBMulti is untouched
+     (still Running, its StatefulSets present in both clusters).
+  5. Re-create the same MongoDBSearch and drive it to Running again — a fresh
+     provision proves the deletion left no wreckage that blocks reinstall.
+
+Runs on the e2e_multi_cluster_2_clusters variant (deletion semantics need no
+third cluster). On this variant the central cluster doubles as member 1, so the
+default-client tools pod would work — but it is pinned to member cluster 0 for
+consistency with the 3-cluster add/remove test where the central cluster is
+outside the mesh.
+
+The source is external, so the operator does not inject search setParameters;
+the test patches every source mongod's mongotHost via OM AC, pointing them all
+at cluster 0's proxy-svc FQDN (single stable target). That FQDN disappears with
+the sweep and reappears on re-create under the same name (cluster indices are
+re-assigned in first-seen spec order after the state CM is GC'd), so no
+re-patching is needed — and a stale mongotHost never affects mongod health or
+the source's Running phase.
+"""
+
+from typing import List
+
+import kubernetes
+from kubernetes.client import CoreV1Api
+from kubetester import create_or_update_secret, try_load
+from kubetester.certs_mongodb_multi import create_multi_cluster_mongodb_tls_certs
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
+from kubetester.mongodb_multi import MongoDBMulti
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.multicluster_client import MultiClusterClient
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import mc_search_helper, search_resource_names
+from tests.common.search.mc_search_helper import (
+    assert_source_mongot_host_observed,
+    build_mongodb_user,
+    create_mc_lb_certificates,
+    create_mc_mongot_tls_cert,
+    patch_source_mongot_host_via_om,
+    replicate_search_secrets_to_members,
+)
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.rs_search_helper import get_mc_rs_search_tester
+from tests.common.search.search_deployment_helper import MCSearchDeploymentHelper
+from tests.common.search.sharded_search_helper import create_issuer_ca, verify_text_search_query
+from tests.multicluster.conftest import cluster_spec_list
+
+logger = test_logger.get_test_logger(__name__)
+
+MDB_RESOURCE_NAME = "mdb-mc-del"
+MDBS_RESOURCE_NAME = "mdb-mc-del-search"
+
+# The source MongoDBMulti RS spans both member clusters and stays fixed.
+# Typed List[int | None] to match cluster_spec_list's signature.
+SOURCE_MEMBERS_PER_CLUSTER: List[int | None] = [2, 2]
+
+MONGOT_REPLICAS_PER_CLUSTER = 1
+ENVOY_LB_REPLICAS = 2
+ENVOY_PROXY_PORT = 27028
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+
+MDBS_TLS_CERT_PREFIX = "certs"
+CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
+SOURCE_CERT_PREFIX = "clustercert"
+SOURCE_BUNDLE_SECRET = f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-cert"
+
+STATE_CONFIGMAP_NAME = mc_search_helper.state_configmap_name(MDBS_RESOURCE_NAME)
+
+SEARCH_INDEX_READY_TIMEOUT = 300
+SEARCH_QUERY_RETRY_TIMEOUT = 120
+# Generous bound for the OnDelete cross-cluster sweep + STS PVC reaping.
+DELETION_SWEEP_TIMEOUT = 300
+
+MARKER = mark.e2e_mc_search_cr_deletion
+
+
+def _build_search_resource(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDBMulti,
+    ca_configmap: str,
+) -> MongoDBSearch:
+    """MongoDBSearch spec over the external MongoDBMulti source, spanning both clusters.
+
+    A module function (not just a fixture body) so phase 5 can construct a FRESH
+    unbound object after the CR has been deleted: try_load finds nothing, leaving
+    the object unbound, so .update() creates it from scratch.
+    """
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-q2-mc-rs-search.yaml"),
+        name=MDBS_RESOURCE_NAME,
+        namespace=namespace,
+    )
+
+    seeds = [f"{svc}.{namespace}.svc.cluster.local:27017" for svc in mdb.service_names()]
+
+    resource["spec"]["source"] = {
+        "username": MONGOT_USER_NAME,
+        "passwordSecretRef": {
+            "name": f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+            "key": "password",
+        },
+        "external": {
+            "hostAndPorts": seeds,
+            "tls": {"ca": {"name": ca_configmap}},
+        },
+    }
+    resource["spec"]["security"] = {
+        "tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX},
+    }
+    resource["spec"]["loadBalancer"] = {
+        "managed": {
+            "externalHostname": (
+                f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-proxy-svc.{namespace}.svc.cluster.local"
+            ),
+        },
+    }
+    resource["spec"]["clusters"] = [
+        {"clusterName": mcc.cluster_name, "replicas": MONGOT_REPLICAS_PER_CLUSTER} for mcc in member_cluster_clients
+    ]
+
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@fixture(scope="module")
+def helper(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> MCSearchDeploymentHelper:
+    return MCSearchDeploymentHelper(
+        namespace=namespace,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        member_cluster_clients={mcc.cluster_name: mcc.core_v1_api() for mcc in member_cluster_clients},
+    )
+
+
+@fixture(scope="module")
+def ca_configmap(
+    issuer_ca_filepath: str,
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+) -> str:
+    return create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME, api_client=central_cluster_client)
+
+
+@fixture(scope="module")
+def stable_mongot_host(namespace: str) -> str:
+    """Cluster 0's proxy-svc FQDN:port — the single mongotHost every source mongod uses.
+
+    The proxy Service name is derived from the persisted cluster index, which is 0
+    for the first cluster both before deletion and after re-create, so this target
+    needs no re-patching across the CR delete/re-create cycle.
+    """
+    return f"{search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, 0)}:{ENVOY_PROXY_PORT}"
+
+
+@fixture(scope="module")
+def tools_pod(namespace: str, member_cluster_clients: List[MultiClusterClient]) -> mongodb_tools_pod.ToolsPod:
+    """mongorestore helper pod, pinned to member cluster 0.
+
+    On e2e_multi_cluster_2_clusters the central cluster doubles as member 1, so the
+    default client would also work — pinned anyway for consistency with the
+    3-cluster add/remove test, where the central cluster is outside the mesh.
+    """
+    return mongodb_tools_pod.get_tools_pod(namespace, api_client=member_cluster_clients[0].api_client)
+
+
+@fixture(scope="module")
+def mdb(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_names: List[str],
+    ca_configmap: str,
+) -> MongoDBMulti:
+    """2-cluster MongoDBMulti RS source with TLS+SCRAM, fixed for the whole test.
+
+    See q2_mc_rs_steady for why mongotHost is NOT set at spec level (the operator
+    would re-apply it to every process every reconcile). The MongoDBSearch deletion
+    under test must never touch this source.
+    """
+    resource = MongoDBMulti.from_yaml(
+        yaml_fixture("search-q2-mc-rs.yaml"),
+        name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    resource["spec"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, SOURCE_MEMBERS_PER_CLUSTER)
+    resource["spec"]["additionalMongodConfig"] = {
+        "setParameter": {
+            "skipAuthenticationToSearchIndexManagementServer": False,
+            "skipAuthenticationToMongot": False,
+            "searchTLSMode": "requireTLS",
+            "useGrpcForSearch": True,
+        },
+    }
+    resource["spec"]["security"] = {
+        "certsSecretPrefix": SOURCE_CERT_PREFIX,
+        "tls": {"ca": ca_configmap},
+        "authentication": {"enabled": True, "modes": ["SCRAM"]},
+    }
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="module")
+def mdbs(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDBMulti,
+    ca_configmap: str,
+) -> MongoDBSearch:
+    return _build_search_resource(namespace, central_cluster_client, member_cluster_clients, mdb, ca_configmap)
+
+
+@fixture(scope="module")
+def admin_user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    return build_mongodb_user(
+        yaml_filename="mongodbuser-mdb-admin.yaml",
+        name=ADMIN_USER_NAME,
+        username=ADMIN_USER_NAME,
+        mdb_resource_name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+        central_cluster_client=central_cluster_client,
+    )
+
+
+@fixture(scope="module")
+def user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    return build_mongodb_user(
+        yaml_filename="mongodbuser-mdb-user.yaml",
+        name=USER_NAME,
+        username=USER_NAME,
+        mdb_resource_name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+        central_cluster_client=central_cluster_client,
+    )
+
+
+@fixture(scope="module")
+def mongot_user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    return build_mongodb_user(
+        yaml_filename="mongodbuser-search-sync-source-user.yaml",
+        name=f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}",
+        username=MONGOT_USER_NAME,
+        mdb_resource_name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+        central_cluster_client=central_cluster_client,
+    )
+
+
+# =============================================================================
+# Phase 1: setup — source RS + MongoDBSearch to Running
+# =============================================================================
+
+
+@MARKER
+def test_install_operator(multi_cluster_operator: Operator):
+    multi_cluster_operator.assert_is_running()
+
+
+@MARKER
+def test_install_source_tls_certificates(
+    multi_cluster_issuer: str,
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+    central_cluster_client: kubernetes.client.ApiClient,
+):
+    create_multi_cluster_mongodb_tls_certs(
+        multi_cluster_issuer,
+        SOURCE_BUNDLE_SECRET,
+        member_cluster_clients,
+        central_cluster_client,
+        mdb,
+    )
+
+
+@MARKER
+def test_create_mdb_resource(mdb: MongoDBMulti):
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=1500)
+
+
+def _apply_user_password(
+    user_resource: MongoDBUser,
+    password: str,
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+) -> None:
+    create_or_update_secret(
+        namespace,
+        name=user_resource["spec"]["passwordSecretKeyRef"]["name"],
+        data={"password": password},
+        api_client=central_cluster_client,
+    )
+    user_resource.update()
+
+
+@MARKER
+def test_create_user_credentials(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    admin_user: MongoDBUser,
+    user: MongoDBUser,
+    mongot_user: MongoDBUser,
+):
+    _apply_user_password(admin_user, ADMIN_USER_PASSWORD, namespace, central_cluster_client)
+    admin_user.assert_reaches_phase(Phase.Updated, timeout=300)
+
+    _apply_user_password(user, USER_PASSWORD, namespace, central_cluster_client)
+    user.assert_reaches_phase(Phase.Updated, timeout=300)
+
+    # mongot user needs searchCoordinator role from the MongoDBSearch CR; don't wait here.
+    _apply_user_password(mongot_user, MONGOT_USER_PASSWORD, namespace, central_cluster_client)
+
+
+@MARKER
+def test_deploy_lb_certificates(
+    namespace: str,
+    multi_cluster_issuer: str,
+    helper: MCSearchDeploymentHelper,
+):
+    create_mc_lb_certificates(
+        namespace=namespace,
+        issuer=multi_cluster_issuer,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        tls_cert_prefix=MDBS_TLS_CERT_PREFIX,
+        helper=helper,
+        envoy_lb_replicas=ENVOY_LB_REPLICAS,
+    )
+
+
+@MARKER
+def test_create_search_tls_certificate(
+    namespace: str,
+    multi_cluster_issuer: str,
+    helper: MCSearchDeploymentHelper,
+):
+    create_mc_mongot_tls_cert(
+        namespace=namespace,
+        issuer=multi_cluster_issuer,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        tls_cert_prefix=MDBS_TLS_CERT_PREFIX,
+        helper=helper,
+    )
+
+
+@MARKER
+def test_replicate_secrets_to_members(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Replicate TLS Secrets, mongot password, and CA to every member cluster.
+
+    MCK does not replicate Secrets in production — that's the customer's job. The
+    Secrets survive the CR deletion (they are customer-owned, not search-owned),
+    which is also what lets phase 5 re-create without re-running this step.
+    """
+    replicate_search_secrets_to_members(
+        namespace=namespace,
+        central_cluster_client=central_cluster_client,
+        member_cluster_clients=member_cluster_clients,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        mdbs_tls_cert_prefix=MDBS_TLS_CERT_PREFIX,
+        mongot_user_name=MONGOT_USER_NAME,
+        ca_configmap_name=CA_CONFIGMAP_NAME,
+    )
+
+
+@MARKER
+def test_create_search_resource(mdbs: MongoDBSearch):
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@MARKER
+def test_patch_source_mongot_host(
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+    stable_mongot_host: str,
+):
+    """Point EVERY source mongod at cluster 0's proxy-svc FQDN via OM AC.
+
+    For an external source the operator does not inject search setParameters, so
+    the source mongods need mongotHost / searchIndexManagementHostAndPort set
+    directly. A single stable target keeps the AC valid across the delete and
+    re-create of the search CR (the per-index proxy Service name is identical
+    before and after).
+    """
+    patch_source_mongot_host_via_om(mdb=mdb, mongot_host=stable_mongot_host)
+    assert_source_mongot_host_observed(
+        mdb=mdb, member_cluster_clients=member_cluster_clients, expected_mongot_host=stable_mongot_host
+    )
+
+
+# =============================================================================
+# Phase 2: presence guard — the full per-cluster resource set exists
+# =============================================================================
+
+
+@MARKER
+def test_full_resource_set_present_per_cluster(
+    namespace: str,
+    helper: MCSearchDeploymentHelper,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Every member cluster carries the complete, owner-labelled mongot + Envoy set
+    AND its mongot data PVC(s). Phase 4 polls these exact kinds to absence — without
+    this guard the deletion assertions could pass vacuously against a half-deployed
+    search.
+    """
+    for mcc in member_cluster_clients:
+        idx = helper.cluster_index(mcc.cluster_name)
+        mc_search_helper.assert_cluster_search_resources_present(
+            mcc=mcc, mdbs_resource_name=MDBS_RESOURCE_NAME, cluster_index=idx, namespace=namespace
+        )
+
+        pvcs = mc_search_helper.data_pvcs_for_cluster(mcc, MDBS_RESOURCE_NAME, idx, namespace)
+        assert len(pvcs) == MONGOT_REPLICAS_PER_CLUSTER, (
+            f"cluster {mcc.cluster_name} (idx={idx}): expected {MONGOT_REPLICAS_PER_CLUSTER} mongot data PVC(s), "
+            f"found {[p.metadata.name for p in pvcs]}"
+        )
+        logger.info(f"cluster {mcc.cluster_name} (idx={idx}) data PVC(s): {[p.metadata.name for p in pvcs]}")
+
+
+@MARKER
+def test_state_configmap_present(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    helper: MCSearchDeploymentHelper,
+):
+    """The <name>-state ConfigMap on the central cluster maps every member cluster
+    to its persisted index. Phase 4 asserts this same ConfigMap is GC'd.
+    """
+    mapping = mc_search_helper.read_persisted_cluster_mapping(
+        namespace=namespace, central_cluster_client=central_cluster_client, mdbs_resource_name=MDBS_RESOURCE_NAME
+    )
+    for cluster_name in helper.member_cluster_names():
+        expected_idx = helper.cluster_index(cluster_name)
+        assert mapping.get(cluster_name) == expected_idx, (
+            f"clusterMapping[{cluster_name!r}]={mapping.get(cluster_name)!r}, want {expected_idx}; "
+            f"full mapping={mapping}"
+        )
+    logger.info(f"state CM {STATE_CONFIGMAP_NAME} present with mapping {mapping}")
+
+
+# =============================================================================
+# Phase 3: light data-plane confidence
+# =============================================================================
+
+
+@MARKER
+def test_create_search_index(mdb: MongoDBMulti, tools_pod):
+    """Restore the sample dataset and create the $search index against the source RS."""
+    tester = get_mc_rs_search_tester(mdb, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    tester.mongorestore_from_url(
+        archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
+        ns_include="sample_mflix.*",
+        tools_pod=tools_pod,
+    )
+
+    user_tester = get_mc_rs_search_tester(mdb, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=user_tester)
+    movies.create_search_index()
+    user_tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@MARKER
+def test_search_serves(mdb: MongoDBMulti):
+    """$search must return non-empty results — the deployment being deleted is real.
+    Polled (generously) since mongot may briefly be in INITIAL_SYNC.
+    """
+    tester = get_mc_rs_search_tester(mdb, USER_NAME, USER_PASSWORD)
+    verify_text_search_query(tester, timeout=SEARCH_QUERY_RETRY_TIMEOUT)
+
+
+# =============================================================================
+# Phase 4: delete the CR — everything search-owned must vanish everywhere
+# =============================================================================
+
+
+@MARKER
+def test_delete_search_cr(mdbs: MongoDBSearch):
+    mdbs.delete()
+
+    def cr_gone():
+        try:
+            mdbs.load()
+            return False, f"MongoDBSearch {mdbs.name} still present"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"MongoDBSearch {mdbs.name} deleted"
+            raise
+
+    run_periodically(cr_gone, timeout=120, sleep_time=5, msg="MongoDBSearch CR deletion")
+
+
+@MARKER
+def test_all_member_clusters_fully_swept(
+    namespace: str,
+    helper: MCSearchDeploymentHelper,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """ZERO search-owned objects remain in ANY member cluster: mongot StatefulSet,
+    headless + proxy Services, mongot ConfigMap, data PVCs (STS retention policy),
+    and the Envoy Deployment + ConfigMap. Each kind is polled independently so a
+    partial sweep names the exact resource that leaked.
+    """
+    for mcc in member_cluster_clients:
+        mc_search_helper.wait_for_cluster_search_resources_absent(
+            mcc=mcc,
+            mdbs_resource_name=MDBS_RESOURCE_NAME,
+            cluster_index=helper.cluster_index(mcc.cluster_name),
+            namespace=namespace,
+            timeout=DELETION_SWEEP_TIMEOUT,
+        )
+
+
+@MARKER
+def test_state_configmap_garbage_collected(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+):
+    """The <name>-state ConfigMap on the central cluster is owner-ref'd to the
+    search CR, so Kubernetes GC removes it with the CR (no operator sweep needed).
+    """
+    core = CoreV1Api(api_client=central_cluster_client)
+
+    def state_cm_gone():
+        try:
+            core.read_namespaced_config_map(name=STATE_CONFIGMAP_NAME, namespace=namespace)
+            return False, f"state CM {STATE_CONFIGMAP_NAME} still exists on the central cluster"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"state CM {STATE_CONFIGMAP_NAME} garbage-collected"
+            raise
+
+    run_periodically(
+        state_cm_gone,
+        timeout=DELETION_SWEEP_TIMEOUT,
+        sleep_time=10,
+        msg=f"state CM {STATE_CONFIGMAP_NAME} GC on central",
+    )
+
+
+@MARKER
+def test_source_mongodb_untouched(
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """The search sweep must not touch the source MongoDBMulti: still Running, and
+    its per-cluster StatefulSets present in both clusters at full member count.
+    (The stale mongotHost in the AC is harmless for an external source — mongod
+    health does not depend on the mongot target being resolvable.)
+    """
+    mdb.load()
+    mdb.assert_reaches_phase(Phase.Running, timeout=120)
+
+    statefulsets = mdb.read_statefulsets(member_cluster_clients)  # raises 404 if any STS was swept
+    assert len(statefulsets) == len(member_cluster_clients)
+    for i, (cluster_name, sts) in enumerate(statefulsets.items()):
+        expected_members = SOURCE_MEMBERS_PER_CLUSTER[i]
+        assert sts.spec.replicas == expected_members, (
+            f"source STS {sts.metadata.name} in {cluster_name}: spec.replicas={sts.spec.replicas}, "
+            f"want {expected_members}"
+        )
+        logger.info(
+            f"source STS {sts.metadata.name} untouched in {cluster_name} "
+            f"(replicas={sts.spec.replicas}, ready={sts.status.ready_replicas})"
+        )
+
+
+# =============================================================================
+# Phase 5: re-create — deletion left nothing that blocks a fresh provision
+# =============================================================================
+
+
+@MARKER
+def test_recreate_search_resource(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDBMulti,
+    ca_configmap: str,
+):
+    """Re-create the same MongoDBSearch CR and drive it to Running. A fresh object
+    is built (the module fixture is still bound to the deleted CR's stale state);
+    try_load finds nothing post-delete, so .update() creates from scratch.
+    """
+    recreated = _build_search_resource(namespace, central_cluster_client, member_cluster_clients, mdb, ca_configmap)
+    recreated.update()
+    recreated.assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@MARKER
+def test_recreated_resources_present_per_cluster(
+    namespace: str,
+    helper: MCSearchDeploymentHelper,
+    member_cluster_clients: List[MultiClusterClient],
+    central_cluster_client: kubernetes.client.ApiClient,
+):
+    """Every member cluster rematerializes its full mongot + Envoy resource set
+    under the same per-cluster indices (state CM was GC'd, so indices are
+    re-assigned in first-seen spec order — identical to the original layout).
+    """
+    # Pin the index-reassignment property explicitly — the AC mongotHost target
+    # staying valid across delete/re-create rests on it.
+    mapping = mc_search_helper.read_persisted_cluster_mapping(
+        namespace=namespace,
+        central_cluster_client=central_cluster_client,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+    )
+    assert mapping == {mcc.cluster_name: helper.cluster_index(mcc.cluster_name) for mcc in member_cluster_clients}, (
+        f"re-created CR must re-assign the original cluster indices, got {mapping}"
+    )
+
+    for mcc in member_cluster_clients:
+        mc_search_helper.wait_for_cluster_search_resources_present(
+            mcc=mcc,
+            mdbs_resource_name=MDBS_RESOURCE_NAME,
+            cluster_index=helper.cluster_index(mcc.cluster_name),
+            namespace=namespace,
+        )


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1232

## Chain of upstream PRs as of 2026-06-28

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1232:
      `search/ga-base` ← `search/lifecycle-teardown`

      * **PR #1241 (THIS ONE)**:
        `search/lifecycle-teardown` ← `search/lifecycle-ondelete`

<!-- end git-machete generated -->

## Summary

Stacked on #1232. Deleting a MongoDBSearch CR in **centralized multi-cluster** mode currently leaks every search-owned resource in member clusters — owner references don't cross cluster boundaries, so Kubernetes GC never reaches them. This PR adds the event-driven `OnDelete` deletion path at **exact sharded-MC parity** (template: `ShardedClusterReconcileHelper.OnDelete`). Per explicit decision: **no finalizer** — same accepted semantics as sharded MC (cleanup is best-effort; operator-down or member-unreachable at delete time are accepted windows).

## What it does

- Both the MongoDBSearch and MongoDBSearchEnvoy controllers now watch the CR with `ResourceEventHandler{deleter}` (the same construction as sharded/RS/standalone/multi controllers; verified behavior-identical for Create/Update events — the embedded enqueue handler is an empty struct).
- **Search controller OnDelete**: in MC mode, runs the #1232 stale sweep with empty expectations across central + all member clusters — deletes every owned mongot StatefulSet/headless Service/ConfigMap/proxy Service; PVCs ride along via the `whenDeleted: Delete` retention policy. Per-cluster failures accumulate (`errors.Join`) and never abort remaining clusters. Watched-resource registrations dropped afterward.
- **Envoy controller OnDelete**: reuses the existing teardown (`deleteAllEnvoyResources`) for Envoy Deployments/ConfigMaps + drops its own watch registrations.
- Single-cluster mode is untouched: owner-ref GC handles everything (the MC predicate also keeps legacy stored CRs with empty `clusters[]` on the GC path).
- New shared `searchcontroller.IsMultiClusterMode` predicate replaces three drift-prone inline copies.

## Tests

- Unit (mutation-verified — stubbing the sweep fails all three): full MC delete removes everything on central + both members while foreign-owned look-alikes survive; one erroring member doesn't block the other's cleanup; state-CM-already-GC'd fallback.
- Unit, second pass closing audit gaps (also mutation-verified): single-cluster OnDelete deletes nothing (owner-ref GC parity) and only drops watch registrations; legacy CR with empty `clusters[]` under an MC operator stays on the GC path (pins the `IsMultiClusterMode` conjunct); both controllers drop only the deleted search's watcher entries; both sweeps clean a cluster already removed from `spec.clusters`; `IsMultiClusterMode` truth table.
- The `ResourceEventHandler` registration itself (the delete event actually reaching `OnDelete` through controller-runtime) has no unit-level pin — the repo has no envtest harness — so `e2e_mc_search_cr_deletion` is the load-bearing test for that wiring.
- NEW e2e `e2e_mc_search_cr_deletion` (2-cluster variant, 19 tests): deploy → presence-guard all 7 resource kinds per member (anti-vacuity anchor) → live `$search` → **delete CR → poll all kinds to zero in both members** (incl. PVCs + Envoy), source MongoDBMulti untouched → re-create the CR → Running again with the original cluster indices re-assigned (explicitly asserted — the AC mongotHost target stays valid).

## Notes

- Found during this work, NOT fixed here (follow-up): the **sharded internal source's** search setParameters (`mongotHost`, `searchIndexManagementHostAndPort`) are sticky in the automation config after search CR deletion — they're injected into `desiredShardsConfiguration` from a spec deep-copy and never reach `LastAchievedSpec`, so the removal diff can't see them. The RS source self-cleans. GA MC path (external sources) is unaffected.
- No RBAC changes, no finalizer, no EventRecorder.

## Validation

Evergreen all green on exec0 — [6a2b2c58](https://evergreen.mongodb.com/patch/6a2b2c5854fbb200078d8677): unit go+python, `e2e_mc_search_cr_deletion`, `e2e_search_q2_mc_rs_steady` (regression for the watch-handler swap), `e2e_mc_search_cluster_add_remove` (regression for the shared-helper refactor).



## Ticket

KUBE-133 — MongoDBSearch CR-delete cleanup across all clusters (centralized MC)