### PR TITLE
KUBE-123: Fix IsRunningEnterpriseImage for Community CR deployment telemetry

### DIFF
--- a/changelog/20260612_fix_community_deployment_enterprise_image_telemetry.md
+++ b/changelog/20260612_fix_community_deployment_enterprise_image_telemetry.md
@@ -1,0 +1,8 @@
+---
+title: Fix Community deployment enterprise image telemetry
+kind: fix
+date: 2026-06-12
+---
+
+* Fixed a bug where all `MongoDBCommunity` deployment telemetry rows incorrectly reported `IsRunningEnterpriseImage = true`. The field was being evaluated against the operator-level enterprise image rather than the image configured in each CR's spec, causing a misleading ~100% enterprise rate for the Community deployment type.
+* `IsRunningEnterpriseImage` for Community deployments is now derived from the `mongod` container image override in `spec.statefulSet.spec.template.spec.containers`, if present. When no override is set, the field correctly defaults to `false`, reflecting that Community CRs use the community MongoDB server image by default.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -77,16 +77,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -127,12 +127,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.1"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.2"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.9.1
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.9.2
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.9.0
+  replaces: mongodb-kubernetes.v1.9.1
   version: 0.0.0

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.9.1
+version: 1.9.2
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.9.1
+  version: 1.9.2
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.9.1
+  version: 1.9.2
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -146,11 +146,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.9.1
+  version: 1.9.2
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.9.1
+  version: 1.9.2
 
 ## Ops Manager
 opsManager:
@@ -158,7 +158,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.9.1
+  version: 1.9.2
 
 agent:
   name: mongodb-agent

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -220,7 +220,7 @@ func collectDeploymentsSnapshot(ctx context.Context, operatorClusterMgr manager.
 	events = append(events, addMultiEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture, now)...)
 	// No need to pass databaseNonStaticImage because it is for sure not enterprise image
 	events = append(events, addOmEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, defaultArchitecture, now)...)
-	events = append(events, addCommunityEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, now)...)
+	events = append(events, addCommunityEvents(ctx, operatorClusterClient, operatorUUID, now)...)
 	events = append(events, addSearchEvents(ctx, operatorClusterClient, operatorUUID, defaultArchitecture, now)...)
 	return events
 }
@@ -352,7 +352,7 @@ func createEvent(properties FlatProperties, now time.Time, eventType EventType) 
 	}
 }
 
-func addCommunityEvents(ctx context.Context, operatorClusterClient kubeclient.Client, operatorUUID, mongodbImage string, now time.Time) []Event {
+func addCommunityEvents(ctx context.Context, operatorClusterClient kubeclient.Client, operatorUUID string, now time.Time) []Event {
 	var events []Event
 	communityList := &mcov1.MongoDBCommunityList{}
 
@@ -366,7 +366,7 @@ func addCommunityEvents(ctx context.Context, operatorClusterClient kubeclient.Cl
 				Architecture:             "static", // Community operator is always static
 				IsMultiCluster:           false,    // Community operator doesn't support multi-cluster
 				Type:                     "Community",
-				IsRunningEnterpriseImage: images.IsEnterpriseImage(mongodbImage),
+				IsRunningEnterpriseImage: isCommunityRunningEnterpriseImage(item),
 			}
 			if event := createEvent(properties, now, Deployments); event != nil {
 				events = append(events, *event)
@@ -374,6 +374,18 @@ func addCommunityEvents(ctx context.Context, operatorClusterClient kubeclient.Cl
 		}
 	}
 	return events
+}
+
+// isCommunityRunningEnterpriseImage checks if a MongoDBCommunity CR is configured to run an
+// enterprise MongoDB image. Community CRs default to the community server image; enterprise
+// is only used when the user explicitly overrides the mongod container image in the CR spec.
+func isCommunityRunningEnterpriseImage(mdb mcov1.MongoDBCommunity) bool {
+	for _, c := range mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.Template.Spec.Containers {
+		if c.Name == "mongod" && len(c.Image) > 0 {
+			return images.IsEnterpriseImage(c.Image)
+		}
+	}
+	return false
 }
 
 func resolveSearchSource(ctx context.Context, operatorClusterClient kubeclient.Client, source *userv1.MongoDBResourceRef, defaultArchitecture architectures.DefaultArchitecture) (architecture string, isEnterprise bool, ok bool) {

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -16,9 +16,11 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdbmulti"
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
@@ -1171,47 +1173,77 @@ func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 	return m.MockGet(ctx, key, obj, opts...)
 }
 
-func TestAddCommunityEvents(t *testing.T) {
-	operatorUUID := "test-operator-uuid"
-
-	// Those 2 cases are when a customer uses Community reconciler to deploy enterprise or community MDB image
-	testCases := []struct {
-		name         string
-		mongodbImage string
-		isEnterprise bool
-	}{
-		{
-			name:         "With community image",
-			mongodbImage: "mongodb-community-server",
-			isEnterprise: false,
-		},
-		{
-			name:         "With enterprise image",
-			mongodbImage: "mongodb-enterprise-server",
-			isEnterprise: true,
+func communityItemWithMongodImage(uid, name, image string) mcov1.MongoDBCommunity {
+	item := mcov1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID(uid),
+			Name: name,
 		},
 	}
-
-	now := time.Now()
-
-	for _, tc := range testCases {
-		t.Run("With community resources", func(t *testing.T) {
-			communityList := &mcov1.MongoDBCommunityList{
-				Items: []mcov1.MongoDBCommunity{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							UID:  types.UID("community-1"),
-							Name: "test-community-1",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							UID:  types.UID("community-2"),
-							Name: "test-community-2",
+	if image != "" {
+		item.Spec.StatefulSetConfiguration = v1.StatefulSetConfiguration{
+			SpecWrapper: v1.StatefulSetSpecWrapper{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "mongod", Image: image},
+							},
 						},
 					},
 				},
-			}
+			},
+		}
+	}
+	return item
+}
+
+func TestAddCommunityEvents(t *testing.T) {
+	operatorUUID := "test-operator-uuid"
+	now := time.Now()
+
+	testCases := []struct {
+		name         string
+		items        []mcov1.MongoDBCommunity
+		isEnterprise []bool
+	}{
+		{
+			name: "No container image override defaults to community (not enterprise)",
+			items: []mcov1.MongoDBCommunity{
+				communityItemWithMongodImage("community-1", "test-community-1", ""),
+				communityItemWithMongodImage("community-2", "test-community-2", ""),
+			},
+			isEnterprise: []bool{false, false},
+		},
+		{
+			name: "Explicit enterprise image override reports enterprise",
+			items: []mcov1.MongoDBCommunity{
+				communityItemWithMongodImage("community-1", "test-community-1", "mongodb-enterprise-server:7.0"),
+				communityItemWithMongodImage("community-2", "test-community-2", "mongodb-enterprise-server:7.0"),
+			},
+			isEnterprise: []bool{true, true},
+		},
+		{
+			name: "Explicit community image override reports non-enterprise",
+			items: []mcov1.MongoDBCommunity{
+				communityItemWithMongodImage("community-1", "test-community-1", "mongodb-community-server:7.0"),
+				communityItemWithMongodImage("community-2", "test-community-2", "mongodb-community-server:7.0"),
+			},
+			isEnterprise: []bool{false, false},
+		},
+		{
+			name: "Mixed: one enterprise override, one default",
+			items: []mcov1.MongoDBCommunity{
+				communityItemWithMongodImage("community-1", "test-community-1", "mongodb-enterprise-server:7.0"),
+				communityItemWithMongodImage("community-2", "test-community-2", ""),
+			},
+			isEnterprise: []bool{true, false},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			communityList := &mcov1.MongoDBCommunityList{Items: tc.items}
 
 			mc := &MockClient{
 				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
@@ -1222,49 +1254,43 @@ func TestAddCommunityEvents(t *testing.T) {
 				},
 			}
 
-			events := addCommunityEvents(context.Background(), mc, operatorUUID, tc.mongodbImage, now)
+			events := addCommunityEvents(context.Background(), mc, operatorUUID, now)
 
-			assert.Len(t, events, 2, "Should return 2 events for 2 community resources")
-
-			assert.Equal(t, now, events[0].Timestamp)
-			assert.Equal(t, Deployments, events[0].Source)
-			assert.Equal(t, "community-1", events[0].Properties["deploymentUID"])
-			assert.Equal(t, operatorUUID, events[0].Properties["operatorID"])
-			assert.Equal(t, false, events[0].Properties["isMultiCluster"])
-			assert.Equal(t, "Community", events[0].Properties["type"])
-			assert.Equal(t, tc.isEnterprise, events[0].Properties["IsRunningEnterpriseImage"])
-
-			assert.Equal(t, "community-2", events[1].Properties["deploymentUID"])
-			assert.Equal(t, tc.isEnterprise, events[1].Properties["IsRunningEnterpriseImage"])
-		})
-
-		t.Run("With list error", func(t *testing.T) {
-			mc := &MockClient{
-				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-					return errors.New("list error")
-				},
+			assert.Len(t, events, len(tc.items), "Should return one event per community resource")
+			for i, event := range events {
+				assert.Equal(t, now, event.Timestamp)
+				assert.Equal(t, Deployments, event.Source)
+				assert.Equal(t, string(tc.items[i].UID), event.Properties["deploymentUID"])
+				assert.Equal(t, operatorUUID, event.Properties["operatorID"])
+				assert.Equal(t, false, event.Properties["isMultiCluster"])
+				assert.Equal(t, "Community", event.Properties["type"])
+				assert.Equal(t, tc.isEnterprise[i], event.Properties["IsRunningEnterpriseImage"])
 			}
-
-			events := addCommunityEvents(context.Background(), mc, operatorUUID, tc.mongodbImage, now)
-
-			assert.Empty(t, events, "Should return empty slice on list error")
-		})
-
-		t.Run("With empty list", func(t *testing.T) {
-			mc := &MockClient{
-				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-					if l, ok := list.(*mcov1.MongoDBCommunityList); ok {
-						*l = mcov1.MongoDBCommunityList{}
-					}
-					return nil
-				},
-			}
-
-			events := addCommunityEvents(context.Background(), mc, operatorUUID, tc.mongodbImage, now)
-
-			assert.Empty(t, events, "Should return empty slice for empty community list")
 		})
 	}
+
+	t.Run("With list error", func(t *testing.T) {
+		mc := &MockClient{
+			MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				return errors.New("list error")
+			},
+		}
+		events := addCommunityEvents(context.Background(), mc, operatorUUID, now)
+		assert.Empty(t, events, "Should return empty slice on list error")
+	})
+
+	t.Run("With empty list", func(t *testing.T) {
+		mc := &MockClient{
+			MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				if l, ok := list.(*mcov1.MongoDBCommunityList); ok {
+					*l = mcov1.MongoDBCommunityList{}
+				}
+				return nil
+			},
+		}
+		events := addCommunityEvents(context.Background(), mc, operatorUUID, now)
+		assert.Empty(t, events, "Should return empty slice for empty community list")
+	})
 }
 
 func TestAddSearchEvents(t *testing.T) {

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -344,7 +344,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -403,16 +403,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -339,7 +339,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -392,16 +392,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -440,12 +440,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.1"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_1
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.1"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.9.2"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_9_2
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.9.2"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -344,7 +344,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.9.1"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.9.2"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -400,16 +400,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: DATABASE_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.9.1"
+              value: "1.9.2"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
@@ -13,6 +13,7 @@ rules:
   - clustermongodbroles
   verbs:
   - '*'
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -113,6 +114,7 @@ rules:
   verbs:
   - list
   - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -140,6 +142,7 @@ rules:
   - /version
   verbs:
   - get
+
 ---
 # Central Cluster, cluster-scoped resources
 apiVersion: rbac.authorization.k8s.io/v1
@@ -157,6 +160,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -173,6 +177,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -189,6 +194,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 # Central Cluster, cluster-scoped resources
 apiVersion: v1
@@ -199,5 +205,5 @@ metadata:
     multi-cluster: "true"
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
----
 
+---

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
@@ -92,6 +92,7 @@ rules:
   - watch
   - delete
   - deletecollection
+
 ---
 # Central Cluster, namespace-scoped resources
 apiVersion: rbac.authorization.k8s.io/v1
@@ -110,6 +111,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 # Central Cluster, namespace-scoped resources
 apiVersion: v1
@@ -120,5 +122,5 @@ metadata:
     multi-cluster: "true"
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
----
 
+---

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.17.0.tgz"
   },
-  "mongodbOperator": "1.9.1",
-  "initDatabaseVersion": "1.9.1",
-  "initOpsManagerVersion": "1.9.1",
-  "databaseImageVersion": "1.9.1",
+  "mongodbOperator": "1.9.2",
+  "initDatabaseVersion": "1.9.2",
+  "initOpsManagerVersion": "1.9.2",
+  "databaseImageVersion": "1.9.2",
   "agentVersion": "108.0.12.8846-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -97,7 +97,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"
@@ -294,7 +295,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"
@@ -317,7 +319,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"
@@ -340,7 +343,8 @@
         "1.8.1",
         "1.8.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.1",
+        "1.9.2"
       ],
       "variants": [
         "ubi"


### PR DESCRIPTION
# Summary

All MongoDBCommunity deployment telemetry rows were reporting `IsRunningEnterpriseImage` = true, producing a misleading ~98% enterprise rate for the Community type.

The root cause: addCommunityEvents evaluated Images.IsEnterpriseImage (mongodbImage) where mongodbImage is the env var used only by MEKO Controllers (e.g. non MongoDBCommunity CRD resources), which - by default - always contains the enterprise string — regardless of what MongoDB Community server image the CR itself is actually running.

Fix

pkg/telemetry/collector.go

- Removed **mongodbImage** from addCommunityEvents (it was the wrong signal entirely).
- Added `isCommunityRunningEnterpriseImage(mdb)`, which mirrors the logic already used by guessEnterprise in the community controller: inspect the mongod container image explicitly set in:

`mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.Template.Spec.Containers`

If the user has overridden it with an enterprise image → true; otherwise → false (Community CRs use the community server image by default).

The MongoDB (enterprise) CR path in `getMdbEvents` already evaluates enterprise status at the CR level via per-resource annotations. The `addCommunityEvents` now follows the same principle — the check is grounded in what the CR is actually configured to run, not what the operator binary itself is built from.

## Proof of Work

Updated TestAddCommunityEvents in collector_test.go:
- Old tests incorrectly validated behavior driven by the (now-removed) `mongodbImage` parameter.
- New test cases cover: 
  - no image override (→ false)
  - explicit enterprise override (→ true)
  - explicit community override (→ false)
  - and mixed CRs in the same list.

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you added changelog file?
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
