### PR TITLE
[KUBE-128] Add server.name in mongot config to pod name

### DIFF
--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -134,6 +134,7 @@ func buildExpectedMongotConfig(search *searchv1.MongoDBSearch, mdbc *mdbcv1.Mong
 			DataPath: searchcontroller.MongotDataPath,
 		},
 		Server: mongot.ConfigServer{
+			Name: searchcontroller.ServerNamePlaceholder,
 			Grpc: &mongot.ConfigGrpc{
 				Address: fmt.Sprintf("0.0.0.0:%d", search.GetMongotGrpcPort()),
 				TLS:     &mongot.ConfigGrpcTLS{Mode: mongot.ConfigTLSModeDisabled},

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1493,6 +1493,7 @@ func baseMongotConfig(search *searchv1.MongoDBSearch, hostAndPorts []string) mon
 			DataPath: MongotDataPath,
 		}
 		config.Server = mongot.ConfigServer{
+			Name: ServerNamePlaceholder,
 			Grpc: &mongot.ConfigGrpc{
 				Address: fmt.Sprintf("0.0.0.0:%d", search.GetMongotGrpcPort()),
 				TLS: &mongot.ConfigGrpcTLS{

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -47,6 +47,11 @@ const (
 	X509ClientCertOperatorMountPath = "/var/lib/tls/x509-client/"
 
 	ServerNamePlaceholder = "__SERVER_NAME__"
+
+	// TempMongotConfigPath is the writable copy of the mongot config used at runtime.
+	// The original is mounted read-only from a ConfigMap; we copy it to /tmp so that
+	// sed can replace the server-name placeholder with the actual pod hostname.
+	TempMongotConfigPath = tempVolumePath + "/" + MongotConfigFilename
 )
 
 // SearchSourceDBResource is an object wrapping a MongoDBCommunity object
@@ -241,9 +246,11 @@ func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster search
 	if usePerPodConfig {
 		mongotStartCommand = mongotPerPodConfigStartCommand(jvmFlags)
 	} else {
-		// replace the string `ServerNamePlaceholder` from base mongot config (server.name) with pod name using `sed`
-		mongotStartCommand = fmt.Sprintf(`sed -i "s/%s/$HOSTNAME/" %s
-/mongot-community/mongot --config %s %s`, ServerNamePlaceholder, MongotConfigPath, MongotConfigPath, jvmFlags)
+		// Copy config from read-only ConfigMap mount to writable /tmp, replace the
+		// server-name placeholder with the actual pod hostname, then start mongot.
+		mongotStartCommand = fmt.Sprintf(`cp %s %s
+sed -i "s/%s/$HOSTNAME/" %s
+/mongot-community/mongot --config %s %s`, MongotConfigPath, TempMongotConfigPath, ServerNamePlaceholder, TempMongotConfigPath, TempMongotConfigPath, jvmFlags)
 	}
 
 	return container.Apply(
@@ -265,12 +272,13 @@ func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster search
 
 // mongotPerPodConfigStartCommand returns the shell script that reads the pod's role from ConfigMap.
 func mongotPerPodConfigStartCommand(jvmFlags string) string {
-	// replace the string `ServerNamePlaceholder` from base mongot config (server.name) with pod name using `sed`
+	// Copy the role-specific config from the read-only ConfigMap mount to writable /tmp,
+	// replace the server-name placeholder with the actual pod hostname, then start mongot.
 	return fmt.Sprintf(`ROLE=$(cat "%s/$HOSTNAME")
-CONFIG_FILE="%s/config-${ROLE}.yml"
-sed -i "s/%s/$HOSTNAME/" "$CONFIG_FILE"
-/mongot-community/mongot --config "$CONFIG_FILE" %s`,
-		MongotPerPodConfigDirPath, MongotPerPodConfigDirPath, ServerNamePlaceholder, jvmFlags)
+cp "%s/config-${ROLE}.yml" %s
+sed -i "s/%s/$HOSTNAME/" %s
+/mongot-community/mongot --config %s %s`,
+		MongotPerPodConfigDirPath, MongotPerPodConfigDirPath, TempMongotConfigPath, ServerNamePlaceholder, TempMongotConfigPath, TempMongotConfigPath, jvmFlags)
 }
 
 func mongotLivenessProbe(search *searchv1.MongoDBSearch) func(*corev1.Probe) {

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -45,6 +45,8 @@ const (
 	TempX509KeyPasswordPath         = tempVolumePath + "/x509-key-password" // #nosec G101 -- path, not a password
 	X509KeyPasswordSecretKey        = "tls.keyFilePassword"                 // #nosec G101 -- secret key name, not a password
 	X509ClientCertOperatorMountPath = "/var/lib/tls/x509-client/"
+
+	ServerNamePlaceholder = "__SERVER_NAME__"
 )
 
 // SearchSourceDBResource is an object wrapping a MongoDBCommunity object
@@ -239,7 +241,8 @@ func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster search
 	if usePerPodConfig {
 		mongotStartCommand = mongotPerPodConfigStartCommand(jvmFlags)
 	} else {
-		mongotStartCommand = fmt.Sprintf("/mongot-community/mongot --config %s %s", MongotConfigPath, jvmFlags)
+		mongotStartCommand = fmt.Sprintf(`sed -i "s/%s/$HOSTNAME/" %s
+/mongot-community/mongot --config %s %s`, ServerNamePlaceholder, MongotConfigPath, MongotConfigPath, jvmFlags)
 	}
 
 	return container.Apply(
@@ -262,8 +265,10 @@ func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster search
 // mongotPerPodConfigStartCommand returns the shell script that reads the pod's role from ConfigMap.
 func mongotPerPodConfigStartCommand(jvmFlags string) string {
 	return fmt.Sprintf(`ROLE=$(cat "%s/$HOSTNAME")
-/mongot-community/mongot --config %s/config-${ROLE}.yml %s`,
-		MongotPerPodConfigDirPath, MongotPerPodConfigDirPath, jvmFlags)
+CONFIG_FILE="%s/config-${ROLE}.yml"
+sed -i "s/%s/$HOSTNAME/" "$CONFIG_FILE"
+/mongot-community/mongot --config "$CONFIG_FILE" %s`,
+		MongotPerPodConfigDirPath, MongotPerPodConfigDirPath, ServerNamePlaceholder, jvmFlags)
 }
 
 func mongotLivenessProbe(search *searchv1.MongoDBSearch) func(*corev1.Probe) {

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -241,6 +241,7 @@ func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster search
 	if usePerPodConfig {
 		mongotStartCommand = mongotPerPodConfigStartCommand(jvmFlags)
 	} else {
+		// replace the string `ServerNamePlaceholder` from base mongot config (server.name) with pod name using `sed`
 		mongotStartCommand = fmt.Sprintf(`sed -i "s/%s/$HOSTNAME/" %s
 /mongot-community/mongot --config %s %s`, ServerNamePlaceholder, MongotConfigPath, MongotConfigPath, jvmFlags)
 	}
@@ -264,6 +265,7 @@ func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster search
 
 // mongotPerPodConfigStartCommand returns the shell script that reads the pod's role from ConfigMap.
 func mongotPerPodConfigStartCommand(jvmFlags string) string {
+	// replace the string `ServerNamePlaceholder` from base mongot config (server.name) with pod name using `sed`
 	return fmt.Sprintf(`ROLE=$(cat "%s/$HOSTNAME")
 CONFIG_FILE="%s/config-${ROLE}.yml"
 sed -i "s/%s/$HOSTNAME/" "$CONFIG_FILE"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -599,6 +599,37 @@ def test_verify_per_cluster_mongot_resources(
 
 
 @mark.e2e_search_q2_mc_rs_steady
+def test_verify_mongot_config_server_name(
+    namespace: str,
+    helper: MCSearchDeploymentHelper,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """The runtime mongot config inside each pod must have server.name set to the pod hostname.
+
+    The operator writes a placeholder in the ConfigMap; the container start script copies
+    the config to /tmp/config.yml and replaces the placeholder with $HOSTNAME via sed.
+    """
+    for mcc in member_cluster_clients:
+        idx = helper.cluster_index(mcc.cluster_name)
+        pod_name = f"{MDBS_RESOURCE_NAME}-search-{idx}-0"
+
+        raw = KubernetesTester.run_command_in_pod_container(
+            pod_name,
+            namespace,
+            ["cat", "/tmp/config.yml"],
+            container="mongot",
+            api_client=mcc.api_client,
+        )
+        parsed = yaml.safe_load(raw) or {}
+        server_name = parsed.get("server", {}).get("name", "")
+        assert server_name == pod_name, (
+            f"mongot pod {pod_name} in cluster {mcc.cluster_name}: "
+            f"server.name={server_name!r}, expected {pod_name!r}"
+        )
+        logger.info(f"[{mcc.cluster_name}] {pod_name}: server.name={server_name} OK")
+
+
+@mark.e2e_search_q2_mc_rs_steady
 def test_verify_per_cluster_envoy_deployment(
     namespace: str,
     helper: MCSearchDeploymentHelper,

--- a/pkg/mongot/mongot_config.go
+++ b/pkg/mongot/mongot_config.go
@@ -71,6 +71,7 @@ type ConfigStorage struct {
 }
 
 type ConfigServer struct {
+	Name      string           `json:"name,omitempty"`
 	Wireproto *ConfigWireproto `json:"wireproto,omitempty"`
 	Grpc      *ConfigGrpc      `json:"grpc,omitempty"`
 }


### PR DESCRIPTION
# Summary

There was a [request made by](https://mongodb.slack.com/archives/C07F4RWNKNH/p1781272920658129) the mongot folks to see if we can set the `server.name` of mongot config with the pod name so that they can show proper name to the customers for the metrics. If `server.name` is not set mongot sets it to randomly generated value.

This PR implements that by making sure that when we create base mongot config we add a string `__SERVER_NAME__` for mongot field `server.name` and then we replace it with actual pod name/host name right before we pass the config to the `mongot` command.

## Proof of Work

Unit test can be written which will verify that the pod CMD has correct string but that isn't that valuable.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
