### PR TITLE
[KUBE-129] Add E2E for x509 and scram mTLS with env keyfile and gRPC mTLS enc server conn

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1450,6 +1450,16 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_ext_mc_rs_x509_enc_mtls
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_search_ext_mc_sharded_scram_enc_mtls
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1095,6 +1095,8 @@ task_groups:
       - e2e_search_q3_mc_sharded_external_mtls
       - e2e_search_connectivity_tool_mc_rs
       - e2e_search_connectivity_tool_mc_sharded
+      - e2e_search_ext_mc_rs_x509_enc_mtls
+      - e2e_search_ext_mc_sharded_scram_enc_mtls
     <<: *teardown_group
 
   - name: e2e_multi_cluster_om_appdb_task_group

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_rs_x509_enc_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_rs_x509_enc_mtls.py
@@ -162,7 +162,8 @@ def mdbs(
     }
 
     resource["spec"]["clusters"] = [
-        {"clusterName": mcc.cluster_name, "replicas": MONGOT_REPLICAS_PER_CLUSTER} for mcc in member_cluster_clients
+        {"clusterName": mcc.cluster_name, "clusterIndex": mcc.cluster_index, "replicas": MONGOT_REPLICAS_PER_CLUSTER}
+        for mcc in member_cluster_clients
     ]
 
     resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
@@ -182,7 +183,9 @@ def _build_user(yaml_filename, name, username, namespace, central_cluster_client
 
 @fixture(scope="module")
 def admin_user(namespace, central_cluster_client):
-    return _build_user("mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client)
+    return _build_user(
+        "mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client
+    )
 
 
 @fixture(scope="module")
@@ -223,13 +226,24 @@ def test_install_source_tls_certificates(
 ):
     """Source MongoDB TLS bundle + agent/clusterfile certs for x509 (multi-cluster aware)."""
     create_multi_cluster_mongodb_x509_tls_certs(
-        multi_cluster_issuer, SOURCE_BUNDLE_SECRET, member_cluster_clients, central_cluster_client, mdb,
+        multi_cluster_issuer,
+        SOURCE_BUNDLE_SECRET,
+        member_cluster_clients,
+        central_cluster_client,
+        mdb,
     )
     create_multi_cluster_x509_agent_certs(
-        multi_cluster_issuer, f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-agent-certs", central_cluster_client, mdb,
+        multi_cluster_issuer,
+        f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-agent-certs",
+        central_cluster_client,
+        mdb,
     )
     create_multi_cluster_mongodb_x509_tls_certs(
-        multi_cluster_issuer, f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-clusterfile", member_cluster_clients, central_cluster_client, mdb,
+        multi_cluster_issuer,
+        f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-clusterfile",
+        member_cluster_clients,
+        central_cluster_client,
+        mdb,
     )
 
 
@@ -247,11 +261,21 @@ def test_create_user_credentials(
     user: MongoDBUser,
     x509_mongot_user: MongoDBUser,
 ):
-    create_or_update_secret(namespace, name=admin_user["spec"]["passwordSecretKeyRef"]["name"], data={"password": ADMIN_USER_PASSWORD}, api_client=central_cluster_client)
+    create_or_update_secret(
+        namespace,
+        name=admin_user["spec"]["passwordSecretKeyRef"]["name"],
+        data={"password": ADMIN_USER_PASSWORD},
+        api_client=central_cluster_client,
+    )
     admin_user.update()
     admin_user.assert_reaches_phase(Phase.Updated, timeout=300)
 
-    create_or_update_secret(namespace, name=user["spec"]["passwordSecretKeyRef"]["name"], data={"password": USER_PASSWORD}, api_client=central_cluster_client)
+    create_or_update_secret(
+        namespace,
+        name=user["spec"]["passwordSecretKeyRef"]["name"],
+        data={"password": USER_PASSWORD},
+        api_client=central_cluster_client,
+    )
     user.update()
     user.assert_reaches_phase(Phase.Updated, timeout=300)
 
@@ -271,16 +295,22 @@ def test_deploy_lb_certificates(namespace: str, multi_cluster_issuer: str, helpe
     ]
 
     create_tls_certs(
-        issuer=multi_cluster_issuer, namespace=namespace,
+        issuer=multi_cluster_issuer,
+        namespace=namespace,
         resource_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
-        replicas=ENVOY_LB_REPLICAS, service_name=server_domains[0].split(".")[0],
-        additional_domains=server_domains, secret_name=lb_server_cert_name,
+        replicas=ENVOY_LB_REPLICAS,
+        service_name=server_domains[0].split(".")[0],
+        additional_domains=server_domains,
+        secret_name=lb_server_cert_name,
     )
     create_tls_certs(
-        issuer=multi_cluster_issuer, namespace=namespace,
+        issuer=multi_cluster_issuer,
+        namespace=namespace,
         resource_name=f"{search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME)}-client",
-        replicas=1, service_name=server_domains[0].split(".")[0],
-        additional_domains=[f"*.{namespace}.svc.cluster.local"], secret_name=lb_client_cert_name,
+        replicas=1,
+        service_name=server_domains[0].split(".")[0],
+        additional_domains=[f"*.{namespace}.svc.cluster.local"],
+        secret_name=lb_client_cert_name,
     )
 
 
@@ -295,9 +325,11 @@ def test_create_search_tls_certificate(namespace: str, multi_cluster_issuer: str
         additional_domains.append(f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc.{namespace}.svc.cluster.local")
 
     create_tls_certs(
-        issuer=multi_cluster_issuer, namespace=namespace,
+        issuer=multi_cluster_issuer,
+        namespace=namespace,
         resource_name=search_resource_names.mongot_statefulset_name(MDBS_RESOURCE_NAME),
-        secret_name=secret_name, additional_domains=additional_domains,
+        secret_name=secret_name,
+        additional_domains=additional_domains,
     )
     encrypt_tls_key_with_password(namespace, secret_name, GRPC_KEY_PASSWORD)
     logger.info(f"gRPC server cert {secret_name} encrypted with password")
@@ -307,12 +339,25 @@ def test_create_search_tls_certificate(namespace: str, multi_cluster_issuer: str
 def test_create_x509_client_certificate(namespace: str, multi_cluster_issuer: str):
     """X509 client cert for mongot auth to mongod, with encrypted key."""
     x509_spec = {
-        "subject": {"countries": ["US"], "provinces": ["NY"], "localities": ["NY"], "organizations": ["cluster.local-client"], "organizationalUnits": [namespace]},
+        "subject": {
+            "countries": ["US"],
+            "provinces": ["NY"],
+            "localities": ["NY"],
+            "organizations": ["cluster.local-client"],
+            "organizationalUnits": [namespace],
+        },
         "commonName": X509_CLIENT_CERT_CN,
         "usages": ["digital signature", "key encipherment", "client auth"],
         "dnsNames": [X509_CLIENT_CERT_CN],
     }
-    generate_cert(namespace=namespace, pod="", dns="", issuer=multi_cluster_issuer, spec=x509_spec, secret_name=X509_CLIENT_CERT_SECRET_NAME)
+    generate_cert(
+        namespace=namespace,
+        pod="",
+        dns="",
+        issuer=multi_cluster_issuer,
+        spec=x509_spec,
+        secret_name=X509_CLIENT_CERT_SECRET_NAME,
+    )
     encrypt_tls_key_with_password(namespace, X509_CLIENT_CERT_SECRET_NAME, X509_AUTH_KEY_PASSWORD)
     logger.info(f"X509 client cert {X509_CLIENT_CERT_SECRET_NAME} created and encrypted")
 
@@ -337,7 +382,13 @@ def test_replicate_secrets_to_members(
     for secret_name in secrets_to_replicate:
         source = central_core.read_namespaced_secret(name=secret_name, namespace=namespace)
         for mcc in member_cluster_clients:
-            create_or_update_secret(namespace, secret_name, read_secret(namespace, secret_name, api_client=central_cluster_client), type=source.type or "Opaque", api_client=mcc.api_client)
+            create_or_update_secret(
+                namespace,
+                secret_name,
+                read_secret(namespace, secret_name, api_client=central_cluster_client),
+                type=source.type or "Opaque",
+                api_client=mcc.api_client,
+            )
         logger.info(f"replicated Secret {secret_name}")
 
     source_cm = central_core.read_namespaced_config_map(name=CA_CONFIGMAP_NAME, namespace=namespace)
@@ -353,7 +404,9 @@ def test_create_search_resource(mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_ext_mc_rs_x509_enc_mtls
-def test_verify_per_cluster_resources(namespace: str, helper: MCSearchDeploymentHelper, member_cluster_clients: List[MultiClusterClient]):
+def test_verify_per_cluster_resources(
+    namespace: str, helper: MCSearchDeploymentHelper, member_cluster_clients: List[MultiClusterClient]
+):
     for mcc in member_cluster_clients:
         idx = helper.cluster_index(mcc.cluster_name)
         mcc.read_namespaced_stateful_set(f"{MDBS_RESOURCE_NAME}-search-{idx}", namespace)
@@ -383,7 +436,9 @@ def test_patch_per_cluster_mongot_host(
         # hostname pattern: mdb-mc-rs-x509-{clusterIdx}-{podIdx}-svc.namespace...
         cluster_idx = int(parts[-2])
 
-        proxy_host = f"{MDBS_RESOURCE_NAME}-search-{cluster_idx}-proxy-svc.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}"
+        proxy_host = (
+            f"{MDBS_RESOURCE_NAME}-search-{cluster_idx}-proxy-svc.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}"
+        )
         set_param = process.setdefault("args2_6", {}).setdefault("setParameter", {})
         set_param["mongotHost"] = proxy_host
         set_param["searchIndexManagementHostAndPort"] = proxy_host
@@ -393,7 +448,6 @@ def test_patch_per_cluster_mongot_host(
     om_tester.om_request("put", ac_path, json_object=ac)
     om_tester.wait_agents_ready(timeout=900)
     logger.info("All agents reached goal state with mongotHost configured")
-
 
 
 def _search_tester(mdb: MongoDBMulti, username: str, password: str) -> SearchTester:
@@ -407,7 +461,8 @@ def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
     tester = _search_tester(mdb, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
     tester.mongorestore_from_url(
         archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
-        ns_include="sample_mflix.*", tools_pod=tools_pod,
+        ns_include="sample_mflix.*",
+        tools_pod=tools_pod,
     )
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_rs_x509_enc_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_rs_x509_enc_mtls.py
@@ -1,0 +1,437 @@
+"""MC-RS e2e: MongoDBSearch with X509 mTLS + gRPC mTLS (encrypted keys).
+
+Based on q2_mc_rs_steady pattern (external MongoDBMulti RS source), adds:
+- Encrypted private keys on mongot gRPC server cert (tls.keyFilePassword)
+- X509 client cert with encrypted private key for mongot->mongod auth
+- Validates operator-managed secrets created on correct member clusters
+"""
+
+from typing import List
+
+import kubernetes
+import pymongo.errors
+from kubernetes.client import CoreV1Api
+from kubetester import create_or_update_configmap, create_or_update_secret, read_secret, try_load
+from kubetester.certs import create_tls_certs, generate_cert
+from kubetester.certs_mongodb_multi import (
+    create_multi_cluster_mongodb_x509_tls_certs,
+    create_multi_cluster_x509_agent_certs,
+)
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
+from kubetester.mongodb_multi import MongoDBMulti
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.multicluster_client import MultiClusterClient
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.multicluster.multicluster_utils import assert_deployment_ready_in_cluster
+from tests.common.search import search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_deployment_helper import MCSearchDeploymentHelper
+from tests.common.search.search_tester import SearchTester
+from tests.common.search.sharded_search_helper import create_issuer_ca
+from tests.common.search.tls_utils import encrypt_tls_key_with_password
+from tests.conftest import get_issuer_ca_filepath
+from tests.multicluster.conftest import cluster_spec_list
+
+logger = test_logger.get_test_logger(__name__)
+
+MDB_RESOURCE_NAME = "mdb-mc-rs-x509"
+MDBS_RESOURCE_NAME = "mdb-mc-rs-x509-search"
+
+MEMBERS_PER_CLUSTER: List[int | None] = [2, 2]
+MONGOT_REPLICAS_PER_CLUSTER = 1
+ENVOY_LB_REPLICAS = 2
+ENVOY_PROXY_PORT = 27028
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+MDBS_TLS_CERT_PREFIX = "certs"
+CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
+SOURCE_CERT_PREFIX = "clustercert"
+SOURCE_BUNDLE_SECRET = f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-cert"
+
+# Encrypted key passwords
+GRPC_KEY_PASSWORD = "test-grpc-key-password"
+X509_CLIENT_CERT_SECRET_NAME = f"{MDBS_RESOURCE_NAME}-x509-sync-client-cert"
+X509_CLIENT_CERT_CN = "mongot-sync-source"
+X509_AUTH_KEY_PASSWORD = "test-x509-key-password"
+
+SEARCH_INDEX_READY_TIMEOUT = 300
+SEARCH_QUERY_RETRY_TIMEOUT = 60
+
+
+def get_x509_subject_dn(namespace: str) -> str:
+    return f"CN={X509_CLIENT_CERT_CN},OU={namespace},O=cluster.local-client,L=NY,ST=NY,C=US"
+
+
+@fixture(scope="module")
+def helper(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> MCSearchDeploymentHelper:
+    return MCSearchDeploymentHelper(
+        namespace=namespace,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        member_cluster_clients={mcc.cluster_name: mcc.core_v1_api() for mcc in member_cluster_clients},
+    )
+
+
+@fixture(scope="module")
+def ca_configmap(issuer_ca_filepath: str, namespace: str) -> str:
+    return create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
+
+
+@fixture(scope="module")
+def mdb(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_names: List[str],
+    ca_configmap: str,
+) -> MongoDBMulti:
+    """2-cluster MongoDBMulti RS source with TLS + X509+SCRAM auth."""
+    resource = MongoDBMulti.from_yaml(
+        yaml_fixture("search-q2-mc-rs.yaml"),
+        name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    resource["spec"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, MEMBERS_PER_CLUSTER)
+    resource["spec"]["additionalMongodConfig"] = {
+        "setParameter": {
+            "skipAuthenticationToSearchIndexManagementServer": False,
+            "skipAuthenticationToMongot": False,
+            "searchTLSMode": "requireTLS",
+            "useGrpcForSearch": True,
+        },
+    }
+    resource["spec"]["security"] = {
+        "certsSecretPrefix": SOURCE_CERT_PREFIX,
+        "tls": {"ca": ca_configmap},
+        "authentication": {
+            "enabled": True,
+            "modes": ["X509", "SCRAM"],
+            "agents": {"mode": "X509"},
+            "internalCluster": "X509",
+        },
+    }
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="module")
+def mdbs(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDBMulti,
+    ca_configmap: str,
+) -> MongoDBSearch:
+    """MongoDBSearch with X509 auth + encrypted gRPC key, MC RS topology."""
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-q2-mc-rs-search.yaml"),
+        name=MDBS_RESOURCE_NAME,
+        namespace=namespace,
+    )
+
+    seeds = [f"{svc}.{namespace}.svc.cluster.local:27017" for svc in mdb.service_names()]
+
+    resource["spec"]["source"] = {
+        "external": {
+            "hostAndPorts": seeds,
+            "tls": {"ca": {"name": ca_configmap}},
+        },
+        "x509": {"clientCertificateSecretRef": {"name": X509_CLIENT_CERT_SECRET_NAME}},
+    }
+
+    resource["spec"]["security"] = {"tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX}}
+
+    resource["spec"]["loadBalancer"] = {
+        "managed": {
+            "externalHostname": (
+                f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-proxy-svc.{namespace}.svc.cluster.local"
+            ),
+        },
+    }
+
+    resource["spec"]["clusters"] = [
+        {"clusterName": mcc.cluster_name, "replicas": MONGOT_REPLICAS_PER_CLUSTER} for mcc in member_cluster_clients
+    ]
+
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+def _build_user(yaml_filename, name, username, namespace, central_cluster_client):
+    resource = MongoDBUser.from_yaml(yaml_fixture(yaml_filename), namespace=namespace, name=name)
+    if not try_load(resource):
+        resource["spec"]["mongodbResourceRef"]["name"] = MDB_RESOURCE_NAME
+        resource["spec"]["username"] = username
+        resource["spec"]["passwordSecretKeyRef"]["name"] = f"{name}-password"
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    return resource
+
+
+@fixture(scope="module")
+def admin_user(namespace, central_cluster_client):
+    return _build_user("mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client)
+
+
+@fixture(scope="module")
+def user(namespace, central_cluster_client):
+    return _build_user("mongodbuser-mdb-user.yaml", USER_NAME, USER_NAME, namespace, central_cluster_client)
+
+
+@fixture(scope="module")
+def x509_mongot_user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    """X509 user for mongot sync source auth in $external."""
+    user_dn = get_x509_subject_dn(namespace)
+    resource = MongoDBUser.from_yaml(
+        yaml_fixture("mongodbuser-search-sync-source-user.yaml"),
+        namespace=namespace,
+        name=f"{MDBS_RESOURCE_NAME}-mongot-x509-user",
+    )
+    if not try_load(resource):
+        resource["spec"]["mongodbResourceRef"]["name"] = MDB_RESOURCE_NAME
+        resource["spec"]["username"] = user_dn
+        resource["spec"]["db"] = "$external"
+        resource["spec"].pop("passwordSecretKeyRef", None)
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    return resource
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_install_operator(multi_cluster_operator: Operator):
+    multi_cluster_operator.assert_is_running()
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_install_source_tls_certificates(
+    multi_cluster_issuer: str,
+    mdb: MongoDBMulti,
+    member_cluster_clients: List[MultiClusterClient],
+    central_cluster_client: kubernetes.client.ApiClient,
+    namespace: str,
+):
+    """Source MongoDB TLS bundle + agent/clusterfile certs for x509 (multi-cluster aware)."""
+    create_multi_cluster_mongodb_x509_tls_certs(
+        multi_cluster_issuer, SOURCE_BUNDLE_SECRET, member_cluster_clients, central_cluster_client, mdb,
+    )
+    create_multi_cluster_x509_agent_certs(
+        multi_cluster_issuer, f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-agent-certs", central_cluster_client, mdb,
+    )
+    create_multi_cluster_mongodb_x509_tls_certs(
+        multi_cluster_issuer, f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-clusterfile", member_cluster_clients, central_cluster_client, mdb,
+    )
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_create_mdb_resource(mdb: MongoDBMulti):
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=1500)
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_create_user_credentials(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    admin_user: MongoDBUser,
+    user: MongoDBUser,
+    x509_mongot_user: MongoDBUser,
+):
+    create_or_update_secret(namespace, name=admin_user["spec"]["passwordSecretKeyRef"]["name"], data={"password": ADMIN_USER_PASSWORD}, api_client=central_cluster_client)
+    admin_user.update()
+    admin_user.assert_reaches_phase(Phase.Updated, timeout=300)
+
+    create_or_update_secret(namespace, name=user["spec"]["passwordSecretKeyRef"]["name"], data={"password": USER_PASSWORD}, api_client=central_cluster_client)
+    user.update()
+    user.assert_reaches_phase(Phase.Updated, timeout=300)
+
+    x509_mongot_user.update()
+    x509_mongot_user.assert_reaches_phase(Phase.Updated, timeout=300)
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_deploy_lb_certificates(namespace: str, multi_cluster_issuer: str, helper: MCSearchDeploymentHelper):
+    """Managed LB server + client certs."""
+    lb_server_cert_name = search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
+    lb_client_cert_name = search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
+
+    server_domains = [
+        f"{MDBS_RESOURCE_NAME}-search-{helper.cluster_index(name)}-proxy-svc.{namespace}.svc.cluster.local"
+        for name in helper.member_cluster_names()
+    ]
+
+    create_tls_certs(
+        issuer=multi_cluster_issuer, namespace=namespace,
+        resource_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
+        replicas=ENVOY_LB_REPLICAS, service_name=server_domains[0].split(".")[0],
+        additional_domains=server_domains, secret_name=lb_server_cert_name,
+    )
+    create_tls_certs(
+        issuer=multi_cluster_issuer, namespace=namespace,
+        resource_name=f"{search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME)}-client",
+        replicas=1, service_name=server_domains[0].split(".")[0],
+        additional_domains=[f"*.{namespace}.svc.cluster.local"], secret_name=lb_client_cert_name,
+    )
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_create_search_tls_certificate(namespace: str, multi_cluster_issuer: str, helper: MCSearchDeploymentHelper):
+    """mongot gRPC server cert with encrypted private key."""
+    secret_name = search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
+    additional_domains: List[str] = []
+    for name in helper.member_cluster_names():
+        idx = helper.cluster_index(name)
+        additional_domains.append(f"{MDBS_RESOURCE_NAME}-search-{idx}-svc.{namespace}.svc.cluster.local")
+        additional_domains.append(f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc.{namespace}.svc.cluster.local")
+
+    create_tls_certs(
+        issuer=multi_cluster_issuer, namespace=namespace,
+        resource_name=search_resource_names.mongot_statefulset_name(MDBS_RESOURCE_NAME),
+        secret_name=secret_name, additional_domains=additional_domains,
+    )
+    encrypt_tls_key_with_password(namespace, secret_name, GRPC_KEY_PASSWORD)
+    logger.info(f"gRPC server cert {secret_name} encrypted with password")
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_create_x509_client_certificate(namespace: str, multi_cluster_issuer: str):
+    """X509 client cert for mongot auth to mongod, with encrypted key."""
+    x509_spec = {
+        "subject": {"countries": ["US"], "provinces": ["NY"], "localities": ["NY"], "organizations": ["cluster.local-client"], "organizationalUnits": [namespace]},
+        "commonName": X509_CLIENT_CERT_CN,
+        "usages": ["digital signature", "key encipherment", "client auth"],
+        "dnsNames": [X509_CLIENT_CERT_CN],
+    }
+    generate_cert(namespace=namespace, pod="", dns="", issuer=multi_cluster_issuer, spec=x509_spec, secret_name=X509_CLIENT_CERT_SECRET_NAME)
+    encrypt_tls_key_with_password(namespace, X509_CLIENT_CERT_SECRET_NAME, X509_AUTH_KEY_PASSWORD)
+    logger.info(f"X509 client cert {X509_CLIENT_CERT_SECRET_NAME} created and encrypted")
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_replicate_secrets_to_members(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Replicate TLS Secrets, CA, and x509 client cert to every member cluster."""
+    central_core = CoreV1Api(api_client=central_cluster_client)
+
+    secrets_to_replicate = [
+        search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        CA_CONFIGMAP_NAME,
+        X509_CLIENT_CERT_SECRET_NAME,
+    ]
+
+    for secret_name in secrets_to_replicate:
+        source = central_core.read_namespaced_secret(name=secret_name, namespace=namespace)
+        for mcc in member_cluster_clients:
+            create_or_update_secret(namespace, secret_name, read_secret(namespace, secret_name, api_client=central_cluster_client), type=source.type or "Opaque", api_client=mcc.api_client)
+        logger.info(f"replicated Secret {secret_name}")
+
+    source_cm = central_core.read_namespaced_config_map(name=CA_CONFIGMAP_NAME, namespace=namespace)
+    for mcc in member_cluster_clients:
+        create_or_update_configmap(namespace, CA_CONFIGMAP_NAME, dict(source_cm.data or {}), api_client=mcc.api_client)
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_create_search_resource(mdbs: MongoDBSearch):
+    """MongoDBSearch must reach Running -- validates operator-managed secrets on members."""
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_verify_per_cluster_resources(namespace: str, helper: MCSearchDeploymentHelper, member_cluster_clients: List[MultiClusterClient]):
+    for mcc in member_cluster_clients:
+        idx = helper.cluster_index(mcc.cluster_name)
+        mcc.read_namespaced_stateful_set(f"{MDBS_RESOURCE_NAME}-search-{idx}", namespace)
+        mcc.read_namespaced_service(f"{MDBS_RESOURCE_NAME}-search-{idx}-svc", namespace)
+        mcc.read_namespaced_service(f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc", namespace)
+        deploy_name = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_index=idx)
+        assert_deployment_ready_in_cluster(mcc.apps_v1_api(), name=deploy_name, namespace=namespace)
+        logger.info(f"[{mcc.cluster_name}] per-cluster resources + Envoy verified")
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_patch_per_cluster_mongot_host(
+    mdb: MongoDBMulti,
+    helper: MCSearchDeploymentHelper,
+    namespace: str,
+):
+    """Patch OM automation config to set mongotHost per process pointing to envoy proxy."""
+    om_tester = mdb.get_om_tester()
+    ac_path = f"/groups/{om_tester.context.project_id}/automationConfig"
+    ac = om_tester.om_request("get", ac_path).json()
+
+    for process in ac.get("processes", []):
+        hostname = process.get("hostname", "")
+        # Determine cluster index from hostname pattern: mdb-mc-rs-x509-{clusterIdx}-{podIdx}-svc...
+        parts = hostname.split("-svc")[0].split("-")
+        # The cluster index is after the resource name parts
+        # hostname pattern: mdb-mc-rs-x509-{clusterIdx}-{podIdx}-svc.namespace...
+        cluster_idx = int(parts[-2])
+
+        proxy_host = f"{MDBS_RESOURCE_NAME}-search-{cluster_idx}-proxy-svc.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}"
+        set_param = process.setdefault("args2_6", {}).setdefault("setParameter", {})
+        set_param["mongotHost"] = proxy_host
+        set_param["searchIndexManagementHostAndPort"] = proxy_host
+        logger.info(f"Patched process {process.get('name')} mongotHost -> {proxy_host}")
+
+    ac["version"] = ac.get("version", 0) + 1
+    om_tester.om_request("put", ac_path, json_object=ac)
+    om_tester.wait_agents_ready(timeout=900)
+    logger.info("All agents reached goal state with mongotHost configured")
+
+
+
+def _search_tester(mdb: MongoDBMulti, username: str, password: str) -> SearchTester:
+    seed_host = f"{mdb.name}-0-0-svc.{mdb.namespace}.svc.cluster.local:27017"
+    conn_str = f"mongodb://{username}:{password}@{seed_host}/?replicaSet={mdb.name}&authSource=admin"
+    return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
+    tester = _search_tester(mdb, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    tester.mongorestore_from_url(
+        archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
+        ns_include="sample_mflix.*", tools_pod=tools_pod,
+    )
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_create_search_index(mdb: MongoDBMulti):
+    tester = _search_tester(mdb, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+    movies.create_search_index()
+    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@mark.e2e_search_ext_mc_rs_x509_enc_mtls
+def test_execute_search_query(mdb: MongoDBMulti):
+    """$search end-to-end proves X509 mTLS + encrypted gRPC keys work in MC RS."""
+    tester = _search_tester(mdb, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+
+    def execute_search() -> tuple:
+        try:
+            results = movies.text_search_movies("Star Wars")
+            if len(results) > 0:
+                return True, f"$search returned {len(results)} results"
+            return False, "$search returned no results"
+        except pymongo.errors.PyMongoError as exc:
+            return False, f"$search error: {exc}"
+
+    run_periodically(execute_search, timeout=SEARCH_QUERY_RETRY_TIMEOUT, sleep_time=5, msg="$search query")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_sharded_scram_enc_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_sharded_scram_enc_mtls.py
@@ -207,7 +207,8 @@ def mdbs(
     }
 
     resource["spec"]["clusters"] = [
-        {"clusterName": mcc.cluster_name, "replicas": MONGOT_REPLICAS_PER_CLUSTER} for mcc in member_cluster_clients
+        {"clusterName": mcc.cluster_name, "clusterIndex": mcc.cluster_index, "replicas": MONGOT_REPLICAS_PER_CLUSTER}
+        for mcc in member_cluster_clients
     ]
 
     resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
@@ -227,7 +228,9 @@ def _build_user(yaml_filename, name, username, namespace, central_cluster_client
 
 @fixture(scope="module")
 def admin_user(namespace, central_cluster_client):
-    return _build_user("mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client)
+    return _build_user(
+        "mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client
+    )
 
 
 @fixture(scope="module")
@@ -276,8 +279,14 @@ def test_install_source_tls_certificates(
         )
 
     for shard_idx in range(SHARD_COUNT):
-        _issue(f"{MDB_RESOURCE_NAME}-{shard_idx}", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-{shard_idx}-cert", MEMBERS_PER_CLUSTER)
-    _issue(f"{MDB_RESOURCE_NAME}-config", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-config-cert", CONFIG_SRV_PER_CLUSTER)
+        _issue(
+            f"{MDB_RESOURCE_NAME}-{shard_idx}",
+            f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-{shard_idx}-cert",
+            MEMBERS_PER_CLUSTER,
+        )
+    _issue(
+        f"{MDB_RESOURCE_NAME}-config", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-config-cert", CONFIG_SRV_PER_CLUSTER
+    )
     _issue(f"{MDB_RESOURCE_NAME}-mongos", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-mongos-cert", MONGOS_PER_CLUSTER)
 
 
@@ -296,7 +305,12 @@ def test_create_user_credentials(
     mongot_user: MongoDBUser,
 ):
     def _apply(u, password):
-        create_or_update_secret(namespace, name=u["spec"]["passwordSecretKeyRef"]["name"], data={"password": password}, api_client=central_cluster_client)
+        create_or_update_secret(
+            namespace,
+            name=u["spec"]["passwordSecretKeyRef"]["name"],
+            data={"password": password},
+            api_client=central_cluster_client,
+        )
         u.update()
 
     _apply(admin_user, ADMIN_USER_PASSWORD)
@@ -436,7 +450,9 @@ def _mongos_search_tester(namespace: str, cluster_index: int) -> SearchTester:
 
 def _admin_search_tester(namespace: str) -> SearchTester:
     mongos_host = f"{MDB_RESOURCE_NAME}-mongos-0-0-svc.{namespace}.svc.cluster.local:27017"
-    conn_str = f"mongodb://{ADMIN_USER_NAME}:{ADMIN_USER_PASSWORD}@{mongos_host}/?directConnection=true&authSource=admin"
+    conn_str = (
+        f"mongodb://{ADMIN_USER_NAME}:{ADMIN_USER_PASSWORD}@{mongos_host}/?directConnection=true&authSource=admin"
+    )
     return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
 
 
@@ -512,4 +528,6 @@ def test_per_cluster_search_query(namespace: str, member_cluster_clients: List[M
             except pymongo.errors.PyMongoError as exc:
                 return False, f"cluster {_idx}: {exc}"
 
-        run_periodically(execute_search, timeout=SEARCH_QUERY_RETRY_TIMEOUT, sleep_time=5, msg=f"cluster {cluster_index}")
+        run_periodically(
+            execute_search, timeout=SEARCH_QUERY_RETRY_TIMEOUT, sleep_time=5, msg=f"cluster {cluster_index}"
+        )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_sharded_scram_enc_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_sharded_scram_enc_mtls.py
@@ -1,0 +1,515 @@
+"""MC-Sharded e2e: MongoDBSearch with SCRAM mTLS + gRPC mTLS (encrypted keys).
+
+Based on q3_mc_sharded_external_mtls, adds:
+- Encrypted private keys on per-shard gRPC server certs (tls.keyFilePassword)
+- SCRAM client cert with encrypted private key for mongot->mongod mTLS
+- Validates operator-managed secrets created on correct member clusters
+"""
+
+from typing import List
+
+import kubernetes
+import pymongo.errors
+from kubernetes.client import CoreV1Api
+from kubetester import create_or_update_configmap, create_or_update_secret, read_secret, try_load
+from kubetester.certs import create_tls_certs, generate_cert
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.multicluster_client import MultiClusterClient
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.multicluster.multicluster_utils import assert_deployment_ready_in_cluster
+from tests.common.search import search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
+from tests.common.search.sharded_search_helper import (
+    create_issuer_ca,
+    create_lb_certificates,
+    create_per_shard_search_tls_certs,
+)
+from tests.common.search.tls_utils import encrypt_tls_key_with_password
+from tests.conftest import get_issuer_ca_filepath
+from tests.multicluster.conftest import cluster_spec_list
+
+logger = test_logger.get_test_logger(__name__)
+
+MDB_RESOURCE_NAME = "mdb-mc-sh-scram"
+MDBS_RESOURCE_NAME = "mdb-mc-sh-scram-search"
+
+SHARD_COUNT = 2
+MEMBERS_PER_CLUSTER: List[int | None] = [1, 1]
+MONGOS_PER_CLUSTER: List[int | None] = [1, 1]
+CONFIG_SRV_PER_CLUSTER: List[int | None] = [1, 1]
+
+MONGOT_REPLICAS_PER_CLUSTER = 1
+ENVOY_PROXY_PORT = 27028
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+
+MDBS_TLS_CERT_PREFIX = "certs"
+CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
+SOURCE_CERT_PREFIX = "clustercert"
+
+# Encrypted key passwords
+GRPC_KEY_PASSWORD = "test-grpc-key-password"
+SCRAM_CLIENT_CERT_SECRET_NAME = f"{MDBS_RESOURCE_NAME}-scram-tls-user"
+SCRAM_KEY_PASSWORD = "test-scram-key-password"
+
+SEARCH_INDEX_READY_TIMEOUT = 300
+SEARCH_QUERY_RETRY_TIMEOUT = 60
+
+
+@fixture(scope="module")
+def ca_configmap(
+    issuer_ca_filepath: str,
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> str:
+    name = create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
+    for mcc in member_cluster_clients:
+        create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME, api_client=mcc.api_client)
+    return name
+
+
+@fixture(scope="module")
+def mdb(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_names: List[str],
+    ca_configmap: str,
+) -> MongoDB:
+    """MC sharded MongoDB source with TLS+SCRAM."""
+    resource = MongoDB.from_yaml(
+        yaml_fixture("search-q3-mc-sharded.yaml"),
+        name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+    )
+
+    resource["spec"]["shard"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, MEMBERS_PER_CLUSTER)
+    resource["spec"]["configSrv"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, CONFIG_SRV_PER_CLUSTER)
+    resource["spec"]["mongos"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, MONGOS_PER_CLUSTER)
+    resource["spec"]["shardCount"] = SHARD_COUNT
+
+    cluster_idx = 0
+    cluster_level_endpoint = (
+        f"{search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, cluster_idx)}:{ENVOY_PROXY_PORT}"
+    )
+
+    def _shard_proxy_endpoint(shard_name: str) -> str:
+        proxy_name = search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, cluster_idx)
+        return f"{proxy_name}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}"
+
+    base_search_set_parameter = {
+        "skipAuthenticationToSearchIndexManagementServer": False,
+        "skipAuthenticationToMongot": False,
+        "searchTLSMode": "requireTLS",
+        "useGrpcForSearch": True,
+    }
+
+    resource["spec"]["shardOverrides"] = [
+        {
+            "shardNames": [f"{MDB_RESOURCE_NAME}-{shard_idx}"],
+            "additionalMongodConfig": {
+                "setParameter": {
+                    **base_search_set_parameter,
+                    "mongotHost": _shard_proxy_endpoint(f"{MDB_RESOURCE_NAME}-{shard_idx}"),
+                    "searchIndexManagementHostAndPort": _shard_proxy_endpoint(f"{MDB_RESOURCE_NAME}-{shard_idx}"),
+                },
+            },
+        }
+        for shard_idx in range(SHARD_COUNT)
+    ]
+
+    resource["spec"]["mongos"]["additionalMongodConfig"] = {
+        "setParameter": {
+            **base_search_set_parameter,
+            "mongotHost": cluster_level_endpoint,
+            "searchIndexManagementHostAndPort": cluster_level_endpoint,
+        },
+    }
+    resource["spec"]["shard"]["additionalMongodConfig"] = {"setParameter": base_search_set_parameter}
+
+    resource["spec"]["security"] = {
+        "certsSecretPrefix": SOURCE_CERT_PREFIX,
+        "tls": {"ca": ca_configmap},
+        "authentication": {"enabled": True, "modes": ["SCRAM"]},
+    }
+
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="module")
+def mdbs(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDB,
+    ca_configmap: str,
+) -> MongoDBSearch:
+    """MongoDBSearch over external sharded source with SCRAM mTLS + encrypted gRPC keys."""
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-q2-mc-rs-search.yaml"),
+        name=MDBS_RESOURCE_NAME,
+        namespace=namespace,
+    )
+
+    router_hosts = [
+        f"{MDB_RESOURCE_NAME}-mongos-{ci}-{pi}-svc.{namespace}.svc.cluster.local:27017"
+        for ci, n in enumerate(MONGOS_PER_CLUSTER)
+        if n
+        for pi in range(n)
+    ]
+
+    shards = [
+        {
+            "shardName": f"{MDB_RESOURCE_NAME}-{si}",
+            "hosts": [
+                f"{MDB_RESOURCE_NAME}-{si}-{ci}-0-svc.{namespace}.svc.cluster.local:27017"
+                for ci in range(len(MEMBERS_PER_CLUSTER))
+                if MEMBERS_PER_CLUSTER[ci] is not None
+            ],
+        }
+        for si in range(SHARD_COUNT)
+    ]
+
+    resource["spec"]["source"] = {
+        "username": MONGOT_USER_NAME,
+        "passwordSecretRef": {"name": f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password", "key": "password"},
+        "external": {
+            "shardedCluster": {"router": {"hosts": router_hosts}, "shards": shards},
+            "tls": {"ca": {"name": ca_configmap}},
+        },
+        "tls": {"clientCertificateSecretRef": {"name": SCRAM_CLIENT_CERT_SECRET_NAME}},
+    }
+
+    resource["spec"]["security"] = {"tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX}}
+
+    resource["spec"]["loadBalancer"] = {
+        "managed": {
+            "externalHostname": (
+                f"{MDBS_RESOURCE_NAME}-search-{{clusterIndex}}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local"
+            ),
+        },
+    }
+
+    resource["spec"]["clusters"] = [
+        {"clusterName": mcc.cluster_name, "replicas": MONGOT_REPLICAS_PER_CLUSTER} for mcc in member_cluster_clients
+    ]
+
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+def _build_user(yaml_filename, name, username, namespace, central_cluster_client):
+    resource = MongoDBUser.from_yaml(yaml_fixture(yaml_filename), namespace=namespace, name=name)
+    if not try_load(resource):
+        resource["spec"]["mongodbResourceRef"]["name"] = MDB_RESOURCE_NAME
+        resource["spec"]["username"] = username
+        resource["spec"]["passwordSecretKeyRef"]["name"] = f"{name}-password"
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    return resource
+
+
+@fixture(scope="module")
+def admin_user(namespace, central_cluster_client):
+    return _build_user("mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client)
+
+
+@fixture(scope="module")
+def user(namespace, central_cluster_client):
+    return _build_user("mongodbuser-mdb-user.yaml", USER_NAME, USER_NAME, namespace, central_cluster_client)
+
+
+@fixture(scope="module")
+def mongot_user(namespace, central_cluster_client):
+    return _build_user(
+        "mongodbuser-search-sync-source-user.yaml",
+        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}",
+        MONGOT_USER_NAME,
+        namespace,
+        central_cluster_client,
+    )
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_install_operator(multi_cluster_operator: Operator):
+    multi_cluster_operator.assert_is_running()
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_ca(ca_configmap: str):
+    assert ca_configmap == CA_CONFIGMAP_NAME
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_install_source_tls_certificates(
+    namespace: str,
+    multi_cluster_issuer: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdb: MongoDB,
+):
+    """Source MongoDB per-component TLS certs."""
+
+    def _issue(component_resource: str, secret_name: str, distribution):
+        create_tls_certs(
+            issuer=multi_cluster_issuer,
+            namespace=namespace,
+            resource_name=component_resource,
+            replicas_cluster_distribution=distribution,
+            secret_name=secret_name,
+            api_client=central_cluster_client,
+        )
+
+    for shard_idx in range(SHARD_COUNT):
+        _issue(f"{MDB_RESOURCE_NAME}-{shard_idx}", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-{shard_idx}-cert", MEMBERS_PER_CLUSTER)
+    _issue(f"{MDB_RESOURCE_NAME}-config", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-config-cert", CONFIG_SRV_PER_CLUSTER)
+    _issue(f"{MDB_RESOURCE_NAME}-mongos", f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-mongos-cert", MONGOS_PER_CLUSTER)
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_mdb_source(mdb: MongoDB):
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=1500)
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_user_credentials(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    admin_user: MongoDBUser,
+    user: MongoDBUser,
+    mongot_user: MongoDBUser,
+):
+    def _apply(u, password):
+        create_or_update_secret(namespace, name=u["spec"]["passwordSecretKeyRef"]["name"], data={"password": password}, api_client=central_cluster_client)
+        u.update()
+
+    _apply(admin_user, ADMIN_USER_PASSWORD)
+    admin_user.assert_reaches_phase(Phase.Updated, timeout=300)
+    _apply(user, USER_PASSWORD)
+    user.assert_reaches_phase(Phase.Updated, timeout=300)
+    _apply(mongot_user, MONGOT_USER_PASSWORD)
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_search_certs(
+    namespace: str,
+    multi_cluster_issuer: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Per-(cluster, shard) mongot gRPC certs with encrypted keys + LB certs."""
+    for i in range(len(member_cluster_clients)):
+        create_per_shard_search_tls_certs(
+            namespace=namespace,
+            issuer=multi_cluster_issuer,
+            prefix=MDBS_TLS_CERT_PREFIX,
+            shard_count=SHARD_COUNT,
+            mdb_resource_name=MDB_RESOURCE_NAME,
+            mdbs_resource_name=MDBS_RESOURCE_NAME,
+            cluster_index=i,
+            api_client=central_cluster_client,
+        )
+        # Encrypt each per-shard cert's private key
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            secret_name = search_resource_names.shard_tls_cert_name(
+                MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index=i
+            )
+            encrypt_tls_key_with_password(namespace, secret_name, GRPC_KEY_PASSWORD)
+        logger.info(f"Per-shard gRPC certs encrypted for cluster_index={i}")
+
+    create_lb_certificates(
+        namespace=namespace,
+        issuer=multi_cluster_issuer,
+        shard_count=SHARD_COUNT,
+        mdb_resource_name=MDB_RESOURCE_NAME,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        tls_cert_prefix=MDBS_TLS_CERT_PREFIX,
+        cluster_indexes=list(range(len(member_cluster_clients))),
+        api_client=central_cluster_client,
+    )
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_scram_client_certificate(namespace: str, multi_cluster_issuer: str):
+    """SCRAM client cert for mongot mTLS to mongod, with encrypted key."""
+    generate_cert(
+        namespace=namespace,
+        pod="",
+        dns="",
+        issuer=multi_cluster_issuer,
+        spec={"usages": ["digital signature", "key encipherment", "client auth"], "dnsNames": ["scram-client"]},
+        secret_name=SCRAM_CLIENT_CERT_SECRET_NAME,
+    )
+    encrypt_tls_key_with_password(namespace, SCRAM_CLIENT_CERT_SECRET_NAME, SCRAM_KEY_PASSWORD)
+    logger.info(f"SCRAM client cert {SCRAM_CLIENT_CERT_SECRET_NAME} created and encrypted")
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_replicate_secrets_to_members(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Copy centrally-issued Secrets to each member cluster."""
+    central_core = CoreV1Api(api_client=central_cluster_client)
+
+    # Cluster-agnostic secrets
+    for secret_name in [
+        search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+        SCRAM_CLIENT_CERT_SECRET_NAME,
+    ]:
+        secret_type = central_core.read_namespaced_secret(name=secret_name, namespace=namespace).type or "Opaque"
+        data = read_secret(namespace, secret_name, api_client=central_cluster_client)
+        for mcc in member_cluster_clients:
+            create_or_update_secret(namespace, secret_name, data, type=secret_type, api_client=mcc.api_client)
+        logger.info(f"Replicated {secret_name}")
+
+    # Per-(cluster, shard) mongot certs
+    for i, mcc in enumerate(member_cluster_clients):
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            secret_name = search_resource_names.shard_tls_cert_name(
+                MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index=i
+            )
+            secret_type = central_core.read_namespaced_secret(name=secret_name, namespace=namespace).type or "Opaque"
+            data = read_secret(namespace, secret_name, api_client=central_cluster_client)
+            create_or_update_secret(namespace, secret_name, data, type=secret_type, api_client=mcc.api_client)
+        logger.info(f"Replicated per-shard certs to {mcc.cluster_name}")
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_search_cr(mdbs: MongoDBSearch):
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_per_cluster_resources_exist(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Every (cluster, shard) pair must have a mongot StatefulSet on the member cluster."""
+    for i, mcc in enumerate(member_cluster_clients):
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            sts_name = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, i)
+            mcc.read_namespaced_stateful_set(sts_name, namespace)
+        logger.info(f"[{mcc.cluster_name}] all per-shard StatefulSets verified")
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_envoy_deployments_ready(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    for i, mcc in enumerate(member_cluster_clients):
+        deploy_name = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_index=i)
+        apps = mcc.apps_v1_api()
+        assert_deployment_ready_in_cluster(apps, name=deploy_name, namespace=namespace)
+        logger.info(f"[{mcc.cluster_name}] Envoy {deploy_name} Ready")
+
+
+def _mongos_search_tester(namespace: str, cluster_index: int) -> SearchTester:
+    mongos_host = f"{MDB_RESOURCE_NAME}-mongos-{cluster_index}-0-svc.{namespace}.svc.cluster.local:27017"
+    conn_str = f"mongodb://{USER_NAME}:{USER_PASSWORD}@{mongos_host}/?directConnection=true&authSource=admin"
+    return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
+
+
+def _admin_search_tester(namespace: str) -> SearchTester:
+    mongos_host = f"{MDB_RESOURCE_NAME}-mongos-0-0-svc.{namespace}.svc.cluster.local:27017"
+    conn_str = f"mongodb://{ADMIN_USER_NAME}:{ADMIN_USER_PASSWORD}@{mongos_host}/?directConnection=true&authSource=admin"
+    return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_restore_sample_database(namespace: str, tools_pod):
+    tester = _admin_search_tester(namespace)
+    tester.mongorestore_from_url(
+        archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
+        ns_include="sample_mflix.*",
+        tools_pod=tools_pod,
+    )
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_shard_sample_collection(namespace: str):
+    """Shard and redistribute the sample collection.
+
+    reshardCollection is a long-running op that may fail if the automation agent
+    restarts mongos mid-operation. Retry with a fresh connection if that happens.
+    """
+
+    def _shard() -> tuple:
+        try:
+            admin = _admin_search_tester(namespace)
+            admin.shard_and_distribute_collection("sample_mflix", "movies")
+            return True, "Collection sharded and distributed"
+        except (pymongo.errors.AutoReconnect, pymongo.errors.ConnectionFailure) as exc:
+            logger.warning(f"Connection lost during sharding, will retry: {exc}")
+            return False, f"Connection error: {exc}"
+
+    run_periodically(_shard, timeout=900, sleep_time=30, msg="shard_and_distribute_collection")
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_create_search_index(namespace: str):
+    tester = _mongos_search_tester(namespace, 0)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+    movies.create_search_index()
+    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_execute_search_query(namespace: str):
+    """$search end-to-end proves SCRAM mTLS + encrypted gRPC keys work in MC sharded."""
+    tester = _mongos_search_tester(namespace, 0)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+
+    def execute_search() -> tuple:
+        try:
+            results = movies.text_search_movies("Star Wars")
+            if len(results) > 0:
+                return True, f"$search returned {len(results)} results"
+            return False, "$search returned no results"
+        except pymongo.errors.PyMongoError as exc:
+            return False, f"$search error: {exc}"
+
+    run_periodically(execute_search, timeout=SEARCH_QUERY_RETRY_TIMEOUT, sleep_time=5, msg="$search via mongos-0")
+
+
+@mark.e2e_search_ext_mc_sharded_scram_enc_mtls
+def test_per_cluster_search_query(namespace: str, member_cluster_clients: List[MultiClusterClient]):
+    """$search via each cluster's mongos -- proves both clusters' mTLS paths work."""
+    for cluster_index in range(len(member_cluster_clients)):
+        tester = _mongos_search_tester(namespace, cluster_index)
+        movies = SampleMoviesSearchHelper(search_tester=tester)
+
+        def execute_search(_idx=cluster_index) -> tuple:
+            try:
+                results = movies.text_search_movies("Star Wars")
+                if len(results) > 0:
+                    return True, f"cluster {_idx}: $search returned {len(results)} results"
+                return False, f"cluster {_idx}: no results"
+            except pymongo.errors.PyMongoError as exc:
+                return False, f"cluster {_idx}: {exc}"
+
+        run_periodically(execute_search, timeout=SEARCH_QUERY_RETRY_TIMEOUT, sleep_time=5, msg=f"cluster {cluster_index}")

--- a/scripts/dev/contexts/e2e_multi_cluster_2_clusters
+++ b/scripts/dev/contexts/e2e_multi_cluster_2_clusters
@@ -6,6 +6,7 @@ script_name=$(readlink -f "${BASH_SOURCE[0]}")
 script_dir=$(dirname "${script_name}")
 
 source "${script_dir}/root-context"
+source "${script_dir}/variables/mongodb_search_dev"
 
 export KUBE_ENVIRONMENT_NAME=multi
 export CLUSTER_NAME="kind-e2e-cluster-1"

--- a/scripts/dev/contexts/e2e_multi_cluster_kind
+++ b/scripts/dev/contexts/e2e_multi_cluster_kind
@@ -7,6 +7,7 @@ script_dir=$(dirname "${script_name}")
 
 source "${script_dir}/root-context"
 source "${script_dir}/variables/om70"
+source "${script_dir}/variables/mongodb_search_dev"
 
 export KUBE_ENVIRONMENT_NAME=multi
 export CLUSTER_NAME="kind-e2e-operator"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_2_clusters
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_2_clusters
@@ -6,6 +6,7 @@ script_name=$(readlink -f "${BASH_SOURCE[0]}")
 script_dir=$(dirname "${script_name}")
 
 source "${script_dir}/root-context"
+source "${script_dir}/variables/mongodb_search_dev"
 
 export KUBE_ENVIRONMENT_NAME=multi
 export CLUSTER_NAME="kind-e2e-cluster-1"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_kind
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_kind
@@ -7,6 +7,7 @@ script_dir=$(dirname "${script_name}")
 
 source "${script_dir}/root-context"
 source "${script_dir}/variables/om70"
+source "${script_dir}/variables/mongodb_search_dev"
 
 export KUBE_ENVIRONMENT_NAME=multi
 export CLUSTER_NAME="kind-e2e-operator"


### PR DESCRIPTION

# Summary

Adds E2E test for the gRPC and SCRAM related changes that we made in the PRs ([1](https://github.com/mongodb/mongodb-kubernetes/pull/1240), [2](https://github.com/mongodb/mongodb-kubernetes/pull/1237)).
In the two tests that are added, we install mongodb and search with mTLS and password encrypted keyfile at the mongot side. We had to add two tests because we can not have x509 and SCRAM auth enabled in the same deployment/instance. 

## Proof of Work

CI passes.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
