### PR TITLE
Fix missing architecture argument in TestReplicaSetReconciler_PVCStatusClearedAfterSuccessfulResize

### DIFF
--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -890,7 +890,7 @@ func TestReplicaSetReconciler_PVCStatusClearedAfterSuccessfulResize(t *testing.T
 			SetPodSpec(&podSpec).
 			Build()
 
-		reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", rs)
+		reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", rs, architectures.NonStatic)
 		checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 
 		// Read the STS the reconciler created and manufacture the matching PVCs


### PR DESCRIPTION
# Summary
The test added in fe050cb1 called `defaultReplicaSetReconciler` with 5 args, missing the `DefaultArchitecture` parameter added in 4e7b59e9.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
