### PR TITLE
test(search): read renamed <name>-search-state state CM (KUBE-124 #1215)

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -41,6 +41,16 @@ def mongot_configmap_name(search_name: str) -> str:
     return mongot_configmap_name_for_cluster(search_name, 0)
 
 
+def search_state_configmap_name(search_name: str) -> str:
+    """State ConfigMap name persisted by the search controllers.
+
+    Matches the operator's ``searchcontroller.SearchStateCMName`` — deliberately
+    ``<name>-search-state`` (not ``<name>-state``) so it cannot collide with the
+    source MongoDB's StateStore ConfigMap when a MongoDBSearch shares its name.
+    """
+    return f"{search_name}-search-state"
+
+
 def mongot_service_host(search_name: str, namespace: str, port: int) -> str:
     """Full hostname:port for the RS mongot Service."""
     return f"{mongot_service_name(search_name)}.{namespace}.svc.cluster.local:{port}"

--- a/docker/mongodb-kubernetes-tests/tests/common/search/sharded_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/sharded_search_helper.py
@@ -499,7 +499,9 @@ def redistribute_chunks_to_new_shard(
 def routing_ready_groups(namespace: str, mdbs_resource_name: str) -> list[str]:
     """The one-way routing-readiness latch from the ``<name>-search-state`` ConfigMap.
     A shard's mongot group is pending iff it is not listed here."""
-    data = KubernetesTester.read_configmap(namespace, f"{mdbs_resource_name}-search-state")
+    data = KubernetesTester.read_configmap(
+        namespace, search_resource_names.search_state_configmap_name(mdbs_resource_name)
+    )
     return json.loads(data["state"]).get("routingReadyMongotGroups") or []
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -30,7 +30,7 @@ from pytest import fixture
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import search_resource_names
-from tests.conftest import get_multi_cluster_operator, read_deployment_state
+from tests.conftest import get_multi_cluster_operator, read_configmap
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -369,13 +369,18 @@ def assert_state_configmap_local_mapping(
     mdbs_resource_name: str,
 ) -> None:
     """Simulated-MC operators narrow spec.clusters[] to their own slice (LocalizeToCluster)
-    before persisting, so each member's `{mdbs}-state` ConfigMap holds a LOCAL-only
+    before persisting, so each member's `{mdbs}-search-state` ConfigMap holds a LOCAL-only
     clusterMapping (this cluster's entry, no foreign name).
     """
     assert_per_cluster_count(per_cluster_mdbs_search)
     names = {mcc.cluster_name for mcc, _ in per_cluster_mdbs_search}
     for mcc, _mdbs in per_cluster_mdbs_search:
-        state = read_deployment_state(mdbs_resource_name, namespace, api_client=mcc.api_client)
+        cm = read_configmap(
+            namespace,
+            search_resource_names.search_state_configmap_name(mdbs_resource_name),
+            api_client=mcc.api_client,
+        )
+        state = json.loads(cm["state"])
         mapping = state.get("clusterMapping") or {}
         assert mapping.get(mcc.cluster_name) == _idx(mcc), (
             f"[{mcc.cluster_name}] state clusterMapping[{mcc.cluster_name!r}]={mapping.get(mcc.cluster_name)!r}, "

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -661,11 +661,11 @@ def test_verify_persisted_cluster_mapping(
     central_cluster_client: kubernetes.client.ApiClient,
     helper: MCSearchDeploymentHelper,
 ):
-    """The `<name>-state` ConfigMap on the central cluster must carry a ClusterMapping
+    """The `<name>-search-state` ConfigMap on the central cluster must carry a ClusterMapping
     entry for every member cluster. This is the operator's source of truth for
     cluster-index pinning across spec.clusters[] reorders and restarts.
     """
-    state_cm_name = f"{MDBS_RESOURCE_NAME}-state"
+    state_cm_name = search_resource_names.search_state_configmap_name(MDBS_RESOURCE_NAME)
     core = CoreV1Api(api_client=central_cluster_client)
     state_cm = core.read_namespaced_config_map(name=state_cm_name, namespace=namespace)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
@@ -574,7 +574,7 @@ def test_state_configmap_mapping_persisted(
     namespace: str,
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
-    """Each cluster's `{mdbs}-state` ConfigMap pins clusterMapping[thisCluster]==thisIndex
+    """Each cluster's `{mdbs}-search-state` ConfigMap pins clusterMapping[thisCluster]==thisIndex
     and must hold ONLY the local entry — it must not leak the foreign cluster's name.
     """
     assert_state_configmap_local_mapping(namespace, per_cluster_mdbs_search, MDBS_RESOURCE_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
@@ -802,7 +802,7 @@ def test_state_configmap_mapping_persisted(
     namespace: str,
     per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
 ):
-    """Each cluster's `{mdbs}-state` ConfigMap pins clusterMapping[thisCluster]==thisIndex.
+    """Each cluster's `{mdbs}-search-state` ConfigMap pins clusterMapping[thisCluster]==thisIndex.
     Simulated-MC narrows spec.clusters[] (LocalizeToCluster) so the mapping is LOCAL-only —
     this cluster's entry, never the foreign cluster's name.
     """


### PR DESCRIPTION
# Summary

Fixes the MC search e2e tests that read the search **state ConfigMap** by the wrong name, leaving them red on `search/ga-base`.

KUBE-124 (#1215) moved search controller state onto a search-owned ConfigMap named **`<name>-search-state`** (`searchcontroller.SearchStateCMName`) — deliberately *not* `<name>-state`, so it can't collide with the source MongoDB's StateStore ConfigMap when a `MongoDBSearch` shares its source's name. But the e2e test code still reads the old `<name>-state` name and gets an instant **404**.

This is **test-only**: the operator persists state correctly under the new name (same `state` data key, same `clusterMapping` structure) — only the e2e reads were stale.

## What was red

- `e2e_search_simulated_mc_rs`, `e2e_search_simulated_mc_sharded`, `e2e_search_simulated_mc_topology` (via the shared `assert_state_configmap_local_mapping` helper)
- `e2e_search_q2_mc_rs_steady` (`test_verify_persisted_cluster_mapping`, inline read)

## Change

- Adds a canonical `search_resource_names.search_state_configmap_name(name)` → `<name>-search-state` (mirrors the operator's `SearchStateCMName`; previously the suffix was a literal scattered across helpers). It is index-free because the operator's `SearchStateCMName` carries no cluster index (unlike the per-cluster mongot `*_for_cluster` names).
- Points the simulated-MC state helper, `q2_mc_rs_steady`, and `sharded_search_helper.routing_ready_groups` at it — so every `<name>-search-state` name now flows through the one helper.
- Corrects two stale `{mdbs}-state` docstrings on the `simulated_mc_{rs,sharded}` state tests to `{mdbs}-search-state` so the prose matches the CM the helper now reads.

Test-only, +25/−8. `py_compile`, `black`, `isort` clean. The identical core fix was independently validated green on the affected tasks via patch `6a33b7cd07cd0f000772757b`.

## Tickets

KUBE-124
