### PR TITLE
CLOUDP-411215: Remove "status" from CustomObject initial backing_obj

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubeobject/customobject.py
+++ b/docker/mongodb-kubernetes-tests/kubeobject/customobject.py
@@ -83,7 +83,6 @@ class CustomObject:
                 "kind": self.kind,
                 "apiVersion": "/".join(filter(None, [group, version])),
                 "spec": {},
-                "status": {},
             }
 
     def load(self) -> Self:


### PR DESCRIPTION
# Summary

`CustomObject.__init__` was initialising `backing_obj` with `"status": {}`. Status is controller-managed in Kubernetes and must not be present on a freshly-built object that hasn't been persisted yet. In practice, `create()` sends the object with `field_validation="Strict"`, so any CRD whose schema does not declare a top-level `status` field rejects the create with a 400 *unknown field "status"* error. One such CRD is `OperatorConfig`, defined in a separate branch that targets this one.

The fix is a one-line deletion.

## Proof of Work

Existing tests pass.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details