### PR TITLE
KUBE-100: Add auto-embedding GA e2e test coverage

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1355,6 +1355,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_auto_embedding_key_handling
+    tags: ["patch-run"]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_community_tls
     tags: ["patch-run"]
     commands:

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1345,6 +1345,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_auto_embedding_version_gate
+    tags: ["patch-run"]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_community_tls
     tags: ["patch-run"]
     commands:

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1360,6 +1360,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_enterprise_external_auto_embedding
+    tags: ["patch-run"]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_community_tls
     tags: ["patch-run"]
     commands:

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1350,6 +1350,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_auto_embedding_bad_secret
+    tags: ["patch-run"]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_community_tls
     tags: ["patch-run"]
     commands:

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1365,6 +1365,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_auto_embedding_rolling_restart
+    tags: ["patch-run"]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_community_tls
     tags: ["patch-run"]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -841,6 +841,7 @@ task_groups:
       - e2e_search_community_auto_embedding
       - e2e_search_community_auto_embedding_multi_mongot
       - e2e_search_auto_embedding_version_gate
+      - e2e_search_auto_embedding_bad_secret
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls
@@ -889,6 +890,7 @@ task_groups:
       - e2e_search_community_auto_embedding
       - e2e_search_community_auto_embedding_multi_mongot
       - e2e_search_auto_embedding_version_gate
+      - e2e_search_auto_embedding_bad_secret
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -840,6 +840,7 @@ task_groups:
       - e2e_search_community_basic
       - e2e_search_community_auto_embedding
       - e2e_search_community_auto_embedding_multi_mongot
+      - e2e_search_auto_embedding_version_gate
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls
@@ -887,6 +888,7 @@ task_groups:
       - e2e_search_community_basic
       - e2e_search_community_auto_embedding
       - e2e_search_community_auto_embedding_multi_mongot
+      - e2e_search_auto_embedding_version_gate
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -842,6 +842,7 @@ task_groups:
       - e2e_search_community_auto_embedding_multi_mongot
       - e2e_search_auto_embedding_version_gate
       - e2e_search_auto_embedding_bad_secret
+      - e2e_search_auto_embedding_key_handling
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls
@@ -891,6 +892,7 @@ task_groups:
       - e2e_search_community_auto_embedding_multi_mongot
       - e2e_search_auto_embedding_version_gate
       - e2e_search_auto_embedding_bad_secret
+      - e2e_search_auto_embedding_key_handling
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -879,6 +879,7 @@ task_groups:
       - e2e_search_sharded_onboarding_no_outage
       - e2e_search_cds_hot_reload
       - e2e_search_envoy_retry_policy
+      - e2e_search_auto_embedding_rolling_restart
     <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.
@@ -923,6 +924,7 @@ task_groups:
       - e2e_search_replicaset_internal_mongodb_multi_mongot_managed_lb
       - e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb
       - e2e_search_replicaset_external_mongodb_proxy_service
+      - e2e_search_auto_embedding_rolling_restart
     <<: *teardown_group
 
   # this task group contains just a one task, which is smoke testing whether the operator

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -843,6 +843,7 @@ task_groups:
       - e2e_search_auto_embedding_version_gate
       - e2e_search_auto_embedding_bad_secret
       - e2e_search_auto_embedding_key_handling
+      - e2e_search_enterprise_external_auto_embedding
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls
@@ -893,6 +894,7 @@ task_groups:
       - e2e_search_auto_embedding_version_gate
       - e2e_search_auto_embedding_bad_secret
       - e2e_search_auto_embedding_key_handling
+      - e2e_search_enterprise_external_auto_embedding
       - e2e_search_community_tls
       - e2e_search_community_external_mongod_basic
       - e2e_search_community_external_mongod_tls

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_bad_secret.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_bad_secret.py
@@ -83,7 +83,8 @@ def test_missing_indexing_key_reconcile_error(mdbs: MongoDBSearch):
     }
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Failed, timeout=120)
-    assert 'Required key "indexing-key" is not present' in mdbs.get_status_message()
+    msg = mdbs.get_status_message()
+    assert msg and 'Required key "indexing-key" is not present' in msg
 
 
 @mark.e2e_search_auto_embedding_bad_secret

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_bad_secret.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_bad_secret.py
@@ -1,0 +1,94 @@
+from kubetester import create_or_update_secret, try_load
+from kubetester.kubetester import KubernetesTester
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb_community import MongoDBCommunity
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.search import search_resource_names
+from tests.conftest import get_default_operator
+
+logger = test_logger.get_test_logger(__name__)
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+MDBC_RESOURCE_NAME = "mdbc-rs"
+BAD_SECRET_NAME = "bad-embedding-secret"
+PROVIDER_ENDPOINT = "https://ai.mongodb.com/v1/embeddings"
+
+
+@fixture(scope="function")
+def mdbc(namespace: str) -> MongoDBCommunity:
+    resource = MongoDBCommunity.from_yaml(
+        yaml_fixture("community-replicaset-sample-mflix.yaml"),
+        name=MDBC_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="function")
+def mdbs(namespace: str) -> MongoDBSearch:
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-minimal.yaml"),
+        namespace=namespace,
+    )
+    try_load(resource)
+    return resource
+
+
+@mark.e2e_search_auto_embedding_bad_secret
+def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
+    operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
+    operator.assert_is_running()
+
+
+@mark.e2e_search_auto_embedding_bad_secret
+def test_install_secrets(namespace: str, mdbs: MongoDBSearch):
+    create_or_update_secret(namespace=namespace, name=f"{USER_NAME}-password", data={"password": USER_PASSWORD})
+    create_or_update_secret(
+        namespace=namespace, name=f"{ADMIN_USER_NAME}-password", data={"password": ADMIN_USER_PASSWORD}
+    )
+    create_or_update_secret(
+        namespace=namespace,
+        name=f"{mdbs.name}-{MONGOT_USER_NAME}-password",
+        data={"password": MONGOT_USER_PASSWORD},
+    )
+    # deliberately missing the required "indexing-key" key
+    create_or_update_secret(
+        namespace=namespace,
+        name=BAD_SECRET_NAME,
+        data={"query-key": "placeholder"},
+    )
+
+
+@mark.e2e_search_auto_embedding_bad_secret
+def test_create_community_resource(mdbc: MongoDBCommunity):
+    mdbc.update()
+    mdbc.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_auto_embedding_bad_secret
+def test_missing_indexing_key_reconcile_error(mdbs: MongoDBSearch):
+    mdbs["spec"]["autoEmbedding"] = {
+        "embeddingModelAPIKeySecret": {"name": BAD_SECRET_NAME},
+        "providerEndpoint": PROVIDER_ENDPOINT,
+    }
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Failed, timeout=120)
+    assert 'Required key "indexing-key" is not present' in mdbs.get_status_message()
+
+
+@mark.e2e_search_auto_embedding_bad_secret
+def test_no_crashlooping_mongot_pods(namespace: str, mdbs: MongoDBSearch):
+    # ensureEmbeddingAPIKeySecret fails before the apply loop, so the mongot STS is never created
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+    pods = KubernetesTester.read_pod_labels(namespace, label_selector=f"app={sts_name}").items
+    assert pods == [], f"mongot pods exist but STS should not have been created: {[p.metadata.name for p in pods]}"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
@@ -1,5 +1,6 @@
 import os
 
+from kubernetes import client as k8s_client
 from kubetester import create_or_update_secret, try_load
 from kubetester.kubetester import KubernetesTester
 from kubetester.kubetester import fixture as yaml_fixture
@@ -134,7 +135,7 @@ def test_keys_not_leaked(mdbs: MongoDBSearch, namespace: str):
     logs = KubernetesTester.read_pod_logs(namespace, pod_name, container=MONGOT_CONTAINER)
     assert idx not in logs and qry not in logs, "embedding key leaked into mongot pod logs"
 
-    pod = KubernetesTester.read_pod(namespace, pod_name)
+    pod = k8s_client.CoreV1Api().read_namespaced_pod(name=pod_name, namespace=namespace)
     ann = pod.metadata.annotations or {}
     h = ann.get("autoEmbeddingDetailsHash")
     assert h and h != idx and h != qry, f"autoEmbeddingDetailsHash must be a hash not the raw key, got: {h!r}"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from kubernetes import client as k8s_client
 from kubetester import create_or_update_secret, try_load
@@ -131,14 +132,20 @@ def test_keys_not_leaked(mdbs: MongoDBSearch, namespace: str):
     assert idx not in status_blob and qry not in status_blob, "embedding key leaked into CR status"
 
     sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
-    pod_name = f"{sts_name}-0"
-    logs = KubernetesTester.read_pod_logs(namespace, pod_name, container=MONGOT_CONTAINER)
-    assert idx not in logs and qry not in logs, "embedding key leaked into mongot pod logs"
+    core_v1 = k8s_client.CoreV1Api()
+    for ordinal in range(2):
+        pod_name = f"{sts_name}-{ordinal}"
+        logs = KubernetesTester.read_pod_logs(namespace, pod_name, container=MONGOT_CONTAINER)
+        assert idx not in logs and qry not in logs, f"embedding key leaked into {pod_name} mongot pod logs"
 
-    pod = k8s_client.CoreV1Api().read_namespaced_pod(name=pod_name, namespace=namespace)
-    ann = pod.metadata.annotations or {}
-    h = ann.get("autoEmbeddingDetailsHash")
-    assert h and h != idx and h != qry, f"autoEmbeddingDetailsHash must be a hash not the raw key, got: {h!r}"
+        pod = core_v1.read_namespaced_pod(name=pod_name, namespace=namespace)
+        ann = pod.metadata.annotations or {}
+        h = ann.get("autoEmbeddingDetailsHash")
+        # hash is SHA-256 encoded as base32 no-padding → 52 chars in [A-Z2-7]
+        assert h and re.fullmatch(r"[A-Z2-7]{52}", h), (
+            f"{pod_name} autoEmbeddingDetailsHash must be a base32 SHA-256 hash, got: {h!r}"
+        )
+        assert h != idx and h != qry, f"{pod_name} autoEmbeddingDetailsHash must not equal a raw key"
 
 
 @mark.e2e_search_auto_embedding_key_handling

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
@@ -1,0 +1,150 @@
+import os
+
+from kubetester import create_or_update_secret, try_load
+from kubetester.kubetester import KubernetesTester
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb_community import MongoDBCommunity
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
+from tests.conftest import get_default_operator
+
+logger = test_logger.get_test_logger(__name__)
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+MDBC_RESOURCE_NAME = "mdbc-rs"
+EMBEDDING_INDEXING_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_INDEXING_KEY"
+EMBEDDING_QUERY_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_QUERY_KEY"
+VOYAGE_API_KEY_SECRET_NAME = "voyage-api-keys"
+PROVIDER_ENDPOINT = "https://ai.mongodb.com/v1/embeddings"
+MONGOT_CONTAINER = "mongot"
+EMBEDDING_SECRETS_PATH = "/etc/mongot/secrets"
+
+
+@fixture(scope="function")
+def mdbc(namespace: str) -> MongoDBCommunity:
+    resource = MongoDBCommunity.from_yaml(
+        yaml_fixture("community-replicaset-sample-mflix.yaml"),
+        name=MDBC_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="function")
+def mdbs(namespace: str) -> MongoDBSearch:
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-minimal.yaml"),
+        namespace=namespace,
+    )
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="function")
+def sample_movies_helper(mdbc: MongoDBCommunity, namespace: str) -> SampleMoviesSearchHelper:
+    from tests.common.search import movies_search_helper
+
+    return movies_search_helper.SampleMoviesSearchHelper(
+        SearchTester.for_replicaset(mdbc, USER_NAME, USER_PASSWORD),
+        tools_pod=mongodb_tools_pod.get_tools_pod(namespace),
+    )
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
+    operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
+    operator.assert_is_running()
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_install_secrets(namespace: str, mdbs: MongoDBSearch):
+    create_or_update_secret(namespace=namespace, name=f"{USER_NAME}-password", data={"password": USER_PASSWORD})
+    create_or_update_secret(
+        namespace=namespace, name=f"{ADMIN_USER_NAME}-password", data={"password": ADMIN_USER_PASSWORD}
+    )
+    create_or_update_secret(
+        namespace=namespace,
+        name=f"{mdbs.name}-{MONGOT_USER_NAME}-password",
+        data={"password": MONGOT_USER_PASSWORD},
+    )
+
+    indexing_key = os.getenv(EMBEDDING_INDEXING_KEY_ENV_VAR)
+    query_key = os.getenv(EMBEDDING_QUERY_KEY_ENV_VAR)
+    if not indexing_key or not query_key:
+        raise ValueError(
+            f"Missing required environment variables: {EMBEDDING_INDEXING_KEY_ENV_VAR} and/or {EMBEDDING_QUERY_KEY_ENV_VAR}"
+        )
+    create_or_update_secret(
+        namespace=namespace,
+        name=VOYAGE_API_KEY_SECRET_NAME,
+        data={"query-key": query_key, "indexing-key": indexing_key},
+    )
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_create_community_resource(mdbc: MongoDBCommunity):
+    mdbc.update()
+    mdbc.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_create_search_resource(mdbs: MongoDBSearch):
+    mdbs["spec"]["autoEmbedding"] = {
+        "embeddingModelAPIKeySecret": {"name": VOYAGE_API_KEY_SECRET_NAME},
+        "providerEndpoint": PROVIDER_ENDPOINT,
+    }
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_restore_sample_database(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.restore_sample_database()
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_keys_not_leaked(mdbs: MongoDBSearch, namespace: str):
+    idx = os.environ[EMBEDDING_INDEXING_KEY_ENV_VAR]
+    qry = os.environ[EMBEDDING_QUERY_KEY_ENV_VAR]
+    assert idx and qry, "key values must be non-empty for the leak check to be meaningful"
+
+    cm_name = search_resource_names.mongot_configmap_name(mdbs.name)
+    cm = KubernetesTester.read_configmap(namespace, cm_name)
+    for blob in cm.values():
+        assert idx not in blob and qry not in blob, f"embedding key leaked into mongot ConfigMap {cm_name}"
+
+    status_blob = str(mdbs.load()["status"])
+    assert idx not in status_blob and qry not in status_blob, "embedding key leaked into CR status"
+
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+    pod_name = f"{sts_name}-0"
+    logs = KubernetesTester.read_pod_logs(namespace, pod_name, container=MONGOT_CONTAINER)
+    assert idx not in logs and qry not in logs, "embedding key leaked into mongot pod logs"
+
+    pod = KubernetesTester.read_pod(namespace, pod_name)
+    ann = pod.metadata.annotations or {}
+    h = ann.get("autoEmbeddingDetailsHash")
+    assert h and h != idx and h != qry, f"autoEmbeddingDetailsHash must be a hash not the raw key, got: {h!r}"
+
+
+@mark.e2e_search_auto_embedding_key_handling
+def test_keys_file_mounted(mdbs: MongoDBSearch, namespace: str):
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+    pod_name = f"{sts_name}-0"
+    out = KubernetesTester.run_command_in_pod_container(
+        pod_name, namespace, ["ls", EMBEDDING_SECRETS_PATH], container=MONGOT_CONTAINER
+    )
+    assert "indexing-key" in out and "query-key" in out, f"key files not mounted under {EMBEDDING_SECRETS_PATH}: {out}"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
@@ -4,7 +4,6 @@ import uuid
 from datetime import datetime, timezone
 
 import pymongo.errors
-
 from kubernetes import client as k8s_client
 from kubetester import create_or_update_secret, try_load
 from kubetester.certs import create_tls_certs

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
@@ -3,6 +3,8 @@ import time
 import uuid
 from datetime import datetime, timezone
 
+import pymongo.errors
+
 from kubernetes import client as k8s_client
 from kubetester import create_or_update_secret, try_load
 from kubetester.certs import create_tls_certs
@@ -206,6 +208,12 @@ def test_create_auto_embedding_index(sample_movies_helper: SampleMoviesSearchHel
 
 
 @mark.e2e_search_auto_embedding_rolling_restart
+def test_wait_for_auto_embedding_index(sample_movies_helper: SampleMoviesSearchHelper):
+    # initial sync embeds ~21k docs through the embedding API; 600s to ensure READY before the roll
+    sample_movies_helper.search_tester.wait_for_search_indexes_ready(DB_NAME, COL_NAME, timeout=600)
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
 def test_backlog_drains_through_roll(
     sample_movies_helper: SampleMoviesSearchHelper, namespace: str, mdbs: MongoDBSearch
 ):
@@ -223,10 +231,11 @@ def test_backlog_drains_through_roll(
 
     wait_for_all_pods_replaced(namespace, old_uids, timeout=600)
 
-    missing = _poll_vector_search_for_sentinel_titles(
-        sample_movies_helper, {s["title"] for s in sentinels}, timeout=300
-    )
-    assert not missing, f"sentinels never indexed after roll (backlog stalled): {missing}"
+    missing_titles = _poll_vector_search_for_sentinel_titles(sample_movies_helper, sentinels, timeout=300)
+    if missing_titles:
+        missing_docs = [s for s in sentinels if s["title"] in missing_titles]
+        diagnostics = _diagnose_missing_sentinels(sample_movies_helper, missing_docs)
+        assert False, f"sentinels never indexed after roll (backlog stalled):\n{diagnostics}"
 
 
 def _make_sentinel_docs(n: int) -> list[dict]:
@@ -252,31 +261,65 @@ def _rollout_restart_sts(namespace: str, sts_name: str) -> None:
 
 
 def _poll_vector_search_for_sentinel_titles(
-    helper: SampleMoviesSearchHelper, expected_titles: set[str], timeout: int = 300
+    helper: SampleMoviesSearchHelper, sentinels: list[dict], timeout: int = 300
 ) -> set[str]:
-    """Return the set of expected titles NOT found within timeout. Empty set = all found."""
-    not_found = set(expected_titles)
+    """Return titles NOT found via $vectorSearch within timeout. Empty set = all indexed."""
+    not_found = {s["title"]: s["plot"] for s in sentinels}
     deadline = time.time() + timeout
     while not_found and time.time() < deadline:
-        for title in list(not_found):
-            results = list(
-                helper.search_tester.client[DB_NAME][COL_NAME].aggregate(
+        for title, plot in list(not_found.items()):
+            try:
+                # plot self-query → cosine ≈ 1.0 → target ranks #1; limit covers all sentinels (tight cluster)
+                results = list(
+                    helper.search_tester.client[DB_NAME][COL_NAME].aggregate(
+                        [
+                            {
+                                "$vectorSearch": {
+                                    "index": "vector_auto_embed_index",
+                                    "path": "plot",
+                                    "query": plot,
+                                    "numCandidates": 150,
+                                    "limit": SENTINEL_COUNT,
+                                }
+                            },
+                            {"$project": {"title": 1, "_id": 0}},
+                        ]
+                    )
+                )
+                if any(r.get("title") == title for r in results):
+                    del not_found[title]
+            except pymongo.errors.OperationFailure:
+                pass  # transient 503 from mongot during recovery; retry next cycle
+        if not_found:
+            time.sleep(5)
+    return set(not_found.keys())
+
+
+def _diagnose_missing_sentinels(helper: SampleMoviesSearchHelper, missing_docs: list[dict]) -> str:
+    """For each missing sentinel emit: exists-in-mongo (insert confirmed) + indexed (embedding ran)."""
+    lines = []
+    col = helper.search_tester.client[DB_NAME][COL_NAME]
+    for s in missing_docs:
+        exists = col.find_one({"_id": s["_id"]}) is not None
+        try:
+            hits = list(
+                col.aggregate(
                     [
                         {
                             "$vectorSearch": {
                                 "index": "vector_auto_embed_index",
                                 "path": "plot",
-                                "query": title,
-                                "numCandidates": 10,
-                                "limit": 5,
+                                "query": s["plot"],
+                                "numCandidates": 150,
+                                "limit": 1,
                             }
                         },
-                        {"$project": {"title": 1, "_id": 0}},
+                        {"$project": {"_id": 1}},
                     ]
                 )
             )
-            if any(r.get("title") == title for r in results):
-                not_found.discard(title)
-        if not_found:
-            time.sleep(5)
-    return not_found
+            indexed = any(r.get("_id") == s["_id"] for r in hits)
+        except Exception:
+            indexed = False
+        lines.append(f"  {s['title']}: exists={exists}, indexed={indexed}")
+    return "\n".join(lines)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
@@ -1,0 +1,282 @@
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+
+from kubernetes import client as k8s_client
+from kubetester import create_or_update_secret, try_load
+from kubetester.certs import create_tls_certs
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb_community import MongoDBCommunity
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import movies_search_helper, search_resource_names
+from tests.common.search.connectivity import wait_for_all_pods_replaced
+from tests.common.search.envoy_helpers import EnvoyProxy
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
+from tests.common.search.sharded_search_helper import create_issuer_ca
+from tests.conftest import get_default_operator
+
+logger = test_logger.get_test_logger(__name__)
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+MONGOT_PORT = 27028
+ENVOY_PROXY_PORT = 27029
+ENVOY_ADMIN_PORT = 9901
+
+MDBC_RESOURCE_NAME = "mdbc-rs"
+MDBS_RESOURCE_NAME = MDBC_RESOURCE_NAME
+MONGOT_USER_PASSWORD_SECRET_NAME = f"mdbc-rs-{MONGOT_USER_NAME}-password"
+
+CA_CONFIGMAP_NAME = f"{MDBC_RESOURCE_NAME}-ca"
+MDBC_TLS_SECRET_NAME = "mdbc-tls-secret"
+MDBS_TLS_SECRET_NAME = search_resource_names.mongot_tls_cert_name(MDBC_RESOURCE_NAME)
+ENVOY_PROXY_SVC_NAME = "envoy-proxy-svc"
+
+EMBEDDING_INDEXING_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_INDEXING_KEY"
+EMBEDDING_QUERY_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_QUERY_KEY"
+VOYAGE_API_KEY_SECRET_NAME = "voyage-api-keys"
+PROVIDER_ENDPOINT = "https://ai.mongodb.com/v1/embeddings"
+
+DB_NAME = "sample_mflix"
+COL_NAME = "movies"
+SENTINEL_COUNT = 20
+
+
+@fixture(scope="module")
+def ca_configmap(issuer_ca_filepath: str, namespace: str) -> str:
+    return create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
+
+
+@fixture(scope="function")
+def envoy(namespace: str) -> EnvoyProxy:
+    return EnvoyProxy(
+        namespace=namespace,
+        ca_configmap_name=CA_CONFIGMAP_NAME,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        mongot_port=MONGOT_PORT,
+        envoy_proxy_port=ENVOY_PROXY_PORT,
+        envoy_admin_port=ENVOY_ADMIN_PORT,
+    )
+
+
+@fixture(scope="function")
+def mdbc(namespace: str) -> MongoDBCommunity:
+    resource = MongoDBCommunity.from_yaml(
+        yaml_fixture("community-replicaset-sample-mflix.yaml"),
+        name=MDBC_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    resource["spec"]["security"]["tls"] = {
+        "enabled": True,
+        "certificateKeySecretRef": {"name": MDBC_TLS_SECRET_NAME},
+        "caCertificateSecretRef": {"name": MDBC_TLS_SECRET_NAME},
+    }
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="function")
+def mdbs(namespace: str, mdbc: MongoDBCommunity) -> MongoDBSearch:
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-minimal.yaml"),
+        namespace=namespace,
+        name=MDBC_RESOURCE_NAME,
+    )
+    if try_load(resource):
+        return resource
+
+    resource["spec"]["source"] = {"passwordSecretRef": {"name": MONGOT_USER_PASSWORD_SECRET_NAME}}
+    resource["spec"]["clusters"] = [{"replicas": 2}]
+    resource["spec"]["loadBalancer"] = {
+        "unmanaged": {
+            "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+        }
+    }
+    resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
+    resource["spec"]["autoEmbedding"] = {
+        "embeddingModelAPIKeySecret": {"name": VOYAGE_API_KEY_SECRET_NAME},
+        "providerEndpoint": PROVIDER_ENDPOINT,
+    }
+    return resource
+
+
+@fixture(scope="function")
+def sample_movies_helper(mdbc: MongoDBCommunity, issuer_ca_filepath: str, namespace: str) -> SampleMoviesSearchHelper:
+    return movies_search_helper.SampleMoviesSearchHelper(
+        SearchTester.for_replicaset(mdbc, USER_NAME, USER_PASSWORD, use_ssl=True, ca_path=issuer_ca_filepath),
+        tools_pod=mongodb_tools_pod.get_tools_pod(namespace),
+    )
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
+    operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
+    operator.assert_is_running()
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_install_secrets(namespace: str, mdbs: MongoDBSearch):
+    create_or_update_secret(namespace=namespace, name=f"{USER_NAME}-password", data={"password": USER_PASSWORD})
+    create_or_update_secret(
+        namespace=namespace, name=f"{ADMIN_USER_NAME}-password", data={"password": ADMIN_USER_PASSWORD}
+    )
+    create_or_update_secret(
+        namespace=namespace,
+        name=MONGOT_USER_PASSWORD_SECRET_NAME,
+        data={"password": MONGOT_USER_PASSWORD},
+    )
+
+    indexing_key = os.getenv(EMBEDDING_INDEXING_KEY_ENV_VAR)
+    query_key = os.getenv(EMBEDDING_QUERY_KEY_ENV_VAR)
+    if not indexing_key or not query_key:
+        raise ValueError(
+            f"Missing required environment variables: {EMBEDDING_INDEXING_KEY_ENV_VAR} and/or {EMBEDDING_QUERY_KEY_ENV_VAR}"
+        )
+    create_or_update_secret(
+        namespace=namespace,
+        name=VOYAGE_API_KEY_SECRET_NAME,
+        data={"query-key": query_key, "indexing-key": indexing_key},
+    )
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_install_tls_certificates(
+    namespace: str, mdbc: MongoDBCommunity, mdbs: MongoDBSearch, issuer: str, ca_configmap: str
+):
+    create_tls_certs(issuer, namespace, mdbc.name, mdbc["spec"]["members"], secret_name=MDBC_TLS_SECRET_NAME)
+
+    search_service_name = search_resource_names.mongot_service_name(mdbs.name)
+    create_tls_certs(
+        issuer,
+        namespace,
+        search_resource_names.mongot_statefulset_name(mdbs.name),
+        replicas=2,
+        service_name=search_service_name,
+        additional_domains=[f"{search_service_name}.{namespace}.svc.cluster.local"],
+        secret_name=MDBS_TLS_SECRET_NAME,
+    )
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_create_database_resource(mdbc: MongoDBCommunity):
+    mdbc.update()
+    mdbc.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_deploy_envoy_certificates(envoy: EnvoyProxy, issuer: str):
+    envoy.create_certificates(issuer)
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_deploy_envoy_proxy(envoy: EnvoyProxy):
+    envoy.deploy()
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_create_search_resource(mdbs: MongoDBSearch):
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_wait_for_database_resource_ready(mdbc: MongoDBCommunity):
+    mdbc.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_restore_sample_database(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.restore_sample_database()
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_create_auto_embedding_index(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.create_auto_embedding_vector_search_index()
+
+
+@mark.e2e_search_auto_embedding_rolling_restart
+def test_backlog_drains_through_roll(
+    sample_movies_helper: SampleMoviesSearchHelper, namespace: str, mdbs: MongoDBSearch
+):
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+    pod_names = [f"{sts_name}-0", f"{sts_name}-1"]
+
+    core_v1 = k8s_client.CoreV1Api()
+    old_uids = {name: core_v1.read_namespaced_pod(name=name, namespace=namespace).metadata.uid for name in pod_names}
+
+    sentinels = _make_sentinel_docs(SENTINEL_COUNT)
+
+    # trigger a real STS rolling restart then insert sentinels across the window
+    _rollout_restart_sts(namespace, sts_name)
+    sample_movies_helper.search_tester.client[DB_NAME][COL_NAME].insert_many(sentinels)
+
+    wait_for_all_pods_replaced(namespace, old_uids, timeout=600)
+
+    missing = _poll_vector_search_for_sentinel_titles(
+        sample_movies_helper, {s["title"] for s in sentinels}, timeout=300
+    )
+    assert not missing, f"sentinels never indexed after roll (backlog stalled): {missing}"
+
+
+def _make_sentinel_docs(n: int) -> list[dict]:
+    tag = uuid.uuid4().hex[:8]
+    return [
+        {
+            "_id": f"sentinel-roll-{tag}-{i}",
+            "title": f"Sentinel Roll {tag} {i}",
+            # distinctive plot text: query by this to find the sentinel as nearest neighbor
+            "plot": f"A unique sentinel document inserted during rolling restart {tag} number {i}.",
+        }
+        for i in range(n)
+    ]
+
+
+def _rollout_restart_sts(namespace: str, sts_name: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    k8s_client.AppsV1Api().patch_namespaced_stateful_set(
+        name=sts_name,
+        namespace=namespace,
+        body={"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}}}},
+    )
+
+
+def _poll_vector_search_for_sentinel_titles(
+    helper: SampleMoviesSearchHelper, expected_titles: set[str], timeout: int = 300
+) -> set[str]:
+    """Return the set of expected titles NOT found within timeout. Empty set = all found."""
+    not_found = set(expected_titles)
+    deadline = time.time() + timeout
+    while not_found and time.time() < deadline:
+        for title in list(not_found):
+            results = list(
+                helper.search_tester.client[DB_NAME][COL_NAME].aggregate(
+                    [
+                        {
+                            "$vectorSearch": {
+                                "index": "vector_auto_embed_index",
+                                "path": "plot",
+                                "query": title,
+                                "numCandidates": 10,
+                                "limit": 5,
+                            }
+                        },
+                        {"$project": {"title": 1, "_id": 0}},
+                    ]
+                )
+            )
+            if any(r.get("title") == title for r in results):
+                not_found.discard(title)
+        if not_found:
+            time.sleep(5)
+    return not_found

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
@@ -54,6 +54,30 @@ DB_NAME = "sample_mflix"
 COL_NAME = "movies"
 SENTINEL_COUNT = 20
 
+# distinct plots: near-identical text clusters in ANN space and makes rank-1 self-match unreliable
+_SENTINEL_PLOTS = [
+    "A submarine crew discovers ancient ruins beneath the Arctic Ocean floor.",
+    "An astronomer traces coded messages hidden inside century-old star charts.",
+    "Rival perfumers battle to recreate a fragrance that triggers lost memories.",
+    "A lighthouse keeper receives transmissions from a ship that sank decades ago.",
+    "Underground engineers reroute medieval aqueducts beneath a modern skyscraper.",
+    "A chess grandmaster tutors prisoners using stolen championship theory.",
+    "Forensic botanists identify a poisoner through rare pollen found in a wound.",
+    "A metallurgist forges swords from ore salvaged inside a meteorite crater.",
+    "Nomadic astronomers chart constellations invisible to settled civilizations.",
+    "A dye merchant smuggles coded dispatches inside bolts of ceremonial fabric.",
+    "Competing salvage crews fight over a sunken nuclear-powered icebreaker.",
+    "Blind clockmakers in a monastery build instruments that predict storms.",
+    "A mycologist discovers a fungal network recording human speech underground.",
+    "Desert travelers find a crashed aircraft carrying classified cargo from 1952.",
+    "A cartographer deciphers coordinates hidden inside cathedral stained glass.",
+    "Rival falconers duel with engineered raptors over contested mountain airspace.",
+    "A disgraced chef recreates a banned recipe using forbidden spice combinations.",
+    "An archaeologist uncovers evidence that rewrites the history of writing itself.",
+    "A volcanologist discovers a civilization living inside a dormant caldera.",
+    "An ice diver recovers a manuscript proving an alternative history of mathematics.",
+]
+
 
 @fixture(scope="module")
 def ca_configmap(issuer_ca_filepath: str, namespace: str) -> str:
@@ -211,6 +235,8 @@ def test_create_auto_embedding_index(sample_movies_helper: SampleMoviesSearchHel
 def test_wait_for_auto_embedding_index(sample_movies_helper: SampleMoviesSearchHelper):
     # initial sync embeds ~21k docs through the embedding API; 600s to ensure READY before the roll
     sample_movies_helper.search_tester.wait_for_search_indexes_ready(DB_NAME, COL_NAME, timeout=600)
+    # metadata READY != queryable; smoke-query until $vectorSearch actually returns results
+    sample_movies_helper.assert_auto_emb_vector_search_query(retry_timeout=60)
 
 
 @mark.e2e_search_auto_embedding_rolling_restart
@@ -225,8 +251,9 @@ def test_backlog_drains_through_roll(
 
     sentinels = _make_sentinel_docs(SENTINEL_COUNT)
 
-    # trigger a real STS rolling restart then insert sentinels across the window
     _rollout_restart_sts(namespace, sts_name)
+    # inserts must land after a pod goes not-Ready; otherwise they land at full health and never hit a backlog
+    _wait_for_pod_not_ready(namespace, f"{sts_name}-1")
     sample_movies_helper.search_tester.client[DB_NAME][COL_NAME].insert_many(sentinels)
 
     wait_for_all_pods_replaced(namespace, old_uids, timeout=600)
@@ -244,8 +271,8 @@ def _make_sentinel_docs(n: int) -> list[dict]:
         {
             "_id": f"sentinel-roll-{tag}-{i}",
             "title": f"Sentinel Roll {tag} {i}",
-            # distinctive plot text: query by this to find the sentinel as nearest neighbor
-            "plot": f"A unique sentinel document inserted during rolling restart {tag} number {i}.",
+            # unique run tag appended so re-runs don't collide with stale data from prior tests
+            "plot": f"{_SENTINEL_PLOTS[i % len(_SENTINEL_PLOTS)]} Unique run: {tag}.",
         }
         for i in range(n)
     ]
@@ -260,18 +287,37 @@ def _rollout_restart_sts(namespace: str, sts_name: str) -> None:
     )
 
 
+def _wait_for_pod_not_ready(namespace: str, pod_name: str, timeout: int = 120) -> None:
+    """Block until the named pod is Gone or NotReady (confirms the disruption window is open)."""
+    core_v1 = k8s_client.CoreV1Api()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            pod = core_v1.read_namespaced_pod(name=pod_name, namespace=namespace)
+            conditions = pod.status.conditions or []
+            if not any(c.type == "Ready" and c.status == "True" for c in conditions):
+                return
+        except Exception as e:
+            if getattr(e, "status", None) == 404:
+                return  # pod deleted → definitely not ready
+            raise
+        time.sleep(2)
+    raise TimeoutError(f"{pod_name} never went not-Ready within {timeout}s")
+
+
 def _poll_vector_search_for_sentinel_titles(
     helper: SampleMoviesSearchHelper, sentinels: list[dict], timeout: int = 300
 ) -> set[str]:
     """Return titles NOT found via $vectorSearch within timeout. Empty set = all indexed."""
-    not_found = {s["title"]: s["plot"] for s in sentinels}
+    not_found = {s["_id"]: (s["title"], s["plot"]) for s in sentinels}
     deadline = time.time() + timeout
+    col = helper.search_tester.client[DB_NAME][COL_NAME]
     while not_found and time.time() < deadline:
-        for title, plot in list(not_found.items()):
+        for doc_id, (title, plot) in list(not_found.items()):
             try:
-                # plot self-query → cosine ≈ 1.0 → target ranks #1; limit covers all sentinels (tight cluster)
-                results = list(
-                    helper.search_tester.client[DB_NAME][COL_NAME].aggregate(
+                # distinct plot self-query → target is rank #1 (cosine ≈ 1.0); limit=1 + _id check is exact
+                hits = list(
+                    col.aggregate(
                         [
                             {
                                 "$vectorSearch": {
@@ -279,20 +325,20 @@ def _poll_vector_search_for_sentinel_titles(
                                     "path": "plot",
                                     "query": plot,
                                     "numCandidates": 150,
-                                    "limit": SENTINEL_COUNT,
+                                    "limit": 1,
                                 }
                             },
-                            {"$project": {"title": 1, "_id": 0}},
+                            {"$project": {"_id": 1}},
                         ]
                     )
                 )
-                if any(r.get("title") == title for r in results):
-                    del not_found[title]
-            except pymongo.errors.OperationFailure:
-                pass  # transient 503 from mongot during recovery; retry next cycle
+                if hits and hits[0].get("_id") == doc_id:
+                    del not_found[doc_id]
+            except pymongo.errors.PyMongoError:
+                pass  # transient path error during recovery; retry next cycle
         if not_found:
             time.sleep(5)
-    return set(not_found.keys())
+    return {title for title, _ in not_found.values()}
 
 
 def _diagnose_missing_sentinels(helper: SampleMoviesSearchHelper, missing_docs: list[dict]) -> str:
@@ -319,7 +365,7 @@ def _diagnose_missing_sentinels(helper: SampleMoviesSearchHelper, missing_docs: 
                 )
             )
             indexed = any(r.get("_id") == s["_id"] for r in hits)
-        except Exception:
-            indexed = False
+        except Exception as exc:
+            indexed = f"err:{exc}"
         lines.append(f"  {s['title']}: exists={exists}, indexed={indexed}")
     return "\n".join(lines)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_version_gate.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_version_gate.py
@@ -1,0 +1,96 @@
+import os
+
+from kubetester import create_or_update_secret, try_load
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb_community import MongoDBCommunity
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.conftest import get_default_operator
+
+logger = test_logger.get_test_logger(__name__)
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+MDBC_RESOURCE_NAME = "mdbc-rs"
+EMBEDDING_INDEXING_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_INDEXING_KEY"
+EMBEDDING_QUERY_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_QUERY_KEY"
+VOYAGE_API_KEY_SECRET_NAME = "voyage-api-keys"
+PROVIDER_ENDPOINT = "https://ai.mongodb.com/v1/embeddings"
+
+
+@fixture(scope="function")
+def mdbc(namespace: str) -> MongoDBCommunity:
+    resource = MongoDBCommunity.from_yaml(
+        yaml_fixture("community-replicaset-sample-mflix.yaml"),
+        name=MDBC_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="function")
+def mdbs(namespace: str) -> MongoDBSearch:
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-minimal.yaml"),
+        namespace=namespace,
+    )
+    try_load(resource)
+    return resource
+
+
+@mark.e2e_search_auto_embedding_version_gate
+def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
+    operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
+    operator.assert_is_running()
+
+
+@mark.e2e_search_auto_embedding_version_gate
+def test_install_secrets(namespace: str, mdbs: MongoDBSearch):
+    create_or_update_secret(namespace=namespace, name=f"{USER_NAME}-password", data={"password": USER_PASSWORD})
+    create_or_update_secret(
+        namespace=namespace, name=f"{ADMIN_USER_NAME}-password", data={"password": ADMIN_USER_PASSWORD}
+    )
+    create_or_update_secret(
+        namespace=namespace,
+        name=f"{mdbs.name}-{MONGOT_USER_NAME}-password",
+        data={"password": MONGOT_USER_PASSWORD},
+    )
+
+    indexing_key = os.getenv(EMBEDDING_INDEXING_KEY_ENV_VAR)
+    query_key = os.getenv(EMBEDDING_QUERY_KEY_ENV_VAR)
+    if not indexing_key or not query_key:
+        raise ValueError(
+            f"Missing required environment variables: {EMBEDDING_INDEXING_KEY_ENV_VAR} and/or {EMBEDDING_QUERY_KEY_ENV_VAR}"
+        )
+    create_or_update_secret(
+        namespace=namespace,
+        name=VOYAGE_API_KEY_SECRET_NAME,
+        data={"query-key": query_key, "indexing-key": indexing_key},
+    )
+
+
+@mark.e2e_search_auto_embedding_version_gate
+def test_create_community_resource(mdbc: MongoDBCommunity):
+    mdbc.update()
+    mdbc.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_auto_embedding_version_gate
+def test_version_gate_rejects_sub_min(mdbs: MongoDBSearch):
+    mdbs["spec"]["version"] = "0.59.0"  # valid semver < minSearchImageVersionForEmbedding (0.60.0)
+    mdbs["spec"]["autoEmbedding"] = {
+        "embeddingModelAPIKeySecret": {"name": VOYAGE_API_KEY_SECRET_NAME},
+        "providerEndpoint": PROVIDER_ENDPOINT,
+    }
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Failed, timeout=120)
+    msg = mdbs.get_status_message()
+    assert "auto embeddings" in msg and "0.60.0" in msg, f"unexpected status message: {msg}"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_version_gate.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_version_gate.py
@@ -93,4 +93,4 @@ def test_version_gate_rejects_sub_min(mdbs: MongoDBSearch):
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Failed, timeout=120)
     msg = mdbs.get_status_message()
-    assert "auto embeddings" in msg and "0.60.0" in msg, f"unexpected status message: {msg}"
+    assert msg and "auto embeddings" in msg and "0.60.0" in msg, f"unexpected status message: {msg}"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_external_auto_embedding.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_external_auto_embedding.py
@@ -1,0 +1,192 @@
+import os
+
+from kubetester import create_or_update_secret
+from kubetester.certs import create_mongodb_tls_certs, create_tls_certs
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.omtester import skip_if_cloud_manager
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import movies_search_helper, search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_deployment_helper import SearchDeploymentHelper
+from tests.common.search.search_tester import SearchTester
+from tests.common.search.sharded_search_helper import create_issuer_ca
+from tests.conftest import get_default_operator, get_issuer_ca_filepath
+from tests.search.om_deployment import get_ops_manager
+
+logger = test_logger.get_test_logger(__name__)
+
+MDB_RESOURCE_NAME = "mdb-rs-ext"
+MDBS_RESOURCE_NAME = MDB_RESOURCE_NAME
+
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+USER_NAME = "mdb-user"
+USER_PASSWORD = "mdb-user-pass"
+
+CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
+MDBS_TLS_SECRET_NAME = search_resource_names.mongot_tls_cert_name(MDB_RESOURCE_NAME)
+
+EMBEDDING_INDEXING_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_INDEXING_KEY"
+EMBEDDING_QUERY_KEY_ENV_VAR = "AI_MONGODB_EMBEDDING_QUERY_KEY"
+VOYAGE_API_KEY_SECRET_NAME = "voyage-api-keys"
+PROVIDER_ENDPOINT = "https://ai.mongodb.com/v1/embeddings"
+
+
+@fixture(scope="module")
+def ca_configmap(issuer_ca_filepath: str, namespace: str) -> str:
+    return create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
+
+
+@fixture(scope="function")
+def helper(namespace: str) -> SearchDeploymentHelper:
+    return SearchDeploymentHelper(
+        namespace=namespace,
+        mdb_resource_name=MDB_RESOURCE_NAME,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        ca_configmap_name=CA_CONFIGMAP_NAME,
+    )
+
+
+@fixture(scope="function")
+def mdb(namespace: str, ca_configmap: str, issuer_ca_configmap: str, helper: SearchDeploymentHelper) -> MongoDB:
+    mongot_host = search_resource_names.mongot_pod_fqdn(MDBS_RESOURCE_NAME, namespace, 27028)
+    return helper.create_replicaset_mdb(
+        mongot_host=mongot_host,
+        issuer_ca_configmap=issuer_ca_configmap,
+        tls_cert_prefix="certs",
+    )
+
+
+@fixture(scope="function")
+def mdbs(namespace: str, helper: SearchDeploymentHelper) -> MongoDBSearch:
+    resource = helper.mdbs_for_ext_rs_source(mongot_user_name=MONGOT_USER_NAME)
+    resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
+    return resource
+
+
+@fixture(scope="function")
+def admin_user(helper: SearchDeploymentHelper) -> MongoDBUser:
+    return helper.admin_user_resource(ADMIN_USER_NAME)
+
+
+@fixture(scope="function")
+def user(helper: SearchDeploymentHelper) -> MongoDBUser:
+    return helper.user_resource(USER_NAME)
+
+
+@fixture(scope="function")
+def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBUser:
+    return helper.mongot_user_resource(mdbs.name, MONGOT_USER_NAME)
+
+
+@fixture(scope="function")
+def sample_movies_helper(mdb: MongoDB, namespace: str) -> SampleMoviesSearchHelper:
+    return movies_search_helper.SampleMoviesSearchHelper(
+        SearchTester.for_replicaset(mdb, USER_NAME, USER_PASSWORD, use_ssl=True, ca_path=get_issuer_ca_filepath()),
+        tools_pod=mongodb_tools_pod.get_tools_pod(namespace),
+    )
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
+    operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
+    operator.assert_is_running()
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+@skip_if_cloud_manager
+def test_create_ops_manager(namespace: str):
+    ops_manager = get_ops_manager(namespace)
+    assert ops_manager is not None
+    ops_manager.update()
+    ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=1200)
+    ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_install_embedding_secret(namespace: str):
+    indexing_key = os.getenv(EMBEDDING_INDEXING_KEY_ENV_VAR)
+    query_key = os.getenv(EMBEDDING_QUERY_KEY_ENV_VAR)
+    if not indexing_key or not query_key:
+        raise ValueError(
+            f"Missing required environment variables: {EMBEDDING_INDEXING_KEY_ENV_VAR} and/or {EMBEDDING_QUERY_KEY_ENV_VAR}"
+        )
+    create_or_update_secret(
+        namespace=namespace,
+        name=VOYAGE_API_KEY_SECRET_NAME,
+        data={"query-key": query_key, "indexing-key": indexing_key},
+    )
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_install_tls_certificates(namespace: str, mdb: MongoDB, mdbs: MongoDBSearch, issuer: str):
+    create_mongodb_tls_certs(issuer, namespace, mdb.name, f"certs-{mdb.name}-cert", mdb.get_members())
+
+    search_service_name = search_resource_names.mongot_service_name(mdbs.name)
+    create_tls_certs(
+        issuer,
+        namespace,
+        search_resource_names.mongot_statefulset_name(mdbs.name),
+        replicas=1,
+        service_name=search_service_name,
+        additional_domains=[f"{search_service_name}.{namespace}.svc.cluster.local"],
+        secret_name=MDBS_TLS_SECRET_NAME,
+    )
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_create_database_resource(mdb: MongoDB):
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_create_users(
+    helper: SearchDeploymentHelper, admin_user: MongoDBUser, user: MongoDBUser, mongot_user: MongoDBUser, mdb: MongoDB
+):
+    helper.deploy_users(
+        admin_user,
+        ADMIN_USER_PASSWORD,
+        user,
+        USER_PASSWORD,
+        mongot_user,
+        MONGOT_USER_PASSWORD,
+    )
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_create_search_resource(mdbs: MongoDBSearch):
+    mdbs["spec"]["autoEmbedding"] = {
+        "embeddingModelAPIKeySecret": {"name": VOYAGE_API_KEY_SECRET_NAME},
+        "providerEndpoint": PROVIDER_ENDPOINT,
+    }
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_wait_for_database_resource_ready(mdb: MongoDB):
+    mdb.get_om_tester().wait_agents_ready()
+    mdb.assert_reaches_phase(Phase.Running, timeout=300)
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_search_restore_sample_database(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.restore_sample_database()
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_create_auto_embedding_index(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.create_auto_embedding_vector_search_index()
+
+
+@mark.e2e_search_enterprise_external_auto_embedding
+def test_auto_embedding_query(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.assert_auto_emb_vector_search_query(retry_timeout=90)


### PR DESCRIPTION
## Summary

Adds e2e test coverage for the MongoDBSearch auto-embedding feature ahead of its GA release. Five test suites cover the operator guardrails, enterprise source support, and backlog-drain reliability:

- **Version gate** (`search_auto_embedding_version_gate`) — asserts that a `spec.version` below the minimum (`0.60.0`) produces a `Failed` phase with an actionable message, before any image is pulled.
- **Bad secret** (`search_auto_embedding_bad_secret`) — asserts that a missing `indexing-key`/`query-key` in the embedding API key Secret produces `Failed` phase; validates the operator's `ensureEmbeddingAPIKeySecret` guardrail.
- **Key-handling / leak-check** (`search_auto_embedding_key_handling`) — verifies that raw embedding API keys are never exposed in ConfigMaps, CR status, pod logs, or pod annotations; the annotation must hold a derived hash, not the key value.
- **Enterprise external RS** (`search_enterprise_external_auto_embedding`) — end-to-end functional coverage for the enterprise source path with a real vector search query using `$vectorSearch` + `autoEmbed` index.
- **Backlog drain through mongot roll** (`search_auto_embedding_rolling_restart`) — inserts sentinel documents after a mongot pod goes not-Ready during a rolling restart, then asserts all sentinels are indexed by the replacement pods. This validates that change-stream resume tokens survive the roll and backlog is drained.

All tests are wired in `.evergreen-tasks.yml` and `.evergreen.yml` under `e2e_mdb_kind_search_task_group` / `e2e_mdb_kind_search_large_task_group` and carry on `e2e_mdb_kind_ubi_cloudqa_large` + `e2e_static_mdb_kind_ubi_cloudqa_large`.

## Proof of Work

- e2e: `e2e_search_auto_embedding_rolling_restart` passed on EVG — patches `6a394ddbf5814c0007b1bfb1` and `6a395cdec348cb00071dc9ab`
- e2e: remaining four markers (`e2e_search_auto_embedding_version_gate`, `e2e_search_auto_embedding_bad_secret`, `e2e_search_auto_embedding_key_handling`, `e2e_search_enterprise_external_auto_embedding`) passed on prior EVG runs on this branch

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->