### PR TITLE
CLOUDP-411215: make assert_is_running the canonical operator readiness check

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -79,8 +79,7 @@ class Operator(object):
         This is equal to helm template...| kubectl apply -"""
         yaml_file = helm_template(self.helm_arguments, helm_chart_path=self.helm_chart_path)
         create_or_replace_from_yaml(client.api_client.ApiClient(), yaml_file)
-        self._wait_for_operator_ready()
-        self._wait_operator_webhook_is_ready()
+        self.assert_is_running()
 
         return self
 
@@ -97,8 +96,7 @@ class Operator(object):
             helm_options=self.helm_options,
             custom_operator_version=custom_operator_version,
         )
-        self._wait_for_operator_ready()
-        self._wait_operator_webhook_is_ready()
+        self.assert_is_running()
 
         return self
 
@@ -118,8 +116,7 @@ class Operator(object):
             custom_operator_version=custom_operator_version,
             apply_crds_first=apply_crds_first,
         )
-        self._wait_for_operator_ready()
-        self._wait_operator_webhook_is_ready(multi_cluster=multi_cluster)
+        self.assert_is_running(multi_cluster=multi_cluster)
 
         return self
 
@@ -145,8 +142,9 @@ class Operator(object):
     def read_deployment(self) -> V1Deployment:
         return client.AppsV1Api(api_client=self.api_client).read_namespaced_deployment(self.name, self.namespace)
 
-    def assert_is_running(self):
+    def assert_is_running(self, multi_cluster: bool = False):
         self._wait_for_operator_ready()
+        self._wait_operator_webhook_is_ready(multi_cluster=multi_cluster)
 
     def _wait_for_operator_ready(self, retries: int = 60):
         """waits until the Operator deployment is ready."""

--- a/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
@@ -350,7 +350,7 @@ def test_removing_role_from_resources(replica_set: MongoDB, sharded_cluster: Mon
 
 @mark.e2e_mongodb_custom_roles
 def test_install_operator_with_clustermongodbroles_disabled(multi_cluster_operator_no_cluster_mongodb_roles):
-    multi_cluster_operator_no_cluster_mongodb_roles.assert_is_running()
+    multi_cluster_operator_no_cluster_mongodb_roles.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_mongodb_custom_roles

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -963,7 +963,7 @@ def install_legacy_deployment_state_meko(
         operator_name=LEGACY_OPERATOR_NAME,
         operator_image=LEGACY_OPERATOR_IMAGE_NAME,
     )
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=is_multi_cluster())
     # Dumping deployments in logs ensures we are using the correct operator version
     log_deployments_info(namespace)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/manual_multi_cluster_tls_no_mesh_2_clusters_eks_gke.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/manual_multi_cluster_tls_no_mesh_2_clusters_eks_gke.py
@@ -131,7 +131,7 @@ def server_certs(
 
 
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 def test_create_mongodb_multi(

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_clusterwide_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_clusterwide_replicaset.py
@@ -186,7 +186,7 @@ def test_create_namespaces(
 
 @pytest.mark.e2e_multi_cluster_2_clusters_clusterwide
 def test_deploy_operator(multi_cluster_operator_clustermode: Operator):
-    multi_cluster_operator_clustermode.assert_is_running()
+    multi_cluster_operator_clustermode.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_2_clusters_clusterwide

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_replicaset.py
@@ -79,7 +79,7 @@ def test_create_kube_config_file(cluster_clients: Dict, member_cluster_names: Li
 
 @pytest.mark.e2e_multi_cluster_2_clusters_replica_set
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_2_clusters_replica_set

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_automated_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_automated_disaster_recovery.py
@@ -57,7 +57,7 @@ def test_create_service_entry(service_entries: List[CustomObject]):
 @mark.e2e_multi_cluster_disaster_recovery
 @mark.e2e_multi_cluster_multi_disaster_recovery
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_disaster_recovery

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
@@ -245,7 +245,7 @@ def oplog_user(
 
 @mark.e2e_multi_cluster_backup_restore
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_backup_restore

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
@@ -318,7 +318,7 @@ def test_update_coredns(
 
 @mark.e2e_multi_cluster_backup_restore_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_backup_restore_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_cli_recover.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_cli_recover.py
@@ -70,7 +70,7 @@ def test_deploy_operator(
     run_kube_config_creation_tool(member_cluster_names[:-1], namespace, namespace, member_cluster_names)
     # deploy the operator without the final cluster
     operator = install_multi_cluster_operator_set_members_fn(member_cluster_names[:-1])
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_recover
@@ -92,7 +92,7 @@ def test_recover_operator_add_cluster(
         api_client=central_cluster_client,
     )
     operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_recover
@@ -118,7 +118,7 @@ def test_recover_operator_remove_cluster(
         api_client=central_cluster_client,
     )
     operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_recover

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
@@ -178,12 +178,12 @@ def test_prepare_namespace(
 
 @mark.e2e_multi_cluster_clusterwide
 def test_deploy_operator(multi_cluster_operator_clustermode: Operator):
-    multi_cluster_operator_clustermode.assert_is_running()
+    multi_cluster_operator_clustermode.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_specific_namespaces
 def test_deploy_operator_specific_namespaces(install_operator: Operator):
-    install_operator.assert_is_running()
+    install_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_specific_namespaces

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_dr_connect.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_dr_connect.py
@@ -40,7 +40,7 @@ def test_create_kube_config_file(cluster_clients: Dict):
 
 @pytest.mark.e2e_multi_cluster_dr
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_dr

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_enable_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_enable_tls.py
@@ -60,7 +60,7 @@ def mongodb_multi(
 
 @mark.e2e_multi_cluster_enable_tls
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_enable_tls

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap.py
@@ -170,7 +170,7 @@ def user_ldap(
 @skip_if_static_containers
 @mark.e2e_multi_cluster_with_ldap
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @skip_if_static_containers

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap_custom_roles.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap_custom_roles.py
@@ -153,7 +153,7 @@ def user_ldap(
 @skip_if_static_containers
 @mark.e2e_multi_cluster_with_ldap_custom_roles
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @skip_if_static_containers

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_group.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_group.py
@@ -39,7 +39,7 @@ def mongodb_multi(
 @pytest.mark.e2e_multi_cluster_oidc_m2m_group
 class TestOIDCMultiCluster(KubernetesTester):
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_create_oidc_replica_set(self, mongodb_multi: MongoDBMulti):
         mongodb_multi.update()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_user.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_user.py
@@ -51,7 +51,7 @@ def oidc_user(namespace) -> MongoDBUser:
 @pytest.mark.e2e_multi_cluster_oidc_m2m_user
 class TestOIDCMultiCluster(KubernetesTester):
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_create_oidc_replica_set(self, mongodb_multi: MongoDBMulti):
         mongodb_multi.update()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_pvc_resize.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_pvc_resize.py
@@ -34,7 +34,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_cluster_pvc_resize
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_pvc_resize

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
@@ -171,7 +171,7 @@ def get_all_users(namespace, mdb: MongoDB) -> list[MongoDBUser]:
 
 @pytest.mark.e2e_om_reconcile_race_with_telemetry
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_om_reconcile_race_with_telemetry
@@ -314,7 +314,7 @@ def test_restart_operator_pod(
 ):
     # this enforces a requeue of all existing resources, increasing the chances of races to happen
     multi_cluster_operator.restart_operator_deployment()
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
     time.sleep(5)
     for r in get_all_rs(ops_manager, namespace):
         r.assert_reaches_phase(Phase.Running)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_clusterwide.py
@@ -189,7 +189,7 @@ def test_delete_cluster_role_and_binding(
 
 @mark.e2e_multi_cluster_recover_clusterwide
 def test_deploy_operator(install_operator: Operator):
-    install_operator.assert_is_running()
+    install_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_recover_clusterwide
@@ -334,7 +334,7 @@ def test_recover_operator_remove_cluster(
         api_client=central_cluster_client,
     )
     operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_recover_clusterwide

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_network_partition.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_network_partition.py
@@ -55,7 +55,7 @@ def test_create_service_entry(service_entries: List[CustomObject]):
 
 @mark.e2e_multi_cluster_recover_network_partition
 def test_deploy_operator(multi_cluster_operator_manual_remediation: Operator):
-    multi_cluster_operator_manual_remediation.assert_is_running()
+    multi_cluster_operator_manual_remediation.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_recover_network_partition
@@ -187,7 +187,7 @@ def test_recover_operator_remove_cluster(
         api_client=central_cluster_client,
     )
     operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_recover_network_partition

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set.py
@@ -64,7 +64,7 @@ def test_create_kube_config_file(cluster_clients: Dict, central_cluster_name: st
 
 @pytest.mark.e2e_multi_cluster_replica_set
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_deletion.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_deletion.py
@@ -33,7 +33,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_cluster_replica_set_deletion
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_deletion

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_member_options.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_member_options.py
@@ -89,7 +89,7 @@ def test_create_kube_config_file(cluster_clients: Dict, central_cluster_name: st
 
 @pytest.mark.e2e_multi_cluster_replica_set_member_options
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_member_options

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
@@ -40,7 +40,7 @@ def mdb_health_checker(mongodb_multi: MongoDBMulti) -> MongoDBBackgroundTester:
 
 @pytest.mark.e2e_multi_cluster_replica_set_migration
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_migration

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_down.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_down.py
@@ -66,7 +66,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_down
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_down

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_up.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_up.py
@@ -70,7 +70,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_up
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_up

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_test_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_test_mtls.py
@@ -32,7 +32,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_cluster_mtls_test
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_mtls_test

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_down_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_down_cluster.py
@@ -64,7 +64,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_scale_down_cluster
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_scale_down_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster.py
@@ -91,7 +91,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
@@ -76,7 +76,7 @@ def test_deploy_operator(
     run_kube_config_creation_tool(member_cluster_names[:-1], namespace, namespace, member_cluster_names)
     # deploy the operator without the final cluster
     operator = install_multi_cluster_operator_set_members_fn(member_cluster_names[:-1])
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster_new_cluster
@@ -126,7 +126,7 @@ def test_re_deploy_operator(
 
     # deploy the operator without all clusters
     operator = install_multi_cluster_operator_set_members_fn(member_cluster_names)
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster_new_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scram.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scram.py
@@ -65,7 +65,7 @@ def mongodb_user(central_cluster_client: kubernetes.client.ApiClient, namespace:
 
 @pytest.mark.e2e_multi_cluster_scram
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_scram

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_split_horizon.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_split_horizon.py
@@ -106,7 +106,7 @@ def mongodb_multi(
 
 @mark.e2e_multi_cluster_split_horizon
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_split_horizon

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_sts_override.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_sts_override.py
@@ -32,7 +32,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_sts_override
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_sts_override

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
@@ -205,7 +205,7 @@ def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient])
 
 @mark.e2e_multi_cluster_tls_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_tls_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_scram.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_scram.py
@@ -96,7 +96,7 @@ def mongodb_user(central_cluster_client: kubernetes.client.ApiClient, namespace:
 
 @mark.e2e_multi_cluster_tls_with_scram
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_tls_with_scram

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_x509.py
@@ -133,7 +133,7 @@ def mongodb_x509_user(central_cluster_client: kubernetes.client.ApiClient, names
 
 @mark.e2e_multi_cluster_tls_with_x509
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_tls_with_x509

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_upgrade_downgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_upgrade_downgrade.py
@@ -36,7 +36,7 @@ def mdb_health_checker(mongodb_multi: MongoDBMulti) -> MongoDBBackgroundTester:
 
 @pytest.mark.e2e_multi_cluster_upgrade_downgrade
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @pytest.mark.e2e_multi_cluster_upgrade_downgrade

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_validation.py
@@ -9,7 +9,7 @@ from kubetester.operator import Operator
 @pytest.mark.e2e_multi_cluster_validation
 class TestWebhookValidation(KubernetesTester):
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_unique_cluster_names(self, central_cluster_client: kubernetes.client.ApiClient):
         resource = yaml.safe_load(open(yaml_fixture("mongodb-multi-cluster.yaml")))

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
@@ -244,7 +244,7 @@ class TestOperatorUpgrade:
 
     def test_install_default_operator(self, namespace: str, multi_cluster_operator: Operator):
         logger.info("Installing the operator built from master")
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
         # Dumping deployments in logs ensure we are using the correct operator version
         log_deployments_info(namespace)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_validation.py
@@ -43,7 +43,7 @@ def ops_manager(
 
 @mark.e2e_multi_cluster_appdb_validation
 def test_install_multi_cluster_operator(namespace: str, multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.usefixtures("multi_cluster_operator")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_om_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_om_validation.py
@@ -46,7 +46,7 @@ def ops_manager(
 
 @mark.e2e_multi_cluster_om_validation
 def test_install_multi_cluster_operator(namespace: str, multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.usefixtures("multi_cluster_operator")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_cleanup.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_cleanup.py
@@ -131,7 +131,7 @@ def ops_manager(
 
 @mark.e2e_multi_cluster_appdb_cleanup
 def test_deploy_operator(multi_cluster_operator_with_monitored_appdb: Operator):
-    multi_cluster_operator_with_monitored_appdb.assert_is_running()
+    multi_cluster_operator_with_monitored_appdb.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_appdb_cleanup

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
@@ -532,7 +532,7 @@ def create_project_config_map(om: MongoDBOpsManager, mdb_name, project_name, cli
 
 @mark.e2e_multi_cluster_om_appdb_no_mesh
 def test_deploy_operator(multi_cluster_operator_with_monitored_appdb: Operator):
-    multi_cluster_operator_with_monitored_appdb.assert_is_running()
+    multi_cluster_operator_with_monitored_appdb.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_om_appdb_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
@@ -45,7 +45,7 @@ def is_cloud_qa() -> bool:
 
 @mark.e2e_multi_cluster_sharded_disaster_recovery
 def test_install_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @fixture(scope="function")
@@ -164,14 +164,14 @@ class TestDeployShardedClusterWithFailedCluster:
 
         # sleeping to ensure the operator will suicide after config map is changed
         # TODO: as part of https://jira.mongodb.org/browse/CLOUDP-288588, and when we re-activate this test, ensure
-        #  this sleep is really nededed or if the subsquent call to multi_cluster_operator.assert_is_running() is enough
+        #  this sleep is really nededed or if the subsquent call to multi_cluster_operator.assert_is_running(multi_cluster=True) is enough
         time.sleep(30)
 
     @skip_if_local
     # Modifying the configmap triggers an (intentional) panic, the pod should restart.
     # Operator process restart has to be done manually when running locally.
     def test_operator_has_restarted(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_delete_all_statefulsets_in_failed_cluster(
         self, sc: MongoDB, central_cluster_client: kubernetes.client.ApiClient

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_external_access_no_ext_domain.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_external_access_no_ext_domain.py
@@ -35,7 +35,7 @@ def sharded_cluster(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_multi_cluster_sharded_external_access_no_ext_domain
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_sharded_external_access_no_ext_domain

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_geo_sharding.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_geo_sharding.py
@@ -38,7 +38,7 @@ class TestShardedClusterGeoSharding:
     desired clusters."""
 
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_create_primary_for_each_shard_in_different_cluster(
         self, sc: MongoDB, custom_mdb_version: str, issuer_ca_configmap: str

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling.py
@@ -33,7 +33,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 class TestShardedClusterScalingInitial:
 
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_create(self, sc: MongoDB, custom_mdb_version: str, issuer_ca_configmap: str):
         sc["spec"]["shard"]["clusterSpecList"] = cluster_spec_list(get_member_cluster_names(), [1, 1, 1])

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling_all_shard_overrides.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling_all_shard_overrides.py
@@ -34,7 +34,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 class TestShardedClusterScalingInitial:
 
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.assert_is_running(multi_cluster=True)
 
     def test_create(self, sc: MongoDB, custom_mdb_version: str, issuer_ca_configmap: str):
         sc["spec"]["shardCount"] = 3

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest.py
@@ -22,7 +22,7 @@ def sharded_cluster(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_multi_cluster_sharded_simplest
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_sharded_simplest

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest_no_mesh.py
@@ -48,7 +48,7 @@ def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient],
 
 @mark.e2e_multi_cluster_sharded_simplest_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_sharded_simplest_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_snippets.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_snippets.py
@@ -58,7 +58,7 @@ def file_to_resource_name(file_name: str) -> str:
 
 @mark.e2e_multi_cluster_sharded_snippets
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_sharded_snippets

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls.py
@@ -121,7 +121,7 @@ def sharded_cluster(
 
 @mark.e2e_multi_cluster_sharded_tls
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_sharded_tls

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls_no_mesh.py
@@ -135,7 +135,7 @@ def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient],
 
 @mark.e2e_multi_cluster_sharded_tls_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.assert_is_running(multi_cluster=True)
 
 
 @mark.e2e_multi_cluster_sharded_tls_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -92,7 +92,7 @@ def replica_set(
 # Installs the latest officially released version of MEKO, from Quay
 @mark.e2e_meko_mck_upgrade
 def test_install_latest_official_operator(official_meko_operator: Operator, namespace: str):
-    official_meko_operator.assert_is_running()
+    official_meko_operator.assert_is_running(multi_cluster=is_multi_cluster())
     # Dumping deployments in logs ensures we are using the correct operator version
     log_deployments_info(namespace)
 
@@ -138,7 +138,7 @@ def test_upgrade_operator(
             name=OPERATOR_NAME,
         )
         operator.install()
-    operator.assert_is_running()
+    operator.assert_is_running(multi_cluster=is_multi_cluster())
     log_deployments_info(namespace)
 
 
@@ -162,7 +162,7 @@ def test_operator_still_running(namespace: str, central_cluster_client: client.A
         namespace=namespace,
     )
     logger.info(f"Checking status of operator '{operator_name}' in namespace '{namespace}'")
-    operator_instance.assert_is_running()
+    operator_instance.assert_is_running(multi_cluster=is_multi_cluster())
     log_deployments_info(namespace)
 
     if is_multi_cluster():


### PR DESCRIPTION
# Summary

Use of `assert_is_running()` will become more widespread in MCK 2.0 where we will be checking for operator readiness more often: potentially after each `OperatorConfig` CRUD operation which trigger operator restart.

`assert_is_running()` previously called only `_wait_for_operator_ready()`, so it checked the pod phase but not the webhook service. Meanwhile `install()`, `upgrade()`, and `install_from_template()` each ended with an explicit two-liner calling both waits. This meant the method advertised as the canonical "operator is fully ready" check was silently incomplete, and the full check was duplicated across three methods rather than owned in one place.

`assert_is_running()` now calls both `_wait_for_operator_ready()` and `_wait_operator_webhook_is_ready()`.

## Proof of Work

Existing tests must pass.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details