### PR TITLE
KUBE-100: fix auto-embedding e2e LB shape + key_handling pod count

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_key_handling.py
@@ -133,7 +133,8 @@ def test_keys_not_leaked(mdbs: MongoDBSearch, namespace: str):
 
     sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
     core_v1 = k8s_client.CoreV1Api()
-    for ordinal in range(2):
+    replicas = k8s_client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace).spec.replicas or 1
+    for ordinal in range(replicas):
         pod_name = f"{sts_name}-{ordinal}"
         logs = KubernetesTester.read_pod_logs(namespace, pod_name, container=MONGOT_CONTAINER)
         assert idx not in logs and qry not in logs, f"embedding key leaked into {pod_name} mongot pod logs"
@@ -142,9 +143,9 @@ def test_keys_not_leaked(mdbs: MongoDBSearch, namespace: str):
         ann = pod.metadata.annotations or {}
         h = ann.get("autoEmbeddingDetailsHash")
         # hash is SHA-256 encoded as base32 no-padding → 52 chars in [A-Z2-7]
-        assert h and re.fullmatch(r"[A-Z2-7]{52}", h), (
-            f"{pod_name} autoEmbeddingDetailsHash must be a base32 SHA-256 hash, got: {h!r}"
-        )
+        assert h and re.fullmatch(
+            r"[A-Z2-7]{52}", h
+        ), f"{pod_name} autoEmbeddingDetailsHash must be a base32 SHA-256 hash, got: {h!r}"
         assert h != idx and h != qry, f"{pod_name} autoEmbeddingDetailsHash must not equal a raw key"
 
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_auto_embedding_rolling_restart.py
@@ -122,12 +122,16 @@ def mdbs(namespace: str, mdbc: MongoDBCommunity) -> MongoDBSearch:
         return resource
 
     resource["spec"]["source"] = {"passwordSecretRef": {"name": MONGOT_USER_PASSWORD_SECRET_NAME}}
-    resource["spec"]["clusters"] = [{"replicas": 2}]
-    resource["spec"]["loadBalancer"] = {
-        "unmanaged": {
-            "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+    resource["spec"]["clusters"] = [
+        {
+            "replicas": 2,
+            "loadBalancer": {
+                "unmanaged": {
+                    "endpoint": f"{ENVOY_PROXY_SVC_NAME}.{namespace}.svc.cluster.local:{ENVOY_PROXY_PORT}",
+                }
+            },
         }
-    }
+    ]
     resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
     resource["spec"]["autoEmbedding"] = {
         "embeddingModelAPIKeySecret": {"name": VOYAGE_API_KEY_SECRET_NAME},


### PR DESCRIPTION
[skip-ci] KUBE-100: fix two auto-embedding e2e tests that #1260 merged to `search/ga-base` red. Both are test bugs, not product bugs.

## Summary
`search_auto_embedding_rolling_restart` set a top-level `spec.loadBalancer`, which the CRD has no such field — it lives at `spec.clusters[].loadBalancer` and is required when `replicas > 1`. The structural schema pruned the unknown top-level field, leaving `replicas: 2` with no load balancer, so the apply was rejected at admission. The block is moved under `clusters[]`, matching `search_replicaset_external_mongodb_proxy_service.py`.

`search_auto_embedding_key_handling` looped `range(2)` over mongot pods, but its `search-minimal.yaml` deploys a single mongot (`clusters: [{}]`), so ordinal 1 raised a 404. The pod count is now derived from the StatefulSet's replicas.

## Proof of Work
- e2e: green in Evergreen — `e2e_search_auto_embedding_rolling_restart` and `e2e_search_auto_embedding_key_handling` passed on `e2e_mdb_kind_ubi_cloudqa_large` and `e2e_static_mdb_kind_ubi_cloudqa_large` (patch `6a3ac94d8efa710007d43b53`).

## Checklist
- [x] Have you linked a relevant ticket? KUBE-100
- [x] Changelog: `skip-changelog` (test-only fix; mirrors #1262)
- [ ] DOCSP ticket