### PR TITLE
CLOUDP-411215: Refactor kubetester's Operator

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/__init__.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/__init__.py
@@ -5,13 +5,17 @@ from base64 import b64decode
 from typing import Any, Callable, Dict, List, Optional
 
 import kubernetes.client
+import requests
 from kubeobject import CustomObject
 from kubernetes import client, utils
 from kubetester.kubetester import run_periodically
+from tests import test_logger
 
 # Re-exports
 from .kubetester import fixture as find_fixture
 from .security_context import assert_pod_container_security_context, assert_pod_security_context
+
+logger = test_logger.get_test_logger(__name__)
 
 
 def create_secret(
@@ -498,31 +502,58 @@ def try_load(resource: CustomObject) -> bool:
     return True
 
 
-def wait_for_webhook(namespace, retries=20, delay=10, service_name="operator-webhook"):
-    webhook_api = client.AdmissionregistrationV1Api()
-    core_api = client.CoreV1Api()
+def wait_for_webhook(namespace, retries: int = 10, multi_cluster: bool = False, service_name="operator-webhook"):
+    from tests.conftest import get_central_cluster_name, get_cluster_domain, get_test_pod_cluster_name, local_operator
 
-    for attempt in range(retries):
+    # we don't want to wait for the operator webhook if the operator is running locally and not in a pod
+    if local_operator():
+        return
+
+    # in multi-cluster mode the operator and the test pod are in different clusters(test pod won't be able to talk to webhook),
+    # so we skip this extra check for multi-cluster
+    if multi_cluster and get_central_cluster_name() != get_test_pod_cluster_name():
+        logger.info(
+            f"Skipping waiting for the webhook as we cannot call the webhook endpoint from a test_pod_cluster ({get_test_pod_cluster_name()}) "
+            f"to central cluster ({get_central_cluster_name()}); sleeping for 10s instead"
+        )
+        # We need to sleep here otherwise the function returns too early and we create a race condition in tests
+        time.sleep(10)
+        return
+
+    webhook_services = client.CoreV1Api().list_namespaced_service(namespace)
+    logger.debug("Listing webhook services...")
+    for svc in webhook_services.items:
+        if "webhook" in svc.metadata.name:
+            logger.debug(
+                f"Service: {svc.metadata.name}, ClusterIP: {svc.spec.cluster_ip}, Ports: {svc.spec.ports}, Selector: {svc.spec.selector}"
+            )
+
+    logger.debug("wait_for_webhook")
+    validation_endpoint = "validate-mongodb-com-v1-mongodb"
+    webhook_endpoint = "https://{}.{}.svc.{}/{}".format(
+        service_name, namespace, get_cluster_domain(), validation_endpoint
+    )
+    headers = {"Content-Type": "application/json"}
+    logger.debug(f"Webhook_endpoint: {webhook_endpoint}")
+    retry_count = retries + 1
+    while retry_count > 0:
+        retry_count -= 1
+        logger.debug("Waiting for operator/webhook to be functional")
         try:
-            core_api.read_namespaced_service(service_name, namespace)
+            response = requests.post(webhook_endpoint, headers=headers, verify=False, timeout=2)
+        except Exception as e:
+            logger.warning(e)
+            time.sleep(2)
+            continue
 
-            # make sure the validating_webhook is installed.
-            wh = webhook_api.read_validating_webhook_configuration("mdbpolicy.mongodb.com")
+        try:
+            # Let's assume that if we get a json response, then the webhook
+            # is already in place.
+            response.json()
+        except Exception:
+            logger.warning("Didn't get a json response from webhook")
+        else:
+            return
+        time.sleep(2)
 
-            # Wait for the caBundle to be injected (cert-manager injects it asynchronously).
-            # Without a populated caBundle the webhook server won't accept connections yet.
-            ca_bundle_ready = any(w.client_config.ca_bundle for w in (wh.webhooks or []) if w.client_config)
-            if not ca_bundle_ready:
-                raise kubernetes.client.ApiException(status=503, reason="caBundle not yet injected")
-
-            # Extra stabilization delay: the TLS certificate may still be loading into
-            # the webhook server's listener even after the caBundle is populated.
-            time.sleep(5)
-            print("Webhook is ready.")
-            return True
-        except kubernetes.client.ApiException as e:
-            print(f"Attempt {attempt + 1} failed, webhook not ready. Sleeping: {delay}, error: {e}")
-            time.sleep(delay)
-
-    print("Webhook did not become ready in time.")
-    return False
+    raise Exception("Operator webhook didn't start after {} retries".format(retries))

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -79,8 +79,8 @@ class Operator(object):
         This is equal to helm template...| kubectl apply -"""
         yaml_file = helm_template(self.helm_arguments, helm_chart_path=self.helm_chart_path)
         create_or_replace_from_yaml(client.api_client.ApiClient(), yaml_file)
-        self._wait_for_operator_ready()
-        self._wait_operator_webhook_is_ready()
+        self.wait_for_operator_ready()
+        self.wait_for_operator_webhook_ready()
 
         return self
 
@@ -97,8 +97,8 @@ class Operator(object):
             helm_options=self.helm_options,
             custom_operator_version=custom_operator_version,
         )
-        self._wait_for_operator_ready()
-        self._wait_operator_webhook_is_ready()
+        self.wait_for_operator_ready()
+        self.wait_for_operator_webhook_ready()
 
         return self
 
@@ -118,8 +118,8 @@ class Operator(object):
             custom_operator_version=custom_operator_version,
             apply_crds_first=apply_crds_first,
         )
-        self._wait_for_operator_ready()
-        self._wait_operator_webhook_is_ready(multi_cluster=multi_cluster)
+        self.wait_for_operator_ready()
+        self.wait_for_operator_webhook_ready(multi_cluster=multi_cluster)
 
         return self
 
@@ -145,10 +145,7 @@ class Operator(object):
     def read_deployment(self) -> V1Deployment:
         return client.AppsV1Api(api_client=self.api_client).read_namespaced_deployment(self.name, self.namespace)
 
-    def assert_is_running(self):
-        self._wait_for_operator_ready()
-
-    def _wait_for_operator_ready(self, retries: int = 60):
+    def wait_for_operator_ready(self, retries: int = 60):
         """waits until the Operator deployment is ready."""
 
         # we don't want to wait for the operator if the operator is running locally and not in a pod
@@ -177,64 +174,8 @@ class Operator(object):
 
         raise Exception(f"Operator hasn't started in specified time after {retries} retries.")
 
-    def _wait_operator_webhook_is_ready(self, retries: int = 10, multi_cluster: bool = False):
-
-        # we don't want to wait for the operator webhook if the operator is running locally and not in a pod
-        from tests.conftest import get_cluster_domain, local_operator
-
-        if local_operator():
-            return
-
-        # in multi-cluster mode the operator and the test pod are in different clusters(test pod won't be able to talk to webhook),
-        # so we skip this extra check for multi-cluster
-        from tests.conftest import get_central_cluster_name, get_test_pod_cluster_name
-
-        if multi_cluster and get_central_cluster_name() != get_test_pod_cluster_name():
-            logger.info(
-                f"Skipping waiting for the webhook as we cannot call the webhook endpoint from a test_pod_cluster ({get_test_pod_cluster_name()}) "
-                f"to central cluster ({get_central_cluster_name()}); sleeping for 10s instead"
-            )
-            # We need to sleep here otherwise the function returns too early and we create a race condition in tests
-            time.sleep(10)
-            return
-
-        webhook_services = client.CoreV1Api().list_namespaced_service(self.namespace)
-        logger.debug("Listing webhook services...")
-        for svc in webhook_services.items:
-            if "webhook" in svc.metadata.name:
-                logger.debug(
-                    f"Service: {svc.metadata.name}, ClusterIP: {svc.spec.cluster_ip}, Ports: {svc.spec.ports}, Selector: {svc.spec.selector}"
-                )
-
-        logger.debug("_wait_operator_webhook_is_ready")
-        validation_endpoint = "validate-mongodb-com-v1-mongodb"
-        webhook_endpoint = "https://operator-webhook.{}.svc.{}/{}".format(
-            self.namespace, get_cluster_domain(), validation_endpoint
-        )
-        headers = {"Content-Type": "application/json"}
-        logger.debug(f"Webhook_endpoint: {webhook_endpoint}")
-        retry_count = retries + 1
-        while retry_count > 0:
-            retry_count -= 1
-            logger.debug("Waiting for operator/webhook to be functional")
-            try:
-                response = requests.post(webhook_endpoint, headers=headers, verify=False, timeout=2)
-            except Exception as e:
-                logger.warning(e)
-                time.sleep(2)
-                continue
-
-            try:
-                # Let's assume that if we get a json response, then the webhook
-                # is already in place.
-                response.json()
-            except Exception:
-                logger.warning("Didn't get a json response from webhook")
-            else:
-                return
-            time.sleep(2)
-
-        raise Exception("Operator webhook didn't start after {} retries".format(retries))
+    def wait_for_operator_webhook_ready(self, retries: int = 10, multi_cluster: bool = False):
+        return wait_for_webhook(namespace=self.namespace, retries=retries, multi_cluster=multi_cluster)
 
     def print_diagnostics(self):
         logger.info("Operator Deployment: ")
@@ -245,9 +186,6 @@ class Operator(object):
             logger.info("Operator pods: %d", len(pods))
             logger.info("Operator spec: %s", pods[0].spec)
             logger.info("Operator status: %s", pods[0].status)
-
-    def wait_for_webhook(self, retries=5, delay=5):
-        return wait_for_webhook(namespace=self.namespace, retries=retries, delay=delay)
 
     def disable_webhook(self):
         webhook_api = client.AdmissionregistrationV1Api()
@@ -282,7 +220,7 @@ class Operator(object):
             [{"op": "replace", "path": "/spec/replicas", "value": 1}],
         )
 
-        return self._wait_for_operator_ready()
+        return self.wait_for_operator_ready()
 
 
 def delete_operator_crds():

--- a/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
@@ -3,6 +3,7 @@ from kubetester.automation_config_tester import AutomationConfigTester
 from kubetester.mongodb import MongoDB, Phase
 from kubetester.mongodb_multi import MongoDBMulti
 from kubetester.mongodb_role import ClusterMongoDBRole, ClusterMongoDBRoleKind
+from kubetester.operator import Operator
 from pytest import fixture, mark
 from tests.multicluster.conftest import cluster_spec_list
 
@@ -349,8 +350,8 @@ def test_removing_role_from_resources(replica_set: MongoDB, sharded_cluster: Mon
 
 
 @mark.e2e_mongodb_custom_roles
-def test_install_operator_with_clustermongodbroles_disabled(multi_cluster_operator_no_cluster_mongodb_roles):
-    multi_cluster_operator_no_cluster_mongodb_roles.assert_is_running()
+def test_install_operator_with_clustermongodbroles_disabled(multi_cluster_operator_no_cluster_mongodb_roles: Operator):
+    multi_cluster_operator_no_cluster_mongodb_roles.wait_for_operator_ready()
 
 
 @mark.e2e_mongodb_custom_roles

--- a/docker/mongodb-kubernetes-tests/tests/clusterwideoperator/om_multiple.py
+++ b/docker/mongodb-kubernetes-tests/tests/clusterwideoperator/om_multiple.py
@@ -146,7 +146,7 @@ def om_operator_clusterwide(namespace: str):
 
 @mark.e2e_om_multiple
 def test_install_operator(om_operator_clusterwide: Operator):
-    om_operator_clusterwide.assert_is_running()
+    om_operator_clusterwide.wait_for_operator_ready()
 
 
 @mark.e2e_om_multiple

--- a/docker/mongodb-kubernetes-tests/tests/community/community_replicaset_scale.py
+++ b/docker/mongodb-kubernetes-tests/tests/community/community_replicaset_scale.py
@@ -22,7 +22,7 @@ def mdbc(namespace: str) -> MongoDBCommunity:
 
 @mark.e2e_community_replicaset_scale
 def test_install_operator(default_operator: Operator):
-    default_operator.assert_is_running()
+    default_operator.wait_for_operator_ready()
 
 
 @mark.e2e_community_replicaset_scale

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -963,7 +963,7 @@ def install_legacy_deployment_state_meko(
         operator_name=LEGACY_OPERATOR_NAME,
         operator_image=LEGACY_OPERATOR_IMAGE_NAME,
     )
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
     # Dumping deployments in logs ensures we are using the correct operator version
     log_deployments_info(namespace)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/manual_multi_cluster_tls_no_mesh_2_clusters_eks_gke.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/manual_multi_cluster_tls_no_mesh_2_clusters_eks_gke.py
@@ -131,7 +131,7 @@ def server_certs(
 
 
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 def test_create_mongodb_multi(

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_clusterwide_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_clusterwide_replicaset.py
@@ -186,7 +186,7 @@ def test_create_namespaces(
 
 @pytest.mark.e2e_multi_cluster_2_clusters_clusterwide
 def test_deploy_operator(multi_cluster_operator_clustermode: Operator):
-    multi_cluster_operator_clustermode.assert_is_running()
+    multi_cluster_operator_clustermode.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_2_clusters_clusterwide

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_2_cluster_replicaset.py
@@ -79,7 +79,7 @@ def test_create_kube_config_file(cluster_clients: Dict, member_cluster_names: Li
 
 @pytest.mark.e2e_multi_cluster_2_clusters_replica_set
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_2_clusters_replica_set

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_automated_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_automated_disaster_recovery.py
@@ -57,7 +57,7 @@ def test_create_service_entry(service_entries: List[CustomObject]):
 @mark.e2e_multi_cluster_disaster_recovery
 @mark.e2e_multi_cluster_multi_disaster_recovery
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_disaster_recovery

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore.py
@@ -245,7 +245,7 @@ def oplog_user(
 
 @mark.e2e_multi_cluster_backup_restore
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_backup_restore

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_backup_restore_no_mesh.py
@@ -318,7 +318,7 @@ def test_update_coredns(
 
 @mark.e2e_multi_cluster_backup_restore_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_backup_restore_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_cli_recover.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_cli_recover.py
@@ -70,7 +70,7 @@ def test_deploy_operator(
     run_kube_config_creation_tool(member_cluster_names[:-1], namespace, namespace, member_cluster_names)
     # deploy the operator without the final cluster
     operator = install_multi_cluster_operator_set_members_fn(member_cluster_names[:-1])
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_recover
@@ -91,8 +91,7 @@ def test_recover_operator_add_cluster(
         namespace=namespace,
         api_client=central_cluster_client,
     )
-    operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_recover
@@ -117,8 +116,7 @@ def test_recover_operator_remove_cluster(
         namespace=namespace,
         api_client=central_cluster_client,
     )
-    operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_recover

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_clusterwide.py
@@ -178,12 +178,12 @@ def test_prepare_namespace(
 
 @mark.e2e_multi_cluster_clusterwide
 def test_deploy_operator(multi_cluster_operator_clustermode: Operator):
-    multi_cluster_operator_clustermode.assert_is_running()
+    multi_cluster_operator_clustermode.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_specific_namespaces
 def test_deploy_operator_specific_namespaces(install_operator: Operator):
-    install_operator.assert_is_running()
+    install_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_specific_namespaces

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_dr_connect.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_dr_connect.py
@@ -40,7 +40,7 @@ def test_create_kube_config_file(cluster_clients: Dict):
 
 @pytest.mark.e2e_multi_cluster_dr
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_dr

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_enable_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_enable_tls.py
@@ -60,7 +60,7 @@ def mongodb_multi(
 
 @mark.e2e_multi_cluster_enable_tls
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_enable_tls

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap.py
@@ -170,7 +170,7 @@ def user_ldap(
 @skip_if_static_containers
 @mark.e2e_multi_cluster_with_ldap
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @skip_if_static_containers

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap_custom_roles.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_ldap_custom_roles.py
@@ -153,7 +153,7 @@ def user_ldap(
 @skip_if_static_containers
 @mark.e2e_multi_cluster_with_ldap_custom_roles
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @skip_if_static_containers

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_group.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_group.py
@@ -39,7 +39,7 @@ def mongodb_multi(
 @pytest.mark.e2e_multi_cluster_oidc_m2m_group
 class TestOIDCMultiCluster(KubernetesTester):
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_create_oidc_replica_set(self, mongodb_multi: MongoDBMulti):
         mongodb_multi.update()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_user.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_oidc_m2m_user.py
@@ -51,7 +51,7 @@ def oidc_user(namespace) -> MongoDBUser:
 @pytest.mark.e2e_multi_cluster_oidc_m2m_user
 class TestOIDCMultiCluster(KubernetesTester):
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_create_oidc_replica_set(self, mongodb_multi: MongoDBMulti):
         mongodb_multi.update()

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_pvc_resize.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_pvc_resize.py
@@ -34,7 +34,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_cluster_pvc_resize
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_pvc_resize

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_reconcile_races.py
@@ -171,7 +171,7 @@ def get_all_users(namespace, mdb: MongoDB) -> list[MongoDBUser]:
 
 @pytest.mark.e2e_om_reconcile_race_with_telemetry
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_om_reconcile_race_with_telemetry
@@ -314,7 +314,7 @@ def test_restart_operator_pod(
 ):
     # this enforces a requeue of all existing resources, increasing the chances of races to happen
     multi_cluster_operator.restart_operator_deployment()
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
     time.sleep(5)
     for r in get_all_rs(ops_manager, namespace):
         r.assert_reaches_phase(Phase.Running)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_clusterwide.py
@@ -189,7 +189,7 @@ def test_delete_cluster_role_and_binding(
 
 @mark.e2e_multi_cluster_recover_clusterwide
 def test_deploy_operator(install_operator: Operator):
-    install_operator.assert_is_running()
+    install_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_recover_clusterwide
@@ -333,8 +333,7 @@ def test_recover_operator_remove_cluster(
         namespace=namespace,
         api_client=central_cluster_client,
     )
-    operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_recover_clusterwide

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_network_partition.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_recover_network_partition.py
@@ -55,7 +55,7 @@ def test_create_service_entry(service_entries: List[CustomObject]):
 
 @mark.e2e_multi_cluster_recover_network_partition
 def test_deploy_operator(multi_cluster_operator_manual_remediation: Operator):
-    multi_cluster_operator_manual_remediation.assert_is_running()
+    multi_cluster_operator_manual_remediation.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_recover_network_partition
@@ -186,8 +186,7 @@ def test_recover_operator_remove_cluster(
         namespace=namespace,
         api_client=central_cluster_client,
     )
-    operator._wait_for_operator_ready()
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_recover_network_partition

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set.py
@@ -64,7 +64,7 @@ def test_create_kube_config_file(cluster_clients: Dict, central_cluster_name: st
 
 @pytest.mark.e2e_multi_cluster_replica_set
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_replica_set

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_deletion.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_deletion.py
@@ -33,7 +33,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_cluster_replica_set_deletion
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_deletion

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_member_options.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_member_options.py
@@ -89,7 +89,7 @@ def test_create_kube_config_file(cluster_clients: Dict, central_cluster_name: st
 
 @pytest.mark.e2e_multi_cluster_replica_set_member_options
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_member_options

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_migration.py
@@ -40,7 +40,7 @@ def mdb_health_checker(mongodb_multi: MongoDBMulti) -> MongoDBBackgroundTester:
 
 @pytest.mark.e2e_multi_cluster_replica_set_migration
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_migration

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_down.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_down.py
@@ -66,7 +66,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_down
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_down

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_up.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_scale_up.py
@@ -70,7 +70,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_up
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_scale_up

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_test_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_test_mtls.py
@@ -32,7 +32,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_cluster_mtls_test
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_mtls_test

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_down_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_down_cluster.py
@@ -64,7 +64,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_scale_down_cluster
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_scale_down_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster.py
@@ -91,7 +91,7 @@ def mongodb_multi(mongodb_multi_unmarshalled: MongoDBMulti, server_certs: str) -
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
@@ -76,7 +76,7 @@ def test_deploy_operator(
     run_kube_config_creation_tool(member_cluster_names[:-1], namespace, namespace, member_cluster_names)
     # deploy the operator without the final cluster
     operator = install_multi_cluster_operator_set_members_fn(member_cluster_names[:-1])
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster_new_cluster
@@ -126,7 +126,7 @@ def test_re_deploy_operator(
 
     # deploy the operator without all clusters
     operator = install_multi_cluster_operator_set_members_fn(member_cluster_names)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster_new_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scram.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scram.py
@@ -65,7 +65,7 @@ def mongodb_user(central_cluster_client: kubernetes.client.ApiClient, namespace:
 
 @pytest.mark.e2e_multi_cluster_scram
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_scram

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_split_horizon.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_split_horizon.py
@@ -106,7 +106,7 @@ def mongodb_multi(
 
 @mark.e2e_multi_cluster_split_horizon
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_split_horizon

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_sts_override.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_sts_override.py
@@ -32,7 +32,7 @@ def mongodb_multi(
 
 @pytest.mark.e2e_multi_sts_override
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_sts_override

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_no_mesh.py
@@ -205,7 +205,7 @@ def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient])
 
 @mark.e2e_multi_cluster_tls_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_tls_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_scram.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_scram.py
@@ -96,7 +96,7 @@ def mongodb_user(central_cluster_client: kubernetes.client.ApiClient, namespace:
 
 @mark.e2e_multi_cluster_tls_with_scram
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_tls_with_scram

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_tls_with_x509.py
@@ -133,7 +133,7 @@ def mongodb_x509_user(central_cluster_client: kubernetes.client.ApiClient, names
 
 @mark.e2e_multi_cluster_tls_with_x509
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_tls_with_x509

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_upgrade_downgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_upgrade_downgrade.py
@@ -36,7 +36,7 @@ def mdb_health_checker(mongodb_multi: MongoDBMulti) -> MongoDBBackgroundTester:
 
 @pytest.mark.e2e_multi_cluster_upgrade_downgrade
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_multi_cluster_upgrade_downgrade

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_validation.py
@@ -9,7 +9,7 @@ from kubetester.operator import Operator
 @pytest.mark.e2e_multi_cluster_validation
 class TestWebhookValidation(KubernetesTester):
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_unique_cluster_names(self, central_cluster_client: kubernetes.client.ApiClient):
         resource = yaml.safe_load(open(yaml_fixture("mongodb-multi-cluster.yaml")))

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
@@ -244,7 +244,7 @@ class TestOperatorUpgrade:
 
     def test_install_default_operator(self, namespace: str, multi_cluster_operator: Operator):
         logger.info("Installing the operator built from master")
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
         # Dumping deployments in logs ensure we are using the correct operator version
         log_deployments_info(namespace)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_validation.py
@@ -43,7 +43,7 @@ def ops_manager(
 
 @mark.e2e_multi_cluster_appdb_validation
 def test_install_multi_cluster_operator(namespace: str, multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.usefixtures("multi_cluster_operator")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_om_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_om_validation.py
@@ -46,7 +46,7 @@ def ops_manager(
 
 @mark.e2e_multi_cluster_om_validation
 def test_install_multi_cluster_operator(namespace: str, multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.usefixtures("multi_cluster_operator")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_cleanup.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_cleanup.py
@@ -131,7 +131,7 @@ def ops_manager(
 
 @mark.e2e_multi_cluster_appdb_cleanup
 def test_deploy_operator(multi_cluster_operator_with_monitored_appdb: Operator):
-    multi_cluster_operator_with_monitored_appdb.assert_is_running()
+    multi_cluster_operator_with_monitored_appdb.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_appdb_cleanup

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_no_mesh.py
@@ -532,7 +532,7 @@ def create_project_config_map(om: MongoDBOpsManager, mdb_name, project_name, cli
 
 @mark.e2e_multi_cluster_om_appdb_no_mesh
 def test_deploy_operator(multi_cluster_operator_with_monitored_appdb: Operator):
-    multi_cluster_operator_with_monitored_appdb.assert_is_running()
+    multi_cluster_operator_with_monitored_appdb.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_om_appdb_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_disaster_recovery.py
@@ -45,7 +45,7 @@ def is_cloud_qa() -> bool:
 
 @mark.e2e_multi_cluster_sharded_disaster_recovery
 def test_install_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @fixture(scope="function")
@@ -164,14 +164,14 @@ class TestDeployShardedClusterWithFailedCluster:
 
         # sleeping to ensure the operator will suicide after config map is changed
         # TODO: as part of https://jira.mongodb.org/browse/CLOUDP-288588, and when we re-activate this test, ensure
-        #  this sleep is really nededed or if the subsquent call to multi_cluster_operator.assert_is_running() is enough
+        #  this sleep is really nededed or if the subsquent call to multi_cluster_operator.wait_for_operator_ready() is enough
         time.sleep(30)
 
     @skip_if_local
     # Modifying the configmap triggers an (intentional) panic, the pod should restart.
     # Operator process restart has to be done manually when running locally.
     def test_operator_has_restarted(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_delete_all_statefulsets_in_failed_cluster(
         self, sc: MongoDB, central_cluster_client: kubernetes.client.ApiClient

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_external_access_no_ext_domain.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_external_access_no_ext_domain.py
@@ -35,7 +35,7 @@ def sharded_cluster(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_multi_cluster_sharded_external_access_no_ext_domain
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_sharded_external_access_no_ext_domain

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_geo_sharding.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_geo_sharding.py
@@ -38,7 +38,7 @@ class TestShardedClusterGeoSharding:
     desired clusters."""
 
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_create_primary_for_each_shard_in_different_cluster(
         self, sc: MongoDB, custom_mdb_version: str, issuer_ca_configmap: str

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling.py
@@ -33,7 +33,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 class TestShardedClusterScalingInitial:
 
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_create(self, sc: MongoDB, custom_mdb_version: str, issuer_ca_configmap: str):
         sc["spec"]["shard"]["clusterSpecList"] = cluster_spec_list(get_member_cluster_names(), [1, 1, 1])

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling_all_shard_overrides.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_scaling_all_shard_overrides.py
@@ -34,7 +34,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 class TestShardedClusterScalingInitial:
 
     def test_deploy_operator(self, multi_cluster_operator: Operator):
-        multi_cluster_operator.assert_is_running()
+        multi_cluster_operator.wait_for_operator_ready()
 
     def test_create(self, sc: MongoDB, custom_mdb_version: str, issuer_ca_configmap: str):
         sc["spec"]["shardCount"] = 3

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest.py
@@ -22,7 +22,7 @@ def sharded_cluster(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_multi_cluster_sharded_simplest
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_sharded_simplest

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_simplest_no_mesh.py
@@ -48,7 +48,7 @@ def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient],
 
 @mark.e2e_multi_cluster_sharded_simplest_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_sharded_simplest_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_snippets.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_snippets.py
@@ -58,7 +58,7 @@ def file_to_resource_name(file_name: str) -> str:
 
 @mark.e2e_multi_cluster_sharded_snippets
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_sharded_snippets

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls.py
@@ -121,7 +121,7 @@ def sharded_cluster(
 
 @mark.e2e_multi_cluster_sharded_tls
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_sharded_tls

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls_no_mesh.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_shardedcluster/multi_cluster_sharded_tls_no_mesh.py
@@ -135,7 +135,7 @@ def test_update_coredns(cluster_clients: dict[str, kubernetes.client.ApiClient],
 
 @mark.e2e_multi_cluster_sharded_tls_no_mesh
 def test_deploy_operator(multi_cluster_operator: Operator):
-    multi_cluster_operator.assert_is_running()
+    multi_cluster_operator.wait_for_operator_ready()
 
 
 @mark.e2e_multi_cluster_sharded_tls_no_mesh

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_clusterwide.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_clusterwide.py
@@ -85,7 +85,7 @@ def unmanaged_mdb(ops_manager: MongoDBOpsManager, unmanaged_namespace: str) -> M
 
 @pytest.mark.e2e_operator_clusterwide
 def test_install_clusterwide_operator(operator_clusterwide: Operator):
-    operator_clusterwide.assert_is_running()
+    operator_clusterwide.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_operator_multi_namespaces
@@ -103,7 +103,7 @@ def test_install_multi_namespace_operator(
     helm_args = operator_installation_config.copy()
     helm_args["operator.watchNamespace"] = ops_manager_namespace + "," + mdb_namespace
 
-    Operator(namespace=namespace, helm_args=helm_args).install().assert_is_running()
+    Operator(namespace=namespace, helm_args=helm_args).install().wait_for_operator_ready()
 
 
 @pytest.mark.e2e_operator_clusterwide

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
@@ -59,7 +59,7 @@ def test_install_operator_ops_manager_and_mongodb_only(
 ):
     """Note, that currently it's not possible to install OpsManager only as it requires MongoDB resources
     (it watches them internally)"""
-    operator_only_ops_manager_and_mongodb.assert_is_running()
+    operator_only_ops_manager_and_mongodb.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_operator_partial_crd
@@ -78,7 +78,7 @@ def test_remove_operator_and_crds(operator_only_ops_manager_and_mongodb: Operato
 
 @pytest.mark.e2e_operator_partial_crd
 def test_install_operator_mongodb_only(operator_only_mongodb: Operator):
-    operator_only_mongodb.assert_is_running()
+    operator_only_mongodb.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_operator_partial_crd

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_proxy.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_proxy.py
@@ -66,7 +66,7 @@ def replica_set(namespace: str, custom_mdb_version: str) -> MongoDB:
 def test_install_operator_with_proxy(
     operator_with_proxy: Operator,
 ):
-    operator_with_proxy.assert_is_running()
+    operator_with_proxy.wait_for_operator_ready()
 
 
 @mark.e2e_operator_proxy

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_validation_webhook.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_validation_webhook.py
@@ -14,7 +14,7 @@ APPDB_SHARD_COUNT_WARNING = "ShardCount field is not configurable for applicatio
 
 @mark.e2e_om_validation_webhook
 def test_wait_for_webhook(namespace: str, default_operator: Operator):
-    default_operator.wait_for_webhook()
+    default_operator.wait_for_operator_webhook_ready()
 
 
 def om_validation(namespace: str) -> MongoDBOpsManager:

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/community_and_meko_replicaset_scale.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/community_and_meko_replicaset_scale.py
@@ -33,7 +33,7 @@ def meko_replica_set(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_community_and_meko_replicaset_scale
 def test_install_operator(default_operator: Operator):
-    default_operator.assert_is_running()
+    default_operator.wait_for_operator_ready()
 
 
 @mark.e2e_community_and_meko_replicaset_scale

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_auto_embedding.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_auto_embedding.py
@@ -56,7 +56,7 @@ def mdbs(namespace: str) -> MongoDBSearch:
 @mark.e2e_search_community_auto_embedding
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_community_auto_embedding

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_auto_embedding_multi_mongot.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_auto_embedding_multi_mongot.py
@@ -139,7 +139,7 @@ def sample_movies_helper(mdbc: MongoDBCommunity, issuer_ca_filepath: str, namesp
 @mark.e2e_search_community_auto_embedding_multi_mongot
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_community_auto_embedding_multi_mongot

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -51,7 +51,7 @@ def mdbs(namespace: str) -> MongoDBSearch:
 @mark.e2e_search_community_basic
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_community_basic

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_external_mongod_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_external_mongod_basic.py
@@ -82,7 +82,7 @@ def mdbs(namespace: str, mdbc: MongoDBCommunity) -> MongoDBSearch:
 @mark.e2e_search_community_external_mongod_basic
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_community_external_mongod_basic

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_external_mongod_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_external_mongod_tls.py
@@ -80,7 +80,7 @@ def mdbs(namespace: str, mdbc: MongoDBCommunity) -> MongoDBSearch:
 @mark.e2e_search_community_external_mongod_tls
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_community_external_mongod_tls

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_tls.py
@@ -74,7 +74,7 @@ def mdbs(namespace: str) -> MongoDBSearch:
 @mark.e2e_search_community_tls
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_community_tls

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
@@ -77,7 +77,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_enterprise_basic
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_enterprise_basic

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_tls.py
@@ -85,7 +85,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_enterprise_tls
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_enterprise_tls

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_x509_cluster_auth.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_x509_cluster_auth.py
@@ -91,7 +91,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_enterprise_x509_cluster_auth
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_enterprise_x509_cluster_auth

--- a/docker/mongodb-kubernetes-tests/tests/search/search_mongot_replicaset_x509_auth.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_mongot_replicaset_x509_auth.py
@@ -158,7 +158,7 @@ def x509_mongot_user(namespace: str, helper: SearchDeploymentHelper) -> MongoDBU
 @mark.e2e_search_mongot_replicaset_x509_auth
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_mongot_replicaset_x509_auth

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_multi_mongot_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_multi_mongot_managed_lb.py
@@ -111,7 +111,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_multi_mongot_unmanaged_lb.py
@@ -140,7 +140,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running."""
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_replicaset_external_mongodb_multi_mongot_unmanaged_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
@@ -227,7 +227,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_replicaset_external_mongodb_proxy_service
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_replicaset_external_mongodb_proxy_service

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_single_mongot.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_single_mongot.py
@@ -84,7 +84,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_replicaset_external_mongodb_single_mongot
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_replicaset_external_mongodb_single_mongot

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_managed_lb.py
@@ -117,7 +117,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_replicaset_internal_mongodb_multi_mongot_managed_lb
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_replicaset_internal_mongodb_multi_mongot_managed_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb.py
@@ -150,7 +150,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running."""
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_enterprise_external_mongod_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_enterprise_external_mongod_managed_lb.py
@@ -125,7 +125,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running."""
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_enterprise_external_mongod_managed_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_external_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_external_mongodb_multi_mongot_unmanaged_lb.py
@@ -130,7 +130,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running."""
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_external_mongodb_multi_mongot_unmanaged_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_external_mongodb_single_mongot.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_external_mongodb_single_mongot.py
@@ -99,7 +99,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_sharded_external_mongodb_single_mongot
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_external_mongodb_single_mongot

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_multi_mongot_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_multi_mongot_managed_lb.py
@@ -120,7 +120,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running."""
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_internal_mongodb_multi_mongot_managed_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_multi_mongot_unmanaged_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_multi_mongot_unmanaged_lb.py
@@ -141,7 +141,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     """Test that the operator is installed and running."""
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_internal_mongodb_multi_mongot_unmanaged_lb

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_single_mongot.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_single_mongot.py
@@ -86,7 +86,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @mark.e2e_search_sharded_internal_mongodb_single_mongot
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_internal_mongodb_single_mongot

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_openshift_external.py
@@ -252,7 +252,7 @@ def test_install_operator(namespace: str, operator_installation_config: dict[str
     operator = get_default_operator(
         namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
     )
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_search_sharded_openshift_external

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
@@ -184,7 +184,7 @@ def mongot_user(helper: SearchDeploymentHelper, mdbs: MongoDBSearch) -> MongoDBU
 @MARKER
 def test_install_operator(namespace: str, operator_installation_config: dict[str, str]):
     operator = get_default_operator(namespace, operator_installation_config=operator_installation_config)
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @MARKER

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster.py
@@ -40,7 +40,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_agent_flags.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_agent_flags.py
@@ -38,7 +38,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_agent_flags
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_agent_flags

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_custom_podspec.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_custom_podspec.py
@@ -47,7 +47,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_custom_podspec
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_custom_podspec

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_migration.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_migration.py
@@ -54,7 +54,7 @@ def mdb_health_checker(mongo_tester: MongoTester) -> MongoDBBackgroundTester:
 class TestShardedClusterMigrationStatic:
 
     def test_install_operator(self, operator: Operator):
-        operator.assert_is_running()
+        operator.wait_for_operator_ready()
 
     def test_create_cluster(self, mdb: MongoDB):
         mdb.update()

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_mongod_options.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_mongod_options.py
@@ -41,7 +41,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_mongod_options_and_log_rotation
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_mongod_options_and_log_rotation

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_pv.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_pv.py
@@ -34,7 +34,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_pv
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_pv

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_pv_resize.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_pv_resize.py
@@ -39,7 +39,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_pv_resize
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_pv_resize

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_recovery.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_recovery.py
@@ -30,7 +30,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_recovery
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_recovery

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_scale_shards.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_scale_shards.py
@@ -43,7 +43,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_scale_shards
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_scale_shards

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_schema_validation.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_schema_validation.py
@@ -5,7 +5,7 @@ from pytest import mark
 
 @mark.e2e_sharded_cluster_schema_validation
 def test_install_operator(default_operator: Operator):
-    default_operator.assert_is_running()
+    default_operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_schema_validation

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_secret.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_secret.py
@@ -28,7 +28,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_secret
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_secret

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_shard_overrides.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_shard_overrides.py
@@ -43,7 +43,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_shard_overrides
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_shard_overrides

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_single_cluster_external_access.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_single_cluster_external_access.py
@@ -40,7 +40,7 @@ def test_disable_istio(disable_istio):
 
 @mark.e2e_sharded_cluster_external_access
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_external_access

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_statefulset_status.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_statefulset_status.py
@@ -47,7 +47,7 @@ def sc(namespace: str, custom_mdb_version: str) -> MongoDB:
 
 @mark.e2e_sharded_cluster_statefulset_status
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_statefulset_status

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_upgrade_downgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_upgrade_downgrade.py
@@ -48,7 +48,7 @@ def mdb_health_checker(mongod_tester: MongoTester) -> MongoDBBackgroundTester:
 
 @mark.e2e_sharded_cluster_upgrade_downgrade
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_sharded_cluster_upgrade_downgrade

--- a/docker/mongodb-kubernetes-tests/tests/tls/e2e_configure_tls_and_x509_simultaneously_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/e2e_configure_tls_and_x509_simultaneously_rs.py
@@ -32,7 +32,7 @@ def agent_certs(issuer: str, namespace: str) -> str:
 
 @pytest.mark.e2e_configure_tls_and_x509_simultaneously_rs
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_configure_tls_and_x509_simultaneously_rs

--- a/docker/mongodb-kubernetes-tests/tests/tls/e2e_configure_tls_and_x509_simultaneously_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/e2e_configure_tls_and_x509_simultaneously_sc.py
@@ -62,7 +62,7 @@ def agent_certs(issuer: str, namespace: str) -> str:
 
 @pytest.mark.e2e_configure_tls_and_x509_simultaneously_sc
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_configure_tls_and_x509_simultaneously_sc

--- a/docker/mongodb-kubernetes-tests/tests/tls/e2e_tls_disable_and_scale.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/e2e_tls_disable_and_scale.py
@@ -28,7 +28,7 @@ def replica_set(namespace: str, server_certs: str, issuer_ca_configmap: str) -> 
 
 @pytest.mark.e2e_disable_tls_and_scale
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_disable_tls_and_scale

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_allowssl.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_allowssl.py
@@ -25,7 +25,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_replica_set_tls_allow
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_replica_set_tls_allow

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_multiple_different_ssl_configs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_multiple_different_ssl_configs.py
@@ -15,7 +15,7 @@ def cert_names(namespace, members=3):
 
 @pytest.mark.e2e_tls_multiple_different_ssl_configs
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_multiple_different_ssl_configs

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_no_status.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_no_status.py
@@ -10,7 +10,7 @@ MDB_RESOURCE = "test-no-tls-no-status"
 
 @pytest.mark.e2e_standalone_no_tls_no_status_is_set
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_standalone_no_tls_no_status_is_set

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_permissions_default.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_permissions_default.py
@@ -30,7 +30,7 @@ def replica_set(
 
 @mark.e2e_replica_set_tls_default
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_replica_set_tls_default

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_permissions_override.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_permissions_override.py
@@ -39,7 +39,7 @@ def replica_set(issuer_ca_configmap: str, namespace: str, certs_secret_prefix) -
 
 @mark.e2e_replica_set_tls_override
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_replica_set_tls_override

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_preferssl.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_preferssl.py
@@ -25,7 +25,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_replica_set_tls_prefer
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_replica_set_tls_prefer

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_replica_set_process_hostnames.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_replica_set_process_hostnames.py
@@ -68,7 +68,7 @@ def replica_set(
 
 @mark.e2e_replica_set_tls_process_hostnames
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_replica_set_tls_process_hostnames

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_replicaset_certsSecretPrefix.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_replicaset_certsSecretPrefix.py
@@ -35,7 +35,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_replica_set_tls_certs_secret_prefix
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_replica_set_tls_certs_secret_prefix

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl.py
@@ -31,7 +31,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_replica_set_tls_require
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_replica_set_tls_require

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl_and_disable.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl_and_disable.py
@@ -31,7 +31,7 @@ def tls_replica_set(namespace: str, custom_mdb_version: str, issuer_ca_configmap
 
 @pytest.mark.e2e_replica_set_tls_require_and_disable
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_replica_set_tls_require_and_disable

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl_to_allow.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl_to_allow.py
@@ -39,7 +39,7 @@ def tls_replica_set(
 
 @mark.e2e_replica_set_tls_require_to_allow
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_replica_set_tls_require_to_allow

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_requiressl_upgrade.py
@@ -28,7 +28,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str, custom_mdb_
 
 @pytest.mark.e2e_replica_set_tls_require_upgrade
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_replica_set_tls_require_upgrade

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_additional_certs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_additional_certs.py
@@ -38,7 +38,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_tls_rs_additional_certs
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_rs_additional_certs

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_external_access.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_external_access.py
@@ -66,7 +66,7 @@ def mdb_multiple_horizons(namespace: str, server_certs_multiple_horizons: str, i
 
 @pytest.mark.e2e_tls_rs_external_access
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_rs_external_access

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_external_access_manual_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_external_access_manual_connectivity.py
@@ -92,7 +92,7 @@ def mdb(
 
 @pytest.mark.e2e_tls_rs_external_access_manual_connectivity
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_rs_external_access_manual_connectivity

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_external_access_transitions_without_approval.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_external_access_transitions_without_approval.py
@@ -7,7 +7,7 @@ from kubetester.operator import Operator
 
 @pytest.mark.e2e_tls_rs_external_access_tls_transition_without_approval
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_rs_external_access_tls_transition_without_approval

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_intermediate_ca.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_rs_intermediate_ca.py
@@ -40,7 +40,7 @@ def mdb(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_tls_rs_intermediate_ca
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_rs_intermediate_ca

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_additional_certs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_additional_certs.py
@@ -64,7 +64,7 @@ def sc(namespace: str, server_certs: str, issuer_ca_configmap: str, custom_mdb_v
 
 @pytest.mark.e2e_tls_sc_additional_certs
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_sc_additional_certs

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_requiressl_custom_ca.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_sc_requiressl_custom_ca.py
@@ -57,7 +57,7 @@ def sc(namespace: str, server_certs: str, issuer_ca_configmap: str) -> MongoDB:
 
 @pytest.mark.e2e_sharded_cluster_tls_require_custom_ca
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_sharded_cluster_tls_require_custom_ca

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_sharded_cluster_certs_prefix.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_sharded_cluster_certs_prefix.py
@@ -74,7 +74,7 @@ def sc(namespace: str, issuer_ca_configmap: str, custom_mdb_version: str, all_ce
 
 @mark.e2e_tls_sharded_cluster_certs_prefix
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_tls_sharded_cluster_certs_prefix

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_rs.py
@@ -37,7 +37,7 @@ def mdb(namespace: str, server_certs: str, agent_certs: str, issuer_ca_configmap
 
 @pytest.mark.e2e_tls_x509_configure_all_options_rs
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_x509_configure_all_options_rs

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_configure_all_options_sc.py
@@ -69,7 +69,7 @@ def sc(namespace: str, server_certs: str, agent_certs: str, issuer_ca_configmap:
 
 @pytest.mark.e2e_tls_x509_configure_all_options_sc
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_x509_configure_all_options_sc

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_rs.py
@@ -32,7 +32,7 @@ def mdb(namespace: str, server_certs: str, agent_certs: str, issuer_ca_configmap
 
 @pytest.mark.e2e_tls_x509_rs
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_x509_rs

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_sc.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_sc.py
@@ -60,7 +60,7 @@ def sharded_cluster(namespace: str, server_certs: str, agent_certs: str, issuer_
 
 @pytest.mark.e2e_tls_x509_sc
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_x509_sc

--- a/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_user_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/tls/tls_x509_user_connectivity.py
@@ -37,7 +37,7 @@ def replica_set(namespace, agent_certs, server_certs, issuer_ca_configmap):
 
 @pytest.mark.e2e_tls_x509_user_connectivity
 def test_install_operator(operator: Operator):
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @pytest.mark.e2e_tls_x509_user_connectivity

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
@@ -98,7 +98,7 @@ def test_install_latest_official_operator(
         operator_name=LEGACY_OPERATOR_NAME,
         operator_image=LEGACY_OPERATOR_IMAGE_NAME,
     )
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_appdb_tls_operator_upgrade_v1_32_to_mck
@@ -150,7 +150,7 @@ def test_upgrade_operator(
         operator = get_default_operator(
             namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
         )
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_appdb_tls_operator_upgrade_v1_32_to_mck

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -92,7 +92,7 @@ def replica_set(
 # Installs the latest officially released version of MEKO, from Quay
 @mark.e2e_meko_mck_upgrade
 def test_install_latest_official_operator(official_meko_operator: Operator, namespace: str):
-    official_meko_operator.assert_is_running()
+    official_meko_operator.wait_for_operator_ready()
     # Dumping deployments in logs ensures we are using the correct operator version
     log_deployments_info(namespace)
 
@@ -138,7 +138,7 @@ def test_upgrade_operator(
             name=OPERATOR_NAME,
         )
         operator.install()
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
     log_deployments_info(namespace)
 
 
@@ -162,7 +162,7 @@ def test_operator_still_running(namespace: str, central_cluster_client: client.A
         namespace=namespace,
     )
     logger.info(f"Checking status of operator '{operator_name}' in namespace '{namespace}'")
-    operator_instance.assert_is_running()
+    operator_instance.wait_for_operator_ready()
     log_deployments_info(namespace)
 
     if is_multi_cluster():

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_ops_manager.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_ops_manager.py
@@ -106,7 +106,7 @@ def some_mdb_health_checker(some_mdb: MongoDB) -> MongoDBBackgroundTester:
 
 @mark.e2e_operator_upgrade_ops_manager
 def test_install_latest_official_operator(official_operator: Operator):
-    official_operator.assert_is_running()
+    official_operator.wait_for_operator_ready()
 
 
 @mark.e2e_operator_upgrade_ops_manager
@@ -157,7 +157,7 @@ def test_upgrade_operator(namespace: str, operator_installation_config: dict[str
     operator = get_default_operator(
         namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
     )
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_operator_upgrade_ops_manager

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_replica_set.py
@@ -83,7 +83,7 @@ def replica_set_user(replica_set: MongoDB) -> MongoDBUser:
 
 @mark.e2e_operator_upgrade_replica_set
 def test_install_latest_official_operator(official_operator: Operator):
-    official_operator.assert_is_running()
+    official_operator.wait_for_operator_ready()
 
 
 @mark.e2e_operator_upgrade_replica_set
@@ -103,7 +103,7 @@ def test_upgrade_operator(namespace: str, operator_installation_config: dict[str
     operator = get_default_operator(
         namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
     )
-    operator.assert_is_running()
+    operator.wait_for_operator_ready()
 
 
 @mark.e2e_operator_upgrade_replica_set

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -119,7 +119,7 @@ def sample_movies_helper(mdb: MongoDB, namespace: str) -> SampleMoviesSearchHelp
 class TestDeployOnOfficialOperator:
 
     def test_install_latest_official_operator(self, namespace: str, official_operator: Operator):
-        official_operator.assert_is_running()
+        official_operator.wait_for_operator_ready()
         log_deployments_info(namespace)
 
     @skip_if_cloud_manager
@@ -179,7 +179,7 @@ class TestOperatorUpgrade:
         operator = get_default_operator(
             namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
         )
-        operator.assert_is_running()
+        operator.wait_for_operator_ready()
         log_deployments_info(namespace)
 
     def test_search_running_after_upgrade(self, mdbs: MongoDBSearch):

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/sharded_cluster_operator_upgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/sharded_cluster_operator_upgrade_v1_27_to_mck.py
@@ -124,7 +124,7 @@ class TestOperatorUpgrade:
         operator = get_default_operator(
             namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
         )
-        operator.assert_is_running()
+        operator.wait_for_operator_ready()
         logger.info("Installing the operator built from master")
         # Dumping deployments in logs ensures we are using the correct operator version
         log_deployments_info(namespace)

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
@@ -278,7 +278,7 @@ def test_enable_vault_role_for_operator_pod(
 
 @mark.e2e_vault_setup
 def test_operator_install_with_vault_backend(operator_vault_secret_backend: Operator):
-    operator_vault_secret_backend.assert_is_running()
+    operator_vault_secret_backend.wait_for_operator_ready()
 
 
 @mark.e2e_vault_setup

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_backup_vault.py
@@ -288,7 +288,7 @@ def test_put_admin_credentials_to_vault(namespace: str, vault_namespace: str, va
 
 @mark.e2e_vault_setup_om_backup
 def test_operator_install_with_vault_backend(operator_vault_secret_backend: Operator):
-    operator_vault_secret_backend.assert_is_running()
+    operator_vault_secret_backend.wait_for_operator_ready()
 
 
 @mark.e2e_vault_setup_om_backup

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/om_deployment_vault.py
@@ -170,7 +170,7 @@ def test_put_admin_credentials_to_vault(namespace: str, vault_namespace: str, va
 
 @mark.e2e_vault_setup_om
 def test_operator_install_with_vault_backend(operator_vault_secret_backend: Operator):
-    operator_vault_secret_backend.assert_is_running()
+    operator_vault_secret_backend.wait_for_operator_ready()
 
 
 @mark.e2e_vault_setup_om

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/vault_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/vault_tls.py
@@ -241,7 +241,7 @@ def test_remove_cert_and_key_from_secret(namespace: str):
 def test_operator_install_with_vault_backend(
     operator_vault_secret_backend_tls: Operator,
 ):
-    operator_vault_secret_backend_tls.assert_is_running()
+    operator_vault_secret_backend_tls.wait_for_operator_ready()
 
 
 @mark.e2e_vault_setup_tls

--- a/docker/mongodb-kubernetes-tests/tests/webhooks/e2e_mongodb_roles_validation_webhook.py
+++ b/docker/mongodb-kubernetes-tests/tests/webhooks/e2e_mongodb_roles_validation_webhook.py
@@ -26,7 +26,7 @@ def mdbr() -> ClusterMongoDBRole:
 
 @pytest.mark.e2e_mongodb_roles_validation_webhook
 def test_wait_for_webhook(namespace: str, default_operator: Operator):
-    default_operator.wait_for_webhook()
+    default_operator.wait_for_operator_webhook_ready()
 
 
 # Basic testing for invalid empty values


### PR DESCRIPTION
# Summary

* Unify operator webhook checks (we previously had two "wait for webhook" implementations in E2E)
* Replace Operator.assert_is_running with Operator.wait_for_operator_ready
* Expose Operator.wait_for_operator_webhook_ready


## Proof of Work

Existing tests must pass

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
