### PR TITLE
[skip-ci] test(search): sharded coverage for advancedMongotConfigs (KUBE-110 follow-up)

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -2712,6 +2712,7 @@ func newBaseMongotStatefulSet() *appsv1.StatefulSet {
 
 func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
+	withAdvancedMongotConfigs(t, search, `{"indexing":{"lucene":{"fieldLimit":1000}}}`)
 
 	shardedSource := &mockShardedSource{
 		shardNames: []string{"my-cluster-0", "my-cluster-1"},
@@ -2771,7 +2772,8 @@ func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 		assert.Equal(t, shardName, sts.Labels["shard"])
 	}
 
-	// Verify per-shard ConfigMaps
+	// Verify per-shard ConfigMaps; each shard's config.yml carries the cluster's
+	// advancedMongotConfigs verbatim (the block is per-cluster, identical across shards).
 	for _, shardName := range shardedSource.GetShardNames() {
 		cmNsName := search.MongotConfigMapForClusterShard(0, shardName)
 		cm, err := fakeClient.GetConfigMap(t.Context(), cmNsName)
@@ -2779,6 +2781,10 @@ func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 
 		assert.Equal(t, fmt.Sprintf("test-search-search-0-%s-config", shardName), cm.Name)
 		assert.Contains(t, cm.Data, MongotConfigFilename)
+
+		rendered := map[string]interface{}{}
+		require.NoError(t, yaml.Unmarshal([]byte(cm.Data[MongotConfigFilename]), &rendered))
+		assert.Equal(t, 1000, maputil.ReadMapValueAsInt(rendered, "advancedConfigs", "indexing", "lucene", "fieldLimit"))
 	}
 }
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_single_mongot.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_internal_mongodb_single_mongot.py
@@ -1,4 +1,5 @@
-from kubetester import try_load
+import yaml
+from kubetester import read_configmap, try_load
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
 from kubetester.mongodb_search import MongoDBSearch
@@ -36,6 +37,8 @@ USER_PASSWORD = "mdb-user-pass"
 MDBS_TLS_CERT_PREFIX = "certs"
 CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
 
+ADVANCED_MONGOT_CONFIGS = {"indexing": {"lucene": {"fieldLimit": 1500}}}
+
 
 @fixture(scope="module")
 def sharded_ca_configmap(issuer_ca_filepath: str, namespace: str) -> str:
@@ -66,6 +69,7 @@ def mdbs(namespace: str) -> MongoDBSearch:
     if try_load(resource):
         return resource
     resource["spec"]["source"]["mongodbResourceRef"]["name"] = MDB_RESOURCE_NAME
+    resource["spec"]["clusters"][0]["advancedMongotConfigs"] = ADVANCED_MONGOT_CONFIGS
     return resource
 
 
@@ -133,9 +137,18 @@ def test_create_search_tls_certificate(namespace: str, issuer: str):
 
 
 @mark.e2e_search_sharded_internal_mongodb_single_mongot
-def test_create_search_resource(mdbs: MongoDBSearch):
+def test_create_search_resource(namespace: str, mdbs: MongoDBSearch):
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+    # advancedMongotConfigs must render verbatim under advancedConfigs in every shard's
+    # config.yml, leaving operator-generated sections untouched.
+    for shard_idx in range(SHARD_COUNT):
+        shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+        data = read_configmap(namespace, search_resource_names.shard_configmap_name(mdbs.name, shard_name))
+        config = yaml.safe_load(data["config.yml"])
+        assert config["advancedConfigs"] == ADVANCED_MONGOT_CONFIGS, f"{shard_name}: block must render verbatim"
+        assert config["storage"]["dataPath"], f"{shard_name}: operator-rendered settings must be unaffected"
 
 
 @mark.e2e_search_sharded_internal_mongodb_single_mongot


### PR DESCRIPTION
Follow-up to #1227 (KUBE-110, `spec.clusters[].advancedMongotConfigs`).

#1227 verified the passthrough for **replicaset** sources. The field is per-cluster, so for **sharded** sources the operator renders the same `advancedConfigs` block into *every* shard's mongot `config.yml` (one ConfigMap per shard, all through the shared `marshalMongotConfig` splice) — correct by construction but previously untested. This PR closes that gap by adding **assertions to existing tests** (no new test functions/files):

- **Unit** (`mongodbsearch_reconcile_helper_test.go`): in the existing `TestReconcileSharded_CreatesPerShardResources`, set `advancedMongotConfigs` on the cluster and assert the block is present in **every** per-shard ConfigMap.
- **e2e** (`tests/search/search_sharded_internal_mongodb_single_mongot.py`): in the existing `test_create_search_resource`, after the search reaches Running, assert `advancedMongotConfigs` renders verbatim under `advancedConfigs` in each shard's `config.yml`.

**Verification:**
- Unit: green locally.
- e2e: Evergreen patch `6a3bca1a177f060007557ab8` (`e2e_search_sharded_internal_mongodb_single_mongot` on `e2e_mdb_kind_ubi_cloudqa_large`) — **passed** (the assertion ran against all shards). The final commit relocates that same assertion into `test_create_search_resource`; behavior is identical.

**Known limitation (not addressed here):** `advancedMongotConfigs` is per-cluster and uniform across shards; `ShardOverride` has no per-shard `advancedMongotConfigs`. Per-shard mongot tuning would be a separate follow-up.

JIRA: [KUBE-110](https://jira.mongodb.org/browse/KUBE-110)
