### PR TITLE
[KUBE-140] Introduce a CR field `routerHostname` to configure the cluster level hostname in mongos

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -265,6 +265,15 @@ type ManagedLBConfig struct {
 	// Required when MongoDB is externally managed. Ignored for operator-managed MongoDB.
 	// +optional
 	ExternalHostname string `json:"externalHostname,omitempty"`
+	// RouterHostname is the host:port a sharded cluster's mongos (router) uses to reach this cluster's
+	// mongot via the managed Envoy LB, and the SNI hostname Envoy matches for the cluster-level filter
+	// chain. Unlike ExternalHostname it is shard-agnostic and must NOT contain a {shardName}
+	// placeholder. This value is per-cluster: in multi-cluster deployments each cluster has its own
+	// Envoy LB and its mongos routes to it, so every cluster's RouterHostname must be distinct.
+	// Required for an external sharded MongoDB source with managed LB; ignored for ReplicaSet sources
+	// and operator-managed MongoDB. Must be covered by the Envoy LB server certificate SANs.
+	// +optional
+	RouterHostname string `json:"routerHostname,omitempty"`
 	// Replicas is the number of Envoy proxy pods to deploy.
 	// Defaults to 1 if not specified.
 	// +optional
@@ -1059,19 +1068,15 @@ func (s *MongoDBSearch) GetManagedLBEndpointForClusterShard(clusterName, shardNa
 	return strings.ReplaceAll(out, ShardNamePlaceholder, shardName)
 }
 
-// GetManagedLBEndpointForClusterLevel derives the mongos-facing endpoint by stripping
-// the leading "{shardName}." from the named cluster's externalHostname. Returns ""
-// when not derivable; callers fall back to the cluster-level proxy Service FQDN.
-func (s *MongoDBSearch) GetManagedLBEndpointForClusterLevel(clusterName string) string {
-	tmpl := s.GetManagedLBEndpointForCluster(clusterName)
-	if tmpl == "" {
+// GetRouterHostnameForCluster returns the named cluster's shard-agnostic cluster-level (mongos)
+// hostname from loadBalancer.managed.routerHostname. Used verbatim (no {shardName} trimming).
+// Returns "" when the cluster has no managed LB or the field is unset.
+func (s *MongoDBSearch) GetRouterHostnameForCluster(clusterName string) string {
+	cfg := s.GetManagedLBForCluster(clusterName)
+	if cfg == nil {
 		return ""
 	}
-	trimmed := strings.TrimPrefix(tmpl, ShardNamePlaceholder+".")
-	if strings.Contains(trimmed, ShardNamePlaceholder) {
-		return ""
-	}
-	return trimmed
+	return cfg.RouterHostname
 }
 
 // IsLoadBalancerReady returns true if managed LB is not configured,

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -264,38 +264,37 @@ func TestGetManagedLBEndpointForClusterShard_NotManaged(t *testing.T) {
 	assert.Equal(t, "", s.GetManagedLBEndpointForClusterShard("", "shard-0"))
 }
 
-func TestGetManagedLBEndpointForClusterLevel(t *testing.T) {
-	mk := func(tmpl string) *MongoDBSearch {
+func TestGetRouterHostnameForCluster(t *testing.T) {
+	mk := func(router string) *MongoDBSearch {
 		return &MongoDBSearch{
 			Spec: MongoDBSearchSpec{
 				Clusters: []ClusterSpec{
-					{Name: "us-east-k8s", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: tmpl}}},
+					{Name: "us-east-k8s", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{RouterHostname: router}}},
 				},
 			},
 		}
 	}
+	// routerHostname is used verbatim — no trimming, even if a {shardName} placeholder is present
+	// (validation rejects that separately).
 	tests := []struct {
-		name     string
-		template string
-		want     string
+		name   string
+		router string
+		want   string
 	}{
-		{"strip leading shardName prefix", "{shardName}.us-east.search.example.com", "us-east.search.example.com"},
-		{"no shardName returned as-is", "us-east.search.example.com", "us-east.search.example.com"},
-		// {shardName} as a name component (not a leading prefix) is not derivable to a
-		// single cluster-level hostname; expect "" so the caller falls back to the
-		// cluster-level proxy Service FQDN.
-		{"shardName as name component returns empty", "search-{shardName}-proxy.example.com", ""},
+		{"returned verbatim", "search.example.com:443", "search.example.com:443"},
+		{"placeholder not trimmed (used as-is)", "search-{shardName}-proxy.example.com", "search-{shardName}-proxy.example.com"},
+		{"empty when unset", "", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, mk(tc.template).GetManagedLBEndpointForClusterLevel("us-east-k8s"))
+			assert.Equal(t, tc.want, mk(tc.router).GetRouterHostnameForCluster("us-east-k8s"))
 		})
 	}
 }
 
-func TestGetManagedLBEndpointForClusterLevel_NotManaged(t *testing.T) {
+func TestGetRouterHostnameForCluster_NotManaged(t *testing.T) {
 	s := &MongoDBSearch{Spec: MongoDBSearchSpec{}}
-	assert.Equal(t, "", s.GetManagedLBEndpointForClusterLevel(""))
+	assert.Equal(t, "", s.GetRouterHostnameForCluster(""))
 }
 
 func TestValidateSimulatedMCClusterIndices(t *testing.T) {

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -106,6 +106,7 @@ func multiClusterValidators() []func(*MongoDBSearch) v1.ValidationResult {
 		validateMCRequiresExternalSource,
 		validateMCRequiresManagedLB,
 		validateMCExternalHostnames,
+		validateMCRouterHostnames,
 	}
 }
 
@@ -116,6 +117,7 @@ func managedLBValidators() []func(*MongoDBSearch) v1.ValidationResult {
 	return []func(*MongoDBSearch) v1.ValidationResult{
 		validateManagedLBExternalHostname,
 		validateExternalHostnameDNSLength,
+		validateRouterHostname,
 	}
 }
 
@@ -217,6 +219,28 @@ func validateManagedLBExternalHostname(s *MongoDBSearch) v1.ValidationResult {
 		}
 		if c.LoadBalancer.Managed.ExternalHostname == "" {
 			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.externalHostname must be specified when using managed load balancer with an external MongoDB source", i)
+		}
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateRouterHostname validates routerHostname for an external sharded MongoDB source with managed
+// LB: it is the shard-agnostic endpoint a mongos uses to reach mongot, so it is required on every
+// cluster's managed LB and must NOT carry a {shardName} placeholder (it is used verbatim). Only
+// applies to sharded external sources (mongos exists only in sharded topologies); ignored otherwise.
+func validateRouterHostname(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsExternalSourceSharded() {
+		return v1.ValidationSuccess()
+	}
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
+			continue
+		}
+		if c.LoadBalancer.Managed.RouterHostname == "" {
+			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.routerHostname must be specified when using managed load balancer with an external sharded MongoDB source", i)
+		}
+		if strings.Contains(c.LoadBalancer.Managed.RouterHostname, ShardNamePlaceholder) {
+			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.routerHostname must not contain %s; it is the shard-agnostic endpoint for mongos", i, ShardNamePlaceholder)
 		}
 	}
 	return v1.ValidationSuccess()
@@ -613,6 +637,35 @@ func validateMCExternalHostnames(s *MongoDBSearch) v1.ValidationResult {
 				i, ShardNamePlaceholder,
 			)
 		}
+	}
+	return v1.ValidationSuccess()
+}
+
+// validateMCRouterHostnames enforces, for multi-cluster specs with a managed LB, that every cluster's
+// routerHostname is distinct: each cluster runs its own Envoy LB and its mongos routes to it, so a
+// shared hostname would collide per-cluster SNI / point clusters at the wrong Envoy. Mirrors
+// validateMCExternalHostnames' distinctness check (the per-field required/placeholder rules live in
+// validateRouterHostname).
+func validateMCRouterHostnames(s *MongoDBSearch) v1.ValidationResult {
+	if !s.IsLBModeManaged() {
+		return v1.ValidationSuccess()
+	}
+	seen := make(map[string]int, len(s.Spec.Clusters))
+	for i, c := range s.Spec.Clusters {
+		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
+			continue
+		}
+		host := c.LoadBalancer.Managed.RouterHostname
+		if host == "" {
+			continue
+		}
+		if first, dup := seen[host]; dup {
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed.routerHostname %q is also used by spec.clusters[%d]; every cluster needs a distinct hostname",
+				i, host, first,
+			)
+		}
+		seen[host] = i
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -641,13 +641,13 @@ func validateMCExternalHostnames(s *MongoDBSearch) v1.ValidationResult {
 	return v1.ValidationSuccess()
 }
 
-// validateMCRouterHostnames enforces, for multi-cluster specs with a managed LB, that every cluster's
-// routerHostname is distinct: each cluster runs its own Envoy LB and its mongos routes to it, so a
-// shared hostname would collide per-cluster SNI / point clusters at the wrong Envoy. Mirrors
-// validateMCExternalHostnames' distinctness check (the per-field required/placeholder rules live in
-// validateRouterHostname).
+// validateMCRouterHostnames enforces, for an external sharded source with a managed LB, that every
+// cluster's routerHostname is distinct: each cluster runs its own Envoy LB and its mongos routes to
+// it, so a shared hostname would collide per-cluster SNI / point clusters at the wrong Envoy.
+// routerHostname is only meaningful for sharded sources (ReplicaSet has no mongos), so this is scoped
+// the same way as validateRouterHostname (the per-field required/placeholder rules live there).
 func validateMCRouterHostnames(s *MongoDBSearch) v1.ValidationResult {
-	if !s.IsLBModeManaged() {
+	if !s.IsExternalSourceSharded() {
 		return v1.ValidationSuccess()
 	}
 	seen := make(map[string]int, len(s.Spec.Clusters))

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -355,6 +355,87 @@ func TestValidateMCExternalHostnames(t *testing.T) {
 	}
 }
 
+func TestValidateRouterHostname(t *testing.T) {
+	// builds a managed-LB cluster spec with the given routerHostnames; sharded toggles whether the
+	// source is an external sharded cluster (the only case the validator applies to).
+	mkSearch := func(routerHostnames []string, sharded bool) *MongoDBSearch {
+		clusters := make([]ClusterSpec, 0, len(routerHostnames))
+		for i, rh := range routerHostnames {
+			c := ClusterSpec{Name: "cluster-" + strconv.Itoa(i), LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{shardName}.c" + strconv.Itoa(i) + ".example.com", RouterHostname: rh}}}
+			clusters = append(clusters, c)
+		}
+		s := &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}, Spec: MongoDBSearchSpec{Clusters: clusters}}
+		if sharded {
+			s.Spec.Source = &MongoDBSource{ExternalMongoDBSource: &ExternalMongoDBSource{ShardedCluster: &ExternalShardedClusterConfig{
+				Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
+				Shards: []ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
+			}}}
+		}
+		return s
+	}
+
+	tests := []struct {
+		name            string
+		routerHostnames []string
+		sharded         bool
+		errorContains   string
+	}{
+		{name: "sharded with routerHostname set", routerHostnames: []string{"search.example.com:443"}, sharded: true},
+		{name: "sharded missing routerHostname rejected", routerHostnames: []string{""}, sharded: true, errorContains: "must be specified"},
+		{name: "sharded routerHostname with shardName placeholder rejected", routerHostnames: []string{"{shardName}.search.example.com:443"}, sharded: true, errorContains: "must not contain"},
+		// Not an external sharded source → validator is a no-op even if unset.
+		{name: "non-sharded source ignored", routerHostnames: []string{""}, sharded: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := validateRouterHostname(mkSearch(tt.routerHostnames, tt.sharded))
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
+			}
+		})
+	}
+}
+
+func TestValidateMCRouterHostnames(t *testing.T) {
+	mkSearch := func(routerHostnames []string) *MongoDBSearch {
+		clusters := make([]ClusterSpec, 0, len(routerHostnames))
+		for i, rh := range routerHostnames {
+			c := ClusterSpec{Name: "cluster-" + strconv.Itoa(i)}
+			if rh != "" {
+				c.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{shardName}.c" + strconv.Itoa(i) + ".example.com", RouterHostname: rh}}
+			}
+			clusters = append(clusters, c)
+		}
+		return &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}, Spec: MongoDBSearchSpec{Clusters: clusters}}
+	}
+
+	tests := []struct {
+		name            string
+		routerHostnames []string
+		errorContains   string
+	}{
+		{name: "distinct routerHostnames", routerHostnames: []string{"us-east.example.com:443", "eu-west.example.com:443"}},
+		{name: "duplicate routerHostnames rejected", routerHostnames: []string{"shared.example.com:443", "shared.example.com:443"}, errorContains: "distinct hostname"},
+		{name: "no managed LB returns success", routerHostnames: []string{"", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := validateMCRouterHostnames(mkSearch(tt.routerHostnames))
+			if tt.errorContains != "" {
+				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
+				assert.Contains(t, res.Msg, tt.errorContains)
+			} else {
+				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
+			}
+		})
+	}
+}
+
 func TestValidateExternalHostnameDNSLength(t *testing.T) {
 	mkSearch := func(hostnames []string, shardNames []string) *MongoDBSearch {
 		clusters := make([]ClusterSpec, 0, len(hostnames))
@@ -622,7 +703,11 @@ func TestValidateClustersClusterIndexRequired(t *testing.T) {
 
 // managedLBWithHostname is a shorthand for a per-cluster managed LB entry.
 func managedLBWithHostname(hostname string) *LoadBalancerConfig {
-	return &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: hostname}}
+	// routerHostname must be set for external sharded managed LB, distinct per cluster, and free of
+	// {shardName}. Derive it from the (distinct) externalHostname by dropping any "{shardName}."
+	// prefix so callers passing distinct externalHostnames get distinct, placeholder-free routers.
+	router := strings.ReplaceAll(hostname, ShardNamePlaceholder+".", "")
+	return &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: hostname, RouterHostname: router}}
 }
 
 func newSearch(name string, shards []ExternalShardConfig, tlsPrefix string, isTLS, isLBManaged bool) *MongoDBSearch {

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -410,7 +410,17 @@ func TestValidateMCRouterHostnames(t *testing.T) {
 			}
 			clusters = append(clusters, c)
 		}
-		return &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}, Spec: MongoDBSearchSpec{Clusters: clusters}}
+		// routerHostname validation is scoped to external sharded sources.
+		return &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+			Spec: MongoDBSearchSpec{
+				Clusters: clusters,
+				Source: &MongoDBSource{ExternalMongoDBSource: &ExternalMongoDBSource{ShardedCluster: &ExternalShardedClusterConfig{
+					Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
+					Shards: []ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
+				}}},
+			},
+		}
 	}
 
 	tests := []struct {
@@ -434,6 +444,19 @@ func TestValidateMCRouterHostnames(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("non-sharded source ignored even with duplicate routerHostnames", func(t *testing.T) {
+		rs := &MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+			Spec: MongoDBSearchSpec{
+				Clusters: []ClusterSpec{
+					{Name: "cluster-0", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{RouterHostname: "shared.example.com:443"}}},
+					{Name: "cluster-1", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{RouterHostname: "shared.example.com:443"}}},
+				},
+			},
+		}
+		assert.Equal(t, v1.SuccessLevel, validateMCRouterHostnames(rs).Level)
+	})
 }
 
 func TestValidateExternalHostnameDNSLength(t *testing.T) {

--- a/config/crd/bases/mongodb.com_mongodbsearch.yaml
+++ b/config/crd/bases/mongodb.com_mongodbsearch.yaml
@@ -260,6 +260,16 @@ spec:
                                     Defaults to "60s" if not specified.
                                   type: string
                               type: object
+                            routerHostname:
+                              description: |-
+                                RouterHostname is the host:port a sharded cluster's mongos (router) uses to reach this cluster's
+                                mongot via the managed Envoy LB, and the SNI hostname Envoy matches for the cluster-level filter
+                                chain. Unlike ExternalHostname it is shard-agnostic and must NOT contain a {shardName}
+                                placeholder. This value is per-cluster: in multi-cluster deployments each cluster has its own
+                                Envoy LB and its mongos routes to it, so every cluster's RouterHostname must be distinct.
+                                Required for an external sharded MongoDB source with managed LB; ignored for ReplicaSet sources
+                                and operator-managed MongoDB. Must be covered by the Envoy LB server certificate SANs.
+                              type: string
                           type: object
                         unmanaged:
                           description: Unmanaged configures a user-provided (BYO)

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -761,16 +761,16 @@ func TestReconcile_SimulatedMC_RePinUpdatesNames(t *testing.T) {
 }
 
 func newSimulatedMCShardedMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
-	// Each cluster gets its own externalHostname (distinct per cluster); the
-	// {shardName}. prefix is required for cluster-level form derivation.
+	// Each cluster gets its own externalHostname (distinct per cluster, {shardName} per-shard) and a
+	// distinct shard-agnostic routerHostname (required for external sharded + managed LB).
 	clusters := []searchv1.ClusterSpec{
 		{
 			Name: "cluster-a", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-a.example.com"}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-a.example.com", RouterHostname: "router.cluster-a.example.com"}},
 		},
 		{
 			Name: "cluster-b", Index: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-b.example.com"}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-b.example.com", RouterHostname: "router.cluster-b.example.com"}},
 		},
 	}
 	return &searchv1.MongoDBSearch{
@@ -986,6 +986,7 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.example.com",
+							RouterHostname:   "mdb-search-search-0-proxy-svc.example.com",
 						},
 					},
 				},
@@ -994,6 +995,7 @@ func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testi
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.example.com",
+							RouterHostname:   "mdb-search-search-1-proxy-svc.example.com",
 						},
 					},
 				},

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -397,10 +397,10 @@ func buildShardRoutes(search *searchv1.MongoDBSearch, shardNames []string, clust
 
 	// Cluster-level route: mongos in this cluster uses this single SNI chain to reach
 	// all local shard mongot pools. SNI is the cluster-level proxy Service FQDN unless
-	// the user supplied a managed-LB externalHostname (with {shardName}. prefix stripped).
+	// the user supplied a managed-LB routerHostname (used verbatim; required for external sharded).
 	clusterLevelSvcName := search.ProxyServiceNamespacedNameForCluster(clusterIndex).Name
 	clusterLevelSNI := fmt.Sprintf("%s.%s.svc.cluster.local", clusterLevelSvcName, namespace)
-	if endpoint := search.GetManagedLBEndpointForClusterLevel(clusterName); endpoint != "" {
+	if endpoint := search.GetRouterHostnameForCluster(clusterName); endpoint != "" {
 		clusterLevelSNI = endpoint
 	}
 

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -176,6 +176,7 @@ func TestBuildShardRoutes(t *testing.T) {
 	tests := []struct {
 		name                    string
 		endpoint                string
+		routerHostname          string
 		expectedShardSNIs       []string
 		expectedClusterLevelSNI string
 	}{
@@ -190,14 +191,25 @@ func TestBuildShardRoutes(t *testing.T) {
 			expectedClusterLevelSNI: "mdb-search-search-0-proxy-svc.test-ns.svc.cluster.local",
 		},
 		{
-			name:     "externalHostname template resolves per shard and strips shardName for cluster-level",
-			endpoint: "{shardName}.search.example.com",
+			name:           "externalHostname resolves per shard; routerHostname used verbatim for cluster-level",
+			endpoint:       "{shardName}.search.example.com",
+			routerHostname: "router.search.example.com",
 			expectedShardSNIs: []string{
 				"mdb-sh-0.search.example.com",
 				"mdb-sh-1.search.example.com",
 			},
-			// GetManagedLBEndpointForClusterLevel strips "{shardName}." → "search.example.com"
-			expectedClusterLevelSNI: "search.example.com",
+			// routerHostname is used verbatim (no trimming) for the cluster-level SNI.
+			expectedClusterLevelSNI: "router.search.example.com",
+		},
+		{
+			name:           "routerHostname need not relate to externalHostname (mid-string {shardName} ok)",
+			endpoint:       "search-{shardName}-proxy.example.com",
+			routerHostname: "router.example.com",
+			expectedShardSNIs: []string{
+				"search-mdb-sh-0-proxy.example.com",
+				"search-mdb-sh-1-proxy.example.com",
+			},
+			expectedClusterLevelSNI: "router.example.com",
 		},
 	}
 
@@ -209,10 +221,10 @@ func TestBuildShardRoutes(t *testing.T) {
 					Namespace: "test-ns",
 				},
 			}
-			if tt.endpoint != "" {
+			if tt.endpoint != "" || tt.routerHostname != "" {
 				search.Spec.Clusters = []searchv1.ClusterSpec{{
 					LoadBalancer: &searchv1.LoadBalancerConfig{
-						Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint},
+						Managed: &searchv1.ManagedLBConfig{ExternalHostname: tt.endpoint, RouterHostname: tt.routerHostname},
 					},
 				}}
 			}
@@ -684,6 +696,7 @@ func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.cluster-a.search.example.com:443",
+							RouterHostname:   "router.cluster-a.search.example.com:443",
 						},
 					},
 				},
@@ -692,6 +705,7 @@ func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 					LoadBalancer: &searchv1.LoadBalancerConfig{
 						Managed: &searchv1.ManagedLBConfig{
 							ExternalHostname: "{shardName}.cluster-b.search.example.com:443",
+							RouterHostname:   "router.cluster-b.search.example.com:443",
 						},
 					},
 				},
@@ -703,14 +717,14 @@ func TestBuildShardRoutes_MC_ClusterLevel_ManagedLB(t *testing.T) {
 
 	require.Len(t, routes, 4)
 
-	// Per-shard SNIs must resolve {shardName} against cluster-b's own hostname.
+	// Per-shard SNIs must resolve {shardName} against cluster-b's own externalHostname.
 	for i, shardName := range shardNames {
 		expected := fmt.Sprintf("%s.cluster-b.search.example.com:443", shardName)
 		assert.Equal(t, expected, routes[i].SNIHostname, "per-shard SNI mismatch for shard %s", shardName)
 	}
 
-	// Cluster-level SNI strips "{shardName}." → "cluster-b.search.example.com:443".
-	assert.Equal(t, "cluster-b.search.example.com:443", routes[3].SNIHostname)
+	// Cluster-level SNI is cluster-b's routerHostname, used verbatim.
+	assert.Equal(t, "router.cluster-b.search.example.com:443", routes[3].SNIHostname)
 	require.Len(t, routes[3].UpstreamHosts, 3)
 }
 
@@ -1645,7 +1659,7 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 			},
 			Clusters: []searchv1.ClusterSpec{{
 				Name:         "cluster-a",
-				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com"}},
+				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com", RouterHostname: "mongot-router.example.com"}},
 			}},
 		},
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -1986,12 +1986,12 @@ func GetMongosConfigParametersForSharded(search *searchv1.MongoDBSearch, cluster
 }
 
 // mongotEndpointForClusterLevel resolves the shard-agnostic mongot endpoint for a cluster's mongos.
-// For managed LB with an externalHostname, returns the cluster-level external form (template with
-// leading `{shardName}.` stripped). Otherwise (managed LB without externalHostname, or no LB) returns
-// the cluster-level proxy Service in-cluster FQDN.
+// For managed LB with a routerHostname (required for external sharded sources), returns that value
+// verbatim. Otherwise (managed LB without routerHostname — e.g. operator-managed MongoDB — or no LB)
+// returns the cluster-level proxy Service in-cluster FQDN.
 func mongotEndpointForClusterLevel(search *searchv1.MongoDBSearch, clusterIndex int, clusterName string, clusterDomain string) string {
 	if search.IsLBModeManaged() {
-		if endpoint := search.GetManagedLBEndpointForClusterLevel(clusterName); endpoint != "" {
+		if endpoint := search.GetRouterHostnameForCluster(clusterName); endpoint != "" {
 			return endpoint
 		}
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -1790,7 +1790,7 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 			expectedHost:  "test-search-search-0-proxy-svc.test-ns.svc.cluster.local:27028",
 		},
 		{
-			name: "Managed LB with externalHostname - uses cluster-level external form",
+			name: "Managed LB with routerHostname - uses it verbatim for mongos",
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-search",
@@ -1806,6 +1806,7 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 						LoadBalancer: &searchv1.LoadBalancerConfig{
 							Managed: &searchv1.ManagedLBConfig{
 								ExternalHostname: "{shardName}.search.example.com:443",
+								RouterHostname:   "search.example.com:443",
 							},
 						},
 					}},
@@ -1813,11 +1814,11 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 			},
 			shardNames:    []string{"test-mdb-0", "test-mdb-1"},
 			clusterDomain: "cluster.local",
-			// Cluster-level form: strip leading "{shardName}." from the template.
+			// mongos uses routerHostname verbatim.
 			expectedHost: "search.example.com:443",
 		},
 		{
-			name: "MC managed LB - cluster-level form uses cluster's own externalHostname for clusterIndex>0",
+			name: "MC managed LB - mongos uses the named cluster's routerHostname for clusterIndex>0",
 			search: &searchv1.MongoDBSearch{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-search",
@@ -1833,11 +1834,13 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 						{Name: "us-east-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
 							Managed: &searchv1.ManagedLBConfig{
 								ExternalHostname: "{shardName}.us-east-k8s.search.example.com:443",
+								RouterHostname:   "us-east-k8s.search.example.com:443",
 							},
 						}},
 						{Name: "eu-west-k8s", LoadBalancer: &searchv1.LoadBalancerConfig{
 							Managed: &searchv1.ManagedLBConfig{
 								ExternalHostname: "{shardName}.eu-west-k8s.search.example.com:443",
+								RouterHostname:   "eu-west-k8s.search.example.com:443",
 							},
 						}},
 					},
@@ -1847,7 +1850,7 @@ func TestGetMongosConfigParametersForSharded(t *testing.T) {
 			clusterName:   "eu-west-k8s",
 			shardNames:    []string{"test-mdb-0", "test-mdb-1"},
 			clusterDomain: "cluster.local",
-			// Strip "{shardName}." from spec.clusters[1]'s own externalHostname.
+			// mongos uses spec.clusters[1]'s routerHostname verbatim.
 			expectedHost: "eu-west-k8s.search.example.com:443",
 		},
 	}
@@ -1888,7 +1891,7 @@ func TestGetMongosConfigParametersForSharded_PinnedIndexNotSpecPosition(t *testi
 			},
 			Clusters: []searchv1.ClusterSpec{
 				{Name: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.b.example.com:443"},
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.b.example.com:443", RouterHostname: "b.example.com:443"},
 				}},
 			},
 		},
@@ -1898,7 +1901,7 @@ func TestGetMongosConfigParametersForSharded_PinnedIndexNotSpecPosition(t *testi
 	setParameter, ok := config["setParameter"].(map[string]any)
 	require.True(t, ok, "setParameter should be a map")
 	assert.Equal(t, "b.example.com:443", setParameter["mongotHost"],
-		"mongos must get cluster-b's externalHostname even though its pinned index (1) is not its spec position (0)")
+		"mongos must get cluster-b's routerHostname even though its pinned index (1) is not its spec position (0)")
 }
 
 func TestMongotHostAndPort_ReplicaSet(t *testing.T) {
@@ -3226,11 +3229,13 @@ func TestBuildShardedPlan_PerClusterShardUnitsForMC(t *testing.T) {
 	search.Spec.Clusters = []searchv1.ClusterSpec{
 		{Name: "cluster-a", Index: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
 		// Pin the second cluster to 7 (!= its array position 1) so the per-(cluster,shard)
 		// assertions below fail if the index ever comes from the loop position.
 		{Name: "cluster-b", Index: ptr.To(int32(7)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-7-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-7-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
 
@@ -3289,9 +3294,11 @@ func TestBuildShardedPlan_PerClusterMatchTagSets(t *testing.T) {
 	search.Spec.Clusters = []searchv1.ClusterSpec{
 		{Name: "cluster-a", Index: ptr.To(int32(0)), SyncSourceSelector: &searchv1.SyncSourceSelector{MatchTagSets: []map[string]string{{"region": "us-east"}}}, LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
 		{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
 
@@ -3339,9 +3346,11 @@ func TestReconcileShardedMC_FanOutUsesPerClusterClient(t *testing.T) {
 	search.Spec.Clusters = []searchv1.ClusterSpec{
 		{Name: "cluster-a", Index: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
 		{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
 
@@ -3460,9 +3469,11 @@ func TestReconcileShardedMC_AllUnitsAppliedBeforeReadinessCheck(t *testing.T) {
 	search.Spec.Clusters = []searchv1.ClusterSpec{
 		{Name: "cluster-a", Index: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
 		{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
 	search.Spec.Source = &searchv1.MongoDBSource{
@@ -3592,9 +3603,11 @@ func newMCShardedFixture(t *testing.T) *mcShardedFixture {
 	search.Spec.Clusters = []searchv1.ClusterSpec{
 		{Name: "cluster-a", Index: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 		}}},
 		{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+			RouterHostname:   "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 		}}},
 	}
 	search.Spec.Source = &searchv1.MongoDBSource{
@@ -3956,6 +3969,7 @@ func TestReconcileSharded_RoutingSwitchOneWay(t *testing.T) {
 		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Managed: &searchv1.ManagedLBConfig{
 				ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+				RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 			},
 		}
 		s.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "certs"}}
@@ -4034,6 +4048,7 @@ func TestReconcileSharded_SwitchErrorsAggregatedAcrossUnits(t *testing.T) {
 		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
 			Managed: &searchv1.ManagedLBConfig{
 				ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+				RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
 			},
 		}
 		s.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "certs"}}

--- a/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/bootstrap_test_mixins.py
@@ -604,6 +604,9 @@ class SearchShardedDeploymentTests(SearchDeploymentTests):
                     "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
                         mdbs_name, self.namespace, i
                     ),
+                    # Shard-agnostic cluster-level endpoint for mongos: the per-cluster proxy-svc FQDN
+                    # (matches the LB cert SAN). Required for external sharded + managed LB.
+                    "routerHostname": search_resource_names.mc_proxy_svc_fqdn(mdbs_name, self.namespace, i),
                 },
             }
         resource["spec"]["clusters"] = clusters

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_deployment_helper.py
@@ -192,7 +192,12 @@ class SearchDeploymentHelper:
                     lb["managed"] = {
                         "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
                             self.mdbs_resource_name, self.namespace, i
-                        )
+                        ),
+                        # Shard-agnostic cluster-level endpoint for mongos: the per-cluster proxy-svc
+                        # FQDN (matches the LB cert SAN). Required for external sharded + managed LB.
+                        "routerHostname": search_resource_names.mc_proxy_svc_fqdn(
+                            self.mdbs_resource_name, self.namespace, i
+                        ),
                     }
                 if lb_endpoint:
                     lb["unmanaged"] = {"endpoint": lb_endpoint}

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import kubernetes
 from kubernetes.client.rest import ApiException
@@ -266,6 +266,7 @@ def build_per_cluster_search_crs(
     mongot_replicas: int,
     external_hostname_for_cluster: Callable[[int], str],
     source_external: dict,
+    router_hostname_for_cluster: Optional[Callable[[int], str]] = None,
 ) -> List[Tuple[MultiClusterClient, MongoDBSearch]]:
     """Build the SAME MongoDBSearch CR (spec.clusters lists all clusters) against each
     member's API; each simulated operator projects to its own slice. `source_external`
@@ -274,20 +275,28 @@ def build_per_cluster_search_crs(
     `external_hostname_for_cluster(cluster_index)` returns that cluster's literal managed-LB
     externalHostname; #1238 moved the LB under spec.clusters[] and dropped the per-cluster
     hostname placeholder, so each cluster needs a distinct literal (validation rejects duplicates).
+
+    `router_hostname_for_cluster(cluster_index)`, when provided (external sharded sources only),
+    returns that cluster's shard-agnostic routerHostname (the mongos-facing cluster-level endpoint).
+    Required and validated for external sharded + managed LB; omitted for ReplicaSet sources.
     """
     results: List[Tuple[MultiClusterClient, MongoDBSearch]] = []
+
+    def _managed(idx: int) -> dict:
+        managed = {
+            "replicas": ENVOY_LB_REPLICAS,
+            "externalHostname": external_hostname_for_cluster(idx),
+        }
+        if router_hostname_for_cluster is not None:
+            managed["routerHostname"] = router_hostname_for_cluster(idx)
+        return managed
 
     clusters_spec = [
         {
             "name": mcc.cluster_name,
             "index": _idx(mcc),
             "replicas": mongot_replicas,
-            "loadBalancer": {
-                "managed": {
-                    "replicas": ENVOY_LB_REPLICAS,
-                    "externalHostname": external_hostname_for_cluster(_idx(mcc)),
-                },
-            },
+            "loadBalancer": {"managed": _managed(_idx(mcc))},
         }
         for mcc in member_cluster_clients
     ]

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -247,6 +247,11 @@ def mdbs(
                         "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
                             MDBS_RESOURCE_NAME, namespace, _idx(mcc)
                         ),
+                        # Shard-agnostic cluster-level endpoint for mongos: the per-cluster proxy-svc
+                        # FQDN (matches the LB cert SAN). Distinct per cluster via the cluster index.
+                        "routerHostname": search_resource_names.mc_proxy_svc_fqdn(
+                            MDBS_RESOURCE_NAME, namespace, _idx(mcc)
+                        ),
                     },
                 },
                 "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: mcc.cluster_name}]},

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_sharded_scram_enc_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_sharded_scram_enc_mtls.py
@@ -214,6 +214,9 @@ def mdbs(
                     "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
                         MDBS_RESOURCE_NAME, namespace, _idx(mcc)
                     ),
+                    # Shard-agnostic cluster-level endpoint for mongos: the per-cluster proxy-svc FQDN
+                    # (matches the LB cert SAN). Distinct per cluster via the cluster index.
+                    "routerHostname": search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, _idx(mcc)),
                 },
             },
         }

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
@@ -275,6 +275,11 @@ def per_cluster_mdbs_search(
             },
             "tls": {"ca": {"name": ca_configmap}},
         },
+        # Shard-agnostic cluster-level endpoint for mongos: the per-cluster proxy-svc FQDN
+        # (distinct per cluster via the cluster index).
+        router_hostname_for_cluster=lambda idx: search_resource_names.mc_proxy_svc_fqdn(
+            MDBS_RESOURCE_NAME, namespace, idx
+        ),
     )
 
 

--- a/docs/search/07-search-external-sharded-mongod-managed-lb/README.md
+++ b/docs/search/07-search-external-sharded-mongod-managed-lb/README.md
@@ -224,6 +224,7 @@ spec:
       loadBalancer:
         managed:
           externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local
+          routerHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local
   source:
     username: search-sync-source
     passwordSecretRef:

--- a/docs/search/07-search-external-sharded-mongod-managed-lb/code_snippets/07_0320_create_mongodb_search_resource.sh
+++ b/docs/search/07-search-external-sharded-mongod-managed-lb/code_snippets/07_0320_create_mongodb_search_resource.sh
@@ -40,6 +40,8 @@ spec:
       loadBalancer:
         managed:
           externalHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local
+          # Shard-agnostic endpoint the mongos routers use to reach mongot.
+          routerHostname: ${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local
       resourceRequirements:
         limits:
           cpu: "2"

--- a/helm_chart/crds/mongodb.com_mongodbsearch.yaml
+++ b/helm_chart/crds/mongodb.com_mongodbsearch.yaml
@@ -260,6 +260,16 @@ spec:
                                     Defaults to "60s" if not specified.
                                   type: string
                               type: object
+                            routerHostname:
+                              description: |-
+                                RouterHostname is the host:port a sharded cluster's mongos (router) uses to reach this cluster's
+                                mongot via the managed Envoy LB, and the SNI hostname Envoy matches for the cluster-level filter
+                                chain. Unlike ExternalHostname it is shard-agnostic and must NOT contain a {shardName}
+                                placeholder. This value is per-cluster: in multi-cluster deployments each cluster has its own
+                                Envoy LB and its mongos routes to it, so every cluster's RouterHostname must be distinct.
+                                Required for an external sharded MongoDB source with managed LB; ignored for ReplicaSet sources
+                                and operator-managed MongoDB. Must be covered by the Envoy LB server certificate SANs.
+                              type: string
                           type: object
                         unmanaged:
                           description: Unmanaged configures a user-provided (BYO)

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4284,6 +4284,16 @@ spec:
                                     Defaults to "60s" if not specified.
                                   type: string
                               type: object
+                            routerHostname:
+                              description: |-
+                                RouterHostname is the host:port a sharded cluster's mongos (router) uses to reach this cluster's
+                                mongot via the managed Envoy LB, and the SNI hostname Envoy matches for the cluster-level filter
+                                chain. Unlike ExternalHostname it is shard-agnostic and must NOT contain a {shardName}
+                                placeholder. This value is per-cluster: in multi-cluster deployments each cluster has its own
+                                Envoy LB and its mongos routes to it, so every cluster's RouterHostname must be distinct.
+                                Required for an external sharded MongoDB source with managed LB; ignored for ReplicaSet sources
+                                and operator-managed MongoDB. Must be covered by the Envoy LB server certificate SANs.
+                              type: string
                           type: object
                         unmanaged:
                           description: Unmanaged configures a user-provided (BYO)


### PR DESCRIPTION
# Summary

In the earlier implementation to figure out the cluster level hostname that should be configured in the mongos we just removed the `{shardname}` **prefix** from the `externalHostname` field. This was not a good idea and the main reason was the `{shardname}` placeholder can be anywhere in the `externalHostname` string. And even if we improved the function and instead of removing the prefix we just removed `{shardname}` placeholder form entire string, we might get into some format problems. For example `abc.{shardname}-us.example.com` or `abc.{shardname}.example.com`, how would be deterministically remove `{shardname}` from above strings.
To fix this problem, this PR introduces a new CR field `routerHostname` under `clusters.loadBalancer.managed`. Which can be used to configure the the hostname in the externally installed mongos processes.

This `routerHostname` would eventually end up in the envoy config in the filter chain that would select all the clusters (mongot groups) in that K8s cluster.

These  are the validations that are applied to the `routerHostname`, validations happen only in case of external sharded mongodb sources with managed load balancers.

- `spec.clusters[i].loadBalancer.managed.routerHostname` must be specified when using managed load balancer with an external sharded MongoDB source
- No `{shardName}` placeholder: it's the shard-agnostic mongos endpoint, so it must not contain `{shardName}`
- `routerHostname` must be distinct across `spec.clusters[i].loadBalancer.managed`

## Proof of Work

Successful CI.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
