### PR TITLE
KUBE-143: delete mongot index PVC on scale-down and CR delete

### DIFF
--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -145,6 +145,7 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 		statefulset.WithReplicas(sizing.ReplicasOrDefault()),
 		statefulset.WithUpdateStrategyType(appsv1.RollingUpdateStatefulSetStrategyType),
 		dataVolumeClaim,
+		withDataPVCRetentionPolicy(),
 		statefulset.WithPodSpecTemplate(
 			podtemplatespec.Apply(
 				podSecurityContext,
@@ -161,6 +162,19 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 	}
 
 	return statefulset.Apply(stsModifications...)
+}
+
+// withDataPVCRetentionPolicy reclaims the mongot index PVC both when the StatefulSet
+// is deleted (the MongoDBSearch CR is removed) and when it is scaled down. The index
+// is rebuildable, so the storage is freed immediately and a later scale-up reindexes
+// from mongod. (Draining a replica before teardown is a planned follow-up.)
+func withDataPVCRetentionPolicy() statefulset.Modification {
+	return func(sts *appsv1.StatefulSet) {
+		sts.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+		}
+	}
 }
 
 // StatefulSetOverrideModification applies the resolved clusters[].statefulSet, with any

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -164,10 +164,9 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 	return statefulset.Apply(stsModifications...)
 }
 
-// withDataPVCRetentionPolicy reclaims the mongot index PVC both when the StatefulSet
-// is deleted (the MongoDBSearch CR is removed) and when it is scaled down. The index
-// is rebuildable, so the storage is freed immediately and a later scale-up reindexes
-// from mongod. (Draining a replica before teardown is a planned follow-up.)
+// withDataPVCRetentionPolicy reclaims the mongot index PVC on StatefulSet delete
+// (CR removed) and on scale-down. The index is rebuildable, so freeing the storage
+// immediately is safe — a later scale-up reindexes from mongod.
 func withDataPVCRetentionPolicy() statefulset.Modification {
 	return func(sts *appsv1.StatefulSet) {
 		sts.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -242,6 +242,11 @@ func TestCreateSearchStatefulSetFunc_DefaultAntiAffinity(t *testing.T) {
 	stsMod := CreateSearchStatefulSetFunc(search, resolvedSizing(t, search, "", ""), "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
 	sts := statefulset.New(stsMod)
 
+	// Reclaim the index PVC immediately on both CR delete and scale-down.
+	require.NotNil(t, sts.Spec.PersistentVolumeClaimRetentionPolicy)
+	assert.Equal(t, appsv1.DeletePersistentVolumeClaimRetentionPolicyType, sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+	assert.Equal(t, appsv1.DeletePersistentVolumeClaimRetentionPolicyType, sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+
 	affinity := sts.Spec.Template.Spec.Affinity
 	require.NotNil(t, affinity)
 	require.NotNil(t, affinity.PodAntiAffinity)

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -811,10 +811,12 @@ def wait_for_mongot_statefulset_drained(
 ) -> None:
     """Wait until the mongot StatefulSet has 0 ready replicas or is deleted.
 
-    The reconciler deletes the STS entirely when ``spec.clusters[].replicas`` drops to 0,
-    so a 404 from the API is the terminal state. ``api_client`` must target the
-    cluster that hosts the STS — for multi-cluster the mongot StatefulSets live
-    on the member clusters, not the operator/default cluster.
+    On ``spec.clusters[].replicas`` -> 0 the operator keeps the StatefulSet but
+    scales it to 0, so ``ready == desired == 0`` is the normal terminal state; a
+    404 is also accepted for callers that remove the STS outright (e.g. CR
+    delete). ``api_client`` must target the cluster that hosts the STS — for
+    multi-cluster the mongot StatefulSets live on the member clusters, not the
+    operator/default cluster.
     """
     apps_v1 = client.AppsV1Api(api_client=api_client)
 

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -837,6 +837,43 @@ def wait_for_mongot_statefulset_drained(
     )
 
 
+def wait_for_mongot_pvcs_deleted(
+    namespace: str,
+    sts_name: str,
+    *,
+    api_client: Optional[client.ApiClient] = None,
+    timeout: int = 300,
+    sleep_time: int = 5,
+) -> None:
+    """Wait until the PVCs backing a mongot StatefulSet are fully deleted.
+
+    Under ``WhenScaled: Delete`` the STS controller GCs the per-ordinal claim on
+    scale-to-0, but the delete is asynchronous. Scaling back up while the old
+    claim is still ``Terminating`` trips a StatefulSet-controller race: the
+    controller skips pod creation for the deleting claim and is not re-enqueued
+    once it is gone, leaving the pod stuck at ``current: 0``. Block on the claim
+    being gone before restoring replicas. PVCs from a volumeClaimTemplate are
+    named ``<template>-<sts>-<ordinal>``, so we match on the ``-<sts>-`` infix.
+    ``api_client`` must target the cluster hosting the STS.
+    """
+    core = client.CoreV1Api(api_client=api_client)
+
+    def deleted() -> tuple[bool, str]:
+        remaining = [
+            pvc.metadata.name
+            for pvc in core.list_namespaced_persistent_volume_claim(namespace).items
+            if f"-{sts_name}-" in f"-{pvc.metadata.name}"
+        ]
+        return not remaining, ("all deleted" if not remaining else f"remaining={remaining}")
+
+    run_periodically(
+        deleted,
+        timeout=timeout,
+        sleep_time=sleep_time,
+        msg=f"mongot PVCs for STS {sts_name} to be deleted",
+    )
+
+
 def hard_kill_pods_by_label(
     core_v1: Any,
     namespace: str,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_rs.py
@@ -169,10 +169,8 @@ class TestSearchConnectivityToolMC:
                         f"served while {outage_label} mongot was scaled to 0"
                     )
             finally:
-                # Under WhenScaled:Delete the mongot PVC is GC'd asynchronously on
-                # scale-to-0; restoring replicas while the old claim is still
-                # Terminating wedges the StatefulSet controller (pod never recreated,
-                # stuck at current:0), so wait for the claim to be gone first.
+                # Wait out the async PVC GC before restoring replicas (see
+                # wait_for_mongot_pvcs_deleted docstring for the STS-controller race).
                 wait_for_mongot_pvcs_deleted(
                     namespace,
                     sts_name,
@@ -271,10 +269,8 @@ class TestSearchConnectivityToolMC:
                 wait_for_mongot_statefulset_drained(sts_name, namespace, api_client=outage_mcc.api_client, timeout=300)
                 fleet.wait_for_operations_all(40)  # observe through the outage
             finally:
-                # Under WhenScaled:Delete the mongot PVC is GC'd asynchronously on
-                # scale-to-0; restoring replicas while the old claim is still
-                # Terminating wedges the StatefulSet controller (pod never recreated,
-                # stuck at current:0), so wait for the claim to be gone first.
+                # Wait out the async PVC GC before restoring replicas (see
+                # wait_for_mongot_pvcs_deleted docstring for the STS-controller race).
                 wait_for_mongot_pvcs_deleted(
                     namespace,
                     sts_name,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_rs.py
@@ -24,6 +24,7 @@ from tests.common.search.connectivity import (
     assert_disruption_observed,
     hard_kill_pods_by_label,
     paging_baseline_and_fault,
+    wait_for_mongot_pvcs_deleted,
     wait_for_mongot_statefulset_drained,
     wait_for_pods_by_label_replaced,
 )
@@ -168,10 +169,22 @@ class TestSearchConnectivityToolMC:
                         f"served while {outage_label} mongot was scaled to 0"
                     )
             finally:
+                # Under WhenScaled:Delete the mongot PVC is GC'd asynchronously on
+                # scale-to-0; restoring replicas while the old claim is still
+                # Terminating wedges the StatefulSet controller (pod never recreated,
+                # stuck at current:0), so wait for the claim to be gone first.
+                wait_for_mongot_pvcs_deleted(
+                    namespace,
+                    sts_name,
+                    api_client=outage_mcc.api_client,
+                    timeout=300,
+                )
                 mdbs.load()
                 mdbs["spec"]["clusters"] = [dict(c) for c in original_clusters]
                 mdbs.update()
-                mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+                # The fresh per-cluster replica must reindex from mongod before it
+                # reports Ready, so allow a generous window.
+                mdbs.assert_reaches_phase(Phase.Running, timeout=1200)
                 logger.info(f"{outage_label}: restored per-cluster replicas, MDBS back to Running")
 
     def test_paging_through_per_cluster_envoy_restart(
@@ -258,10 +271,22 @@ class TestSearchConnectivityToolMC:
                 wait_for_mongot_statefulset_drained(sts_name, namespace, api_client=outage_mcc.api_client, timeout=300)
                 fleet.wait_for_operations_all(40)  # observe through the outage
             finally:
+                # Under WhenScaled:Delete the mongot PVC is GC'd asynchronously on
+                # scale-to-0; restoring replicas while the old claim is still
+                # Terminating wedges the StatefulSet controller (pod never recreated,
+                # stuck at current:0), so wait for the claim to be gone first.
+                wait_for_mongot_pvcs_deleted(
+                    namespace,
+                    sts_name,
+                    api_client=outage_mcc.api_client,
+                    timeout=300,
+                )
                 mdbs.load()
                 mdbs["spec"]["clusters"] = [dict(c) for c in original_clusters]
                 mdbs.update()
-                mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+                # The fresh per-cluster replica must reindex from mongod before it
+                # reports Ready, so allow a generous window.
+                mdbs.assert_reaches_phase(Phase.Running, timeout=1200)
                 logger.info(f"restored cluster {outage_idx} mongot replicas, MDBS back to Running")
 
         fleet.assert_single_cluster_outage(outage_idx)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -1,6 +1,6 @@
 import yaml
 from kubernetes import client
-from kubetester import create_or_update_secret, read_configmap, try_load
+from kubetester import create_or_update_secret, read_configmap, statefulset_is_deleted, try_load
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.kubetester import run_periodically
 from kubetester.mongodb_community import MongoDBCommunity
@@ -125,37 +125,31 @@ def test_zz_delete_search_cr_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     """On MongoDBSearch CR delete (single-cluster), owner-ref GC removes the mongot
     StatefulSet and the persistentVolumeClaimRetentionPolicy{whenDeleted:Delete}
     reclaims its data PVC."""
-    apps_v1 = client.AppsV1Api()
     core_v1 = client.CoreV1Api()
 
     sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
     pvc_prefix = f"data-{sts_name}-"
 
+    def mongot_data_pvcs() -> list[str]:
+        return [
+            pvc.metadata.name
+            for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
+            if pvc.metadata.name.startswith(pvc_prefix)
+        ]
+
     # Presence guard: the STS and its data PVC must exist before delete, otherwise
     # the post-delete absence checks below could pass vacuously.
-    apps_v1.read_namespaced_stateful_set(sts_name, namespace)
-    pvcs_before = [
-        pvc.metadata.name
-        for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
-        if pvc.metadata.name.startswith(pvc_prefix)
-    ]
+    client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace)
+    pvcs_before = mongot_data_pvcs()
     assert pvcs_before, f"expected at least one mongot data PVC with prefix {pvc_prefix!r} before delete"
     logger.info(f"pre-delete: STS {sts_name} present, data PVCs {pvcs_before}")
 
     mdbs.delete()
 
     def _sts_and_pvc_gone() -> tuple[bool, str]:
-        try:
-            apps_v1.read_namespaced_stateful_set(sts_name, namespace)
+        if not statefulset_is_deleted(namespace, sts_name, api_client=None):
             return False, f"StatefulSet {sts_name} still present"
-        except client.exceptions.ApiException as e:
-            if e.status != 404:
-                raise
-        remaining = [
-            pvc.metadata.name
-            for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
-            if pvc.metadata.name.startswith(pvc_prefix)
-        ]
+        remaining = mongot_data_pvcs()
         if remaining:
             return False, f"data PVCs not yet reclaimed: {remaining}"
         return True, f"StatefulSet {sts_name} gone and all {pvc_prefix!r} PVCs reclaimed"

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -1,6 +1,8 @@
 import yaml
+from kubernetes import client
 from kubetester import create_or_update_secret, read_configmap, try_load
 from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
 from kubetester.mongodb_community import MongoDBCommunity
 from kubetester.mongodb_search import MongoDBSearch
 from kubetester.phase import Phase
@@ -116,3 +118,51 @@ def test_search_create_search_index(sample_movies_helper: SampleMoviesSearchHelp
 @mark.e2e_search_community_basic
 def test_search_assert_search_query(sample_movies_helper: SampleMoviesSearchHelper):
     sample_movies_helper.assert_search_query(retry_timeout=60)
+
+
+@mark.e2e_search_community_basic
+def test_zz_delete_search_cr_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
+    """On MongoDBSearch CR delete (single-cluster), owner-ref GC removes the mongot
+    StatefulSet and the persistentVolumeClaimRetentionPolicy{whenDeleted:Delete}
+    reclaims its data PVC."""
+    apps_v1 = client.AppsV1Api()
+    core_v1 = client.CoreV1Api()
+
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+    pvc_prefix = f"data-{sts_name}-"
+
+    # Presence guard: the STS and its data PVC must exist before delete, otherwise
+    # the post-delete absence checks below could pass vacuously.
+    apps_v1.read_namespaced_stateful_set(sts_name, namespace)
+    pvcs_before = [
+        pvc.metadata.name
+        for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
+        if pvc.metadata.name.startswith(pvc_prefix)
+    ]
+    assert pvcs_before, f"expected at least one mongot data PVC with prefix {pvc_prefix!r} before delete"
+    logger.info(f"pre-delete: STS {sts_name} present, data PVCs {pvcs_before}")
+
+    mdbs.delete()
+
+    def _sts_and_pvc_gone() -> tuple[bool, str]:
+        try:
+            apps_v1.read_namespaced_stateful_set(sts_name, namespace)
+            return False, f"StatefulSet {sts_name} still present"
+        except client.exceptions.ApiException as e:
+            if e.status != 404:
+                raise
+        remaining = [
+            pvc.metadata.name
+            for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
+            if pvc.metadata.name.startswith(pvc_prefix)
+        ]
+        if remaining:
+            return False, f"data PVCs not yet reclaimed: {remaining}"
+        return True, f"StatefulSet {sts_name} gone and all {pvc_prefix!r} PVCs reclaimed"
+
+    run_periodically(
+        _sts_and_pvc_gone,
+        timeout=300,
+        sleep_time=5,
+        msg="mongot StatefulSet + data PVC reclaim after MongoDBSearch delete",
+    )

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -10,6 +10,7 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import movies_search_helper, search_resource_names
+from tests.common.search.connectivity import wait_for_mongot_pvcs_deleted, wait_for_mongot_statefulset_drained
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_tester import SearchTester
 from tests.conftest import get_default_operator
@@ -120,43 +121,65 @@ def test_search_assert_search_query(sample_movies_helper: SampleMoviesSearchHelp
     sample_movies_helper.assert_search_query(retry_timeout=60)
 
 
+def _mongot_data_pvc_names(namespace: str, sts_name: str) -> list[str]:
+    """Names of the data PVCs backing a mongot StatefulSet (volumeClaimTemplate
+    ``data`` -> ``data-<sts>-<ordinal>``)."""
+    core_v1 = client.CoreV1Api()
+    prefix = f"data-{sts_name}-"
+    return [
+        pvc.metadata.name
+        for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
+        if pvc.metadata.name.startswith(prefix)
+    ]
+
+
+@mark.e2e_search_community_basic
+def test_zy_scale_mongot_offline_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
+    """whenScaled:Delete - scaling mongot to 0 keeps the CR and StatefulSet object
+    but reclaims the orphaned ordinal's data PVC; restoring to 1 reindexes from
+    mongod onto a fresh volume."""
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+
+    # Presence guard: the STS and its data PVC must exist before scale-down, else
+    # the reclaim assertion below passes vacuously.
+    client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace)
+    assert _mongot_data_pvc_names(namespace, sts_name), f"expected a mongot data PVC for {sts_name} before scale-down"
+
+    mdbs.load()
+    mdbs["spec"]["clusters"][0]["replicas"] = 0
+    mdbs.update()
+
+    wait_for_mongot_statefulset_drained(sts_name, namespace, timeout=300)
+    # Block on the delete completing before scaling back up to dodge the
+    # scale-up-while-Terminating race (see wait_for_mongot_pvcs_deleted).
+    wait_for_mongot_pvcs_deleted(namespace, sts_name, timeout=300)
+
+    mdbs.load()
+    mdbs["spec"]["clusters"][0]["replicas"] = 1
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
 @mark.e2e_search_community_basic
 def test_zz_delete_search_cr_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     """On MongoDBSearch CR delete (single-cluster), owner-ref GC removes the mongot
     StatefulSet and the persistentVolumeClaimRetentionPolicy{whenDeleted:Delete}
     reclaims its data PVC."""
-    core_v1 = client.CoreV1Api()
-
     sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
-    pvc_prefix = f"data-{sts_name}-"
-
-    def mongot_data_pvcs() -> list[str]:
-        return [
-            pvc.metadata.name
-            for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
-            if pvc.metadata.name.startswith(pvc_prefix)
-        ]
 
     # Presence guard: the STS and its data PVC must exist before delete, otherwise
     # the post-delete absence checks below could pass vacuously.
     client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace)
-    pvcs_before = mongot_data_pvcs()
-    assert pvcs_before, f"expected at least one mongot data PVC with prefix {pvc_prefix!r} before delete"
+    pvcs_before = _mongot_data_pvc_names(namespace, sts_name)
+    assert pvcs_before, f"expected at least one mongot data PVC for {sts_name} before delete"
     logger.info(f"pre-delete: STS {sts_name} present, data PVCs {pvcs_before}")
 
     mdbs.delete()
 
-    def _sts_and_pvc_gone() -> tuple[bool, str]:
-        if not statefulset_is_deleted(namespace, sts_name, api_client=None):
-            return False, f"StatefulSet {sts_name} still present"
-        remaining = mongot_data_pvcs()
-        if remaining:
-            return False, f"data PVCs not yet reclaimed: {remaining}"
-        return True, f"StatefulSet {sts_name} gone and all {pvc_prefix!r} PVCs reclaimed"
-
     run_periodically(
-        _sts_and_pvc_gone,
+        lambda: statefulset_is_deleted(namespace, sts_name, api_client=None),
         timeout=300,
         sleep_time=5,
-        msg="mongot StatefulSet + data PVC reclaim after MongoDBSearch delete",
+        msg=f"mongot StatefulSet {sts_name} deletion after MongoDBSearch delete",
     )
+    wait_for_mongot_pvcs_deleted(namespace, sts_name, timeout=300)


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1048

## Chain of upstream PRs as of 2026-06-28

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * **PR #1273 (THIS ONE)**:
      `search/ga-base` ← `search/pvc-retention-policy`

<!-- end git-machete generated -->

**Jira:** [KUBE-143](https://jira.mongodb.org/browse/KUBE-143)

## What

Sets `persistentVolumeClaimRetentionPolicy: {whenDeleted: Delete, whenScaled: Delete}` on the mongot StatefulSet built by `CreateSearchStatefulSetFunc`.

This is the **first, self-contained slice** of Search GA lifecycle teardown. It is intentionally minimal and has **zero dependency on the cluster-index mapping machinery** removed by #1239, so it lands cleanly on current ga-base.

## Why these values

The mongot search index is a **rebuildable derived** index, not primary data — so freeing its storage promptly is the desired behaviour, and a rebuild from mongod is an acceptable cost.

- **`whenDeleted: Delete`** — when the `MongoDBSearch` CR is deleted, owner-ref GC removes the StatefulSet and the retention policy cascades the PVC deletion, so we don't leak index storage.
- **`whenScaled: Delete`** — on scale-down, the StatefulSet controller immediately removes the orphaned ordinal's PVC. A later scale-up reindexes from mongod.

> **Product decision:** immediate PVC reclaim on scale-down. This deviates from the Kubernetes default (`Retain`) and from data-bearing workloads (mongod/AppDB retain their PVCs) precisely because the search index is rebuildable. **Draining a replica before teardown is a planned follow-up** — this PR does not gate teardown on drain.

## Scope / coverage

- ✅ **Single-cluster teardown**: CR delete → owner-ref GC deletes the StatefulSet → `whenDeleted: Delete` cascades the PVC.
- ✅ **Scale-down (per cluster)**: replica reduction → `whenScaled: Delete` removes the orphaned ordinal's PVC.
- ➡️ **Multi-cluster CR-delete reclaim** activates via the member-cluster `OnDelete` sweep in #1274 (stacked on this PR): member StatefulSets aren't owned by the central CR, so the sweep deletes them and `whenDeleted: Delete` then reclaims their PVCs.
- ⏳ **Shard / cluster scale-down** (per-shard mongot teardown, dropping a cluster from `spec.clusters`) reclaim their PVCs the same way once the operator deletes those StatefulSets — that teardown sweep is tracked separately.

## Convention alignment

- No controller in MCK sets `persistentVolumeClaimRetentionPolicy` today; mongod and AppDB rely on the Kubernetes default `Retain`/`Retain` for primary data. The helper is **search-local** (one consumer) rather than promoted to `pkg/statefulset` — generalizing would imply a delete policy the data-bearing controllers explicitly don't want.
- Overridable per cluster via the existing `clusters[].statefulSet` path if a customer ever needs to retain the index — no new CRD surface added.

## K8s support

Requires the `StatefulSetAutoDeletePVC` feature gate (beta/on-by-default since k8s 1.27, GA 1.32). The operator's stated minimum is 1.30, so the field is honored on every supported cluster.

## Testing

- Unit: retention-policy assertions folded into `TestCreateSearchStatefulSetFunc_DefaultAntiAffinity`.
- **e2e (`search_community_basic`)**: `test_zz_delete_search_cr_reclaims_pvc` deletes the `MongoDBSearch` CR and asserts owner-ref GC removes the mongot StatefulSet and `whenDeleted: Delete` reclaims its data PVC. A presence guard checks the StatefulSet + data PVC exist before delete so the absence assertion can't pass vacuously.
- The `whenScaled`/`whenDeleted` STS-teardown→PVC-reclaim path is additionally exercised end-to-end by the shard scale-down teardown e2e in #1277 (stacked above), and the multi-cluster CR-delete PVC reclaim by `e2e_mc_search_cr_deletion` in #1274.

