### PR TITLE
search: reap stale shard's mongot resources on shard scale-down

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -803,26 +804,37 @@ func isOwnedBy(obj client.Object, owner client.Object) bool {
 	return false
 }
 
-// cleanupStaleShardResources deletes per-shard proxy Services for shards that no
-// longer exist. In MC the proxy Services live on the member clusters, so we
-// iterate the central client plus every member-cluster client and only touch
-// Services we own (by UID on central, by search-owner label on members —
-// cross-cluster owner refs don't exist).
+// cleanupStaleShardResources reaps the per-shard mongot resources of shards that no
+// longer exist (shard scale-down): proxy Service, headless Service, ConfigMap, and the
+// mongot StatefulSet — whose whenDeleted=Delete policy then cascades its PVC. For every
+// live shard it rebuilds the expected resource names; anything we own carrying the
+// matching scope label but not in those sets belongs to a removed shard and is deleted.
 //
-// STSs / ConfigMaps / headless Services for stale shards are not handled here:
-// in MC their owners live cross-cluster and aren't GC'd by Kubernetes.
+// Owner refs don't cross clusters, so we iterate the central client plus every member
+// client and guard ownership by UID on central, by search-owner label on members.
+// Best-effort: per-kind/per-cluster failures are aggregated and retried next reconcile.
 func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Context, log *zap.SugaredLogger, currentShardNames []string) error {
 	if r.mdbSearch.IsShardedUnmanagedLB() {
 		return nil
 	}
 
-	expectedNames := make(map[string]bool)
+	// Per-kind expected-name sets. They are kept separate (rather than merged) because
+	// shard names can be customer-provided: a stale shard named e.g. "x-svc" would yield
+	// a StatefulSet name that collides with a live shard "x"'s headless Service name, and
+	// a shared set would then wrongly preserve the stale StatefulSet.
+	expectedProxy := map[string]bool{}
+	expectedHeadless := map[string]bool{}
+	expectedSTS := map[string]bool{}
+	expectedConfig := map[string]bool{}
 	seenClusters := map[int]bool{}
 	for _, w := range r.buildShardedWorkList(currentShardNames) {
-		expectedNames[r.mdbSearch.ProxyServiceNameForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedProxy[r.mdbSearch.ProxyServiceNameForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedHeadless[r.mdbSearch.MongotServiceForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedSTS[r.mdbSearch.MongotStatefulSetForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedConfig[r.mdbSearch.MongotConfigMapForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
 		if !seenClusters[w.ClusterIndex] {
 			seenClusters[w.ClusterIndex] = true
-			expectedNames[r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex).Name] = true
+			expectedProxy[r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex).Name] = true
 		}
 	}
 
@@ -831,40 +843,67 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 		clients[name] = c
 	}
 
-	for clusterName, c := range clients {
-		serviceList := &corev1.ServiceList{}
-		if err := c.List(ctx, serviceList,
-			client.InNamespace(r.mdbSearch.Namespace),
-			client.MatchingLabels{"component": proxyServiceComponent},
-		); err != nil {
-			return xerrors.Errorf("failed to list proxy services on cluster %q: %w", clusterName, err)
-		}
+	// The mongot StatefulSet is the only StatefulSet we own, so it's scoped by owner
+	// label; proxy and headless Services share a kind but carry distinct component
+	// labels; the mongot ConfigMap carries the mongot component label.
+	sweeps := []struct {
+		newList  func() client.ObjectList
+		selector client.MatchingLabels
+		expected map[string]bool
+		kind     string
+	}{
+		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels(searchOwnerLabels(r.mdbSearch, "")), expectedSTS, "StatefulSet"},
+		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: proxyServiceComponent}, expectedProxy, "proxy Service"},
+		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedHeadless, "headless Service"},
+		{func() client.ObjectList { return &corev1.ConfigMapList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedConfig, "ConfigMap"},
+	}
 
-		for i := range serviceList.Items {
-			svc := &serviceList.Items[i]
-			if expectedNames[svc.Name] {
-				continue
-			}
-			// Owner refs don't cross clusters, so for member-cluster Services the
-			// owner check is by search-owner label instead of UID. Same intent:
-			// only touch Services we created.
-			if clusterName == "" {
-				if !isOwnedBy(svc, r.mdbSearch) {
-					continue
-				}
-			} else {
-				if svc.Labels[khandler.MongoDBSearchOwnerNameLabel] != r.mdbSearch.Name ||
-					svc.Labels[khandler.MongoDBSearchOwnerNamespaceLabel] != r.mdbSearch.Namespace {
-					continue
-				}
-			}
-			log.Infof("Deleting stale proxy Service %s on cluster %q", svc.Name, clusterName)
-			if err := c.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
-				return xerrors.Errorf("failed to delete stale proxy Service %s on cluster %q: %w", svc.Name, clusterName, err)
+	var errs error
+	for clusterName, c := range clients {
+		for _, s := range sweeps {
+			if err := r.sweepStaleShardResources(ctx, log, c, clusterName, s.newList(), s.selector, s.expected, s.kind); err != nil {
+				errs = multierror.Append(errs, err)
 			}
 		}
 	}
-	return nil
+	return errs
+}
+
+// sweepStaleShardResources lists one resource kind on a cluster (scoped by selector)
+// and deletes every object this search owns whose name isn't in expected.
+func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Context, log *zap.SugaredLogger, c kubernetesClient.Client, clusterName string, list client.ObjectList, selector client.MatchingLabels, expected map[string]bool, kind string) error {
+	if err := c.List(ctx, list, client.InNamespace(r.mdbSearch.Namespace), selector); err != nil {
+		return xerrors.Errorf("failed to list %ss on cluster %q: %w", kind, clusterName, err)
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return xerrors.Errorf("failed to extract %s list on cluster %q: %w", kind, clusterName, err)
+	}
+
+	var errs error
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok || expected[obj.GetName()] || !r.ownsForSweep(obj, clusterName) {
+			continue
+		}
+		log.Infof("Deleting stale %s %s on cluster %q", kind, obj.GetName(), clusterName)
+		if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			errs = multierror.Append(errs, xerrors.Errorf("failed to delete stale %s %s on cluster %q: %w", kind, obj.GetName(), clusterName, err))
+		}
+	}
+	return errs
+}
+
+// ownsForSweep reports whether obj belongs to this search: by owner-reference UID on
+// the central cluster (clusterName ""), by search-owner label on member clusters
+// (cross-cluster owner refs don't exist).
+func (r *MongoDBSearchReconcileHelper) ownsForSweep(obj client.Object, clusterName string) bool {
+	if clusterName == "" {
+		return isOwnedBy(obj, r.mdbSearch)
+	}
+	labels := obj.GetLabels()
+	return labels[khandler.MongoDBSearchOwnerNameLabel] == r.mdbSearch.Name &&
+		labels[khandler.MongoDBSearchOwnerNamespaceLabel] == r.mdbSearch.Namespace
 }
 
 // CleanupMemberClusterResources deletes every member-cluster resource this search
@@ -1050,6 +1089,7 @@ func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, l
 		if cm.Labels == nil {
 			cm.Labels = map[string]string{}
 		}
+		cm.Labels[componentLabelKey] = mongotComponent
 		for k, v := range searchOwnerLabels(r.mdbSearch, clusterName) {
 			cm.Labels[k] = v
 		}
@@ -1205,7 +1245,15 @@ func mongotServicePorts(search *searchv1.MongoDBSearch) []corev1.ServicePort {
 const (
 	appLabelKey           = "app"
 	shardLabelKey         = "shard"
+	componentLabelKey     = "component"
 	proxyServiceComponent = "search-proxy"
+	// mongotComponent is the component-label value stamped on the per-shard mongot
+	// headless Service and ConfigMap, letting the stale-shard sweep find and reap them
+	// on shard scale-down without touching Envoy or state resources. The mongot
+	// StatefulSet is not component-labelled — it is swept by owner label instead, being
+	// the only StatefulSet the search owns (a coarser scope that also catches STSs
+	// created before this label existed).
+	mongotComponent = "mongot"
 
 	nameLabelKey       = "app.kubernetes.io/name"
 	managedByLabelKey  = "app.kubernetes.io/managed-by"
@@ -1216,7 +1264,10 @@ const (
 // buildHeadlessService builds a headless Service for a reconcile unit. All topology-specific
 // behavior comes from the unit's explicit fields — no branching on "is this a shard?".
 func buildHeadlessService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev1.Service {
-	svcLabels := map[string]string{appLabelKey: unit.headlessSvc.Name}
+	svcLabels := map[string]string{
+		appLabelKey:       unit.headlessSvc.Name,
+		componentLabelKey: mongotComponent,
+	}
 	for k, v := range unit.additionalSvcLabels {
 		svcLabels[k] = v
 	}
@@ -1258,8 +1309,8 @@ func buildProxyService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev
 	}
 
 	labels := map[string]string{
-		appLabelKey: unit.proxySvc.Name,
-		"component": proxyServiceComponent,
+		appLabelKey:       unit.proxySvc.Name,
+		componentLabelKey: proxyServiceComponent,
 	}
 	for k, v := range unit.additionalSvcLabels {
 		labels[k] = v
@@ -1304,8 +1355,8 @@ func buildClusterLevelProxyService(search *searchv1.MongoDBSearch, res clusterLe
 	}
 
 	labels := map[string]string{
-		appLabelKey: res.svcName.Name,
-		"component": proxyServiceComponent,
+		appLabelKey:       res.svcName.Name,
+		componentLabelKey: proxyServiceComponent,
 	}
 	for k, v := range searchOwnerLabels(search, res.clusterName) {
 		labels[k] = v

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -2891,11 +2891,56 @@ func TestCleanupStaleShardResources(t *testing.T) {
 		return svc
 	}
 
+	// Per-shard mongot resources carry owner labels (STS, swept by owner label) and the
+	// mongot component label (headless Service + ConfigMap, swept by component label).
+	ownerLabels := searchOwnerLabels(search, "")
+	mongotLabels := func(extra map[string]string) map[string]string {
+		labels := map[string]string{}
+		for k, v := range extra {
+			labels[k] = v
+		}
+		for k, v := range ownerLabels {
+			labels[k] = v
+		}
+		return labels
+	}
+	setOwner := func(obj client.Object, owned bool) {
+		uid := types.UID("other-uid")
+		if owned {
+			uid = search.UID
+		}
+		obj.SetOwnerReferences([]metav1.OwnerReference{{UID: uid}})
+	}
+	mongotSTS := func(shard string, owned bool) *appsv1.StatefulSet {
+		sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotStatefulSetForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(nil),
+		}}
+		setOwner(sts, owned)
+		return sts
+	}
+	mongotHeadless := func(shard string, owned bool) *corev1.Service {
+		svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotServiceForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(map[string]string{"component": mongotComponent}),
+		}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2", Ports: []corev1.ServicePort{{Port: 27027}}}}
+		setOwner(svc, owned)
+		return svc
+	}
+	mongotCM := func(shard string, owned bool) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(map[string]string{"component": mongotComponent}),
+		}}
+		setOwner(cm, owned)
+		return cm
+	}
+
 	fakeClient := newTestFakeClient(search,
 		proxySvc("shard-0", true),  // active, owned
 		proxySvc("shard-1", true),  // active, owned
 		proxySvc("shard-2", true),  // stale, owned
 		proxySvc("shard-x", false), // different owner
+		mongotSTS("shard-1", true), mongotSTS("shard-2", true),
+		mongotHeadless("shard-1", true), mongotHeadless("shard-2", true), mongotHeadless("shard-x", false),
+		mongotCM("shard-1", true), mongotCM("shard-2", true), mongotCM("shard-x", false),
 	)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 	require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), []string{"shard-0", "shard-1"}))
@@ -2908,6 +2953,24 @@ func TestCleanupStaleShardResources(t *testing.T) {
 	assert.Error(t, err, "stale shard deleted")
 	_, err = fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-x"))
 	assert.NoError(t, err, "different owner untouched")
+
+	// The removed shard's mongot StatefulSet, headless Service, and ConfigMap are reaped
+	// (the STS delete then cascades its PVC via whenDeleted=Delete); active and
+	// different-owner resources survive.
+	gone := func(nn types.NamespacedName, obj client.Object, msg string) {
+		assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), nn, obj)), msg)
+	}
+	present := func(nn types.NamespacedName, obj client.Object, msg string) {
+		assert.NoError(t, fakeClient.Get(t.Context(), nn, obj), msg)
+	}
+	present(search.MongotStatefulSetForClusterShard(0, "shard-1"), &appsv1.StatefulSet{}, "active shard STS preserved")
+	gone(search.MongotStatefulSetForClusterShard(0, "shard-2"), &appsv1.StatefulSet{}, "stale shard STS deleted")
+	present(search.MongotServiceForClusterShard(0, "shard-1"), &corev1.Service{}, "active shard headless Service preserved")
+	gone(search.MongotServiceForClusterShard(0, "shard-2"), &corev1.Service{}, "stale shard headless Service deleted")
+	present(search.MongotServiceForClusterShard(0, "shard-x"), &corev1.Service{}, "different-owner headless Service untouched")
+	present(search.MongotConfigMapForClusterShard(0, "shard-1"), &corev1.ConfigMap{}, "active shard ConfigMap preserved")
+	gone(search.MongotConfigMapForClusterShard(0, "shard-2"), &corev1.ConfigMap{}, "stale shard ConfigMap deleted")
+	present(search.MongotConfigMapForClusterShard(0, "shard-x"), &corev1.ConfigMap{}, "different-owner ConfigMap untouched")
 }
 
 func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
@@ -3780,12 +3843,41 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		}
 	}
 
+	// Per-shard mongot resources on a member cluster: STS swept by owner label,
+	// headless Service + ConfigMap by the mongot component label; owned=false drops the
+	// owner labels so they must be left alone.
+	withMemberOwner := func(labels map[string]string, owned bool) map[string]string {
+		if owned {
+			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
+			labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
+		}
+		return labels
+	}
+	memberSTS := func(idx int, shard string, owned bool) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotStatefulSetForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{}, owned),
+		}}
+	}
+	memberMongotSvc := func(idx int, shard string, owned bool) *corev1.Service {
+		return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotServiceForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
+		}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.3", Ports: []corev1.ServicePort{{Port: 27027}}}}
+	}
+	memberCM := func(idx int, shard string, owned bool) *corev1.ConfigMap {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotConfigMapForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
+		}}
+	}
+
 	// cluster-a (idx 0): keep shard-0 + cluster-level; sh-stale should be deleted.
 	clusterA := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(
 		memberProxySvc("mdb-search-search-0-sh-0-proxy-svc", true),
 		memberProxySvc("mdb-search-search-0-sh-stale-proxy-svc", true),
 		memberProxySvc("mdb-search-search-0-proxy-svc", true),
 		memberProxySvc("foreign-svc", false), // not search-owned
+		memberSTS(0, "sh-0", true), memberSTS(0, "sh-stale", true),
+		memberMongotSvc(0, "sh-0", true), memberMongotSvc(0, "sh-stale", true), memberMongotSvc(0, "sh-foreign", false),
+		memberCM(0, "sh-0", true), memberCM(0, "sh-stale", true),
 	).Build())
 	// cluster-b (idx 1): same pattern, plus an unrelated owned-by-other-CR svc
 	// to guard the label-name check.
@@ -3833,6 +3925,24 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		err = tc.c.Get(t.Context(), types.NamespacedName{Name: tc.foreign, Namespace: "ns"}, &corev1.Service{})
 		require.NoError(t, err, "%s: foreign Service %q must be untouched", tc.cluster, tc.foreign)
 	}
+
+	// Per-shard mongot resources on cluster-a: STS swept by owner label, headless
+	// Service + ConfigMap by the mongot component label. Active sh-0 survives, stale
+	// sh-stale is reaped, and the component-labelled but unowned sh-foreign is left alone.
+	present := func(name string, obj client.Object, what string) {
+		require.NoError(t, clusterA.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "ns"}, obj), "cluster-a: %s must survive cleanup", what)
+	}
+	gone := func(name string, obj client.Object, what string) {
+		err := clusterA.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "ns"}, obj)
+		require.True(t, apierrors.IsNotFound(err), "cluster-a: %s must be deleted, got err=%v", what, err)
+	}
+	present(search.MongotStatefulSetForClusterShard(0, "sh-0").Name, &appsv1.StatefulSet{}, "active mongot StatefulSet")
+	gone(search.MongotStatefulSetForClusterShard(0, "sh-stale").Name, &appsv1.StatefulSet{}, "stale mongot StatefulSet")
+	present(search.MongotServiceForClusterShard(0, "sh-0").Name, &corev1.Service{}, "active headless Service")
+	gone(search.MongotServiceForClusterShard(0, "sh-stale").Name, &corev1.Service{}, "stale headless Service")
+	present(search.MongotServiceForClusterShard(0, "sh-foreign").Name, &corev1.Service{}, "unowned headless Service")
+	present(search.MongotConfigMapForClusterShard(0, "sh-0").Name, &corev1.ConfigMap{}, "active mongot ConfigMap")
+	gone(search.MongotConfigMapForClusterShard(0, "sh-stale").Name, &corev1.ConfigMap{}, "stale mongot ConfigMap")
 }
 
 // Empty GetShardNames() yields an empty work list. The reconciler must not fail

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
@@ -10,7 +10,9 @@ the MongoDBSearch resource correctly reconciles:
 Test flow:
   Phase 1: Deploy sharded cluster (2 shards) + MongoDBSearch with managed LB, verify search
   Phase 2: Scale UP to 3 shards, redistribute data, verify search works across all 3 shards
-  Phase 3: Scale DOWN to 2 shards, verify cleanup and search still works
+  Phase 3: Scale DOWN to 2 shards, verify FULL teardown of the removed shard's mongot
+           resources (StatefulSet, headless + proxy Services, ConfigMap, PVCs) and that
+           search still works
 """
 
 import kubernetes
@@ -101,6 +103,20 @@ def verify_shard_resources_exist(namespace: str, mdbs_name: str, shard_name: str
     assert proxy_svc is not None, f"Proxy Service {proxy_svc_name} not found"
     logger.info(f"Proxy Service {proxy_svc_name} exists")
 
+    # Assert the ConfigMap and PVC(s) exist too, so the matching absence checks in
+    # verify_shard_resources_deleted can't pass vacuously if a future rename drifts
+    # the expected names.
+    cm_name = search_resource_names.shard_configmap_name(mdbs_name, shard_name)
+    cm = core_v1.read_namespaced_config_map(cm_name, namespace)
+    assert cm is not None, f"mongot ConfigMap {cm_name} not found"
+    logger.info(f"mongot ConfigMap {cm_name} exists")
+
+    pvc_prefix = f"data-{sts_name}-"
+    pvcs = core_v1.list_namespaced_persistent_volume_claim(namespace)
+    matching = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
+    assert matching, f"no PVC with prefix {pvc_prefix!r} found for shard {shard_name}"
+    logger.info(f"PVC(s) {matching} exist for shard {shard_name}")
+
 
 def verify_shard_proxy_service_deleted(namespace: str, mdbs_name: str, shard_name: str):
     core_v1 = client.CoreV1Api()
@@ -117,6 +133,73 @@ def verify_shard_proxy_service_deleted(namespace: str, mdbs_name: str, shard_nam
 
     run_periodically(check, timeout=300, sleep_time=10, msg=f"proxy service {proxy_svc_name} deletion")
     logger.info(f"Proxy service {proxy_svc_name} confirmed deleted")
+
+
+def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: str):
+    """Assert FULL teardown of a removed shard's mongot resources.
+
+    The stale-resource sweep deletes the per-shard mongot StatefulSet, headless
+    Service, proxy Service, and mongot ConfigMap; the StatefulSet's
+    ``persistentVolumeClaimRetentionPolicy.whenDeleted: Delete`` then reaps the
+    backing PVC(s). Each kind is polled independently so a partial sweep surfaces
+    the specific resource that leaked. We poll until 404 (or empty list for PVCs)
+    rather than reading once — the sweep runs asynchronously after the
+    MongoDBSearch reports Running.
+    """
+    apps_v1 = client.AppsV1Api()
+    core_v1 = client.CoreV1Api()
+
+    sts_name = search_resource_names.shard_statefulset_name(mdbs_name, shard_name)
+    svc_name = search_resource_names.shard_service_name(mdbs_name, shard_name)
+    cm_name = search_resource_names.shard_configmap_name(mdbs_name, shard_name)
+    # PVCs are named "<volumeClaimName>-<sts-name>-<ordinal>"; the mongot data
+    # volume claim is "data" (search_construction.go), so the prefix is "data-<sts>-".
+    pvc_prefix = f"data-{sts_name}-"
+
+    def sts_gone():
+        try:
+            apps_v1.read_namespaced_stateful_set(sts_name, namespace)
+            return False, f"StatefulSet {sts_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"StatefulSet {sts_name} deleted"
+            raise
+
+    def headless_svc_gone():
+        try:
+            core_v1.read_namespaced_service(svc_name, namespace)
+            return False, f"headless Service {svc_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"headless Service {svc_name} deleted"
+            raise
+
+    def configmap_gone():
+        try:
+            core_v1.read_namespaced_config_map(cm_name, namespace)
+            return False, f"mongot ConfigMap {cm_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"mongot ConfigMap {cm_name} deleted"
+            raise
+
+    def pvcs_gone():
+        pvcs = core_v1.list_namespaced_persistent_volume_claim(namespace)
+        leftover = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
+        if leftover:
+            return False, f"PVC(s) for removed shard still exist: {leftover}"
+        return True, f"no PVCs with prefix {pvc_prefix!r} remain"
+
+    # Proxy Service is covered by verify_shard_proxy_service_deleted; here we
+    # add the StatefulSet, headless Service, ConfigMap, and PVCs.
+    for check, label in (
+        (sts_gone, f"StatefulSet {sts_name}"),
+        (headless_svc_gone, f"headless Service {svc_name}"),
+        (configmap_gone, f"mongot ConfigMap {cm_name}"),
+        (pvcs_gone, f"PVCs {pvc_prefix}*"),
+    ):
+        run_periodically(check, timeout=300, sleep_time=10, msg=f"{label} deletion")
+        logger.info(f"{label} confirmed deleted for removed shard {shard_name}")
 
 
 # ---------------------------------------------------------------------------
@@ -460,10 +543,17 @@ def test_scale_down_wait_for_search_running(mdbs: MongoDBSearch):
 
 @MARKER
 def test_scale_down_verify_stale_resources_cleaned(namespace: str):
-    """Verify that the proxy service for the removed shard is cleaned up by the operator."""
+    """Verify the removed shard's mongot resources are FULLY torn down by the operator.
+
+    Beyond the proxy Service (the only kind the original sweep removed), the
+    generalized stale-resource sweep deletes the per-shard mongot StatefulSet,
+    headless Service, and ConfigMap, and the StatefulSet's PVC retention policy
+    reaps the backing PVC(s). Runs after MongoDBSearch reaches Running.
+    """
     removed_shard_name = f"{MDB_RESOURCE_NAME}-{SCALED_UP_SHARD_COUNT - 1}"
     verify_shard_proxy_service_deleted(namespace, MDBS_RESOURCE_NAME, removed_shard_name)
-    logger.info(f"Stale proxy service for {removed_shard_name} confirmed deleted")
+    verify_shard_resources_deleted(namespace, MDBS_RESOURCE_NAME, removed_shard_name)
+    logger.info(f"Stale mongot resources for {removed_shard_name} confirmed fully deleted")
 
 
 @MARKER


### PR DESCRIPTION
[skip-ci]

<!-- start git-machete generated -->

# Based on PR #1274

## Chain of upstream PRs as of 2026-06-28

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1273:
      `search/ga-base` ← `search/pvc-retention-policy`

      * PR #1274:
        `search/pvc-retention-policy` ← `search/mc-cleanup-ondelete`

        * **PR #1277 (THIS ONE)**:
          `search/mc-cleanup-ondelete` ← `search/shard-scaledown-teardown`

<!-- end git-machete generated -->

## What

On shard scale-down (a shard removed from a sharded MongoDB source), reap the removed shard's per-shard mongot resources across the central **and every member** cluster:

- mongot **StatefulSet** — deleting it cascades its data PVC via the `whenDeleted: Delete` retention policy (#1273)
- per-shard **proxy Service**
- **headless Service**
- mongot **ConfigMap**

## Why

In multi-cluster mode, owner references don't cross cluster boundaries, so Kubernetes GC never reclaims these resources when a shard goes away — they leak (StatefulSets, Services, ConfigMaps, and their PVCs) on every shard scale-down. The previous sweep only removed the per-shard proxy Service.

## How

Generalizes `cleanupStaleShardResources` from a proxy-Service-only sweep into a label-scoped, multi-kind sweep:

- For every live shard it rebuilds the expected resource names; anything we own carrying the matching scope label but absent from those sets belongs to a removed shard and is deleted.
- Scope labels: the mongot StatefulSet by **owner label** (it is the only StatefulSet the search owns — strictly safer than a component label, it also catches STSs created before the label existed); proxy/headless Services by their distinct `component` labels; the mongot ConfigMap by `component=mongot`.
- Cross-cluster ownership is guarded by owner-reference UID on the central cluster and by search-owner label on member clusters.
- Best-effort: per-kind/per-cluster failures are aggregated (`multierror`) and retried on the next reconcile.

## Tests

- **Unit** (`mongodbsearch_reconcile_helper_test.go`): single-cluster `TestCleanupStaleShardResources` and `TestCleanupStaleShardResources_MCFanOut` both assert the stale shard's StatefulSet / headless Service / ConfigMap are reaped while active shards' and other owners'/unowned resources are preserved (member-cluster owner-label path covered).
- **e2e** (`search_sharded_scale_shards_managed_lb.py`): the scale-down phase now asserts FULL teardown of the removed shard — StatefulSet, headless Service, mongot ConfigMap, and backing PVCs all absent (polled via `run_periodically`) — and the scale-up presence check reads the ConfigMap + PVCs so the absence assertions can't pass vacuously.

## Stack

Stacked on #1274 → #1273 → `search/ga-base`. Cluster-removal teardown is intentionally parked for a follow-up.
