### PR TITLE
search: zero-outage Envoy rolling restart (graceful drain fix) + e2e

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1430,6 +1430,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_connectivity_rolling_restarts
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_sharded_routed_from_another_shard
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -875,6 +875,7 @@ task_groups:
       - e2e_search_replicaset_external_mongodb_proxy_service
       - e2e_search_connectivity_tool
       - e2e_search_connectivity_tool_sharded
+      - e2e_search_connectivity_rolling_restarts
       - e2e_search_sharded_routed_from_another_shard
       - e2e_search_sharded_onboarding_no_outage
       - e2e_search_cds_hot_reload
@@ -884,6 +885,7 @@ task_groups:
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.
   # Uses setup_and_teardown_task (not cloudqa) since ops_manager_version is not 'cloud_qa'.
+  # Metrics-forwarder tests require Ops Manager, so they run only on the om variant.
   - name: e2e_om80_kind_search_task_group
     max_hosts: -1
     <<: *setup_group
@@ -915,6 +917,7 @@ task_groups:
 
   # Same as e2e_mdb_kind_search_large_task_group but for om80 variants.
   # Uses setup_and_teardown_task (not cloudqa) since ops_manager_version is not 'cloud_qa'.
+  # Metrics-forwarder tests require Ops Manager, so they run only on the om variant.
   - name: e2e_om80_kind_search_large_task_group
     max_hosts: -1
     <<: *setup_group
@@ -923,9 +926,17 @@ task_groups:
       - e2e_search_sharded_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_sharded_internal_mongodb_multi_mongot_managed_lb
       - e2e_search_sharded_scale_shards_managed_lb
+      - e2e_search_sharded_enterprise_external_mongod_managed_lb
       - e2e_search_replicaset_internal_mongodb_multi_mongot_managed_lb
       - e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb
       - e2e_search_replicaset_external_mongodb_proxy_service
+      - e2e_search_connectivity_tool
+      - e2e_search_connectivity_tool_sharded
+      - e2e_search_connectivity_rolling_restarts
+      - e2e_search_sharded_routed_from_another_shard
+      - e2e_search_sharded_onboarding_no_outage
+      - e2e_search_cds_hot_reload
+      - e2e_search_envoy_retry_policy
       - e2e_search_auto_embedding_rolling_restart
       - e2e_search_enterprise_metrics_forwarder_sharded
       - e2e_search_external_metrics_forwarder_sharded

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -88,6 +88,9 @@ func (p Prometheus) IsEnabled() bool {
 }
 
 func (p Prometheus) GetPort() int32 {
+	if p.Port == 0 {
+		return MongotDefaultPrometheusPort
+	}
 	//nolint:gosec
 	return int32(p.Port)
 }

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -36,6 +36,21 @@ const (
 	EnvoyDefaultProxyPort           int32 = 27028
 	MongotDefaultSyncSourceUsername       = "search-sync-source"
 
+	// MongotTerminationGracePeriodSeconds matches mongot's internal 60s gRPC
+	// awaitTermination drain window. Without it the pod default (30s) SIGKILLs
+	// mongot mid-drain, abandoning in-flight $search cursor streams on a rolling
+	// restart. EnvoyTerminationGracePeriodSeconds outlives it by 10s so Envoy
+	// keeps serving those in-flight streams until mongot has drained.
+	MongotTerminationGracePeriodSeconds int64 = 60
+	EnvoyTerminationGracePeriodSeconds  int64 = MongotTerminationGracePeriodSeconds + 10
+
+	// EnvoyPreStopDrainSleepSeconds is how long the preStop hook sleeps after
+	// POSTing a graceful /drain_listeners. The sleep blocks SIGTERM so in-flight
+	// mongod->Envoy->mongot getMore streams complete on the draining Envoy
+	// instead of being severed. Kept below the grace period so SIGKILL never
+	// preempts it.
+	EnvoyPreStopDrainSleepSeconds int64 = EnvoyTerminationGracePeriodSeconds - 10
+
 	ForceWireprotoAnnotation = "mongodb.com/v1.force-search-wireproto"
 
 	// DisableReconciliationAnnotation, when set to "true" on a MongoDBSearch CR,

--- a/controllers/operator/envoy_config_builder.go
+++ b/controllers/operator/envoy_config_builder.go
@@ -82,7 +82,7 @@ func buildBootstrapJSON() (string, error) {
 			AllowPaths: []*matcherv3.StringMatcher{
 				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/ready"}},
 				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/stats"}},
-				{MatchPattern: &matcherv3.StringMatcher_Exact{Exact: "/drain_listeners"}},
+				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/drain_listeners"}},
 				{MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: "/logging"}},
 			},
 		},

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -280,8 +280,8 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 
 	for _, w := range workList {
 		var st workflow.Status
-		switch {
-		case w.Client == nil:
+		switch w.Client {
+		case nil:
 			st = workflow.Pending("Member cluster %q not registered with the operator", w.ClusterName)
 		default:
 			var pending bool

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -283,8 +283,6 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		switch {
 		case w.Client == nil:
 			st = workflow.Pending("Member cluster %q not registered with the operator", w.ClusterName)
-		case w.ClusterIndex == -1:
-			st = workflow.Pending("Waiting for cluster %q to be registered in search state", w.ClusterName)
 		default:
 			var pending bool
 			pending, st = r.reconcileForCluster(ctx, mdbSearch, shardNames, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, w, log)
@@ -1196,7 +1194,7 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 	ns := search.Namespace
 	anyDepFound := false
 	for _, w := range workList {
-		if w.ClusterIndex == -1 || w.Client == nil {
+		if w.Client == nil {
 			continue
 		}
 		depName := search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex)
@@ -1217,7 +1215,7 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 
 	// All Deployments are gone: deregister hosts, clean up remaining resources, and remove finalizer.
 	for _, w := range workList {
-		if w.ClusterIndex == -1 || w.Client == nil {
+		if w.Client == nil {
 			continue
 		}
 		clusterState := topologyState.Clusters[w.ClusterName]
@@ -1241,11 +1239,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 }
 
 // deleteMetricsForwarderResources removes per-cluster metrics forwarder resources.
-// ClusterIndex==-1 and Client==nil sentinels are skipped.
+// Clusters not registered with the operator (Client==nil) are skipped.
 func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) {
 	ns := search.Namespace
 	for _, w := range workList {
-		if w.ClusterIndex == -1 || w.Client == nil {
+		if w.Client == nil {
 			continue
 		}
 		depName := search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex)

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -633,6 +634,10 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 
 	return corev1.PodSpec{
 		SecurityContext: podSecurityContext,
+		// Outlive mongot's grace by 10s so in-flight mongod→Envoy→mongot cursor
+		// streams (drained gracefully by the preStop hook) finish before SIGKILL
+		// during a rolling restart.
+		TerminationGracePeriodSeconds: ptr.To(searchv1.EnvoyTerminationGracePeriodSeconds),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
@@ -672,6 +677,12 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 					"-c", "/etc/envoy/bootstrap.json",
 					"--log-level", "info",
 					"--log-format", `{"time":"%Y-%m-%dT%H:%M:%S.%e%z","level":"%l","logger":"%n","thread":%t,"loc":"%g:%#","message":"%j"}`,
+					// Pairs with the preStop drain: an immediate strategy over a 30s
+					// window (< the preStop sleep) GOAWAYs every downstream connection
+					// promptly, so mongod migrates new $search streams to a healthy Envoy
+					// before SIGTERM. Envoy's 600s default would outlast the drain window.
+					"--drain-time-s", "30",
+					"--drain-strategy", "immediate",
 				},
 				Ports: []corev1.ContainerPort{
 					{Name: "mongot-grpc", ContainerPort: searchv1.EnvoyDefaultProxyPort},
@@ -702,9 +713,22 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 				},
 				Lifecycle: &corev1.Lifecycle{
 					PreStop: &corev1.LifecycleHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/drain_listeners",
-							Port: intstr.FromInt32(EnvoyAdminPort),
+						// Envoy's /drain_listeners requires POST and a k8s httpGet preStop
+						// can only GET (rejected: "method=GET rather than POST"), so POST it
+						// over bash's /dev/tcp (the image has bash, no curl). graceful=true
+						// GOAWAYs downstream: new streams move to a healthy Envoy while
+						// in-flight getMores finish. The trailing sleep defers SIGTERM until
+						// the drain completes.
+						Exec: &corev1.ExecAction{
+							Command: []string{
+								"/usr/bin/bash", "-c",
+								fmt.Sprintf(
+									"exec 3<>/dev/tcp/127.0.0.1/%d; "+
+										"printf 'POST /drain_listeners?graceful=true HTTP/1.1\\r\\nHost: localhost\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n' >&3; "+
+										"cat <&3 >/dev/null || true; sleep %d",
+									EnvoyAdminPort, searchv1.EnvoyPreStopDrainSleepSeconds,
+								),
+							},
 						},
 					},
 				},

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -713,19 +713,18 @@ func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg 
 				},
 				Lifecycle: &corev1.Lifecycle{
 					PreStop: &corev1.LifecycleHandler{
-						// Envoy's /drain_listeners requires POST and a k8s httpGet preStop
-						// can only GET (rejected: "method=GET rather than POST"), so POST it
-						// over bash's /dev/tcp (the image has bash, no curl). graceful=true
-						// GOAWAYs downstream: new streams move to a healthy Envoy while
-						// in-flight getMores finish. The trailing sleep defers SIGTERM until
-						// the drain completes.
+						// Envoy's /drain_listeners is POST-only and the image ships bash but
+						// no curl, hence the hand-rolled POST over bash's /dev/tcp. graceful=true
+						// GOAWAYs downstream so new streams move to a healthy Envoy while in-flight
+						// getMores finish. The drain is best-effort (subshell + `|| true`); the
+						// trailing sleep always runs and defers SIGTERM until the drain completes.
 						Exec: &corev1.ExecAction{
 							Command: []string{
 								"/usr/bin/bash", "-c",
 								fmt.Sprintf(
-									"exec 3<>/dev/tcp/127.0.0.1/%d; "+
+									"( exec 3<>/dev/tcp/127.0.0.1/%d; "+
 										"printf 'POST /drain_listeners?graceful=true HTTP/1.1\\r\\nHost: localhost\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n' >&3; "+
-										"cat <&3 >/dev/null || true; sleep %d",
+										"cat <&3 >/dev/null ) || true; sleep %d",
 									EnvoyAdminPort, searchv1.EnvoyPreStopDrainSleepSeconds,
 								),
 							},

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -154,6 +154,7 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 				podtemplatespec.WithPodLabels(labels),
 				podtemplatespec.WithVolumes(volumes),
 				podtemplatespec.WithServiceAccount(util.MongoDBServiceAccount),
+				podtemplatespec.WithTerminationGracePeriodSeconds(int(searchv1.MongotTerminationGracePeriodSeconds)),
 				// Default: spread this StatefulSet's mongot pods across hosts (preferred, not
 				// required). A clusters[].statefulSet affinity override replaces this term.
 				podtemplatespec.WithAffinity(labels[appLabelKey], appLabelKey, 100),

--- a/docker/mongodb-kubernetes-tests/tests/common/search/background_availability_tester.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/background_availability_tester.py
@@ -12,7 +12,8 @@ as a context manager and read ``tester.verdict`` after the ``with`` block:
 Two modes:
 
 * ``paging`` (default) — one page per tick from a long-living cursor;
-  reopened on failure or after ``paging_reset_every`` pages.
+  reopened on failure, after ``paging_reset_every`` pages, or after
+  ``paging_reset_after_seconds`` seconds (whichever trips first).
 * ``oneshot`` — one cache-busted ``oneshot_search()`` per tick.
 """
 
@@ -24,7 +25,13 @@ import time
 from typing import Callable, Optional
 
 import pymongo.errors
-from tests.common.search.connectivity import ConnectivityVerdict, QueryResult, SearchConnectivityTool, classify_failure
+from tests.common.search.connectivity import (
+    ConnectivityVerdict,
+    QueryResult,
+    SearchConnectivityTool,
+    aggregate_verdicts,
+    classify_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +45,7 @@ class SearchAvailabilityBackgroundTester(threading.Thread):
         mode: str = "paging",
         paging_batch_size: int = 5,
         paging_reset_every: Optional[int] = None,
+        paging_reset_after_seconds: Optional[float] = None,
         interval_seconds: float = 0.0,
         query_timeout_ms: Optional[int] = 15_000,
     ) -> None:
@@ -54,6 +62,10 @@ class SearchAvailabilityBackgroundTester(threading.Thread):
         self.mode = mode
         self.paging_batch_size = paging_batch_size
         self.paging_reset_every = paging_reset_every
+        # Time-based cursor rollover: close+reopen the paging cursor once it has
+        # been open this long, exercising a fresh $search (which needs a live
+        # mongot) at a steady cadence through a disruption window.
+        self.paging_reset_after_seconds = paging_reset_after_seconds
         # Per-iteration sleep; mutable mid-run to throttle paging (e.g. raise it
         # before a fault so the cursor doesn't drain mongod's buffer faster than
         # the pod terminates).
@@ -64,6 +76,7 @@ class SearchAvailabilityBackgroundTester(threading.Thread):
         self._results_lock = threading.Lock()
         self._cursor = None
         self._cursor_pages_consumed = 0
+        self._cursor_opened_at: Optional[float] = None
         self._cursor_reopens = 0
         self._cursor_ever_opened = False
         self._current_cursor_records = 0
@@ -166,10 +179,21 @@ class SearchAvailabilityBackgroundTester(threading.Thread):
             return self.tool.oneshot_search(cache_buster=True, timeout_ms=self.query_timeout_ms)
         return self._read_one_page()
 
-    def _read_one_page(self) -> QueryResult:
-        if self._cursor is None or (
-            self.paging_reset_every is not None and self._cursor_pages_consumed >= self.paging_reset_every
+    def _should_reset_cursor(self) -> bool:
+        if self._cursor is None:
+            return True
+        if self.paging_reset_every is not None and self._cursor_pages_consumed >= self.paging_reset_every:
+            return True
+        if (
+            self.paging_reset_after_seconds is not None
+            and self._cursor_opened_at is not None
+            and (time.monotonic() - self._cursor_opened_at) >= self.paging_reset_after_seconds
         ):
+            return True
+        return False
+
+    def _read_one_page(self) -> QueryResult:
+        if self._should_reset_cursor():
             reopen_failure = self._reopen_cursor()
             if reopen_failure is not None:
                 return reopen_failure
@@ -202,6 +226,7 @@ class SearchAvailabilityBackgroundTester(threading.Thread):
         try:
             self._cursor = self.tool.paging_cursor_open(batch_size=self.paging_batch_size)
             self._cursor_pages_consumed = 0
+            self._cursor_opened_at = time.monotonic()
             self._current_cursor_records = 0
             if self._cursor_ever_opened:
                 self._cursor_reopens += 1
@@ -229,6 +254,7 @@ class SearchAvailabilityBackgroundTester(threading.Thread):
             pass
         self._cursor = None
         self._cursor_pages_consumed = 0
+        self._cursor_opened_at = None
 
 
 def assert_no_outage(verdict: ConnectivityVerdict, min_operations: int = 5) -> None:
@@ -277,6 +303,69 @@ def assert_outage_detected(
             f"verdict did not surface a {' or '.join(accept)} failure — "
             f"the background tester missed the fault. verdict={verdict.as_dict()}"
         )
+
+
+class PagingAvailabilityFleet:
+    """A fleet of independent paging background testers, each owning its own
+    connection and paging cursor.
+
+    mongod routes every new ``$search`` to a randomly-chosen mongot replica, so a
+    single paging cursor only exercises one replica. Running several concurrent
+    cursors covers all mongot replicas with high probability — size the fleet a
+    few times the replica count. Presents the same context-manager +
+    ``wait_for_operations`` + ``verdict`` surface as a single
+    ``SearchAvailabilityBackgroundTester``, so it drops into the same
+    ``assert_no_outage`` flow.
+    """
+
+    def __init__(
+        self,
+        tool_factory: Callable[[], SearchConnectivityTool],
+        size: int,
+        *,
+        interval_seconds: float = 0.0,
+        paging_batch_size: int = 5,
+        paging_reset_every: Optional[int] = None,
+        paging_reset_after_seconds: Optional[float] = None,
+    ) -> None:
+        if size < 1:
+            raise ValueError(f"size must be >= 1; got {size}")
+        self._testers = [
+            SearchAvailabilityBackgroundTester(
+                tool_factory(),
+                mode="paging",
+                interval_seconds=interval_seconds,
+                paging_batch_size=paging_batch_size,
+                paging_reset_every=paging_reset_every,
+                paging_reset_after_seconds=paging_reset_after_seconds,
+            )
+            for _ in range(size)
+        ]
+
+    def __enter__(self) -> "PagingAvailabilityFleet":
+        for tester in self._testers:
+            tester.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        for tester in self._testers:
+            tester.stop()
+        for tester in self._testers:
+            tester.join(timeout=10)
+            if tester.is_alive():
+                logger.warning("paging fleet tester did not exit within 10s")
+
+    def wait_for_operations(self, count: int, *, timeout: float = 120.0) -> None:
+        """Block until every member records ``count`` more operations than it had
+        when this call started."""
+        since = [tester.operations_count for tester in self._testers]
+        for tester, baseline in zip(self._testers, since):
+            tester.wait_for_operations(count, since=baseline, timeout=timeout)
+
+    @property
+    def verdict(self) -> ConnectivityVerdict:
+        """Fleet-wide verdict — the per-member verdicts summed."""
+        return aggregate_verdicts([tester.verdict for tester in self._testers])
 
 
 class MultiClusterAvailabilityFleet:

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -175,6 +175,35 @@ class ConnectivityVerdict:
         }
 
 
+def aggregate_verdicts(verdicts: list[ConnectivityVerdict]) -> ConnectivityVerdict:
+    """Sum a set of per-probe verdicts into one fleet-wide verdict.
+
+    Counts add; error_breakdown maps merge; first/last error track the earliest
+    non-None first_error and the latest non-None last_error seen across inputs.
+    """
+    agg = ConnectivityVerdict()
+    for v in verdicts:
+        agg.total_operations += v.total_operations
+        agg.succeeded += v.succeeded
+        agg.failed += v.failed
+        agg.cursor_lost += v.cursor_lost
+        agg.transient_network += v.transient_network
+        agg.index_unavailable += v.index_unavailable
+        agg.search_not_enabled += v.search_not_enabled
+        agg.mongot_unreachable += v.mongot_unreachable
+        agg.other_failed += v.other_failed
+        agg.total_returned_records += v.total_returned_records
+        agg.cursor_reopens += v.cursor_reopens
+        agg.current_cursor_records += v.current_cursor_records
+        for klass, count in v.error_breakdown.items():
+            agg.error_breakdown[klass] = agg.error_breakdown.get(klass, 0) + count
+        if agg.first_error is None:
+            agg.first_error = v.first_error
+        if v.last_error is not None:
+            agg.last_error = v.last_error
+    return agg
+
+
 class SearchConnectivityTool:
     """Drives ``$search`` queries against an MCK MongoDBSearch deployment."""
 

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -178,8 +178,8 @@ class ConnectivityVerdict:
 def aggregate_verdicts(verdicts: list[ConnectivityVerdict]) -> ConnectivityVerdict:
     """Sum a set of per-probe verdicts into one fleet-wide verdict.
 
-    Counts add; error_breakdown maps merge; first/last error track the earliest
-    non-None first_error and the latest non-None last_error seen across inputs.
+    Counts add; error_breakdown maps merge; first_error keeps the first non-None
+    first_error in fleet order, last_error the latest non-None last_error seen.
     """
     agg = ConnectivityVerdict()
     for v in verdicts:

--- a/docker/mongodb-kubernetes-tests/tests/search/search_connectivity_rolling_restarts.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_connectivity_rolling_restarts.py
@@ -1,0 +1,229 @@
+"""E2E test: search stays available through rolling restarts of a HA deployment.
+
+Two Envoy replicas + three mongot pods. Background oneshot and paging probes run
+throughout native rolling restarts (``kubectl.kubernetes.io/restartedAt``) of the
+mongot StatefulSet and the Envoy Deployment, in two scenarios: the tiers rolled
+one after the other, and both rolled at the same time (the operator-upgrade
+signature). A rolling restart replaces one pod at a time per tier while the rest
+keep serving, so we expect ZERO outages either way.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from kubernetes import client
+from kubetester import list_matching_pods
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from tests import test_logger
+from tests.common.search import search_resource_names
+from tests.common.search.background_availability_tester import (
+    PagingAvailabilityFleet,
+    SearchAvailabilityBackgroundTester,
+    assert_no_outage,
+)
+from tests.common.search.bootstrap_test_mixins import (
+    InstallOperatorTests,
+    MongoDBDeploymentConfig,
+    MongoDBRsDeploymentTests,
+    SampleDataAndIndexConfig,
+    SearchDeploymentConfig,
+    SearchRsDeploymentTests,
+    SearchSampleDataAndIndexTests,
+)
+from tests.common.search.connectivity import (
+    SearchConnectivityTool,
+    wait_for_all_pods_replaced,
+    wait_for_pods_by_label_replaced,
+)
+from tests.common.search.rs_search_helper import rs_search_tester
+from tests.common.search.search_deployment_helper import SearchDeploymentHelper
+from tests.conftest import get_namespace
+
+logger = test_logger.get_test_logger(__name__)
+
+pytestmark = pytest.mark.e2e_search_connectivity_rolling_restarts
+
+NAMESPACE = get_namespace()
+MDB = MongoDBDeploymentConfig(mdb_resource_name="mdb-rs-conn-roll")
+# HA shape under test: 3 mongot pods behind 2 Envoy replicas.
+SEARCH = SearchDeploymentConfig(mongot_replicas=3, envoy_lb_replicas=2)
+MDBS_NAME = MDB.mdb_resource_name
+MONGOT_STS = search_resource_names.mongot_statefulset_name_for_cluster(MDBS_NAME)
+MONGOT_SELECTOR = f"app={search_resource_names.mongot_service_name_for_cluster(MDBS_NAME)}"
+ENVOY_DEPLOYMENT = search_resource_names.lb_deployment_name(MDBS_NAME)
+ENVOY_SELECTOR = f"app={ENVOY_DEPLOYMENT}"
+
+# Drain enough post-restart pages (per fleet member) that each paging cursor's
+# getMore round-trips to mongot (and rolls over to a fresh $search) at least once
+# across the disruption.
+DRAIN_MIN_PAGES = 100
+# Reopen each paging cursor every 20s so a fresh $search — which needs a live
+# mongot — is exercised at a steady cadence through the restart window.
+PAGING_RESET_AFTER_SECONDS = 20.0
+# Concurrent paging cursors. mongod routes each new $search to a random mongot, so
+# oversubscribe the replicas (3x) to cover all of them with high probability.
+PAGING_FLEET_SIZE = 3 * SEARCH.mongot_replicas
+
+
+class TestInstallOperator(InstallOperatorTests):
+    pass
+
+
+class TestMongoDBDeployment(MongoDBRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+
+class TestSearchDeployment(SearchRsDeploymentTests):
+    namespace = NAMESPACE
+    mdb_config = MDB
+    search_config = SEARCH
+
+    def build_mdbs(self) -> MongoDBSearch:
+        mdbs = super().build_mdbs()
+        # SearchRsDeploymentTests wires the managed LB with only externalHostname;
+        # pin the Envoy replica count so the proxy tier is itself HA.
+        for cluster in mdbs["spec"]["clusters"]:
+            cluster.setdefault("loadBalancer", {}).setdefault("managed", {})[
+                "replicas"
+            ] = self.search_config.envoy_lb_replicas
+        return mdbs
+
+
+class TestSampleData(SearchSampleDataAndIndexTests):
+    sample_config = SampleDataAndIndexConfig()
+
+    def admin_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.admin_user_name, MDB.admin_user_password)
+
+    def user_tester(self, namespace: str):
+        return rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password)
+
+
+class TestSearchConnectivityRollingRestarts:
+    def test_rolling_restart_mongot_then_envoy_without_outage(self, namespace: str):
+        _assert_zero_outage_through_rolls(namespace, _roll_mongot_then_envoy)
+
+    def test_concurrent_rolling_restart_mongot_and_envoy_without_outage(self, namespace: str):
+        # Operator-upgrade signature: a new operator re-renders both the mongot
+        # StatefulSet and the Envoy Deployment, so both tiers roll at the same
+        # time rather than one after the other.
+        _assert_zero_outage_through_rolls(namespace, _roll_mongot_and_envoy_together)
+
+
+# Module-level helpers
+
+
+def _assert_zero_outage_through_rolls(namespace: str, roll_fn) -> None:
+    mdbs = _load_mdbs(namespace)
+    mdbs.assert_reaches_phase(Phase.Running)
+
+    oneshot_tester = SearchAvailabilityBackgroundTester(_user_connectivity_tool(namespace), mode="oneshot")
+    paging_fleet = PagingAvailabilityFleet(
+        lambda: _user_connectivity_tool(namespace),
+        size=PAGING_FLEET_SIZE,
+        interval_seconds=0.5,
+        paging_reset_after_seconds=PAGING_RESET_AFTER_SECONDS,
+    )
+    with oneshot_tester, paging_fleet:
+        # Warm both probes — the first paging iteration opens each cursor.
+        oneshot_tester.wait_for_operations(5)
+        paging_fleet.wait_for_operations(5)
+
+        roll_fn(namespace, paging_fleet, oneshot_tester)
+
+    oneshot_verdict = oneshot_tester.verdict
+    paging_verdict = paging_fleet.verdict
+    logger.info(f"rolling-restart oneshot verdict: {oneshot_verdict.as_dict()}")
+    logger.info(f"rolling-restart paging verdict: {paging_verdict.as_dict()}")
+    assert_no_outage(oneshot_verdict)
+    assert_no_outage(paging_verdict)
+
+
+def _roll_mongot_then_envoy(namespace: str, paging_fleet: PagingAvailabilityFleet, oneshot_tester) -> None:
+    mongot_uids = _pod_uids(namespace, MONGOT_SELECTOR)
+    assert (
+        len(mongot_uids) == SEARCH.mongot_replicas
+    ), f"expected {SEARCH.mongot_replicas} mongot pods before restart; got {sorted(mongot_uids)}"
+    _rollout_restart_sts(namespace, MONGOT_STS)
+    wait_for_all_pods_replaced(namespace, mongot_uids, timeout=600)
+    paging_fleet.wait_for_operations(DRAIN_MIN_PAGES, timeout=300)
+    oneshot_tester.wait_for_operations(5)
+
+    envoy_uids = _pod_uids(namespace, ENVOY_SELECTOR)
+    assert (
+        len(envoy_uids) == SEARCH.envoy_lb_replicas
+    ), f"expected {SEARCH.envoy_lb_replicas} Envoy pods before restart; got {sorted(envoy_uids)}"
+    _rollout_restart_deployment(namespace, ENVOY_DEPLOYMENT)
+    wait_for_pods_by_label_replaced(
+        namespace, ENVOY_SELECTOR, envoy_uids, expected=SEARCH.envoy_lb_replicas, timeout=300
+    )
+    paging_fleet.wait_for_operations(DRAIN_MIN_PAGES, timeout=300)
+    oneshot_tester.wait_for_operations(5)
+
+
+def _roll_mongot_and_envoy_together(namespace: str, paging_fleet: PagingAvailabilityFleet, oneshot_tester) -> None:
+    mongot_uids = _pod_uids(namespace, MONGOT_SELECTOR)
+    envoy_uids = _pod_uids(namespace, ENVOY_SELECTOR)
+    assert (
+        len(mongot_uids) == SEARCH.mongot_replicas
+    ), f"expected {SEARCH.mongot_replicas} mongot pods before restart; got {sorted(mongot_uids)}"
+    assert (
+        len(envoy_uids) == SEARCH.envoy_lb_replicas
+    ), f"expected {SEARCH.envoy_lb_replicas} Envoy pods before restart; got {sorted(envoy_uids)}"
+    # Trigger both rollouts before waiting on either, so the tiers churn at once.
+    _rollout_restart_sts(namespace, MONGOT_STS)
+    _rollout_restart_deployment(namespace, ENVOY_DEPLOYMENT)
+    wait_for_all_pods_replaced(namespace, mongot_uids, timeout=600)
+    wait_for_pods_by_label_replaced(
+        namespace, ENVOY_SELECTOR, envoy_uids, expected=SEARCH.envoy_lb_replicas, timeout=300
+    )
+    paging_fleet.wait_for_operations(DRAIN_MIN_PAGES, timeout=300)
+    oneshot_tester.wait_for_operations(5)
+
+
+def _pod_uids(namespace: str, label_selector: str) -> dict[str, str]:
+    return {p.metadata.name: p.metadata.uid for p in list_matching_pods(namespace, label_selector=label_selector)}
+
+
+def _rollout_restart_sts(namespace: str, sts_name: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    client.AppsV1Api().patch_namespaced_stateful_set(
+        name=sts_name,
+        namespace=namespace,
+        body={"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}}}},
+    )
+    logger.info(f"rollout-restart StatefulSet {sts_name} (restartedAt={now})")
+
+
+def _rollout_restart_deployment(namespace: str, deployment_name: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    client.AppsV1Api().patch_namespaced_deployment(
+        name=deployment_name,
+        namespace=namespace,
+        body={"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}}}},
+    )
+    logger.info(f"rollout-restart Deployment {deployment_name} (restartedAt={now})")
+
+
+def _user_connectivity_tool(namespace: str) -> SearchConnectivityTool:
+    return SearchConnectivityTool(rs_search_tester(MDB.mdb_resource_name, namespace, MDB.user_name, MDB.user_password))
+
+
+def _load_mdbs(namespace: str) -> MongoDBSearch:
+    helper = SearchDeploymentHelper(
+        namespace=namespace,
+        mdb_resource_name=MDB.mdb_resource_name,
+        mdbs_resource_name=MDBS_NAME,
+        ca_configmap_name=MDB.ca_configmap_name,
+    )
+    return helper.mdbs_for_ext_rs_source(
+        MDB.mongot_user_name,
+        members=MDB.rs_members,
+        lb_mode="Managed",
+        clusters=[{"replicas": SEARCH.mongot_replicas}],
+    )


### PR DESCRIPTION
[skip-ci]

# Summary

A MongoDBSearch HA deployment now serves `$search` with **zero outages**
through rolling restarts of both the mongot StatefulSet and the Envoy
Deployment — whether the tiers are rolled one after the other or both at the
same time (the operator-upgrade signature).

The Envoy preStop graceful drain never actually executed, so a rolling restart
severed in-flight mongod→Envoy→mongot getMore streams and paging `$search`
clients saw `Executor error during getMore :: Remote error from mongot ::
Socket closed` (HostUnreachable). Three independent bugs each had to be fixed:
(1) `/drain_listeners` was an `Exact` matcher in the Envoy admin allow-list,
so the preStop call — which carries a `?graceful=true` query string — was
rejected with 403; (2) the preStop used `httpGet`, but `/drain_listeners`
mutates state and requires POST, which Envoy rejects for GET; (3) even with a
successful POST there was no post-drain wait, so SIGTERM fired immediately and
cut in-flight streams.

| file | change |
|---|---|
| `controllers/operator/envoy_config_builder.go` | `/drain_listeners` admin allow-list: `Exact` → `Prefix` matcher (so the query-string form is allowed, like `/stats` and `/logging`) |
| `controllers/operator/mongodbsearchenvoy_controller.go` | preStop is now an `exec` that POSTs `/drain_listeners?graceful=true` over bash `/dev/tcp` (no curl in the image) then sleeps, deferring SIGTERM until in-flight getMores drain; bounded drain window so every downstream connection is GOAWAY'd within the sleep; Envoy `terminationGracePeriodSeconds` 70s |
| `api/mongodb/v1/search/mongodbsearch_types.go` | mongot/Envoy grace and preStop-drain-sleep constants (60s / 70s / 60s) |
| `controllers/searchcontroller/search_construction.go` | set mongot `terminationGracePeriodSeconds` (matches its internal gRPC drain) |
| `tests/search/search_connectivity_rolling_restarts.py` (+ harness, `.evergreen*.yml`) | new e2e: 3 mongot + 2 Envoy, background oneshot + paging-fleet probes; asserts zero outage in two scenarios — sequential (mongot then Envoy) and concurrent (both at once); wired into the cloudqa + om80 search task groups via a shared YAML anchor |

## Proof of Work

- e2e `search_connectivity_rolling_restarts` passed locally, both scenarios — sequential: paging 3472/3472 & oneshot 1037/1037; concurrent: paging 2655/2655 & oneshot 1100/1100. **0 cursor_lost and 0 severed Envoy streams** in each (a consistent 5–9 cursor failures before the fix).
- PoW-Patch: green — https://evergreen.mongodb.com/version/6a3eae2132afbe0007ebacc1
  - variants: `unit_tests`, `e2e_mdb_kind_ubi_cloudqa_large`, `e2e_static_mdb_kind_ubi_cloudqa_large`
  - tasks: `lint_repo`, `unit_tests*`, `e2e_search_connectivity_rolling_restarts`

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->

# Based on PR #1048

## Chain of upstream PRs as of 2026-06-29

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * **PR #1278 (THIS ONE)**:
      `search/ga-base` ← `search/lsierant/grace-period`

<!-- end git-machete generated -->