### PR TITLE
fix(e2e): close poll-sleep race and suppress noisy kubernetes.client.rest DEBUG logs

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_common.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_common.py
@@ -49,6 +49,14 @@ class MongoDBCommon:
             timeout -= wait
             time.sleep(wait)
 
+        # ponytail: one last check -- condition may have become true during the final sleep
+        try:
+            self.reload()
+        except Exception:
+            pass
+        if fn(self):
+            return True
+
         if should_raise:
             raise Exception("Timeout ({}) reached while waiting for {}".format(initial_timeout, self))
 

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -41,6 +41,8 @@ def _load_env_from_local_file_for_development():
 
 _load_env_from_local_file_for_development()
 
+logging.getLogger("kubernetes.client.rest").setLevel(logging.WARNING)
+
 import kubernetes
 import kubernetes.client.rest
 import requests

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -68,18 +68,18 @@ def test_install_secrets(namespace: str, mdbs: MongoDBSearch):
 @mark.e2e_search_community_basic
 def test_create_database_resource(mdbc: MongoDBCommunity):
     mdbc.update()
-    mdbc.assert_reaches_phase(Phase.Running, timeout=300)
+    mdbc.assert_reaches_phase(Phase.Running, timeout=600)
 
 
 @mark.e2e_search_community_basic
 def test_create_search_resource(mdbs: MongoDBSearch):
     mdbs.update()
-    mdbs.assert_reaches_phase(Phase.Running, timeout=300)
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
 
 
 @mark.e2e_search_community_basic
 def test_wait_for_community_resource_ready(mdbc: MongoDBCommunity):
-    mdbc.assert_reaches_phase(Phase.Running, timeout=300)
+    mdbc.assert_reaches_phase(Phase.Running, timeout=600)
 
 
 @fixture(scope="function")


### PR DESCRIPTION
## Summary

Two changes to reduce e2e test flakiness and log noise:

1. **Close poll-sleep race in `wait_for`**: When a resource reaches the desired phase during the 3s sleep window after the timeout counter hits zero, the loop exits without checking. Added a final `reload()+check` before raising Timeout to catch this boundary condition.

2. **Suppress noisy `kubernetes.client.rest` DEBUG logs**: `log_cli_level = DEBUG` in `pytest.ini` dumps full K8s API response bodies on every poll. Set `kubernetes.client.rest` logger to WARNING in conftest so these aren't printed at DEBUG. Actual test/operator logs at DEBUG are preserved.

3. **Bump timeouts** in `search_community_basic.py` from 300s to 600s — matching the `search_community_tls` precedent (PR #1256) where p95 for community replica set readiness was 279s.

## Proof of Work

https://spruce.corp.mongodb.com/task/mongodb_kubernetes_e2e_mdb_kind_ubi_cloudqa_large_e2e_search_community_basic_patch_5081f278ca788c56c75054b38c32eb0d47d7e70e_6a3e6728b2e7e90007e814dd_26_06_26_11_49_00/logs?execution=0 passed

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details