### PR TITLE
search: block single-operator reconcile of multi-cluster MongoDBSearch (feature-flagged)

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1435,6 +1435,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_block_multi_cluster
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_sharded_routed_from_another_shard
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -836,7 +836,7 @@ task_groups:
     max_hosts: -1
     <<: *setup_group
     <<: *setup_and_teardown_task_cloudqa
-    tasks:
+    tasks: &single_cluster_search_tasks
       - e2e_search_community_basic
       - e2e_search_community_auto_embedding
       - e2e_search_community_auto_embedding_multi_mongot
@@ -881,6 +881,22 @@ task_groups:
       - e2e_search_cds_hot_reload
       - e2e_search_envoy_retry_policy
       - e2e_search_auto_embedding_rolling_restart
+    <<: *teardown_group
+
+  # Coverage for the multi-cluster block (GA default). The
+  # e2e_mdb_kind_ubi_cloudqa_search_block variant leaves MDB_SEARCH_ENABLE_MULTI_CLUSTER
+  # unset, so the operator rejects MC-shaped MongoDBSearch. Asserts that rejection
+  # (e2e_search_block_multi_cluster) and runs a single-cluster smoke subset (community +
+  # replicaset + sharded sources) proving SC search is unaffected.
+  - name: e2e_mdb_kind_search_block_task_group
+    max_hosts: -1
+    <<: *setup_group
+    <<: *setup_and_teardown_task_cloudqa
+    tasks:
+      - e2e_search_block_multi_cluster
+      - e2e_search_community_basic
+      - e2e_search_replicaset_external_mongodb_single_mongot
+      - e2e_search_sharded_internal_mongodb_single_mongot
     <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.
@@ -1542,6 +1558,18 @@ buildvariants:
     tasks:
       - name: e2e_mdb_kind_search_task_group
       - name: e2e_mdb_kind_search_large_task_group
+
+  # Runs with multi-cluster search reconciliation disabled (the GA default: the context
+  # leaves MDB_SEARCH_ENABLE_MULTI_CLUSTER unset), so the operator's MC block is active.
+  # Asserts MC-shaped MongoDBSearch is rejected and that single-cluster search still works.
+  - name: e2e_mdb_kind_ubi_cloudqa_search_block
+    display_name: e2e_mdb_kind_ubi_cloudqa_search_block
+    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    run_on:
+      - ubuntu2404-large
+    <<: *base_no_om_image_dependency
+    tasks:
+      - name: e2e_mdb_kind_search_block_task_group
 
   # We do not want to run openshift variants on every PR.
   - name: e2e_mdb_openshift_ubi_cloudqa

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -54,6 +54,12 @@ type prepareSearchFunc func(search *searchv1.MongoDBSearch, log *zap.SugaredLogg
 // misconfigured MC specs.
 func newPrepareSearch(operatorClusterName string) prepareSearchFunc {
 	validateSpec := func(search *searchv1.MongoDBSearch, log *zap.SugaredLogger, writeStatus func(workflow.Status) (reconcile.Result, error)) (bool, reconcile.Result, error) {
+		// A single operator (no operatorClusterName) cannot manage a multi-cluster (>1)
+		// search deployment; per-cluster operators narrow to their own entry below.
+		if operatorClusterName == "" && len(search.Spec.Clusters) > 1 && !env.ReadBoolOrDefault(util.SearchEnableMultiClusterEnv, false) { // nolint:forbidigo
+			r, e := writeStatus(workflow.Invalid("multi-cluster MongoDBSearch is not supported yet: spec.clusters must contain a single entry"))
+			return true, r, e
+		}
 		if vErr := search.ValidateSpec(); vErr != nil {
 			r, e := writeStatus(workflow.Invalid("%s", vErr.Error()))
 			return true, r, e

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -370,6 +370,84 @@ func TestMongoDBSearchReconcile_MultipleSearchResources(t *testing.T) {
 	checkSearchReconcileFailed(ctx, t, reconciler, c, search1, "multiple MongoDBSearch")
 }
 
+func TestMongoDBSearchReconcile_MultiClusterBlocked(t *testing.T) {
+	ctx := context.Background()
+	// workflow.Invalid capitalizes the first char, so match on the stable substring.
+	const blockMsg = "MongoDBSearch is not supported yet"
+
+	twoClusters := func(s *searchv1.MongoDBSearch) {
+		s.Spec.Clusters = []searchv1.ClusterSpec{
+			pinnedCluster("us-east", 0),
+			pinnedCluster("us-west", 1),
+		}
+	}
+
+	// A single operator (operatorClusterName == "") blocks >1 clusters. The block
+	// defaults on when the enable flag is unset and stays on when explicitly "false"; an
+	// empty value is not a valid bool, so it falls back to the default-on behavior too.
+	for _, flag := range []struct{ name, value string }{
+		{"flag empty (default on)", ""},
+		{"flag false", "false"},
+	} {
+		t.Run(flag.name, func(t *testing.T) {
+			t.Setenv(util.SearchEnableMultiClusterEnv, flag.value)
+			search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+			twoClusters(search)
+			mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+			reconciler, c := newSearchReconciler(mdbc, search)
+			checkSearchReconcileFailed(ctx, t, reconciler, c, search, blockMsg)
+		})
+	}
+
+	// A single unnamed cluster is never blocked, regardless of the flag.
+	t.Run("single cluster is allowed", func(t *testing.T) {
+		search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+		mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+		reconciler, c := newSearchReconciler(mdbc, search)
+
+		updated := reconcileAndLoad(ctx, t, reconciler, c, search)
+		assert.NotContains(t, updated.Status.Message, blockMsg, "single-cluster spec must not be blocked")
+	})
+
+	// A per-cluster operator (operatorClusterName set) narrows to its own entry, so >1
+	// clusters is allowed even with the block on.
+	t.Run("per-cluster operator is allowed", func(t *testing.T) {
+		search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+		twoClusters(search)
+		reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "us-east", search)
+
+		updated := reconcileAndLoad(ctx, t, reconciler, c, search)
+		assert.NotContains(t, updated.Status.Message, blockMsg, "per-cluster operator must not be blocked")
+	})
+
+	// With the block disabled, a single operator with >1 clusters is not blocked either.
+	t.Run("flag true skips the block", func(t *testing.T) {
+		enableSearchMCReconcile(t)
+		search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+		twoClusters(search)
+		mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+		reconciler, c := newSearchReconciler(mdbc, search)
+
+		updated := reconcileAndLoad(ctx, t, reconciler, c, search)
+		assert.NotContains(t, updated.Status.Message, blockMsg, "block must be skipped when flag is false")
+	})
+}
+
+// reconcileAndLoad runs a single reconcile pass and returns the reloaded MongoDBSearch.
+func reconcileAndLoad(
+	ctx context.Context,
+	t *testing.T,
+	reconciler *MongoDBSearchReconciler,
+	c client.Client,
+	search *searchv1.MongoDBSearch,
+) *searchv1.MongoDBSearch {
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+	updated := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, updated))
+	return updated
+}
+
 func TestMongoDBSearchReconcile_InvalidSearchImageVersion(t *testing.T) {
 	ctx := context.Background()
 	expectedMsg := "MongoDBSearch version 1.47.0 is not supported because of breaking changes. The operator will ignore this resource: it will not reconcile or reconfigure the workload. Existing deployments will continue to run, but cannot be managed by the operator. To regain operator management, you must delete and recreate the MongoDBSearch resource."
@@ -484,7 +562,14 @@ func pinnedCluster(name string, idx int32) searchv1.ClusterSpec {
 	return searchv1.ClusterSpec{Name: name, Index: ptr.To(idx)}
 }
 
+// enableSearchMCReconcile turns off the default multi-cluster block for tests that
+// exercise multi-cluster reconcile behavior.
+func enableSearchMCReconcile(t *testing.T) {
+	t.Setenv(util.SearchEnableMultiClusterEnv, "true")
+}
+
 func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 
 	// MC GA requires external source (Q2); managed source + MC (Q3) is post-MVP.
@@ -673,6 +758,7 @@ var simulatedMCProjectionCases = []struct {
 }
 
 func TestReconcile_SimulatedMC_ProjectedReconcilesLocalOnly(t *testing.T) {
+	enableSearchMCReconcile(t)
 	for _, tc := range simulatedMCProjectionCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -718,6 +804,7 @@ func TestReconcile_SimulatedMC_ProjectedReconcilesLocalOnly(t *testing.T) {
 }
 
 func TestReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
 
@@ -754,6 +841,7 @@ func TestReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
 // Customer pin is authoritative: re-pinning renders at the new index. The
 // old-index resources leak — accepted MVP scope, no cleanup.
 func TestReconcile_SimulatedMC_RePinUpdatesNames(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
 
@@ -823,6 +911,7 @@ func simulatedMCShardedTLSSecrets(search *searchv1.MongoDBSearch, clusterIndex i
 }
 
 func TestReconcile_SimulatedMC_ShardedSource_ProjectedReconcilesLocalOnly(t *testing.T) {
+	enableSearchMCReconcile(t)
 	for _, tc := range simulatedMCProjectionCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -883,6 +972,7 @@ func TestReconcile_SimulatedMC_ShardedSource_ProjectedReconcilesLocalOnly(t *tes
 }
 
 func TestReconcile_SimulatedMC_ShardedSource_NoMatchSilentNoOp(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	search := newSimulatedMCShardedMongoDBSearch("mdb-search", mock.TestNamespace)
 
@@ -919,6 +1009,7 @@ func TestReconcile_SimulatedMC_ShardedSource_NoMatchSilentNoOp(t *testing.T) {
 
 // ClusterIndex enforcement runs before LocalizeToCluster, so bad shapes surface as Failed.
 func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 
 	t.Run("missing clusterIndex on a single entry is Invalid", func(t *testing.T) {
@@ -988,6 +1079,7 @@ func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
 
 // Cluster-level proxy Service selector must match the label Envoy Deployment stamps on its Pods.
 func TestMongoDBSearchReconcile_MCSharded_CrossControllerLabelInvariant(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 
 	search := &searchv1.MongoDBSearch{

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -1095,6 +1095,7 @@ func TestBuildClusterWorkList_UnpinnedEntry_IndexZero(t *testing.T) {
 }
 
 func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	search := &searchv1.MongoDBSearch{
@@ -1215,6 +1216,7 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 // (succeeds), the other isn't (Pending). The top-level Phase must be the
 // worst-of across both clusters (Pending here).
 func TestReconcile_WorstOfPhase_Aggregated(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1323,6 +1325,7 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 // <name>-search-state ConfigMap present, a fully-registered MC spec still renders
 // its Envoy resources at the pinned indices.
 func TestReconcile_NoStateCM_RendersFromPins(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1373,6 +1376,7 @@ func TestReconcile_NoStateCM_RendersFromPins(t *testing.T) {
 // TestReconcile_UsesPinnedIndices asserts that Envoy resources are named with
 // the spec.clusters[].clusterIndex pins, not the cluster names.
 func TestReconcile_UsesPinnedIndices(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1453,6 +1457,7 @@ func TestReconcile_UsesPinnedIndices(t *testing.T) {
 // cluster from spec.clusters does not shift the indices of remaining clusters.
 // "b" at index 1 must still be index 1 after "a" is removed.
 func TestReconcile_StableIndexAcrossClusterRemovals(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1640,6 +1645,7 @@ func TestEnvoyConfigHash_WhitespaceInvariant(t *testing.T) {
 // switched-on shards route to their own mongot cluster; switched-off shards route
 // to mongot_cluster_level_cluster with the routed_from_another_shard header.
 func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
@@ -1854,6 +1860,7 @@ func TestEnqueueMemberClusterObjectToSearch(t *testing.T) {
 }
 
 func TestEnvoyReconcile_LBCleanup_DeletesAtPinnedIndex(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
@@ -1908,6 +1915,7 @@ func TestEnvoyReconcile_MultiCluster_FailedFirstThenOK_AggregatesFailed(t *testi
 }
 
 func TestEnvoyReconcile_SimulatedMC_Match_RendersAtPinnedIndex(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
@@ -1947,6 +1955,7 @@ func TestEnvoyReconcile_SimulatedMC_Match_RendersAtPinnedIndex(t *testing.T) {
 }
 
 func TestEnvoyReconcile_SimulatedMC_MissingClusterIndex_Invalid(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
@@ -1972,6 +1981,7 @@ func TestEnvoyReconcile_SimulatedMC_MissingClusterIndex_Invalid(t *testing.T) {
 }
 
 func TestEnvoyReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
@@ -2003,6 +2013,7 @@ func TestEnvoyReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
 }
 
 func TestEnvoyReconcile_UnregisteredCluster_PendingAndNoCentralWrites(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
@@ -2136,6 +2147,7 @@ func TestBuildRoutesForCluster_LBResolvedByName_NotSpecPosition(t *testing.T) {
 // configured replica count, landing at its pinned index (1) regardless of its
 // spec position (0).
 func TestReconcile_LBConfigSurvivesClusterRemoval(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/docker/mongodb-kubernetes-tests/tests/search/search_block_multi_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_block_multi_cluster.py
@@ -1,0 +1,56 @@
+"""E2E: a single operator rejects multi-cluster MongoDBSearch when the block is on.
+
+A single-operator install cannot manage a multi-cluster (>1 entries) search deployment,
+so such a spec must fail fast with a "not supported yet" status before any source
+handling. No MongoDB source is deployed — the block fires before source resolution, so
+the source reference is irrelevant.
+"""
+
+from __future__ import annotations
+
+import pytest
+from kubetester import try_load
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.phase import Phase
+from tests import test_logger
+from tests.common.search.bootstrap_test_mixins import InstallOperatorTests
+from tests.conftest import get_namespace
+
+logger = test_logger.get_test_logger(__name__)
+
+pytestmark = pytest.mark.e2e_search_block_multi_cluster
+
+NAMESPACE = get_namespace()
+
+# workflow.Invalid capitalizes the first char, so match from "MongoDBSearch".
+BLOCK_MSG_RE = r".*MongoDBSearch is not supported yet.*"
+
+# More than one cluster entry: passes CRD admission (each entry has name + index) but
+# the single operator in this install (no operatorClusterName) rejects it.
+TWO_CLUSTERS = [
+    {"name": "cluster-0", "index": 0},
+    {"name": "cluster-1", "index": 1},
+]
+
+
+def assert_multi_cluster_is_blocked(fixture_name: str, mdbs_name: str):
+    """Apply a >1-cluster spec to a source-specific MongoDBSearch fixture and assert the
+    single operator fails it fast."""
+    resource = MongoDBSearch.from_yaml(yaml_fixture(fixture_name), namespace=NAMESPACE, name=mdbs_name)
+    try_load(resource)
+    resource["spec"]["clusters"] = TWO_CLUSTERS
+    resource.update()
+    resource.assert_reaches_phase(Phase.Failed, msg_regexp=BLOCK_MSG_RE, timeout=120)
+
+
+class TestInstallOperator(InstallOperatorTests):
+    pass
+
+
+def test_replica_set_source_blocked():
+    assert_multi_cluster_is_blocked("search-rs-managed-lb.yaml", "mdb-rs-block")
+
+
+def test_sharded_source_blocked():
+    assert_multi_cluster_is_blocked("search-sharded-external-mongod.yaml", "mdb-sh-block")

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -289,6 +289,10 @@ spec:
               value: "{{ .Values.search.envoyImage }}"
             - name: MDB_SEARCH_METRICS_FORWARDER_IMAGE
               value: "{{ .Values.search.metricsForwarderImage }}"
+      {{- if and (hasKey .Values.search "enableMultiCluster") (ne (printf "%v" .Values.search.enableMultiCluster) "false") }}
+            - name: MDB_SEARCH_ENABLE_MULTI_CLUSTER
+              value: "{{ .Values.search.enableMultiCluster }}"
+      {{- end }}
     {{- end }}
     {{- if .Values.customEnvVars }}
       {{- range split "&" .Values.customEnvVars }}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -227,6 +227,10 @@ const (
 	SearchVersionEnv         = "MDB_SEARCH_VERSION"
 	EnvoyImageEnv            = "MDB_ENVOY_IMAGE"
 	MetricsForwarderImageEnv = "MDB_SEARCH_METRICS_FORWARDER_IMAGE"
+	// SearchEnableMultiClusterEnv lets a single operator reconcile a MongoDBSearch with
+	// more than one spec.clusters entry; defaults to false (block on) when unset, so an
+	// accidentally-set or zero-value bool fails safe to blocking.
+	SearchEnableMultiClusterEnv = "MDB_SEARCH_ENABLE_MULTI_CLUSTER"
 
 	// Different default configuration values
 	DefaultMongodStorageSize           = "16G"

--- a/scripts/dev/contexts/e2e_mdb_kind_ubi_cloudqa_search_block
+++ b/scripts/dev/contexts/e2e_mdb_kind_ubi_cloudqa_search_block
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_mdb_kind_ubi_cloudqa_large"
+
+# Leave multi-cluster search reconciliation disabled (the GA default): unsetting the flag
+# omits the env var from the deployment, so the operator's MC block stays active.
+unset MDB_SEARCH_ENABLE_MULTI_CLUSTER

--- a/scripts/dev/contexts/variables/mongodb_search_dev
+++ b/scripts/dev/contexts/variables/mongodb_search_dev
@@ -6,3 +6,7 @@ set -Eeou pipefail
 export MDB_SEARCH_VERSION="72ae26a806"
 export MDB_SEARCH_NAME="staging/mongodb-search"
 export MDB_SEARCH_REPO_URL="268558157000.dkr.ecr.us-east-1.amazonaws.com"
+
+# Keep multi-cluster search reconciliation enabled for the existing search e2e suite;
+# the block-on variant overrides this back to the default.
+export MDB_SEARCH_ENABLE_MULTI_CLUSTER="true"

--- a/scripts/funcs/operator_deployment
+++ b/scripts/funcs/operator_deployment
@@ -47,6 +47,12 @@ get_operator_helm_values() {
     config+=("operator.telemetry.installClusterRole=${MDB_OPERATOR_TELEMETRY_INSTALL_CLUSTER_ROLE_INSTALLATION}")
   fi
 
+  # Only set search.enableMultiCluster when explicitly defined; undefined leaves the
+  # operator default (block on) and omits the env var from the deployment.
+  if [[ "${MDB_SEARCH_ENABLE_MULTI_CLUSTER:-}" != "" ]]; then
+    config+=("search.enableMultiCluster=${MDB_SEARCH_ENABLE_MULTI_CLUSTER}")
+  fi
+
   # Add OpenTelemetry values if any of the environment variables are set
   if [[ -n "${otel_trace_id:-}" || -n "${otel_parent_id:-}" || -n "${otel_collector_endpoint:-}" ]]; then
     config+=("operator.opentelemetry.tracing.enabled=true")


### PR DESCRIPTION
[skip-ci]

# Summary

A single operator cannot manage a multi-cluster MongoDBSearch deployment, so it must not act on such a spec. This adds a fast pre-narrow validation gate that rejects it with an informative `Invalid` status before any per-cluster narrowing or source handling.

- Blocks when the operator has **no** `operatorClusterName` **and** `len(spec.clusters) > 1`.
- Per-cluster operators (`operatorClusterName` set) narrow to their own entry via `LocalizeToCluster` and are unaffected; a single-cluster spec is always allowed.
- Gated by the **undocumented** operator env `MDB_SEARCH_ENABLE_MULTI_CLUSTER`; default `false` = block on, so an accidentally-set or zero-value bool fails safe to blocking. The status message never references the flag.
- Helm emits the env only when defined and not `"false"`; existing search suites set it `true` via the dev context, so they are unaffected.

## Proof of Work

Rebased onto `search/ga-base` @ `532b1efa9`. Local `make precommit` + `make all-tests` green (only the unrelated host `wt_ctl` network-registry tests fail, sensitive to the active worktree's registry slot).

**New block e2e — `e2e_search_block_multi_cluster`** (in the `e2e_mdb_kind_ubi_cloudqa_search_block` variant, block on): applies a two-cluster `spec.clusters` to a single-operator MongoDBSearch (RS + sharded sources) and asserts it reaches `Phase.Failed` with the "not supported yet" status — i.e. the block fires.

- The block variant now also runs **on PR patches** (`pr_patch` tag added), and the block-on regression check is trimmed to a **3-test single-cluster smoke subset** (community + replicaset + sharded sources) instead of re-running the full suite, to cut cost.
- PoW-Patch (merged block task group): https://spruce.mongodb.com/version/6a42924bd5bb4100078a9c4b — **16/17**. The merged `e2e_mdb_kind_search_block_task_group` ran cleanly: the block assertion `e2e_search_block_multi_cluster` + the replicaset and sharded smoke tasks all passed. The lone failure is again `e2e_search_community_basic :: test_zz_delete_search_cr_reclaims_pvc` (300s PVC-reclaim timeout) — a base-branch test added by KUBE-143 (#1273), unrelated to the block (gate never fires for single-cluster).
- Prior runs (pre-rename): PoW green https://spruce.mongodb.com/version/6a419232ca864f00073e9bb7 (14/14); full search sweep 159/162 https://spruce.mongodb.com/version/6a41924fa369580007bc4ed8 (3 persistent failures all pre-existing/environmental — x509 `SearchNotEnabled` quiesce race + the known KUBE-124/PR #1215 onboarding-no-outage PodSecurity failure; block off and gate never fired in all of them).
- Unit tests cover: single-operator + >1 clusters blocked (flag unset/false), single cluster allowed, per-cluster operator allowed, flag-true allowed.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->