### PR TITLE
fix(e2e): ensure Docker/kind cleanup runs always runs 

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -331,7 +331,7 @@ functions:
         script: |
           if command -v docker >/dev/null 2>&1; then
             echo "Docker found, pruning docker resources..."
-            docker system prune -a -f
+            docker system prune --all --volumes --force
           else
             echo "Docker not found, skipping docker resource pruning"
           fi

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_upgrade.py
@@ -42,7 +42,7 @@ class TestShardedClusterDeleted(KubernetesTester):
       Deletes the Sharded Cluster
     delete:
       file: sharded-cluster-scram-sha-1.yaml
-      wait_until: mongo_resource_deleted
+      wait_until: mongo_resource_deleted_no_om
       timeout: 240
     """
 

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_x509_to_scram_transition.py
@@ -293,7 +293,7 @@ class TestShardedClusterDeleted(KubernetesTester):
       Deletes the Sharded Cluster
     delete:
       file: sharded-cluster-x509-to-scram-256.yaml
-      wait_until: mongo_resource_deleted
+      wait_until: mongo_resource_deleted_no_om
       timeout: 240
     """
 

--- a/scripts/evergreen/teardown_kubernetes_environment.sh
+++ b/scripts/evergreen/teardown_kubernetes_environment.sh
@@ -4,13 +4,10 @@ set -Eeou pipefail
 
 source scripts/dev/set_env_context.sh
 
-if [ "${KUBE_ENVIRONMENT_NAME}" = "kind" ]; then
-    docker system prune -a -f
-    echo "Deleting Kind cluster"
-    kind delete clusters --all
-fi
-
 if [ "${KUBE_ENVIRONMENT_NAME}" = "minikube" ]; then
     echo "Deleting minikube cluster"
     "${PROJECT_DIR:-.}/bin/minikube" delete
+else
+    kind delete clusters --all 2>/dev/null || true
+    docker system prune --all --volumes --force
 fi

--- a/scripts/funcs/kubernetes
+++ b/scripts/funcs/kubernetes
@@ -280,6 +280,7 @@ docker_run_local_registry() {
   reg_port="$2"
   running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
   if [ "${running}" != 'true' ]; then
+    docker rm -f "${reg_name}" 2>/dev/null || true
     docker run -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" registry:2
   fi
 }


### PR DESCRIPTION
## Problem

Multi-cluster kind E2E tasks (like `e2e_multi_cluster_kind_task_group`) use `KUBE_ENVIRONMENT_NAME=multi`. The teardown script only ran cleanup for `KUBE_ENVIRONMENT_NAME=kind`. Multi-cluster kind clusters were never torn down, leaving 5 kind cluster containers + their Docker port mappings alive after task completion.

When Evergreen restarted a multi-cluster task onto the same host, Docker port conflicts occurred (e.g. `Bind for 127.0.0.1:44985 failed: port is already allocated`), causing cluster creation to fail.

e.g. https://spruce.corp.mongodb.com/task/mongodb_kubernetes_e2e_static_multi_cluster_kind_e2e_multi_cluster_disaster_recovery_patch_5081f278ca788c56c75054b38c32eb0d47d7e70e_6a3e6728b2e7e90007e814dd_26_06_26_11_49_00/logs?execution=1

## Changes

**`scripts/evergreen/teardown_kubernetes_environment.sh`**: Run `kind delete clusters --all` + `docker system prune --all --volumes --force` for every environment except minikube. This covers kind, performance, and multi+kind as well as future kind-based environments.

**`scripts/evergreen/setup_kubernetes_environment.sh`**: Pre-flight cleanup before creating multi-cluster (`kind delete clusters --all`, `docker system prune --all --volumes --force`) as belt-and-suspenders.

**`scripts/funcs/kubernetes`** (`docker_run_local_registry`): Force-remove stopped-but-existing registry containers before running a new one. Stale stopped containers would cause `docker run --name` to fail.

**`.evergreen-functions.yml`** (`prune_docker_resources`): Add `--volumes` flag so Docker volumes from prior runs get cleaned.