### PR TITLE
test(search): real-infra AWS multi-cluster sharded MongoDBSearch e2e (manual)

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1475,11 +1475,6 @@ tasks:
     commands:
       - func: "e2e_test"
 
-  - name: e2e_aws_simulated_mc_sharded
-    tags: [ "patch-run" ]
-    commands:
-      - func: "e2e_test"
-
   - name: e2e_search_q3_mc_sharded_external_mtls
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1475,6 +1475,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_aws_simulated_mc_sharded
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_q3_mc_sharded_external_mtls
     tags: [ "patch-run" ]
     commands:

--- a/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py
@@ -32,6 +32,7 @@ from kubernetes import client
 from kubetester import create_or_update_configmap
 from kubetester.kubetester import run_periodically
 from tests import test_logger
+from tests.common.multicluster.multicluster_utils import create_internet_facing_nlb, wait_for_nlb_hostname
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -246,63 +247,19 @@ layered_runtime:
             else:
                 raise
 
-    def _service_annotations(self) -> dict:
-        # internet-facing NLB; corp-prefix-locked via the security-group annotation.
-        # Never 0.0.0.0/0 — the SG must come from the corp managed prefix list.
-        annotations = {
-            "service.beta.kubernetes.io/aws-load-balancer-type": "external",
-            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
-            "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
-        }
-        if self.lb_security_groups:
-            annotations["service.beta.kubernetes.io/aws-load-balancer-security-groups"] = ",".join(
-                self.lb_security_groups
-            )
-            # BYO frontend SG ⇒ the AWS LB Controller no longer auto-opens the node SG to
-            # the NLB; without this the targets fail health checks (i/o timeout).
-            annotations[
-                "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules"
-            ] = "true"
-        if self.external_dns_hostname:
-            annotations["external-dns.alpha.kubernetes.io/hostname"] = self.external_dns_hostname
-        return annotations
-
-    def _service_manifest(self) -> dict:
-        return {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {
-                "name": self.service_name,
-                "labels": {"app": self.name},
-                "annotations": self._service_annotations(),
-            },
-            "spec": {
-                "type": "LoadBalancer",
-                "selector": {"app": self.name},
-                "ports": [
-                    {"name": "mongod-sni", "port": self.listen_port, "targetPort": self.listen_port},
-                ],
-            },
-        }
-
     def create_service(self) -> None:
-        if self.lb_security_groups == []:
-            # Fail closed: an internet-facing NLB with no corp SG would default to open.
-            raise ValueError(
-                f"[{self.cluster_id}] mongodEnvoy refuses to create an internet-facing NLB without "
-                "a corp security group; pass lb_security_groups from the provisioned prefix-locked SGs"
-            )
-        core = client.CoreV1Api(api_client=self.api_client)
-        manifest = self._service_manifest()
-        try:
-            core.create_namespaced_service(self.namespace, manifest)
-            logger.info(f"[{self.cluster_id}] mongodEnvoy Service {self.service_name} (LoadBalancer) created")
-        except kubernetes.client.ApiException as e:
-            if e.status == 409:
-                core.patch_namespaced_service(self.service_name, self.namespace, manifest)
-                logger.info(f"[{self.cluster_id}] mongodEnvoy Service {self.service_name} updated")
-            else:
-                raise
+        create_internet_facing_nlb(
+            self.api_client,
+            self.namespace,
+            name=self.service_name,
+            selector_app=self.name,
+            port=self.listen_port,
+            port_name="mongod-sni",
+            security_groups=self.lb_security_groups,
+            external_dns_hostname=self.external_dns_hostname,
+            cluster_id=self.cluster_id,
+        )
+        logger.info(f"[{self.cluster_id}] mongodEnvoy Service {self.service_name} (LoadBalancer) applied")
 
     # ---- Lifecycle ----------------------------------------------------------------
 
@@ -322,27 +279,11 @@ layered_runtime:
         )
 
     def lb_hostname(self, timeout: int = 300) -> str:
-        """Block until the NLB is provisioned and return its external hostname.
-
-        external-dns publishes ``external_dns_hostname`` as a CNAME to this; callers
-        usually use the stable external-dns name, but this is handy for diagnostics.
-        """
-        core = client.CoreV1Api(api_client=self.api_client)
-
-        result: dict = {}
-
-        def check() -> tuple:
-            svc = core.read_namespaced_service(self.service_name, self.namespace)
-            ingress = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
-            if ingress and (ingress[0].hostname or ingress[0].ip):
-                result["host"] = ingress[0].hostname or ingress[0].ip
-                return True, f"NLB provisioned: {result['host']}"
-            return False, "NLB hostname not yet assigned"
-
-        run_periodically(
-            check, timeout=timeout, sleep_time=10, msg=f"[{self.cluster_id}] mongodEnvoy NLB provisioning"
+        """Block until the NLB is provisioned and return its external hostname (for diagnostics;
+        callers usually use the stable external-dns name that CNAMEs to it)."""
+        return wait_for_nlb_hostname(
+            self.api_client, self.namespace, self.service_name, cluster_id=self.cluster_id, timeout=timeout
         )
-        return result["host"]
 
     def deploy(self) -> None:
         self.create_configmap()

--- a/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py
@@ -1,0 +1,352 @@
+"""Self-managed L4 SNI-passthrough Envoy for the data plane (the "mongodEnvoy").
+
+This is the data-plane front for the AWS real-infra multi-cluster scenario
+(``aws_simulated_mc_sharded.py``): one mongodEnvoy per data cluster, behind a single
+internet-facing NLB with an external-dns wildcard, replacing per-pod LoadBalancers.
+It gives the source sharded MongoDB a stable external identity reachable from the
+search clusters with NO Istio mesh and NO VPC peering.
+
+It is deliberately NOT the operator-managed / BYO ``EnvoyProxy`` in
+``tests/common/search/envoy_helpers.py``. That one is an L7 (HTTP/2 + gRPC) proxy that
+*terminates* mongod's TLS and re-initiates mTLS to mongot. This one is pure L4: the
+``tls_inspector`` listener filter reads the TLS ClientHello SNI WITHOUT terminating,
+and ``tcp_proxy`` forwards the still-encrypted MongoDB wire stream untouched to the
+matching internal pod. So mongod<->mongos<->client TLS stays end-to-end; Envoy only
+demultiplexes by SNI. That means no server/client certs on the proxy itself — it never
+participates in the handshake.
+
+Routing model: each external pod FQDN (published by the MC MongoDB ``externalDomain``,
+e.g. ``<pod>.mongodb-proxy.<clusterId>.mc.mongokubernetes.com``) resolves via the
+external-dns wildcard to the one NLB. Envoy matches that FQDN as the SNI server name and
+``tcp_proxy``-forwards to the pod's internal ClusterIP/headless Service. mongos and
+per-shard mongod multiplex onto a single listener port — SNI alone disambiguates them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import kubernetes
+from kubernetes import client
+from kubetester import create_or_update_configmap
+from kubetester.kubetester import run_periodically
+from tests import test_logger
+
+logger = test_logger.get_test_logger(__name__)
+
+
+@dataclass(frozen=True)
+class SniRoute:
+    """One SNI-passthrough route.
+
+    ``server_name`` is the external FQDN the client puts in the TLS SNI (the pod's
+    ``externalDomain`` hostname). ``upstream_host``/``upstream_port`` is the in-cluster
+    address Envoy forwards the encrypted stream to (the pod's internal Service).
+    """
+
+    server_name: str
+    upstream_host: str
+    upstream_port: int = 27017
+
+    @property
+    def _ident(self) -> str:
+        # A stable, DNS-label-ish identifier for Envoy stat_prefix / cluster names.
+        return self.server_name.replace(".", "_").replace("*", "wildcard").replace("-", "_")
+
+
+class MongodEnvoy:
+    """Deploys a per-cluster L4 SNI-passthrough Envoy (ConfigMap + Deployment + NLB Service).
+
+    All Kubernetes writes go through ``api_client`` so the same helper deploys into any
+    member cluster's API. AWS writes (the NLB) happen via the in-tree cloud provider
+    reacting to the LoadBalancer Service — never an ad-hoc ``aws`` CLI call.
+    """
+
+    DEFAULT_IMAGE = "envoyproxy/envoy:v1.37-latest"
+
+    def __init__(
+        self,
+        namespace: str,
+        cluster_id: str,
+        routes: List[SniRoute],
+        *,
+        listen_port: int = 27017,
+        admin_port: int = 9901,
+        name: str = "mongod-envoy",
+        configmap_name: str = "mongod-envoy-config",
+        service_name: str = "mongod-envoy-svc",
+        external_dns_hostname: Optional[str] = None,
+        lb_security_groups: Optional[List[str]] = None,
+        api_client: Optional[kubernetes.client.ApiClient] = None,
+        image: str = DEFAULT_IMAGE,
+    ):
+        if not routes:
+            raise ValueError("MongodEnvoy requires at least one SniRoute")
+        self.namespace = namespace
+        self.cluster_id = cluster_id
+        self.routes = routes
+        self.listen_port = listen_port
+        self.admin_port = admin_port
+        self.name = name
+        self.configmap_name = configmap_name
+        self.service_name = service_name
+        self.external_dns_hostname = external_dns_hostname
+        self.lb_security_groups = lb_security_groups or []
+        self.api_client = api_client
+        self.image = image
+
+    # ---- Envoy config (L4 SNI passthrough) ---------------------------------------
+
+    def _build_filter_chain(self, route: SniRoute) -> str:
+        cluster_name = f"upstream_{route._ident}"
+        return f"""
+        - filter_chain_match:
+            server_names:
+            - "{route.server_name}"
+          filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: sni_{route._ident}
+              cluster: {cluster_name}"""
+
+    def _build_cluster(self, route: SniRoute) -> str:
+        cluster_name = f"upstream_{route._ident}"
+        # No transport_socket: passthrough. Envoy forwards the raw TLS bytes; the
+        # MongoDB handshake completes between the real client and the real mongod/mongos.
+        return f"""
+      - name: {cluster_name}
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: {cluster_name}
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {route.upstream_host}
+                    port_value: {route.upstream_port}
+        upstream_connection_options:
+          tcp_keepalive:
+            keepalive_time: 10
+            keepalive_interval: 3
+            keepalive_probes: 3"""
+
+    def _build_config(self) -> str:
+        filter_chains = "".join(self._build_filter_chain(r) for r in self.routes)
+        clusters = "".join(self._build_cluster(r) for r in self.routes)
+        return f"""admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: {self.admin_port}
+
+static_resources:
+  listeners:
+  - name: mongod_sni_listener
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: {self.listen_port}
+    listener_filters:
+    - name: envoy.filters.listener.tls_inspector
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    filter_chains:{filter_chains}
+
+  clusters:{clusters}
+
+layered_runtime:
+  layers:
+  - name: static_layer
+    static_layer:
+      overload:
+        global_downstream_max_connections: 50000
+"""
+
+    def create_configmap(self) -> None:
+        create_or_update_configmap(
+            self.namespace,
+            self.configmap_name,
+            {"envoy.yaml": self._build_config()},
+            api_client=self.api_client,
+        )
+        logger.info(
+            f"[{self.cluster_id}] mongodEnvoy ConfigMap {self.configmap_name} created "
+            f"with {len(self.routes)} SNI routes"
+        )
+
+    # ---- Workload (Deployment + NLB Service) -------------------------------------
+
+    def _deployment_manifest(self) -> dict:
+        labels = {"app": self.name, "component": "mongod-envoy"}
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": self.name, "labels": labels},
+            "spec": {
+                "replicas": 1,
+                "selector": {"matchLabels": {"app": self.name}},
+                "template": {
+                    "metadata": {"labels": labels},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "envoy",
+                                "image": self.image,
+                                "command": ["/usr/local/bin/envoy"],
+                                "args": ["-c", "/etc/envoy/envoy.yaml", "--log-level", "info"],
+                                "ports": [
+                                    {"name": "mongod-sni", "containerPort": self.listen_port},
+                                    {"name": "admin", "containerPort": self.admin_port},
+                                ],
+                                "resources": {
+                                    "requests": {"cpu": "100m", "memory": "128Mi"},
+                                    "limits": {"cpu": "500m", "memory": "512Mi"},
+                                },
+                                "readinessProbe": {
+                                    "httpGet": {"path": "/ready", "port": self.admin_port},
+                                    "initialDelaySeconds": 5,
+                                    "periodSeconds": 5,
+                                },
+                                "volumeMounts": [
+                                    {"name": "envoy-config", "mountPath": "/etc/envoy", "readOnly": True},
+                                ],
+                                "securityContext": {
+                                    "allowPrivilegeEscalation": False,
+                                    "capabilities": {"drop": ["ALL"]},
+                                },
+                            }
+                        ],
+                        "securityContext": {
+                            "runAsNonRoot": True,
+                            "runAsUser": 2000,
+                            "seccompProfile": {"type": "RuntimeDefault"},
+                        },
+                        "volumes": [
+                            {"name": "envoy-config", "configMap": {"name": self.configmap_name}},
+                        ],
+                    },
+                },
+            },
+        }
+
+    def create_deployment(self) -> None:
+        apps = client.AppsV1Api(api_client=self.api_client)
+        manifest = self._deployment_manifest()
+        try:
+            apps.create_namespaced_deployment(self.namespace, manifest)
+            logger.info(f"[{self.cluster_id}] mongodEnvoy Deployment {self.name} created")
+        except kubernetes.client.ApiException as e:
+            if e.status == 409:
+                apps.patch_namespaced_deployment(self.name, self.namespace, manifest)
+                logger.info(f"[{self.cluster_id}] mongodEnvoy Deployment {self.name} updated")
+            else:
+                raise
+
+    def _service_annotations(self) -> dict:
+        # internet-facing NLB; corp-prefix-locked via the security-group annotation.
+        # Never 0.0.0.0/0 — the SG must come from the corp managed prefix list.
+        annotations = {
+            "service.beta.kubernetes.io/aws-load-balancer-type": "external",
+            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+            "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+        }
+        if self.lb_security_groups:
+            annotations["service.beta.kubernetes.io/aws-load-balancer-security-groups"] = ",".join(
+                self.lb_security_groups
+            )
+            # BYO frontend SG ⇒ the AWS LB Controller no longer auto-opens the node SG to
+            # the NLB; without this the targets fail health checks (i/o timeout).
+            annotations[
+                "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules"
+            ] = "true"
+        if self.external_dns_hostname:
+            annotations["external-dns.alpha.kubernetes.io/hostname"] = self.external_dns_hostname
+        return annotations
+
+    def _service_manifest(self) -> dict:
+        return {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": self.service_name,
+                "labels": {"app": self.name},
+                "annotations": self._service_annotations(),
+            },
+            "spec": {
+                "type": "LoadBalancer",
+                "selector": {"app": self.name},
+                "ports": [
+                    {"name": "mongod-sni", "port": self.listen_port, "targetPort": self.listen_port},
+                ],
+            },
+        }
+
+    def create_service(self) -> None:
+        if self.lb_security_groups == []:
+            # Fail closed: an internet-facing NLB with no corp SG would default to open.
+            raise ValueError(
+                f"[{self.cluster_id}] mongodEnvoy refuses to create an internet-facing NLB without "
+                "a corp security group; pass lb_security_groups from the provisioned prefix-locked SGs"
+            )
+        core = client.CoreV1Api(api_client=self.api_client)
+        manifest = self._service_manifest()
+        try:
+            core.create_namespaced_service(self.namespace, manifest)
+            logger.info(f"[{self.cluster_id}] mongodEnvoy Service {self.service_name} (LoadBalancer) created")
+        except kubernetes.client.ApiException as e:
+            if e.status == 409:
+                core.patch_namespaced_service(self.service_name, self.namespace, manifest)
+                logger.info(f"[{self.cluster_id}] mongodEnvoy Service {self.service_name} updated")
+            else:
+                raise
+
+    # ---- Lifecycle ----------------------------------------------------------------
+
+    def wait_for_ready(self, timeout: int = 180) -> None:
+        apps = client.AppsV1Api(api_client=self.api_client)
+
+        def check() -> tuple:
+            try:
+                dep = apps.read_namespaced_deployment(self.name, self.namespace)
+                ready = dep.status.ready_replicas or 0
+                return ready >= 1, f"ready_replicas={ready}"
+            except Exception as e:  # noqa: BLE001 - surface any read error as not-ready
+                return False, f"Deployment {self.name} not readable: {e}"
+
+        run_periodically(
+            check, timeout=timeout, sleep_time=5, msg=f"[{self.cluster_id}] mongodEnvoy {self.name} ready"
+        )
+
+    def lb_hostname(self, timeout: int = 300) -> str:
+        """Block until the NLB is provisioned and return its external hostname.
+
+        external-dns publishes ``external_dns_hostname`` as a CNAME to this; callers
+        usually use the stable external-dns name, but this is handy for diagnostics.
+        """
+        core = client.CoreV1Api(api_client=self.api_client)
+
+        result: dict = {}
+
+        def check() -> tuple:
+            svc = core.read_namespaced_service(self.service_name, self.namespace)
+            ingress = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
+            if ingress and (ingress[0].hostname or ingress[0].ip):
+                result["host"] = ingress[0].hostname or ingress[0].ip
+                return True, f"NLB provisioned: {result['host']}"
+            return False, "NLB hostname not yet assigned"
+
+        run_periodically(
+            check, timeout=timeout, sleep_time=10, msg=f"[{self.cluster_id}] mongodEnvoy NLB provisioning"
+        )
+        return result["host"]
+
+    def deploy(self) -> None:
+        self.create_configmap()
+        self.create_deployment()
+        self.create_service()
+        self.wait_for_ready()
+        logger.info(f"[{self.cluster_id}] mongodEnvoy deployed ({len(self.routes)} SNI routes)")

--- a/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py
@@ -25,7 +25,7 @@ per-shard mongod multiplex onto a single listener port — SNI alone disambiguat
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import kubernetes
 from kubernetes import client
@@ -41,14 +41,23 @@ logger = test_logger.get_test_logger(__name__)
 class SniRoute:
     """One SNI-passthrough route.
 
-    ``server_name`` is the external FQDN the client puts in the TLS SNI (the pod's
-    ``externalDomain`` hostname). ``upstream_host``/``upstream_port`` is the in-cluster
-    address Envoy forwards the encrypted stream to (the pod's internal Service).
+    ``server_name`` is the external FQDN the client puts in the TLS SNI. The upstream Envoy
+    forwards the encrypted stream to is either a single ``upstream_host``/``upstream_port``,
+    or ``upstreams`` (round-robin endpoints, e.g. cross-cluster failover).
     """
 
     server_name: str
-    upstream_host: str
+    upstream_host: Optional[str] = None
     upstream_port: int = 27017
+    upstreams: Optional[Tuple[Tuple[str, int], ...]] = None
+
+    def __post_init__(self) -> None:
+        if not self.upstreams and not self.upstream_host:
+            raise ValueError("SniRoute requires upstream_host or upstreams")
+
+    @property
+    def endpoints(self) -> List[Tuple[str, int]]:
+        return list(self.upstreams) if self.upstreams else [(self.upstream_host, self.upstream_port)]
 
     @property
     def _ident(self) -> str:
@@ -116,6 +125,15 @@ class MongodEnvoy:
         cluster_name = f"upstream_{route._ident}"
         # No transport_socket: passthrough. Envoy forwards the raw TLS bytes; the
         # MongoDB handshake completes between the real client and the real mongod/mongos.
+        lb_endpoints = "".join(
+            f"""
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {host}
+                    port_value: {port}"""
+            for host, port in route.endpoints
+        )
         return f"""
       - name: {cluster_name}
         type: STRICT_DNS
@@ -123,12 +141,7 @@ class MongodEnvoy:
         load_assignment:
           cluster_name: {cluster_name}
           endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: {route.upstream_host}
-                    port_value: {route.upstream_port}
+          - lb_endpoints:{lb_endpoints}
         upstream_connection_options:
           tcp_keepalive:
             keepalive_time: 10

--- a/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/source_routes.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/source_routes.py
@@ -1,0 +1,105 @@
+"""Build the ``SniRoute`` list for a data cluster's mongodEnvoy from the source topology.
+
+Kept in the ``mongod_envoy`` package (not scattered in the test) so the SNI/passthrough
+routing model lives in one place. Each route maps the external pod FQDN a peer dials
+(``<pod>.<externalDomain>``, published by the MC MongoDB ``externalAccess.externalDomain``)
+to that pod's operator-generated external Service (``<pod>-svc-external.<ns>.svc.cluster.local``,
+a ClusterIP because externalService.spec.type is overridden to ClusterIP), which the L4 Envoy
+``tcp_proxy``-forwards the still-encrypted MongoDB wire stream to.
+
+Pod naming mirrors api/mongodb/v1/mdb/mongodb_types.go + pkg/dns for an MC sharded
+MongoDB:
+  - shard mongod:  ``{mdb}-{shardIdx}-{clusterIdx}-{member}``
+  - mongos:        ``{mdb}-mongos-{clusterIdx}-{pod}``
+  - config server: ``{mdb}-config-{clusterIdx}-{member}``
+
+``clusterIdx`` here is the SOURCE-internal cluster index (the position of the cluster in
+the MongoDB ``clusterSpecList``), NOT the harness ``cluster_index``.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from tests.common.mongod_envoy.mongod_envoy import SniRoute
+
+MONGODB_WIRE_PORT = 27017
+
+
+def _pod_route(mdb_name: str, pod: str, namespace: str, external_domain: str) -> SniRoute:
+    # Upstream is the pod's operator-generated EXTERNAL Service. Because every component
+    # (AppDB + source shard/config/mongos) overrides externalAccess.externalService to
+    # spec.type=ClusterIP, the operator names the per-pod Service `<pod>-svc-external`
+    # (a ClusterIP whose single endpoint is the pod) — there is NO `<pod>-svc`. Pointing
+    # the SNI passthrough at `-svc-external` is what lets a member reach its own external
+    # FQDN in-cluster (NLB -> Envoy -> here).
+    return SniRoute(
+        server_name=f"{pod}.{external_domain}",
+        upstream_host=f"{pod}-svc-external.{namespace}.svc.cluster.local",
+        upstream_port=MONGODB_WIRE_PORT,
+    )
+
+
+def build_replicaset_sni_routes(
+    *,
+    name: str,
+    namespace: str,
+    cluster_index: int,
+    members: int,
+    external_domain: str,
+) -> List[SniRoute]:
+    """One SNI route per replica-set member pod in a single member cluster.
+
+    Used for a non-sharded MC replica set fronted by one SNI Envoy (e.g. the OM AppDB):
+    pods are ``{name}-{cluster_index}-{member}``, the external FQDN is
+    ``<pod>.<external_domain>`` (resolved by the external-dns wildcard to the Envoy NLB),
+    and the upstream is the pod's internal per-pod headless Service ``<pod>-svc``.
+    """
+    return [
+        _pod_route(name, f"{name}-{cluster_index}-{member_idx}", namespace, external_domain)
+        for member_idx in range(members)
+    ]
+
+
+def build_source_sni_routes(
+    *,
+    mdb_name: str,
+    namespace: str,
+    source_cluster_index: int,
+    external_domain: str,
+    shard_count: int,
+    shard_members: int,
+    config_members: int,
+    mongos_members: int,
+) -> List[SniRoute]:
+    """One SNI route per source pod that physically lives in this data cluster.
+
+    ``external_domain`` is this data cluster's ``externalAccess.externalDomain``
+    (e.g. ``mongodb-proxy.<clusterId>.mc.mongokubernetes.com``); the external pod FQDN is
+    ``<pod>.<external_domain>``, which the external-dns wildcard ``*.<external_domain>``
+    resolves to this cluster's single mongodEnvoy NLB.
+    """
+    routes: List[SniRoute] = []
+
+    for pod_idx in range(mongos_members):
+        routes.append(
+            _pod_route(mdb_name, f"{mdb_name}-mongos-{source_cluster_index}-{pod_idx}", namespace, external_domain)
+        )
+
+    for member_idx in range(config_members):
+        routes.append(
+            _pod_route(mdb_name, f"{mdb_name}-config-{source_cluster_index}-{member_idx}", namespace, external_domain)
+        )
+
+    for shard_idx in range(shard_count):
+        for member_idx in range(shard_members):
+            routes.append(
+                _pod_route(
+                    mdb_name,
+                    f"{mdb_name}-{shard_idx}-{source_cluster_index}-{member_idx}",
+                    namespace,
+                    external_domain,
+                )
+            )
+
+    return routes

--- a/docker/mongodb-kubernetes-tests/tests/common/multicluster/multicluster_utils.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/multicluster/multicluster_utils.py
@@ -1,7 +1,80 @@
-from kubernetes.client import AppsV1Api
+from typing import Optional
+
+from kubernetes.client import ApiClient, AppsV1Api, CoreV1Api
 from kubernetes.client.rest import ApiException
 from kubetester.kubetester import run_periodically
 from kubetester.multicluster_client import MultiClusterClient
+
+
+def create_internet_facing_nlb(
+    api_client: Optional[ApiClient],
+    namespace: str,
+    *,
+    name: str,
+    selector_app: str,
+    port: int,
+    port_name: str,
+    security_groups: list[str],
+    external_dns_hostname: Optional[str] = None,
+    cluster_id: str = "",
+) -> None:
+    """Create-or-update a corp-SG-locked internet-facing NLB Service selecting ``app=selector_app``.
+
+    Fail-closed: refuses to provision an internet-facing NLB without a corp security group, so a
+    misconfigured run can never default to an open (0.0.0.0/0) load balancer.
+    """
+    if not security_groups:
+        raise ValueError(
+            f"[{cluster_id}] refusing to create internet-facing NLB {name!r} without a corp security "
+            "group; pass the provisioned prefix-locked SG(s)"
+        )
+    annotations = {
+        "service.beta.kubernetes.io/aws-load-balancer-type": "external",
+        "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+        "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+        "service.beta.kubernetes.io/aws-load-balancer-security-groups": ",".join(security_groups),
+        # BYO frontend SG ⇒ the AWS LB Controller no longer auto-opens the node SG to the NLB;
+        # without this the targets fail health checks (i/o timeout).
+        "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
+    }
+    if external_dns_hostname:
+        annotations["external-dns.alpha.kubernetes.io/hostname"] = external_dns_hostname
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": name, "labels": {"app": selector_app}, "annotations": annotations},
+        "spec": {
+            "type": "LoadBalancer",
+            "selector": {"app": selector_app},
+            "ports": [{"name": port_name, "port": port, "targetPort": port}],
+        },
+    }
+    core = CoreV1Api(api_client=api_client)
+    try:
+        core.create_namespaced_service(namespace, manifest)
+    except ApiException as exc:
+        if exc.status != 409:
+            raise
+        core.patch_namespaced_service(name, namespace, manifest)
+
+
+def wait_for_nlb_hostname(
+    api_client: Optional[ApiClient], namespace: str, name: str, *, cluster_id: str = "", timeout: int = 300
+) -> str:
+    """Block until the NLB Service has an ingress hostname/IP and return it."""
+    core = CoreV1Api(api_client=api_client)
+    result: dict = {}
+
+    def check():
+        svc = core.read_namespaced_service(name, namespace)
+        ingress = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
+        if ingress and (ingress[0].hostname or ingress[0].ip):
+            result["host"] = ingress[0].hostname or ingress[0].ip
+            return True, f"NLB provisioned: {result['host']}"
+        return False, "NLB hostname not yet assigned"
+
+    run_periodically(check, timeout=timeout, sleep_time=10, msg=f"[{cluster_id}] NLB {name} provisioning")
+    return result["host"]
 
 
 def multi_cluster_pod_names(replica_set_name: str, cluster_index_with_members: list[tuple[int, int]]) -> list[str]:

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -1292,13 +1292,11 @@ def get_cluster_clients() -> dict[str, kubernetes.client.api_client.ApiClient]:
             LEGACY_CENTRAL_CLUSTER_NAME: kubernetes.client.ApiClient(),
         }
 
-    member_clusters = [
-        _read_multi_cluster_config_value("member_cluster_1"),
-        _read_multi_cluster_config_value("member_cluster_2"),
-    ]
-
-    if len(get_member_cluster_names()) == 3:
-        member_clusters.append(_read_multi_cluster_config_value("member_cluster_3"))
+    # Read member_cluster_1..N (N = number of MEMBER_CLUSTERS); generalised from the
+    # former hard-coded 2/3 cases so 4-cluster real-infra runs (om-mdb-az1, mdb-az2,
+    # search-az1, search-az2) resolve too.
+    num_members = len(get_member_cluster_names())
+    member_clusters = [_read_multi_cluster_config_value(f"member_cluster_{i}") for i in range(1, num_members + 1)]
     return get_clients_for_clusters(member_clusters)
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/AWS_MC_SEARCH_ARCHITECTURE.md
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/AWS_MC_SEARCH_ARCHITECTURE.md
@@ -1,0 +1,286 @@
+# AWS multi-cluster sharded-search e2e — architecture & deployment
+
+Single reference for the real-infra (AWS EKS) multi-cluster MongoDBSearch scenario: **what
+the deployed architecture looks like** and **what deploys it** (infra scripts + the MCK e2e
+test). This is a mesh-free, VPC-peering-free cross-cluster search topology reached entirely
+over internet-facing NLBs fronted by L4 SNI-passthrough Envoys.
+
+- Infra provisioning: `scripts/aws/provision_aws_mc_infra.sh` (+ the `mongot_multicluster-infra` repo)
+- Cluster-side bootstrap: `scripts/dev/bootstrap_aws_mc_e2e.sh`
+- Context: `scripts/dev/contexts/e2e_aws_simulated_mc_sharded`
+- Runner: `scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh`
+- Test: `docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py`
+  (marker `e2e_aws_simulated_mc_sharded`, manual-only — never wired into Evergreen)
+- Data-plane Envoy helper: `docker/mongodb-kubernetes-tests/tests/common/mongod_envoy/mongod_envoy.py`
+
+---
+
+## 1. AWS infrastructure
+
+- **Account** `268558157000`, **region** `eu-south-1`, AWS profile **`mck-admin`**.
+- **Four EKS clusters**, each in its own VPC (no peering, no shared mesh). Provisioned by the
+  `mongot_multicluster-infra` repo's boto3 orchestrator (`scripts/enterprise/multicluster.py`),
+  one manifest per cluster (`manifest-mc-<ctx>.yaml`). EKS cluster name = `test-cluster-<clusterId>`.
+- **clusterId** = `<prefix>-mc-<context>`, prefix default `ls` (`MDB_MC_CLUSTER_ID_PREFIX`). So
+  contexts `om-mdb-az1`/`mdb-az2`/`search-az1`/`search-az2` → clusterIds `ls-mc-om-mdb-az1`, etc.
+- **Node storage**: search nodes are `r5d.xlarge` with instance-store NVMe; the infra runs a
+  `local-volume-provisioner` DaemonSet exposing a **`local-nvme`** StorageClass (whole-disk
+  ~139Gi PVs). mongot PVCs bind to `local-nvme` (not EBS gp2).
+- **In-cluster infra add-ons** (installed by the provisioner): AWS Load Balancer Controller,
+  external-dns, cert-manager, the storage classes / NVMe provisioner.
+- **Access**: EKS API endpoints are corp-VPN-prefix-locked. The harness authenticates with
+  long-lived per-cluster ServiceAccount **bearer tokens** (kube-system SA), not the kubeconfig
+  `aws eks get-token` exec.
+
+### Cluster roles (pinned by context name — never by harness sort index)
+
+| Context      | clusterId            | Role                                             |
+|--------------|----------------------|--------------------------------------------------|
+| `om-mdb-az1` | `ls-mc-om-mdb-az1`   | Central operator + OM/AppDB + shard data **AZ1** + cross-AZ **failover Envoy** |
+| `mdb-az2`    | `ls-mc-mdb-az2`      | Shard data **AZ2**                               |
+| `search-az1` | `ls-mc-search-az1`   | mongot search, **AZ1** (+ hosts the e2e test pod)|
+| `search-az2` | `ls-mc-search-az2`   | mongot search, **AZ2**                           |
+
+> **Index caveat:** the harness SORTS `MEMBER_CLUSTERS`, so harness `cluster_index` is
+> alphabetical: `mdb-az2=0, om-mdb-az1=1, search-az1=2, search-az2=3` — **not** declaration
+> order. Separately, the operator assigns the **source-internal** cluster index by sorted
+> data-cluster name: `mdb-az2 → 0 (AZ2)`, `om-mdb-az1 → 1 (AZ1)`. The two index systems never
+> collide (source idx ∈ {0,1}, search idx ∈ {2,3}).
+
+---
+
+## 2. Connectivity model — NLBs + SNI Envoys (no mesh, no peering)
+
+Every `*.svc.cluster.local` cross-cluster hop is replaced by an **external FQDN** behind an
+internet-facing NLB. NLBs are created from `LoadBalancer` Services via the AWS LB Controller
+(`create_internet_facing_nlb`, `multicluster_utils.py`): `scheme=internet-facing`,
+`nlb-target-type=instance`, and — critically — **corp-locked security groups** (never
+`0.0.0.0/0`; fail closed). external-dns publishes a wildcard CNAME per NLB.
+
+### LB security groups & ports (provisioned per cluster as `eks-lb-<svc>-sg-<clusterId>`)
+
+| `<svc>` | Port    | Fronts                                                    |
+|---------|---------|-----------------------------------------------------------|
+| `mongos`| `27017` | data-plane **mongodb-envoy** NLB (source mongod/mongos/AppDB) |
+| `mongod`| `27028` | search-managed **Envoy** NLB + the **failover** Envoy NLB (mongod→mongot) |
+| `om`    | `443`   | Ops Manager external LB                                    |
+
+Referenced from the Service via `aws-load-balancer-security-groups` using the exact
+cluster-suffixed name (`lb_sg()` in the test). `ENVOY_PROXY_PORT = 27028`.
+
+### DNS zones (external-dns)
+
+- Parent zone `mc.mongokubernetes.com`; per-cluster child zone `<clusterId>.mc.mongokubernetes.com`.
+- `*.mongodb-proxy.<clusterZone>` → that cluster's **mongodb-envoy** NLB (all MongoDB processes).
+- `*.envoy-proxy.<clusterZone>` → that cluster's **search-managed Envoy** NLB.
+- `*.envoy-proxy-failover.<centralZone>` → the **cross-AZ failover Envoy** NLB (central cluster).
+
+---
+
+## 3. Envoys
+
+Three Envoy layers. TLS stays **end-to-end** across the L4 ones — they read the ClientHello
+SNI with `tls_inspector` and `tcp_proxy`-forward the still-encrypted stream (no certs on the
+proxy). Only the operator-managed Envoy terminates TLS.
+
+### (a) Data-plane `mongodb-envoy` — L4 SNI passthrough (`MongodEnvoy`)
+One per **data** cluster (`mongodb_envoys` fixture). Fronts every MongoDB process in that
+cluster — source shard/config/mongos pods, plus the OM AppDB members (central only) — behind
+a single NLB + `*.mongodb-proxy.<clusterZone>` wildcard. The L4 listener demultiplexes by SNI
+server-name (pod FQDN); upstreams are the pods' internal headless Services. STRICT_DNS/round-robin.
+
+### (b) Search-managed Envoy — L7 (operator-owned), externally exposed
+The operator's managed-LB Envoy terminates mongod's TLS and re-initiates mTLS/gRPC to mongot,
+SNI-routing every per-(cluster,shard) and cluster-level FQDN on one `:27028` listener. The
+operator creates it as ClusterIP only, so the test adds **one** `LoadBalancer` Service
+(`<envoy>-ext`) selecting the Envoy pod + a `*.envoy-proxy.<clusterZone>` wildcard
+(`test_expose_search_managed_envoy_externally`). `ENVOY_LB_REPLICAS = 2`.
+
+### (c) Cross-AZ failover Envoy — L4 SNI passthrough (`search_failover_envoy`)
+One extra `MongodEnvoy` in the **central** cluster that **round-robins across both** search
+clusters' exposed managed-Envoy NLBs (az1 + az2), no health checks, fronted by its own NLB at
+`*.envoy-proxy-failover.<centralZone>`. Because L4 cannot rewrite SNI, functional failover
+requires the two search clusters to present **shard-unique, cluster-agnostic** SNI server names
+(the *same* per-shard hostname in both AZs) so the preserved SNI matches whichever AZ a
+connection lands on — see §5.
+
+---
+
+## 4. Source topology & per-AZ sync
+
+- Source sharded MongoDB `mdb-aws-mc-sh`: **2 shards**, spread across the two data clusters.
+  Per-shard members **2 in AZ1 / 1 in AZ2**; config RS 2/1; mongos 1 per AZ. In source-index
+  order (`SORTED_DATA=[mdb-az2, om-mdb-az1]`) that is `SHARD_MEMBERS_PER_CLUSTER=[1,2]`.
+- Source pods carry AZ **tags** (`memberConfig[].tags`, key `CLUSTER_LOCATION_TAG_KEY`); each
+  search cluster's MongoDBSearch `syncSourceSelector.matchTagSets` matches its own AZ, so a
+  cluster's mongot only syncs from same-AZ shard members (`az1 → search-az1`, `az2 → search-az2`).
+- OM/AppDB: OM `om-aws-mc` deployed by the scenario (not cloud-qa), OM 8.0.x; AppDB 3 members
+  in the central cluster, mesh-free via external FQDNs on the mongodb-envoy wildcard.
+- One `MongoDBSearch` CR **per search cluster** (`per_cluster_mdbs_search`), managed LB mode,
+  `MONGOT_REPLICAS_PER_CLUSTER=1`, persistence `local-nvme`/100Gi, mongot image
+  `quay.io/mongodb/mongodb-search:1.70.1`.
+
+---
+
+## 5. mongotHost wiring modes (`SOURCE_MONGOT_HOST_MODE`)
+
+The source processes' `mongotHost` (and `searchIndexManagementHostAndPort`) is set by patching
+the **OM AutomationConfig** directly (`_wire_source_mongot_host` → `patch_mongot_host_via_ac`),
+because there's no per-cluster `additionalMongodConfig` for an external source. Two switchable
+modes (resolver is a swappable function):
+
+- **`per_az_direct`** — each process → its OWN-AZ search cluster's managed-Envoy endpoint under
+  `*.envoy-proxy.<searchClusterZone>` (`_external_shard_envoy_endpoint` / `_external_mongos_envoy_endpoint`).
+- **`failover`** (current default) — every process → a **shard-unique, cluster-agnostic** host
+  under the failover wildcard, identical in both AZs (`_failover_shard_proxy_host` /
+  `_failover_router_host`, e.g. `mdb-aws-mc-sh-search-<shardName>-proxy-svc.envoy-proxy-failover.<centralZone>:27028`).
+  Routed through the failover Envoy, round-robined across both AZs.
+
+**Operator dependency:** failover mode needs the same managed-LB `externalHostname` /
+`routerHostname` on **both** clusters' CRs. The operator's original MC validation forbade shared
+hostnames across clusters; relaxing that is **PR #1305** (`search: allow shared managed-LB
+hostname across clusters`, branch `search/lsierant/relax-mc-hostname-validation`, off `master`).
+The `{shardName}` placeholder requirement is retained. The operator image used here is built
+from that branch.
+
+---
+
+## 6. TLS / certificates
+
+- cert-manager issues all certs. Source processes get external SANs covering their
+  `mongodb-proxy` FQDNs; OM/AppDB similarly.
+- Managed-LB server certs (`certs-…-search-lb-<idx>-cert`) carry **dual SANs** — both the
+  az-local (`*.envoy-proxy.<searchZone>`) and the failover (`*.envoy-proxy-failover.<centralZone>`)
+  hostnames — so flipping `SOURCE_MONGOT_HOST_MODE` needs no cert reissue
+  (`_create_external_lb_certificates`).
+- Source→mongot hop is enforced mTLS+gRPC via `setParameters` the operator applies and the test
+  asserts: `searchTLSMode=requireTLS`, `useGrpcForSearch=true`,
+  `skipAuthenticationToMongot=false`, `skipAuthenticationToSearchIndexManagementServer=false`.
+
+---
+
+## 7. Component versions / images
+
+| Component        | Image / version |
+|------------------|-----------------|
+| Operator         | `268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/mongodb-kubernetes:<patch-version_id>` (built from PR #1305 branch) |
+| mongot / search  | `quay.io/mongodb/mongodb-search:1.70.1` (`variables/mongodb_search_dev`; matches `release.json .search.version`) |
+| Ops Manager/AppDB | OM 8.0.x (`variables/om80`) |
+| Envoy (L4 self-managed) | `envoyproxy/envoy:v1.37-latest` |
+| Other operator sidecars | `…/staging:latest` (init/database/OM/readiness/upgradeHook) |
+
+Operator image is pinned in the **gitignored** `scripts/dev/contexts/private-context`
+(`OPERATOR_REGISTRY=…/dev` + `OPERATOR_VERSION=<patch version_id>`), NOT via
+`OVERRIDE_VERSION_ID` (which would wrongly pin all sidecars to the version_id on the staging
+registry). The operator install image is delivered through the `operator-installation-config`
+ConfigMap (`operator.version`, `search.*`), so an image repin requires re-running the bootstrap.
+
+---
+
+## 8. Deployment
+
+### 8.1 Provision AWS infra — `scripts/aws/provision_aws_mc_infra.sh`
+Orchestrates the `mongot_multicluster-infra` boto3 provisioner and writes the merged kubeconfig
+(`~/mdb/mongot_multicluster-infra/tmp/search-onprem.kubeconfig`). Phases:
+
+`preflight` → `reset` (clear stale `state-*.json`) → `up` (EKS control planes + node groups,
+through cert-manager) → `cpsubnets` (add free-IP public subnet per AZ; fixes the dense central
+cluster's IP exhaustion before apiaccess) → `apiaccess` (second pass: cross-cluster NAT
+allowlist) → `kubeconfig` (per-cluster `update-kubeconfig`, aliased to short context) → `verify`
+(node reachability, needs VPN). `full` also runs `tokens` + `bootstrap`.
+
+```
+AWS_PROFILE=mck-admin scripts/aws/provision_aws_mc_infra.sh          # default pipeline
+AWS_PROFILE=mck-admin scripts/aws/provision_aws_mc_infra.sh full     # + tokens + bootstrap
+```
+Teardown: `mongot_multicluster-infra/scripts/enterprise/multicluster.py down` (note: LB-Controller
+NLBs/TGs can orphan → VPC DependencyViolation; delete NLBs+TGs first).
+
+### 8.2 SA bearer tokens — `scripts/dev/prepare_aws_mc_tokens.sh`
+Extracts per-cluster kube-system SA tokens into `MULTI_CLUSTER_CONFIG_DIR`
+(`~/.mck-aws-mc-config`: `central_cluster`, `member_cluster_1..4`, one per context). The harness
+reads bearer tokens from here.
+
+### 8.3 Cluster-side bootstrap — `scripts/dev/bootstrap_aws_mc_e2e.sh`
+Idempotent (does NOT deploy workloads). Replaces the kind-specific `prepare_local_e2e_run.sh`.
+Per cluster: test namespace (`evg=task` label), `image-registries-secret` (ECR pull),
+`mongodb-kubernetes-database-pods` / `-appdb` ServiceAccounts (Helm-owned, wired to the pull
+secret). Central: the **`operator-installation-config` ConfigMap** (operator + search image
+values via `get_operator_helm_values`). test-pod cluster: `test-pod-kubeconfig` secret
+(member API-server discovery). **Re-run this after any operator/search image repin.**
+
+### 8.4 Context — `scripts/dev/contexts/e2e_aws_simulated_mc_sharded`
+Sources `root-context` + `variables/om80` + `variables/mongodb_search_dev`; forces the AWS
+kubeconfig + `MEMBER_CLUSTERS`/`CENTRAL_CLUSTER`/`test_pod_cluster`, `LOCAL_OPERATOR=false`,
+`OPERATOR_NAME=mongodb-kubernetes-operator-multi-cluster`, `MDB_MC_CLUSTER_ID_PREFIX=ls`.
+
+### 8.5 Runner — `scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh`
+Self-contained: preloads `.generated/context.env` (for `REGISTRY`), sources the AWS context,
+applies the `MCK_DEVC_NET_PREFIX → <ns>-<prefix>` namespace mapping (+ `WATCH_NAMESPACE`), stages
+the gitignored `helm_chart` into the test dir (so `helm template` resolves the local chart),
+activates the venv, then runs pytest with marker `e2e_aws_simulated_mc_sharded`.
+
+```
+MCK_DEVC_NET_PREFIX=1280 AWS_PROFILE=mck-admin \
+  scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh -- [extra pytest args]
+```
+
+> These scripts previously depended on the devcontainer layer (`scripts/dev/devenv`, the
+> `MCK_DEVC_NET_PREFIX` mapping). This branch is AWS-only and operator-clean; the runner/bootstrap
+> reproduce those inline.
+
+---
+
+## 9. e2e test flow (`aws_simulated_mc_sharded.py`, in order)
+
+1. `test_install_central_mc_operator` — central MC operator via Helm (`wait_for_operator_ready`).
+2. `test_deploy_mongodb_envoys` — one L4 mongodb-envoy + NLB per data cluster.
+3. `test_deploy_ops_manager` — OM + AppDB (mesh-free external FQDNs).
+4. `test_install_source_tls_certificates` — source/shard external-SAN certs.
+5. `test_create_mdb_source` — the sharded MongoDB source.
+6. `test_mongodb_running`, `test_source_spread_across_data_clusters` — shards land per AZ.
+7. `test_create_users` — admin / app / mongot users.
+8. `test_install_simulated_operators_on_search_clusters` — per-search-cluster operators
+   (Helm `--install`, release **`mongodb-kubernetes`**, watches `mongodbsearch` only).
+9. `test_create_search_tls_certificates` — managed-LB dual-SAN (az-local + failover) certs.
+10. `test_replicate_search_secrets_to_members` — copy CA/user secrets to search clusters.
+11. `test_search_cr_reaches_running_per_cluster` — both MongoDBSearch CRs reach **Running**
+    (shared failover hostname → requires the relaxed operator, §5).
+12. `test_expose_search_managed_envoy_externally` — add the `<envoy>-ext` NLB + wildcard.
+13. `test_deploy_search_failover_envoy` — cross-AZ failover Envoy + NLB.
+14. `test_per_cluster_sharded_resources_exist` — per-(cluster,shard) mongot STS/Svc/CM/proxy.
+15. `test_status_per_cluster_local_only` — per-cluster CR status.
+16. `test_shard_sample_collection`, `test_restore_sample_database`, `test_shard_distribution`
+    — load + shard `sample_mflix` (**skip on a no-clean rerun** — they duplicate data).
+17. `test_wire_source_mongot_host_per_az` — patch OM AC `mongotHost` per `SOURCE_MONGOT_HOST_MODE`.
+18. `test_create_search_index_and_query` — create `$search` index + query.
+19. `test_search_results_from_all_shards` — deterministic `$search` fan-out across both shards
+    (validated live via the **failover** path).
+20. `test_create_vector_search_index`, `test_vector_search_query_via_source_mongos` — vector search.
+21. `test_cross_cluster_isolation_absence` — negative isolation checks.
+
+---
+
+## 10. End-to-end path (failover mode)
+
+```
+                        ┌─────────────────────────────── om-mdb-az1 (central) ───────────────────────────────┐
+ $search client         │  MC operator + OM/AppDB + shard data AZ1                                            │
+      │                 │                                                                                     │
+      ▼                 │   ┌── mongodb-envoy (L4 SNI) ──┐        ┌── search-failover-envoy (L4 SNI) ──┐       │
+ mongos (source) ───────┼──►│ *.mongodb-proxy.<az1>      │        │ *.envoy-proxy-failover.<az1>       │       │
+   mongotHost =         │   └── upstreams: source pods ──┘        │ round-robin, no health checks       │      │
+   *.envoy-proxy-       │                                          └──────┬───────────────┬────────────┘      │
+   failover.<az1>:27028 └─────────────────────────────────────────────────┼───────────────┼──────────────────┘
+                                                                           ▼               ▼
+                                              ┌── search-az1 ──────────────┐   ┌── search-az2 ──────────────┐
+                                              │ managed Envoy (L7, mTLS/gRPC)│   │ managed Envoy (L7, mTLS/gRPC)│
+                                              │ *.envoy-proxy.<az1>-ext NLB  │   │ *.envoy-proxy.<az2>-ext NLB  │
+                                              │        ▼ mongot (1.70.1)     │   │        ▼ mongot (1.70.1)     │
+                                              │        NVMe (local-nvme)     │   │        NVMe (local-nvme)     │
+                                              └──────────────────────────────┘   └──────────────────────────────┘
+      (mdb-az2 mirrors om-mdb-az1's data role for AZ2; its own mongodb-envoy fronts AZ2 source pods)
+```
+
+The same shard-unique SNI hostname is presented in both AZs, so the failover Envoy can
+round-robin to either search cluster's managed Envoy and the preserved SNI still matches.

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -302,13 +302,23 @@ def _router_host_seeds() -> List[str]:
 
 def _external_shard_proxy_template(search_context: str, harness_idx: int) -> str:
     """Managed-LB externalHostname for a search cluster: the per-shard proxy-svc name with
-    the {shardName} placeholder retained (operator resolves per shard), under the search
-    cluster's external-dns wildcard. The operator also derives the cluster-level (mongos)
-    proxy host by stripping the per-shard segment."""
+    the {shardName} placeholder retained (operator resolves it per shard via ReplaceAll),
+    under the search cluster's external-dns wildcard. Host-only (no port): the operator uses
+    it verbatim as the per-shard Envoy SNI server_name, which a TLS ClientHello carries
+    without a port. The shard-agnostic mongos SNI is configured separately via routerHostname
+    (see _external_mongos_proxy_host)."""
     return (
         f"{MDBS_RESOURCE_NAME}-search-{harness_idx}-{{shardName}}-proxy-svc."
         f"{search_proxy_wildcard(search_context)}"
     )
+
+
+def _external_mongos_proxy_host(search_context: str, harness_idx: int) -> str:
+    """Managed-LB routerHostname for a search cluster: the shard-agnostic cluster-level
+    proxy-svc host the mongos reaches, under the external-dns wildcard. Host-only (no port):
+    the operator uses it verbatim as the cluster-level Envoy SNI server_name. Must be in the
+    managed-LB server cert SANs (see test_create_search_tls_certificates)."""
+    return f"{MDBS_RESOURCE_NAME}-search-{harness_idx}-proxy-svc.{search_proxy_wildcard(search_context)}"
 
 
 def _external_shard_envoy_endpoint(search_context: str, harness_idx: int, shard_idx: int) -> str:
@@ -323,11 +333,9 @@ def _external_shard_envoy_endpoint(search_context: str, harness_idx: int, shard_
 
 def _external_mongos_envoy_endpoint(search_context: str, harness_idx: int) -> str:
     """A search cluster's cluster-level managed-Envoy endpoint (external), the mongos
-    mongotHost target."""
-    return (
-        f"{MDBS_RESOURCE_NAME}-search-{harness_idx}-proxy-svc."
-        f"{search_proxy_wildcard(search_context)}:{ENVOY_PROXY_PORT}"
-    )
+    mongotHost target. Host:port — the source mongos automationConfig needs the port; the
+    SNI server_name (routerHostname) is the host-only form."""
+    return f"{_external_mongos_proxy_host(search_context, harness_idx)}:{ENVOY_PROXY_PORT}"
 
 
 def _source_mongos_search_tester(
@@ -784,6 +792,7 @@ def per_cluster_mdbs_search(
                     "managed": {
                         "replicas": ENVOY_LB_REPLICAS,
                         "externalHostname": _external_shard_proxy_template(ctx, idx),
+                        "routerHostname": _external_mongos_proxy_host(ctx, idx),
                     },
                 },
                 "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: AZ_BY_SEARCH_CLUSTER[ctx]}]},

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -379,23 +379,28 @@ def _external_mongos_envoy_endpoint(search_context: str, harness_idx: int) -> st
     return f"{_external_mongos_proxy_host(search_context, harness_idx)}:{ENVOY_PROXY_PORT}"
 
 
+def _failover_shard_proxy_host(shard_name: str) -> str:
+    """Shard-unique, cluster-AGNOSTIC per-shard proxy host (no port) under the failover wildcard:
+    the SAME hostname in BOTH AZs (no cluster idx / clusterId), so the SNI a connection carries
+    matches whichever AZ the failover Envoy round-robins onto. shard_name is the operator's
+    literal {shardName} placeholder (managed-LB externalHostname) or a concrete shard name
+    (mongotHost target / cert SAN)."""
+    return f"{MDBS_RESOURCE_NAME}-search-{shard_name}-proxy-svc.{search_failover_wildcard(SEARCH_FAILOVER_HOST_CLUSTER)}"
+
+
+def _failover_router_host() -> str:
+    """Cluster-AGNOSTIC cluster-level (mongos) proxy host (no port) under the failover wildcard."""
+    return f"{MDBS_RESOURCE_NAME}-search-proxy-svc.{search_failover_wildcard(SEARCH_FAILOVER_HOST_CLUSTER)}"
+
+
 def _failover_shard_proxy_endpoint(shard_idx: int) -> str:
-    """Shard-unique, cluster-AGNOSTIC per-shard mongot endpoint under the failover wildcard:
-    the SAME hostname in both AZs (no cluster idx / clusterId), so the SNI a connection carries
-    matches whichever AZ the failover Envoy round-robins onto. host:port form."""
-    shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
-    return (
-        f"{MDBS_RESOURCE_NAME}-search-{shard_name}-proxy-svc."
-        f"{search_failover_wildcard(SEARCH_FAILOVER_HOST_CLUSTER)}:{ENVOY_PROXY_PORT}"
-    )
+    """Cluster-agnostic per-shard mongot endpoint (host:port) — the mongod mongotHost target."""
+    return f"{_failover_shard_proxy_host(f'{MDB_RESOURCE_NAME}-{shard_idx}')}:{ENVOY_PROXY_PORT}"
 
 
 def _failover_mongos_proxy_endpoint() -> str:
-    """Cluster-AGNOSTIC cluster-level mongot endpoint under the failover wildcard (mongos)."""
-    return (
-        f"{MDBS_RESOURCE_NAME}-search-proxy-svc."
-        f"{search_failover_wildcard(SEARCH_FAILOVER_HOST_CLUSTER)}:{ENVOY_PROXY_PORT}"
-    )
+    """Cluster-agnostic cluster-level mongot endpoint (host:port) — the mongos mongotHost target."""
+    return f"{_failover_router_host()}:{ENVOY_PROXY_PORT}"
 
 
 def _source_mongos_search_tester(
@@ -845,6 +850,16 @@ def per_cluster_mdbs_search(
     for mcc in search_mccs:
         idx = _idx(mcc)
         ctx = mcc.cluster_name
+        # The managed Envoy's SNI server_name (filter-chain match + server-cert validation) follows
+        # SOURCE_MONGOT_HOST_MODE: az-local per-cluster names, or the cluster-agnostic failover names
+        # (identical in both AZs, so the failover Envoy can round-robin either way). The server cert
+        # SANs cover BOTH, so flipping the mode needs no cert reissue.
+        if SOURCE_MONGOT_HOST_MODE == "failover":
+            external_hostname = _failover_shard_proxy_host("{shardName}")
+            router_hostname = _failover_router_host()
+        else:
+            external_hostname = _external_shard_proxy_template(ctx, idx)
+            router_hostname = _external_mongos_proxy_host(ctx, idx)
         clusters_spec.append(
             {
                 "name": ctx,
@@ -854,8 +869,8 @@ def per_cluster_mdbs_search(
                 "loadBalancer": {
                     "managed": {
                         "replicas": ENVOY_LB_REPLICAS,
-                        "externalHostname": _external_shard_proxy_template(ctx, idx),
-                        "routerHostname": _external_mongos_proxy_host(ctx, idx),
+                        "externalHostname": external_hostname,
+                        "routerHostname": router_hostname,
                     },
                 },
                 "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: AZ_BY_SEARCH_CLUSTER[ctx]}]},
@@ -1110,10 +1125,14 @@ def _create_external_lb_certificates(*, namespace, issuer, search_mccs, api_clie
         server_domains: List[str] = []
         for shard_idx in range(SHARD_COUNT):
             shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            # az-local: per-cluster SNI (per_az_direct mode).
             server_domains.append(
                 f"{MDBS_RESOURCE_NAME}-search-{idx}-{shard_name}-proxy-svc.{search_proxy_wildcard(ctx)}"
             )
+            # failover: cluster-agnostic SNI, identical in both AZs (failover mode).
+            server_domains.append(_failover_shard_proxy_host(shard_name))
         server_domains.append(f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc.{search_proxy_wildcard(ctx)}")
+        server_domains.append(_failover_router_host())
 
         create_tls_certs(
             issuer=issuer,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -281,7 +281,7 @@ SOURCE_SEARCH_SET_PARAMETERS = {
 #                     failover Envoy wildcard, round-robined across both AZs. Functional only
 #                     once both search clusters present the same cluster-agnostic SNI server
 #                     names + cert SANs (the failover follow-up).
-SOURCE_MONGOT_HOST_MODE = "per_az_direct"
+SOURCE_MONGOT_HOST_MODE = "failover"
 
 
 # ---------------------------------------------------------------------------
@@ -891,7 +891,10 @@ def per_cluster_mdbs_search(
         }
         mdbs["spec"]["security"] = {"tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX}}
         mdbs.api = kubernetes.client.CustomObjectsApi(mcc.api_client)
-        try_load(mdbs)
+        # try_load would mark the object bound and make create_or_update patch the SERVER's
+        # existing spec on the first try, dropping our changes. Leave it unbound so the rebuilt
+        # spec (failover-mode externalHostname/persistence/etc.) is actually applied.
+        # try_load(mdbs)
         results.append((mcc, mdbs))
     return results
 
@@ -913,7 +916,7 @@ def tools_pod(namespace: str, member_cluster_clients: List[MultiClusterClient]) 
 
 @mark.e2e_aws_simulated_mc_sharded
 def test_install_central_mc_operator(central_mc_operator: Operator):
-    central_mc_operator.assert_is_running()
+    central_mc_operator.wait_for_operator_ready()
 
 
 @mark.e2e_aws_simulated_mc_sharded
@@ -1077,7 +1080,7 @@ def test_install_simulated_operators_on_search_clusters(
     base_helm_args = dict(multi_cluster_operator_installation_config)
     for mcc in _search_mccs(member_cluster_clients):
         operator = _install_simulated_operator(namespace, base_helm_args, mcc)
-        operator.assert_is_running()
+        operator.wait_for_operator_ready()
 
 
 @mark.e2e_aws_simulated_mc_sharded
@@ -1430,7 +1433,11 @@ def _assert_source_routed_per_az(
             s_idx = search_idx[search_ctx]
             mcc = _mcc(member_cluster_clients, data_context)
             for shard_idx in range(SHARD_COUNT):
-                expected = _external_shard_envoy_endpoint(search_ctx, s_idx, shard_idx)
+                expected = (
+                    _failover_shard_proxy_endpoint(shard_idx)
+                    if SOURCE_MONGOT_HOST_MODE == "failover"
+                    else _external_shard_envoy_endpoint(search_ctx, s_idx, shard_idx)
+                )
                 for member_idx in range(SHARD_MEMBERS_PER_CLUSTER[src_idx] or 0):
                     pod_name = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}-{member_idx}"
                     try:
@@ -1460,7 +1467,11 @@ def _assert_source_routed_per_az(
     get_params.update({k: 1 for k in SOURCE_SEARCH_SET_PARAMETERS})
     for data_context in DATA_CLUSTERS:
         search_ctx = SEARCH_FOR_DATA_CLUSTER[data_context]
-        mongos_expected = _external_mongos_envoy_endpoint(search_ctx, search_idx[search_ctx])
+        mongos_expected = (
+            _failover_mongos_proxy_endpoint()
+            if SOURCE_MONGOT_HOST_MODE == "failover"
+            else _external_mongos_envoy_endpoint(search_ctx, search_idx[search_ctx])
+        )
         tester = _source_mongos_search_tester(
             member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD, data_context=data_context
         )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -1055,14 +1055,14 @@ def test_create_search_tls_certificates(
 
 
 def _create_external_lb_certificates(*, namespace, issuer, search_mccs, api_client) -> None:
-    """Managed-LB (search Envoy) server + client certs. The SERVER cert SANs the EXTERNAL
-    per-shard + cluster-level proxy FQDNs (what the source mongod dials as mongotHost); the
-    CLIENT cert (Envoy -> mongot, internal) keeps the in-cluster wildcard. Single secret
-    name (no cluster index), so one cert covers every search cluster's external FQDNs."""
-    server_domains: List[str] = []
+    """Per-cluster managed-LB (search Envoy) server + client certs. The SERVER cert SANs the
+    EXTERNAL per-shard + cluster-level proxy FQDNs (what the source mongod dials as mongotHost);
+    the CLIENT cert (Envoy -> mongot, internal) keeps the in-cluster wildcard. Secret names
+    carry the cluster index (search-lb-{idx}-cert) to match the operator's per-cluster LB certs."""
     for mcc in search_mccs:
         idx = _idx(mcc)
         ctx = mcc.cluster_name
+        server_domains: List[str] = []
         for shard_idx in range(SHARD_COUNT):
             shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
             server_domains.append(
@@ -1070,29 +1070,29 @@ def _create_external_lb_certificates(*, namespace, issuer, search_mccs, api_clie
             )
         server_domains.append(f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc.{search_proxy_wildcard(ctx)}")
 
-    create_tls_certs(
-        issuer=issuer,
-        namespace=namespace,
-        resource_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
-        replicas=1,
-        service_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
-        additional_domains=server_domains,
-        secret_name=search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
-        api_client=api_client,
-    )
-    logger.info(f"managed-LB server cert created with EXTERNAL SANs={server_domains}")
+        create_tls_certs(
+            issuer=issuer,
+            namespace=namespace,
+            resource_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, idx),
+            replicas=1,
+            service_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, idx),
+            additional_domains=server_domains,
+            secret_name=search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, idx),
+            api_client=api_client,
+        )
+        logger.info(f"[{ctx}] managed-LB server cert (idx={idx}) created with EXTERNAL SANs={server_domains}")
 
-    create_tls_certs(
-        issuer=issuer,
-        namespace=namespace,
-        resource_name=f"{search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME)}-client",
-        replicas=1,
-        service_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
-        additional_domains=[f"*.{namespace}.svc.cluster.local"],
-        secret_name=search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
-        api_client=api_client,
-    )
-    logger.info("managed-LB client cert created with internal SANs")
+        create_tls_certs(
+            issuer=issuer,
+            namespace=namespace,
+            resource_name=f"{search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, idx)}-client",
+            replicas=1,
+            service_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, idx),
+            additional_domains=[f"*.{namespace}.svc.cluster.local"],
+            secret_name=search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, idx),
+            api_client=api_client,
+        )
+        logger.info(f"[{ctx}] managed-LB client cert (idx={idx}) created with internal SANs")
 
 
 @mark.e2e_aws_simulated_mc_sharded
@@ -1115,24 +1115,23 @@ def test_replicate_search_secrets_to_members(
         for mcc in targets:
             create_or_update_secret(namespace, secret_name, data, type=secret_type, api_client=mcc.api_client)
 
-    for secret_name in [
-        search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
-        search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
-        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
-    ]:
-        _copy(secret_name, search_mccs)
-        logger.info(f"replicated shared Secret {secret_name} to {len(search_mccs)} search cluster(s)")
+    _copy(f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password", search_mccs)
+    logger.info(f"replicated shared mongot password Secret to {len(search_mccs)} search cluster(s)")
 
     for mcc in search_mccs:
+        idx = _idx(mcc)
+        # Per-cluster managed-LB certs (search-lb-{idx}-cert) go only to their own cluster.
+        _copy(search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, idx), [mcc])
+        _copy(search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, idx), [mcc])
         for shard_idx in range(SHARD_COUNT):
             shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
             _copy(
                 search_resource_names.shard_tls_cert_name(
-                    MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index=_idx(mcc)
+                    MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index=idx
                 ),
                 [mcc],
             )
-        logger.info(f"replicated per-shard Secrets to {mcc.cluster_name} (cluster_index={_idx(mcc)})")
+        logger.info(f"replicated per-cluster LB + per-shard Secrets to {mcc.cluster_name} (cluster_index={idx})")
 
 
 @mark.e2e_aws_simulated_mc_sharded

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -1,13 +1,12 @@
 """Real-infra (AWS EKS) multi-cluster MongoDBSearch e2e with a SHARDED external source.
 
-Forked from simulated_mc_sharded.py to run on the four real EKS clusters in
-mongot_multicluster-infra (see tmp/INFRASTRUCTURE.md, tmp/MULTICLUSTER_PLAN.md,
-tmp/E2E_SCENARIO_PLAN.md). Unlike the simulated variant, this runs with NO Istio mesh
+Runs against the four real EKS clusters in mongot_multicluster-infra with NO Istio mesh
 and NO VPC peering: every cross-cluster hop flows over per-cluster internet-facing NLBs.
 The data plane is fronted by a self-managed L4 SNI-passthrough Envoy (mongodEnvoy), one
 per data cluster, behind a single NLB + external-dns wildcard. The source sharded
-MongoDB is spread across two AZ data clusters (no single-cluster index pin), OM is
-deployed by the scenario, and per-AZ mongot targeting uses member tagSets.
+MongoDB is spread across two AZ data clusters, OM is deployed by the scenario, and per-AZ
+mongot targeting uses member tagSets. This marker is run manually (not wired into Evergreen);
+it requires the corp VPN and the provisioned four-cluster infra.
 
 Cluster roles (pin explicitly; the harness SORTS MEMBER_CLUSTERS, so harness indexes are
 alphabetical: mdb-az2=0, om-mdb-az1=1, search-az1=2, search-az2=3 — NOT declaration
@@ -17,8 +16,7 @@ order). Never derive a role from a harness sort index.
   - search-az1  (ls-mc-search-az1): mongot search, AZ1
   - search-az2  (ls-mc-search-az2): mongot search, AZ2
 
-Index model (this is the crux that differs from the base, which pinned the source to one
-cluster => everything had a "-0-" suffix):
+Index model:
   * The source sharded MongoDB spans the TWO data clusters. Its SOURCE-internal cluster
     index is assigned by the operator in SORTED cluster-name order (NOT clusterSpecList
     declaration order — see mongodbshardedcluster_controller.go: slices.Sort before
@@ -34,16 +32,16 @@ cluster => everything had a "-0-" suffix):
     per-(cluster, shard) mongot resource names ({mdbs}-search-{harnessIdx}-{shard}-...).
     The two index systems never collide (source idx in {0,1}, search idx in {2,3}).
 
-Connectivity seams vs the base (the fork's whole job): every ".svc.cluster.local"
-cross-cluster hop is swapped for an EXTERNAL FQDN served by an SNI front:
+Connectivity seams: every ".svc.cluster.local" cross-cluster hop is served instead by an
+EXTERNAL FQDN behind an SNI front:
   * source mongod/mongos seeds (mongot syncSource) AND the OM AppDB members -> external
     FQDNs under *.mongodb-proxy.<dataClusterId>.mc... (the shared per-cluster mongodb-envoy NLB).
   * the mongotHost flip endpoints (mongos cluster-level + per-shard) -> external FQDNs
     under *.envoy-proxy.<searchClusterId>.mc... (the operator-managed search Envoy LB).
   * mongodEnvoy upstreams stay INTERNAL (the per-pod headless Services).
 
-mongotHost routing stays on the interim OM Automation Config patch until the operator
-gains per-cluster additionalMongodConfig (E2E_SCENARIO_PLAN.md gap #1).
+The source mongotHost is set by patching the OM Automation Config directly, since the
+operator has no per-cluster additionalMongodConfig for an external source.
 """
 
 from __future__ import annotations
@@ -72,7 +70,11 @@ from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.common.mongod_envoy.mongod_envoy import MongodEnvoy, SniRoute
 from tests.common.mongod_envoy.source_routes import build_replicaset_sni_routes, build_source_sni_routes
 from tests.common.mongodb_tools_pod.mongodb_tools_pod import ToolsPod, get_tools_pod
-from tests.common.multicluster.multicluster_utils import assert_workload_ready_in_cluster
+from tests.common.multicluster.multicluster_utils import (
+    assert_workload_ready_in_cluster,
+    create_internet_facing_nlb,
+    wait_for_nlb_hostname,
+)
 from tests.common.search import search_resource_names
 from tests.common.search.connectivity import CLUSTER_LOCATION_TAG_KEY
 from tests.common.search.mc_search_helper import (
@@ -126,11 +128,15 @@ DATA_MDB_AZ2 = "mdb-az2"
 SEARCH_AZ1 = "search-az1"
 SEARCH_AZ2 = "search-az2"
 
+# Infra-assigned clusterId per context, of the form "<prefix>-mc-<context>" (see the
+# mongot_multicluster-infra manifest-mc-*.yaml clusterId fields). The prefix identifies the
+# deployment/infra and names + tags every cloud resource (EKS cluster, DNS child zone, LB
+# security groups), so it MUST match the infra the run targets — parameterized via
+# MDB_MC_CLUSTER_ID_PREFIX (the e2e context exports it; defaults to "ls" for the current infra).
+CLUSTER_ID_PREFIX = os.environ.get("MDB_MC_CLUSTER_ID_PREFIX", "ls")
 CLUSTER_IDS = {
-    CENTRAL_OM_MDB_AZ1: "ls-mc-om-mdb-az1",
-    DATA_MDB_AZ2: "ls-mc-mdb-az2",
-    SEARCH_AZ1: "ls-mc-search-az1",
-    SEARCH_AZ2: "ls-mc-search-az2",
+    ctx: f"{CLUSTER_ID_PREFIX}-mc-{ctx}"
+    for ctx in (CENTRAL_OM_MDB_AZ1, DATA_MDB_AZ2, SEARCH_AZ1, SEARCH_AZ2)
 }
 
 DATA_CLUSTERS = [CENTRAL_OM_MDB_AZ1, DATA_MDB_AZ2]
@@ -149,14 +155,14 @@ SOURCE_CLUSTER_INDEX = {ctx: i for i, ctx in enumerate(SORTED_DATA)}
 # AZ tag applied to source shard members (memberConfig[].tags) and matched by each search
 # cluster's syncSourceSelector so a search cluster's mongot only syncs from its same-AZ
 # shard members. Tag key reuses the shared CLUSTER_LOCATION_TAG_KEY (operator renders it to
-# mongot syncSource.replicationReader.tagSets, the q3 path).
+# mongot syncSource.replicationReader.tagSets).
 AZ_BY_DATA_CLUSTER = {CENTRAL_OM_MDB_AZ1: "az1", DATA_MDB_AZ2: "az2"}
 AZ_BY_SEARCH_CLUSTER = {SEARCH_AZ1: "az1", SEARCH_AZ2: "az2"}
 
 PARENT_ZONE = "mc.mongokubernetes.com"
 
-# Corp-prefix-locked LB security groups provisioned by create_eks_cluster.py (one port each;
-# INFRASTRUCTURE.md). Referenced by the AWS Load Balancer Controller via the
+# Corp-prefix-locked LB security groups provisioned by the infra (create_eks_cluster.py, one
+# port each). Referenced by the AWS Load Balancer Controller via the
 # aws-load-balancer-security-groups annotation so every internet-facing NLB is corp-locked
 # (NEVER 0.0.0.0/0 — fail closed). The infra names each SG per-cluster as
 # `eks-lb-<svc>-sg-<clusterId>` (create_eks_cluster.py: _ensure_sg(..., f"eks-lb-{svc}-sg-{cluster_id}")),
@@ -868,9 +874,9 @@ def test_install_source_tls_certificates(
     central_cluster_client: kubernetes.client.ApiClient,
     mdb: MongoDB,
 ):
-    """Source per-component TLS certs (q3 pattern) issued on central; the central MongoDB
-    controller replicates them to the data members. Certs carry EXTERNAL domains only
-    (added as additional_domains): the operator publishes external process hostnames."""
+    """Source per-component TLS certs issued on central; the central MongoDB controller
+    replicates them to the data members. Certs carry EXTERNAL domains only (added as
+    additional_domains): the operator publishes external process hostnames."""
 
     def _issue(component_resource: str, secret_name: str, distribution: List[int | None], additional_domains: List[str]):
         create_tls_certs(
@@ -1147,64 +1153,26 @@ def test_expose_search_managed_envoy_externally(
     into LoadBalancers; that both mutates operator state and yields N pending NLBs all selecting
     the same pod). The new Service is created by the test and owned by the test.
     """
-    mongot_grpc_port = 27028  # Envoy listener (see LB_SVC_MONGOD)
     ext_svcs: List[Tuple[MultiClusterClient, str]] = []
     for mcc, _mdbs in per_cluster_mdbs_search:
-        idx = _idx(mcc)
-        core = CoreV1Api(api_client=mcc.api_client)
-        envoy_app = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, idx)
-
-        # Fail closed: an internet-facing NLB MUST be corp-SG-locked (never 0.0.0.0/0).
-        sg = lb_sg(LB_SVC_MONGOD, mcc.cluster_name)
+        envoy_app = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, _idx(mcc))
         ext_svc_name = f"{envoy_app}-ext"
-        annotations = {
-            "service.beta.kubernetes.io/aws-load-balancer-type": "external",
-            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
-            "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
-            "service.beta.kubernetes.io/aws-load-balancer-security-groups": sg,
-            # BYO frontend SG ⇒ controller no longer auto-opens the node SG to the NLB; without
-            # this the targets fail health checks (i/o timeout).
-            "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
-            "external-dns.alpha.kubernetes.io/hostname": f"*.{search_proxy_wildcard(mcc.cluster_name)}",
-        }
-        manifest = {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {"name": ext_svc_name, "labels": {"app": envoy_app}, "annotations": annotations},
-            "spec": {
-                "type": "LoadBalancer",
-                "selector": {"app": envoy_app},
-                "ports": [{"name": "mongot-grpc", "port": mongot_grpc_port, "targetPort": mongot_grpc_port}],
-            },
-        }
-        try:
-            core.create_namespaced_service(namespace, manifest)
-            logger.info(
-                f"[{mcc.cluster_name}] created single Envoy LB {ext_svc_name} -> *.{search_proxy_wildcard(mcc.cluster_name)}"
-            )
-        except kubernetes.client.ApiException as exc:
-            if exc.status == 409:
-                core.patch_namespaced_service(ext_svc_name, namespace, manifest)
-                logger.info(f"[{mcc.cluster_name}] updated single Envoy LB {ext_svc_name}")
-            else:
-                raise
+        create_internet_facing_nlb(
+            mcc.api_client,
+            namespace,
+            name=ext_svc_name,
+            selector_app=envoy_app,
+            port=ENVOY_PROXY_PORT,
+            port_name="mongot-grpc",
+            security_groups=[lb_sg(LB_SVC_MONGOD, mcc.cluster_name)],
+            external_dns_hostname=f"*.{search_proxy_wildcard(mcc.cluster_name)}",
+            cluster_id=mcc.cluster_name,
+        )
         ext_svcs.append((mcc, ext_svc_name))
 
-    # Block until each Envoy NLB is provisioned (external hostname/IP assigned) so the
-    # subsequent mongotHost flip + createSearchIndex can actually connect.
+    # Block until each NLB is provisioned so the mongotHost flip + createSearchIndex can connect.
     for mcc, ext_svc_name in ext_svcs:
-        core = CoreV1Api(api_client=mcc.api_client)
-
-        def check(_svc=ext_svc_name, _core=core):
-            svc = _core.read_namespaced_service(_svc, namespace)
-            ingress = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
-            if ingress and (ingress[0].hostname or ingress[0].ip):
-                return True, f"NLB provisioned: {ingress[0].hostname or ingress[0].ip}"
-            return False, "NLB hostname not yet assigned"
-
-        run_periodically(
-            check, timeout=300, sleep_time=10, msg=f"[{mcc.cluster_name}] search Envoy NLB provisioning"
-        )
+        wait_for_nlb_hostname(mcc.api_client, namespace, ext_svc_name, cluster_id=mcc.cluster_name)
 
 
 @mark.e2e_aws_simulated_mc_sharded
@@ -1338,7 +1306,8 @@ def _assert_source_routed_to(
                             )
                         else:
                             msgs.append(f"[{mcc.cluster_name}] {pod_name}: mongotHost={expected} + search TLS params OK")
-                    except Exception as exc:  # noqa: BLE001
+                    except pymongo.errors.PyMongoError as exc:
+                        # Transient while the Automation Config rolls out; poll again.
                         all_ok = False
                         msgs.append(f"[{mcc.cluster_name}] {pod_name}: error reading conf: {exc}")
         return all_ok, "\n".join(msgs)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -941,19 +941,28 @@ def test_source_spread_across_data_clusters(
 ):
     """Guard the index model every downstream FQDN depends on: each shard's STS exists with
     the expected member count in BOTH data clusters (source idx 0 = AZ1 / 2 members, idx 1
-    = AZ2 / 1 member)."""
-    for data_context in DATA_CLUSTERS:
-        src_idx = SOURCE_CLUSTER_INDEX[data_context]
-        mcc = _mcc(member_cluster_clients, data_context)
-        expected_members = SHARD_MEMBERS_PER_CLUSTER[src_idx]
-        for shard_idx in range(SHARD_COUNT):
-            # MC sharded STS = {mdb}-{shardIdx}-{srcClusterIdx} (MultiShardRsName).
-            sts_name = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}"
-            sts = mcc.read_namespaced_stateful_set(sts_name, namespace)
-            assert (sts.status.ready_replicas or 0) >= (expected_members or 0), (
-                f"[{mcc.cluster_name}] {sts_name} ready={sts.status.ready_replicas} expected>={expected_members}"
-            )
-            logger.info(f"[{mcc.cluster_name}] source shard STS {sts_name} ready ({expected_members} member(s))")
+    = AZ2 / 1 member). Polls: test_mongodb_running returns on the MDB resource's OM-agent
+    phase=Running, which can precede the last STS pod's EBS PVC binding."""
+
+    def shards_ready() -> Tuple[bool, str]:
+        all_ready = True
+        msgs: List[str] = []
+        for data_context in DATA_CLUSTERS:
+            src_idx = SOURCE_CLUSTER_INDEX[data_context]
+            mcc = _mcc(member_cluster_clients, data_context)
+            expected_members = SHARD_MEMBERS_PER_CLUSTER[src_idx]
+            for shard_idx in range(SHARD_COUNT):
+                # MC sharded STS = {mdb}-{shardIdx}-{srcClusterIdx} (MultiShardRsName).
+                sts_name = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}"
+                ready = mcc.read_namespaced_stateful_set(sts_name, namespace).status.ready_replicas or 0
+                if ready >= (expected_members or 0):
+                    msgs.append(f"[{mcc.cluster_name}] {sts_name} ready ({ready}/{expected_members})")
+                else:
+                    all_ready = False
+                    msgs.append(f"[{mcc.cluster_name}] {sts_name} ready={ready} expected>={expected_members}")
+        return all_ready, "\n".join(msgs)
+
+    run_periodically(shards_ready, timeout=600, sleep_time=10, msg="source shard STS readiness across data clusters")
 
 
 @mark.e2e_aws_simulated_mc_sharded

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -49,6 +49,7 @@ clusters by each shard's primary placement.
 
 from __future__ import annotations
 
+import functools
 import os
 from typing import Dict, List, Optional, Tuple
 
@@ -145,6 +146,10 @@ CLUSTER_IDS = {
 DATA_CLUSTERS = [CENTRAL_OM_MDB_AZ1, DATA_MDB_AZ2]
 SEARCH_CLUSTERS = [SEARCH_AZ1, SEARCH_AZ2]
 
+# Cluster hosting the cross-AZ search failover Envoy. A data cluster (not a search cluster), so
+# it survives either search cluster going down; its zone publishes *.envoy-proxy-failover.<zone>.
+SEARCH_FAILOVER_HOST_CLUSTER = CENTRAL_OM_MDB_AZ1
+
 # CRITICAL: the operator assigns the SOURCE-internal cluster index by SORTED cluster name
 # (controllers/operator/mongodbshardedcluster_controller.go: slices.Sort(allReferencedClusterNames)
 # before AssignIndexesForMemberClusterNames), NOT by clusterSpecList declaration order. So for
@@ -210,6 +215,12 @@ def search_proxy_wildcard(context_name: str) -> str:
     return f"envoy-proxy.{cluster_zone(context_name)}"
 
 
+def search_failover_wildcard(context_name: str) -> str:
+    """external-dns wildcard parent for the cross-AZ search failover Envoy NLB (its host
+    cluster's zone). Cluster-agnostic shard-unique proxy hostnames live under this wildcard."""
+    return f"envoy-proxy-failover.{cluster_zone(context_name)}"
+
+
 # ---------------------------------------------------------------------------
 # Resource + topology constants
 # ---------------------------------------------------------------------------
@@ -262,6 +273,15 @@ SOURCE_SEARCH_SET_PARAMETERS = {
     "searchTLSMode": "requireTLS",
     "useGrpcForSearch": True,
 }
+
+# How the source processes' mongotHost is wired in the OM AutomationConfig (see
+# _wire_source_mongot_host). Switchable between:
+#   "per_az_direct" — each process -> its OWN-AZ search cluster's managed-Envoy endpoint.
+#   "failover"      — every process -> a shard-unique, cluster-AGNOSTIC hostname under the
+#                     failover Envoy wildcard, round-robined across both AZs. Functional only
+#                     once both search clusters present the same cluster-agnostic SNI server
+#                     names + cert SANs (the failover follow-up).
+SOURCE_MONGOT_HOST_MODE = "per_az_direct"
 
 
 # ---------------------------------------------------------------------------
@@ -357,6 +377,25 @@ def _external_mongos_envoy_endpoint(search_context: str, harness_idx: int) -> st
     mongotHost target. Host:port — the source mongos automationConfig needs the port; the
     SNI server_name (routerHostname) is the host-only form."""
     return f"{_external_mongos_proxy_host(search_context, harness_idx)}:{ENVOY_PROXY_PORT}"
+
+
+def _failover_shard_proxy_endpoint(shard_idx: int) -> str:
+    """Shard-unique, cluster-AGNOSTIC per-shard mongot endpoint under the failover wildcard:
+    the SAME hostname in both AZs (no cluster idx / clusterId), so the SNI a connection carries
+    matches whichever AZ the failover Envoy round-robins onto. host:port form."""
+    shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+    return (
+        f"{MDBS_RESOURCE_NAME}-search-{shard_name}-proxy-svc."
+        f"{search_failover_wildcard(SEARCH_FAILOVER_HOST_CLUSTER)}:{ENVOY_PROXY_PORT}"
+    )
+
+
+def _failover_mongos_proxy_endpoint() -> str:
+    """Cluster-AGNOSTIC cluster-level mongot endpoint under the failover wildcard (mongos)."""
+    return (
+        f"{MDBS_RESOURCE_NAME}-search-proxy-svc."
+        f"{search_failover_wildcard(SEARCH_FAILOVER_HOST_CLUSTER)}:{ENVOY_PROXY_PORT}"
+    )
 
 
 def _source_mongos_search_tester(
@@ -1192,6 +1231,46 @@ def test_expose_search_managed_envoy_externally(
         wait_for_nlb_hostname(mcc.api_client, namespace, ext_svc_name, cluster_id=mcc.cluster_name)
 
 
+@fixture(scope="module")
+def search_failover_envoy(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> MongodEnvoy:
+    """One L4 SNI-passthrough Envoy in the central data cluster that round-robins across BOTH
+    search clusters' exposed managed-Envoy NLBs (az1 + az2), fronted by its own internet-facing
+    NLB at *.envoy-proxy-failover.<centralZone>. Single round-robin upstream, no health checks.
+
+    Functional failover requires the search clusters to present shard-unique, cluster-agnostic
+    SNI server names (same per-shard hostname in both AZs) so the preserved SNI matches whichever
+    AZ a connection lands on — see _mongot_host_for_process modes."""
+    host_ctx = SEARCH_FAILOVER_HOST_CLUSTER
+    upstreams = tuple(
+        (_external_mongos_proxy_host(mcc.cluster_name, _idx(mcc)), ENVOY_PROXY_PORT)
+        for mcc in _search_mccs(member_cluster_clients)
+    )
+    failover_wildcard = search_failover_wildcard(host_ctx)
+    return MongodEnvoy(
+        namespace=namespace,
+        cluster_id=CLUSTER_IDS[host_ctx],
+        routes=[SniRoute(server_name=f"*.{failover_wildcard}", upstreams=upstreams)],
+        listen_port=ENVOY_PROXY_PORT,
+        name="search-failover-envoy",
+        configmap_name="search-failover-envoy-config",
+        service_name="search-failover-envoy-svc",
+        external_dns_hostname=f"*.{failover_wildcard}",
+        lb_security_groups=[lb_sg(LB_SVC_MONGOD, host_ctx)],
+        api_client=_mcc(member_cluster_clients, host_ctx).api_client,
+    )
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_deploy_search_failover_envoy(search_failover_envoy: MongodEnvoy):
+    """Deploy the cross-AZ search failover Envoy + its NLB (round-robin over both search
+    clusters' managed-Envoy NLBs, TLS passthrough, no health checks for now)."""
+    search_failover_envoy.deploy()
+    search_failover_envoy.lb_hostname()
+
+
 @mark.e2e_aws_simulated_mc_sharded
 def test_per_cluster_sharded_resources_exist(
     namespace: str,
@@ -1265,25 +1344,42 @@ def _search_idx_by_ctx(member_cluster_clients: List[MultiClusterClient]) -> Dict
     return {sc: _idx(_mcc(member_cluster_clients, sc)) for sc in SEARCH_CLUSTERS}
 
 
-def _wire_source_mongot_host_per_az(mdb: MongoDB, member_cluster_clients: List[MultiClusterClient]) -> None:
-    """Point every source process at the mongot in its OWN AZ via OM AC (NO global flip):
-    mongos -> its same-AZ search cluster's cluster-level endpoint, shard mongod -> that
-    cluster's per-shard endpoint, config servers untouched. The target search cluster is
-    chosen by the source process's own cluster index (AZ), not a single global target."""
+def _resolve_mongot_host_per_az_direct(process_name: str, search_idx: Dict[str, int]) -> Optional[str]:
+    """per_az_direct mode: each process -> the managed-Envoy endpoint of the search cluster in
+    its OWN AZ (chosen by the process's source cluster index), config servers untouched."""
+    classified = _classify_sharded_process(process_name, MDB_RESOURCE_NAME, multi_cluster=True)
+    if classified is None:
+        return None
+    role, cluster_index, shard_index = classified
+    search_ctx = SEARCH_FOR_DATA_CLUSTER[SORTED_DATA[cluster_index]]
+    idx = search_idx[search_ctx]
+    if role == "mongos":
+        return _external_mongos_envoy_endpoint(search_ctx, idx)
+    assert shard_index is not None
+    return _external_shard_envoy_endpoint(search_ctx, idx, shard_index)
+
+
+def _resolve_mongot_host_failover(process_name: str) -> Optional[str]:
+    """failover mode: every process -> a shard-unique, cluster-AGNOSTIC hostname under the
+    failover Envoy wildcard (same per-shard host in both AZs), config servers untouched."""
+    classified = _classify_sharded_process(process_name, MDB_RESOURCE_NAME, multi_cluster=True)
+    if classified is None:
+        return None
+    role, _cluster_index, shard_index = classified
+    if role == "mongos":
+        return _failover_mongos_proxy_endpoint()
+    assert shard_index is not None
+    return _failover_shard_proxy_endpoint(shard_index)
+
+
+def _wire_source_mongot_host(mdb: MongoDB, member_cluster_clients: List[MultiClusterClient]) -> None:
+    """Wire every source process's mongotHost via OM AC, per SOURCE_MONGOT_HOST_MODE. The
+    host-resolution mode is a swappable function so we can flip per_az_direct <-> failover."""
     search_idx = _search_idx_by_ctx(member_cluster_clients)
-
-    def resolve_host(process_name: str) -> Optional[str]:
-        classified = _classify_sharded_process(process_name, MDB_RESOURCE_NAME, multi_cluster=True)
-        if classified is None:
-            return None
-        role, cluster_index, shard_index = classified
-        search_ctx = SEARCH_FOR_DATA_CLUSTER[SORTED_DATA[cluster_index]]
-        idx = search_idx[search_ctx]
-        if role == "mongos":
-            return _external_mongos_envoy_endpoint(search_ctx, idx)
-        assert shard_index is not None
-        return _external_shard_envoy_endpoint(search_ctx, idx, shard_index)
-
+    if SOURCE_MONGOT_HOST_MODE == "failover":
+        resolve_host = _resolve_mongot_host_failover
+    else:
+        resolve_host = functools.partial(_resolve_mongot_host_per_az_direct, search_idx=search_idx)
     patch_mongot_host_via_ac(mdb, resolve_host)
 
 
@@ -1422,7 +1518,7 @@ def test_wire_source_mongot_host_per_az(
     """Wire each source process at the mongot in its OWN AZ and verify the AC applied it:
     az1 processes -> search-az1, az2 processes -> search-az2 (no global flip)."""
     assert_per_cluster_count(_search_mccs(member_cluster_clients))
-    _wire_source_mongot_host_per_az(mdb, member_cluster_clients)
+    _wire_source_mongot_host(mdb, member_cluster_clients)
     _assert_source_routed_per_az(namespace, member_cluster_clients)
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -1,0 +1,1502 @@
+"""Real-infra (AWS EKS) multi-cluster MongoDBSearch e2e with a SHARDED external source.
+
+Forked from simulated_mc_sharded.py to run on the four real EKS clusters in
+mongot_multicluster-infra (see tmp/INFRASTRUCTURE.md, tmp/MULTICLUSTER_PLAN.md,
+tmp/E2E_SCENARIO_PLAN.md). Unlike the simulated variant, this runs with NO Istio mesh
+and NO VPC peering: every cross-cluster hop flows over per-cluster internet-facing NLBs.
+The data plane is fronted by a self-managed L4 SNI-passthrough Envoy (mongodEnvoy), one
+per data cluster, behind a single NLB + external-dns wildcard. The source sharded
+MongoDB is spread across two AZ data clusters (no single-cluster index pin), OM is
+deployed by the scenario, and per-AZ mongot targeting uses member tagSets.
+
+Cluster roles (pin explicitly; the harness SORTS MEMBER_CLUSTERS, so harness indexes are
+alphabetical: mdb-az2=0, om-mdb-az1=1, search-az1=2, search-az2=3 — NOT declaration
+order). Never derive a role from a harness sort index.
+  - om-mdb-az1  (ls-mc-om-mdb-az1): central operator + OM/AppDB + shard data AZ1
+  - mdb-az2     (ls-mc-mdb-az2):    shard data AZ2
+  - search-az1  (ls-mc-search-az1): mongot search, AZ1
+  - search-az2  (ls-mc-search-az2): mongot search, AZ2
+
+Index model (this is the crux that differs from the base, which pinned the source to one
+cluster => everything had a "-0-" suffix):
+  * The source sharded MongoDB spans the TWO data clusters. Its SOURCE-internal cluster
+    index is assigned by the operator in SORTED cluster-name order (NOT clusterSpecList
+    declaration order — see mongodbshardedcluster_controller.go: slices.Sort before
+    AssignIndexesForMemberClusterNames). For our names that means: mdb-az2 -> 0 (AZ2),
+    om-mdb-az1 -> 1 (AZ1). MC pod names embed this index: shard mongod
+    {mdb}-{shardIdx}-{srcIdx}-{member}, mongos {mdb}-mongos-{srcIdx}-{pod}, config
+    {mdb}-config-{srcIdx}-{member}.
+  * Per the locked topology each shard has 2 members in AZ1 / 1 in AZ2 (config RS 2/1;
+    mongos 1/AZ). In SOURCE-INDEX order that is SHARD_MEMBERS_PER_CLUSTER = [1, 2]
+    (idx0=AZ2/mdb-az2=1, idx1=AZ1/om-mdb-az1=2). So a shard's mongod set is
+    {mdb}-{shardIdx}-0-0 (AZ2) and {mdb}-{shardIdx}-1-0, {mdb}-{shardIdx}-1-1 (AZ1).
+  * The SEARCH side keeps the HARNESS cluster_index (search-az1=2, search-az2=3) for its
+    per-(cluster, shard) mongot resource names ({mdbs}-search-{harnessIdx}-{shard}-...).
+    The two index systems never collide (source idx in {0,1}, search idx in {2,3}).
+
+Connectivity seams vs the base (the fork's whole job): every ".svc.cluster.local"
+cross-cluster hop is swapped for an EXTERNAL FQDN served by an SNI front:
+  * source mongod/mongos seeds (mongot syncSource) AND the OM AppDB members -> external
+    FQDNs under *.mongodb-proxy.<dataClusterId>.mc... (the shared per-cluster mongodb-envoy NLB).
+  * the mongotHost flip endpoints (mongos cluster-level + per-shard) -> external FQDNs
+    under *.envoy-proxy.<searchClusterId>.mc... (the operator-managed search Envoy LB).
+  * mongodEnvoy upstreams stay INTERNAL (the per-pod headless Services).
+
+mongotHost routing stays on the interim OM Automation Config patch until the operator
+gains per-cluster additionalMongodConfig (E2E_SCENARIO_PLAN.md gap #1).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Tuple
+
+import kubernetes
+import pymongo.errors
+import pytest
+from kubernetes.client import CoreV1Api
+from kubetester import create_or_update_configmap, create_or_update_secret, read_secret, try_load
+from kubetester.certs import create_ops_manager_tls_certs, create_tls_certs
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.multicluster_client import MultiClusterClient
+from kubetester.operator import Operator
+from kubetester.opsmanager import MongoDBOpsManager
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.cert.cert_issuer import create_appdb_certs
+from tests.common.mongod_envoy.mongod_envoy import MongodEnvoy, SniRoute
+from tests.common.mongod_envoy.source_routes import build_replicaset_sni_routes, build_source_sni_routes
+from tests.common.mongodb_tools_pod.mongodb_tools_pod import ToolsPod, get_tools_pod
+from tests.common.multicluster.multicluster_utils import assert_workload_ready_in_cluster
+from tests.common.search import search_resource_names
+from tests.common.search.connectivity import CLUSTER_LOCATION_TAG_KEY
+from tests.common.search.mc_search_helper import (
+    _classify_sharded_process,
+    assert_mongot_sync_source_hosts,
+    patch_mongot_host_via_ac,
+    read_mongod_set_parameter,
+    verify_per_cluster_envoy_sni,
+)
+from tests.common.search.movies_search_helper import (
+    EMBEDDING_QUERY_KEY_ENV_VAR,
+    EmbeddedMoviesSearchHelper,
+    SampleMoviesSearchHelper,
+)
+from tests.common.search.search_tester import SearchTester
+from tests.common.search.sharded_search_helper import (
+    create_issuer_ca,
+    create_per_shard_search_tls_certs,
+    per_cluster_search_tester,
+    verify_search_results_from_all_shards,
+)
+from tests.multicluster.conftest import cluster_spec_list
+from tests.multicluster_search.conftest import (
+    ADMIN_USER_NAME,
+    ADMIN_USER_PASSWORD,
+    ENVOY_LB_REPLICAS,
+    ENVOY_PROXY_PORT,
+    MDBS_TLS_CERT_PREFIX,
+    MONGOT_USER_NAME,
+    SOURCE_CERT_PREFIX,
+    USER_NAME,
+    USER_PASSWORD,
+    _idx,
+    _install_simulated_operator,
+    apply_search_crs_and_assert_running,
+    assert_cross_cluster_isolation,
+    assert_per_cluster_count,
+    assert_status_running_local_only,
+    create_search_users,
+    install_central_mc_operator,
+)
+
+logger = test_logger.get_test_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cluster context names (kubeconfig contexts), pinned by role — never derive role from
+# harness sort order.
+# ---------------------------------------------------------------------------
+CENTRAL_OM_MDB_AZ1 = "om-mdb-az1"
+DATA_MDB_AZ2 = "mdb-az2"
+SEARCH_AZ1 = "search-az1"
+SEARCH_AZ2 = "search-az2"
+
+CLUSTER_IDS = {
+    CENTRAL_OM_MDB_AZ1: "ls-mc-om-mdb-az1",
+    DATA_MDB_AZ2: "ls-mc-mdb-az2",
+    SEARCH_AZ1: "ls-mc-search-az1",
+    SEARCH_AZ2: "ls-mc-search-az2",
+}
+
+DATA_CLUSTERS = [CENTRAL_OM_MDB_AZ1, DATA_MDB_AZ2]
+SEARCH_CLUSTERS = [SEARCH_AZ1, SEARCH_AZ2]
+
+# CRITICAL: the operator assigns the SOURCE-internal cluster index by SORTED cluster name
+# (controllers/operator/mongodbshardedcluster_controller.go: slices.Sort(allReferencedClusterNames)
+# before AssignIndexesForMemberClusterNames), NOT by clusterSpecList declaration order. So for
+# our two data clusters the source index is: "mdb-az2" -> 0 (AZ2), "om-mdb-az1" -> 1 (AZ1).
+# Every source pod FQDN ({mdb}-{shard}-{srcIdx}-{m}), per-component distribution list (consumed
+# positionally by create_tls_certs/cluster_spec_list), and on-disk pod check below is keyed off
+# this sorted order. SORTED_DATA[i] is the cluster at source index i.
+SORTED_DATA = sorted(DATA_CLUSTERS)  # ["mdb-az2", "om-mdb-az1"] => src idx 0, 1
+SOURCE_CLUSTER_INDEX = {ctx: i for i, ctx in enumerate(SORTED_DATA)}
+
+# AZ tag applied to source shard members (memberConfig[].tags) and matched by each search
+# cluster's syncSourceSelector so a search cluster's mongot only syncs from its same-AZ
+# shard members. Tag key reuses the shared CLUSTER_LOCATION_TAG_KEY (operator renders it to
+# mongot syncSource.replicationReader.tagSets, the q3 path).
+AZ_BY_DATA_CLUSTER = {CENTRAL_OM_MDB_AZ1: "az1", DATA_MDB_AZ2: "az2"}
+AZ_BY_SEARCH_CLUSTER = {SEARCH_AZ1: "az1", SEARCH_AZ2: "az2"}
+
+PARENT_ZONE = "mc.mongokubernetes.com"
+
+# Corp-prefix-locked LB security groups provisioned by create_eks_cluster.py (one port each;
+# INFRASTRUCTURE.md). Referenced by the AWS Load Balancer Controller via the
+# aws-load-balancer-security-groups annotation so every internet-facing NLB is corp-locked
+# (NEVER 0.0.0.0/0 — fail closed). The infra names each SG per-cluster as
+# `eks-lb-<svc>-sg-<clusterId>` (create_eks_cluster.py: _ensure_sg(..., f"eks-lb-{svc}-sg-{cluster_id}")),
+# so the annotation must carry the cluster-suffixed name — a bare `eks-lb-om-sg` resolves to
+# nothing and the controller errors `couldn't find all security groups`. Use lb_sg().
+LB_SVC_MONGOS = "mongos"  # :27017 — data-plane mongodEnvoy NLB
+LB_SVC_MONGOD = "mongod"  # :27028 — search-managed Envoy LB (mongod -> mongot)
+LB_SVC_OM = "om"  # :443  — Ops Manager external LB
+
+
+def lb_sg(svc: str, context_name: str) -> str:
+    """Per-cluster corp-locked LB security-group NAME, as created by the infra.
+
+    The AWS Load Balancer Controller resolves this name within the cluster's VPC; it
+    must match the infra's `eks-lb-<svc>-sg-<clusterId>` naming exactly.
+    """
+    return f"eks-lb-{svc}-sg-{CLUSTER_IDS[context_name]}"
+
+
+def cluster_zone(context_name: str) -> str:
+    """Per-cluster public DNS zone <clusterId>.mc.mongokubernetes.com."""
+    return f"{CLUSTER_IDS[context_name]}.{PARENT_ZONE}"
+
+
+def mongodb_proxy_wildcard(context_name: str) -> str:
+    """externalAccess.externalDomain for ALL MongoDB processes in a cluster (AppDB +
+    source shard/config/mongos); the external-dns wildcard *.<this> maps to that cluster's
+    single mongodb-envoy NLB. Pod FQDN = <pod>.<this>. One wildcard per cluster because pod
+    names are globally unique, so one SNI Envoy demultiplexes every process type."""
+    return f"mongodb-proxy.{cluster_zone(context_name)}"
+
+
+def search_proxy_wildcard(context_name: str) -> str:
+    """external-dns wildcard parent for a search cluster's managed Envoy NLB."""
+    return f"envoy-proxy.{cluster_zone(context_name)}"
+
+
+# ---------------------------------------------------------------------------
+# Resource + topology constants
+# ---------------------------------------------------------------------------
+MDB_RESOURCE_NAME = "mdb-aws-mc-sh"
+MDBS_RESOURCE_NAME = "mdb-aws-mc-sh-search"
+
+OM_NAME = "om-aws-mc"
+OM_CERT_PREFIX = "om-prefix"
+APPDB_CERT_PREFIX = "appdb-prefix"
+OM_PROJECT_NAME = "aws-mc-sharded"
+
+# AppDB: single member cluster (om-mdb-az1) today, but deployed mesh-free with external
+# FQDNs (externalAccess.externalDomain) so the cross-cluster path is already wired. Its
+# cluster-internal index is 0 (only position in the AppDB clusterSpecList); pods are
+# {OM_NAME}-db-0-{member}, per-pod headless Service {pod}-svc.
+APPDB_MEMBERS = 3
+
+SHARD_COUNT = 2
+# Per the locked topology: 2 members in AZ1 / 1 in AZ2 per shard; config RS 2/1; mongos 1/AZ.
+# Keyed by CONTEXT NAME (AZ1 = om-mdb-az1, AZ2 = mdb-az2)...
+SHARD_MEMBERS_BY_CONTEXT = {CENTRAL_OM_MDB_AZ1: 2, DATA_MDB_AZ2: 1}
+CONFIG_MEMBERS_BY_CONTEXT = {CENTRAL_OM_MDB_AZ1: 2, DATA_MDB_AZ2: 1}
+MONGOS_BY_CONTEXT = {CENTRAL_OM_MDB_AZ1: 1, DATA_MDB_AZ2: 1}
+
+# ...then projected into SOURCE-INDEX order (SORTED_DATA). Position i = source index i, which is
+# exactly what create_tls_certs(replicas_cluster_distribution) and cluster_spec_list consume
+# positionally and what the source pod names embed. With SORTED_DATA = [mdb-az2, om-mdb-az1]
+# these are [1, 2] (NOT [2, 1]): index 0 = AZ2 (1 member), index 1 = AZ1 (2 members).
+SHARD_MEMBERS_PER_CLUSTER: List[int | None] = [SHARD_MEMBERS_BY_CONTEXT[c] for c in SORTED_DATA]
+CONFIG_SRV_PER_CLUSTER: List[int | None] = [CONFIG_MEMBERS_BY_CONTEXT[c] for c in SORTED_DATA]
+MONGOS_PER_CLUSTER: List[int | None] = [MONGOS_BY_CONTEXT[c] for c in SORTED_DATA]
+
+MONGOT_REPLICAS_PER_CLUSTER = 1
+
+CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
+
+SEARCH_INDEX_READY_TIMEOUT = 300
+SEARCH_QUERY_RETRY_TIMEOUT = 90
+
+# Search setParameters the operator must apply to every source mongod/mongos so the
+# mongod -> Envoy -> mongot hop is mTLS + gRPC. Asserted back at runtime, not just set.
+SOURCE_SEARCH_SET_PARAMETERS = {
+    "skipAuthenticationToSearchIndexManagementServer": False,
+    "skipAuthenticationToMongot": False,
+    "searchTLSMode": "requireTLS",
+    "useGrpcForSearch": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Role-pinned cluster selection (by context name, never by harness sort index).
+# ---------------------------------------------------------------------------
+
+
+def _mcc(member_cluster_clients: List[MultiClusterClient], context_name: str) -> MultiClusterClient:
+    for mcc in member_cluster_clients:
+        if mcc.cluster_name == context_name:
+            return mcc
+    raise AssertionError(f"cluster context {context_name!r} not found among {[m.cluster_name for m in member_cluster_clients]}")
+
+
+def _data_mccs(member_cluster_clients: List[MultiClusterClient]) -> List[MultiClusterClient]:
+    """Data clusters in SOURCE-internal clusterSpecList order (AZ1 then AZ2)."""
+    return [_mcc(member_cluster_clients, ctx) for ctx in DATA_CLUSTERS]
+
+
+def _search_mccs(member_cluster_clients: List[MultiClusterClient]) -> List[MultiClusterClient]:
+    return [_mcc(member_cluster_clients, ctx) for ctx in SEARCH_CLUSTERS]
+
+
+# ---------------------------------------------------------------------------
+# External FQDN host builders (the connectivity seams).
+# ---------------------------------------------------------------------------
+
+
+def _source_pod_external_fqdn(pod: str, data_context: str) -> str:
+    """External FQDN a peer dials for a source pod (resolves to that data cluster's
+    mongodEnvoy NLB; Envoy SNI-routes to the pod's internal Service)."""
+    return f"{pod}.{mongodb_proxy_wildcard(data_context)}"
+
+
+def _shard_host_seeds(shard_idx: int) -> List[str]:
+    """A shard's source-mongod EXTERNAL seed hosts (what its mongot syncs from), spanning
+    both data clusters. Mirrors the per-shard `hosts` in per_cluster_mdbs_search."""
+    seeds: List[str] = []
+    for data_context in DATA_CLUSTERS:
+        src_idx = SOURCE_CLUSTER_INDEX[data_context]
+        n = SHARD_MEMBERS_PER_CLUSTER[src_idx]
+        for member_idx in range(n or 0):
+            pod = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}-{member_idx}"
+            seeds.append(f"{_source_pod_external_fqdn(pod, data_context)}:27017")
+    return seeds
+
+
+def _router_host_seeds() -> List[str]:
+    """The source mongos EXTERNAL seed hosts (one per data cluster)."""
+    seeds: List[str] = []
+    for data_context in DATA_CLUSTERS:
+        src_idx = SOURCE_CLUSTER_INDEX[data_context]
+        n = MONGOS_PER_CLUSTER[src_idx]
+        for pod_idx in range(n or 0):
+            pod = f"{MDB_RESOURCE_NAME}-mongos-{src_idx}-{pod_idx}"
+            seeds.append(f"{_source_pod_external_fqdn(pod, data_context)}:27017")
+    return seeds
+
+
+def _external_shard_proxy_template(search_context: str, harness_idx: int) -> str:
+    """Managed-LB externalHostname for a search cluster: the per-shard proxy-svc name with
+    the {shardName} placeholder retained (operator resolves per shard), under the search
+    cluster's external-dns wildcard. The operator also derives the cluster-level (mongos)
+    proxy host by stripping the per-shard segment."""
+    return (
+        f"{MDBS_RESOURCE_NAME}-search-{harness_idx}-{{shardName}}-proxy-svc."
+        f"{search_proxy_wildcard(search_context)}"
+    )
+
+
+def _external_shard_envoy_endpoint(search_context: str, harness_idx: int, shard_idx: int) -> str:
+    """A search cluster's per-shard managed-Envoy endpoint (external), the per-shard mongod
+    mongotHost target."""
+    shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+    return (
+        f"{MDBS_RESOURCE_NAME}-search-{harness_idx}-{shard_name}-proxy-svc."
+        f"{search_proxy_wildcard(search_context)}:{ENVOY_PROXY_PORT}"
+    )
+
+
+def _external_mongos_envoy_endpoint(search_context: str, harness_idx: int) -> str:
+    """A search cluster's cluster-level managed-Envoy endpoint (external), the mongos
+    mongotHost target."""
+    return (
+        f"{MDBS_RESOURCE_NAME}-search-{harness_idx}-proxy-svc."
+        f"{search_proxy_wildcard(search_context)}:{ENVOY_PROXY_PORT}"
+    )
+
+
+def _source_mongos_search_tester(
+    member_cluster_clients: List[MultiClusterClient],
+    namespace: str,
+    username: str,
+    password: str,
+) -> SearchTester:
+    """SearchTester pinned to the AZ1 source mongos via its EXTERNAL FQDN (reachable
+    cross-cluster over the mongodEnvoy NLB — there is no mesh here). TLS + issuer CA on."""
+    src_idx = SOURCE_CLUSTER_INDEX[CENTRAL_OM_MDB_AZ1]
+    pod = f"{MDB_RESOURCE_NAME}-mongos-{src_idx}-0"
+    host = f"{_source_pod_external_fqdn(pod, CENTRAL_OM_MDB_AZ1)}:27017"
+    return per_cluster_search_tester(host, username, password)
+
+
+# ---------------------------------------------------------------------------
+# Ops Manager (deployed by the scenario, MC mode, single member cluster om-mdb-az1).
+# ---------------------------------------------------------------------------
+
+
+def _om_external_fqdn() -> str:
+    return f"{OM_NAME}.{cluster_zone(CENTRAL_OM_MDB_AZ1)}"
+
+
+def _appdb_pod_external_fqdn(member_idx: int) -> str:
+    """External FQDN an AppDB member registers as / its peers dial (resolves via the
+    mongodb-proxy wildcard to the shared mongodb-envoy NLB in om-mdb-az1)."""
+    pod = f"{OM_NAME}-db-0-{member_idx}"
+    return f"{pod}.{mongodb_proxy_wildcard(CENTRAL_OM_MDB_AZ1)}"
+
+
+@fixture(scope="module")
+def appdb_certs(namespace: str, multi_cluster_issuer: str) -> str:
+    """AppDB server TLS cert. create_appdb_certs adds the internal per-pod Service FQDNs
+    automatically; we add the EXTERNAL pod FQDNs (the externalDomain hostnames the members
+    register as and verify TLS against) as additional SANs."""
+    return create_appdb_certs(
+        namespace,
+        multi_cluster_issuer,
+        f"{OM_NAME}-db",
+        cluster_index_with_members=[(0, APPDB_MEMBERS)],
+        cert_prefix=APPDB_CERT_PREFIX,
+        additional_domains=[_appdb_pod_external_fqdn(m) for m in range(APPDB_MEMBERS)],
+    )
+
+
+@fixture(scope="module")
+def ops_manager_certs(
+    namespace: str,
+    multi_cluster_issuer: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+) -> str:
+    """OM server TLS cert covering the external OM FQDN (agents in mdb-az2 dial it over
+    the internet-facing :443 LB)."""
+    return create_ops_manager_tls_certs(
+        multi_cluster_issuer,
+        namespace,
+        OM_NAME,
+        secret_name=f"{OM_CERT_PREFIX}-{OM_NAME}-cert",
+        additional_domains=[_om_external_fqdn()],
+        api_client=central_cluster_client,
+    )
+
+
+@fixture(scope="module")
+def ops_manager(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    custom_version: str,
+    custom_appdb_version: str,
+    ops_manager_certs: str,
+    appdb_certs: str,
+    multi_cluster_issuer_ca_configmap: str,
+) -> MongoDBOpsManager:
+    """OM + AppDB in MultiCluster topology pinned to the single central cluster
+    (om-mdb-az1). The AppDB is deployed mesh-free with external FQDNs
+    (externalAccess.externalDomain -> the mongodb-proxy wildcard), fronted by the shared
+    per-cluster mongodb-envoy SNI NLB rather than per-pod LoadBalancers — exactly as a
+    cross-cluster AppDB would be, so spreading it later is a topology change only. External
+    connectivity also exposes OM itself: an internet-facing :443 LB locked to the OM corp SG
+    with an external-dns hostname, so the source agents in mdb-az2 can register.
+
+    FLAGGED (see report): OM-on-AWS-no-mesh is the least-validated fixture here. Backups
+    are disabled to keep it minimal; OM memory request may need tuning for the om node
+    group.
+    """
+    resource = MongoDBOpsManager.from_yaml(yaml_fixture("om_ops_manager_basic.yaml"), name=OM_NAME, namespace=namespace)
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    resource["spec"]["version"] = custom_version
+    resource["spec"]["topology"] = "MultiCluster"
+    resource["spec"]["backup"] = {"enabled": False}
+    resource["spec"]["clusterSpecList"] = [{"clusterName": CENTRAL_OM_MDB_AZ1, "members": 1}]
+
+    # AppDB: mesh-free external access. externalAccess.externalDomain publishes external
+    # pod FQDNs (<pod>.mongodb-proxy.<clusterZone>); the per-cluster externalService is
+    # overridden to ClusterIP so the operator does NOT create per-pod LoadBalancers — the
+    # shared per-cluster mongodb-envoy SNI NLB fronts the per-pod <pod>-svc-external instead.
+    appdb_external_domain = mongodb_proxy_wildcard(CENTRAL_OM_MDB_AZ1)
+    resource["spec"]["applicationDatabase"] = {
+        "topology": "MultiCluster",
+        "version": custom_appdb_version,
+        # skipHostAliasesCheck: all AppDB members share ONE envoy NLB IP (wildcard
+        # *.mongodb-proxy -> single NLB), which defeats the automation agent's IP-based
+        # local-process detection (hosts/hostequiv.go IsHostOnLocalMachine): every member
+        # FQDN resolves to the same IP, so an agent treats ALL members as "local" and
+        # reports >1 process, breaking the readiness wait-step shortcut and deadlocking the
+        # OrderedReady bootstrap (member-1 never Ready -> member-2 never created -> RsInit
+        # never runs). This flag disables the DNS IP-equivalence fallback, leaving only the
+        # exact host==overrideLocalHost match, so each agent owns exactly its own process.
+        "agent": {"logLevel": "DEBUG", "startupOptions": {"skipHostAliasesCheck": "true"}},
+        "externalAccess": {"externalDomain": appdb_external_domain},
+        "clusterSpecList": [
+            {
+                "clusterName": CENTRAL_OM_MDB_AZ1,
+                "members": APPDB_MEMBERS,
+                "externalAccess": {
+                    "externalDomain": appdb_external_domain,
+                    "externalService": {
+                        "spec": {
+                            "type": "ClusterIP",
+                            "ports": [{"name": "mongodb", "port": 27017}],
+                        }
+                    },
+                },
+            }
+        ],
+        "security": {
+            "certsSecretPrefix": APPDB_CERT_PREFIX,
+            "tls": {"ca": multi_cluster_issuer_ca_configmap},
+        },
+    }
+
+    resource["spec"]["security"] = {
+        "certsSecretPrefix": OM_CERT_PREFIX,
+        "tls": {"ca": multi_cluster_issuer_ca_configmap},
+    }
+    resource["spec"]["externalConnectivity"] = {
+        "type": "LoadBalancer",
+        "port": 443,
+        "annotations": {
+            "service.beta.kubernetes.io/aws-load-balancer-type": "external",
+            "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+            "service.beta.kubernetes.io/aws-load-balancer-security-groups": lb_sg(LB_SVC_OM, CENTRAL_OM_MDB_AZ1),
+            # BYO frontend SG ⇒ the controller stops auto-managing backend (node) SG rules
+            # unless this is "true"; without it the NLB can't reach the nodePort and all
+            # targets fail health checks (i/o timeout). See lb_sg() note.
+            "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
+            "external-dns.alpha.kubernetes.io/hostname": _om_external_fqdn(),
+        },
+    }
+    resource["spec"]["opsManagerURL"] = f"https://{_om_external_fqdn()}:443"
+
+    resource.create_admin_secret(api_client=central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+# ---------------------------------------------------------------------------
+# Operators.
+# ---------------------------------------------------------------------------
+
+
+@fixture(scope="module")
+def central_mc_operator(
+    namespace: str,
+    central_cluster_name: str,
+    multi_cluster_operator_installation_config: dict,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    member_cluster_names: List[str],
+) -> Operator:
+    """Central MC operator on om-mdb-az1: manages OM + the source sharded MongoDB across
+    the data clusters (watch_search=True registers the MongoDBSearch field index the
+    sharded controller needs every reconcile)."""
+    return install_central_mc_operator(
+        namespace,
+        central_cluster_name,
+        multi_cluster_operator_installation_config,
+        central_cluster_client,
+        member_cluster_clients,
+        member_cluster_names,
+        watch_search=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CA + source MongoDB.
+# ---------------------------------------------------------------------------
+
+
+@fixture(scope="module")
+def ca_configmap(
+    issuer_ca_filepath: str,
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> str:
+    """Issuer CA written to central + ALL members: data clusters verify their own source
+    TLS, and search clusters' mongots verify the source's TLS during sync."""
+    name = create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
+    for mcc in member_cluster_clients:
+        create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME, api_client=mcc.api_client)
+        logger.info(f"CA ConfigMap/Secret {CA_CONFIGMAP_NAME} created in cluster {mcc.cluster_name}")
+    return name
+
+
+def _source_external_san_list(component: str) -> List[str]:
+    """External pod FQDNs that the source's per-component TLS cert must carry (certs carry
+    EXTERNAL domains only). `component` is "shard", "config", or "mongos"."""
+    sans: List[str] = []
+    for data_context in DATA_CLUSTERS:
+        src_idx = SOURCE_CLUSTER_INDEX[data_context]
+        if component == "mongos":
+            for pod_idx in range(MONGOS_PER_CLUSTER[src_idx] or 0):
+                sans.append(_source_pod_external_fqdn(f"{MDB_RESOURCE_NAME}-mongos-{src_idx}-{pod_idx}", data_context))
+        elif component == "config":
+            for member_idx in range(CONFIG_SRV_PER_CLUSTER[src_idx] or 0):
+                sans.append(_source_pod_external_fqdn(f"{MDB_RESOURCE_NAME}-config-{src_idx}-{member_idx}", data_context))
+    return sans
+
+
+def _shard_external_san_list(shard_idx: int) -> List[str]:
+    sans: List[str] = []
+    for data_context in DATA_CLUSTERS:
+        src_idx = SOURCE_CLUSTER_INDEX[data_context]
+        for member_idx in range(SHARD_MEMBERS_PER_CLUSTER[src_idx] or 0):
+            sans.append(_source_pod_external_fqdn(f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}-{member_idx}", data_context))
+    return sans
+
+
+@fixture(scope="module")
+def mdb(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    ca_configmap: str,
+) -> MongoDB:
+    """MC sharded MongoDB source (TLS+SCRAM) spread 2x3 across the two AZ data clusters,
+    with externalAccess.externalDomain per data cluster + the operator-generated external
+    Service overridden to ClusterIP (so no per-pod LoadBalancers — the single mongodEnvoy
+    NLB fronts everything), and per-shard-member AZ tagSets for same-AZ mongot sync."""
+    # Build the clusterSpecList in the operator's SORTED-name order so list position == the
+    # source-internal cluster index the operator assigns (and == the positional index the
+    # distribution lists + create_tls_certs use). SORTED_DATA = [mdb-az2, om-mdb-az1].
+    source_cluster_names = list(SORTED_DATA)
+
+    resource = MongoDB.from_yaml(yaml_fixture("search-q3-mc-sharded.yaml"), name=MDB_RESOURCE_NAME, namespace=namespace)
+    resource["spec"]["shardCount"] = SHARD_COUNT
+
+    # Tag each shard member with its AZ so every search cluster's mongot matchTagSets
+    # selects only its same-AZ shard members. Tag only shard members (mongot reads shards).
+    shard_member_configs = [
+        [{"tags": {CLUSTER_LOCATION_TAG_KEY: AZ_BY_DATA_CLUSTER[name]}} for _ in range(count or 0)]
+        for name, count in zip(source_cluster_names, SHARD_MEMBERS_PER_CLUSTER)
+    ]
+    resource["spec"]["shard"]["clusterSpecList"] = cluster_spec_list(
+        source_cluster_names, SHARD_MEMBERS_PER_CLUSTER, member_configs=shard_member_configs
+    )
+    resource["spec"]["configSrv"]["clusterSpecList"] = cluster_spec_list(source_cluster_names, CONFIG_SRV_PER_CLUSTER)
+    resource["spec"]["mongos"]["clusterSpecList"] = cluster_spec_list(source_cluster_names, MONGOS_PER_CLUSTER)
+
+    # externalAccess per component + per cluster: externalDomain publishes external pod
+    # FQDNs; spec.type=ClusterIP suppresses the operator's per-pod LoadBalancers (the
+    # mongodEnvoy fronts the per-pod internal Services instead).
+    resource["spec"]["externalAccess"] = {}
+    for component in ("shard", "configSrv", "mongos"):
+        for index, data_context in enumerate(source_cluster_names):
+            resource["spec"][component]["clusterSpecList"][index]["externalAccess"] = {
+                "externalDomain": mongodb_proxy_wildcard(data_context),
+                "externalService": {
+                    "spec": {
+                        "type": "ClusterIP",
+                        "ports": [{"name": "mongodb", "port": 27017}],
+                    }
+                },
+            }
+
+    # Same shared-NLB-IP issue as AppDB: shard/configSrv each have 2 members in om-mdb-az1
+    # (SHARD_MEMBERS_PER_CLUSTER=[1,2]) behind the one mongodEnvoy NLB, so every same-cluster
+    # member FQDN resolves to the same IP and the automation agent's IP-based local-process
+    # detection (hostequiv.go IsHostOnLocalMachine) would treat them all as local.
+    # skipHostAliasesCheck disables the DNS IP-equivalence fallback, leaving only the exact
+    # host==overrideLocalHost match so each agent owns exactly its own process. Harmless on
+    # mongos (not a replica set). See the AppDB agent block above for the full rationale.
+    for _component in ("shard", "configSrv", "mongos"):
+        _agent_cfg = resource["spec"][_component].setdefault("agent", {})
+        _agent_cfg.setdefault("startupOptions", {})["skipHostAliasesCheck"] = "true"
+
+    # mongotHost/searchIndexManagementHostAndPort are intentionally ABSENT from the CR
+    # spec: routing is set later directly on the OM Automation Config (the flip test), so
+    # operator reconciles never clobber the patch. The non-routing search setParameters
+    # are applied per component here and asserted back at runtime.
+    resource["spec"]["mongos"]["additionalMongodConfig"] = {"setParameter": dict(SOURCE_SEARCH_SET_PARAMETERS)}
+    resource["spec"]["shard"]["additionalMongodConfig"] = {"setParameter": dict(SOURCE_SEARCH_SET_PARAMETERS)}
+
+    resource["spec"]["security"] = {
+        "certsSecretPrefix": SOURCE_CERT_PREFIX,
+        "tls": {"ca": ca_configmap},
+        "authentication": {"enabled": True, "modes": ["SCRAM"]},
+    }
+
+    # Requests-only (no CPU limits): limits throttle the source's CPU-hungry TLS/replset
+    # startup, widening the window where mongot races it.
+    def _pod_spec(cpu: str, memory: str) -> dict:
+        return {
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "mongodb-enterprise-database",
+                            "resources": {"requests": {"cpu": cpu, "memory": memory}},
+                        }
+                    ]
+                }
+            }
+        }
+
+    resource["spec"]["configSrvPodSpec"] = _pod_spec("0.5", "512Mi")
+    resource["spec"]["shardPodSpec"] = _pod_spec("0.5", "512Mi")
+    resource["spec"]["mongosPodSpec"] = _pod_spec("0.2", "256Mi")
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+# ---------------------------------------------------------------------------
+# Users (admin / app / mongot-sync-source). Local builder so usernames map to
+# MDB_RESOURCE_NAME without relying on the simulated conftest's request.module fixtures.
+# ---------------------------------------------------------------------------
+
+
+def _build_user(yaml_filename: str, name: str, username: str, namespace: str, central_cluster_client) -> MongoDBUser:
+    resource = MongoDBUser.from_yaml(yaml_fixture(yaml_filename), namespace=namespace, name=name)
+    if not try_load(resource):
+        resource["spec"]["mongodbResourceRef"]["name"] = MDB_RESOURCE_NAME
+        resource["spec"]["username"] = username
+        resource["spec"]["passwordSecretKeyRef"]["name"] = f"{name}-password"
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    return resource
+
+
+@fixture(scope="module")
+def admin_user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    return _build_user("mongodbuser-mdb-admin.yaml", ADMIN_USER_NAME, ADMIN_USER_NAME, namespace, central_cluster_client)
+
+
+@fixture(scope="module")
+def mdb_user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    return _build_user("mongodbuser-mdb-user.yaml", USER_NAME, USER_NAME, namespace, central_cluster_client)
+
+
+@fixture(scope="module")
+def mongot_user(namespace: str, central_cluster_client: kubernetes.client.ApiClient) -> MongoDBUser:
+    return _build_user(
+        "mongodbuser-search-sync-source-user.yaml",
+        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}",
+        MONGOT_USER_NAME,
+        namespace,
+        central_cluster_client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# mongodb-envoy (one per data cluster; serves AppDB + source shard/config/mongos via SNI).
+# ---------------------------------------------------------------------------
+
+
+@fixture(scope="module")
+def mongodb_envoys(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> Dict[str, MongodEnvoy]:
+    """ONE SNI-passthrough Envoy per data cluster (named "mongodb-envoy"), fronting EVERY
+    MongoDB process that lives in that cluster behind a single corp-SG-locked internet-facing
+    NLB + external-dns wildcard (*.mongodb-proxy.<clusterZone>):
+
+      * the source shard / configSrv / mongos pods (both data clusters), and
+      * the OM AppDB members (om-mdb-az1 only — AppDB is single-cluster today).
+
+    All process types share one wildcard and one NLB; the L4 tls_inspector demultiplexes by
+    SNI server-name, so one Envoy serves them all. Upstreams are each pod's <pod>-svc-external
+    ClusterIP. Deployed BEFORE OM so the wildcard exists when the AppDB members first resolve
+    each other; the source routes resolve later (STRICT_DNS re-resolves once those pods exist)."""
+    envoys: Dict[str, MongodEnvoy] = {}
+    for data_context in DATA_CLUSTERS:
+        src_idx = SOURCE_CLUSTER_INDEX[data_context]
+        external_domain = mongodb_proxy_wildcard(data_context)
+        routes: List[SniRoute] = build_source_sni_routes(
+            mdb_name=MDB_RESOURCE_NAME,
+            namespace=namespace,
+            source_cluster_index=src_idx,
+            external_domain=external_domain,
+            shard_count=SHARD_COUNT,
+            shard_members=SHARD_MEMBERS_PER_CLUSTER[src_idx] or 0,
+            config_members=CONFIG_SRV_PER_CLUSTER[src_idx] or 0,
+            mongos_members=MONGOS_PER_CLUSTER[src_idx] or 0,
+        )
+        # AppDB lives only in the central cluster; fold its members into that cluster's Envoy.
+        if data_context == CENTRAL_OM_MDB_AZ1:
+            routes += build_replicaset_sni_routes(
+                name=f"{OM_NAME}-db",
+                namespace=namespace,
+                cluster_index=0,
+                members=APPDB_MEMBERS,
+                external_domain=external_domain,
+            )
+        envoys[data_context] = MongodEnvoy(
+            namespace=namespace,
+            cluster_id=CLUSTER_IDS[data_context],
+            routes=routes,
+            name="mongodb-envoy",
+            configmap_name="mongodb-envoy-config",
+            service_name="mongodb-envoy-svc",
+            external_dns_hostname=f"*.{external_domain}",
+            lb_security_groups=[lb_sg(LB_SVC_MONGOS, data_context)],
+            api_client=_mcc(member_cluster_clients, data_context).api_client,
+        )
+    return envoys
+
+
+# ---------------------------------------------------------------------------
+# Per-cluster MongoDBSearch CRs (one per search cluster).
+# ---------------------------------------------------------------------------
+
+
+@fixture(scope="module")
+def per_cluster_mdbs_search(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+    ca_configmap: str,
+) -> List[Tuple[MultiClusterClient, MongoDBSearch]]:
+    """The SAME MongoDBSearch CR (spec.clusters lists both search clusters) applied to each
+    search cluster's API; each simulated operator projects its own per-(cluster, shard)
+    slice. The source is the EXTERNAL sharded MongoDB (mongos + per-shard mongod seeds are
+    external FQDNs), the managed-LB externalHostname is the search cluster's external Envoy
+    FQDN, and syncSourceSelector pins same-AZ sync."""
+    search_mccs = _search_mccs(member_cluster_clients)
+
+    router_hosts = _router_host_seeds()
+    shards = [
+        {"shardName": f"{MDB_RESOURCE_NAME}-{shard_idx}", "hosts": _shard_host_seeds(shard_idx)}
+        for shard_idx in range(SHARD_COUNT)
+    ]
+
+    clusters_spec = []
+    for mcc in search_mccs:
+        idx = _idx(mcc)
+        ctx = mcc.cluster_name
+        clusters_spec.append(
+            {
+                "name": ctx,
+                "index": idx,
+                "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+                "loadBalancer": {
+                    "managed": {
+                        "replicas": ENVOY_LB_REPLICAS,
+                        "externalHostname": _external_shard_proxy_template(ctx, idx),
+                    },
+                },
+                "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: AZ_BY_SEARCH_CLUSTER[ctx]}]},
+            }
+        )
+
+    results: List[Tuple[MultiClusterClient, MongoDBSearch]] = []
+    for mcc in search_mccs:
+        mdbs = MongoDBSearch.from_yaml(yaml_fixture("simulated-mc-search.yaml"), name=MDBS_RESOURCE_NAME, namespace=namespace)
+        mdbs["spec"]["clusters"] = clusters_spec
+        mdbs["spec"]["source"] = {
+            "username": MONGOT_USER_NAME,
+            "passwordSecretRef": {"name": f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password", "key": "password"},
+            "external": {
+                "shardedCluster": {"router": {"hosts": router_hosts}, "shards": shards},
+                "tls": {"ca": {"name": ca_configmap}},
+            },
+        }
+        mdbs["spec"]["security"] = {"tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX}}
+        mdbs.api = kubernetes.client.CustomObjectsApi(mcc.api_client)
+        try_load(mdbs)
+        results.append((mcc, mdbs))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# tools_pod: run in a DATA cluster (om-mdb-az1) so mongorestore reaches the source mongos.
+# ---------------------------------------------------------------------------
+
+
+@fixture(scope="module")
+def tools_pod(namespace: str, member_cluster_clients: List[MultiClusterClient]) -> ToolsPod:
+    return get_tools_pod(namespace, api_client=_mcc(member_cluster_clients, CENTRAL_OM_MDB_AZ1).api_client)
+
+
+# =============================================================================
+# Test steps
+# =============================================================================
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_install_central_mc_operator(central_mc_operator: Operator):
+    central_mc_operator.assert_is_running()
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_deploy_mongodb_envoys(mongodb_envoys: Dict[str, MongodEnvoy]):
+    """Deploy the per-data-cluster mongodb-envoy (SNI NLB + external-dns wildcard) BEFORE OM,
+    so the *.mongodb-proxy.<clusterZone> wildcard is published when the AppDB members first
+    resolve each other by external FQDN (no mesh). Each Envoy already carries the source
+    shard/config/mongos routes too; those upstreams (<pod>-svc-external) appear once the
+    source MongoDB deploys later — Envoy STRICT_DNS re-resolves them, so deploying upfront
+    is safe."""
+    for data_context, envoy in mongodb_envoys.items():
+        logger.info(f"Deploying mongodb-envoy in {data_context}")
+        envoy.deploy()
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_deploy_ops_manager(ops_manager: MongoDBOpsManager):
+    """Deploy OM + AppDB on om-mdb-az1 and wait Running. AppDB is mesh-free (external FQDNs
+    via the mongodb-proxy wildcard + the central mongodb-envoy). FLAGGED: OM-on-AWS-no-mesh
+    is the least-validated piece (external LB exposure, OM memory)."""
+    ops_manager.update()
+    ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=1800)
+    ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=1800)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_install_source_tls_certificates(
+    namespace: str,
+    multi_cluster_issuer: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdb: MongoDB,
+):
+    """Source per-component TLS certs (q3 pattern) issued on central; the central MongoDB
+    controller replicates them to the data members. Certs carry EXTERNAL domains only
+    (added as additional_domains): the operator publishes external process hostnames."""
+
+    def _issue(component_resource: str, secret_name: str, distribution: List[int | None], additional_domains: List[str]):
+        create_tls_certs(
+            issuer=multi_cluster_issuer,
+            namespace=namespace,
+            resource_name=component_resource,
+            replicas_cluster_distribution=distribution,
+            additional_domains=additional_domains,
+            secret_name=secret_name,
+            api_client=central_cluster_client,
+        )
+
+    for shard_idx in range(SHARD_COUNT):
+        _issue(
+            component_resource=f"{MDB_RESOURCE_NAME}-{shard_idx}",
+            secret_name=f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-{shard_idx}-cert",
+            distribution=SHARD_MEMBERS_PER_CLUSTER,
+            additional_domains=_shard_external_san_list(shard_idx),
+        )
+    _issue(
+        component_resource=f"{MDB_RESOURCE_NAME}-config",
+        secret_name=f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-config-cert",
+        distribution=CONFIG_SRV_PER_CLUSTER,
+        additional_domains=_source_external_san_list("config"),
+    )
+    _issue(
+        component_resource=f"{MDB_RESOURCE_NAME}-mongos",
+        secret_name=f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-mongos-cert",
+        distribution=MONGOS_PER_CLUSTER,
+        additional_domains=_source_external_san_list("mongos"),
+    )
+    logger.info(f"Source sharded per-component TLS certs created with external SANs (prefix={SOURCE_CERT_PREFIX})")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_create_mdb_source(
+    mdb: MongoDB,
+    ops_manager: MongoDBOpsManager,
+    multi_cluster_issuer_ca_configmap: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+):
+    """Wire the source to the scenario-deployed OM (project ConfigMap + credentials) and
+    create it (non-blocking; readiness is asserted in test_mongodb_running)."""
+    assert multi_cluster_issuer_ca_configmap is not None, "issuer CA ConfigMap required for OM-API TLS trust"
+    mdb.configure(ops_manager, OM_PROJECT_NAME)
+    # OM serves its API over TLS (cert-manager). configure() builds the project ConfigMap
+    # without a CA reference, so the operator cannot verify OM's server cert when
+    # reading/creating the project ("x509: certificate signed by unknown authority").
+    # Point the project ConfigMap at the issuer CA via sslMMSCAConfigMap (same as the
+    # reference no-mesh OM tests).
+    base_url = ops_manager.om_status().get_url()
+    assert base_url is not None, "OM status has no baseUrl yet"
+    create_or_update_configmap(
+        mdb.namespace,
+        f"{MDB_RESOURCE_NAME}-config",
+        {
+            "baseUrl": base_url,
+            "projectName": OM_PROJECT_NAME,
+            "orgId": "",
+            "sslMMSCAConfigMap": multi_cluster_issuer_ca_configmap,
+        },
+        api_client=central_cluster_client,
+    )
+    mdb.update()
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_mongodb_running(mdb: MongoDB):
+    # ignore_errors=True: tolerate transient phase=Failed from controller-runtime cache lag on MC STS Create.
+    mdb.assert_reaches_phase(Phase.Running, timeout=2400, ignore_errors=True)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_source_spread_across_data_clusters(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Guard the index model every downstream FQDN depends on: each shard's STS exists with
+    the expected member count in BOTH data clusters (source idx 0 = AZ1 / 2 members, idx 1
+    = AZ2 / 1 member)."""
+    for data_context in DATA_CLUSTERS:
+        src_idx = SOURCE_CLUSTER_INDEX[data_context]
+        mcc = _mcc(member_cluster_clients, data_context)
+        expected_members = SHARD_MEMBERS_PER_CLUSTER[src_idx]
+        for shard_idx in range(SHARD_COUNT):
+            # MC sharded STS = {mdb}-{shardIdx}-{srcClusterIdx} (MultiShardRsName).
+            sts_name = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}"
+            sts = mcc.read_namespaced_stateful_set(sts_name, namespace)
+            assert (sts.status.ready_replicas or 0) >= (expected_members or 0), (
+                f"[{mcc.cluster_name}] {sts_name} ready={sts.status.ready_replicas} expected>={expected_members}"
+            )
+            logger.info(f"[{mcc.cluster_name}] source shard STS {sts_name} ready ({expected_members} member(s))")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_create_users(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    admin_user: MongoDBUser,
+    mdb_user: MongoDBUser,
+    mongot_user: MongoDBUser,
+):
+    """Create users before sim-ops install: AC must propagate to mongod agents while the
+    cluster is undisturbed."""
+    create_search_users(namespace, central_cluster_client, admin_user, mdb_user, mongot_user)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_install_simulated_operators_on_search_clusters(
+    namespace: str,
+    central_mc_operator: Operator,
+    multi_cluster_operator_installation_config: dict,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Install a search-only simulated operator on each SEARCH cluster (by context name —
+    NOT member_cluster_clients[:2], whose harness indexes are the data clusters here)."""
+    base_helm_args = dict(multi_cluster_operator_installation_config)
+    for mcc in _search_mccs(member_cluster_clients):
+        operator = _install_simulated_operator(namespace, base_helm_args, mcc)
+        operator.assert_is_running()
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_create_search_tls_certificates(
+    namespace: str,
+    multi_cluster_issuer: str,
+    member_cluster_clients: List[MultiClusterClient],
+    central_cluster_client: kubernetes.client.ApiClient,
+):
+    """Per-(cluster, shard) mongot TLS certs + managed-LB certs, issued on central (cert-
+    manager runs there). mongot certs carry INTERNAL .svc.cluster.local SANs only; the
+    managed-LB SERVER cert carries the EXTERNAL proxy FQDNs the source dials. Resource
+    names use the HARNESS cluster_index (search-az1=2, search-az2=3)."""
+    search_mccs = _search_mccs(member_cluster_clients)
+
+    for mcc in search_mccs:
+        create_per_shard_search_tls_certs(
+            namespace=namespace,
+            issuer=multi_cluster_issuer,
+            prefix=MDBS_TLS_CERT_PREFIX,
+            shard_count=SHARD_COUNT,
+            mdb_resource_name=MDB_RESOURCE_NAME,
+            mdbs_resource_name=MDBS_RESOURCE_NAME,
+            cluster_index=_idx(mcc),
+            api_client=central_cluster_client,
+        )
+        logger.info(f"Per-shard mongot TLS certs created on central for cluster_index={_idx(mcc)}")
+
+    _create_external_lb_certificates(
+        namespace=namespace,
+        issuer=multi_cluster_issuer,
+        search_mccs=search_mccs,
+        api_client=central_cluster_client,
+    )
+
+
+def _create_external_lb_certificates(*, namespace, issuer, search_mccs, api_client) -> None:
+    """Managed-LB (search Envoy) server + client certs. The SERVER cert SANs the EXTERNAL
+    per-shard + cluster-level proxy FQDNs (what the source mongod dials as mongotHost); the
+    CLIENT cert (Envoy -> mongot, internal) keeps the in-cluster wildcard. Single secret
+    name (no cluster index), so one cert covers every search cluster's external FQDNs."""
+    server_domains: List[str] = []
+    for mcc in search_mccs:
+        idx = _idx(mcc)
+        ctx = mcc.cluster_name
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            server_domains.append(
+                f"{MDBS_RESOURCE_NAME}-search-{idx}-{shard_name}-proxy-svc.{search_proxy_wildcard(ctx)}"
+            )
+        server_domains.append(f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc.{search_proxy_wildcard(ctx)}")
+
+    create_tls_certs(
+        issuer=issuer,
+        namespace=namespace,
+        resource_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
+        replicas=1,
+        service_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
+        additional_domains=server_domains,
+        secret_name=search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        api_client=api_client,
+    )
+    logger.info(f"managed-LB server cert created with EXTERNAL SANs={server_domains}")
+
+    create_tls_certs(
+        issuer=issuer,
+        namespace=namespace,
+        resource_name=f"{search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME)}-client",
+        replicas=1,
+        service_name=search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME),
+        additional_domains=[f"*.{namespace}.svc.cluster.local"],
+        secret_name=search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        api_client=api_client,
+    )
+    logger.info("managed-LB client cert created with internal SANs")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_replicate_search_secrets_to_members(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Copy centrally-issued Search Secrets to each search cluster (the simulated operators
+    read only their own etcd). Uses the HARNESS cluster_index for the per-shard cert names,
+    NOT an enumerate position — the search clusters are harness idx 2/3 here, so the shared
+    replicate_sharded_search_secrets_to_members helper (which assumes enumerate==idx) cannot
+    be reused as-is."""
+    search_mccs = _search_mccs(member_cluster_clients)
+    central_core = CoreV1Api(api_client=central_cluster_client)
+
+    def _copy(secret_name: str, targets: List[MultiClusterClient]) -> None:
+        secret_type = central_core.read_namespaced_secret(name=secret_name, namespace=namespace).type or "Opaque"
+        data = read_secret(namespace, secret_name, api_client=central_cluster_client)
+        for mcc in targets:
+            create_or_update_secret(namespace, secret_name, data, type=secret_type, api_client=mcc.api_client)
+
+    for secret_name in [
+        search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
+        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+    ]:
+        _copy(secret_name, search_mccs)
+        logger.info(f"replicated shared Secret {secret_name} to {len(search_mccs)} search cluster(s)")
+
+    for mcc in search_mccs:
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            _copy(
+                search_resource_names.shard_tls_cert_name(
+                    MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index=_idx(mcc)
+                ),
+                [mcc],
+            )
+        logger.info(f"replicated per-shard Secrets to {mcc.cluster_name} (cluster_index={_idx(mcc)})")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_search_cr_reaches_running_per_cluster(
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Same CR applied to each search cluster; each simulated operator stamps Running on
+    its own slice."""
+    apply_search_crs_and_assert_running(per_cluster_mdbs_search)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_expose_search_managed_envoy_externally(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Expose each search cluster's operator-managed Envoy with ONE internet-facing NLB
+    (corp-SG-locked + external-dns wildcard) selecting the Envoy pod — mirroring the source
+    mongodEnvoy pattern.
+
+    The operator-managed Envoy already SNI-routes every per-(cluster,shard) and cluster-level
+    external FQDN (``*-proxy-svc.envoy-proxy.<clusterZone>``) to the right mongot upstream on a
+    single :27028 listener. So a SINGLE LoadBalancer Service fronting the Envoy pod, plus one
+    ``*.envoy-proxy.<clusterZone>`` external-dns wildcard pointing at it, serves ALL search
+    endpoints in the cluster.
+
+    The operator does NOT create a LoadBalancer for the Envoy (its proxy Services are ClusterIP
+    upstreams). We add ONE NEW Service of our own (``<envoy>-ext``) selecting the Envoy pod —
+    and we do NOT modify any operator-owned resource (no patching the ClusterIP proxy Services
+    into LoadBalancers; that both mutates operator state and yields N pending NLBs all selecting
+    the same pod). The new Service is created by the test and owned by the test.
+    """
+    mongot_grpc_port = 27028  # Envoy listener (see LB_SVC_MONGOD)
+    ext_svcs: List[Tuple[MultiClusterClient, str]] = []
+    for mcc, _mdbs in per_cluster_mdbs_search:
+        idx = _idx(mcc)
+        core = CoreV1Api(api_client=mcc.api_client)
+        envoy_app = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, idx)
+
+        # Fail closed: an internet-facing NLB MUST be corp-SG-locked (never 0.0.0.0/0).
+        sg = lb_sg(LB_SVC_MONGOD, mcc.cluster_name)
+        ext_svc_name = f"{envoy_app}-ext"
+        annotations = {
+            "service.beta.kubernetes.io/aws-load-balancer-type": "external",
+            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+            "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+            "service.beta.kubernetes.io/aws-load-balancer-security-groups": sg,
+            # BYO frontend SG ⇒ controller no longer auto-opens the node SG to the NLB; without
+            # this the targets fail health checks (i/o timeout).
+            "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
+            "external-dns.alpha.kubernetes.io/hostname": f"*.{search_proxy_wildcard(mcc.cluster_name)}",
+        }
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": ext_svc_name, "labels": {"app": envoy_app}, "annotations": annotations},
+            "spec": {
+                "type": "LoadBalancer",
+                "selector": {"app": envoy_app},
+                "ports": [{"name": "mongot-grpc", "port": mongot_grpc_port, "targetPort": mongot_grpc_port}],
+            },
+        }
+        try:
+            core.create_namespaced_service(namespace, manifest)
+            logger.info(
+                f"[{mcc.cluster_name}] created single Envoy LB {ext_svc_name} -> *.{search_proxy_wildcard(mcc.cluster_name)}"
+            )
+        except kubernetes.client.ApiException as exc:
+            if exc.status == 409:
+                core.patch_namespaced_service(ext_svc_name, namespace, manifest)
+                logger.info(f"[{mcc.cluster_name}] updated single Envoy LB {ext_svc_name}")
+            else:
+                raise
+        ext_svcs.append((mcc, ext_svc_name))
+
+    # Block until each Envoy NLB is provisioned (external hostname/IP assigned) so the
+    # subsequent mongotHost flip + createSearchIndex can actually connect.
+    for mcc, ext_svc_name in ext_svcs:
+        core = CoreV1Api(api_client=mcc.api_client)
+
+        def check(_svc=ext_svc_name, _core=core):
+            svc = _core.read_namespaced_service(_svc, namespace)
+            ingress = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
+            if ingress and (ingress[0].hostname or ingress[0].ip):
+                return True, f"NLB provisioned: {ingress[0].hostname or ingress[0].ip}"
+            return False, "NLB hostname not yet assigned"
+
+        run_periodically(
+            check, timeout=300, sleep_time=10, msg=f"[{mcc.cluster_name}] search Envoy NLB provisioning"
+        )
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_per_cluster_sharded_resources_exist(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Each search cluster materialises its own (cluster, shard) mongot STS/Svc/CM/proxy,
+    the cluster-level mongos-target proxy svc, and a per-cluster Envoy LB. The mongot
+    syncSource seeds are the EXTERNAL per-shard FQDNs; Envoy upstreams stay INTERNAL."""
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    upstreams_by_idx: Dict[int, List[str]] = {}
+    for mcc, mdbs in per_cluster_mdbs_search:
+        ci = _idx(mcc)
+        sts_ready = {}
+        local_mongot_upstreams: List[str] = []
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            sts_name = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            svc_name = search_resource_names.shard_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            cm_name = search_resource_names.shard_configmap_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            proxy_svc_name = search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+
+            sts = mcc.read_namespaced_stateful_set(sts_name, namespace)
+            assert sts.spec.replicas == MONGOT_REPLICAS_PER_CLUSTER, (
+                f"[{mcc.cluster_name}] {sts_name} expected {MONGOT_REPLICAS_PER_CLUSTER} replicas, got {sts.spec.replicas}"
+            )
+            mcc.read_namespaced_service(svc_name, namespace)
+            mcc.read_namespaced_service(proxy_svc_name, namespace)
+            sts_ready[sts_name] = MONGOT_REPLICAS_PER_CLUSTER
+            local_mongot_upstreams.append(f"{svc_name}.{namespace}.svc.cluster.local")
+            # mongot syncSource hosts == the EXTERNAL per-shard seed list.
+            assert_mongot_sync_source_hosts(mcc, cm_name, namespace, _shard_host_seeds(shard_idx))
+            logger.info(
+                f"[{mcc.cluster_name}] (cluster_index={ci}, shard={shard_name}): sts={sts_name} "
+                f"svc={svc_name} proxy={proxy_svc_name} cm={cm_name}"
+            )
+        upstreams_by_idx[ci] = local_mongot_upstreams
+
+        mcc.read_namespaced_service(search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, ci), namespace)
+
+        envoy_dep_name = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, ci)
+        assert_workload_ready_in_cluster(mcc, namespace, sts_ready, envoy_dep_name)
+        mdbs.assert_lb_status()
+        logger.info(f"[{mcc.cluster_name}] envoy_lb={envoy_dep_name} ready; mongot STSs ready: {list(sts_ready)}")
+
+    # SNI anchor: upstream check stays internal (the local mongot Service FQDNs). Omit the
+    # helper SNI-FQDN anchor (simulated sharded SNI carries per-shard external FQDNs, not the
+    # per-cluster proxy-svc FQDN that anchor checks).
+    verify_per_cluster_envoy_sni(
+        namespace=namespace,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        member_cluster_clients=[mcc for mcc, _ in per_cluster_mdbs_search],
+        expected_upstreams_by_idx=upstreams_by_idx,
+    )
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_status_per_cluster_local_only(
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    assert_status_running_local_only(per_cluster_mdbs_search)
+
+
+# The source is a single sharded deployment; there are NO per-cluster source processes to
+# route locally. Instead we FLIP the source's mongotHost to each search cluster's external
+# Envoy endpoint in turn, proving each cluster's mongot independently indexes the shared
+# source and serves correct rows.
+
+
+def _flip_source_mongot_host(mdb: MongoDB, target_search_context: str, target_harness_idx: int) -> None:
+    """Point every source process at the TARGET search cluster's external Envoy via OM AC:
+    mongos -> cluster-level external endpoint, shard mongod -> per-shard external endpoint,
+    config servers untouched. Routing depends only on the target SEARCH cluster, not on the
+    source process's own cluster index."""
+    mongos_endpoint = _external_mongos_envoy_endpoint(target_search_context, target_harness_idx)
+
+    def resolve_host(process_name: str) -> Optional[str]:
+        classified = _classify_sharded_process(process_name, MDB_RESOURCE_NAME, multi_cluster=True)
+        if classified is None:
+            return None
+        role, _cluster_index, shard_index = classified
+        if role == "mongos":
+            return mongos_endpoint
+        assert shard_index is not None
+        return _external_shard_envoy_endpoint(target_search_context, target_harness_idx, shard_index)
+
+    patch_mongot_host_via_ac(mdb, resolve_host)
+
+
+def _search_tls_param_mismatches(params: dict) -> List[str]:
+    # automation-mongod.conf serializes bool setParameters as "true"/"false" strings while
+    # mongos getParameter returns real bools; coerce both sides so a correct value never
+    # reads as a mismatch.
+    return [
+        f"{k}={params.get(k)!r} expected {v!r}"
+        for k, v in SOURCE_SEARCH_SET_PARAMETERS.items()
+        if str(params.get(k)).lower() != str(v).lower()
+    ]
+
+
+def _assert_source_routed_to(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+    target_search_context: str,
+    target_harness_idx: int,
+) -> None:
+    """Positively verify the new mongotHost is APPLIED on every source shard mongod (across
+    BOTH data clusters) before querying, then on the (stateless) mongos via getParameter."""
+
+    def shards_on_disk() -> tuple:
+        all_ok = True
+        msgs: List[str] = []
+        for data_context in DATA_CLUSTERS:
+            src_idx = SOURCE_CLUSTER_INDEX[data_context]
+            mcc = _mcc(member_cluster_clients, data_context)
+            for shard_idx in range(SHARD_COUNT):
+                expected = _external_shard_envoy_endpoint(target_search_context, target_harness_idx, shard_idx)
+                for member_idx in range(SHARD_MEMBERS_PER_CLUSTER[src_idx] or 0):
+                    pod_name = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}-{member_idx}"
+                    try:
+                        params = read_mongod_set_parameter(pod_name, namespace, mcc.api_client)
+                        got_host = params.get("mongotHost", "")
+                        got_mgmt = params.get("searchIndexManagementHostAndPort", "")
+                        tls_bad = _search_tls_param_mismatches(params)
+                        if got_host != expected or got_mgmt != expected or tls_bad:
+                            all_ok = False
+                            msgs.append(
+                                f"[{mcc.cluster_name}] {pod_name}: mongotHost={got_host!r} "
+                                f"searchIndexMgmt={got_mgmt!r} expected={expected!r} tls_bad={tls_bad}"
+                            )
+                        else:
+                            msgs.append(f"[{mcc.cluster_name}] {pod_name}: mongotHost={expected} + search TLS params OK")
+                    except Exception as exc:  # noqa: BLE001
+                        all_ok = False
+                        msgs.append(f"[{mcc.cluster_name}] {pod_name}: error reading conf: {exc}")
+        return all_ok, "\n".join(msgs)
+
+    run_periodically(
+        shards_on_disk, timeout=300, sleep_time=10, msg=f"source shard mongotHost -> {target_search_context}"
+    )
+
+    mongos_expected = _external_mongos_envoy_endpoint(target_search_context, target_harness_idx)
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    get_params = {"getParameter": 1, "mongotHost": 1, "searchIndexManagementHostAndPort": 1}
+    get_params.update({k: 1 for k in SOURCE_SEARCH_SET_PARAMETERS})
+    params = tester.client.admin.command(get_params)
+    got_host = params.get("mongotHost", "")
+    got_mgmt = params.get("searchIndexManagementHostAndPort", "")
+    tls_bad = _search_tls_param_mismatches(params)
+    assert got_host == mongos_expected and got_mgmt == mongos_expected and not tls_bad, (
+        f"mongos mongotHost={got_host!r} searchIndexMgmt={got_mgmt!r} expected {mongos_expected!r}; tls_bad={tls_bad}"
+    )
+    logger.info(f"source routed to {target_search_context}: mongos+shards mongotHost + search TLS params confirmed")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_shard_sample_collection(namespace: str, member_cluster_clients: List[MultiClusterClient]):
+    """Hash-shard the EMPTY sample_mflix.movies before loading data so hashed _id
+    distributes docs across both shards at insert time. Skip reshardCollection."""
+    admin = _source_mongos_search_tester(member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    ns = "sample_mflix.movies"
+    try:
+        admin.client.admin.command("enableSharding", "sample_mflix")
+    except pymongo.errors.OperationFailure as exc:
+        if exc.code != 23 and "already enabled" not in str(exc):  # AlreadyInitialized
+            raise
+    admin.client["sample_mflix"]["movies"].create_index([("_id", pymongo.HASHED)])
+    try:
+        admin.client.admin.command("shardCollection", ns, key={"_id": "hashed"}, unique=False)
+    except pymongo.errors.OperationFailure as exc:
+        if "already sharded" in str(exc) or exc.code == 20:
+            logger.info(f"{ns} already sharded")
+        else:
+            raise
+    logger.info(f"{ns} hash-sharded empty (skipping reshardCollection redistribution)")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_restore_sample_database(namespace: str, member_cluster_clients: List[MultiClusterClient], tools_pod: ToolsPod):
+    """Restore sample_mflix via the source mongos WITHOUT --drop (the movies collection is
+    already hash-sharded empty, so inserts distribute across both shards)."""
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    tester.mongorestore_from_url(
+        archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
+        ns_include="sample_mflix.*",
+        tools_pod=tools_pod,
+        drop=False,
+    )
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_shard_distribution(namespace: str, member_cluster_clients: List[MultiClusterClient]):
+    """Both shards must hold data — proves the pre-shard-then-load distributed inserts."""
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+
+    def check() -> tuple:
+        counts = movies.get_shard_document_counts()
+        total = sum(counts.values())
+        if len(counts) != SHARD_COUNT or not all(c > 0 for c in counts.values()):
+            return False, f"not all {SHARD_COUNT} shards non-empty: counts={counts} total={total}"
+        if min(counts.values()) <= total * 0.10:
+            return False, f"shard balance floor not met: min={min(counts.values())} <= 10% of {total}; counts={counts}"
+        return True, f"per-shard counts: {counts} total={total}"
+
+    run_periodically(check, timeout=120, sleep_time=5, msg="per-shard document distribution")
+
+
+def _route_and_query(
+    namespace: str,
+    mdb: MongoDB,
+    member_cluster_clients: List[MultiClusterClient],
+    target_search_context: str,
+    *,
+    create_index: bool,
+) -> None:
+    """Flip the source at the target search cluster's external Envoy, verify it APPLIED,
+    then assert the deterministic $search count via the source mongos. create_index=True
+    (first flip) builds the index; later flips reuse it and just wait READY so a propagation
+    failure surfaces as a timeout, not an empty $search."""
+    search_mccs = _search_mccs(member_cluster_clients)
+    assert_per_cluster_count(search_mccs)
+    target_mcc = _mcc(member_cluster_clients, target_search_context)
+    target_idx = _idx(target_mcc)
+
+    _flip_source_mongot_host(mdb, target_search_context, target_idx)
+    _assert_source_routed_to(namespace, member_cluster_clients, target_search_context, target_idx)
+
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+    if create_index:
+        movies.create_search_index()
+    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+    movies.assert_search_query(retry_timeout=SEARCH_QUERY_RETRY_TIMEOUT)
+    logger.info(f"search cluster {target_search_context}: deterministic $search via source mongos OK")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_route_to_search_az1_and_query(
+    namespace: str,
+    mdb: MongoDB,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Flip 1 of 2: route the source at search-az1's mongot and create the index."""
+    _route_and_query(namespace, mdb, member_cluster_clients, SEARCH_AZ1, create_index=True)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_search_results_from_all_shards(namespace: str, member_cluster_clients: List[MultiClusterClient]):
+    """Cross-shard completeness (still routed at search-az1): a wildcard $search via the
+    source mongos returns total-1 docs, proving EVERY shard's mongot contributes."""
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
+    verify_search_results_from_all_shards(tester)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_create_vector_search_index(namespace: str, member_cluster_clients: List[MultiClusterClient]):
+    """Create a $vectorSearch index on embedded_movies and wait READY (still routed at
+    search-az1). Indexing needs no Voyage key; the query is env-gated."""
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
+    embedded = EmbeddedMoviesSearchHelper(search_tester=tester)
+    embedded.create_vector_search_index()
+    embedded.wait_for_vector_search_index(timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_vector_search_query_via_source_mongos(namespace: str, member_cluster_clients: List[MultiClusterClient]):
+    """$vectorSearch via the source mongos in the search-az1 window. embedded_movies is
+    never sharded, so it lives on the primary shard and limit=4 against thousands of
+    pre-embedded docs returns exactly 4."""
+    if EMBEDDING_QUERY_KEY_ENV_VAR not in os.environ:
+        pytest.skip(f"missing {EMBEDDING_QUERY_KEY_ENV_VAR} — required to generate the query vector")
+
+    target_idx = _idx(_mcc(member_cluster_clients, SEARCH_AZ1))
+    _assert_source_routed_to(namespace, member_cluster_clients, SEARCH_AZ1, target_idx)
+
+    limit = 4
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
+    embedded = EmbeddedMoviesSearchHelper(search_tester=tester)
+    embedded.wait_for_vector_search_index(timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+    query_vector = embedded.generate_query_vector("space exploration")
+    doc_count = embedded.count_documents_with_embeddings()
+    assert doc_count >= limit, f"only {doc_count} embedded_movies docs have embeddings — need >= {limit}"
+
+    embedded.assert_vector_search_count_eventually(
+        query_vector, limit, timeout=SEARCH_QUERY_RETRY_TIMEOUT, msg_prefix="via source mongos: "
+    )
+    logger.info(f"deterministic $vectorSearch (=={limit}) via source mongos OK")
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_route_to_search_az2_and_query(
+    namespace: str,
+    mdb: MongoDB,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Flip 2 of 2: re-point at search-az2's mongot, proving it independently indexes +
+    serves the shared source (index created once under flip 1)."""
+    _route_and_query(namespace, mdb, member_cluster_clients, SEARCH_AZ2, create_index=False)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_cross_cluster_isolation_absence(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Each search cluster must NOT contain the OTHER cluster's per-(cluster,shard) Search
+    resources — confirms each simulated operator only materialises its own LocalizeToCluster
+    slice."""
+    shard_names = [f"{MDB_RESOURCE_NAME}-{shard_idx}" for shard_idx in range(SHARD_COUNT)]
+    assert_cross_cluster_isolation(namespace, per_cluster_mdbs_search, MDBS_RESOURCE_NAME, shard_names=shard_names)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -244,6 +244,11 @@ MONGOS_PER_CLUSTER: List[int | None] = [MONGOS_BY_CONTEXT[c] for c in SORTED_DAT
 
 MONGOT_REPLICAS_PER_CLUSTER = 1
 
+# mongot data on node-local NVMe (r5d.xlarge instance store) via the infra's local-volume
+# provisioner StorageClass, not EBS gp2. Local PVs are whole-disk (~139Gi); the request fits within.
+MONGOT_STORAGE_CLASS = "local-nvme"
+MONGOT_STORAGE_SIZE = "100Gi"
+
 CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
 
 SEARCH_INDEX_READY_TIMEOUT = 300
@@ -806,6 +811,7 @@ def per_cluster_mdbs_search(
                 "name": ctx,
                 "index": idx,
                 "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+                "persistence": {"single": {"storage": MONGOT_STORAGE_SIZE, "storageClass": MONGOT_STORAGE_CLASS}},
                 "loadBalancer": {
                     "managed": {
                         "replicas": ENVOY_LB_REPLICAS,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/aws_simulated_mc_sharded.py
@@ -36,12 +36,15 @@ Connectivity seams: every ".svc.cluster.local" cross-cluster hop is served inste
 EXTERNAL FQDN behind an SNI front:
   * source mongod/mongos seeds (mongot syncSource) AND the OM AppDB members -> external
     FQDNs under *.mongodb-proxy.<dataClusterId>.mc... (the shared per-cluster mongodb-envoy NLB).
-  * the mongotHost flip endpoints (mongos cluster-level + per-shard) -> external FQDNs
+  * the per-AZ mongotHost endpoints (mongos cluster-level + per-shard) -> external FQDNs
     under *.envoy-proxy.<searchClusterId>.mc... (the operator-managed search Envoy LB).
   * mongodEnvoy upstreams stay INTERNAL (the per-pod headless Services).
 
 The source mongotHost is set by patching the OM Automation Config directly, since the
-operator has no per-cluster additionalMongodConfig for an external source.
+operator has no per-cluster additionalMongodConfig for an external source. Each source
+process points at the mongot co-located in its OWN AZ (no global flip): az1 processes ->
+search-az1, az2 processes -> search-az2, so a single $search fans out across both search
+clusters by each shard's primary placement.
 """
 
 from __future__ import annotations
@@ -158,6 +161,13 @@ SOURCE_CLUSTER_INDEX = {ctx: i for i, ctx in enumerate(SORTED_DATA)}
 # mongot syncSource.replicationReader.tagSets).
 AZ_BY_DATA_CLUSTER = {CENTRAL_OM_MDB_AZ1: "az1", DATA_MDB_AZ2: "az2"}
 AZ_BY_SEARCH_CLUSTER = {SEARCH_AZ1: "az1", SEARCH_AZ2: "az2"}
+
+# Same-AZ search cluster for each data cluster. Each source process queries the mongot
+# co-located in its OWN AZ (no global flip): az1 data -> search-az1, az2 data -> search-az2.
+SEARCH_FOR_DATA_CLUSTER = {
+    data_ctx: next(sc for sc, az in AZ_BY_SEARCH_CLUSTER.items() if az == data_az)
+    for data_ctx, data_az in AZ_BY_DATA_CLUSTER.items()
+}
 
 PARENT_ZONE = "mc.mongokubernetes.com"
 
@@ -349,12 +359,14 @@ def _source_mongos_search_tester(
     namespace: str,
     username: str,
     password: str,
+    data_context: str = CENTRAL_OM_MDB_AZ1,
 ) -> SearchTester:
-    """SearchTester pinned to the AZ1 source mongos via its EXTERNAL FQDN (reachable
-    cross-cluster over the mongodEnvoy NLB — there is no mesh here). TLS + issuer CA on."""
-    src_idx = SOURCE_CLUSTER_INDEX[CENTRAL_OM_MDB_AZ1]
+    """SearchTester pinned to a data cluster's source mongos via its EXTERNAL FQDN (default
+    AZ1; reachable cross-cluster over the mongodEnvoy NLB — there is no mesh here). TLS +
+    issuer CA on."""
+    src_idx = SOURCE_CLUSTER_INDEX[data_context]
     pod = f"{MDB_RESOURCE_NAME}-mongos-{src_idx}-0"
-    host = f"{_source_pod_external_fqdn(pod, CENTRAL_OM_MDB_AZ1)}:27017"
+    host = f"{_source_pod_external_fqdn(pod, data_context)}:27017"
     return per_cluster_search_tester(host, username, password)
 
 
@@ -1237,28 +1249,35 @@ def test_status_per_cluster_local_only(
     assert_status_running_local_only(per_cluster_mdbs_search)
 
 
-# The source is a single sharded deployment; there are NO per-cluster source processes to
-# route locally. Instead we FLIP the source's mongotHost to each search cluster's external
-# Envoy endpoint in turn, proving each cluster's mongot independently indexes the shared
-# source and serves correct rows.
+# Each source process queries the mongot co-located in its OWN AZ (no global flip): a process
+# in data cluster C uses the search cluster in C's AZ. So a single $search fans out across
+# BOTH search clusters — each shard's serving member hits its same-AZ mongot.
 
 
-def _flip_source_mongot_host(mdb: MongoDB, target_search_context: str, target_harness_idx: int) -> None:
-    """Point every source process at the TARGET search cluster's external Envoy via OM AC:
-    mongos -> cluster-level external endpoint, shard mongod -> per-shard external endpoint,
-    config servers untouched. Routing depends only on the target SEARCH cluster, not on the
-    source process's own cluster index."""
-    mongos_endpoint = _external_mongos_envoy_endpoint(target_search_context, target_harness_idx)
+def _search_idx_by_ctx(member_cluster_clients: List[MultiClusterClient]) -> Dict[str, int]:
+    """Harness cluster_index per search context (search-az1=2, search-az2=3), read from the
+    live member-client list rather than hardcoded."""
+    return {sc: _idx(_mcc(member_cluster_clients, sc)) for sc in SEARCH_CLUSTERS}
+
+
+def _wire_source_mongot_host_per_az(mdb: MongoDB, member_cluster_clients: List[MultiClusterClient]) -> None:
+    """Point every source process at the mongot in its OWN AZ via OM AC (NO global flip):
+    mongos -> its same-AZ search cluster's cluster-level endpoint, shard mongod -> that
+    cluster's per-shard endpoint, config servers untouched. The target search cluster is
+    chosen by the source process's own cluster index (AZ), not a single global target."""
+    search_idx = _search_idx_by_ctx(member_cluster_clients)
 
     def resolve_host(process_name: str) -> Optional[str]:
         classified = _classify_sharded_process(process_name, MDB_RESOURCE_NAME, multi_cluster=True)
         if classified is None:
             return None
-        role, _cluster_index, shard_index = classified
+        role, cluster_index, shard_index = classified
+        search_ctx = SEARCH_FOR_DATA_CLUSTER[SORTED_DATA[cluster_index]]
+        idx = search_idx[search_ctx]
         if role == "mongos":
-            return mongos_endpoint
+            return _external_mongos_envoy_endpoint(search_ctx, idx)
         assert shard_index is not None
-        return _external_shard_envoy_endpoint(target_search_context, target_harness_idx, shard_index)
+        return _external_shard_envoy_endpoint(search_ctx, idx, shard_index)
 
     patch_mongot_host_via_ac(mdb, resolve_host)
 
@@ -1274,23 +1293,24 @@ def _search_tls_param_mismatches(params: dict) -> List[str]:
     ]
 
 
-def _assert_source_routed_to(
+def _assert_source_routed_per_az(
     namespace: str,
     member_cluster_clients: List[MultiClusterClient],
-    target_search_context: str,
-    target_harness_idx: int,
 ) -> None:
-    """Positively verify the new mongotHost is APPLIED on every source shard mongod (across
-    BOTH data clusters) before querying, then on the (stateless) mongos via getParameter."""
+    """Verify each source process's mongotHost points at its OWN-AZ search cluster: per-shard
+    endpoint on every shard mongod (both data clusters), cluster-level endpoint on each mongos."""
+    search_idx = _search_idx_by_ctx(member_cluster_clients)
 
     def shards_on_disk() -> tuple:
         all_ok = True
         msgs: List[str] = []
         for data_context in DATA_CLUSTERS:
             src_idx = SOURCE_CLUSTER_INDEX[data_context]
+            search_ctx = SEARCH_FOR_DATA_CLUSTER[data_context]
+            s_idx = search_idx[search_ctx]
             mcc = _mcc(member_cluster_clients, data_context)
             for shard_idx in range(SHARD_COUNT):
-                expected = _external_shard_envoy_endpoint(target_search_context, target_harness_idx, shard_idx)
+                expected = _external_shard_envoy_endpoint(search_ctx, s_idx, shard_idx)
                 for member_idx in range(SHARD_MEMBERS_PER_CLUSTER[src_idx] or 0):
                     pod_name = f"{MDB_RESOURCE_NAME}-{shard_idx}-{src_idx}-{member_idx}"
                     try:
@@ -1313,21 +1333,26 @@ def _assert_source_routed_to(
         return all_ok, "\n".join(msgs)
 
     run_periodically(
-        shards_on_disk, timeout=300, sleep_time=10, msg=f"source shard mongotHost -> {target_search_context}"
+        shards_on_disk, timeout=300, sleep_time=10, msg="source shard mongotHost -> own-AZ search cluster"
     )
 
-    mongos_expected = _external_mongos_envoy_endpoint(target_search_context, target_harness_idx)
-    tester = _source_mongos_search_tester(member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
     get_params = {"getParameter": 1, "mongotHost": 1, "searchIndexManagementHostAndPort": 1}
     get_params.update({k: 1 for k in SOURCE_SEARCH_SET_PARAMETERS})
-    params = tester.client.admin.command(get_params)
-    got_host = params.get("mongotHost", "")
-    got_mgmt = params.get("searchIndexManagementHostAndPort", "")
-    tls_bad = _search_tls_param_mismatches(params)
-    assert got_host == mongos_expected and got_mgmt == mongos_expected and not tls_bad, (
-        f"mongos mongotHost={got_host!r} searchIndexMgmt={got_mgmt!r} expected {mongos_expected!r}; tls_bad={tls_bad}"
-    )
-    logger.info(f"source routed to {target_search_context}: mongos+shards mongotHost + search TLS params confirmed")
+    for data_context in DATA_CLUSTERS:
+        search_ctx = SEARCH_FOR_DATA_CLUSTER[data_context]
+        mongos_expected = _external_mongos_envoy_endpoint(search_ctx, search_idx[search_ctx])
+        tester = _source_mongos_search_tester(
+            member_cluster_clients, namespace, ADMIN_USER_NAME, ADMIN_USER_PASSWORD, data_context=data_context
+        )
+        params = tester.client.admin.command(get_params)
+        got_host = params.get("mongotHost", "")
+        got_mgmt = params.get("searchIndexManagementHostAndPort", "")
+        tls_bad = _search_tls_param_mismatches(params)
+        assert got_host == mongos_expected and got_mgmt == mongos_expected and not tls_bad, (
+            f"[{data_context}] mongos mongotHost={got_host!r} searchIndexMgmt={got_mgmt!r} "
+            f"expected {mongos_expected!r}; tls_bad={tls_bad}"
+        )
+    logger.info("source routed per-AZ: mongos+shards mongotHost + search TLS params confirmed")
 
 
 @mark.e2e_aws_simulated_mc_sharded
@@ -1383,43 +1408,32 @@ def test_shard_distribution(namespace: str, member_cluster_clients: List[MultiCl
     run_periodically(check, timeout=120, sleep_time=5, msg="per-shard document distribution")
 
 
-def _route_and_query(
-    namespace: str,
-    mdb: MongoDB,
-    member_cluster_clients: List[MultiClusterClient],
-    target_search_context: str,
-    *,
-    create_index: bool,
-) -> None:
-    """Flip the source at the target search cluster's external Envoy, verify it APPLIED,
-    then assert the deterministic $search count via the source mongos. create_index=True
-    (first flip) builds the index; later flips reuse it and just wait READY so a propagation
-    failure surfaces as a timeout, not an empty $search."""
-    search_mccs = _search_mccs(member_cluster_clients)
-    assert_per_cluster_count(search_mccs)
-    target_mcc = _mcc(member_cluster_clients, target_search_context)
-    target_idx = _idx(target_mcc)
-
-    _flip_source_mongot_host(mdb, target_search_context, target_idx)
-    _assert_source_routed_to(namespace, member_cluster_clients, target_search_context, target_idx)
-
-    tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
-    movies = SampleMoviesSearchHelper(search_tester=tester)
-    if create_index:
-        movies.create_search_index()
-    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
-    movies.assert_search_query(retry_timeout=SEARCH_QUERY_RETRY_TIMEOUT)
-    logger.info(f"search cluster {target_search_context}: deterministic $search via source mongos OK")
-
-
 @mark.e2e_aws_simulated_mc_sharded
-def test_route_to_search_az1_and_query(
+def test_wire_source_mongot_host_per_az(
     namespace: str,
     mdb: MongoDB,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    """Flip 1 of 2: route the source at search-az1's mongot and create the index."""
-    _route_and_query(namespace, mdb, member_cluster_clients, SEARCH_AZ1, create_index=True)
+    """Wire each source process at the mongot in its OWN AZ and verify the AC applied it:
+    az1 processes -> search-az1, az2 processes -> search-az2 (no global flip)."""
+    assert_per_cluster_count(_search_mccs(member_cluster_clients))
+    _wire_source_mongot_host_per_az(mdb, member_cluster_clients)
+    _assert_source_routed_per_az(namespace, member_cluster_clients)
+
+
+@mark.e2e_aws_simulated_mc_sharded
+def test_create_search_index_and_query(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Create the $search index and assert the deterministic count via the source mongos;
+    per-AZ wiring fans the query out to each shard's co-located search cluster."""
+    tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+    movies.create_search_index()
+    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+    movies.assert_search_query(retry_timeout=SEARCH_QUERY_RETRY_TIMEOUT)
+    logger.info("per-AZ routing: deterministic $search via source mongos OK")
 
 
 @mark.e2e_aws_simulated_mc_sharded
@@ -1448,8 +1462,7 @@ def test_vector_search_query_via_source_mongos(namespace: str, member_cluster_cl
     if EMBEDDING_QUERY_KEY_ENV_VAR not in os.environ:
         pytest.skip(f"missing {EMBEDDING_QUERY_KEY_ENV_VAR} — required to generate the query vector")
 
-    target_idx = _idx(_mcc(member_cluster_clients, SEARCH_AZ1))
-    _assert_source_routed_to(namespace, member_cluster_clients, SEARCH_AZ1, target_idx)
+    _assert_source_routed_per_az(namespace, member_cluster_clients)
 
     limit = 4
     tester = _source_mongos_search_tester(member_cluster_clients, namespace, USER_NAME, USER_PASSWORD)
@@ -1464,17 +1477,6 @@ def test_vector_search_query_via_source_mongos(namespace: str, member_cluster_cl
         query_vector, limit, timeout=SEARCH_QUERY_RETRY_TIMEOUT, msg_prefix="via source mongos: "
     )
     logger.info(f"deterministic $vectorSearch (=={limit}) via source mongos OK")
-
-
-@mark.e2e_aws_simulated_mc_sharded
-def test_route_to_search_az2_and_query(
-    namespace: str,
-    mdb: MongoDB,
-    member_cluster_clients: List[MultiClusterClient],
-):
-    """Flip 2 of 2: re-point at search-az2's mongot, proving it independently indexes +
-    serves the shared source (index created once under flip 1)."""
-    _route_and_query(namespace, mdb, member_cluster_clients, SEARCH_AZ2, create_index=False)
 
 
 @mark.e2e_aws_simulated_mc_sharded

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -40,7 +40,7 @@ logger = test_logger.get_test_logger(__name__)
 
 ENVOY_LB_REPLICAS = 2
 ENVOY_PROXY_PORT = 27028
-SIMULATED_OPERATOR_NAME = "mongodb-kubernetes-operator-simulated"
+SIMULATED_OPERATOR_NAME = "mongodb-kubernetes"
 
 ADMIN_USER_NAME = "mdb-admin-user"
 ADMIN_USER_PASSWORD = "mdb-admin-user-pass"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -38,7 +38,7 @@ logger = test_logger.get_test_logger(__name__)
 # Shared simulated-MC constants
 # ---------------------------------------------------------------------------
 
-ENVOY_LB_REPLICAS = 1
+ENVOY_LB_REPLICAS = 2
 ENVOY_PROXY_PORT = 27028
 SIMULATED_OPERATOR_NAME = "mongodb-kubernetes-operator-simulated"
 

--- a/scripts/aws/provision_aws_mc_infra.sh
+++ b/scripts/aws/provision_aws_mc_infra.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+#
+# Provision (or re-provision) the four-EKS-cluster AWS multi-cluster perf/e2e
+# infrastructure in eu-south-1, regenerate the merged kubeconfig, and verify node
+# reachability. This is SHORT-LIVED infra — tear it down with
+# `mongot_multicluster-infra/scripts/enterprise/multicluster.py down`.
+#
+# Pairs with scripts/dev/contexts/e2e_aws_simulated_mc_sharded (which consumes the
+# kubeconfig this script writes). The actual AWS resource provisioning lives in the
+# mongot_multicluster-infra repo's hand-rolled boto3 orchestrator (multicluster.py).
+#
+# Prereqs:
+#   - AWS profile `mck-admin` (IAM user, acct 268558157000) with a valid session.
+#   - On the corp VPN: EKS API endpoints are corp-prefix-locked, and the in-cluster
+#     provisioning steps (lbcontroller/certmanager/storageclasses/nvme) use kubectl/helm.
+#   - aws, kubectl, helm on PATH; a python venv with boto3/click/pyyaml/requests.
+#
+# Usage:
+#   scripts/aws/provision_aws_mc_infra.sh [PHASE ...]
+#     (no args)            -> runs the default pipeline: reset up apiaccess kubeconfig verify
+#     all                  -> same as no args
+#     full                 -> default pipeline + e2e-prep (tokens + bootstrap)
+#     <phase> [<phase>...] -> run only the named phase(s), in the given order
+#   Phases: preflight reset up cpsubnets apiaccess kubeconfig verify tokens bootstrap
+#
+# Env overrides:
+#   INFRA_REPO   (default: ~/mdb/mongot_multicluster-infra)
+#   PY           (default: <this repo>/venv/bin/python3)
+#   AWS_PROFILE  (default: mck-admin)
+#   REGION       (default: eu-south-1)
+#   KUBECONFIG_OUT (default: $INFRA_REPO/tmp/search-onprem.kubeconfig)
+#   CONCURRENCY  (default: 4)
+
+set -Eeuo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+THIS_REPO="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+INFRA_REPO="${INFRA_REPO:-${HOME}/mdb/mongot_multicluster-infra}"
+ENT_DIR="${INFRA_REPO}/scripts/enterprise"
+PY="${PY:-${THIS_REPO}/venv/bin/python3}"
+export AWS_PROFILE="${AWS_PROFILE:-mck-admin}"
+REGION="${REGION:-eu-south-1}"
+KUBECONFIG_OUT="${KUBECONFIG_OUT:-${INFRA_REPO}/tmp/search-onprem.kubeconfig}"
+CONCURRENCY="${CONCURRENCY:-4}"
+
+# Manifests (one per cluster). Filenames are relative to ENT_DIR.
+MANIFESTS=(
+  manifest-mc-om-mdb-az1.yaml
+  manifest-mc-mdb-az2.yaml
+  manifest-mc-search-az1.yaml
+  manifest-mc-search-az2.yaml
+)
+CENTRAL_CONTEXT="om-mdb-az1"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m    ok: %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m    warn: %s\033[0m\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+trap 'die "failed at line ${LINENO} (phase: ${CURRENT_PHASE:-?})"' ERR
+CURRENT_PHASE=""
+
+# clusterId from a manifest file (e.g. ls-mc-om-mdb-az1)
+cluster_id_of() { grep -E '^clusterId:' "${ENT_DIR}/$1" | awk '{print $2}'; }
+# short context = clusterId without the ls-mc- prefix (e.g. om-mdb-az1)
+short_of()      { local cid; cid="$(cluster_id_of "$1")"; echo "${cid#ls-mc-}"; }
+# EKS cluster name = test-cluster-<clusterId>  (lib/manifest.py derivation)
+cluster_name_of(){ echo "test-cluster-$(cluster_id_of "$1")"; }
+
+manifest_flags() { local m; for m in "${MANIFESTS[@]}"; do printf -- '--manifest %s ' "$m"; done; }
+
+# ---------------------------------------------------------------------------
+# Phases
+# ---------------------------------------------------------------------------
+phase_preflight() {
+  CURRENT_PHASE=preflight; log "preflight"
+  [[ -d "${ENT_DIR}" ]] || die "infra repo not found: ${ENT_DIR} (set INFRA_REPO)"
+  [[ -x "${PY}" ]] || die "python not found/executable: ${PY} (set PY)"
+  "${PY}" -c "import boto3,click,yaml,requests" || die "venv missing boto3/click/pyyaml/requests"
+  local t; for t in aws kubectl helm; do command -v "$t" >/dev/null || die "$t not on PATH"; done
+  local m; for m in "${MANIFESTS[@]}"; do [[ -f "${ENT_DIR}/$m" ]] || die "manifest missing: ${ENT_DIR}/$m"; done
+  local ident
+  ident="$(aws sts get-caller-identity --profile "${AWS_PROFILE}" --region "${REGION}" --query 'Arn' --output text)" \
+    || die "AWS profile '${AWS_PROFILE}' cannot authenticate (session expired? wrong profile?)"
+  ok "AWS identity: ${ident}"
+  ok "infra repo: ${ENT_DIR}"
+  ok "python: ${PY}"
+}
+
+# Remove the provisioner's per-cluster state files. A teardown leaves them STALE
+# (lbControllerReady/certManagerReady/apiAllowlistReady=true), which makes `up`
+# wrongly SKIP those steps on a fresh deploy. Back them up, then clear.
+phase_reset() {
+  CURRENT_PHASE=reset; log "reset stale state-*.json"
+  local backup; backup="/tmp/mck-aws-mc-state-backup-$(date +%Y%m%d-%H%M%S)"
+  if compgen -G "${ENT_DIR}/state-ls-mc-*.json" >/dev/null; then
+    mkdir -p "${backup}"
+    cp "${ENT_DIR}"/state-ls-mc-*.json "${backup}/" 2>/dev/null || true
+    rm -f "${ENT_DIR}"/state-ls-mc-*.json
+    ok "cleared state files (backup: ${backup})"
+  else
+    ok "no state files present (already clean)"
+  fi
+}
+
+phase_up() {
+  CURRENT_PHASE=up; log "provision (multicluster.py up --to certmanager) — EKS control planes + node groups, ~15-25 min"
+  # Stop before apiaccess: the dense cluster (om-mdb-az1, 11 nodes) exhausts its
+  # private /24 subnet via the VPC CNI warm-IP pool, and apiaccess's
+  # UpdateClusterConfig needs >=2 free IPs per AZ. The cpsubnets phase fixes that first.
+  ( cd "${ENT_DIR}" && eval "${PY} multicluster.py up $(manifest_flags) --profile ${AWS_PROFILE} --concurrency ${CONCURRENCY} --to certmanager" )
+  ok "up (through certmanager) complete"
+}
+
+# Ensure every cluster's control-plane subnet set has a subnet with free IPs in each
+# AZ, by adding the (lightly-used) public subnet. Without this, apiaccess's
+# UpdateClusterConfig fails with "Atleast one subnet in each AZ should have 2 free IPs"
+# on the dense cluster whose private subnet the CNI has exhausted. Idempotent.
+phase_cpsubnets() {
+  CURRENT_PHASE=cpsubnets; log "ensure free-IP control-plane subnet per AZ (pre-apiaccess guard)"
+  local m cid cname pub cur
+  for m in "${MANIFESTS[@]}"; do
+    cid="$(cluster_id_of "${m}")"; cname="test-cluster-${cid}"
+    pub="$(aws ec2 describe-subnets --profile "${AWS_PROFILE}" --region "${REGION}" \
+      --filters "Name=tag:Name,Values=search-onprem-public-${cid}" \
+      --query 'Subnets[0].SubnetId' --output text 2>/dev/null)"
+    [[ -n "${pub}" && "${pub}" != "None" ]] || { warn "${cid}: no public subnet found, skipping"; continue; }
+    cur="$(aws eks describe-cluster --profile "${AWS_PROFILE}" --region "${REGION}" \
+      --name "${cname}" --query 'cluster.resourcesVpcConfig.subnetIds' --output text 2>/dev/null)"
+    if grep -qw "${pub}" <<<"${cur}"; then ok "${cid}: public subnet already registered"; continue; fi
+    local joined; joined="$(echo "${cur}" | tr '\t' ',')",${pub}
+    aws eks update-cluster-config --profile "${AWS_PROFILE}" --region "${REGION}" \
+      --name "${cname}" --resources-vpc-config "subnetIds=${joined}" >/dev/null
+    printf '    %s: added public subnet %s, waiting ACTIVE' "${cid}" "${pub}"
+    local i st
+    for i in $(seq 1 40); do
+      st="$(aws eks describe-cluster --profile "${AWS_PROFILE}" --region "${REGION}" --name "${cname}" --query 'cluster.status' --output text 2>/dev/null)"
+      [[ "${st}" == "ACTIVE" ]] && break
+      printf '.'; sleep 20
+    done
+    echo; ok "${cid}: control-plane subnets updated"
+  done
+}
+
+# Cross-cluster NAT allowlisting needs ALL clusters' NAT gateways to exist, so on a
+# cold start the first apiaccess pass can't see siblings. Re-run it as a final pass.
+phase_apiaccess() {
+  CURRENT_PHASE=apiaccess; log "second apiaccess pass (cross-cluster NAT allowlist)"
+  ( cd "${ENT_DIR}" && eval "${PY} multicluster.py up $(manifest_flags) --profile ${AWS_PROFILE} --from apiaccess" )
+  ok "apiaccess complete"
+}
+
+# Rebuild the merged kubeconfig: one update-kubeconfig per cluster, aliased to the
+# short context name (om-mdb-az1, ...). Auth is exec `aws eks get-token` w/ the profile.
+phase_kubeconfig() {
+  CURRENT_PHASE=kubeconfig; log "regenerate merged kubeconfig -> ${KUBECONFIG_OUT}"
+  mkdir -p "$(dirname "${KUBECONFIG_OUT}")"
+  rm -f "${KUBECONFIG_OUT}"
+  local m short cname
+  for m in "${MANIFESTS[@]}"; do
+    short="$(short_of "$m")"; cname="$(cluster_name_of "$m")"
+    aws eks update-kubeconfig --name "${cname}" --region "${REGION}" \
+      --profile "${AWS_PROFILE}" --alias "${short}" --kubeconfig "${KUBECONFIG_OUT}"
+    ok "context ${short} -> ${cname}"
+  done
+  KUBECONFIG="${KUBECONFIG_OUT}" kubectl config use-context "${CENTRAL_CONTEXT}" >/dev/null
+  ok "current-context: ${CENTRAL_CONTEXT}"
+}
+
+phase_verify() {
+  CURRENT_PHASE=verify; log "verify node reachability (requires corp VPN)"
+  local m short n
+  for m in "${MANIFESTS[@]}"; do
+    short="$(short_of "$m")"
+    n="$(KUBECONFIG="${KUBECONFIG_OUT}" kubectl --context "${short}" get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+    if [[ "${n}" -gt 0 ]]; then ok "${short}: ${n} node(s)"; else warn "${short}: 0 nodes reachable (VPN? still joining?)"; fi
+  done
+}
+
+# --- optional e2e harness prep (not strictly "infra") ---
+phase_tokens() {
+  CURRENT_PHASE=tokens; log "extract SA bearer tokens (prepare_aws_mc_tokens.sh)"
+  # Invoke via bash so a missing +x bit can't break it.
+  ( cd "${THIS_REPO}" && source scripts/dev/contexts/e2e_aws_simulated_mc_sharded \
+      && AWS_PROFILE="${AWS_PROFILE}" bash scripts/dev/prepare_aws_mc_tokens.sh )
+  ok "tokens prepared"
+}
+
+phase_bootstrap() {
+  CURRENT_PHASE=bootstrap; log "cluster-side bootstrap (bootstrap_aws_mc_e2e.sh)"
+  ( cd "${THIS_REPO}" && source scripts/dev/contexts/e2e_aws_simulated_mc_sharded \
+      && AWS_PROFILE="${AWS_PROFILE}" bash scripts/dev/bootstrap_aws_mc_e2e.sh )
+  ok "bootstrap complete"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+DEFAULT_PIPELINE=(preflight reset up cpsubnets apiaccess kubeconfig verify)
+FULL_PIPELINE=(preflight reset up cpsubnets apiaccess kubeconfig verify tokens bootstrap)
+
+phases=()
+if [[ $# -eq 0 || "${1:-}" == "all" ]]; then
+  phases=("${DEFAULT_PIPELINE[@]}")
+elif [[ "${1:-}" == "full" ]]; then
+  phases=("${FULL_PIPELINE[@]}")
+else
+  phases=("$@")
+fi
+
+log "AWS MC infra provisioning — phases: ${phases[*]}"
+for p in "${phases[@]}"; do
+  case "$p" in
+    preflight|reset|up|cpsubnets|apiaccess|kubeconfig|verify|tokens|bootstrap) "phase_${p}" ;;
+    *) die "unknown phase: $p" ;;
+  esac
+done
+
+CURRENT_PHASE=""
+log "DONE. KUBECONFIG=${KUBECONFIG_OUT}"
+echo "Next: source scripts/dev/contexts/e2e_aws_simulated_mc_sharded && scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh"

--- a/scripts/dev/bootstrap_aws_mc_e2e.sh
+++ b/scripts/dev/bootstrap_aws_mc_e2e.sh
@@ -23,8 +23,23 @@ set -Eeou pipefail
 test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 
 cd "$(git rev-parse --show-toplevel)"
+# Preload the generated env (REGISTRY + base vars), then source the AWS context fresh so its
+# overrides (operator/search image pins, NAMESPACE, CENTRAL_CLUSTER, ...) win.
+set -a
+# shellcheck disable=SC1090,SC1091
+source .generated/context.env
+set +a
 # shellcheck disable=SC1091
-source scripts/dev/devenv
+source scripts/dev/contexts/e2e_aws_simulated_mc_sharded
+# Apply the devc network-prefix to the namespace inline: the prefix tooling lives in the
+# devcontainer layer (not carried by this AWS-only branch), and private-context resets
+# NAMESPACE to the un-prefixed base. WATCH_NAMESPACE must match or the operator cache-syncs
+# the wrong namespace and times out.
+if [[ -n "${MCK_DEVC_NET_PREFIX:-}" ]]; then
+  export NAMESPACE="${NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
+  export WATCH_NAMESPACE="${NAMESPACE}"
+fi
+# shellcheck disable=SC1091
 source scripts/funcs/printing
 source scripts/funcs/operator_deployment
 

--- a/scripts/dev/bootstrap_aws_mc_e2e.sh
+++ b/scripts/dev/bootstrap_aws_mc_e2e.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Minimal e2e environment bootstrap for the AWS real-infra multi-cluster run.
+#
+# The canonical bootstrap (scripts/dev/prepare_local_e2e_run.sh) is kind-specific (it does
+# `kubectl get nodes | grep control-plane`, istio labelling, a reset, etc.) and aborts on
+# EKS. This does just the cluster-side prerequisites the harness fixtures assume already
+# exist, for the four EKS clusters:
+#   - the test namespace (+ evg=task label) on central + every member;
+#   - `image-registries-secret` (docker-registry) for the private ECR the images live in
+#     (us-east-1 ECR; clusters are eu-south-1, same account) on every cluster/namespace;
+#   - the `mongodb-kubernetes-database-pods` / `mongodb-kubernetes-appdb` ServiceAccounts
+#     (with Helm ownership metadata so the operator chart adopts them);
+#   - the `operator-installation-config` ConfigMap on the central cluster.
+#
+# CRDs + the cross-cluster kubeconfig Secret are installed by the operator Helm releases /
+# run_kube_config_creation_tool that the test fixtures invoke, so they are NOT done here.
+#
+# Usage (context must already be switched: scripts/dev/switch_context.sh e2e_aws_simulated_mc_sharded):
+#   AWS_PROFILE=mck-admin scripts/dev/bootstrap_aws_mc_e2e.sh
+
+set -Eeou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1091
+source scripts/dev/devenv
+source scripts/funcs/printing
+source scripts/funcs/operator_deployment
+
+: "${NAMESPACE:?NAMESPACE unset — switch_context first}"
+: "${MEMBER_CLUSTERS:?MEMBER_CLUSTERS unset}"
+: "${CENTRAL_CLUSTER:?CENTRAL_CLUSTER unset}"
+export AWS_PROFILE="${AWS_PROFILE:-mck-admin}"
+
+ECR_HOST="268558157000.dkr.ecr.us-east-1.amazonaws.com"
+ECR_REGION="us-east-1"
+HELM_RELEASE_NAME="${OPERATOR_NAME:-mongodb-kubernetes-operator}"
+
+ALL_CONTEXTS=$(printf '%s\n' "${CENTRAL_CLUSTER}" ${MEMBER_CLUSTERS} | sort -u)
+
+echo "==> ECR login token (${ECR_HOST}, ${ECR_REGION})"
+ECR_PW="$(aws ecr get-login-password --region "${ECR_REGION}")"
+
+for ctx in ${ALL_CONTEXTS}; do
+  echo "==> [${ctx}] namespace ${NAMESPACE}"
+  kubectl --context "${ctx}" create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl --context "${ctx}" apply -f -
+  kubectl --context "${ctx}" label namespace "${NAMESPACE}" evg=task --overwrite
+
+  echo "==> [${ctx}] image-registries-secret"
+  kubectl --context "${ctx}" -n "${NAMESPACE}" create secret docker-registry image-registries-secret \
+    --docker-server="${ECR_HOST}" --docker-username=AWS --docker-password="${ECR_PW}" \
+    --dry-run=client -o yaml | kubectl --context "${ctx}" apply -f -
+
+  echo "==> [${ctx}] database-pod ServiceAccounts"
+  for sa in mongodb-kubernetes-database-pods mongodb-kubernetes-appdb; do
+    kubectl --context "${ctx}" -n "${NAMESPACE}" create serviceaccount "${sa}" --dry-run=client -o yaml \
+      | kubectl --context "${ctx}" apply -f -
+    kubectl --context "${ctx}" -n "${NAMESPACE}" label serviceaccount "${sa}" "app.kubernetes.io/managed-by=Helm" --overwrite
+    kubectl --context "${ctx}" -n "${NAMESPACE}" annotate serviceaccount "${sa}" \
+      "meta.helm.sh/release-name=${HELM_RELEASE_NAME}" \
+      "meta.helm.sh/release-namespace=${NAMESPACE}" --overwrite
+    # Wire the pull secret onto the SA so DB/mongot/OM pods can pull from the private ECR.
+    kubectl --context "${ctx}" -n "${NAMESPACE}" patch serviceaccount "${sa}" \
+      -p '{"imagePullSecrets":[{"name":"image-registries-secret"}]}'
+  done
+done
+
+echo "==> [${CENTRAL_CLUSTER}] operator-installation-config ConfigMap"
+prepare_operator_config_map "${CENTRAL_CLUSTER}"
+
+# The harness (conftest get_api_servers_from_test_pod_kubeconfig) reads this secret on the
+# test-pod cluster to discover each member cluster's API server URL when LOCAL_OPERATOR=false.
+# Auth still uses the long-lived bearer tokens in MULTI_CLUSTER_CONFIG_DIR (kube-system SA),
+# so the exec-based merged kubeconfig is fine here — only the server URLs are parsed out.
+# `make reset` wipes namespaced secrets, so recreate it on every bootstrap.
+: "${test_pod_cluster:?test_pod_cluster unset}"
+echo "==> [${test_pod_cluster}] test-pod-kubeconfig secret (member API-server discovery)"
+kubectl --context "${test_pod_cluster}" -n "${NAMESPACE}" delete secret test-pod-kubeconfig --ignore-not-found
+kubectl --context "${test_pod_cluster}" -n "${NAMESPACE}" create secret generic test-pod-kubeconfig \
+  --from-file=kubeconfig="${KUBECONFIG}"
+
+echo "Bootstrap complete."

--- a/scripts/dev/contexts/e2e_aws_simulated_mc_sharded
+++ b/scripts/dev/contexts/e2e_aws_simulated_mc_sharded
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Context for the real-infra (AWS EKS) multi-cluster sharded search e2e.
+# Targets the four persistent EKS clusters in mongot_multicluster-infra (eu-south-1),
+# NOT the kind fabric. Requires the corp VPN and the merged AWS kubeconfig.
+#
+# Harness index caveat: get_member_cluster_names() SORTS MEMBER_CLUSTERS, so the
+# resulting cluster_index order is alphabetical (mdb-az2=0, om-mdb-az1=1, search-az1=2,
+# search-az2=3), NOT the order below. The test module pins roles by context name.
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/root-context"
+# OM 8.0 + AppDB 8.0: sets CUSTOM_OM_VERSION=8.0.x, CUSTOM_APPDB_VERSION=8.0.x-ent,
+# CUSTOM_MDB_VERSION=8.0.x, AGENT_VERSION, and ops_manager_version=${CUSTOM_OM_VERSION}.
+source "${script_dir}/variables/om80"
+source "${script_dir}/variables/mongodb_search_dev"
+
+export KUBE_ENVIRONMENT_NAME=multi
+
+# AWS merged kubeconfig. root-context/site-context unconditionally set KUBECONFIG to the
+# kind `.generated/current.kubeconfig`, so we FORCE the merged AWS kubeconfig here (a plain
+# `${KUBECONFIG:-...}` default would be a no-op). Override with AWS_MC_KUBECONFIG if needed.
+export KUBECONFIG="${AWS_MC_KUBECONFIG:-${HOME}/mdb/mongot_multicluster-infra/tmp/search-onprem.kubeconfig}"
+
+# Four member clusters; central also hosts AZ1 shard data + OM/AppDB.
+export MEMBER_CLUSTERS="om-mdb-az1 mdb-az2 search-az1 search-az2"
+export CENTRAL_CLUSTER="om-mdb-az1"
+export CLUSTER_NAME="om-mdb-az1"
+export test_pod_cluster="search-az1"
+export TEST_POD_CLUSTER="search-az1"
+
+# Per-cluster long-lived SA bearer tokens are extracted into this dir (central_cluster,
+# member_cluster_1..4, and one file per context name) by the AWS prepare step — the
+# harness reads bearer tokens here, it does NOT use the kubeconfig aws-eks-get-token exec.
+# FORCED (site-context unconditionally points this at .multi_cluster_local_test_files).
+# Override with AWS_MC_CONFIG_DIR if needed.
+export MULTI_CLUSTER_CONFIG_DIR="${AWS_MC_CONFIG_DIR:-${HOME}/.mck-aws-mc-config}"
+
+# OM is deployed by the scenario (not cloud-qa); version comes from variables/om80 above
+# (ops_manager_version=${CUSTOM_OM_VERSION}=8.0.x).
+
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"
+
+# Deploy operators as PODS in the clusters, not locally via `go run`. private-context
+# defaults LOCAL_OPERATOR=true for laptop dev; this scenario installs the operator via
+# Helm into each cluster, so force it off. Requires built images in the registry — set
+# OVERRIDE_VERSION_ID below to a patch version_id whose init_test_run built all images.
+export LOCAL_OPERATOR=false
+
+# NOTE: operator image pinning is done in private-context (OPERATOR_REGISTRY=.../dev +
+# OPERATOR_VERSION=<patch version_id>), NOT via OVERRIDE_VERSION_ID. Two reasons OVERRIDE_VERSION_ID
+# is the WRONG lever here: (1) the init_test_run patch pushes images to .../dev tagged with the
+# patch version_id, but the local REGISTRY is .../staging (the full working master set incl OM
+# 8.0.24) — OVERRIDE keeps the staging registry so it 404s the version_id tag; (2) OVERRIDE pins
+# ALL of operator/readiness/upgradeHook and cascades init/database to <version_id> on staging,
+# which lacks those tags. So we pin ONLY the operator to dev:<version_id> and keep the rest on
+# staging:latest. (conftest's version_id fixture is unused in this scenario.)

--- a/scripts/dev/contexts/e2e_aws_simulated_mc_sharded
+++ b/scripts/dev/contexts/e2e_aws_simulated_mc_sharded
@@ -43,6 +43,11 @@ export MULTI_CLUSTER_CONFIG_DIR="${AWS_MC_CONFIG_DIR:-${HOME}/.mck-aws-mc-config
 # OM is deployed by the scenario (not cloud-qa); version comes from variables/om80 above
 # (ops_manager_version=${CUSTOM_OM_VERSION}=8.0.x).
 
+# Infra clusterId prefix: the test derives each cluster's id/DNS-zone/LB-SG name as
+# "<prefix>-mc-<context>" (mongot_multicluster-infra manifest-mc-*.yaml clusterId). Must match
+# the targeted infra's prefix; override when running against a differently-prefixed deployment.
+export MDB_MC_CLUSTER_ID_PREFIX="${MDB_MC_CLUSTER_ID_PREFIX:-ls}"
+
 export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"
 
 # Deploy operators as PODS in the clusters, not locally via `go run`. private-context

--- a/scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh
+++ b/scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Run the real-infra (AWS EKS) multi-cluster sharded search e2e against the four
+# persistent EKS clusters in mongot_multicluster-infra (eu-south-1).
+#
+# Prerequisites:
+#   - On the corp VPN (EKS API endpoints are corp-prefix-locked).
+#   - AWS `mck-admin` profile resolvable (the kubeconfig exec uses it).
+#   - Per-cluster SA bearer tokens extracted into MULTI_CLUSTER_CONFIG_DIR
+#     (run the AWS prepare step first — see E2E_SCENARIO_PLAN.md gap #3).
+#
+# Usage: e2e_aws_simulated_multi_cluster_sharded.sh [-- <extra pytest args>]
+#
+# This targets persistent external infra, so it is NOT part of the kind-based
+# e2e_run.sh flow and is NOT auto-run in the standard evergreen task group.
+
+set -Eeou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+
+# Load the AWS multi-cluster context (KUBECONFIG, MEMBER_CLUSTERS, CENTRAL_CLUSTER, etc.).
+# shellcheck disable=SC1091
+source scripts/dev/contexts/e2e_aws_simulated_mc_sharded
+
+# shellcheck disable=SC1091
+. scripts/dev/devenv
+
+if [[ ! -d venv ]]; then
+  echo "ERROR: venv not found at $(pwd)/venv. Run scripts/dev/recreate_python_venv.sh first." >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source venv/bin/activate
+
+if [[ ! -f "${MULTI_CLUSTER_CONFIG_DIR}/central_cluster" ]]; then
+  echo "ERROR: ${MULTI_CLUSTER_CONFIG_DIR}/central_cluster missing — run the AWS token-extraction prepare step first." >&2
+  exit 1
+fi
+
+extra_args=()
+if [[ "${1:-}" == "--" ]]; then
+  shift
+  extra_args=("$@")
+fi
+
+mkdir -p logs
+log_path="logs/test-e2e_aws_simulated_mc_sharded-$(date +%Y%m%d-%H%M%S).log"
+ln -sf "${log_path#logs/}" logs/test.log
+
+cd docker/mongodb-kubernetes-tests
+pytest_args=(-v -s -m e2e_aws_simulated_mc_sharded)
+if [[ ${#extra_args[@]} -gt 0 ]]; then
+  pytest_args+=("${extra_args[@]}")
+fi
+echo "Running: pytest ${pytest_args[*]}"
+exec pytest "${pytest_args[@]}" 2>&1 | tee "../../${log_path}"

--- a/scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh
+++ b/scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh
@@ -19,12 +19,23 @@ test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
 
-# Load the AWS multi-cluster context (KUBECONFIG, MEMBER_CLUSTERS, CENTRAL_CLUSTER, etc.).
+# Preload the generated env (REGISTRY + base vars) so the AWS context — which references
+# ${REGISTRY} under `set -u` — resolves, then source the AWS context fresh so its overrides
+# (operator/search image pins, KUBECONFIG, MEMBER_CLUSTERS, CENTRAL_CLUSTER, ...) win.
+set -a
+# shellcheck disable=SC1090,SC1091
+source .generated/context.env
+set +a
 # shellcheck disable=SC1091
 source scripts/dev/contexts/e2e_aws_simulated_mc_sharded
-
-# shellcheck disable=SC1091
-. scripts/dev/devenv
+# Apply the devc network-prefix to the namespace inline: the prefix tooling lives in the
+# devcontainer layer (not carried by this AWS-only branch), and private-context resets
+# NAMESPACE to the un-prefixed base. WATCH_NAMESPACE must match or the operator cache-syncs
+# the wrong namespace and times out.
+if [[ -n "${MCK_DEVC_NET_PREFIX:-}" ]]; then
+  export NAMESPACE="${NAMESPACE}-${MCK_DEVC_NET_PREFIX}"
+  export WATCH_NAMESPACE="${NAMESPACE}"
+fi
 
 if [[ ! -d venv ]]; then
   echo "ERROR: venv not found at $(pwd)/venv. Run scripts/dev/recreate_python_venv.sh first." >&2
@@ -47,6 +58,12 @@ fi
 mkdir -p logs
 log_path="logs/test-e2e_aws_simulated_mc_sharded-$(date +%Y%m%d-%H%M%S).log"
 ln -sf "${log_path#logs/}" logs/test.log
+
+# The helm-based operator install renders the chart from the test-dir-relative `helm_chart`
+# (LOCAL_HELM_CHART_DIR). It's gitignored and normally staged by prepare_local_e2e_run.sh;
+# refresh it here so this runner is self-contained.
+rm -rf docker/mongodb-kubernetes-tests/helm_chart
+cp -rf helm_chart docker/mongodb-kubernetes-tests/helm_chart
 
 cd docker/mongodb-kubernetes-tests
 pytest_args=(-v -s -m e2e_aws_simulated_mc_sharded)

--- a/scripts/dev/prepare_aws_mc_tokens.sh
+++ b/scripts/dev/prepare_aws_mc_tokens.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# AWS multi-cluster token-extraction prepare step (E2E_SCENARIO_PLAN.md gap #3).
+#
+# The e2e harness (docker/mongodb-kubernetes-tests/tests/conftest.py::_get_client_for_cluster)
+# does NOT use the kubeconfig `aws eks get-token` exec flow — it reads pre-extracted,
+# long-lived ServiceAccount bearer tokens from $MULTI_CLUSTER_CONFIG_DIR. This script
+# creates, per cluster, a cluster-admin ServiceAccount + a `kubernetes.io/service-account-token`
+# Secret (the same long-lived, OIDC-independent mechanism the operator uses), reads the
+# token, and writes the files the harness expects:
+#
+#   $MULTI_CLUSTER_CONFIG_DIR/
+#     central_cluster        -> central context NAME
+#     member_cluster_1..N    -> each member context NAME (alphabetical sort order)
+#     <context>              -> the long-lived bearer token for that context
+#
+# All cluster writes go through the K8s API (kubectl), never ad-hoc `aws` CLI mutations.
+#
+# Usage:
+#   source scripts/dev/contexts/e2e_aws_simulated_mc_sharded   # sets KUBECONFIG, MEMBER_CLUSTERS, ...
+#   AWS_PROFILE=mck-admin scripts/dev/prepare_aws_mc_tokens.sh
+
+set -Eeou pipefail
+
+: "${KUBECONFIG:?source scripts/dev/contexts/e2e_aws_simulated_mc_sharded first}"
+: "${MEMBER_CLUSTERS:?MEMBER_CLUSTERS unset}"
+: "${CENTRAL_CLUSTER:?CENTRAL_CLUSTER unset}"
+export AWS_PROFILE="${AWS_PROFILE:-mck-admin}"
+
+CONFIG_DIR="${MULTI_CLUSTER_CONFIG_DIR:-${HOME}/.mck-aws-mc-config}"
+SA_NAMESPACE="kube-system"
+SA_NAME="mck-e2e-admin"
+SECRET_NAME="mck-e2e-admin-token"
+CRB_NAME="mck-e2e-admin-cluster-admin"
+
+mkdir -p "${CONFIG_DIR}"
+
+# The harness sorts MEMBER_CLUSTERS, and the cluster_index it assigns is that alphabetical
+# position. The member_cluster_N pointer files must follow the SAME sort so indexes line up.
+read -r -a _members <<<"${MEMBER_CLUSTERS}"
+mapfile -t SORTED_MEMBERS < <(printf '%s\n' "${_members[@]}" | sort)
+
+# Every distinct context we need a token for (central may also be a member; dedup).
+ALL_CONTEXTS=$(printf '%s\n' "${CENTRAL_CLUSTER}" "${SORTED_MEMBERS[@]}" | sort -u)
+
+extract_token_for_context() {
+  local ctx=$1
+  echo "[${ctx}] ensuring cluster-admin ServiceAccount + token Secret"
+
+  kubectl --context "${ctx}" -n "${SA_NAMESPACE}" create serviceaccount "${SA_NAME}" \
+    --dry-run=client -o yaml | kubectl --context "${ctx}" apply -f - >/dev/null
+
+  kubectl --context "${ctx}" create clusterrolebinding "${CRB_NAME}" \
+    --clusterrole=cluster-admin \
+    --serviceaccount="${SA_NAMESPACE}:${SA_NAME}" \
+    --dry-run=client -o yaml | kubectl --context "${ctx}" apply -f - >/dev/null
+
+  kubectl --context "${ctx}" -n "${SA_NAMESPACE}" apply -f - >/dev/null <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${SECRET_NAME}
+  annotations:
+    kubernetes.io/service-account.name: ${SA_NAME}
+type: kubernetes.io/service-account-token
+EOF
+
+  # The token controller populates .data.token asynchronously after the Secret is created.
+  local token="" i
+  for i in $(seq 1 30); do
+    token=$(kubectl --context "${ctx}" -n "${SA_NAMESPACE}" get secret "${SECRET_NAME}" \
+      -o jsonpath='{.data.token}' 2>/dev/null | base64 --decode 2>/dev/null || true)
+    [[ -n "${token}" ]] && break
+    sleep 2
+  done
+  if [[ -z "${token}" ]]; then
+    echo "ERROR: [${ctx}] token Secret ${SECRET_NAME} never populated" >&2
+    return 1
+  fi
+
+  printf '%s' "${token}" >"${CONFIG_DIR}/${ctx}"
+  echo "[${ctx}] token written to ${CONFIG_DIR}/${ctx}"
+}
+
+for ctx in ${ALL_CONTEXTS}; do
+  extract_token_for_context "${ctx}"
+done
+
+# Pointer files: contents are context NAMES (the harness then reads <name> for the token).
+printf '%s' "${CENTRAL_CLUSTER}" >"${CONFIG_DIR}/central_cluster"
+idx=1
+for member in "${SORTED_MEMBERS[@]}"; do
+  printf '%s' "${member}" >"${CONFIG_DIR}/member_cluster_${idx}"
+  echo "member_cluster_${idx} -> ${member}"
+  ((idx++))
+done
+
+echo "Done. ${CONFIG_DIR} now contains:"
+ls -1 "${CONFIG_DIR}"


### PR DESCRIPTION
[skip-ci] Real-infra (AWS EKS) multi-cluster `MongoDBSearch` e2e with a sharded external source.

<!-- start git-machete generated -->

# Based on PR #909

## Chain of upstream PRs as of 2026-06-29

* PR #1166:
  `master` ← `lsierant/devcontainer`

  * PR #1048:
    `lsierant/devcontainer` ← `search/ga-base`

    * PR #1278:
      `search/ga-base` ← `search/lsierant/grace-period`

      * PR #1284:
        `search/lsierant/grace-period` ← `search/lsierant/fix-hardcoded-zero-index`

        * PR #909:
          `search/lsierant/fix-hardcoded-zero-index` ← `search/lsierant/ca-as-configmap`

          * **PR #1283 (THIS ONE)**:
            `search/lsierant/ca-as-configmap` ← `search/lsierant/simulated-mc-on-aws`

<!-- end git-machete generated -->


## What

Adds a manually-run e2e (`e2e_aws_simulated_mc_sharded`) that exercises a sharded external
MongoDB source feeding `MongoDBSearch` across four real EKS clusters with **no Istio mesh and
no VPC peering** — every cross-cluster hop flows over per-cluster internet-facing NLBs fronted
by L4 SNI Envoys:

- Source sharded MongoDB spread across two AZ data clusters (+ OM/AppDB on the central one),
  exposed via a self-managed SNI-passthrough `mongodEnvoy` per data cluster.
- `mongot` search fleets on two AZ search clusters, each syncing from its same-AZ shard members
  via tag-set selectors.
- The operator-managed search Envoy LB is exposed by one corp-SG-locked NLB per search cluster
  (`*.envoy-proxy.<clusterZone>` wildcard); the source `mongotHost` (per-shard + cluster-level
  `routerHostname`) targets those external FQDNs.

## Notes for reviewers

- **Manual-only**: not wired into Evergreen (requires the corp VPN + the provisioned
  four-cluster infra). No build variant schedules it.
- Cluster ids are parameterized via `MDB_MC_CLUSTER_ID_PREFIX` so the suite can target a
  differently-prefixed infra.
- Internet-facing NLBs are always corp-security-group-locked (fail-closed; never `0.0.0.0/0`).
- The corp-locked-NLB create + provisioning-wait is a shared `multicluster_utils` helper used
  by both the source `mongodEnvoy` and the search-Envoy exposure.

## Test

Run manually against the four-cluster infra:

```
make switch context=e2e_aws_simulated_mc_sharded
scripts/dev/bootstrap_aws_mc_e2e.sh
scripts/dev/e2e_aws_simulated_multi_cluster_sharded.sh
```

Latest full run: 23 passed, 1 skipped (the skip is the vector-search query, gated on an
embedding API key that isn't provisioned in this environment).
