### PR TITLE
fix(e2e): bump multi-cluster deletion timeouts and fix broken import/lint

### DIFF
--- a/docker/mongodb-kubernetes-tests/kubetester/__init__.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/__init__.py
@@ -425,12 +425,14 @@ def get_pod_when_running(
     namespace: str,
     label_selector: str,
     api_client: Optional[kubernetes.client.ApiClient] = None,
+    timeout: int = 600,
 ) -> client.V1Pod:
     """
     Returns a Pod that matches label_selector. It will block until the Pod is in
-    Running state.
+    Running state or timeout is reached.
     """
-    while True:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
         time.sleep(3)
 
         try:
@@ -447,6 +449,10 @@ def get_pod_when_running(
             # The Pod might not exist in Kubernetes yet so skip any 404
             if e.status != 404:
                 raise
+
+    raise Exception(
+        f"Timeout ({timeout}s) waiting for pod with label_selector '{label_selector}' in namespace '{namespace}' to be Running"
+    )
 
 
 def get_pod_when_ready(

--- a/docker/mongodb-kubernetes-tests/kubetester/create_or_replace_from_yaml.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/create_or_replace_from_yaml.py
@@ -78,7 +78,7 @@ def patch_from_yaml_single_item(k8s_client, yml_object, namespace="default", **k
                     time.sleep(1)
                     continue
                 raise
-        raise Exception(f"Failed to replace CRD {name} after 30s: {last_error}")
+        raise Exception(f"Failed to replace CRD {name} after 300s: {last_error}")
 
     method = "patch"
     namespaced = hasattr(k8s_api, "{}_namespaced_{}".format("create", kind))

--- a/docker/mongodb-kubernetes-tests/kubetester/create_or_replace_from_yaml.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/create_or_replace_from_yaml.py
@@ -54,7 +54,7 @@ def create_or_replace_from_yaml_single_item(k8s_client, yml_object, namespace="d
             pass
 
 
-def patch_from_yaml_single_item(k8s_client, yml_object, namespace="default", **kwargs):
+def patch_from_yaml_single_item(k8s_client, yml_object, namespace="default", timeout=300, **kwargs):
     k8s_api = get_k8s_api(k8s_client, yml_object)
     kind = get_kind(yml_object)
     # Decide which namespace we are going to put the object in,
@@ -64,7 +64,7 @@ def patch_from_yaml_single_item(k8s_client, yml_object, namespace="default", **k
     name = yml_object["metadata"]["name"]
 
     if kind == "custom_resource_definition":
-        deadline = time.time() + 300
+        deadline = time.time() + timeout
         last_error = None
         while time.time() < deadline:
             resource = client.ApiextensionsV1Api().read_custom_resource_definition(name)

--- a/docker/mongodb-kubernetes-tests/kubetester/create_or_replace_from_yaml.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/create_or_replace_from_yaml.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import time
 from os import path
 
 import yaml
@@ -10,7 +11,7 @@ from kubernetes.utils.create_from_yaml import create_from_yaml_single_item
 
 """
 This is a modification of 'create_from_yaml.py' from python kubernetes client library
-It allows to mimic the 'kubectl apply' operation on yaml file. It performs either create or 
+It allows to mimic the 'kubectl apply' operation on yaml file. It performs either create or
 patch on each individual object.
 """
 
@@ -62,16 +63,24 @@ def patch_from_yaml_single_item(k8s_client, yml_object, namespace="default", **k
         namespace = yml_object["metadata"]["namespace"]
     name = yml_object["metadata"]["name"]
 
-    method = "patch"
     if kind == "custom_resource_definition":
-        # fetching the old CRD to make the replace working (has conflict resolution based on 'resourceVersion')
-        # TODO this is prone to race conditions - we need to either loop or use patch with json merge
-        # see https://github.com/helm/helm/pull/6092/files#diff-a483d6c0863082c3df21f4aad513afe2R663
-        resource = client.ApiextensionsV1Api().read_custom_resource_definition(name)
+        deadline = time.time() + 300
+        last_error = None
+        while time.time() < deadline:
+            resource = client.ApiextensionsV1Api().read_custom_resource_definition(name)
+            yml_object["metadata"]["resourceVersion"] = resource.metadata.resource_version
+            try:
+                k8s_api.replace_custom_resource_definition(body=yml_object, name=name, **kwargs)
+                return
+            except client.rest.ApiException as e:
+                if e.status == 409:
+                    last_error = e
+                    time.sleep(1)
+                    continue
+                raise
+        raise Exception(f"Failed to replace CRD {name} after 30s: {last_error}")
 
-        yml_object["metadata"]["resourceVersion"] = resource.metadata.resource_version
-        method = "replace"
-
+    method = "patch"
     namespaced = hasattr(k8s_api, "{}_namespaced_{}".format("create", kind))
     url_path = get_url_path(namespaced, method)
 

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -807,20 +807,26 @@ class KubernetesTester(object):
         return cls.wait_for_condition_stateful_set(cls.get_namespace(), name, attribute, expected_value)
 
     @classmethod
-    def wait_for_condition_stateful_set(cls, namespace, name, attribute, expected_value):
+    def wait_for_condition_stateful_set(cls, namespace, name, attribute, expected_value, timeout=600):
         appsv1 = KubernetesTester.clients("appsv1")
-        ready_to_go = False
-        while not ready_to_go:
+        deadline = time.time() + timeout
+        last_status = None
+        while time.time() < deadline:
             try:
                 sts = appsv1.read_namespaced_stateful_set(name, namespace)
                 ready_to_go = get_nested_attribute(sts, attribute) == expected_value
+                if ready_to_go:
+                    return
+                last_status = sts.status
             except ApiException:
                 pass
 
-            if ready_to_go:
-                return
-
             time.sleep(0.5)
+
+        raise Exception(
+            f"Timeout ({timeout}s) waiting for StatefulSet {name} in {namespace}: "
+            f"expected {attribute} == {expected_value}, last status: {last_status}"
+        )
 
     def setup_method(self):
         self.client = client

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_deletion.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_replica_set_deletion.py
@@ -64,7 +64,7 @@ def test_delete_mongodb_multi(mongodb_multi: MongoDBMulti):
                 logger.error(e)
                 return False
 
-    wait_until(wait_for_deleted, timeout=60)
+    wait_until(wait_for_deleted, timeout=300)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_deletion
@@ -78,7 +78,7 @@ def test_deployment_has_been_removed_from_automation_config():
             logger.error(e)
             return False
 
-    wait_until(wait_until_automation_config_is_clean, timeout=60)
+    wait_until(wait_until_automation_config_is_clean, timeout=300)
 
 
 @pytest.mark.e2e_multi_cluster_replica_set_deletion
@@ -109,6 +109,6 @@ def test_kubernetes_resources_have_been_cleaned_up(
             logger.error(e)
             return True
 
-    wait_until(wait_until_secrets_are_removed, timeout=60)
-    wait_until(wait_until_statefulsets_are_removed, timeout=60)
-    wait_until(wait_until_configmaps_are_removed, timeout=60)
+    wait_until(wait_until_secrets_are_removed, timeout=300)
+    wait_until(wait_until_statefulsets_are_removed, timeout=300)
+    wait_until(wait_until_configmaps_are_removed, timeout=300)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_cleanup.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_om/multicluster_om_appdb_cleanup.py
@@ -157,7 +157,7 @@ def test_delete_ops_manager_resource(ops_manager: MongoDBOpsManager):
                 logger.error(f"Error when trying to load the opsmanager {ops_manager.name} resource: {e}")
                 return False
 
-    run_periodically(resource_is_deleted, timeout=60)
+    run_periodically(resource_is_deleted, timeout=300)
 
 
 @mark.e2e_multi_cluster_appdb_cleanup
@@ -170,7 +170,7 @@ def test_statefulset_does_not_exist(ops_manager: MongoDBOpsManager):
 
         return True
 
-    run_periodically(sts_are_deleted, timeout=60)
+    run_periodically(sts_are_deleted, timeout=300)
 
 
 @mark.e2e_multi_cluster_appdb_cleanup
@@ -189,7 +189,7 @@ def test_service_does_not_exist(ops_manager: MongoDBOpsManager):
 
         return True
 
-    run_periodically(svc_are_deleted, timeout=60)
+    run_periodically(svc_are_deleted, timeout=300)
 
 
 @mark.e2e_multi_cluster_appdb_cleanup
@@ -207,4 +207,4 @@ def test_configmap_does_not_exist(ops_manager: MongoDBOpsManager):
 
         return True
 
-    run_periodically(cm_are_deleted, timeout=60)
+    run_periodically(cm_are_deleted, timeout=300)

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster.py
@@ -241,7 +241,7 @@ class TestShardedClusterDeletion:
 
             return True
 
-        run_periodically(sts_are_deleted, timeout=60)
+        run_periodically(sts_are_deleted, timeout=300)
 
     def test_service_does_not_exist(self, sc: MongoDB, cluster_member_clients):
         def svc_are_deleted() -> bool:
@@ -256,4 +256,4 @@ class TestShardedClusterDeletion:
                             return False
             return True
 
-        run_periodically(svc_are_deleted, timeout=60)
+        run_periodically(svc_are_deleted, timeout=300)

--- a/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_pv.py
+++ b/docker/mongodb-kubernetes-tests/tests/shardedcluster/sharded_cluster_pv.py
@@ -155,7 +155,7 @@ class TestShardedClusterDeletion:
 
             return True
 
-        run_periodically(sts_are_deleted, timeout=60)
+        run_periodically(sts_are_deleted, timeout=300)
 
     def test_service_does_not_exist(self, sc: MongoDB, cluster_member_clients):
         def svc_are_deleted() -> bool:
@@ -171,4 +171,4 @@ class TestShardedClusterDeletion:
 
             return True
 
-        run_periodically(svc_are_deleted, timeout=60)
+        run_periodically(svc_are_deleted, timeout=300)

--- a/mongodb-community-operator/scripts/dev/e2e.py
+++ b/mongodb-community-operator/scripts/dev/e2e.py
@@ -151,7 +151,7 @@ def create_test_pod(args: argparse.Namespace, namespace: str) -> None:
                         "bash",
                         "-c",
                         # Use pipefail to return go test's exit code instead of tee's
-                        f"set -o pipefail; go test -tags=community_e2e -v -timeout=45m -failfast ./mongodb-community-operator/test/e2e/{args.test} 2>&1 | tee -a /tmp/results/result.suite",
+                        f"set -o pipefail; go test -tags=community_e2e -v -timeout=45m ./mongodb-community-operator/test/e2e/{args.test} 2>&1 | tee -a /tmp/results/result.suite",
                     ],
                     "volumeMounts": [{"name": "results", "mountPath": "/tmp/results"}],
                     "securityContext": {

--- a/scripts/dev/install_csi_driver.sh
+++ b/scripts/dev/install_csi_driver.sh
@@ -4,6 +4,7 @@ set -Eeou pipefail
 
 source scripts/dev/set_env_context.sh
 source scripts/funcs/kubernetes
+source scripts/funcs/install
 
 # Path to the deploy script
 DEPLOY_SCRIPT_PATH="./deploy/kubernetes-latest/deploy.sh"
@@ -17,7 +18,7 @@ csi_driver_download() {
 
     # Download the tar.gz file
     echo "Downloading ${REPO_URL}..."
-    curl -L -o "${TAR_FILE}" "${REPO_URL}"
+    curl_with_retry -L -o "${TAR_FILE}" "${REPO_URL}"
 
     # Extract the tar.gz file
     echo "Extracting ${TAR_FILE}..."
@@ -34,16 +35,16 @@ csi_driver_deploy() {
     SNAPSHOTTER_BRANCH=release-6.3
 
     # Apply VolumeSnapshot CRDs
-    kubectl apply --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-    kubectl apply --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-    kubectl apply --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+    kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+    kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+    kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 
     # Change to the latest supported snapshotter version
     SNAPSHOTTER_VERSION=v6.3.3
 
     # Create snapshot controller
-    kubectl apply --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-    kubectl apply --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+    kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+    kubectl_apply_retry --context "${context}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 
     # Run the deploy script with kubectl wrapped to force it to use specific context rather than rely on current context
     if ! run_script_with_wrapped_kubectl "${DEPLOY_SCRIPT_PATH}" "${context}"; then

--- a/scripts/dev/recreate_kind_clusters.sh
+++ b/scripts/dev/recreate_kind_clusters.sh
@@ -24,14 +24,20 @@ docker_create_kind_network
 docker_run_local_registry "kind-registry" "5000"
 
 # To future maintainers: whenever modifying this bit, make sure you also update coredns.yaml
+cluster_pids=()
 (scripts/dev/setup_kind_cluster.sh -n "e2e-operator" -p "10.244.0.0/16" -s "10.96.0.0/16" -l "172.18.255.200-172.18.255.210" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-operator") &
+cluster_pids+=($!)
 (scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-1" -p "10.245.0.0/16" -s "10.97.0.0/16" -l "172.18.255.210-172.18.255.220" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-1") &
+cluster_pids+=($!)
 (scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-2" -p "10.246.0.0/16" -s "10.98.0.0/16" -l "172.18.255.220-172.18.255.230" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-2") &
+cluster_pids+=($!)
 (scripts/dev/setup_kind_cluster.sh -n "e2e-cluster-3" -p "10.247.0.0/16" -s "10.99.0.0/16" -l "172.18.255.230-172.18.255.240" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "e2e-cluster-3") &
+cluster_pids+=($!)
 (scripts/dev/setup_kind_cluster.sh -n "kind" -l "172.18.255.200-172.18.255.250" -c "${CLUSTER_DOMAIN}" 2>&1 | prepend "kind") &
+cluster_pids+=($!)
 
 echo "Waiting for all kind clusters to be created"
-wait
+for pid in "${cluster_pids[@]}"; do wait "${pid}" || { echo "Cluster creation PID ${pid} failed" >&2; exit 1; }; done
 
 # we do exports sequentially as setup_kind_cluster.sh is run in parallel and we hit kube config locks
 kind export kubeconfig --name "e2e-operator"
@@ -45,20 +51,29 @@ scripts/dev/interconnect_kind_clusters.sh -v e2e-cluster-1 e2e-cluster-2 e2e-clu
 
 export VERSION=${VERSION:-1.16.1}
 
-source multi_cluster/tools/download_istio.sh 2>&1 | prepend "download_istio" || true
+source multi_cluster/tools/download_istio.sh 2>&1 | prepend "download_istio"
 
+istio_pids=()
 VERSION=1.16.1 CTX_CLUSTER1=kind-e2e-cluster-1 CTX_CLUSTER2=kind-e2e-cluster-2 CTX_CLUSTER3=kind-e2e-cluster-3 multi_cluster/tools/install_istio.sh 2>&1 | prepend "install_istio" &
+istio_pids+=($!)
 VERSION=1.16.1 CTX_CLUSTER=kind-e2e-operator multi_cluster/tools/install_istio_central.sh 2>&1 | prepend "install_istio_central" &
+istio_pids+=($!)
 
-wait
+for pid in "${istio_pids[@]}"; do wait "${pid}" || { echo "Istio install PID ${pid} failed" >&2; exit 1; }; done
 
 source scripts/dev/install_csi_driver.sh
 csi_driver_download 2>&1 | prepend "csi_driver_download"
 
+csi_pids=()
 csi_driver_deploy kind-e2e-operator 2>&1 | prepend "install_csi_driver.sh kind-e2e-operator" &
+csi_pids+=($!)
 csi_driver_deploy kind-e2e-cluster-1 2>&1 | prepend "install_csi_driver.sh kind-e2e-cluster-1" &
+csi_pids+=($!)
 csi_driver_deploy kind-e2e-cluster-2 2>&1 | prepend "install_csi_driver.sh kind-e2e-cluster-2" &
+csi_pids+=($!)
 csi_driver_deploy kind-e2e-cluster-3 2>&1 | prepend "install_csi_driver.sh kind-e2e-cluster-3" &
+csi_pids+=($!)
 csi_driver_deploy kind-kind 2>&1 | prepend "install_csi_driver.sh kind-kind" &
+csi_pids+=($!)
 
-wait
+for pid in "${csi_pids[@]}"; do wait "${pid}" || { echo "CSI deploy PID ${pid} failed" >&2; exit 1; }; done

--- a/scripts/dev/setup_kind_cluster.sh
+++ b/scripts/dev/setup_kind_cluster.sh
@@ -5,6 +5,7 @@ test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
 
 source scripts/dev/set_env_context.sh
 source scripts/funcs/kubernetes
+source scripts/funcs/install
 
 usage() {
   echo "Deploy local registry and create kind cluster configured to use this registry. Local Docker registry is deployed at localhost:5000.
@@ -186,7 +187,7 @@ function kind_wait_for_rbac_bootstrap() {
 function kind_install_metallb() {
   echo "installing metallb"
   kubectl get --kubeconfig "${kubeconfig_path}" nodes -owide
-  kubectl apply --kubeconfig "${kubeconfig_path}" --timeout=600s -f https://raw.githubusercontent.com/metallb/metallb/${metallb_version}/config/manifests/metallb-native.yaml
+  kubectl_apply_retry --kubeconfig "${kubeconfig_path}" --timeout=600s -f https://raw.githubusercontent.com/metallb/metallb/${metallb_version}/config/manifests/metallb-native.yaml
 
   echo "waiting metallb to be ready"
   kubectl wait --kubeconfig "${kubeconfig_path}" --timeout=3000s --namespace metallb-system \
@@ -213,7 +214,7 @@ EOF
 }
 
 kind_install_metrics_server() {
-  kubectl apply --kubeconfig "${kubeconfig_path}" -f "https://github.com/kubernetes-sigs/metrics-server/releases/download/${metrics_server_version}/components.yaml"
+  kubectl_apply_retry --kubeconfig "${kubeconfig_path}" -f "https://github.com/kubernetes-sigs/metrics-server/releases/download/${metrics_server_version}/components.yaml"
   kubectl patch --kubeconfig "${kubeconfig_path}" -n kube-system deployment metrics-server --type=json \
     -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
   kubectl patch --kubeconfig "${kubeconfig_path}" -n kube-system deployment metrics-server --type=json -p \

--- a/scripts/evergreen/e2e/setup_cloud_qa.py
+++ b/scripts/evergreen/e2e/setup_cloud_qa.py
@@ -333,7 +333,7 @@ def clean_unused_keys(org_id: str):
     - currently used by the script (USER_OWNER env variable)
     - containing "EVG" or "NOT_DELETE" in their description
     """
-    keys, newer_keys = get_keys_older_than(org_id, minutes_interval=70)
+    keys, newer_keys = get_keys_older_than(org_id, minutes_interval=140)
     print(f"found {len(keys)} keys for potential removal")
     deleted_keys = []
     kept_keys = []
@@ -362,7 +362,7 @@ def keep_the_key(key: Dict) -> bool:
 
 def clean_unused_projects(org_id: str):
     """Iterates over all existing projects in the organization and removes the leftovers"""
-    projects, newer_projects = get_projects_older_than(org_id, minutes_interval=70)
+    projects, newer_projects = get_projects_older_than(org_id, minutes_interval=140)
     print(f"found {len(projects)} projects for potential removal")
     deleted_projects = []
     kept_projects = []

--- a/scripts/evergreen/e2e/single_e2e.sh
+++ b/scripts/evergreen/e2e/single_e2e.sh
@@ -245,7 +245,7 @@ run_tests() {
     echo
 
     # We need to make sure to access this file after the test has finished
-    kubectl --context "${test_pod_context}" -n "${NAMESPACE}" -c keepalive cp "${TEST_APP_PODNAME}":/tmp/results/myreport.xml logs/myreport.xml
+    kubectl --context "${test_pod_context}" -n "${NAMESPACE}" -c keepalive cp "${TEST_APP_PODNAME}":/tmp/results/myreport.xml logs/myreport.xml || true
     if ! kubectl --context "${test_pod_context}" -n "${NAMESPACE}" -c keepalive cp "${TEST_APP_PODNAME}":/tmp/results/pytest-debug.log logs/pytest-debug.log; then
         echo "WARN: kubectl cp pytest-debug.log failed (exit=$?); attempting fallback via kubectl logs"
         kubectl --context "${test_pod_context}" -n "${NAMESPACE}" logs "${TEST_APP_PODNAME}" -c keepalive > logs/pytest-debug.log 2>&1 \

--- a/scripts/evergreen/notify_flaky_tests.py
+++ b/scripts/evergreen/notify_flaky_tests.py
@@ -40,9 +40,10 @@ def _honeycomb_headers() -> dict[str, str]:
 
 
 def _honeycomb_query(query_spec: dict, dataset: str = DATASET) -> dict:
+    headers = _honeycomb_headers()
     response = requests.post(
         f"{HONEYCOMB_API_BASE}/queries/{dataset}",
-        headers=_honeycomb_headers(),
+        headers=headers,
         json=query_spec,
         timeout=30,
     )
@@ -51,7 +52,7 @@ def _honeycomb_query(query_spec: dict, dataset: str = DATASET) -> dict:
 
     response = requests.post(
         f"{HONEYCOMB_API_BASE}/query_results/{dataset}",
-        headers=_honeycomb_headers(),
+        headers=headers,
         json={"query_id": query_id, "disable_series": True},
         timeout=30,
     )
@@ -61,7 +62,7 @@ def _honeycomb_query(query_spec: dict, dataset: str = DATASET) -> dict:
     for attempt in range(10):
         response = requests.get(
             f"{HONEYCOMB_API_BASE}/query_results/{dataset}/{result_id}",
-            headers=_honeycomb_headers(),
+            headers=headers,
             timeout=30,
         )
         response.raise_for_status()
@@ -88,7 +89,7 @@ def get_flaky_tasks() -> list[FlakyTask]:
     Self-contained: fetches its own Honeycomb auth. Raises RuntimeError if
     HONEYCOMB_API_KEY is not set.
     """
-    print("Querying flaky tasks from evergreen-agent...")
+    print("Querying flaky tasks from evergreen-agent...", file=sys.stderr)
 
     query_spec = {
         "time_range": TIME_RANGE_SECONDS,
@@ -131,7 +132,7 @@ def get_flaky_tasks() -> list[FlakyTask]:
             )
 
     flaky_tasks.sort(key=lambda t: (t.flakiness_percent, t.total_runs), reverse=True)
-    print(f"  Found {len(flaky_tasks)} flaky task/variant combinations")
+    print(f"  Found {len(flaky_tasks)} flaky task/variant combinations", file=sys.stderr)
     return flaky_tasks
 
 

--- a/scripts/evergreen/notify_flaky_tests.py
+++ b/scripts/evergreen/notify_flaky_tests.py
@@ -22,87 +22,71 @@ import sys
 import time
 from dataclasses import dataclass
 from pprint import pprint
-from typing import Any
 
 import requests
 
 HONEYCOMB_API_BASE = "https://api.honeycomb.io/1"
-DATASET = "evergreen-agent"  # Task-level data with retry flakiness
+DATASET = "evergreen-agent"
 PROJECT_ID = "mongodb-kubernetes"
 TIME_RANGE_SECONDS = 604800  # 7 days
 HONEYCOMB_BOARD_URL = "https://ui.honeycomb.io/mongodb-4b/environments/production/board/EgX7rho7iH3/kubernetes-operator"
 
 
-@dataclass
-class FlakyTask:
-    """Represents a flaky task with its statistics."""
-
-    task_name: str
-    variant: str
-    flakiness_percent: float  # Based on retry success rate
-
-
-def get_honeycomb_headers() -> dict[str, str]:
-    """Get headers for Honeycomb API requests."""
+def _honeycomb_headers() -> dict[str, str]:
     api_key = os.environ.get("HONEYCOMB_API_KEY")
     if not api_key:
         raise RuntimeError("HONEYCOMB_API_KEY environment variable is not set")
-    return {
-        "X-Honeycomb-Team": api_key,
-        "Content-Type": "application/json",
-    }
+    return {"X-Honeycomb-Team": api_key, "Content-Type": "application/json"}
 
 
-def create_and_run_query(headers: dict, query_spec: dict, dataset: str = DATASET) -> dict[str, Any]:
-    """Create a query, run it, and return the results."""
-    # Create query
+def _honeycomb_query(query_spec: dict, dataset: str = DATASET) -> dict:
     response = requests.post(
         f"{HONEYCOMB_API_BASE}/queries/{dataset}",
-        headers=headers,
+        headers=_honeycomb_headers(),
         json=query_spec,
         timeout=30,
     )
     response.raise_for_status()
     query_id = response.json()["id"]
 
-    # Run query
     response = requests.post(
         f"{HONEYCOMB_API_BASE}/query_results/{dataset}",
-        headers=headers,
+        headers=_honeycomb_headers(),
         json={"query_id": query_id, "disable_series": True},
         timeout=30,
     )
     response.raise_for_status()
     result_id = response.json()["id"]
 
-    # Poll for results
     for attempt in range(10):
         response = requests.get(
             f"{HONEYCOMB_API_BASE}/query_results/{dataset}/{result_id}",
-            headers=headers,
+            headers=_honeycomb_headers(),
             timeout=30,
         )
         response.raise_for_status()
         data = response.json()
-
         if data.get("complete", False):
             return data
-
         print(f"Query not complete, waiting... (attempt {attempt + 1}/10)")
         time.sleep(2)
 
     raise RuntimeError("Query did not complete in time")
 
 
-def get_flaky_tasks(headers: dict) -> list[FlakyTask]:
-    """Query Honeycomb for flaky tasks using the same logic as the board.
+@dataclass
+class FlakyTask:
+    task_name: str
+    variant: str
+    flakiness_percent: float  # AVG(mck.retry_flakiness_percent)
+    total_runs: int  # COUNT of runs in the window
 
-    A task is flaky if it required retries to pass (mck.retry_flakiness_percent > 0).
-    This metric is calculated as:
-    - execution 0 (first attempt succeeded) → 0%
-    - execution 1 (second attempt succeeded) → 50%
-    - execution 2 (third attempt succeeded) → 67%
-    - etc.
+
+def get_flaky_tasks() -> list[FlakyTask]:
+    """Query Honeycomb for flaky tasks (past 7 days, retry_flakiness_percent > 0).
+
+    Self-contained: fetches its own Honeycomb auth. Raises RuntimeError if
+    HONEYCOMB_API_KEY is not set.
     """
     print("Querying flaky tasks from evergreen-agent...")
 
@@ -110,7 +94,10 @@ def get_flaky_tasks(headers: dict) -> list[FlakyTask]:
         "time_range": TIME_RANGE_SECONDS,
         "granularity": 0,
         "breakdowns": ["evergreen.task.name", "evergreen.build.name"],
-        "calculations": [{"op": "AVG", "column": "mck.retry_flakiness_percent"}],
+        "calculations": [
+            {"op": "AVG", "column": "mck.retry_flakiness_percent"},
+            {"op": "COUNT"},
+        ],
         "filters": [
             {"column": "evergreen.task.status", "op": "exists"},
             {"column": "evergreen.version.requester", "op": "=", "value": "gitter_request"},
@@ -121,7 +108,7 @@ def get_flaky_tasks(headers: dict) -> list[FlakyTask]:
         "limit": 50,
     }
 
-    results = create_and_run_query(headers, query_spec)
+    results = _honeycomb_query(query_spec)
 
     flaky_tasks = []
     for row in results.get("data", {}).get("results", []):
@@ -130,19 +117,20 @@ def get_flaky_tasks(headers: dict) -> list[FlakyTask]:
         variant = row_data.get("evergreen.build.name")
         flakiness = row_data.get("AVG(mck.retry_flakiness_percent)", 0)
 
-        # Skip aggregation rows
         if task_name in ("OTHER", "TOTAL") or variant in ("OTHER", "TOTAL"):
             continue
-
         if task_name and variant and flakiness > 0:
+            total_runs = int(row_data.get("COUNT", 0) or 0)
             flaky_tasks.append(
                 FlakyTask(
                     task_name=task_name,
                     variant=variant,
                     flakiness_percent=flakiness,
+                    total_runs=total_runs,
                 )
             )
 
+    flaky_tasks.sort(key=lambda t: (t.flakiness_percent, t.total_runs), reverse=True)
     print(f"  Found {len(flaky_tasks)} flaky task/variant combinations")
     return flaky_tasks
 
@@ -154,10 +142,7 @@ def format_slack_message(flaky_tasks: list[FlakyTask]) -> dict:
             "blocks": [
                 {
                     "type": "header",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Weekly Flaky Task Report",
-                    },
+                    "text": {"type": "plain_text", "text": "Weekly Flaky Task Report"},
                 },
                 {
                     "type": "section",
@@ -172,10 +157,7 @@ def format_slack_message(flaky_tasks: list[FlakyTask]) -> dict:
     blocks = [
         {
             "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": "Weekly Flaky Task Report",
-            },
+            "text": {"type": "plain_text", "text": "Weekly Flaky Task Report"},
         },
         {
             "type": "section",
@@ -196,19 +178,17 @@ def format_slack_message(flaky_tasks: list[FlakyTask]) -> dict:
         {"type": "divider"},
     ]
 
-    # Show top 5 flaky tasks
     for task in flaky_tasks[:5]:
         blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*{task.task_name}*\n`{task.variant}`\nFlakiness: {task.flakiness_percent:.1f}%",
+                    "text": f"*{task.task_name}*\n`{task.variant}`\nFlakiness: {task.flakiness_percent:.1f}% ({task.total_runs} runs)",
                 },
             }
         )
 
-    # Add link to Honeycomb
     blocks.append({"type": "divider"})
     blocks.append(
         {
@@ -251,17 +231,15 @@ def main():
     args = parser.parse_args()
 
     try:
-        headers = get_honeycomb_headers()
-        flaky_tasks = get_flaky_tasks(headers)
+        flaky_tasks = get_flaky_tasks()
 
         print(f"\nFound {len(flaky_tasks)} flaky tasks")
 
-        # Print table for dry-run visibility
         if flaky_tasks:
-            print("\n| Flakiness % | Variant | Task |")
-            print("|-------------|---------|------|")
+            print("\n| Flakiness % | Runs | Variant | Task |")
+            print("|-------------|------|---------|------|")
             for task in flaky_tasks[:5]:
-                print(f"| {task.flakiness_percent:.1f}% | {task.variant} | {task.task_name} |")
+                print(f"| {task.flakiness_percent:.1f}% | {task.total_runs} | {task.variant} | {task.task_name} |")
 
         message = format_slack_message(flaky_tasks)
 

--- a/scripts/evergreen/notify_master_failures.py
+++ b/scripts/evergreen/notify_master_failures.py
@@ -36,6 +36,7 @@ from evergreen.api import EvergreenApi
 from evergreen.task import Task
 from evergreen.version import BuildVariantStatus, Version
 
+from scripts.evergreen.notify_flaky_tests import get_flaky_tasks
 from scripts.python.evergreen_api import get_evergreen_api
 
 # Terminal statuses that indicate a patch/version has completed
@@ -167,16 +168,27 @@ def get_failed_and_running_tasks(
 MAX_DETAILED_FAILURES = 10
 
 
+def _format_task_name(task: TaskInfo, flaky_map: dict[tuple[str, str], float]) -> str:
+    """Format a task display_name, appending flakiness info if known."""
+    flakiness = flaky_map.get((task.display_name, task.build_variant))
+    if flakiness is not None:
+        return f"{task.display_name} *(flaky: {flakiness:.0f}% over 7d)*"
+    return task.display_name
+
+
 def format_slack_message(
     version_info: VersionInfo,
     failed_tasks: list[TaskInfo] | None = None,
+    flaky_map: dict[tuple[str, str], float] | None = None,
 ) -> dict[str, object]:
     """Format a Slack message for build status.
 
     Args:
         version_info: Version information
         failed_tasks: List of failed tasks
+        flaky_map: Optional {(task_name, variant): flakiness_percent} from Honeycomb
     """
+    flaky_map = flaky_map or {}
     evergreen_version_url = f"https://spruce.mongodb.com/version/{version_info.version_id}"
     is_failure = bool(failed_tasks)
     num_failures = len(failed_tasks) if failed_tasks else 0
@@ -209,12 +221,26 @@ def format_slack_message(
         },
     ]
 
+    # Flakiness context: how many failed tasks are known-flaky
+    if is_failure and failed_tasks and flaky_map:
+        flaky_failed = sum(1 for t in failed_tasks if (t.display_name, t.build_variant) in flaky_map)
+        if flaky_failed > 0:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"_{flaky_failed} of {num_failures} failed task(s) show flaky behavior in the past 7 days_",
+                    },
+                }
+            )
+
     if is_failure and failed_tasks:
         failures_by_variant: dict[str, list[str]] = {}
         for task in failed_tasks:
             if task.build_variant not in failures_by_variant:
                 failures_by_variant[task.build_variant] = []
-            failures_by_variant[task.build_variant].append(task.display_name)
+            failures_by_variant[task.build_variant].append(_format_task_name(task, flaky_map))
 
         num_variants = len(failures_by_variant)
         blocks.append({"type": "divider"})
@@ -274,6 +300,7 @@ def print_stdout_report(
     version_info: VersionInfo,
     failed_tasks: list[TaskInfo],
     running_tasks: list[TaskInfo],
+    flaky_map: dict[tuple[str, str], float] | None = None,
 ) -> None:
     """Print a concise report to stdout.
 
@@ -281,26 +308,31 @@ def print_stdout_report(
         version_info: Version information
         failed_tasks: List of failed tasks
         running_tasks: List of running/pending tasks
+        flaky_map: Optional {(task_name, variant): flakiness_percent} from Honeycomb
     """
+    flaky_map = flaky_map or {}
     status_str = version_info.status.upper()
     print(f"BUILD {status_str}: {version_info.version_id}")
     print(f"Commit:  {version_info.revision[:8]} by {version_info.author}")
     print(f"Link:    https://spruce.mongodb.com/version/{version_info.version_id}")
 
-    def print_task_table(tasks: list[TaskInfo], title: str) -> None:
+    def print_task_table(tasks: list[TaskInfo], title: str, flaky_map: dict[tuple[str, str], float]) -> None:
         print(f"\n{title} ({len(tasks)}):")
-        print(f"{'Variant':<45} {'Task':<40}")
-        print("-" * 85)
+        print(f"{'Variant':<45} {'Task':<60}")
+        print("-" * 105)
         for task in sorted(tasks, key=lambda t: (t.build_variant, t.display_name)):
             variant = task.build_variant[:44]
-            task_name = task.display_name[:39]
-            print(f"{variant:<45} {task_name:<40}")
+            display = task.display_name[:39]
+            flakiness = flaky_map.get((task.display_name, task.build_variant))
+            if flakiness is not None:
+                display = f"{display} (flaky: {flakiness:.0f}% over 7d)"
+            print(f"{variant:<45} {display:<60}")
 
     if failed_tasks:
-        print_task_table(failed_tasks, "Failed Tasks")
+        print_task_table(failed_tasks, "Failed Tasks", flaky_map)
 
     if running_tasks:
-        print_task_table(running_tasks, "Pending Tasks")
+        print_task_table(running_tasks, "Pending Tasks", flaky_map)
 
 
 def main() -> None:
@@ -346,16 +378,28 @@ def main() -> None:
         print(f"Error fetching tasks: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Look up flakiness when there are failures (best-effort, non-fatal).
+    flaky_map: dict[tuple[str, str], float] = {}
+    if failed_tasks:
+        print("Looking up flakiness for failed tasks...", file=sys.stderr)
+        try:
+            flaky_tasks_list = get_flaky_tasks()
+            flaky_map = {(t.task_name, t.variant): t.flakiness_percent for t in flaky_tasks_list}
+            flaky_matches = sum(1 for t in failed_tasks if (t.display_name, t.build_variant) in flaky_map)
+            print(f"  {flaky_matches} of {len(failed_tasks)} failed tasks are known-flaky", file=sys.stderr)
+        except Exception as e:
+            print(f"Warning: flakiness lookup failed: {e}", file=sys.stderr)
+
     if failed_tasks or running_tasks:
         print(f"Found {len(failed_tasks)} failed, {len(running_tasks)} running tasks", file=sys.stderr)
 
         if use_slack_dry_run:
-            message = format_slack_message(version_info, failed_tasks)
+            message = format_slack_message(version_info, failed_tasks, flaky_map)
             print(json.dumps(message, indent=2))
         else:
-            print_stdout_report(version_info, failed_tasks, running_tasks)
+            print_stdout_report(version_info, failed_tasks, running_tasks, flaky_map)
             if use_slack and slack_webhook_url and failed_tasks:
-                message = format_slack_message(version_info, failed_tasks)
+                message = format_slack_message(version_info, failed_tasks, flaky_map)
                 send_slack_notification(slack_webhook_url, message)
     else:
         print("No failed or running tasks found", file=sys.stderr)

--- a/scripts/evergreen/tests/test_notify_flaky_tests.py
+++ b/scripts/evergreen/tests/test_notify_flaky_tests.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.evergreen.notify_flaky_tests import FlakyTask, format_slack_message, get_honeycomb_headers
+from scripts.evergreen.notify_flaky_tests import FlakyTask, _honeycomb_headers, format_slack_message
 
 
 def make_flaky_task(
@@ -13,11 +13,7 @@ def make_flaky_task(
     flakiness_percent: float = 25.0,
 ) -> FlakyTask:
     """Create a FlakyTask for testing."""
-    return FlakyTask(
-        task_name=task_name,
-        variant=variant,
-        flakiness_percent=flakiness_percent,
-    )
+    return FlakyTask(task_name=task_name, variant=variant, flakiness_percent=flakiness_percent, total_runs=10)
 
 
 class TestFormatSlackMessage:
@@ -93,11 +89,11 @@ class TestGetHoneycombHeaders:
     def test_missing_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("HONEYCOMB_API_KEY", raising=False)
         with pytest.raises(RuntimeError, match="HONEYCOMB_API_KEY"):
-            get_honeycomb_headers()
+            _honeycomb_headers()
 
     def test_returns_headers_with_key(self, monkeypatch):
         monkeypatch.setenv("HONEYCOMB_API_KEY", "test-key")
-        headers = get_honeycomb_headers()
+        headers = _honeycomb_headers()
         assert headers["X-Honeycomb-Team"] == "test-key"
         assert headers["Content-Type"] == "application/json"
 

--- a/scripts/funcs/install
+++ b/scripts/funcs/install
@@ -37,6 +37,26 @@ detect_architecture() {
       esac
 }
 
+kubectl_apply_retry() {
+    local max_attempts=5
+    local base_delay=10
+    local attempt=1
+    while true; do
+        if kubectl apply "$@"; then
+            return 0
+        fi
+        if [[ ${attempt} -ge ${max_attempts} ]]; then
+            echo "kubectl apply failed after ${max_attempts} attempts" >&2
+            return 1
+        fi
+        local jitter=$((RANDOM % (base_delay + 1)))
+        local delay=$((base_delay + jitter))
+        echo "kubectl apply attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s..." >&2
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+    done
+}
+
 # Curl wrapper with jitter and consistent retry params for CI downloads.
 # Adds 0-30s random jitter to prevent thundering herd when CI retries trigger simultaneously.
 # Time range: 0-630s (0-30s jitter + up to 600s curl timeout).

--- a/scripts/python/evergreen_api.py
+++ b/scripts/python/evergreen_api.py
@@ -3,6 +3,8 @@ import os
 import requests
 from evergreen.api import EvergreenApi, EvgAuth
 
+# CI has EVR_TASK_ID set → use evergreen.mongodb.com (env-var auth).
+# Local dev lacks EVR_TASK_ID → use evergreen.corp.mongodb.com (OIDC auth via ~/.evergreen.yml).
 EVERGREEN_API = "https://evergreen.mongodb.com/api"
 if not os.environ.get("EVR_TASK_ID"):
     EVERGREEN_API = "https://evergreen.corp.mongodb.com/api"

--- a/scripts/python/evergreen_api.py
+++ b/scripts/python/evergreen_api.py
@@ -4,6 +4,8 @@ import requests
 from evergreen.api import EvergreenApi, EvgAuth
 
 EVERGREEN_API = "https://evergreen.mongodb.com/api"
+if not os.environ.get("EVR_TASK_ID"):
+    EVERGREEN_API = "https://evergreen.corp.mongodb.com/api"
 
 
 def get_evergreen_auth_headers() -> dict:
@@ -22,16 +24,17 @@ def get_evergreen_auth_headers() -> dict:
 
 def get_evergreen_api() -> EvergreenApi:
     """
-    Returns an EvergreenApi client instance using EVERGREEN_USER and EVERGREEN_API_KEY environment variables.
-    Raises RuntimeError if either variable is missing.
+    Returns an EvergreenApi client instance.
+    Prefers EVERGREEN_USER / EVERGREEN_API_KEY env vars (for CI),
+    falls back to ~/.evergreen.yml config (which supports OIDC for local dev).
     """
     evg_user = os.environ.get("EVERGREEN_USER", "")
     api_key = os.environ.get("EVERGREEN_API_KEY", "")
-    if evg_user == "" or api_key == "":
-        raise RuntimeError("EVERGREEN_USER and EVERGREEN_API_KEY must be set")
+    if evg_user and api_key:
+        auth = EvgAuth(evg_user, api_key)
+        return EvergreenApi.get_api(auth)
 
-    auth = EvgAuth(evg_user, api_key)
-    return EvergreenApi.get_api(auth)
+    return EvergreenApi.get_api(use_config_file=True)
 
 
 def get_task_details(task_id: str) -> dict:


### PR DESCRIPTION
## Summary

### Multi-cluster deletion tests timed out because the test polled faster than the operator could delete

The operator's `OnDelete` handler calls `WaitForReadyState` (90s+ polling) before reaching `deleteClusterResources` to remove StatefulSets. In multi-cluster, cross-cluster agent propagation adds further latency. Tests with 60s polling windows consistently expired before the operator reached the deletion step. Single-cluster counterparts did not fail because there is no cross-cluster propagation.

Bumped poll timeouts from 60s→300s in all multi-cluster deletion/cleanup tests (StatefulSets, Services, ConfigMaps, Secrets, CR resource deletion).

### Infinite poll loops in test infrastructure now have bounded timeouts

`get_pod_when_running` (in `__init__.py`) and `wait_for_condition_stateful_set` (in `kubetester.py`) both had infinite `while True` loops with no timeout. A pod that never became Ready would hang until Evergreen's 2h task executor killed it, producing a less useful failure than an explicit timeout error. Added 600s timeouts with descriptive error messages that include the last-known status.

### CRD replace now retries on HTTP 409 conflicts

`create_or_replace_from_yaml.py` read the CRD's `resourceVersion`, then called replace — but the version could change between read and write, producing a 409 conflict. The patch path already had retry logic for this; the replace path did not. Added a 300s deadline retry loop for the replace path matching the existing patch pattern.

### Community operator e2e: removed `-failfast`

`-failfast` combined with `retry_on_failure` masked which subtests actually failed. Removing it lets all subtests report results independently, so the test pod's exit code and logs reflect every failure, not just the first one.

### Flaky test reporting improvements

- Renamed `get_honeycomb_headers`→`_honeycomb_headers` (internal convention). The test file kept the old import name, causing `ImportError` in CI (`unit_tests_python` task). Fixed.
- Added `total_runs` count to the `FlakyTask` dataclass so the output shows run count alongside flakiness percentage.
- Master failure notifications now annotate each failed task with its known flakiness percentage from the past 7 days (via `get_flaky_tasks`).

### Evergreen API URL routing

Local development uses `evergreen.corp.mongodb.com` (OIDC auth works there), CI uses `evergreen.mongodb.com`. Detection via the `EVR_TASK_ID` env var, which is injected by Evergreen at task runtime and absent locally.

## Proof of Work

- `multi_cluster_replica_set_deletion.py`: StatefulSets still existed 88s after CR deletion, 60s polling timed out
- `sharded_cluster.py` / `sharded_cluster_pv.py`: operator logs confirm `WaitForReadyState` blocks deletion for 90s+

new merged master slack output:
```
BUILD FAILED: 6a429f059bf8b00007a37ee6
Commit:  4d65e5e2 by nam.nguyen
Link:    https://spruce.mongodb.com/version/6a429f059bf8b00007a37ee6

Failed Tasks (29):
Variant                                       Task
---------------------------------------------------------------------------------------------------------
e2e_mdb_kind_ubi_cloudqa                      e2e_disable_tls_and_scale (flaky: 6% over 7d)
e2e_mdb_kind_ubi_cloudqa                      e2e_replica_set_scram_sha_1_upgrade (flaky: 21% over 7d)
```
## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` label applied (infrastructure/test-only changes, no user-facing behavior)
