### PR TITLE
Rename VoyageAI CRD plural to voyageais

### DIFF
--- a/api/voyageai/v1/vai/voyageai_types.go
+++ b/api/voyageai/v1/vai/voyageai_types.go
@@ -35,7 +35,7 @@ const (
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="VoyageAI version reconciled by the operator."
 // +kubebuilder:printcolumn:name="Model",type="string",JSONPath=".spec.model",description="VoyageAI model."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The time since the VoyageAI resource was created."
-// +kubebuilder:resource:path=voyageai,scope=Namespaced,shortName=vai
+// +kubebuilder:resource:path=voyageais,scope=Namespaced,shortName=vai
 type VoyageAI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/ai.mongodb.com_voyageais.yaml
+++ b/config/crd/bases/ai.mongodb.com_voyageais.yaml
@@ -4,13 +4,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: voyageai.ai.mongodb.com
+  name: voyageais.ai.mongodb.com
 spec:
   group: ai.mongodb.com
   names:
     kind: VoyageAI
     listKind: VoyageAIList
-    plural: voyageai
+    plural: voyageais
     shortNames:
     - vai
     singular: voyageai

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - bases/mongodb.com_mongodbsearch.yaml
 - bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
 - bases/mongodb.com_clustermongodbroles.yaml
-- bases/ai.mongodb.com_voyageai.yaml
+- bases/ai.mongodb.com_voyageais.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
             - -watch-resource=mongodbusers
             - -watch-resource=mongodbcommunity
             - -watch-resource=mongodbsearch
-            - -watch-resource=voyageai
+            - -watch-resource=voyageais
             - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator

--- a/config/rbac/operator-roles-base.yaml
+++ b/config/rbac/operator-roles-base.yaml
@@ -85,9 +85,9 @@ rules:
     verbs:
       - '*'
     resources:
-      - voyageai
-      - voyageai/finalizers
-      - voyageai/status
+      - voyageais
+      - voyageais/finalizers
+      - voyageais/status
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding

--- a/controllers/operator/voyageai_controller.go
+++ b/controllers/operator/voyageai_controller.go
@@ -74,7 +74,7 @@ func newVoyageAIReconciler(client client.Client, imageRepository string) *Voyage
 	}
 }
 
-// +kubebuilder:rbac:groups=ai.mongodb.com,resources={voyageai,voyageai/status,voyageai/finalizers},verbs=*,namespace=placeholder
+// +kubebuilder:rbac:groups=ai.mongodb.com,resources={voyageais,voyageais/status,voyageais/finalizers},verbs=*,namespace=placeholder
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete,namespace=placeholder
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete,namespace=placeholder
 func (r *VoyageAIReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/helm_chart/crds/ai.mongodb.com_voyageais.yaml
+++ b/helm_chart/crds/ai.mongodb.com_voyageais.yaml
@@ -4,13 +4,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: voyageai.ai.mongodb.com
+  name: voyageais.ai.mongodb.com
 spec:
   group: ai.mongodb.com
   names:
     kind: VoyageAI
     listKind: VoyageAIList
-    plural: voyageai
+    plural: voyageais
     shortNames:
     - vai
     singular: voyageai

--- a/helm_chart/templates/operator-roles-base.yaml
+++ b/helm_chart/templates/operator-roles-base.yaml
@@ -97,9 +97,9 @@ rules:
     verbs:
       - '*'
     resources:
-      - voyageai
-      - voyageai/finalizers
-      - voyageai/status
+      - voyageais
+      - voyageais/finalizers
+      - voyageais/status
 {{- if eq $roleScope "ClusterRole" }}
   - apiGroups:
       - ''

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -26,7 +26,7 @@ operator:
   - mongodbusers
   - mongodbcommunity
   - mongodbsearch
-  - voyageai
+  - voyageais
 
   nodeSelector: {}
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ const (
 	mongoDBMultiClusterCRDPlural = "mongodbmulticluster"
 	mongoDBCommunityCRDPlural    = "mongodbcommunity"
 	mongoDBSearchCRDPlural       = "mongodbsearch"
-	voyageAICRDPlural            = "voyageai"
+	voyageAICRDPlural            = "voyageais"
 	clusterMongoDBRoleCRDPlural  = "clustermongodbroles"
 )
 

--- a/pkg/kubectl-mongodb/common/common.go
+++ b/pkg/kubectl-mongodb/common/common.go
@@ -398,7 +398,7 @@ func getCentralRules() []rbacv1.PolicyRule {
 		},
 		{
 			Verbs:     []string{"*"},
-			Resources: []string{"voyageai", "voyageai/finalizers", "voyageai/status"},
+			Resources: []string{"voyageais", "voyageais/finalizers", "voyageais/status"},
 			APIGroups: []string{"ai.mongodb.com"},
 		},
 	}

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -4,13 +4,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: voyageai.ai.mongodb.com
+  name: voyageais.ai.mongodb.com
 spec:
   group: ai.mongodb.com
   names:
     kind: VoyageAI
     listKind: VoyageAIList
-    plural: voyageai
+    plural: voyageais
     shortNames:
     - vai
     singular: voyageai

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -85,9 +85,9 @@ rules:
     verbs:
       - '*'
     resources:
-      - voyageai
-      - voyageai/finalizers
-      - voyageai/status
+      - voyageais
+      - voyageais/finalizers
+      - voyageais/status
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding
@@ -352,7 +352,7 @@ spec:
             - -watch-resource=mongodbusers
             - -watch-resource=mongodbcommunity
             - -watch-resource=mongodbsearch
-            - -watch-resource=voyageai
+            - -watch-resource=voyageais
             - -watch-resource=mongodbmulticluster
             - -watch-resource=clustermongodbroles
           command:

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -85,9 +85,9 @@ rules:
     verbs:
       - '*'
     resources:
-      - voyageai
-      - voyageai/finalizers
-      - voyageai/status
+      - voyageais
+      - voyageais/finalizers
+      - voyageais/status
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding
@@ -347,7 +347,7 @@ spec:
             - -watch-resource=mongodbusers
             - -watch-resource=mongodbcommunity
             - -watch-resource=mongodbsearch
-            - -watch-resource=voyageai
+            - -watch-resource=voyageais
             - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -85,9 +85,9 @@ rules:
     verbs:
       - '*'
     resources:
-      - voyageai
-      - voyageai/finalizers
-      - voyageai/status
+      - voyageais
+      - voyageais/finalizers
+      - voyageais/status
 ---
 # Source: mongodb-kubernetes/templates/operator-roles-base.yaml
 kind: RoleBinding
@@ -352,7 +352,7 @@ spec:
             - -watch-resource=mongodbusers
             - -watch-resource=mongodbcommunity
             - -watch-resource=mongodbsearch
-            - -watch-resource=voyageai
+            - -watch-resource=voyageais
             - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
@@ -53,9 +53,9 @@ rules:
 - apiGroups:
   - ai.mongodb.com
   resources:
-  - voyageai
-  - voyageai/finalizers
-  - voyageai/status
+  - voyageais
+  - voyageais/finalizers
+  - voyageais/status
   verbs:
   - '*'
 - apiGroups:

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
@@ -39,9 +39,9 @@ rules:
 - apiGroups:
   - ai.mongodb.com
   resources:
-  - voyageai
-  - voyageai/finalizers
-  - voyageai/status
+  - voyageais
+  - voyageais/finalizers
+  - voyageais/status
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
# Summary

Plural was voyageai (== singular); team standardized on voyageais. Singular stays voyageai.

## Proof of Work

Test should pass

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
