### PR TITLE
KUBE-143: reap stale shard's mongot resources on shard scale-down (single-cluster)

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -27,7 +28,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -27,6 +27,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
@@ -811,26 +812,37 @@ func isOwnedBy(obj client.Object, owner client.Object) bool {
 	return false
 }
 
-// cleanupStaleShardResources deletes per-shard proxy Services for shards that no
-// longer exist. In MC the proxy Services live on the member clusters, so we
-// iterate the central client plus every member-cluster client and only touch
-// Services we own (by UID on central, by search-owner label on members —
-// cross-cluster owner refs don't exist).
+// cleanupStaleShardResources reaps the per-shard mongot resources of shards that no
+// longer exist (shard scale-down): proxy Service, headless Service, ConfigMap, and the
+// mongot StatefulSet — whose whenDeleted=Delete policy then cascades its PVC. For every
+// live shard it rebuilds the expected resource names; anything we own carrying the
+// matching scope label but not in those sets belongs to a removed shard and is deleted.
 //
-// STSs / ConfigMaps / headless Services for stale shards are not handled here:
-// in MC their owners live cross-cluster and aren't GC'd by Kubernetes.
+// Owner refs don't cross clusters, so we iterate the central client plus every member
+// client and guard ownership by UID on central, by search-owner label on members.
+// Best-effort: per-kind/per-cluster failures are aggregated and retried next reconcile.
 func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Context, log *zap.SugaredLogger, currentShardNames []string) error {
 	if r.mdbSearch.IsShardedUnmanagedLB() {
 		return nil
 	}
 
-	expectedNames := make(map[string]bool)
+	// Per-kind expected-name sets. They are kept separate (rather than merged) because
+	// shard names can be customer-provided: a stale shard named e.g. "x-svc" would yield
+	// a StatefulSet name that collides with a live shard "x"'s headless Service name, and
+	// a shared set would then wrongly preserve the stale StatefulSet.
+	expectedProxy := map[string]bool{}
+	expectedHeadless := map[string]bool{}
+	expectedSTS := map[string]bool{}
+	expectedConfig := map[string]bool{}
 	seenClusters := map[int]bool{}
 	for _, w := range r.buildShardedWorkList(currentShardNames) {
-		expectedNames[r.mdbSearch.ProxyServiceNameForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedProxy[r.mdbSearch.ProxyServiceNameForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedHeadless[r.mdbSearch.MongotServiceForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedSTS[r.mdbSearch.MongotStatefulSetForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedConfig[r.mdbSearch.MongotConfigMapForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
 		if !seenClusters[w.ClusterIndex] {
 			seenClusters[w.ClusterIndex] = true
-			expectedNames[r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex).Name] = true
+			expectedProxy[r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex).Name] = true
 		}
 	}
 
@@ -839,40 +851,67 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 		clients[name] = c
 	}
 
-	for clusterName, c := range clients {
-		serviceList := &corev1.ServiceList{}
-		if err := c.List(ctx, serviceList,
-			client.InNamespace(r.mdbSearch.Namespace),
-			client.MatchingLabels{"component": proxyServiceComponent},
-		); err != nil {
-			return xerrors.Errorf("failed to list proxy services on cluster %q: %w", clusterName, err)
-		}
+	// The mongot StatefulSet is the only StatefulSet we own, so it's scoped by owner
+	// label; proxy and headless Services share a kind but carry distinct component
+	// labels; the mongot ConfigMap carries the mongot component label.
+	sweeps := []struct {
+		newList  func() client.ObjectList
+		selector client.MatchingLabels
+		expected map[string]bool
+		kind     string
+	}{
+		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels(searchOwnerLabels(r.mdbSearch, "")), expectedSTS, "StatefulSet"},
+		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: proxyServiceComponent}, expectedProxy, "proxy Service"},
+		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedHeadless, "headless Service"},
+		{func() client.ObjectList { return &corev1.ConfigMapList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedConfig, "ConfigMap"},
+	}
 
-		for i := range serviceList.Items {
-			svc := &serviceList.Items[i]
-			if expectedNames[svc.Name] {
-				continue
-			}
-			// Owner refs don't cross clusters, so for member-cluster Services the
-			// owner check is by search-owner label instead of UID. Same intent:
-			// only touch Services we created.
-			if clusterName == "" {
-				if !isOwnedBy(svc, r.mdbSearch) {
-					continue
-				}
-			} else {
-				if svc.Labels[khandler.MongoDBSearchOwnerNameLabel] != r.mdbSearch.Name ||
-					svc.Labels[khandler.MongoDBSearchOwnerNamespaceLabel] != r.mdbSearch.Namespace {
-					continue
-				}
-			}
-			log.Infof("Deleting stale proxy Service %s on cluster %q", svc.Name, clusterName)
-			if err := c.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
-				return xerrors.Errorf("failed to delete stale proxy Service %s on cluster %q: %w", svc.Name, clusterName, err)
+	var errs error
+	for clusterName, c := range clients {
+		for _, s := range sweeps {
+			if err := r.sweepStaleShardResources(ctx, log, c, clusterName, s.newList(), s.selector, s.expected, s.kind); err != nil {
+				errs = multierror.Append(errs, err)
 			}
 		}
 	}
-	return nil
+	return errs
+}
+
+// sweepStaleShardResources lists one resource kind on a cluster (scoped by selector)
+// and deletes every object this search owns whose name isn't in expected.
+func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Context, log *zap.SugaredLogger, c kubernetesClient.Client, clusterName string, list client.ObjectList, selector client.MatchingLabels, expected map[string]bool, kind string) error {
+	if err := c.List(ctx, list, client.InNamespace(r.mdbSearch.Namespace), selector); err != nil {
+		return xerrors.Errorf("failed to list %ss on cluster %q: %w", kind, clusterName, err)
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return xerrors.Errorf("failed to extract %s list on cluster %q: %w", kind, clusterName, err)
+	}
+
+	var errs error
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok || expected[obj.GetName()] || !r.ownsForSweep(obj, clusterName) {
+			continue
+		}
+		log.Infof("Deleting stale %s %s on cluster %q", kind, obj.GetName(), clusterName)
+		if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			errs = multierror.Append(errs, xerrors.Errorf("failed to delete stale %s %s on cluster %q: %w", kind, obj.GetName(), clusterName, err))
+		}
+	}
+	return errs
+}
+
+// ownsForSweep reports whether obj belongs to this search: by owner-reference UID on
+// the central cluster (clusterName ""), by search-owner label on member clusters
+// (cross-cluster owner refs don't exist).
+func (r *MongoDBSearchReconcileHelper) ownsForSweep(obj client.Object, clusterName string) bool {
+	if clusterName == "" {
+		return isOwnedBy(obj, r.mdbSearch)
+	}
+	labels := obj.GetLabels()
+	return labels[khandler.MongoDBSearchOwnerNameLabel] == r.mdbSearch.Name &&
+		labels[khandler.MongoDBSearchOwnerNamespaceLabel] == r.mdbSearch.Namespace
 }
 
 // ensureKeyfileModification returns the keyfile StatefulSet modification if wireproto is enabled.
@@ -1022,6 +1061,7 @@ func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, l
 		if cm.Labels == nil {
 			cm.Labels = map[string]string{}
 		}
+		cm.Labels[componentLabelKey] = mongotComponent
 		for k, v := range searchOwnerLabels(r.mdbSearch, clusterName) {
 			cm.Labels[k] = v
 		}
@@ -1177,7 +1217,15 @@ func mongotServicePorts(search *searchv1.MongoDBSearch) []corev1.ServicePort {
 const (
 	appLabelKey           = "app"
 	shardLabelKey         = "shard"
+	componentLabelKey     = "component"
 	proxyServiceComponent = "search-proxy"
+	// mongotComponent is the component-label value stamped on the per-shard mongot
+	// headless Service and ConfigMap, letting the stale-shard sweep find and reap them
+	// on shard scale-down without touching Envoy or state resources. The mongot
+	// StatefulSet is not component-labelled — it is swept by owner label instead, being
+	// the only StatefulSet the search owns (a coarser scope that also catches STSs
+	// created before this label existed).
+	mongotComponent = "mongot"
 
 	nameLabelKey       = "app.kubernetes.io/name"
 	managedByLabelKey  = "app.kubernetes.io/managed-by"
@@ -1188,7 +1236,10 @@ const (
 // buildHeadlessService builds a headless Service for a reconcile unit. All topology-specific
 // behavior comes from the unit's explicit fields — no branching on "is this a shard?".
 func buildHeadlessService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev1.Service {
-	svcLabels := map[string]string{appLabelKey: unit.headlessSvc.Name}
+	svcLabels := map[string]string{
+		appLabelKey:       unit.headlessSvc.Name,
+		componentLabelKey: mongotComponent,
+	}
 	for k, v := range unit.additionalSvcLabels {
 		svcLabels[k] = v
 	}
@@ -1230,8 +1281,8 @@ func buildProxyService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev
 	}
 
 	labels := map[string]string{
-		appLabelKey: unit.proxySvc.Name,
-		"component": proxyServiceComponent,
+		appLabelKey:       unit.proxySvc.Name,
+		componentLabelKey: proxyServiceComponent,
 	}
 	for k, v := range unit.additionalSvcLabels {
 		labels[k] = v
@@ -1276,8 +1327,8 @@ func buildClusterLevelProxyService(search *searchv1.MongoDBSearch, res clusterLe
 	}
 
 	labels := map[string]string{
-		appLabelKey: res.svcName.Name,
-		"component": proxyServiceComponent,
+		appLabelKey:       res.svcName.Name,
+		componentLabelKey: proxyServiceComponent,
 	}
 	for k, v := range searchOwnerLabels(search, res.clusterName) {
 		labels[k] = v

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -800,27 +800,14 @@ func (r *MongoDBSearchReconcileHelper) pruneRoutingReady(ctx context.Context, li
 	return nil
 }
 
-// isOwnedBy returns true if the object has an owner reference pointing to the given owner.
-// Unlike metav1.IsControlledBy, this does not require the controller: true field,
-// which is not set by controllerutil.SetOwnerReference.
-func isOwnedBy(obj client.Object, owner client.Object) bool {
-	for _, ref := range obj.GetOwnerReferences() {
-		if ref.UID == owner.GetUID() {
-			return true
-		}
-	}
-	return false
-}
-
 // cleanupStaleShardResources reaps the per-shard mongot resources of shards that no
 // longer exist (shard scale-down): proxy Service, headless Service, ConfigMap, and the
 // mongot StatefulSet — whose whenDeleted=Delete policy then cascades its PVC. For every
 // live shard it rebuilds the expected resource names; anything we own carrying the
 // matching scope label but not in those sets belongs to a removed shard and is deleted.
 //
-// Owner refs don't cross clusters, so we iterate the central client plus every member
-// client and guard ownership by UID on central, by search-owner label on members.
-// Best-effort: per-kind/per-cluster failures are aggregated and retried next reconcile.
+// It fans out over the central client and every member client; per-kind/per-cluster
+// failures are best-effort — aggregated and retried next reconcile.
 func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Context, log *zap.SugaredLogger, currentShardNames []string) error {
 	if r.mdbSearch.IsShardedUnmanagedLB() {
 		return nil
@@ -891,7 +878,7 @@ func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Cont
 	var errs error
 	for _, item := range items {
 		obj, ok := item.(client.Object)
-		if !ok || expected[obj.GetName()] || !r.ownsForSweep(obj, clusterName) {
+		if !ok || expected[obj.GetName()] || !r.ownsForSweep(obj) {
 			continue
 		}
 		log.Infof("Deleting stale %s %s on cluster %q", kind, obj.GetName(), clusterName)
@@ -902,13 +889,10 @@ func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Cont
 	return errs
 }
 
-// ownsForSweep reports whether obj belongs to this search: by owner-reference UID on
-// the central cluster (clusterName ""), by search-owner label on member clusters
-// (cross-cluster owner refs don't exist).
-func (r *MongoDBSearchReconcileHelper) ownsForSweep(obj client.Object, clusterName string) bool {
-	if clusterName == "" {
-		return isOwnedBy(obj, r.mdbSearch)
-	}
+// ownsForSweep reports whether obj belongs to this search by its owner-name +
+// owner-namespace labels. Owner refs don't cross clusters, so labels are the
+// uniform ownership signal on central and member clusters alike.
+func (r *MongoDBSearchReconcileHelper) ownsForSweep(obj client.Object) bool {
 	labels := obj.GetLabels()
 	return labels[khandler.MongoDBSearchOwnerNameLabel] == r.mdbSearch.Name &&
 		labels[khandler.MongoDBSearchOwnerNamespaceLabel] == r.mdbSearch.Namespace
@@ -1219,12 +1203,8 @@ const (
 	shardLabelKey         = "shard"
 	componentLabelKey     = "component"
 	proxyServiceComponent = "search-proxy"
-	// mongotComponent is the component-label value stamped on the per-shard mongot
-	// headless Service and ConfigMap, letting the stale-shard sweep find and reap them
-	// on shard scale-down without touching Envoy or state resources. The mongot
-	// StatefulSet is not component-labelled — it is swept by owner label instead, being
-	// the only StatefulSet the search owns (a coarser scope that also catches STSs
-	// created before this label existed).
+	// mongotComponent is the component-label value on the per-shard mongot headless
+	// Service and ConfigMap (the StatefulSet is swept by owner label instead).
 	mongotComponent = "mongot"
 
 	nameLabelKey       = "app.kubernetes.io/name"

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -2994,63 +2994,36 @@ func TestCleanupStaleShardResources(t *testing.T) {
 		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
 	})
 
-	proxySvc := func(shard string, owned bool) *corev1.Service {
-		svc := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: search.ProxyServiceNameForClusterShard(0, shard).Name, Namespace: "test-ns",
-				Labels: map[string]string{"component": proxyServiceComponent},
-			},
-			Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1", Ports: []corev1.ServicePort{{Port: 27028}}},
-		}
+	withOwner := func(labels map[string]string, owned bool) map[string]string {
 		if owned {
-			svc.OwnerReferences = []metav1.OwnerReference{{UID: search.UID}}
-		} else {
-			svc.OwnerReferences = []metav1.OwnerReference{{}}
-			svc.OwnerReferences[0].UID = "other-uid"
-		}
-		return svc
-	}
-
-	// Per-shard mongot resources carry owner labels (STS, swept by owner label) and the
-	// mongot component label (headless Service + ConfigMap, swept by component label).
-	ownerLabels := searchOwnerLabels(search, "")
-	mongotLabels := func(extra map[string]string) map[string]string {
-		labels := map[string]string{}
-		for k, v := range extra {
-			labels[k] = v
-		}
-		for k, v := range ownerLabels {
-			labels[k] = v
+			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
+			labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
 		}
 		return labels
 	}
-	setOwner := func(obj client.Object, owned bool) {
-		uid := types.UID("other-uid")
-		if owned {
-			uid = search.UID
+	proxySvc := func(shard string, owned bool) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: search.ProxyServiceNameForClusterShard(0, shard).Name, Namespace: "test-ns",
+				Labels: withOwner(map[string]string{"component": proxyServiceComponent}, owned),
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1", Ports: []corev1.ServicePort{{Port: 27028}}},
 		}
-		obj.SetOwnerReferences([]metav1.OwnerReference{{UID: uid}})
 	}
 	mongotSTS := func(shard string, owned bool) *appsv1.StatefulSet {
-		sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
-			Name: search.MongotStatefulSetForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(nil),
+		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotStatefulSetForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{}, owned),
 		}}
-		setOwner(sts, owned)
-		return sts
 	}
 	mongotHeadless := func(shard string, owned bool) *corev1.Service {
-		svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name: search.MongotServiceForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(map[string]string{"component": mongotComponent}),
+		return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotServiceForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
 		}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2", Ports: []corev1.ServicePort{{Port: 27027}}}}
-		setOwner(svc, owned)
-		return svc
 	}
 	mongotCM := func(shard string, owned bool) *corev1.ConfigMap {
-		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
-			Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(map[string]string{"component": mongotComponent}),
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
 		}}
-		setOwner(cm, owned)
-		return cm
 	}
 
 	fakeClient := newTestFakeClient(search,
@@ -3061,9 +3034,12 @@ func TestCleanupStaleShardResources(t *testing.T) {
 		mongotSTS("shard-1", true), mongotSTS("shard-2", true),
 		mongotHeadless("shard-1", true), mongotHeadless("shard-2", true), mongotHeadless("shard-x", false),
 		mongotCM("shard-1", true), mongotCM("shard-2", true), mongotCM("shard-x", false),
+		// Name collision: live shard "x"'s headless Svc name == stale "x-svc"'s STS name.
+		// Separate per-kind expected sets keep them apart; a merged set would leak the stale STS.
+		mongotHeadless("x", true), mongotSTS("x-svc", true),
 	)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
-	require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), []string{"shard-0", "shard-1"}))
+	require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), []string{"shard-0", "shard-1", "x"}))
 
 	_, err := fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-0"))
 	assert.NoError(t, err, "active shard preserved")
@@ -3074,9 +3050,6 @@ func TestCleanupStaleShardResources(t *testing.T) {
 	_, err = fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-x"))
 	assert.NoError(t, err, "different owner untouched")
 
-	// The removed shard's mongot StatefulSet, headless Service, and ConfigMap are reaped
-	// (the STS delete then cascades its PVC via whenDeleted=Delete); active and
-	// different-owner resources survive.
 	gone := func(nn types.NamespacedName, obj client.Object, msg string) {
 		assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), nn, obj)), msg)
 	}
@@ -3091,6 +3064,9 @@ func TestCleanupStaleShardResources(t *testing.T) {
 	present(search.MongotConfigMapForClusterShard(0, "shard-1"), &corev1.ConfigMap{}, "active shard ConfigMap preserved")
 	gone(search.MongotConfigMapForClusterShard(0, "shard-2"), &corev1.ConfigMap{}, "stale shard ConfigMap deleted")
 	present(search.MongotConfigMapForClusterShard(0, "shard-x"), &corev1.ConfigMap{}, "different-owner ConfigMap untouched")
+
+	present(search.MongotServiceForClusterShard(0, "x"), &corev1.Service{}, "live shard x headless Service preserved despite name-collision with stale x-svc STS")
+	gone(search.MongotStatefulSetForClusterShard(0, "x-svc"), &appsv1.StatefulSet{}, "stale x-svc STS reaped despite name-collision with live x headless Service")
 }
 
 func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
@@ -3978,9 +3954,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		}
 	}
 
-	// Per-shard mongot resources on a member cluster: STS swept by owner label,
-	// headless Service + ConfigMap by the mongot component label; owned=false drops the
-	// owner labels so they must be left alone.
+	// owned=false drops the owner labels, so the sweep must leave these alone.
 	withMemberOwner := func(labels map[string]string, owned bool) map[string]string {
 		if owned {
 			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
@@ -4061,9 +4035,6 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		require.NoError(t, err, "%s: foreign Service %q must be untouched", tc.cluster, tc.foreign)
 	}
 
-	// Per-shard mongot resources on cluster-a: STS swept by owner label, headless
-	// Service + ConfigMap by the mongot component label. Active sh-0 survives, stale
-	// sh-stale is reaped, and the component-labelled but unowned sh-foreign is left alone.
 	present := func(name string, obj client.Object, what string) {
 		require.NoError(t, clusterA.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "ns"}, obj), "cluster-a: %s must survive cleanup", what)
 	}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3011,11 +3011,56 @@ func TestCleanupStaleShardResources(t *testing.T) {
 		return svc
 	}
 
+	// Per-shard mongot resources carry owner labels (STS, swept by owner label) and the
+	// mongot component label (headless Service + ConfigMap, swept by component label).
+	ownerLabels := searchOwnerLabels(search, "")
+	mongotLabels := func(extra map[string]string) map[string]string {
+		labels := map[string]string{}
+		for k, v := range extra {
+			labels[k] = v
+		}
+		for k, v := range ownerLabels {
+			labels[k] = v
+		}
+		return labels
+	}
+	setOwner := func(obj client.Object, owned bool) {
+		uid := types.UID("other-uid")
+		if owned {
+			uid = search.UID
+		}
+		obj.SetOwnerReferences([]metav1.OwnerReference{{UID: uid}})
+	}
+	mongotSTS := func(shard string, owned bool) *appsv1.StatefulSet {
+		sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotStatefulSetForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(nil),
+		}}
+		setOwner(sts, owned)
+		return sts
+	}
+	mongotHeadless := func(shard string, owned bool) *corev1.Service {
+		svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotServiceForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(map[string]string{"component": mongotComponent}),
+		}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2", Ports: []corev1.ServicePort{{Port: 27027}}}}
+		setOwner(svc, owned)
+		return svc
+	}
+	mongotCM := func(shard string, owned bool) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: mongotLabels(map[string]string{"component": mongotComponent}),
+		}}
+		setOwner(cm, owned)
+		return cm
+	}
+
 	fakeClient := newTestFakeClient(search,
 		proxySvc("shard-0", true),  // active, owned
 		proxySvc("shard-1", true),  // active, owned
 		proxySvc("shard-2", true),  // stale, owned
 		proxySvc("shard-x", false), // different owner
+		mongotSTS("shard-1", true), mongotSTS("shard-2", true),
+		mongotHeadless("shard-1", true), mongotHeadless("shard-2", true), mongotHeadless("shard-x", false),
+		mongotCM("shard-1", true), mongotCM("shard-2", true), mongotCM("shard-x", false),
 	)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 	require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), []string{"shard-0", "shard-1"}))
@@ -3028,6 +3073,24 @@ func TestCleanupStaleShardResources(t *testing.T) {
 	assert.Error(t, err, "stale shard deleted")
 	_, err = fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-x"))
 	assert.NoError(t, err, "different owner untouched")
+
+	// The removed shard's mongot StatefulSet, headless Service, and ConfigMap are reaped
+	// (the STS delete then cascades its PVC via whenDeleted=Delete); active and
+	// different-owner resources survive.
+	gone := func(nn types.NamespacedName, obj client.Object, msg string) {
+		assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), nn, obj)), msg)
+	}
+	present := func(nn types.NamespacedName, obj client.Object, msg string) {
+		assert.NoError(t, fakeClient.Get(t.Context(), nn, obj), msg)
+	}
+	present(search.MongotStatefulSetForClusterShard(0, "shard-1"), &appsv1.StatefulSet{}, "active shard STS preserved")
+	gone(search.MongotStatefulSetForClusterShard(0, "shard-2"), &appsv1.StatefulSet{}, "stale shard STS deleted")
+	present(search.MongotServiceForClusterShard(0, "shard-1"), &corev1.Service{}, "active shard headless Service preserved")
+	gone(search.MongotServiceForClusterShard(0, "shard-2"), &corev1.Service{}, "stale shard headless Service deleted")
+	present(search.MongotServiceForClusterShard(0, "shard-x"), &corev1.Service{}, "different-owner headless Service untouched")
+	present(search.MongotConfigMapForClusterShard(0, "shard-1"), &corev1.ConfigMap{}, "active shard ConfigMap preserved")
+	gone(search.MongotConfigMapForClusterShard(0, "shard-2"), &corev1.ConfigMap{}, "stale shard ConfigMap deleted")
+	present(search.MongotConfigMapForClusterShard(0, "shard-x"), &corev1.ConfigMap{}, "different-owner ConfigMap untouched")
 }
 
 func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
@@ -3915,12 +3978,41 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		}
 	}
 
+	// Per-shard mongot resources on a member cluster: STS swept by owner label,
+	// headless Service + ConfigMap by the mongot component label; owned=false drops the
+	// owner labels so they must be left alone.
+	withMemberOwner := func(labels map[string]string, owned bool) map[string]string {
+		if owned {
+			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
+			labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
+		}
+		return labels
+	}
+	memberSTS := func(idx int, shard string, owned bool) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotStatefulSetForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{}, owned),
+		}}
+	}
+	memberMongotSvc := func(idx int, shard string, owned bool) *corev1.Service {
+		return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotServiceForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
+		}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.3", Ports: []corev1.ServicePort{{Port: 27027}}}}
+	}
+	memberCM := func(idx int, shard string, owned bool) *corev1.ConfigMap {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: search.MongotConfigMapForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
+		}}
+	}
+
 	// cluster-a (idx 0): keep shard-0 + cluster-level; sh-stale should be deleted.
 	clusterA := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(
 		memberProxySvc("mdb-search-search-0-sh-0-proxy-svc", true),
 		memberProxySvc("mdb-search-search-0-sh-stale-proxy-svc", true),
 		memberProxySvc("mdb-search-search-0-proxy-svc", true),
 		memberProxySvc("foreign-svc", false), // not search-owned
+		memberSTS(0, "sh-0", true), memberSTS(0, "sh-stale", true),
+		memberMongotSvc(0, "sh-0", true), memberMongotSvc(0, "sh-stale", true), memberMongotSvc(0, "sh-foreign", false),
+		memberCM(0, "sh-0", true), memberCM(0, "sh-stale", true),
 	).Build())
 	// cluster-b (idx 1): same pattern, plus an unrelated owned-by-other-CR svc
 	// to guard the label-name check.
@@ -3968,6 +4060,24 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		err = tc.c.Get(t.Context(), types.NamespacedName{Name: tc.foreign, Namespace: "ns"}, &corev1.Service{})
 		require.NoError(t, err, "%s: foreign Service %q must be untouched", tc.cluster, tc.foreign)
 	}
+
+	// Per-shard mongot resources on cluster-a: STS swept by owner label, headless
+	// Service + ConfigMap by the mongot component label. Active sh-0 survives, stale
+	// sh-stale is reaped, and the component-labelled but unowned sh-foreign is left alone.
+	present := func(name string, obj client.Object, what string) {
+		require.NoError(t, clusterA.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "ns"}, obj), "cluster-a: %s must survive cleanup", what)
+	}
+	gone := func(name string, obj client.Object, what string) {
+		err := clusterA.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "ns"}, obj)
+		require.True(t, apierrors.IsNotFound(err), "cluster-a: %s must be deleted, got err=%v", what, err)
+	}
+	present(search.MongotStatefulSetForClusterShard(0, "sh-0").Name, &appsv1.StatefulSet{}, "active mongot StatefulSet")
+	gone(search.MongotStatefulSetForClusterShard(0, "sh-stale").Name, &appsv1.StatefulSet{}, "stale mongot StatefulSet")
+	present(search.MongotServiceForClusterShard(0, "sh-0").Name, &corev1.Service{}, "active headless Service")
+	gone(search.MongotServiceForClusterShard(0, "sh-stale").Name, &corev1.Service{}, "stale headless Service")
+	present(search.MongotServiceForClusterShard(0, "sh-foreign").Name, &corev1.Service{}, "unowned headless Service")
+	present(search.MongotConfigMapForClusterShard(0, "sh-0").Name, &corev1.ConfigMap{}, "active mongot ConfigMap")
+	gone(search.MongotConfigMapForClusterShard(0, "sh-stale").Name, &corev1.ConfigMap{}, "stale mongot ConfigMap")
 }
 
 // Empty GetShardNames() yields an empty work list. The reconciler must not fail

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -134,7 +134,7 @@ def _mongot_data_pvc_names(namespace: str, sts_name: str) -> list[str]:
 
 
 @mark.e2e_search_community_basic
-def test_zy_scale_mongot_offline_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
+def test_scale_mongot_offline_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     """whenScaled:Delete - scaling mongot to 0 keeps the CR and StatefulSet object
     but reclaims the orphaned ordinal's data PVC; restoring to 1 reindexes from
     mongod onto a fresh volume."""
@@ -161,7 +161,7 @@ def test_zy_scale_mongot_offline_reclaims_pvc(namespace: str, mdbs: MongoDBSearc
 
 
 @mark.e2e_search_community_basic
-def test_zz_delete_search_cr_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
+def test_delete_search_cr_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     """On MongoDBSearch CR delete (single-cluster), owner-ref GC removes the mongot
     StatefulSet and the persistentVolumeClaimRetentionPolicy{whenDeleted:Delete}
     reclaims its data PVC."""

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
@@ -10,7 +10,9 @@ the MongoDBSearch resource correctly reconciles:
 Test flow:
   Phase 1: Deploy sharded cluster (2 shards) + MongoDBSearch with managed LB, verify search
   Phase 2: Scale UP to 3 shards, redistribute data, verify search works across all 3 shards
-  Phase 3: Scale DOWN to 2 shards, verify cleanup and search still works
+  Phase 3: Scale DOWN to 2 shards, verify FULL teardown of the removed shard's mongot
+           resources (StatefulSet, headless + proxy Services, ConfigMap, PVCs) and that
+           search still works
 """
 
 import kubernetes
@@ -101,6 +103,20 @@ def verify_shard_resources_exist(namespace: str, mdbs_name: str, shard_name: str
     assert proxy_svc is not None, f"Proxy Service {proxy_svc_name} not found"
     logger.info(f"Proxy Service {proxy_svc_name} exists")
 
+    # Assert the ConfigMap and PVC(s) exist too, so the matching absence checks in
+    # verify_shard_resources_deleted can't pass vacuously if a future rename drifts
+    # the expected names.
+    cm_name = search_resource_names.shard_configmap_name(mdbs_name, shard_name)
+    cm = core_v1.read_namespaced_config_map(cm_name, namespace)
+    assert cm is not None, f"mongot ConfigMap {cm_name} not found"
+    logger.info(f"mongot ConfigMap {cm_name} exists")
+
+    pvc_prefix = f"data-{sts_name}-"
+    pvcs = core_v1.list_namespaced_persistent_volume_claim(namespace)
+    matching = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
+    assert matching, f"no PVC with prefix {pvc_prefix!r} found for shard {shard_name}"
+    logger.info(f"PVC(s) {matching} exist for shard {shard_name}")
+
 
 def verify_shard_proxy_service_deleted(namespace: str, mdbs_name: str, shard_name: str):
     core_v1 = client.CoreV1Api()
@@ -117,6 +133,73 @@ def verify_shard_proxy_service_deleted(namespace: str, mdbs_name: str, shard_nam
 
     run_periodically(check, timeout=300, sleep_time=10, msg=f"proxy service {proxy_svc_name} deletion")
     logger.info(f"Proxy service {proxy_svc_name} confirmed deleted")
+
+
+def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: str):
+    """Assert FULL teardown of a removed shard's mongot resources.
+
+    The stale-resource sweep deletes the per-shard mongot StatefulSet, headless
+    Service, proxy Service, and mongot ConfigMap; the StatefulSet's
+    ``persistentVolumeClaimRetentionPolicy.whenDeleted: Delete`` then reaps the
+    backing PVC(s). Each kind is polled independently so a partial sweep surfaces
+    the specific resource that leaked. We poll until 404 (or empty list for PVCs)
+    rather than reading once — the sweep runs asynchronously after the
+    MongoDBSearch reports Running.
+    """
+    apps_v1 = client.AppsV1Api()
+    core_v1 = client.CoreV1Api()
+
+    sts_name = search_resource_names.shard_statefulset_name(mdbs_name, shard_name)
+    svc_name = search_resource_names.shard_service_name(mdbs_name, shard_name)
+    cm_name = search_resource_names.shard_configmap_name(mdbs_name, shard_name)
+    # PVCs are named "<volumeClaimName>-<sts-name>-<ordinal>"; the mongot data
+    # volume claim is "data" (search_construction.go), so the prefix is "data-<sts>-".
+    pvc_prefix = f"data-{sts_name}-"
+
+    def sts_gone():
+        try:
+            apps_v1.read_namespaced_stateful_set(sts_name, namespace)
+            return False, f"StatefulSet {sts_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"StatefulSet {sts_name} deleted"
+            raise
+
+    def headless_svc_gone():
+        try:
+            core_v1.read_namespaced_service(svc_name, namespace)
+            return False, f"headless Service {svc_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"headless Service {svc_name} deleted"
+            raise
+
+    def configmap_gone():
+        try:
+            core_v1.read_namespaced_config_map(cm_name, namespace)
+            return False, f"mongot ConfigMap {cm_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"mongot ConfigMap {cm_name} deleted"
+            raise
+
+    def pvcs_gone():
+        pvcs = core_v1.list_namespaced_persistent_volume_claim(namespace)
+        leftover = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
+        if leftover:
+            return False, f"PVC(s) for removed shard still exist: {leftover}"
+        return True, f"no PVCs with prefix {pvc_prefix!r} remain"
+
+    # Proxy Service is covered by verify_shard_proxy_service_deleted; here we
+    # add the StatefulSet, headless Service, ConfigMap, and PVCs.
+    for check, label in (
+        (sts_gone, f"StatefulSet {sts_name}"),
+        (headless_svc_gone, f"headless Service {svc_name}"),
+        (configmap_gone, f"mongot ConfigMap {cm_name}"),
+        (pvcs_gone, f"PVCs {pvc_prefix}*"),
+    ):
+        run_periodically(check, timeout=300, sleep_time=10, msg=f"{label} deletion")
+        logger.info(f"{label} confirmed deleted for removed shard {shard_name}")
 
 
 # ---------------------------------------------------------------------------
@@ -460,10 +543,17 @@ def test_scale_down_wait_for_search_running(mdbs: MongoDBSearch):
 
 @MARKER
 def test_scale_down_verify_stale_resources_cleaned(namespace: str):
-    """Verify that the proxy service for the removed shard is cleaned up by the operator."""
+    """Verify the removed shard's mongot resources are FULLY torn down by the operator.
+
+    Beyond the proxy Service (the only kind the original sweep removed), the
+    generalized stale-resource sweep deletes the per-shard mongot StatefulSet,
+    headless Service, and ConfigMap, and the StatefulSet's PVC retention policy
+    reaps the backing PVC(s). Runs after MongoDBSearch reaches Running.
+    """
     removed_shard_name = f"{MDB_RESOURCE_NAME}-{SCALED_UP_SHARD_COUNT - 1}"
     verify_shard_proxy_service_deleted(namespace, MDBS_RESOURCE_NAME, removed_shard_name)
-    logger.info(f"Stale proxy service for {removed_shard_name} confirmed deleted")
+    verify_shard_resources_deleted(namespace, MDBS_RESOURCE_NAME, removed_shard_name)
+    logger.info(f"Stale mongot resources for {removed_shard_name} confirmed fully deleted")
 
 
 @MARKER


### PR DESCRIPTION
## What

Ports the **single-cluster / central-cluster** portion of the shard "generalized sweep" from #1277 directly onto **search/ga-base**, deliberately omitting the multi-cluster machinery that #1277 inherits from #1274.

On **shard scale-down** (a shard removed from a sharded topology — distinct from a replica 1->0 scale-down), the operator now reaps the removed shard's orphaned mongot resources in the central/single cluster:

- mongot **StatefulSet**
- mongot **headless Service**
- mongot **ConfigMap**
- **proxy Service** (previously the only kind reaped)

The sweep is gated by the **search-owner labels** (uniformly across central and member clusters — owner refs don't cross cluster boundaries) plus **component labels** (`component: mongot`), so unrelated search components are left untouched.

## Changes

- **cleanupStaleShardResources** generalized from proxy-Service-only to a multi-kind sweep (STS + headless Service + ConfigMap + proxy Service) via **sweepStaleShardResources** / **ownsForSweep** helpers and component-label plumbing on buildHeadlessService / buildProxyService / ensureMongotConfig.
- **Ownership is label-only.** `ownsForSweep` gates on the search-owner labels uniformly across central and member clusters (every owned resource is stamped with them at its write site) — no owner-ref/UID branch and no `isOwnedBy` helper. Owner refs don't cross clusters, so labels are the single ownership mechanism (mck-code rule 5).
- **Unit tests:** TestCleanupStaleShardResources + _MCFanOut assert full teardown of STS/Svc/CM with label-based ownership; a dedicated `x` / `x-svc` cross-kind name-collision row locks the four separate per-kind expected-name sets (a merged set would silently leak the stale STS + its PVC).
- **e2e:** search_sharded_scale_shards_managed_lb asserts STS / headless-Svc / CM / PVC deletion after shard scale-down.
- **Test naming:** dropped the zy/zz ordering prefixes from the PVC-reclaim community-basic tests.

## Out of scope

No multi-cluster member-cluster fan-out / OnDelete machinery (that lives in #1274). This branch is single / simulated-cluster only.

## Validation

- **Local:** gofmt, go build, full `go test ./controllers/searchcontroller/...` — all pass.
- **Evergreen (head 014511d50):** `unit_tests_golang`, `lint_repo`, `e2e_search_community_basic`, `e2e_search_sharded_scale_shards_managed_lb` — all green on CloudQA (real data-plane teardown + the `x`/`x-svc` collision verified).
- **Rebased 2026-06-30** onto current `search/ga-base` (`f151fe01c`, #1299), which carries #1291's metrics-forwarder finalizer fix. The earlier `e2e_search_community_basic::test_delete_search_cr_reclaims_pvc` red was that pre-existing ga-base CR-delete GC bug, not this change.

## Relation to the rest of the search stack

This started as a **rebased subset of #1277** targeting **search/ga-base** directly (after #1273 PVC-retention was merged into ga-base), skipping the #1274 dependency, and was then simplified here to label-only ownership. See the PR thread for the full stack map.

Ticket: **KUBE-143** — https://jira.mongodb.org/browse/KUBE-143
