### PR TITLE
test(search): assert mongot STS owner-ref to MongoDBSearch CR

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3063,6 +3063,11 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-search-search-0-svc", sts.Labels["app"])
 	assert.Empty(t, sts.Labels["shard"])
 
+	// Owner-ref back to the MongoDBSearch CR drives PVC reclaim via GC on CR delete.
+	assert.True(t, slices.ContainsFunc(sts.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name
+	}))
+
 	// Verify ConfigMap
 	cmNsName := search.MongotConfigConfigMapNameForCluster(0)
 	cm, err := fakeClient.GetConfigMap(t.Context(), cmNsName)


### PR DESCRIPTION
## What

Folds a unit assertion into the existing single-cluster reconcile test `TestReconcileReplicaSet_CreatesResources` proving the mongot StatefulSet built by the reconciler carries an owner-reference back to the `MongoDBSearch` CR.

## Why

This locks down the owner-ref link of the single-cluster **CR-delete → owner-ref GC → PVC reclaim** chain. Previously that link was only exercised end-to-end by `test_zz_delete_search_cr_reclaims_pvc` (real-cluster GC); there was no isolated unit assertion that the STS actually gets the CR owner-ref. Combined with:

- the retention-policy unit test (`search_construction_test.go` — `whenDeleted/whenScaled=Delete`), and
- the `test_zz_delete_search_cr_reclaims_pvc` e2e (PVC absence after CR delete),

the single-cluster CR-delete PVC-reclaim chain is now fully covered (construction + owner-ref + e2e).

## Notes

- Test-only change (no production code touched). Owner-ref is set in `mongodbsearch_reconcile_helper.go` via `controllerutil.SetOwnerReference(r.mdbSearch, sts, ...)`; the assertion matches on `Kind`/`Name` (it is a plain owner-ref, not a controller-ref, so `IsControlledBy`/UID checks would not apply).
- Verified: `go test ./controllers/searchcontroller/` green; mutation check (bogus Kind) confirms the assertion is load-bearing.