### PR TITLE
helm: clarify clusterIdentity.clusterName comment (MongoDBSearch operator-per-cluster, unified CRD)

### DIFF
--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -28,9 +28,11 @@ operator:
   - mongodbsearch
   - voyageai
 
-  # When clusterName is set, this operator only reconciles spec.clusters[i] entries
-  # whose clusterName matches (multi-cluster with one operator per cluster).
-  # Leave empty for the single-operator (hub-and-spoke) multi-cluster pattern.
+  # Scopes MongoDBSearch reconciliation only. When clusterName is set, this operator
+  # reconciles only MongoDBSearch resources whose spec.clusters[i].name matches this
+  # value -- the operator-per-cluster model, where each cluster runs its own operator
+  # against a single unified CRD. Leave empty for the single-operator (hub-and-spoke)
+  # multi-cluster pattern.
   clusterIdentity:
     clusterName: ''
 


### PR DESCRIPTION
## Summary

Corrects the comment for `operator.clusterIdentity.clusterName` in `helm_chart/values.yaml`. The previous wording implied the setting scoped **all** workloads ("this operator only reconciles spec.clusters[i] entries…"), but the env var it produces (`OPERATOR_CLUSTER_NAME`) only affects **MongoDBSearch** reconciliation.

## Why

In `main.go`, `OPERATOR_CLUSTER_NAME` is read solely inside the `mongoDBSearchCRDPlural` setup block and passed only to the MongoDBSearch controllers (search, envoy, metrics forwarder). It does not influence MongoDB, AppDB, Ops Manager, or any other reconciler. The old comment also used the generic "multi-cluster" framing; this reframes it as the **operator-per-cluster model with a single unified CRD**, where each cluster runs its own operator and reconciles only the `spec.clusters[i].name` entries that match its identity.

## Changes

- `helm_chart/values.yaml`: comment-only update on the `clusterIdentity.clusterName` block.

No behavior change:
- The value stays a documented, `--set`-able chart value.
- The operator template already injects `OPERATOR_CLUSTER_NAME` only when the value is non-empty.

## Before / After

Before:
```
# When clusterName is set, this operator only reconciles spec.clusters[i] entries
# whose clusterName matches (multi-cluster with one operator per cluster).
# Leave empty for the single-operator (hub-and-spoke) multi-cluster pattern.
```

After:
```
# Scopes MongoDBSearch reconciliation only. When clusterName is set, this operator
# reconciles only MongoDBSearch resources whose spec.clusters[i].name matches this
# value -- the operator-per-cluster model, where each cluster runs its own operator
# against a single unified CRD. Leave empty for the single-operator pattern.
```
