### PR TITLE
search: consume source TLS CA as ConfigMap (not Secret) in MC search e2e harness

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
@@ -164,9 +164,6 @@ def replicate_search_secrets_to_members(
     shared_secrets = [
         search_resource_names.mongot_tls_cert_name(mdbs_resource_name, mdbs_tls_cert_prefix),
         f"{mdbs_resource_name}-{mongot_user_name}-password",
-        # The CA is stored as both a ConfigMap and a Secret; replicate the Secret half here
-        # (the operator mounts it as a Secret volume on per-cluster mongot pods).
-        ca_configmap_name,
     ]
     for secret_name in shared_secrets:
         _copy(secret_name, member_cluster_clients)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -470,9 +470,6 @@ def test_replicate_secrets_to_members(
     shared_secrets = [
         search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
         f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
-        # The CA is stored as both a ConfigMap and a Secret; replicate the Secret half here
-        # (the operator mounts it as a Secret volume on per-cluster mongot pods).
-        CA_CONFIGMAP_NAME,
     ]
     for secret_name in shared_secrets:
         _copy(secret_name, member_cluster_clients)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -89,7 +89,7 @@ def ca_configmap(
     name = create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
     for mcc in member_cluster_clients:
         create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME, api_client=mcc.api_client)
-        logger.info(f"CA ConfigMap/Secret {CA_CONFIGMAP_NAME} created in cluster {mcc.cluster_name}")
+        logger.info(f"CA ConfigMap {CA_CONFIGMAP_NAME} created in cluster {mcc.cluster_name}")
     return name
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_rs_x509_enc_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_mc_ext_rs_x509_enc_mtls.py
@@ -408,7 +408,6 @@ def test_replicate_secrets_to_members(
     # Shared Secrets — same copy to every member cluster.
     for secret_name in [
         search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX),
-        CA_CONFIGMAP_NAME,
         X509_CLIENT_CERT_SECRET_NAME,
         GRPC_KEY_PASSWORD_SECRET_NAME,
         X509_KEY_PASSWORD_SECRET_NAME,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
@@ -75,8 +75,8 @@ SEARCH_INDEX_READY_TIMEOUT = 300
 # mongot may still be in INITIAL_SYNC briefly after the index reports READY.
 SEARCH_QUERY_RETRY_TIMEOUT = 90
 
-# create_issuer_ca writes BOTH a ConfigMap (MongoDBMulti.spec.security.tls.ca, key
-# ca-pem) and a same-named Secret (MongoDBSearch source.external.tls.ca, key ca.crt).
+# create_issuer_ca writes a ConfigMap (keys ca-pem/ca.crt/mms-ca.crt) consumed as the CA by
+# both MongoDBMulti.spec.security.tls.ca and MongoDBSearch source.external.tls.ca — never a Secret.
 CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
 # Must match the operator's cert-secret convention `{certsSecretPrefix}-{name}-cert`
 # (see certsSecretPrefix below); otherwise the operator can't find the TLS bundle.

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
@@ -162,14 +162,14 @@ def ca_configmap(
     namespace: str,
     member_cluster_clients: List[MultiClusterClient],
 ) -> str:
-    """Issuer CA written to central + ALL members: the source cluster (cluster-3) needs
-    the ConfigMap half to verify its own TLS material, and the search clusters need the
-    Secret half so their mongots verify the source's TLS during sync.
+    """Issuer CA ConfigMap written to central + ALL members: the source cluster (cluster-3)
+    verifies its own TLS material against it, and the search clusters' mongots verify the
+    source's TLS during sync. The operator consumes the CA as a ConfigMap, never a Secret.
     """
     name = create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
     for mcc in member_cluster_clients:
         create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME, api_client=mcc.api_client)
-        logger.info(f"CA ConfigMap/Secret {CA_CONFIGMAP_NAME} created in cluster {mcc.cluster_name}")
+        logger.info(f"CA ConfigMap {CA_CONFIGMAP_NAME} created in cluster {mcc.cluster_name}")
     return name
 
 


### PR DESCRIPTION
[skip-ci]

# Summary

The multi-cluster search e2e harness replicated the source TLS CA to member clusters as a **Secret** (`read_namespaced_secret("<name>-ca")`). CLOUDP-386696 (#909) switched the CA to **ConfigMap-only** (`create_issuer_ca` no longer creates a Secret) and the operator mounts the source CA solely via `statefulset.CreateVolumeFromConfigMap("ca", …)` across all source variants — so the stale Secret read 404'd deterministically and failed every MC search test that replicates secrets.

This removes the CA from the secret-copy lists (the CA ConfigMap is already replicated separately a few lines below in each helper) and corrects the now-false "CA is also a Secret" comments/log lines.

## Proof of Work

PoW patch — all tasks green: https://spruce.mongodb.com/version/6a4340555102a20007779e96

- `e2e_search_connectivity_tool_mc_rs`, `e2e_search_ext_mc_rs_x509_enc_mtls`, `e2e_search_q2_mc_rs_steady` (e2e_multi_cluster_2_clusters)
- `e2e_search_simulated_mc_rs` (e2e_multi_cluster_kind + e2e_static_multi_cluster_kind)
- `lint_repo`, `unit_tests_golang`, `unit_tests_python`, `unit_tests_helm`

All five MC search tasks previously failed with `secrets "<name>-ca" not found` (404) and now pass.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?