### PR TITLE
Only run e2e tests on PRs when production code is touched

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -235,8 +235,8 @@ patch_aliases:
   - alias: "staging"
     variant_tags: [ "staging" ]
     task: ".*"
-  - alias: "pr_patch"
-    variant_tags: [ "pr_patch" ]
+  - alias: "pr_patch_static"
+    variant_tags: [ "pr_patch_static" ]
     task: ".*"
   - alias: "static"
     description: "Run all static container variants"
@@ -253,8 +253,11 @@ patch_aliases:
 
 # Triggered whenever the GitHub PR is created
 github_pr_aliases:
-  - variant_tags: [ "pr_patch" ]
+  - variant_tags: [ "pr_patch_static" ]
     task: ".*"
+  - variant_tags: [ "pr_patch_e2e" ]
+    task: ".*"
+    file_pattern: '^(api|cmd|controllers|docker|internal|mongodb-community-operator|pkg|scripts)/.*\.(go|py)$|^[^/]+\.(go|py)$'
 
 # Allows to see evergreen checks in GitHub commits
 # https://github.com/mongodb/mongodb-kubernetes/commits/master/
@@ -1442,7 +1445,7 @@ buildvariants:
 
   - name: check_ocp_version_drift
     display_name: check_ocp_version_drift
-    tags: [ "pr_patch", "staging" ]
+    tags: [ "pr_patch_static", "staging" ]
     run_on:
       - ubuntu2404-small
     tasks:
@@ -1452,7 +1455,7 @@ buildvariants:
 
   - name: unit_tests
     display_name: "unit_tests"
-    tags: [ "pr_patch", "staging", "unit_tests" ]
+    tags: [ "pr_patch_static", "staging", "unit_tests" ]
     run_on:
       - ubuntu2204-small #TODO: Uses older ubuntu2204, because for some reason on ubuntu2404 the helm binary is not found
     tasks:
@@ -1470,7 +1473,7 @@ buildvariants:
   # MongoDBCommunity build variant
   - name: e2e_mdb_community
     display_name: e2e_mdb_community
-    tags: [ "pr_patch", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     run_on:
       - ubuntu2404-large
     <<: *community_dependency
@@ -1480,7 +1483,7 @@ buildvariants:
   ## MongoDB build variants
   - name: e2e_mdb_kind_ubi_cloudqa
     display_name: e2e_mdb_kind_ubi_cloudqa
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-medium
     <<: *base_no_om_image_dependency
@@ -1489,7 +1492,7 @@ buildvariants:
 
   - name: e2e_custom_domain_mdb_kind_ubi_cloudqa
     display_name: e2e_custom_domain_mdb_kind_ubi_cloudqa
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_no_om_image_dependency
@@ -1498,7 +1501,7 @@ buildvariants:
 
   - name: e2e_static_mdb_kind_ubi_cloudqa
     display_name: e2e_static_mdb_kind_ubi_cloudqa
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "static" ]
     run_on:
       - ubuntu2404-medium
     <<: *base_no_om_image_dependency
@@ -1527,7 +1530,7 @@ buildvariants:
 
   - name: e2e_mdb_kind_ubi_cloudqa_large
     display_name: e2e_mdb_kind_ubi_cloudqa_large
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_no_om_image_dependency
@@ -1550,7 +1553,7 @@ buildvariants:
   # Asserts MC-shaped MongoDBSearch is rejected and that single-cluster search still works.
   - name: e2e_mdb_kind_ubi_cloudqa_search_block
     display_name: e2e_mdb_kind_ubi_cloudqa_search_block
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_no_om_image_dependency
@@ -1652,7 +1655,7 @@ buildvariants:
 
   - name: e2e_om80_kind_ubi
     display_name: e2e_om80_kind_ubi
-    tags: [ "pr_patch", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     run_on:
       - ubuntu2204-medium-high-memory
     <<: *base_om8_dependency
@@ -1677,7 +1680,7 @@ buildvariants:
 
   - name: e2e_om80_kind_ubi_large
     display_name: e2e_om80_kind_ubi_large
-    tags: [ "pr_patch", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om8_dependency
@@ -1826,7 +1829,7 @@ buildvariants:
 
   - name: e2e_multi_cluster_kind
     display_name: e2e_multi_cluster_kind
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
@@ -1844,7 +1847,7 @@ buildvariants:
 
   - name: e2e_multi_cluster_2_clusters
     display_name: e2e_multi_cluster_2_clusters
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
@@ -1862,7 +1865,7 @@ buildvariants:
 
   - name: e2e_multi_cluster_om_appdb
     display_name: e2e_multi_cluster_om_appdb
-    tags: [ "pr_patch", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
@@ -1880,7 +1883,7 @@ buildvariants:
 
   - name: e2e_multi_cluster_om_operator_not_in_mesh
     display_name: e2e_multi_cluster_om_operator_not_in_mesh
-    tags: [ "pr_patch", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
@@ -1891,7 +1894,7 @@ buildvariants:
 
   - name: e2e_operator_kind_ubi_cloudqa
     display_name: e2e_operator_kind_ubi_cloudqa
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_no_om_image_dependency
@@ -1909,7 +1912,7 @@ buildvariants:
 
   - name: e2e_operator_no_webhook_roles_cloudqa
     display_name: e2e_operator_no_webhook_roles_cloudqa
-    tags: [ "pr_patch", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_no_om_image_dependency
@@ -1918,7 +1921,7 @@ buildvariants:
 
   - name: e2e_kind_olm_ubi
     display_name: e2e_kind_olm_ubi
-    tags: [ "pr_patch", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     run_on:
       - ubuntu2404-large
     depends_on:
@@ -1959,7 +1962,7 @@ buildvariants:
     # This variants runs the tests from MCO with the MEKO operator binary
   - name: e2e_mco_tests
     display_name: "e2e_mco_tests"
-    tags: [ "pr_patch", "staging", "e2e_mco_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_mco_test_suite" ]
     <<: *community_dependency
     run_on:
       - ubuntu2404-large
@@ -2001,7 +2004,7 @@ buildvariants:
   - name: init_test_run
     display_name: init_test_run
     max_hosts: -1
-    tags: [ "pr_patch", "staging" ]
+    tags: [ "pr_patch_static", "staging" ]
     run_on:
       - ubuntu2404-small
     tasks:
@@ -2063,7 +2066,7 @@ buildvariants:
     priority: 70
     display_name: run_pre_commit
     allowed_requesters: [ "patch", "github_pr" ]
-    tags: [ "pr_patch", "auto_bump" ]
+    tags: [ "pr_patch_static", "auto_bump" ]
     run_on:
       - ubuntu2404-small
     tasks:
@@ -2082,7 +2085,7 @@ buildvariants:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
-    tags: [ "pr_patch", "staging" ]
+    tags: [ "pr_patch_static", "staging" ]
     run_on:
       - ubuntu2404-small
     tasks:
@@ -2138,7 +2141,7 @@ buildvariants:
 
   - name: build_om80_images
     display_name: build_om80_images
-    tags: [ "pr_patch", "staging" ]
+    tags: [ "pr_patch_static", "staging" ]
     run_on:
       - ubuntu2404-small
     tasks:

--- a/ci/internal/evergreen/aliases_test.go
+++ b/ci/internal/evergreen/aliases_test.go
@@ -1,0 +1,164 @@
+package evergreen_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestE2EFilePattern(t *testing.T) {
+	re := loadE2EFilePattern(t)
+
+	tests := []struct {
+		desc        string
+		files       []string
+		shouldMatch bool
+	}{
+		// --- should trigger e2e ---
+		{
+			desc:        "root-level Go file",
+			files:       []string{"main.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "root-level Python file",
+			files:       []string{"generate_ssdlc_report_test.py"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "api package",
+			files:       []string{"api/v1/types.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "controllers package",
+			files:       []string{"controllers/operator/foo.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "internal package",
+			files:       []string{"internal/util/foo.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "pkg package",
+			files:       []string{"pkg/kube/client.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "cmd package",
+			files:       []string{"cmd/manager/main.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "docker package",
+			files:       []string{"docker/agent/main.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "scripts Go file",
+			files:       []string{"scripts/dev/reset/main.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "scripts Python file",
+			files:       []string{"scripts/release/version.py"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "docker Python test",
+			files:       []string{"docker/mongodb-kubernetes-tests/kubetester/test_identifiers.py"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "mongodb-community-operator package",
+			files:       []string{"mongodb-community-operator/pkg/foo.go"},
+			shouldMatch: true,
+		},
+		{
+			desc:        "mix of prod and non-prod files",
+			files:       []string{".evergreen.yml", "api/v1/types.go"},
+			shouldMatch: true,
+		},
+		// --- should NOT trigger e2e ---
+		{
+			desc:        "evergreen config only",
+			files:       []string{".evergreen.yml"},
+			shouldMatch: false,
+		},
+		{
+			desc:        "ci tooling Go files",
+			files:       []string{"ci/cmd/mckci/main.go", "ci/internal/cli/root.go"},
+			shouldMatch: false,
+		},
+		{
+			desc:        "Makefile only",
+			files:       []string{"Makefile"},
+			shouldMatch: false,
+		},
+		{
+			desc:        "scripts non-code files only",
+			files:       []string{"scripts/mckci", "scripts/code_snippets/archive.sh"},
+			shouldMatch: false,
+		},
+		{
+			desc:        "docs and yaml only",
+			files:       []string{"README.md", "helm_chart/values.yaml", "release.json"},
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			matched := false
+			for _, f := range tc.files {
+				if re.MatchString(f) {
+					matched = true
+					break
+				}
+			}
+			if matched != tc.shouldMatch {
+				if tc.shouldMatch {
+					t.Errorf("expected at least one of %v to match %s, but none did", tc.files, re)
+				} else {
+					t.Errorf("expected none of %v to match %s, but at least one did", tc.files, re)
+				}
+			}
+		})
+	}
+}
+
+// loadE2EFilePattern reads the file_pattern from the pr_patch_e2e entry in
+// github_pr_aliases so the test stays in sync with the real config.
+func loadE2EFilePattern(t *testing.T) *regexp.Regexp {
+	t.Helper()
+	data, err := os.ReadFile("../../../.evergreen.yml")
+	if err != nil {
+		t.Fatalf("read .evergreen.yml: %v", err)
+	}
+
+	var doc struct {
+		GithubPRAliases []struct {
+			VariantTags []string `yaml:"variant_tags"`
+			FilePattern string   `yaml:"file_pattern"`
+		} `yaml:"github_pr_aliases"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse .evergreen.yml: %v", err)
+	}
+
+	for _, entry := range doc.GithubPRAliases {
+		for _, tag := range entry.VariantTags {
+			if tag == "pr_patch_e2e" {
+				if entry.FilePattern == "" {
+					t.Fatal("pr_patch_e2e alias has no file_pattern")
+				}
+				return regexp.MustCompile(entry.FilePattern)
+			}
+		}
+	}
+	t.Fatal("no pr_patch_e2e entry found in github_pr_aliases")
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.12
 	k8s.io/apimachinery v0.33.12
 	k8s.io/client-go v0.33.12
@@ -143,7 +144,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.12.3 // indirect
 	k8s.io/apiextensions-apiserver v0.32.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect


### PR DESCRIPTION
# Summary

Split `pr_patch` into **static** and **e2e**. The e2e even is only triggered when the go files un production dirs are touched.

## Proof of Work

CI passes.
✅ [Patch with pr_patch_static skips e2e tests](https://spruce.corp.mongodb.com/version/6a43a003e23a2600071f537f/tasks)
✅ [Patch with both PR patch aliases includes e2e tests](https://spruce.corp.mongodb.com/patch/6a43a2289e8efc0007cec79f)

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
