### PR TITLE
Correct the names to operator per cluster with unified CR

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -1344,9 +1344,9 @@ func (s *MongoDBSearch) GetKind() string {
 	return "MongoDBSearch"
 }
 
-// ValidateSimulatedMCClusterIndices requires a non-empty spec.clusters where every entry pins
-// a distinct Index. Called only by operators in simulated-MC mode (operatorClusterName set).
-func (s *MongoDBSearch) ValidateSimulatedMCClusterIndices() error {
+// ValidateOperatorPerClusterIndices requires a non-empty spec.clusters where every entry pins
+// a distinct Index. Called only by operators in operator-per-cluster with unified CR mode (operatorClusterName set).
+func (s *MongoDBSearch) ValidateOperatorPerClusterIndices() error {
 	if len(s.Spec.Clusters) == 0 {
 		return fmt.Errorf("running one operator per cluster requires spec.clusters to be set")
 	}

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -297,7 +297,7 @@ func TestGetRouterHostnameForCluster_NotManaged(t *testing.T) {
 	assert.Equal(t, "", s.GetRouterHostnameForCluster(""))
 }
 
-func TestValidateSimulatedMCClusterIndices(t *testing.T) {
+func TestValidateOperatorPerClusterIndices(t *testing.T) {
 	tests := []struct {
 		name     string
 		clusters []ClusterSpec
@@ -341,7 +341,7 @@ func TestValidateSimulatedMCClusterIndices(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: tc.clusters}}
-			err := s.ValidateSimulatedMCClusterIndices()
+			err := s.ValidateOperatorPerClusterIndices()
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -378,7 +378,7 @@ func TestMongotConfigConfigMapNameForCluster(t *testing.T) {
 
 func TestMongoDBSearch_LocalizeToCluster(t *testing.T) {
 	twoClusters := func() []ClusterSpec {
-		// LocalizeToCluster is the simulated-MC narrowing function, so clusterIndex
+		// LocalizeToCluster is the operator-per-cluster with unified CR narrowing function, so clusterIndex
 		// is mandatory and must be unique on every entry.
 		return []ClusterSpec{
 			{Name: "us-east", Index: ptr.To(int32(0))},

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -73,7 +73,7 @@ func newPrepareSearch(operatorClusterName string) prepareSearchFunc {
 		if skip, r, e := validateSpec(search, log, writeStatus); skip {
 			return skip, r, e
 		}
-		if vErr := search.ValidateSimulatedMCClusterIndices(); vErr != nil {
+		if vErr := search.ValidateOperatorPerClusterIndices(); vErr != nil {
 			r, e := writeStatus(workflow.Invalid("%s", vErr.Error()))
 			return true, r, e
 		}

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -723,7 +723,7 @@ func assertSearchOwnerLabels(t *testing.T, search *searchv1.MongoDBSearch, clust
 	}
 }
 
-func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
+func newOperatorPerClusterMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
 	clusters := []searchv1.ClusterSpec{
 		{
 			Name: "cluster-a", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
@@ -748,9 +748,9 @@ func newSimulatedMCMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch
 	}
 }
 
-// simulatedMCProjectionCases drives the RS and sharded projected-reconcile tests;
+// operatorPerClusterProjectionCases drives the RS and sharded projected-reconcile tests;
 // the non-zero pin guards that naming follows the pinned index, not array position.
-var simulatedMCProjectionCases = []struct {
+var operatorPerClusterProjectionCases = []struct {
 	name        string
 	opCluster   string
 	pinClusterB *int32 // override spec.clusters[1].clusterIndex when non-nil
@@ -761,12 +761,12 @@ var simulatedMCProjectionCases = []struct {
 	{name: "cluster_b_pinned_to_index_7", opCluster: "cluster-b", pinClusterB: ptr.To(int32(7)), wantIdx: 7, wrongIdx: 0},
 }
 
-func TestReconcile_SimulatedMC_ProjectedReconcilesLocalOnly(t *testing.T) {
+func TestReconcile_OperatorPerCluster_ProjectedReconcilesLocalOnly(t *testing.T) {
 	enableSearchMCReconcile(t)
-	for _, tc := range simulatedMCProjectionCases {
+	for _, tc := range operatorPerClusterProjectionCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+			search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
 			if tc.pinClusterB != nil {
 				search.Spec.Clusters[1].Index = tc.pinClusterB
 			}
@@ -807,10 +807,10 @@ func TestReconcile_SimulatedMC_ProjectedReconcilesLocalOnly(t *testing.T) {
 	}
 }
 
-func TestReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
+func TestReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
-	search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
 
 	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
 	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
@@ -844,10 +844,10 @@ func TestReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
 
 // Customer pin is authoritative: re-pinning renders at the new index. The
 // old-index resources leak — accepted MVP scope, no cleanup.
-func TestReconcile_SimulatedMC_RePinUpdatesNames(t *testing.T) {
+func TestReconcile_OperatorPerCluster_RePinUpdatesNames(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
-	search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
 
 	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-a", search)
 	driveSearchReconcileToRunning(ctx, t, reconciler, c, search, 5)
@@ -868,7 +868,7 @@ func TestReconcile_SimulatedMC_RePinUpdatesNames(t *testing.T) {
 		"mongot ConfigMap must exist at the new pinned index 2")
 }
 
-func newSimulatedMCShardedMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
+func newOperatorPerClusterShardedMongoDBSearch(name, namespace string) *searchv1.MongoDBSearch {
 	// Each cluster gets its own externalHostname (distinct per cluster, {shardName} per-shard) and a
 	// distinct shard-agnostic routerHostname (required for external sharded + managed LB).
 	clusters := []searchv1.ClusterSpec{
@@ -902,7 +902,7 @@ func newSimulatedMCShardedMongoDBSearch(name, namespace string) *searchv1.MongoD
 	}
 }
 
-func simulatedMCShardedTLSSecrets(search *searchv1.MongoDBSearch, clusterIndex int) []client.Object {
+func operatorPerClusterShardedTLSSecrets(search *searchv1.MongoDBSearch, clusterIndex int) []client.Object {
 	shards := []string{"sh-0", "sh-1"}
 	out := make([]client.Object, 0, len(shards))
 	for _, shard := range shards {
@@ -915,18 +915,18 @@ func simulatedMCShardedTLSSecrets(search *searchv1.MongoDBSearch, clusterIndex i
 	return out
 }
 
-func TestReconcile_SimulatedMC_ShardedSource_ProjectedReconcilesLocalOnly(t *testing.T) {
+func TestReconcile_OperatorPerCluster_ShardedSource_ProjectedReconcilesLocalOnly(t *testing.T) {
 	enableSearchMCReconcile(t)
-	for _, tc := range simulatedMCProjectionCases {
+	for _, tc := range operatorPerClusterProjectionCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			search := newSimulatedMCShardedMongoDBSearch("mdb-search", mock.TestNamespace)
+			search := newOperatorPerClusterShardedMongoDBSearch("mdb-search", mock.TestNamespace)
 			if tc.pinClusterB != nil {
 				search.Spec.Clusters[1].Index = tc.pinClusterB
 			}
 
 			reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, tc.opCluster, search)
-			for _, obj := range simulatedMCShardedTLSSecrets(search, tc.wantIdx) {
+			for _, obj := range operatorPerClusterShardedTLSSecrets(search, tc.wantIdx) {
 				require.NoError(t, c.Create(ctx, obj))
 			}
 
@@ -976,10 +976,10 @@ func TestReconcile_SimulatedMC_ShardedSource_ProjectedReconcilesLocalOnly(t *tes
 	}
 }
 
-func TestReconcile_SimulatedMC_ShardedSource_NoMatchSilentNoOp(t *testing.T) {
+func TestReconcile_OperatorPerCluster_ShardedSource_NoMatchSilentNoOp(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
-	search := newSimulatedMCShardedMongoDBSearch("mdb-search", mock.TestNamespace)
+	search := newOperatorPerClusterShardedMongoDBSearch("mdb-search", mock.TestNamespace)
 
 	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
 	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
@@ -1013,12 +1013,12 @@ func TestReconcile_SimulatedMC_ShardedSource_NoMatchSilentNoOp(t *testing.T) {
 }
 
 // ClusterIndex enforcement runs before LocalizeToCluster, so bad shapes surface as Failed.
-func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
+func TestReconcile_OperatorPerCluster_ClusterIndexEnforcement(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
 
 	t.Run("missing clusterIndex on a single entry is Invalid", func(t *testing.T) {
-		search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+		search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
 		// Single-entry unpinned passes ValidateSpec (MC validators skip at len==1), so the
 		// failure is attributable to the sim-MC gate requiring the pin even on one entry.
 		search.Spec.Clusters = []searchv1.ClusterSpec{
@@ -1037,11 +1037,11 @@ func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
 		// workflow.Invalid capitalizes the first char, so match on the stable substring.
 		assert.Contains(t, got.Status.Message,
 			"one operator per cluster requires index on every spec.clusters[] entry (missing on",
-			"failure must come from ValidateSimulatedMCClusterIndices")
+			"failure must come from ValidateOperatorPerClusterIndices")
 	})
 
 	t.Run("partial pin on a multi-entry spec is Invalid", func(t *testing.T) {
-		search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+		search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
 		// Drop the pin on the second entry: the general ValidateSpec rule fires
 		// before the sim-MC gate.
 		search.Spec.Clusters[1].Index = nil
@@ -1062,7 +1062,7 @@ func TestReconcile_SimulatedMC_ClusterIndexEnforcement(t *testing.T) {
 	})
 
 	t.Run("empty clusters is Invalid", func(t *testing.T) {
-		search := newSimulatedMCMongoDBSearch("mdb-search", mock.TestNamespace)
+		search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
 		// Empty clusters means there is no per-cluster loadBalancer either, so the
 		// failure is attributable to the clusters check, not the LB validators.
 		search.Spec.Clusters = []searchv1.ClusterSpec{}

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -1696,7 +1696,7 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 		"pending shard's fallback route must inject the routed_from_another_shard header")
 }
 
-// --- simulated-MC envoy tests carried over from search/ga-base (ported to clusterWorkItem + routingReadyMongotGroups signatures) ---
+// --- operator-per-cluster with uniified CR envoy tests carried over from search/ga-base (ported to clusterWorkItem + routingReadyMongotGroups signatures) ---
 func newMCEnvoySearch(name, namespace, uid string, clusters ...searchv1.ClusterSpec) *searchv1.MongoDBSearch {
 	// Give each cluster its own literal managed-LB hostname (the {clusterName}
 	// placeholder was removed; per-cluster hostnames must be distinct).
@@ -1718,7 +1718,7 @@ func newMCEnvoySearch(name, namespace, uid string, clusters ...searchv1.ClusterS
 	}
 }
 
-func newSimulatedMCEnvoySearch(name, namespace string, clusterBIndex int32) *searchv1.MongoDBSearch {
+func newOperatorPerClusterEnvoySearch(name, namespace string, clusterBIndex int32) *searchv1.MongoDBSearch {
 	clusterA := pinnedCluster("cluster-a", 0)
 	clusterA.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"}}
 	clusterB := pinnedCluster("cluster-b", clusterBIndex)
@@ -1734,8 +1734,8 @@ func newSimulatedMCEnvoySearch(name, namespace string, clusterBIndex int32) *sea
 	}
 }
 
-func TestBuildClusterWorkList_SimulatedMC_UsesProjectedIndex(t *testing.T) {
-	// Simulated-MC: members map empty; LocalizeToCluster already narrowed
+func TestBuildClusterWorkList_OperatorPerCluster_UsesProjectedIndex(t *testing.T) {
+	// Operator-per-cluster with unified CR: members map empty; LocalizeToCluster already narrowed
 	// spec.Clusters to one entry whose projected clusterIndex must be honoured.
 	central := fake.NewClientBuilder().Build()
 	// operatorClusterName is "" — this test exercises buildClusterWorkList directly, not Reconcile.
@@ -1750,8 +1750,8 @@ func TestBuildClusterWorkList_SimulatedMC_UsesProjectedIndex(t *testing.T) {
 	wl := r.buildClusterWorkList(search)
 	require.Len(t, wl, 1)
 	assert.Equal(t, "kind-e2e-cluster-2", wl[0].ClusterName)
-	assert.Equal(t, 1, wl[0].ClusterIndex, "simulated-MC must honour the projected clusterIndex, not 0")
-	assert.Equal(t, r.kubeClient, wl[0].Client, "simulated-MC: client must fall back to kubeClient")
+	assert.Equal(t, 1, wl[0].ClusterIndex, "operator-per-cluster with unified CR must honour the projected clusterIndex, not 0")
+	assert.Equal(t, r.kubeClient, wl[0].Client, "operator-per-cluster with unified CR: client must fall back to kubeClient")
 }
 
 func TestBuildReplicaSetRouteForCluster_ResolvedIndexNotArrayPos(t *testing.T) {
@@ -1774,7 +1774,7 @@ func TestBuildReplicaSetRouteForCluster_ResolvedIndexNotArrayPos(t *testing.T) {
 	assert.Equal(t, "mdb-search-search-7-svc.test-ns.svc.cluster.local", route.UpstreamHosts[0])
 }
 
-func TestBuildRoutesForCluster_SimulatedMC_Sharded_PerShardSNIUsesProjectedIndex(t *testing.T) {
+func TestBuildRoutesForCluster_OperatorPerCluster_Sharded_PerShardSNIUsesProjectedIndex(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
@@ -1914,14 +1914,14 @@ func TestEnvoyReconcile_MultiCluster_FailedFirstThenOK_AggregatesFailed(t *testi
 		"a Failed + b OK must aggregate to top-level Failed regardless of cluster order")
 }
 
-func TestEnvoyReconcile_SimulatedMC_Match_RendersAtPinnedIndex(t *testing.T) {
+func TestEnvoyReconcile_OperatorPerCluster_Match_RendersAtPinnedIndex(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
-	search := newSimulatedMCEnvoySearch("mdb-search", "ns", 7)
+	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 7)
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
-	// members map empty: simulated-MC falls back to kubeClient (= central).
+	// members map empty: operator-per-cluster with unified CR falls back to kubeClient (= central).
 	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-b")
 
 	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
@@ -1954,13 +1954,13 @@ func TestEnvoyReconcile_SimulatedMC_Match_RendersAtPinnedIndex(t *testing.T) {
 		"no Envoy ConfigMap may render at array-position index 0")
 }
 
-func TestEnvoyReconcile_SimulatedMC_MissingClusterIndex_Invalid(t *testing.T) {
+func TestEnvoyReconcile_OperatorPerCluster_MissingClusterIndex_Invalid(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
 	// Single entry, no pin — built via the generic MC helper because
-	// newSimulatedMCEnvoySearch can only produce pinned entries.
+	// newOperatorPerClusterEnvoySearch can only produce pinned entries.
 	search := newMCEnvoySearch("mdb-search", "ns", "", searchv1.ClusterSpec{Name: "cluster-a"})
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 
@@ -1977,16 +1977,16 @@ func TestEnvoyReconcile_SimulatedMC_MissingClusterIndex_Invalid(t *testing.T) {
 	// workflow.Invalid capitalizes the first char, so match on the stable substring.
 	assert.Contains(t, patched.Status.LoadBalancer.Message,
 		"one operator per cluster requires index on every spec.clusters[] entry (missing on",
-		"message must come from ValidateSimulatedMCClusterIndices")
+		"message must come from ValidateOperatorPerClusterIndices")
 }
 
-func TestEnvoyReconcile_SimulatedMC_NoMatchSilentNoOp(t *testing.T) {
+func TestEnvoyReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
 	// Both entries pinned so the no-op is attributable to LocalizeToCluster, not validation.
-	search := newSimulatedMCEnvoySearch("mdb-search", "ns", 1)
+	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 1)
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 
 	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
@@ -2053,7 +2053,7 @@ func TestEnvoyReconcile_ValidationFailure_NoLBConfigured_NoLBStatusWrite(t *test
 
 	// Removing the LB from the fully-pinned 2-cluster fixture makes ValidateSpec fail
 	// (multi-cluster requires spec.clusters[].loadBalancer.managed) on a CR with no LB surface.
-	search := newSimulatedMCEnvoySearch("mdb-search", "ns", 1)
+	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 1)
 	for i := range search.Spec.Clusters {
 		search.Spec.Clusters[i].LoadBalancer = nil
 	}
@@ -2070,10 +2070,10 @@ func TestEnvoyReconcile_ValidationFailure_NoLBConfigured_NoLBStatusWrite(t *test
 		"validation failure on a CR without spec.loadBalancer must not create a loadBalancer sub-status")
 }
 
-func TestReconcileForCluster_SimulatedMC_ShardedSource_RendersToProvidedClient(t *testing.T) {
+func TestReconcileForCluster_OperatorPerCluster_ShardedSource_RendersToProvidedClient(t *testing.T) {
 	scheme := envoyTestScheme(t)
 	central := fake.NewClientBuilder().WithScheme(scheme).Build()
-	// members map is nil (simulated-MC: one operator per member cluster).
+	// members map is nil (operator-per-cluster with unified CR: one operator per member cluster).
 	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
 
 	search := &searchv1.MongoDBSearch{
@@ -2088,9 +2088,9 @@ func TestReconcileForCluster_SimulatedMC_ShardedSource_RendersToProvidedClient(t
 	source := &mockShardedSourceForEnvoy{shardNames: []string{"sh-0", "sh-1"}}
 
 	// Drive reconcileForCluster directly with the projected cluster name and
-	// r.kubeClient — the simulated-MC path that buildClusterWorkList wires.
+	// r.kubeClient — the operator-per-cluster with unified CR path that buildClusterWorkList wires.
 	st := r.reconcileForCluster(context.Background(), search, source, false, nil, clusterWorkItem{ClusterName: "kind-e2e-cluster-1", ClusterIndex: 0, Client: r.kubeClient}, nil, zap.S())
-	require.True(t, st.IsOK(), "simulated-MC sharded reconcile should succeed, got %s: %s",
+	require.True(t, st.IsOK(), "operator-per-cluster with unified CR sharded reconcile should succeed, got %s: %s",
 		st.Phase(), searchcontroller.MessageFromStatus(st))
 
 	// Envoy Deployment + ConfigMap landed in kubeClient at index 0.

--- a/controllers/searchcontroller/secrets_presence.go
+++ b/controllers/searchcontroller/secrets_presence.go
@@ -43,7 +43,7 @@ func CheckSecretsPresence(
 	}
 
 	if len(members) == 0 {
-		// Single-cluster or simulated-MC. In simulated-MC the narrowed 1-entry
+		// Single-cluster or operator-per-cluster with unified CR. In operator-per-cluster with unified CR the narrowed 1-entry
 		// spec.clusters may be pinned to a non-zero index; index-keyed names
 		// (per-shard TLS certs) must be probed at that index, not 0.
 		appendIfMissing("", central, expectedSecretNamesForCluster(search, ResolveSingleClusterIndex(search)))

--- a/controllers/searchcontroller/secrets_presence_test.go
+++ b/controllers/searchcontroller/secrets_presence_test.go
@@ -215,9 +215,9 @@ func TestCheckSecretsPresence_SingleClusterSharded_CentralIncludesPerShardCerts(
 	assert.Equal(t, []string{s_tlsShardNameAt("lt", "s", "shard-0", 0)}, got[0].Missing)
 }
 
-// Simulated-MC: per-shard cert names must be probed at the pinned index, not
+// Operator-per-cluster with unified CR: per-shard cert names must be probed at the pinned index, not
 // hard-coded 0 — else absent index-0 names look like phantom gaps and requeue forever.
-func TestCheckSecretsPresence_SimulatedMC_UsesPinnedIndex(t *testing.T) {
+func TestCheckSecretsPresence_OperatorPerCluster_UsesPinnedIndex(t *testing.T) {
 	newPinnedSearch := func() *searchv1.MongoDBSearch {
 		s := mcShardedTLSSearch(t, "s", "ns", "shard-0")
 		s.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-b", Index: ptr.To(int32(7))}}


### PR DESCRIPTION
# Summary

Correct the names that we had for alternatives of operator per cluster with unified CR.