### PR TITLE
search: allow shared managed-LB hostname across clusters (cross-AZ failover)

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -106,7 +106,6 @@ func multiClusterValidators() []func(*MongoDBSearch) v1.ValidationResult {
 		validateMCRequiresExternalSource,
 		validateMCRequiresManagedLB,
 		validateMCExternalHostnames,
-		validateMCRouterHostnames,
 	}
 }
 
@@ -602,11 +601,11 @@ func ValidateShardNameRFC1123(shardName string) error {
 	return nil
 }
 
-// validateMCExternalHostnames enforces, for multi-cluster specs with a managed LB:
-//   - every cluster's externalHostname must be distinct, so per-cluster SNI
-//     hostnames don't collide;
-//   - when the source is external sharded, each hostname must contain {shardName}
-//     so the per-shard form is derivable.
+// validateMCExternalHostnames enforces, for multi-cluster specs with a managed LB and an
+// external sharded source, that each cluster's externalHostname contains {shardName} so the
+// per-shard SNI form is derivable. Hostnames may be shared across clusters: a cross-AZ
+// failover proxy fronts multiple clusters' Envoys behind one SNI, so a given shard uses the
+// same hostname in every cluster.
 //
 // The dispatch scopes this to multi-cluster (len > 1); the LB-mode check stays
 // inline because this group is not LB-mode-scoped (it also runs for unmanaged MC,
@@ -615,7 +614,6 @@ func validateMCExternalHostnames(s *MongoDBSearch) v1.ValidationResult {
 	if !s.IsLBModeManaged() {
 		return v1.ValidationSuccess()
 	}
-	seen := make(map[string]int, len(s.Spec.Clusters))
 	for i, c := range s.Spec.Clusters {
 		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
 			continue
@@ -624,48 +622,12 @@ func validateMCExternalHostnames(s *MongoDBSearch) v1.ValidationResult {
 		if tmpl == "" {
 			continue
 		}
-		if first, dup := seen[tmpl]; dup {
-			return v1.ValidationError(
-				"spec.clusters[%d].loadBalancer.managed.externalHostname %q is also used by spec.clusters[%d]; every cluster needs a distinct hostname",
-				i, tmpl, first,
-			)
-		}
-		seen[tmpl] = i
 		if s.IsExternalSourceSharded() && !strings.Contains(tmpl, ShardNamePlaceholder) {
 			return v1.ValidationError(
 				"spec.clusters[%d].loadBalancer.managed.externalHostname must contain %s for multi-cluster sharded deployments",
 				i, ShardNamePlaceholder,
 			)
 		}
-	}
-	return v1.ValidationSuccess()
-}
-
-// validateMCRouterHostnames enforces, for an external sharded source with a managed LB, that every
-// cluster's routerHostname is distinct: each cluster runs its own Envoy LB and its mongos routes to
-// it, so a shared hostname would collide per-cluster SNI / point clusters at the wrong Envoy.
-// routerHostname is only meaningful for sharded sources (ReplicaSet has no mongos), so this is scoped
-// the same way as validateRouterHostname (the per-field required/placeholder rules live there).
-func validateMCRouterHostnames(s *MongoDBSearch) v1.ValidationResult {
-	if !s.IsExternalSourceSharded() {
-		return v1.ValidationSuccess()
-	}
-	seen := make(map[string]int, len(s.Spec.Clusters))
-	for i, c := range s.Spec.Clusters {
-		if c.LoadBalancer == nil || c.LoadBalancer.Managed == nil {
-			continue
-		}
-		host := c.LoadBalancer.Managed.RouterHostname
-		if host == "" {
-			continue
-		}
-		if first, dup := seen[host]; dup {
-			return v1.ValidationError(
-				"spec.clusters[%d].loadBalancer.managed.routerHostname %q is also used by spec.clusters[%d]; every cluster needs a distinct hostname",
-				i, host, first,
-			)
-		}
-		seen[host] = i
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -315,9 +315,8 @@ func TestValidateMCExternalHostnames(t *testing.T) {
 			hostnames: []string{"us-east.lb.example.com:443", "eu-west.lb.example.com:443"},
 		},
 		{
-			name:          "MC RS with duplicate hostnames rejected",
-			hostnames:     []string{"static.lb.example.com:443", "static.lb.example.com:443"},
-			errorContains: "distinct hostname",
+			name:      "MC RS with shared hostname across clusters allowed",
+			hostnames: []string{"static.lb.example.com:443", "static.lb.example.com:443"},
 		},
 		{
 			name:      "MC sharded with shardName in each hostname",
@@ -333,6 +332,11 @@ func TestValidateMCExternalHostnames(t *testing.T) {
 		{
 			name:      "MC sharded shardName as name component is allowed",
 			hostnames: []string{"search-us-east-{shardName}-proxy.lb.example.com:443", "search-eu-west-{shardName}-proxy.lb.example.com:443"},
+			sharded:   true,
+		},
+		{
+			name:      "MC sharded shared hostname across clusters allowed (cross-AZ failover)",
+			hostnames: []string{"search-{shardName}-proxy.failover.example.com:443", "search-{shardName}-proxy.failover.example.com:443"},
 			sharded:   true,
 		},
 		{
@@ -398,65 +402,6 @@ func TestValidateRouterHostname(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateMCRouterHostnames(t *testing.T) {
-	mkSearch := func(routerHostnames []string) *MongoDBSearch {
-		clusters := make([]ClusterSpec, 0, len(routerHostnames))
-		for i, rh := range routerHostnames {
-			c := ClusterSpec{Name: "cluster-" + strconv.Itoa(i)}
-			if rh != "" {
-				c.LoadBalancer = &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{shardName}.c" + strconv.Itoa(i) + ".example.com", RouterHostname: rh}}
-			}
-			clusters = append(clusters, c)
-		}
-		// routerHostname validation is scoped to external sharded sources.
-		return &MongoDBSearch{
-			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-			Spec: MongoDBSearchSpec{
-				Clusters: clusters,
-				Source: &MongoDBSource{ExternalMongoDBSource: &ExternalMongoDBSource{ShardedCluster: &ExternalShardedClusterConfig{
-					Router: ExternalRouterConfig{Hosts: []string{"mongos.example.com:27017"}},
-					Shards: []ExternalShardConfig{{ShardName: "shard-0", Hosts: []string{"h:27017"}}},
-				}}},
-			},
-		}
-	}
-
-	tests := []struct {
-		name            string
-		routerHostnames []string
-		errorContains   string
-	}{
-		{name: "distinct routerHostnames", routerHostnames: []string{"us-east.example.com:443", "eu-west.example.com:443"}},
-		{name: "duplicate routerHostnames rejected", routerHostnames: []string{"shared.example.com:443", "shared.example.com:443"}, errorContains: "distinct hostname"},
-		{name: "no managed LB returns success", routerHostnames: []string{"", ""}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			res := validateMCRouterHostnames(mkSearch(tt.routerHostnames))
-			if tt.errorContains != "" {
-				assert.Equal(t, v1.ErrorLevel, res.Level, "expected error, got %+v", res)
-				assert.Contains(t, res.Msg, tt.errorContains)
-			} else {
-				assert.Equal(t, v1.SuccessLevel, res.Level, "expected success, got %+v", res)
-			}
-		})
-	}
-
-	t.Run("non-sharded source ignored even with duplicate routerHostnames", func(t *testing.T) {
-		rs := &MongoDBSearch{
-			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
-			Spec: MongoDBSearchSpec{
-				Clusters: []ClusterSpec{
-					{Name: "cluster-0", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{RouterHostname: "shared.example.com:443"}}},
-					{Name: "cluster-1", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{RouterHostname: "shared.example.com:443"}}},
-				},
-			},
-		}
-		assert.Equal(t, v1.SuccessLevel, validateMCRouterHostnames(rs).Level)
-	})
 }
 
 func TestValidateExternalHostnameDNSLength(t *testing.T) {


### PR DESCRIPTION
search: allow shared managed-LB hostname across clusters (cross-AZ failover)

## Summary
Relaxes the multi-cluster MongoDBSearch managed-LB validation so a given shard can use the **same SNI hostname in every cluster**.

- `validateMCExternalHostnames`: dropped the cross-cluster *distinct-hostname* check; kept the `{shardName}` placeholder requirement and the managed-LB guard.
- `validateMCRouterHostnames`: this function was *only* the cross-cluster distinct check, so it's removed entirely (its call site too). Per-field routerHostname rules remain in `validateRouterHostname`.

## Why
A cross-AZ search **failover** proxy is an L4 SNI-passthrough Envoy that fronts multiple clusters' managed Envoys behind one hostname. Because L4 can't rewrite SNI, the preserved client SNI must match whichever AZ the connection lands on — i.e. the shard's hostname has to be identical across clusters. The old distinct-hostname rule forbade exactly that. Each cluster still runs its own Envoy, so a shared SNI `server_name` does not collide within a cluster.

## Proof of Work
- PoW-Patch (unit + lint): **green** — https://spruce.mongodb.com/version/6a43a79337a14b0007188ead
- Operator image (`build_operator_ubi`): green — https://spruce.mongodb.com/version/6a43a5606b27e8000731add6
- Local: `golangci-lint` (full + fmt) + `govulncheck` clean on the change; `go build ./...` + `go test ./api/mongodb/v1/search/... ./controllers/searchcontroller/...` green.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?