### PR TITLE
CLOUDP-411215: Add voyageais to OperatorConfig watchedResources enum

### DIFF
--- a/api/operator/v1/operatorconfig_types.go
+++ b/api/operator/v1/operatorconfig_types.go
@@ -14,7 +14,7 @@ const (
 )
 
 // WatchedResource identifies a CRD that the operator will actively reconcile.
-// +kubebuilder:validation:Enum=mongodb;opsmanagers;mongodbusers;mongodbcommunity;mongodbsearch;mongodbmulticluster;clustermongodbroles
+// +kubebuilder:validation:Enum=mongodb;opsmanagers;mongodbusers;mongodbcommunity;mongodbsearch;mongodbmulticluster;clustermongodbroles;voyageais
 type WatchedResource string
 
 const (
@@ -25,6 +25,7 @@ const (
 	WatchedResourceMongoDBSearch       WatchedResource = "mongodbsearch"
 	WatchedResourceMongoDBMultiCluster WatchedResource = "mongodbmulticluster"
 	WatchedResourceClusterMongoDBRoles WatchedResource = "clustermongodbroles"
+	WatchedResourceVoyageAI            WatchedResource = "voyageais"
 )
 
 // Architecture defines the container architecture used by operator-managed workloads.

--- a/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
@@ -273,6 +273,7 @@ spec:
                   - mongodbsearch
                   - mongodbmulticluster
                   - clustermongodbroles
+                  - voyageais
                   type: string
                 type: array
                 x-kubernetes-list-type: set

--- a/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
+++ b/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
@@ -273,6 +273,7 @@ spec:
                   - mongodbsearch
                   - mongodbmulticluster
                   - clustermongodbroles
+                  - voyageais
                   type: string
                 type: array
                 x-kubernetes-list-type: set

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -9032,6 +9032,7 @@ spec:
                   - mongodbsearch
                   - mongodbmulticluster
                   - clustermongodbroles
+                  - voyageais
                   type: string
                 type: array
                 x-kubernetes-list-type: set


### PR DESCRIPTION
# Summary

Master catch-up for the OperatorConfig work. Since the technical design was frozen, master introduced a new VoyageAI controller (KUBE-126) with its own watched CRD, and PR #1287 renamed that CRD's plural to `voyageais`. The `OperatorConfig` CRD's `watchedResources` enum did not know about it.

This adds `voyageais` to the `WatchedResource` enum in `api/operator/v1/operatorconfig_types.go` and regenerates the CRD manifests (`config/crd/bases`, `helm_chart/crds`, `public/crds.yaml`) so the enum stays in sync with the operator's watch list (`voyageAICRDPlural = "voyageais"`).

Note: the `watchedResources` runtime wiring is a separate work item; this only authors the enum value, consistent with the rest of the already-authored OperatorConfig spec.

## Proof of Work

- `go build ./...` passes.
- `go test ./pkg/operatorconfig/...` passes.
- Regenerated CRDs verified to contain `voyageais` in the `watchedResources` enum, with no other schema drift.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details