### PR TITLE
Fix the Metrics Forwarder OM CA cert path constant

### DIFF
--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -59,6 +59,7 @@ import (
 const (
 	metricsForwarderConfigPath           = "/etc/otelcol"
 	metricsForwarderConfigFileName       = "config.yaml"
+	metricsForwarderCACertVolumeName     = "mms-ca-cert"
 	metricsForwarderCACertMountPath      = "/mongodb-automation/certs"
 	metricsForwarderConfigHashAnnotation = "mongodb.com/metrics-forwarder-config-hash"
 	metricsForwarderLabelName            = "search-metrics-forwarder"
@@ -1048,7 +1049,7 @@ func buildMetricsForwarderPodSpec(search *searchv1.MongoDBSearch, agentKeySecret
 	// Mount CA cert if configured
 	if caConfigMapName != "" {
 		volumes = append(volumes, corev1.Volume{
-			Name: "mms-ca-cert",
+			Name: metricsForwarderCACertVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: caConfigMapName},
@@ -1056,7 +1057,7 @@ func buildMetricsForwarderPodSpec(search *searchv1.MongoDBSearch, agentKeySecret
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name: "mms-ca-cert", MountPath: metricsForwarderCACertMountPath, ReadOnly: true,
+			Name: metricsForwarderCACertVolumeName, MountPath: metricsForwarderCACertMountPath, ReadOnly: true,
 		})
 	}
 

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -303,11 +303,11 @@ func TestBuildMetricsForwarderPodSpec_Volumes(t *testing.T) {
 		podSpec := buildMetricsForwarderPodSpec(search, "agent-key-secret", "my-ca-cm", 0, testDefaultImage, resources, false)
 
 		assert.Len(t, podSpec.Volumes, 3)
-		assert.Equal(t, "mms-ca-cert", podSpec.Volumes[2].Name)
+		assert.Equal(t, metricsForwarderCACertVolumeName, podSpec.Volumes[2].Name)
 		assert.Equal(t, "my-ca-cm", podSpec.Volumes[2].ConfigMap.Name)
 
 		assert.Len(t, podSpec.Containers[0].VolumeMounts, 3)
-		assert.Equal(t, "mms-ca-cert", podSpec.Containers[0].VolumeMounts[2].Name)
+		assert.Equal(t, metricsForwarderCACertVolumeName, podSpec.Containers[0].VolumeMounts[2].Name)
 		assert.Equal(t, metricsForwarderCACertMountPath, podSpec.Containers[0].VolumeMounts[2].MountPath)
 	})
 }
@@ -1061,7 +1061,7 @@ func TestReconcile_WithCACert(t *testing.T) {
 	}
 	caCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ca-configmap", Namespace: testNamespace},
-		Data:       map[string]string{"mms-ca.crt": "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"},
+		Data:       map[string]string{util.CaCertMMS: "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"},
 	}
 
 	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, caCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
@@ -1077,12 +1077,31 @@ func TestReconcile_WithCACert(t *testing.T) {
 
 	foundCAVolume := false
 	for _, vol := range dep.Spec.Template.Spec.Volumes {
-		if vol.Name == "mms-ca-cert" {
+		if vol.Name == metricsForwarderCACertVolumeName {
 			assert.Equal(t, search.MetricsForwarderCACertConfigMapNameForCluster(0), vol.ConfigMap.Name)
 			foundCAVolume = true
 		}
 	}
 	assert.True(t, foundCAVolume, "expected mms-ca-cert volume to be present")
+
+	var caCertMountPath string
+	for _, vm := range dep.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if vm.Name == metricsForwarderCACertVolumeName {
+			caCertMountPath = vm.MountPath
+			break
+		}
+	}
+	require.NotEmpty(t, caCertMountPath, "expected mms-ca-cert volume mount to be present")
+
+	// Verify the collector ConfigMap has ca_file pointing to the mounted volume path.
+	cm := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      search.MetricsForwarderConfigMapNameForCluster(0),
+	}, cm)
+	require.NoError(t, err)
+	assert.Contains(t, cm.Data["config.yaml"], "ca_file: "+caCertMountPath+"/"+util.CaCertMMS,
+		"expected exporters.otlp_http.tls.ca_file to point to the mounted CA cert volume")
 }
 
 func TestResolveFromEnterpriseSource(t *testing.T) {

--- a/controllers/searchcontroller/metrics_forwarder_otel_config.yaml.tmpl
+++ b/controllers/searchcontroller/metrics_forwarder_otel_config.yaml.tmpl
@@ -311,7 +311,7 @@ exporters:
       queue_size: ${env:SENDING_QUEUE_SIZE}
     tls:
       {{ if .HasOMCaCert }}
-      ca_file: /mongodb-automation/om-ca-cert/ca.crt
+      ca_file: /mongodb-automation/certs/mms-ca.crt
       {{ end }}
       insecure_skip_verify: {{ .RequireValidMMSServerCertificates | not }}
 service:


### PR DESCRIPTION
# Summary
The yaml template for the Metrics Forwarder's OTel Collector configuration hardcoded the wrong path for the Ops Manager CA certificate. This change fixes the path and adds an explicit assertion that the generated collector config points to the volume and key set up by the metrics controller.

## Proof of Work
New test assertion

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

