### PR TITLE
CLOUDP-411215: Move watchedResources setting to OperatorConfig

### DIFF
--- a/.run/Operator multi-cluster.run.xml
+++ b/.run/Operator multi-cluster.run.xml
@@ -2,7 +2,6 @@
   <configuration default="false" name="Operator multi-cluster" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="mongodb-kubernetes" />
     <working_directory value="$PROJECT_DIR$" />
-    <parameters value="-watch-resource=mongodb -watch-resource=opsmanagers -watch-resource=mongodbusers -watch-resource=mongodbcommunity -watch-resource=mongodbsearch -watch-resource=clustermongodbroles -watch-resource=mongodbmulticluster" />
     <kind value="FILE" />
     <package value="github.com/mongodb/mongodb-kubernetes" />
     <directory value="$PROJECT_DIR$" />

--- a/api/operator/v1/operatorconfig_types.go
+++ b/api/operator/v1/operatorconfig_types.go
@@ -28,6 +28,19 @@ const (
 	WatchedResourceVoyageAI            WatchedResource = "voyageais"
 )
 
+// AllWatchedResources lists every CRD the operator can reconcile. It is the default value
+// for OperatorConfig.spec.watchedResources when the field is omitted.
+var AllWatchedResources = []WatchedResource{
+	WatchedResourceMongoDB,
+	WatchedResourceOpsManagers,
+	WatchedResourceMongoDBUsers,
+	WatchedResourceMongoDBCommunity,
+	WatchedResourceMongoDBSearch,
+	WatchedResourceMongoDBMultiCluster,
+	WatchedResourceClusterMongoDBRoles,
+	WatchedResourceVoyageAI,
+}
+
 // Architecture defines the container architecture used by operator-managed workloads.
 // +kubebuilder:validation:Enum=NonStatic;Static
 type Architecture string

--- a/api/operator/v1/operatorconfig_types.go
+++ b/api/operator/v1/operatorconfig_types.go
@@ -14,7 +14,7 @@ const (
 )
 
 // WatchedResource identifies a CRD that the operator will actively reconcile.
-// +kubebuilder:validation:Enum=mongodb;opsmanagers;mongodbusers;mongodbcommunity;mongodbsearch;mongodbmulticluster;clustermongodbroles
+// +kubebuilder:validation:Enum=mongodb;opsmanagers;mongodbusers;mongodbcommunity;mongodbsearch;mongodbmulticluster;clustermongodbroles;voyageais
 type WatchedResource string
 
 const (
@@ -25,6 +25,7 @@ const (
 	WatchedResourceMongoDBSearch       WatchedResource = "mongodbsearch"
 	WatchedResourceMongoDBMultiCluster WatchedResource = "mongodbmulticluster"
 	WatchedResourceClusterMongoDBRoles WatchedResource = "clustermongodbroles"
+	WatchedResourceVoyageAI            WatchedResource = "voyageais"
 )
 
 // Architecture defines the container architecture used by operator-managed workloads.

--- a/changelog/20260701_breaking_watchedresources_moved_to_operatorconfig.md
+++ b/changelog/20260701_breaking_watchedresources_moved_to_operatorconfig.md
@@ -1,0 +1,6 @@
+---
+kind: breaking
+date: 2026-07-01
+---
+
+* **Operator**: The `operator.watchedResources` Helm value and the `-watch-resource` operator flag have been removed. Configure which custom resources the operator reconciles using `.spec.watchedResources` in the `OperatorConfig` CR instead. When omitted, it defaults to all known MCK CRDs (`mongodb`, `opsmanagers`, `mongodbusers`, `mongodbcommunity`, `mongodbsearch`, `mongodbmulticluster`, `clustermongodbroles`, `voyageais`). The previously implicit enablement of `mongodbmulticluster` (derived from the `multiCluster.clusters` Helm value) and `clustermongodbroles` (derived from the `operator.enableClusterMongoDBRoles` Helm value) is now expressed explicitly through this list. In particular, `operator.enableClusterMongoDBRoles` now only controls creation of the `ClusterMongoDBRole` RBAC and no longer affects whether the operator reconciles `ClusterMongoDBRole` resources: to stop the operator reconciling them, omit `clustermongodbroles` from `.spec.watchedResources` (rather than setting `operator.enableClusterMongoDBRoles=false`). Users who previously restricted the watched resources must create or update their `OperatorConfig` resource before upgrading to MCK 2.0.

--- a/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
@@ -273,6 +273,7 @@ spec:
                   - mongodbsearch
                   - mongodbmulticluster
                   - clustermongodbroles
+                  - voyageais
                   type: string
                 type: array
                 x-kubernetes-list-type: set

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,14 +26,6 @@ spec:
         - name: mongodb-kubernetes-operator
           image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
-          args:
-            - -watch-resource=mongodb
-            - -watch-resource=opsmanagers
-            - -watch-resource=mongodbusers
-            - -watch-resource=mongodbcommunity
-            - -watch-resource=mongodbsearch
-            - -watch-resource=voyageais
-            - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
           volumeMounts:

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -141,7 +141,7 @@ func (r *ReconcileCommonController) getRoles(ctx context.Context, db mdbv1.DbCom
 	var roles []mdbv1.MongoDBRole
 	if len(roleRefs) > 0 {
 		if !enableClusterMongoDBRoles {
-			return nil, xerrors.Errorf("RoleRefs are not supported when ClusterMongoDBRoles are disabled. Please enable ClusterMongoDBRoles in the operator configuration. This can be done by setting the operator.enableClusterMongoDBRoles to true in the helm values file, which will automatically installed the necessary RBAC. Alternatively, it can be enabled by adding -watch-resource=clustermongodbroles flag to the operator deployment, and manually creating the necessary RBAC.")
+			return nil, xerrors.Errorf("RoleRefs are not supported when ClusterMongoDBRoles are disabled. To enable them, include `clustermongodbroles` in `.spec.watchedResources` of the OperatorConfig CR (it is included by default) and ensure the necessary RBAC exists. Setting operator.enableClusterMongoDBRoles to true in the helm values file creates that RBAC automatically; otherwise create the ClusterRole and ClusterRoleBinding manually.")
 		}
 		var err error
 		roles, err = r.getRoleRefs(ctx, roleRefs, mongodbResourceNsName, db.Version)

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -201,6 +201,7 @@ def apply_operator_config_from_test_env(
     api_client=None,
     name: str = "mongodb-kubernetes-operator",
     wait_for_ready: Optional[Callable[[], None]] = None,
+    extra_spec: Optional[dict] = None,
 ) -> bool:
     """Creates the OperatorConfig CR from test env vars (if any non-default settings exist) and waits for
     the operator to restart and reload its configuration.
@@ -222,6 +223,8 @@ def apply_operator_config_from_test_env(
     from tests.conftest import local_operator
 
     spec = build_operator_config_spec_from_test_env()
+    if extra_spec:
+        spec.update(extra_spec)
     if not spec:
         return False
 

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -146,7 +146,9 @@ class Operator(object):
     def read_deployment(self) -> V1Deployment:
         return client.AppsV1Api(api_client=self.api_client).read_namespaced_deployment(self.name, self.namespace)
 
-    def apply_operator_config_and_wait(self, multi_cluster: bool = False):
+    def apply_operator_config_and_wait(
+        self, multi_cluster: bool = False, watched_resources: Optional[List[str]] = None
+    ):
         """Creates the OperatorConfig CR from test env vars (if any non-default settings exist) and waits
         for the operator to restart, reload its configuration and become ready again.
 
@@ -162,8 +164,13 @@ class Operator(object):
             self.wait_for_operator_ready()
             self.wait_for_operator_webhook_ready(multi_cluster=multi_cluster)
 
+        extra_spec = {"watchedResources": watched_resources} if watched_resources is not None else None
         apply_operator_config_from_test_env(
-            self.namespace, api_client=self.api_client, name=self.name, wait_for_ready=wait_for_ready
+            self.namespace,
+            api_client=self.api_client,
+            name=self.name,
+            wait_for_ready=wait_for_ready,
+            extra_spec=extra_spec,
         )
 
     def wait_for_operator_ready(self, retries: int = 60):

--- a/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/mongodb_custom_roles.py
@@ -358,7 +358,7 @@ def test_install_operator_with_clustermongodbroles_disabled(multi_cluster_operat
 def test_replicaset_is_failed(replica_set: MongoDB):
     replica_set.assert_reaches_phase(
         Phase.Failed,
-        msg_regexp="RoleRefs are not supported when ClusterMongoDBRoles are disabled. Please enable ClusterMongoDBRoles in the operator configuration.",
+        msg_regexp="RoleRefs are not supported when ClusterMongoDBRoles are disabled",
     )
 
 

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -688,8 +688,6 @@ def get_multi_cluster_operator(
         # override the serviceAccountName for the operator deployment
         "operator.createOperatorServiceAccount": "false",
     }
-    if watched_resources is not None:
-        helm_opts["operator.watchedResources"] = "{" + ",".join(watched_resources) + "}"
     return _install_multi_cluster_operator(
         namespace,
         multi_cluster_operator_installation_config,
@@ -698,6 +696,7 @@ def get_multi_cluster_operator(
         helm_opts,
         central_cluster_name,
         apply_crds_first=apply_crds_first,
+        watched_resources=watched_resources,
     )
 
 
@@ -781,10 +780,20 @@ def multi_cluster_operator_no_cluster_mongodb_roles(
             "operator.name": MULTI_CLUSTER_OPERATOR_NAME,
             # override the serviceAccountName for the operator deployment
             "operator.createOperatorServiceAccount": "false",
+            # Skip creating the ClusterMongoDBRole RBAC.
             "operator.enableClusterMongoDBRoles": "false",
         },
         central_cluster_name,
         apply_crds_first=apply_crds_first,
+        watched_resources=[
+            "mongodb",
+            "opsmanagers",
+            "mongodbusers",
+            "mongodbcommunity",
+            "mongodbsearch",
+            "mongodbmulticluster",
+            "voyageais",
+        ],
     )
 
 
@@ -865,6 +874,7 @@ def _install_multi_cluster_operator(
     custom_operator_version: Optional[str] = None,
     apply_crds_first: bool = False,
     create_operator_config: bool = True,
+    watched_resources: Optional[List[str]] = None,
 ) -> Operator:
     multi_cluster_operator_installation_config.update(helm_opts)
 
@@ -897,7 +907,7 @@ def _install_multi_cluster_operator(
     # OperatorConfig CRD, so creating the CR would fail. Such installs pass create_operator_config=False
     # and the upgrade test creates the CR explicitly once the CRD has been applied.
     if create_operator_config:
-        operator.apply_operator_config_and_wait(multi_cluster=True)
+        operator.apply_operator_config_and_wait(multi_cluster=True, watched_resources=watched_resources)
     else:
         operator.wait_for_operator_ready()
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -104,7 +104,6 @@ def _install_simulated_operator(
     # ownership-metadata check fails if we re-render them.
     helm_args["operator.createResourcesServiceAccountsAndRoles"] = "false"
     helm_args["operator.clusterIdentity.clusterName"] = mcc.cluster_name
-    helm_args["operator.watchedResources"] = "{mongodbsearch}"
 
     # upgrade(multi_cluster=True) = `helm upgrade --install`, and skips the
     # webhook wait because the test pod's cluster != central cluster, so it can't
@@ -115,6 +114,9 @@ def _install_simulated_operator(
         helm_args=helm_args,
         api_client=mcc.api_client,
     ).upgrade(multi_cluster=True)
+    # Restrict this operator to mongodbsearch only via OperatorConfig (the watch set is no longer a
+    # Helm value). This triggers a graceful restart so the operator reloads and watches search only.
+    operator.apply_operator_config_and_wait(multi_cluster=True, watched_resources=["mongodbsearch"])
     logger.info(
         f"installed simulated-MC operator in {mcc.cluster_name} "
         f"(identity={mcc.cluster_name}, name={SIMULATED_OPERATOR_NAME}, watches=mongodbsearch only)"

--- a/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
+++ b/docker/mongodb-kubernetes-tests/tests/operator/operator_partial_crd.py
@@ -4,6 +4,8 @@ from typing import Dict
 import pytest
 from kubernetes import client
 from kubetester.create_or_replace_from_yaml import create_or_replace_from_yaml
+from kubetester.helm import apply_operator_config_crd
+from kubetester.kubetester import create_operator_config
 from kubetester.operator import Operator, delete_operator_crds, list_operator_crds
 from pytest import fixture
 
@@ -13,9 +15,9 @@ def ops_manager_and_mongodb_crds():
     """Installs OM and MDB CRDs only (we need to do this manually as Helm 3 doesn't support templating for CRDs"""
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_mongodb.yaml")
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_opsmanagers.yaml")
-    create_or_replace_from_yaml(
-        client.api_client.ApiClient(), "helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml"
-    )
+    # apply_operator_config_crd waits for the CRD to be Established before we create the CR below;
+    # create_or_replace_from_yaml does not, which races the API server after a prior CRD deletion.
+    apply_operator_config_crd(api_client=client.api_client.ApiClient())
 
 
 @fixture(scope="module")
@@ -24,12 +26,14 @@ def operator_only_ops_manager_and_mongodb(
     namespace: str,
     operator_installation_config: Dict[str, str],
 ) -> Operator:
-    helm_args = operator_installation_config.copy()
-    helm_args["operator.watchedResources"] = "{opsmanagers,mongodb}"
+    # Restrict which CRDs the operator reconciles via OperatorConfig. The CR must exist before the
+    # operator starts: with no CR it defaults to watching all CRDs and would crash on the ones that
+    # aren't installed in this test.
+    create_operator_config(namespace, {"watchedResources": ["opsmanagers", "mongodb"]})
 
     return Operator(
         namespace=namespace,
-        helm_args=helm_args,
+        helm_args=operator_installation_config,
         helm_options=["--skip-crds"],
     ).install()
 
@@ -38,9 +42,9 @@ def operator_only_ops_manager_and_mongodb(
 def mongodb_crds():
     """Installs OM and MDB CRDs only (we need to do this manually as Helm 3 doesn't support templating for CRDs"""
     create_or_replace_from_yaml(client.api_client.ApiClient(), "helm_chart/crds/mongodb.com_mongodb.yaml")
-    create_or_replace_from_yaml(
-        client.api_client.ApiClient(), "helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml"
-    )
+    # Waits for the CRD to be Established before we create the CR below. This fixture runs after
+    # test_remove_operator_and_crds deletes the CRD, so the API server must re-register the endpoint.
+    apply_operator_config_crd(api_client=client.api_client.ApiClient())
 
 
 @fixture(scope="module")
@@ -49,12 +53,13 @@ def operator_only_mongodb(
     namespace: str,
     operator_installation_config: Dict[str, str],
 ) -> Operator:
-    helm_args = operator_installation_config.copy()
-    helm_args["operator.watchedResources"] = "{mongodb}"
+    # See operator_only_ops_manager_and_mongodb: the OperatorConfig CR must exist before the operator
+    # starts so it only reconciles the installed CRDs.
+    create_operator_config(namespace, {"watchedResources": ["mongodb"]})
 
     return Operator(
         namespace=namespace,
-        helm_args=helm_args,
+        helm_args=operator_installation_config,
         helm_options=["--skip-crds"],
     ).install()
 

--- a/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
+++ b/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
@@ -273,6 +273,7 @@ spec:
                   - mongodbsearch
                   - mongodbmulticluster
                   - clustermongodbroles
+                  - voyageais
                   type: string
                 type: array
                 x-kubernetes-list-type: set

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -45,23 +45,14 @@ spec:
         - name: {{ .Values.operator.name }}
           image: "{{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}{{ .Values.operator.build }}"
           imagePullPolicy: {{ .Values.registry.pullPolicy }}
-          {{- if .Values.operator.watchedResources }}
+          {{- with .Values.operator.additionalArguments }}
           args:
-            {{- range .Values.operator.watchedResources }}
-            - -watch-resource={{ . }}
-            {{- end }}
-            {{- if .Values.multiCluster.clusters }}
-            - -watch-resource=mongodbmulticluster
-            {{- end }}
-            {{- if .Values.operator.enableClusterMongoDBRoles }}
-            - -watch-resource=clustermongodbroles
-            {{- end }}
-            {{- range .Values.operator.additionalArguments }}
+            {{- range . }}
             - {{ . }}
             {{- end }}
+          {{- end }}
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
-          {{- end }}
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-server-dir

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -15,15 +15,6 @@ operator:
   # Version of mongodb-kubernetes-operator
   version: 2.0.0
 
-  # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
-  watchedResources:
-  - mongodb
-  - opsmanagers
-  - mongodbusers
-  - mongodbcommunity
-  - mongodbsearch
-  - voyageais
-
   # Scopes MongoDBSearch reconciliation only. When clusterName is set, this operator
   # reconciles only MongoDBSearch resources whose spec.clusters[i].name matches this
   # value -- the operator-per-cluster model, where each cluster runs its own operator
@@ -79,8 +70,8 @@ operator:
   createResourcesServiceAccountsAndRoles: true
 
   # If true, the helm chart will create the ClusterRole and ClusterRoleBinding for the operator to be able to access the ClusterMongoDBRole resources.
-  # It will also set the --watch-resource flag, to enable the operator to watch the ClusterMongoDBRole resources for changes.
-  # Set to false to not create the ClusterRole and ClusterRoleBinding and to disable the operator watching the ClusterMongoDBRole resources.
+  # Whether the operator actually reconciles ClusterMongoDBRole resources is controlled separately via `.spec.watchedResources` in the OperatorConfig CR (which includes `clustermongodbroles` by default).
+  # Set to false to not create the ClusterRole and ClusterRoleBinding.
   enableClusterMongoDBRoles: true
 
   # Set to false to not create the RBAC for enabling access to the PVC for resizing for the operator

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	golog "log"
@@ -84,9 +85,6 @@ var (
 	operatorEnvironments = []string{util.OperatorEnvironmentDev.String(), util.OperatorEnvironmentLocal.String(), util.OperatorEnvironmentProd.String()}
 
 	scheme = runtime.NewScheme()
-
-	// Default CRDs to watch (if not specified on the command line)
-	crds crdsToWatch
 )
 
 func init() {
@@ -97,21 +95,6 @@ func init() {
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(vaiv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
-
-	flag.Var(&crds, "watch-resource", "A Watch Resource specifies if the Operator should watch the given resource")
-}
-
-// crdsToWatch is a custom Value implementation which can be
-// used to receive command line arguments
-type crdsToWatch []string
-
-func (c *crdsToWatch) Set(value string) error {
-	*c = append(*c, strings.ToLower(value))
-	return nil
-}
-
-func (c *crdsToWatch) String() string {
-	return strings.Join(*c, ",")
 }
 
 func main() {
@@ -123,18 +106,6 @@ func main() {
 
 func run() error {
 	flag.Parse()
-	// If no CRDs are specified, we set default to non-multicluster CRDs
-	if len(crds) == 0 {
-		crds = crdsToWatch{
-			mongoDBCRDPlural,
-			mongoDBUserCRDPlural,
-			mongoDBOpsManagerCRDPlural,
-			mongoDBCommunityCRDPlural,
-			mongoDBSearchCRDPlural,
-			voyageAICRDPlural,
-			clusterMongoDBRoleCRDPlural,
-		}
-	}
 
 	ctx := signals.SetupSignalHandler()
 	ctx, cancel := context.WithCancel(ctx)
@@ -156,7 +127,6 @@ func run() error {
 
 	agentDebug := env.ReadBoolOrDefault(util.EnvVarDebug, false)
 	agentDebugImage := env.ReadOrDefault(util.EnvVarDebugImage, "")
-	enableClusterMongoDBRoles := slices.Contains(crds, clusterMongoDBRoleCRDPlural)
 
 	// Get trace and span IDs from environment variables
 	traceIDHex := os.Getenv("OTEL_TRACE_ID")
@@ -240,6 +210,13 @@ func run() error {
 		defaultArchitecture = architectures.Static
 	}
 
+	// The CRDs the operator reconciles are configured via OperatorConfig.spec.watchedResources
+	watchedResources := make([]string, len(operatorCfg.Spec.WatchedResources))
+	for i, r := range operatorCfg.Spec.WatchedResources {
+		watchedResources[i] = string(r)
+	}
+	enableClusterMongoDBRoles := slices.Contains(watchedResources, clusterMongoDBRoleCRDPlural)
+
 	log.Info("Registering Components.")
 
 	if err := mgr.Add(operatorconfig.NewWatcher(mgr.GetCache(), cancel)); err != nil {
@@ -254,7 +231,7 @@ func run() error {
 	// memberClusterObjectsMap is a map of clusterName -> clusterObject
 	memberClusterObjectsMap := make(map[string]runtime_cluster.Cluster)
 
-	if slices.Contains(crds, mongoDBMultiClusterCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBMultiClusterCRDPlural) {
 		memberClustersNames, err := getMemberClusters(ctx, cfg, currentNamespace)
 		if err != nil {
 			return err
@@ -305,27 +282,27 @@ func run() error {
 	}
 
 	// Setup all Controllers
-	if slices.Contains(crds, mongoDBCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBCRDPlural) {
 		if err := setupMongoDBCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, memberClusterObjectsMap, backupEnableDelay, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
-	if slices.Contains(crds, mongoDBOpsManagerCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBOpsManagerCRDPlural) {
 		if err := setupMongoDBOpsManagerCRD(ctx, mgr, memberClusterObjectsMap, imageUrls, initDatabaseNonStaticImageVersion, initOpsManagerImageVersion, defaultArchitecture, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
-	if slices.Contains(crds, mongoDBUserCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBUserCRDPlural) {
 		if err := setupMongoDBUserCRD(ctx, mgr, memberClusterObjectsMap, backupEnableDelay, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
-	if slices.Contains(crds, mongoDBMultiClusterCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBMultiClusterCRDPlural) {
 		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, memberClusterObjectsMap, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
-	if slices.Contains(crds, mongoDBSearchCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBSearchCRDPlural) {
 		operatorClusterName := env.ReadOrDefault(util.OperatorClusterNameEnv, "")
 		if operatorClusterName != "" {
 			log.Infof("Per-cluster operator mode enabled for MongoDBSearch: operator cluster identity = %q", operatorClusterName)
@@ -334,17 +311,17 @@ func run() error {
 			return err
 		}
 	}
-	if slices.Contains(crds, voyageAICRDPlural) {
+	if slices.Contains(watchedResources, voyageAICRDPlural) {
 		if err := setupVoyageAICRD(ctx, mgr, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
 
-	for _, r := range crds {
+	for _, r := range watchedResources {
 		log.Infof("Registered CRD: %s", r)
 	}
 
-	if slices.Contains(crds, mongoDBCommunityCRDPlural) {
+	if slices.Contains(watchedResources, mongoDBCommunityCRDPlural) {
 		if err := setupCommunityController(
 			ctx,
 			mgr,
@@ -521,6 +498,12 @@ func getMemberClusters(ctx context.Context, cfg *rest.Config, currentNamespace s
 
 	m := corev1.ConfigMap{}
 	err = c.Get(ctx, types.NamespacedName{Name: util.MemberListConfigMapName, Namespace: currentNamespace}, &m)
+	if apierrors.IsNotFound(err) {
+		// No multi-cluster configuration present: run as single-cluster with no member clusters.
+		// The member-list ConfigMap is absent on single-cluster installs (e.g. when
+		// mongodbmulticluster is watched by default). Callers handle an empty member list.
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/mongodb-community-operator/pkg/helm/helm.go
+++ b/mongodb-community-operator/pkg/helm/helm.go
@@ -30,7 +30,6 @@ func Install(t *testing.T, chartPath, chartName string, flags, templateValues ma
 			helmArgs = append(helmArgs, flagValue)
 		}
 	}
-	templateValues["operator.watchedResources"] = "{opsmanagers,mongodb,mongodbusers,mongodbcommunity}"
 	helmArgs = append(helmArgs, mapToHelmValuesArg(templateValues)...)
 	return executeHelmCommand(t, helmArgs, nil)
 }

--- a/pkg/operatorconfig/operatorconfig.go
+++ b/pkg/operatorconfig/operatorconfig.go
@@ -3,6 +3,7 @@ package operatorconfig
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +35,9 @@ func withDefaults(cfg operatorv1.OperatorConfig) operatorv1.OperatorConfig {
 	}
 	if cfg.Spec.MaxConcurrentReconciles == 0 {
 		cfg.Spec.MaxConcurrentReconciles = 1
+	}
+	if len(cfg.Spec.WatchedResources) == 0 {
+		cfg.Spec.WatchedResources = slices.Clone(operatorv1.AllWatchedResources)
 	}
 	return cfg
 }

--- a/pkg/operatorconfig/operatorconfig_test.go
+++ b/pkg/operatorconfig/operatorconfig_test.go
@@ -34,6 +34,7 @@ func TestLoad_AbsentCR(t *testing.T) {
 	assert.Empty(t, cfg.ResourceVersion)
 	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
 	assert.Equal(t, 1, cfg.Spec.MaxConcurrentReconciles)
+	assert.Equal(t, operatorv1.AllWatchedResources, cfg.Spec.WatchedResources)
 }
 
 func TestLoad_PresentCR(t *testing.T) {
@@ -54,7 +55,31 @@ func TestLoad_PresentCR(t *testing.T) {
 	assert.Equal(t, 4, cfg.Spec.MaxConcurrentReconciles)
 	// DefaultArchitecture was omitted in the CR; withDefaults fills it in
 	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
+	// WatchedResources was omitted in the CR; withDefaults fills in all known CRDs
+	assert.Equal(t, operatorv1.AllWatchedResources, cfg.Spec.WatchedResources)
 	assert.NotEmpty(t, cfg.ResourceVersion)
+}
+
+func TestLoad_WatchedResourcesSubsetPreserved(t *testing.T) {
+	subset := []operatorv1.WatchedResource{
+		operatorv1.WatchedResourceMongoDB,
+		operatorv1.WatchedResourceMongoDBUsers,
+	}
+	cr := &operatorv1.OperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.DefaultOperatorConfigName,
+			Namespace: testNamespace,
+		},
+		Spec: operatorv1.OperatorConfigSpec{
+			WatchedResources: subset,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+	cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+	require.NoError(t, err)
+	assert.Equal(t, subset, cfg.Spec.WatchedResources)
 }
 
 func TestLoad_ClientError(t *testing.T) {

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -9032,6 +9032,7 @@ spec:
                   - mongodbsearch
                   - mongodbmulticluster
                   - clustermongodbroles
+                  - voyageais
                   type: string
                 type: array
                 x-kubernetes-list-type: set

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -354,15 +354,6 @@ spec:
         - name: mongodb-kubernetes-operator-multi-cluster
           image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
-          args:
-            - -watch-resource=mongodb
-            - -watch-resource=opsmanagers
-            - -watch-resource=mongodbusers
-            - -watch-resource=mongodbcommunity
-            - -watch-resource=mongodbsearch
-            - -watch-resource=voyageais
-            - -watch-resource=mongodbmulticluster
-            - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
           volumeMounts:

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -349,14 +349,6 @@ spec:
         - name: mongodb-kubernetes-operator
           image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
-          args:
-            - -watch-resource=mongodb
-            - -watch-resource=opsmanagers
-            - -watch-resource=mongodbusers
-            - -watch-resource=mongodbcommunity
-            - -watch-resource=mongodbsearch
-            - -watch-resource=voyageais
-            - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
           volumeMounts:

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -354,14 +354,6 @@ spec:
         - name: mongodb-kubernetes-operator
           image: "quay.io/mongodb/mongodb-kubernetes:2.0.0"
           imagePullPolicy: Always
-          args:
-            - -watch-resource=mongodb
-            - -watch-resource=opsmanagers
-            - -watch-resource=mongodbusers
-            - -watch-resource=mongodbcommunity
-            - -watch-resource=mongodbsearch
-            - -watch-resource=voyageais
-            - -watch-resource=clustermongodbroles
           command:
             - /usr/local/bin/mongodb-kubernetes-operator
           volumeMounts:


### PR DESCRIPTION
# Summary

Continues migrating operator settings into the `OperatorConfig` CR. Moves the set of CRDs the operator reconciles off the `-watch-resource` flag / `operator.watchedResources` Helm value onto `OperatorConfig.spec.watchedResources`, defaulting to all known CRDs. The previously implicit enablement of `mongodbmulticluster` (from `multiCluster.clusters`) and `clustermongodbroles` (from `operator.enableClusterMongoDBRoles`) is now expressed explicitly in that list. Member-cluster discovery now tolerates a missing member-list ConfigMap, so single-cluster operators start even with `mongodbmulticluster` watched.

Note: this branch also carries the commit from #1306 (voyageais catchup) — close #1306 in favour of this PR.

## Proof of Work

- `pkg/operatorconfig/operatorconfig_test.go` — defaulting (absent CR → all CRDs; explicit subset preserved)
- `helm template helm_chart` renders with no `-watch-resource` args across default / `multiCluster.clusters` / `enableClusterMongoDBRoles=false`
- e2e `operator_partial_crd` and `multicluster_search` migrated to `OperatorConfig`

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->