### PR TITLE
CLOUDP-411215: Move memberClusterClientTimeout setting to OperatorConfig

### DIFF
--- a/changelog/20260701_breaking_memberclusterclienttimeout_moved_to_operatorconfig.md
+++ b/changelog/20260701_breaking_memberclusterclienttimeout_moved_to_operatorconfig.md
@@ -1,0 +1,6 @@
+---
+kind: breaking
+date: 2026-07-01
+---
+
+* **Operator**: The `multiCluster.clusterClientTimeout` Helm value and the `CLUSTER_CLIENT_TIMEOUT` environment variable have been removed. Configure the timeout (in seconds) the Operator uses when connecting to a member cluster's Kubernetes API server using `.spec.multiCluster.memberClusterClientTimeout` in the `OperatorConfig` CR instead. The default value remains `10`.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,8 +55,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: CLUSTER_CLIENT_TIMEOUT
-              value: "10"
             - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
               value: "5"
             - name: IMAGE_PULL_POLICY

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
@@ -1118,7 +1119,7 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileOMCAConfigMap(ctx context.Con
 
 // AddMultiReplicaSetController creates a new MongoDbMultiReplicaset Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, requiredHealthyStreak int, memberClustersMap map[string]cluster.Cluster, maxConcurrentReconciles int) error {
+func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, requiredHealthyStreak int, memberClusterClientTimeout int, memberClustersMap map[string]cluster.Cluster, maxConcurrentReconciles int) error {
 	// Create a new controller
 	reconciler := newMultiClusterReplicaSetReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, om.NewOpsManagerConnection, multicluster.ClustersMapToClientMap(memberClustersMap))
 	c, err := controller.New(util.MongoDbMultiClusterController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: maxConcurrentReconciles})
@@ -1180,6 +1181,7 @@ func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imag
 		Cache:                 make(map[string]memberwatch.ClusterHealthChecker),
 		HealthyStreak:         make(map[string]int),
 		RequiredHealthyStreak: requiredHealthyStreak,
+		ClientTimeout:         time.Duration(memberClusterClientTimeout) * time.Second,
 	}
 	go memberClusterHealthChecker.WatchMemberClusterHealth(ctx, zap.S(), eventChannel, reconciler.client, memberClustersMap)
 

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -300,6 +300,7 @@ func AddMongoDBSearchController(
 	memberClusterObjectsMap map[string]cluster.Cluster,
 	operatorClusterName string,
 	maxConcurrentReconciles int,
+	memberClusterClientTimeout int,
 ) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, mdbcSearchIndexBuilder); err != nil {
 		return err
@@ -349,6 +350,7 @@ func AddMongoDBSearchController(
 			Cache:                 make(map[string]memberwatch.ClusterHealthChecker),
 			HealthyStreak:         make(map[string]int),
 			RequiredHealthyStreak: env.ReadIntOrDefault(util.RequiredHealthyStreakEnv, util.DefaultRequiredHealthyStreak), // nolint:forbidigo
+			ClientTimeout:         time.Duration(memberClusterClientTimeout) * time.Second,
 		}
 		go healthChecker.WatchMemberClusterHealth(ctx, zap.S(), eventChannel, r.kubeClient, memberClusterObjectsMap)
 

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -139,10 +139,6 @@ spec:
             - name: MDB_OPERATOR_TELEMETRY_SEND_BASEURL
               value: "{{ $telemetry.send.baseUrl }}"
     {{- end }}
-    {{- if .Values.multiCluster.clusterClientTimeout }}
-            - name: CLUSTER_CLIENT_TIMEOUT
-              value: "{{ .Values.multiCluster.clusterClientTimeout }}"
-    {{- end }}
     {{- if .Values.multiCluster.memberClusterRequiredHealthyStreak }}
             - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
               value: "{{ .Values.multiCluster.memberClusterRequiredHealthyStreak }}"

--- a/helm_chart/values-multi-cluster.yaml
+++ b/helm_chart/values-multi-cluster.yaml
@@ -12,5 +12,4 @@ multiCluster:
     ]
   kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
   performFailOver: true
-  clusterClientTimeout: 10
   memberClusterRequiredHealthyStreak: 5

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -188,7 +188,6 @@ multiCluster:
   clusters: []
   kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
   performFailOver: true
-  clusterClientTimeout: 10
   memberClusterRequiredHealthyStreak: 5
 
 # Resources only for the MongoDBCommunity resource reconciler

--- a/main.go
+++ b/main.go
@@ -210,6 +210,11 @@ func run() error {
 		defaultArchitecture = architectures.Static
 	}
 
+	// The member-cluster API client timeout is configured via
+	// OperatorConfig.spec.multiCluster.memberClusterClientTimeout (seconds).
+	// operatorconfig.Load guarantees MultiCluster is non-nil and defaulted.
+	memberClusterClientTimeout := operatorCfg.Spec.MultiCluster.MemberClusterClientTimeout
+
 	// The CRDs the operator reconciles are configured via OperatorConfig.spec.watchedResources
 	watchedResources := make([]string, len(operatorCfg.Spec.WatchedResources))
 	for i, r := range operatorCfg.Spec.WatchedResources {
@@ -243,7 +248,7 @@ func run() error {
 			log.Warnf("The operator did not detect any member clusters")
 		}
 
-		memberClusterClients, err := multicluster.CreateMemberClusterClients(memberClustersNames, multicluster.GetKubeConfigPath())
+		memberClusterClients, err := multicluster.CreateMemberClusterClients(memberClustersNames, multicluster.GetKubeConfigPath(), memberClusterClientTimeout)
 		if err != nil {
 			return err
 		}
@@ -298,7 +303,7 @@ func run() error {
 		}
 	}
 	if slices.Contains(watchedResources, mongoDBMultiClusterCRDPlural) {
-		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, memberClusterObjectsMap, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
+		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, memberClusterClientTimeout, memberClusterObjectsMap, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
@@ -307,7 +312,7 @@ func run() error {
 		if operatorClusterName != "" {
 			log.Infof("Per-cluster operator mode enabled for MongoDBSearch: operator cluster identity = %q", operatorClusterName)
 		}
-		if err := setupMongoDBSearchCRD(ctx, mgr, memberClusterObjectsMap, operatorClusterName, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
+		if err := setupMongoDBSearchCRD(ctx, mgr, memberClusterObjectsMap, operatorClusterName, operatorCfg.Spec.MaxConcurrentReconciles, memberClusterClientTimeout); err != nil {
 			return err
 		}
 	}
@@ -422,9 +427,9 @@ func setupMongoDBUserCRD(ctx context.Context, mgr manager.Manager, memberCluster
 	return operator.AddMongoDBUserController(ctx, mgr, memberClusterObjectsMap, backupEnableDelay, maxConcurrentReconciles)
 }
 
-func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClusterObjectsMap map[string]runtime_cluster.Cluster, maxConcurrentReconciles int) error {
+func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClusterClientTimeout int, memberClusterObjectsMap map[string]runtime_cluster.Cluster, maxConcurrentReconciles int) error {
 	requiredHealthyStreak := env.ReadIntOrDefault(util.RequiredHealthyStreakEnv, util.DefaultRequiredHealthyStreak)
-	if err := operator.AddMultiReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, requiredHealthyStreak, memberClusterObjectsMap, maxConcurrentReconciles); err != nil {
+	if err := operator.AddMultiReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, requiredHealthyStreak, memberClusterClientTimeout, memberClusterObjectsMap, maxConcurrentReconciles); err != nil {
 		return err
 	}
 	return ctrl.NewWebhookManagedBy(mgr).For(&mdbmultiv1.MongoDBMultiCluster{}).
@@ -443,12 +448,13 @@ func setupMongoDBSearchCRD(
 	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
 	operatorClusterName string,
 	maxConcurrentReconciles int,
+	memberClusterClientTimeout int,
 ) error {
 	if err := operator.AddMongoDBSearchController(ctx, mgr, searchcontroller.OperatorSearchConfig{
 		SearchRepo:    env.ReadOrPanic(util.SearchRepoURLEnv),
 		SearchName:    env.ReadOrPanic(util.SearchNameEnv),
 		SearchVersion: env.ReadOrPanic(util.SearchVersionEnv),
-	}, memberClusterObjectsMap, operatorClusterName, maxConcurrentReconciles); err != nil {
+	}, memberClusterObjectsMap, operatorClusterName, maxConcurrentReconciles, memberClusterClientTimeout); err != nil {
 		return err
 	}
 

--- a/pkg/multicluster/memberwatch/clusterhealth.go
+++ b/pkg/multicluster/memberwatch/clusterhealth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"go.uber.org/zap"
 
-	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
 
@@ -32,6 +31,10 @@ var (
 	DefaultRetryMax     = 10
 )
 
+// DefaultClientTimeout is the fallback timeout for the member-cluster health-check
+// HTTP client when no explicit timeout is supplied via WithTimeout.
+const DefaultClientTimeout = 10 * time.Second
+
 // HealthCheckOption is a functional option for configuring MemberHealthCheck
 type HealthCheckOption func(*retryablehttp.Client)
 
@@ -41,6 +44,13 @@ func WithRetryConfig(retryWaitMin, retryWaitMax time.Duration, retryMax int) Hea
 		client.RetryWaitMin = retryWaitMin
 		client.RetryWaitMax = retryWaitMax
 		client.RetryMax = retryMax
+	}
+}
+
+// WithTimeout configures the timeout of the health check client's underlying HTTP client.
+func WithTimeout(timeout time.Duration) HealthCheckOption {
+	return func(client *retryablehttp.Client) {
+		client.HTTPClient.Timeout = timeout
 	}
 }
 
@@ -69,7 +79,7 @@ func NewMemberHealthCheck(server string, ca []byte, token string, log *zap.Sugar
 	client := &retryablehttp.Client{
 		HTTPClient: &http.Client{
 			Transport: transport,
-			Timeout:   time.Duration(env.ReadIntOrDefault(multicluster.ClusterClientTimeoutEnv, 10)) * time.Second, // nolint:forbidigo
+			Timeout:   DefaultClientTimeout,
 		},
 		RetryWaitMin: DefaultRetryWaitMin,
 		RetryWaitMax: DefaultRetryWaitMax,

--- a/pkg/multicluster/memberwatch/memberwatch.go
+++ b/pkg/multicluster/memberwatch/memberwatch.go
@@ -27,7 +27,10 @@ type MemberClusterHealthChecker struct {
 	Cache                 map[string]ClusterHealthChecker
 	HealthyStreak         map[string]int
 	RequiredHealthyStreak int
-	mu                    sync.RWMutex
+	// ClientTimeout is the timeout for the per-cluster health-check HTTP client.
+	// When zero, DefaultClientTimeout is used.
+	ClientTimeout time.Duration
+	mu            sync.RWMutex
 }
 
 func (m *MemberClusterHealthChecker) HealthyStreakFor(cluster string) int {
@@ -87,6 +90,11 @@ func (m *MemberClusterHealthChecker) populateCache(clustersMap map[string]cluste
 		return
 	}
 
+	timeout := m.ClientTimeout
+	if timeout <= 0 {
+		timeout = DefaultClientTimeout
+	}
+
 	for n := range kubeConfig.Contexts {
 		kubeContext := kubeConfig.Contexts[n]
 		clusterName := kubeContext.Context.Cluster
@@ -95,7 +103,7 @@ func (m *MemberClusterHealthChecker) populateCache(clustersMap map[string]cluste
 			log.Errorf("Skipping cluster %s: %v", clusterName, err)
 			continue
 		}
-		m.Cache[clusterName] = NewMemberHealthCheck(credentials.Server, credentials.CertificateAuthority, credentials.Token, log)
+		m.Cache[clusterName] = NewMemberHealthCheck(credentials.Server, credentials.CertificateAuthority, credentials.Token, log, WithTimeout(timeout))
 		m.HealthyStreak[clusterName] = 0
 	}
 }

--- a/pkg/multicluster/multicluster.go
+++ b/pkg/multicluster/multicluster.go
@@ -25,9 +25,8 @@ import (
 
 const (
 	// kubeconfig path holding the credentials for different member clusters
-	DefaultKubeConfigPath   = "/etc/config/kubeconfig/kubeconfig"
-	KubeConfigPathEnv       = "KUBE_CONFIG_PATH"
-	ClusterClientTimeoutEnv = "CLUSTER_CLIENT_TIMEOUT"
+	DefaultKubeConfigPath = "/etc/config/kubeconfig/kubeconfig"
+	KubeConfigPathEnv     = "KUBE_CONFIG_PATH"
 )
 
 type KubeConfig struct {
@@ -61,7 +60,7 @@ func (k KubeConfig) LoadKubeConfigFile() (KubeConfigFile, error) {
 }
 
 // CreateMemberClusterClients creates a client(map of cluster-name to client) to talk to the API-Server corresponding to each member clusters.
-func CreateMemberClusterClients(clusterNames []string, kubeConfigPath string) (map[string]*restclient.Config, error) {
+func CreateMemberClusterClients(clusterNames []string, kubeConfigPath string, clientTimeoutSeconds int) (map[string]*restclient.Config, error) {
 	clusterClientsMap := map[string]*restclient.Config{}
 
 	for _, c := range clusterNames {
@@ -72,7 +71,7 @@ func CreateMemberClusterClients(clusterNames []string, kubeConfigPath string) (m
 		if clientset == nil {
 			return nil, xerrors.Errorf("failed to get clientset for cluster: %s", c)
 		}
-		clientset.Timeout = time.Duration(env.ReadIntOrDefault(ClusterClientTimeoutEnv, 10)) * time.Second // nolint:forbidigo
+		clientset.Timeout = time.Duration(clientTimeoutSeconds) * time.Second
 		clusterClientsMap[c] = clientset
 	}
 	return clusterClientsMap, nil

--- a/pkg/operatorconfig/operatorconfig.go
+++ b/pkg/operatorconfig/operatorconfig.go
@@ -39,5 +39,15 @@ func withDefaults(cfg operatorv1.OperatorConfig) operatorv1.OperatorConfig {
 	if len(cfg.Spec.WatchedResources) == 0 {
 		cfg.Spec.WatchedResources = slices.Clone(operatorv1.AllWatchedResources)
 	}
+	// MultiCluster is a pointer, so an omitted block leaves the API server's
+	// nested defaults (e.g. memberClusterClientTimeout=10) unapplied. Ensure the
+	// block exists and the timeout is defaulted so member-cluster clients never
+	// end up with a zero (i.e. no) timeout.
+	if cfg.Spec.MultiCluster == nil {
+		cfg.Spec.MultiCluster = &operatorv1.MultiClusterConfig{}
+	}
+	if cfg.Spec.MultiCluster.MemberClusterClientTimeout == 0 {
+		cfg.Spec.MultiCluster.MemberClusterClientTimeout = 10
+	}
 	return cfg
 }

--- a/pkg/operatorconfig/operatorconfig_test.go
+++ b/pkg/operatorconfig/operatorconfig_test.go
@@ -35,6 +35,48 @@ func TestLoad_AbsentCR(t *testing.T) {
 	assert.Equal(t, operatorv1.ArchitectureNonStatic, cfg.Spec.DefaultArchitecture)
 	assert.Equal(t, 1, cfg.Spec.MaxConcurrentReconciles)
 	assert.Equal(t, operatorv1.AllWatchedResources, cfg.Spec.WatchedResources)
+	// MultiCluster is a pointer; withDefaults must materialise it and default the timeout
+	require.NotNil(t, cfg.Spec.MultiCluster)
+	assert.Equal(t, 10, cfg.Spec.MultiCluster.MemberClusterClientTimeout)
+}
+
+func TestLoad_MemberClusterClientTimeout(t *testing.T) {
+	t.Run("omitted multiCluster block defaults to 10", func(t *testing.T) {
+		cr := &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.DefaultOperatorConfigName,
+				Namespace: testNamespace,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+		cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Spec.MultiCluster)
+		assert.Equal(t, 10, cfg.Spec.MultiCluster.MemberClusterClientTimeout)
+	})
+
+	t.Run("explicit value is preserved", func(t *testing.T) {
+		cr := &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.DefaultOperatorConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: operatorv1.OperatorConfigSpec{
+				MultiCluster: &operatorv1.MultiClusterConfig{
+					MemberClusterClientTimeout: 42,
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+		cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Spec.MultiCluster)
+		assert.Equal(t, 42, cfg.Spec.MultiCluster.MemberClusterClientTimeout)
+	})
 }
 
 func TestLoad_PresentCR(t *testing.T) {

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -388,8 +388,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: CLUSTER_CLIENT_TIMEOUT
-              value: "10"
             - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
               value: "5"
             - name: IMAGE_PULL_POLICY

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -378,8 +378,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: CLUSTER_CLIENT_TIMEOUT
-              value: "10"
             - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
               value: "5"
             - name: IMAGE_PULL_POLICY

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -386,8 +386,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: CLUSTER_CLIENT_TIMEOUT
-              value: "10"
             - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
               value: "5"
             - name: IMAGE_PULL_POLICY


### PR DESCRIPTION
# Summary

Part of the Installation UX epic: operator settings are being moved out of Helm values / environment variables and into the `OperatorConfig` CR so they can be configured post-installation, consistently across Helm, OLM and raw YAML. This PR migrates the member-cluster API client timeout.

Previously the timeout was set via the `multiCluster.clusterClientTimeout` Helm value / `CLUSTER_CLIENT_TIMEOUT` environment variable and read directly from the environment at two sites. Now it is read once at startup from `.spec.multiCluster.memberClusterClientTimeout` and threaded into the member-cluster clients (`CreateMemberClusterClients`) and the member-cluster health checker (`MemberClusterHealthChecker`, via a new `WithTimeout` option). The Helm value, template block and rendered env var in the public manifests have been removed. The default remains `10` seconds.

Because `spec.multiCluster` is an optional pointer block, `operatorconfig.withDefaults` now materialises it and defaults the timeout to `10`, so an omitted block cannot leave clients with a zero (i.e. no) timeout.

This is a breaking change for anyone who set `multiCluster.clusterClientTimeout` / `CLUSTER_CLIENT_TIMEOUT`; a `breaking` changelog entry is included.

## Proof of Work

- `pkg/operatorconfig/operatorconfig_test.go` — added `TestLoad_MemberClusterClientTimeout` (omitted block defaults to `10`; explicit value preserved) and extended `TestLoad_AbsentCR` to assert the defaulted timeout.
- `go build ./...`, `go vet` on the touched packages, and `go test ./pkg/operatorconfig/... ./pkg/multicluster/...` all pass locally.
- `grep` confirms no remaining `CLUSTER_CLIENT_TIMEOUT` / `clusterClientTimeout` references outside the changelog; the `OperatorConfig` CRD YAML is unchanged (the field already existed).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
