### PR TITLE
CLOUDP-411215: Move memberClusterRequiredHealthyStreak setting to OperatorConfig

### DIFF
--- a/changelog/20260701_breaking_memberclusterrequiredhealthystreak_moved_to_operatorconfig.md
+++ b/changelog/20260701_breaking_memberclusterrequiredhealthystreak_moved_to_operatorconfig.md
@@ -1,0 +1,6 @@
+---
+kind: breaking
+date: 2026-07-01
+---
+
+* **Operator**: The `multiCluster.memberClusterRequiredHealthyStreak` Helm value and the `MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK` environment variable have been removed. Configure the number of consecutive successful health checks required before a previously failed member cluster is considered recovered using `.spec.multiCluster.memberClusterRequiredHealthyStreak` in the `OperatorConfig` CR instead. The default value remains `5`.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,8 +55,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
-              value: "5"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -301,6 +301,7 @@ func AddMongoDBSearchController(
 	operatorClusterName string,
 	maxConcurrentReconciles int,
 	memberClusterClientTimeout int,
+	requiredHealthyStreak int,
 ) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, mdbcSearchIndexBuilder); err != nil {
 		return err
@@ -349,7 +350,7 @@ func AddMongoDBSearchController(
 		healthChecker := memberwatch.MemberClusterHealthChecker{
 			Cache:                 make(map[string]memberwatch.ClusterHealthChecker),
 			HealthyStreak:         make(map[string]int),
-			RequiredHealthyStreak: env.ReadIntOrDefault(util.RequiredHealthyStreakEnv, util.DefaultRequiredHealthyStreak), // nolint:forbidigo
+			RequiredHealthyStreak: requiredHealthyStreak,
 			ClientTimeout:         time.Duration(memberClusterClientTimeout) * time.Second,
 		}
 		go healthChecker.WatchMemberClusterHealth(ctx, zap.S(), eventChannel, r.kubeClient, memberClusterObjectsMap)

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -139,10 +139,6 @@ spec:
             - name: MDB_OPERATOR_TELEMETRY_SEND_BASEURL
               value: "{{ $telemetry.send.baseUrl }}"
     {{- end }}
-    {{- if .Values.multiCluster.memberClusterRequiredHealthyStreak }}
-            - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
-              value: "{{ .Values.multiCluster.memberClusterRequiredHealthyStreak }}"
-    {{- end }}
     {{- $mongodbEnterpriseDatabaseImageEnv := "MONGODB_ENTERPRISE_DATABASE_IMAGE" -}}
     {{- $initDatabaseImageRepositoryEnv := "INIT_DATABASE_IMAGE_REPOSITORY" -}}
     {{- $opsManagerImageRepositoryEnv := "OPS_MANAGER_IMAGE_REPOSITORY" -}}

--- a/helm_chart/values-multi-cluster.yaml
+++ b/helm_chart/values-multi-cluster.yaml
@@ -12,4 +12,3 @@ multiCluster:
     ]
   kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
   performFailOver: true
-  memberClusterRequiredHealthyStreak: 5

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -188,7 +188,6 @@ multiCluster:
   clusters: []
   kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
   performFailOver: true
-  memberClusterRequiredHealthyStreak: 5
 
 # Resources only for the MongoDBCommunity resource reconciler
 community:

--- a/main.go
+++ b/main.go
@@ -215,6 +215,8 @@ func run() error {
 	// operatorconfig.Load guarantees MultiCluster is non-nil and defaulted.
 	memberClusterClientTimeout := operatorCfg.Spec.MultiCluster.MemberClusterClientTimeout
 
+	requiredHealthyStreak := operatorCfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak
+
 	// The CRDs the operator reconciles are configured via OperatorConfig.spec.watchedResources
 	watchedResources := make([]string, len(operatorCfg.Spec.WatchedResources))
 	for i, r := range operatorCfg.Spec.WatchedResources {
@@ -303,7 +305,7 @@ func run() error {
 		}
 	}
 	if slices.Contains(watchedResources, mongoDBMultiClusterCRDPlural) {
-		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, memberClusterClientTimeout, memberClusterObjectsMap, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
+		if err := setupMongoDBMultiClusterCRD(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, requiredHealthyStreak, memberClusterClientTimeout, memberClusterObjectsMap, operatorCfg.Spec.MaxConcurrentReconciles); err != nil {
 			return err
 		}
 	}
@@ -312,7 +314,7 @@ func run() error {
 		if operatorClusterName != "" {
 			log.Infof("Per-cluster operator mode enabled for MongoDBSearch: operator cluster identity = %q", operatorClusterName)
 		}
-		if err := setupMongoDBSearchCRD(ctx, mgr, memberClusterObjectsMap, operatorClusterName, operatorCfg.Spec.MaxConcurrentReconciles, memberClusterClientTimeout); err != nil {
+		if err := setupMongoDBSearchCRD(ctx, mgr, memberClusterObjectsMap, operatorClusterName, operatorCfg.Spec.MaxConcurrentReconciles, memberClusterClientTimeout, requiredHealthyStreak); err != nil {
 			return err
 		}
 	}
@@ -427,8 +429,7 @@ func setupMongoDBUserCRD(ctx context.Context, mgr manager.Manager, memberCluster
 	return operator.AddMongoDBUserController(ctx, mgr, memberClusterObjectsMap, backupEnableDelay, maxConcurrentReconciles)
 }
 
-func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClusterClientTimeout int, memberClusterObjectsMap map[string]runtime_cluster.Cluster, maxConcurrentReconciles int) error {
-	requiredHealthyStreak := env.ReadIntOrDefault(util.RequiredHealthyStreakEnv, util.DefaultRequiredHealthyStreak)
+func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, requiredHealthyStreak int, memberClusterClientTimeout int, memberClusterObjectsMap map[string]runtime_cluster.Cluster, maxConcurrentReconciles int) error {
 	if err := operator.AddMultiReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, requiredHealthyStreak, memberClusterClientTimeout, memberClusterObjectsMap, maxConcurrentReconciles); err != nil {
 		return err
 	}
@@ -449,12 +450,13 @@ func setupMongoDBSearchCRD(
 	operatorClusterName string,
 	maxConcurrentReconciles int,
 	memberClusterClientTimeout int,
+	requiredHealthyStreak int,
 ) error {
 	if err := operator.AddMongoDBSearchController(ctx, mgr, searchcontroller.OperatorSearchConfig{
 		SearchRepo:    env.ReadOrPanic(util.SearchRepoURLEnv),
 		SearchName:    env.ReadOrPanic(util.SearchNameEnv),
 		SearchVersion: env.ReadOrPanic(util.SearchVersionEnv),
-	}, memberClusterObjectsMap, operatorClusterName, maxConcurrentReconciles, memberClusterClientTimeout); err != nil {
+	}, memberClusterObjectsMap, operatorClusterName, maxConcurrentReconciles, memberClusterClientTimeout, requiredHealthyStreak); err != nil {
 		return err
 	}
 

--- a/pkg/operatorconfig/operatorconfig.go
+++ b/pkg/operatorconfig/operatorconfig.go
@@ -49,5 +49,8 @@ func withDefaults(cfg operatorv1.OperatorConfig) operatorv1.OperatorConfig {
 	if cfg.Spec.MultiCluster.MemberClusterClientTimeout == 0 {
 		cfg.Spec.MultiCluster.MemberClusterClientTimeout = 10
 	}
+	if cfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak == 0 {
+		cfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak = 5
+	}
 	return cfg
 }

--- a/pkg/operatorconfig/operatorconfig_test.go
+++ b/pkg/operatorconfig/operatorconfig_test.go
@@ -38,6 +38,7 @@ func TestLoad_AbsentCR(t *testing.T) {
 	// MultiCluster is a pointer; withDefaults must materialise it and default the timeout
 	require.NotNil(t, cfg.Spec.MultiCluster)
 	assert.Equal(t, 10, cfg.Spec.MultiCluster.MemberClusterClientTimeout)
+	assert.Equal(t, 5, cfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak)
 }
 
 func TestLoad_MemberClusterClientTimeout(t *testing.T) {
@@ -76,6 +77,45 @@ func TestLoad_MemberClusterClientTimeout(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cfg.Spec.MultiCluster)
 		assert.Equal(t, 42, cfg.Spec.MultiCluster.MemberClusterClientTimeout)
+	})
+}
+
+func TestLoad_MemberClusterRequiredHealthyStreak(t *testing.T) {
+	t.Run("omitted multiCluster block defaults to 5", func(t *testing.T) {
+		cr := &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.DefaultOperatorConfigName,
+				Namespace: testNamespace,
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+		cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Spec.MultiCluster)
+		assert.Equal(t, 5, cfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak)
+	})
+
+	t.Run("explicit value is preserved", func(t *testing.T) {
+		cr := &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.DefaultOperatorConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: operatorv1.OperatorConfigSpec{
+				MultiCluster: &operatorv1.MultiClusterConfig{
+					MemberClusterRequiredHealthyStreak: 7,
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+		cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Spec.MultiCluster)
+		assert.Equal(t, 7, cfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak)
 	})
 }
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -218,11 +218,6 @@ const (
 	MdbWebhookPortEnv                  = "MDB_WEBHOOK_PORT"
 	MdbWebhookNameEnv                  = "MDB_WEBHOOK_NAME"
 
-	// This default for the healthy streak is also configured in the values.yaml file.
-	// It should always be consistent with the default in the helm chart. Always change both.
-	DefaultRequiredHealthyStreak = 5
-	RequiredHealthyStreakEnv     = "MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK"
-
 	// Search environment variables
 	SearchRepoURLEnv         = "MDB_SEARCH_REPO_URL"
 	SearchNameEnv            = "MDB_SEARCH_NAME"

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -388,8 +388,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
-              value: "5"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -378,8 +378,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
-              value: "5"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -386,8 +386,6 @@ spec:
               value: "1h"
             - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
               value: "168h"
-            - name: MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK
-              value: "5"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database


### PR DESCRIPTION
# Summary

Continuing the CLOUDP-411215 migration of operator configuration from Helm values/env vars into the `OperatorConfig` CRD, this PR moves the `multiCluster.memberClusterRequiredHealthyStreak` setting.

This setting controls the number of consecutive successful health checks required before a previously failed member cluster is considered recovered and its failed-cluster annotation is removed (only relevant when automatic failover is disabled).

- Removes the `multiCluster.memberClusterRequiredHealthyStreak` Helm value and the `MDB_MEMBER_CLUSTER_REQUIRED_HEALTHY_STREAK` environment variable.
- The operator now reads `.spec.multiCluster.memberClusterRequiredHealthyStreak` from the `OperatorConfig` CR at startup and threads it into the member cluster health checkers for `MongoDBMultiCluster` and `MongoDBSearch`.
- The default value remains `5`; the CRD field already existed (scaffolded ahead of time), so no CRD schema changes were needed.

This is a breaking change — see the changelog entry.

## Proof of Work

- `pkg/operatorconfig/operatorconfig_test.go`: new `TestLoad_MemberClusterRequiredHealthyStreak` covering the omitted-defaults-to-5 and explicit-value-preserved cases, plus an updated assertion in `TestLoad_AbsentCR`.
- `go build ./...`, `go vet ./...` and `go test ./pkg/operatorconfig/... ./pkg/multicluster/... ./controllers/operator/...` all pass.
- `helm lint helm_chart` and `helm template` (both default and multi-cluster values) confirm the removed env var no longer renders and the chart still lints clean.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->

# Based on PR #1314

## Chain of upstream PRs as of 2026-07-01

* PR #1011:
  `master` ← `feature/mc-installation-ux`

  * PR #1310:
    `feature/mc-installation-ux` ← `iux-operatorconfig-spec-watchedResources`

    * PR #1314:
      `iux-operatorconfig-spec-watchedResources` ← `iux-operatorconfig-multicluster-memberclusterclienttimeout`

      * **PR #1316 (THIS ONE)**:
        `iux-operatorconfig-multicluster-memberclusterclienttimeout` ← `iux-operatorconfig-multicluster-memberclusterrequiredhealthystreak`

<!-- end git-machete generated -->