### PR TITLE
CLOUDP-400897: Remove operator env from helm charts

### DIFF
--- a/changelog/20260724_breaking_remove_operator_env_helm_value.md
+++ b/changelog/20260724_breaking_remove_operator_env_helm_value.md
@@ -1,0 +1,10 @@
+---
+kind: breaking
+date: 2026-07-24
+---
+
+* Remove Operator Env Helm Value
+
+This Helm value (and associated env var `OPERATOR_ENV`) affects default timeouts, logging level/format, and bind addresses for the operator process.
+It defaults to `prod`, but `dev` and undocumented `local` also exist, mainly for internal/dev use.
+There is no reason to expose this externally as a Helm value - we can instead set it for internal use via the env var.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,8 +39,6 @@ spec:
               cpu: 500m
               memory: 200Mi
           env:
-            - name: OPERATOR_ENV
-              value: prod
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.9.1
+  replaces: mongodb-kubernetes.v1.9.2
   version: 0.0.0

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.9.2
+  replaces: mongodb-kubernetes.v1.9.1
   version: 0.0.0

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -277,6 +277,7 @@ def list_operator_crds() -> List[V1CustomResourceDefinition]:
         key=lambda crd: crd.metadata.name,
     )
 
+
 def add_to_custom_env_vars_value(helm_args: dict, key: str, value: str) -> None:
     existing = helm_args.get("customEnvVars")
     env_vars = existing.split("&") if existing else []

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -60,7 +60,10 @@ class Operator(object):
             helm_args = {}
 
         helm_args["namespace"] = namespace
-        helm_args["operator.env"] = "dev"
+        if helm_args.get("customEnvVars"):
+            helm_args["customEnvVars"] += "\&OPERATOR_ENV=dev"
+        else:
+            helm_args["customEnvVars"] = "OPERATOR_ENV=dev"
 
         # the import is done here to prevent circular dependency
         from tests.conftest import local_operator

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -60,10 +60,8 @@ class Operator(object):
             helm_args = {}
 
         helm_args["namespace"] = namespace
-        if helm_args.get("customEnvVars"):
-            helm_args["customEnvVars"] += "\&OPERATOR_ENV=dev"
-        else:
-            helm_args["customEnvVars"] = "OPERATOR_ENV=dev"
+
+        add_to_custom_env_vars_value(helm_args, "OPERATOR_ENV", "dev")
 
         # the import is done here to prevent circular dependency
         from tests.conftest import local_operator
@@ -278,3 +276,9 @@ def list_operator_crds() -> List[V1CustomResourceDefinition]:
         ],
         key=lambda crd: crd.metadata.name,
     )
+
+def add_to_custom_env_vars_value(helm_args: dict, key: str, value: str) -> None:
+    existing = helm_args.get("customEnvVars")
+    env_vars = existing.split("&") if existing else []
+    env_vars.append(f"{key}={value}")
+    helm_args["customEnvVars"] = "&".join(env_vars)

--- a/docker/mongodb-kubernetes-tests/kubetester/operator.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/operator.py
@@ -280,6 +280,7 @@ def list_operator_crds() -> List[V1CustomResourceDefinition]:
 
 def add_to_custom_env_vars_value(helm_args: dict, key: str, value: str) -> None:
     existing = helm_args.get("customEnvVars")
-    env_vars = existing.split("&") if existing else []
+    # the value is passed to helm through a shell, so "&" must stay escaped
+    env_vars = existing.split("\\&") if existing else []
     env_vars.append(f"{key}={value}")
-    helm_args["customEnvVars"] = "&".join(env_vars)
+    helm_args["customEnvVars"] = "\\&".join(env_vars)

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -72,8 +72,6 @@ spec:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}
           {{- end }}
           env:
-            - name: OPERATOR_ENV
-              value: {{ .Values.operator.env }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -3,9 +3,6 @@
 managedSecurityContext: false
 
 operator:
-  # Execution environment for the operator, dev or prod. Use dev for more verbose logging
-  env: prod
-
   # Name that will be assigned to most internal Kubernetes objects like Deployment, ServiceAccount, Role etc.
   name: mongodb-kubernetes-operator
 

--- a/main.go
+++ b/main.go
@@ -583,7 +583,7 @@ func getMemberClusters(ctx context.Context, cfg *rest.Config, currentNamespace s
 }
 
 func isInLocalMode() bool {
-	return operatorEnvironments[1] == env.ReadOrPanic(util.OmOperatorEnv)
+	return operatorEnvironments[1] == env.ReadOrDefault(util.OmOperatorEnv, util.OperatorEnvironmentProd.String())
 }
 
 // setupWebhook sets up the validation webhook for MongoDB resources in order
@@ -692,9 +692,9 @@ func getOperatorEnv() util.OperatorEnvironment {
 	if !validateOperatorEnv(operatorEnv) {
 		operatorEnvOnce.Do(func() {
 			golog.Printf("Configured environment %s, not recognized. Must be one of %v", operatorEnv, operatorEnvironments)
-			golog.Printf("Using default environment, %s, instead", util.OperatorEnvironmentDev)
+			golog.Printf("Using default environment, %s, instead", util.OperatorEnvironmentProd)
 		})
-		operatorEnv = util.OperatorEnvironmentDev
+		operatorEnv = util.OperatorEnvironmentProd
 	}
 	return operatorEnv
 }

--- a/mongodb-community-operator/pkg/helm/helm.go
+++ b/mongodb-community-operator/pkg/helm/helm.go
@@ -18,7 +18,7 @@ func Uninstall(t *testing.T, chartName string, namespace string) error {
 // Install a helm chert at the given path with the given name and the provided set arguments.
 func Install(t *testing.T, chartPath, chartName string, flags, templateValues map[string]string) error {
 	// let's ensure we never send telemetry by accident from community
-	templateValues["operator.env"] = "dev"
+	templateValues["customEnvVars"] = "OPERATOR_ENV=dev"
 	templateValues["operator.telemetry.send.enabled"] = strconv.FormatBool(false)
 	templateValues["operator.telemetry.send.baseUrl"] = "https://cloud-dev.mongodb.com/"
 

--- a/public/architectures/setup-multi-cluster/ra-02-setup-operator/code_snippets/ra-02_0210_helm_install_operator.sh
+++ b/public/architectures/setup-multi-cluster/ra-02-setup-operator/code_snippets/ra-02_0210_helm_install_operator.sh
@@ -12,4 +12,4 @@ helm upgrade --install \
   --set operator.createResourcesServiceAccountsAndRoles=false \
   --set "multiCluster.clusters={${K8S_CLUSTER_0_CONTEXT_NAME},${K8S_CLUSTER_1_CONTEXT_NAME},${K8S_CLUSTER_2_CONTEXT_NAME}}" \
   --set "${OPERATOR_ADDITIONAL_HELM_VALUES:-"dummy=value"}" \
-  --set operator.env=dev
+  --set customEnvVars=OPERATOR_ENV=dev

--- a/public/architectures/setup-multi-cluster/ra-02-setup-operator/code_snippets/ra-02_0210_helm_install_operator.sh
+++ b/public/architectures/setup-multi-cluster/ra-02-setup-operator/code_snippets/ra-02_0210_helm_install_operator.sh
@@ -12,4 +12,4 @@ helm upgrade --install \
   --set operator.createResourcesServiceAccountsAndRoles=false \
   --set "multiCluster.clusters={${K8S_CLUSTER_0_CONTEXT_NAME},${K8S_CLUSTER_1_CONTEXT_NAME},${K8S_CLUSTER_2_CONTEXT_NAME}}" \
   --set "${OPERATOR_ADDITIONAL_HELM_VALUES:-"dummy=value"}" \
-  --set customEnvVars=OPERATOR_ENV=dev
+  --set "customEnvVars=OPERATOR_ENV=dev"

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -375,8 +375,6 @@ spec:
               drop:
               - ALL
           env:
-            - name: OPERATOR_ENV
-              value: prod
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -363,8 +363,6 @@ spec:
               cpu: 500m
               memory: 200Mi
           env:
-            - name: OPERATOR_ENV
-              value: prod
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -373,8 +373,6 @@ spec:
               drop:
               - ALL
           env:
-            - name: OPERATOR_ENV
-              value: prod
             - name: NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Summary

Remove the operator env variable (dev/prod) from helm charts. Keep the functionality in the Operator, so it can be used by manually setting the env var.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
