### PR TITLE
Fix flake in `TestStreakResetsOnUnhealthyWhenAlmostRecovered` unit test

### DIFF
--- a/pkg/multicluster/memberwatch/clusterhealth_test.go
+++ b/pkg/multicluster/memberwatch/clusterhealth_test.go
@@ -249,17 +249,20 @@ func TestStreakResetsOnUnhealthyWhenAlmostRecovered(t *testing.T) {
 
 		go checker.WatchMemberClusterHealth(ctx, zap.S(), watchChannel, central, nil)
 
-		require.Eventually(t, func() bool {
-			return checker.HealthyStreakFor("cluster1") == 0
-		}, 5*time.Second, 50*time.Millisecond)
+		// Let the watcher run its health-check iteration to completion and block on the
+		// next 10s tick. At that durable blocking point both the streak reset and the
+		// annotation write from this iteration have already happened, so we can assert on
+		// them directly instead of polling with Eventually/Never (whose own timers and
+		// goroutines interact nondeterministically with the synctest fake clock).
+		synctest.Wait()
 
-		assert.Never(t, func() bool {
-			got := &mdbmulti.MongoDBMultiCluster{}
-			if err := fakeClient.Get(ctx, types.NamespacedName{Name: "mdbmc", Namespace: "ns"}, got); err != nil {
-				return true
-			}
-			return !isInFailedClusterAnnotation(got.Annotations, "cluster1")
-		}, 5*time.Second, 50*time.Millisecond)
+		// The unhealthy report reset the near-complete streak back to zero...
+		assert.Equal(t, 0, checker.HealthyStreakFor("cluster1"))
+
+		// ...and the cluster was recorded in the failed-cluster annotation.
+		got := &mdbmulti.MongoDBMultiCluster{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "mdbmc", Namespace: "ns"}, got))
+		assert.True(t, isInFailedClusterAnnotation(got.Annotations, "cluster1"))
 	})
 }
 


### PR DESCRIPTION
# Summary

This test appears to be slow and flaky (example [here](https://spruce.corp.mongodb.com/task/__feature_mc_installation_ux_unit_tests_unit_tests_golang_patch_c257dc894cb71bc6c033e16d09ae5529c3106487_6a461391df3f460007946b47_26_07_02_07_30_27/logs?execution=1)) due to waits. This is an attempt to solve this with `synctest.Wait()`.

## Proof of Work

N/A

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
