### PR TITLE
Harden remaining memberwatch clusterhealth tests against synctest scheduling races

### DIFF
--- a/pkg/multicluster/memberwatch/clusterhealth_test.go
+++ b/pkg/multicluster/memberwatch/clusterhealth_test.go
@@ -112,13 +112,13 @@ func TestAnnotationIsAdded(t *testing.T) {
 
 		go checker.WatchMemberClusterHealth(ctx, zap.S(), watchChannel, central, nil)
 
-		require.Eventually(t, func() bool {
-			got := &mdbmulti.MongoDBMultiCluster{}
-			if err := fakeClient.Get(ctx, types.NamespacedName{Name: "mdbmc", Namespace: "ns"}, got); err != nil {
-				return false
-			}
-			return isInFailedClusterAnnotation(got.Annotations, "cluster1")
-		}, 5*time.Second, 50*time.Millisecond)
+		// Let the watcher run its health-check iteration to completion and block on the
+		// next 10s tick, so the annotation write from this iteration has already happened.
+		synctest.Wait()
+
+		got := &mdbmulti.MongoDBMultiCluster{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "mdbmc", Namespace: "ns"}, got))
+		assert.True(t, isInFailedClusterAnnotation(got.Annotations, "cluster1"))
 	})
 }
 
@@ -183,14 +183,13 @@ func TestNoEventBeforeStreakThreshold(t *testing.T) {
 
 		go checker.WatchMemberClusterHealth(ctx, zap.S(), watchChannel, central, nil)
 
-		assert.Never(t, func() bool {
-			return len(watchChannel) > 0
-		}, 500*time.Millisecond, 50*time.Millisecond)
+		// Let the watcher run its health-check iteration to completion and block on the
+		// next 10s tick, so this iteration's streak update has already happened.
+		synctest.Wait()
 
-		// Confirm the health check ran and incremented the streak without crossing the threshold.
-		assert.Eventually(t, func() bool {
-			return checker.HealthyStreakFor("cluster1") == testRequiredHealthyStreak-1
-		}, 5*time.Second, 50*time.Millisecond)
+		// The health check ran and incremented the streak without crossing the threshold.
+		assert.Equal(t, testRequiredHealthyStreak-1, checker.HealthyStreakFor("cluster1"))
+		assert.Empty(t, watchChannel)
 	})
 }
 
@@ -214,14 +213,13 @@ func TestNoEventWhenStreakAtCapWithoutAnnotation(t *testing.T) {
 
 		go checker.WatchMemberClusterHealth(ctx, zap.S(), watchChannel, central, nil)
 
-		assert.Never(t, func() bool {
-			return len(watchChannel) > 0
-		}, 500*time.Millisecond, 50*time.Millisecond)
+		// Let the watcher run its health-check iteration to completion and block on the
+		// next 10s tick, so this iteration's streak update has already happened.
+		synctest.Wait()
 
-		// Confirm the streak stayed capped and didn't wrap or overflow.
-		assert.Eventually(t, func() bool {
-			return checker.HealthyStreakFor("cluster1") == testRequiredHealthyStreak
-		}, 5*time.Second, 50*time.Millisecond)
+		// The streak stayed capped and didn't wrap or overflow.
+		assert.Equal(t, testRequiredHealthyStreak, checker.HealthyStreakFor("cluster1"))
+		assert.Empty(t, watchChannel)
 	})
 }
 
@@ -286,14 +284,13 @@ func TestNoEventWhenClusterNotInAnnotationAtThreshold(t *testing.T) {
 
 		go checker.WatchMemberClusterHealth(ctx, zap.S(), watchChannel, central, nil)
 
-		assert.Never(t, func() bool {
-			return len(watchChannel) > 0
-		}, 500*time.Millisecond, 50*time.Millisecond)
+		// Let the watcher run its health-check iteration to completion and block on the
+		// next 10s tick, so this iteration's streak update has already happened.
+		synctest.Wait()
 
-		// Confirm the streak reached the threshold even though no event was fired (no annotation present).
-		assert.Eventually(t, func() bool {
-			return checker.HealthyStreakFor("cluster1") == testRequiredHealthyStreak
-		}, 5*time.Second, 50*time.Millisecond)
+		// The streak reached the threshold even though no event was fired (no annotation present).
+		assert.Equal(t, testRequiredHealthyStreak, checker.HealthyStreakFor("cluster1"))
+		assert.Empty(t, watchChannel)
 	})
 }
 
@@ -418,10 +415,12 @@ func TestFailedClusterAnnotationStaysWhenPerformFailoverTrue(t *testing.T) {
 
 		go checker.WatchMemberClusterHealth(ctx, zap.S(), watchChannel, central, nil)
 
-		assert.Never(t, func() bool {
-			return len(watchChannel) > 0
-		}, 500*time.Millisecond, 50*time.Millisecond)
-		assert.Never(t, func() bool { return checker.HealthyStreakFor("cluster1") > 0 }, 500*time.Millisecond, 50*time.Millisecond)
+		// Let the watcher run its health-check iteration to completion and block on the
+		// next 10s tick, so this iteration's (lack of) streak update has already happened.
+		synctest.Wait()
+
+		assert.Empty(t, watchChannel)
+		assert.Equal(t, 0, checker.HealthyStreakFor("cluster1"))
 
 		got := &mdbmulti.MongoDBMultiCluster{}
 		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "mdbmc", Namespace: "ns"}, got))


### PR DESCRIPTION
# Summary

Stacked on #1319, which fixed a flake in `TestStreakResetsOnUnhealthyWhenAlmostRecovered` caused by `assert.Eventually`/`assert.Never` racing the watcher goroutine inside a `synctest` bubble: testify spawns a fresh goroutine per poll, so two non-atomic effects of the same watcher iteration (streak update, then annotation write) can be observed out of order.

This PR applies the same `synctest.Wait()` pattern to the other tests in `clusterhealth_test.go` that used `assert.Never`/`assert.Eventually` pairs, for consistency and to remove the arbitrary 500ms/5s polling timeouts. Tests that already synchronize correctly via `<-watchChannel` (a genuine happens-before point, since the channel send happens after the relevant writes in the watcher's program order) are left unchanged.

## Proof of Work

- `pkg/multicluster/memberwatch/clusterhealth_test.go` — ran the full package with `go test ./pkg/multicluster/memberwatch/... -race -count=20` and `go test ./pkg/multicluster/... -race -count=5`; all pass with no flakes.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title? — N/A, test-only deflake follow-up
- [x] Have you checked whether your jira ticket required DOCSP changes? — N/A, no jira ticket
- [x] Have you added changelog file?
    - `skip-changelog` label applied (test-only change, no user-facing behaviour)