### PR TITLE
KUBE-78: redirect automation agent stderr to stdout instead of PVC file

### DIFF
--- a/changelog/20260702_fix_automation_agent_stderr_no_longer_written_to_pvc.md
+++ b/changelog/20260702_fix_automation_agent_stderr_no_longer_written_to_pvc.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-07-02
+---
+
+* **MongoDB**: Fixed an issue where the automation agent's stderr output was written to `automation-agent-stderr.log` on the persistent volume. Under certain failure conditions (for example, when agent logging failed to initialize due to corrupted `.slogger-state-*` files), this file would grow without bound, eventually filling the PVC and crashing the pod. The automation agent's stderr is now streamed directly to the pod's stdout, eliminating unbounded file growth.

--- a/changelog/20260702_fix_automation_agent_stderr_no_longer_written_to_pvc.md
+++ b/changelog/20260702_fix_automation_agent_stderr_no_longer_written_to_pvc.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-07-02
 ---
 
-* **MongoDB**: Fixed an issue where the automation agent's stderr output was written to `automation-agent-stderr.log` on the persistent volume. Under certain failure conditions (for example, when agent logging failed to initialize due to corrupted `.slogger-state-*` files), this file would grow without bound, eventually filling the PVC and crashing the pod. The automation agent's stderr is now streamed directly to the pod's stdout, eliminating unbounded file growth.
+* **MongoDB**: Fixed an issue where `automation-agent-stderr.log` could grow unboundedly on the persistent volume and fill the PVC. The automation agent's stderr is now streamed directly to the pod's stdout instead of written to a file.

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -62,7 +62,6 @@ const (
 
 	LogFileAutomationAgentEnv        = "MDB_LOG_FILE_AUTOMATION_AGENT"
 	LogFileAutomationAgentVerboseEnv = "MDB_LOG_FILE_AUTOMATION_AGENT_VERBOSE"
-	LogFileAutomationAgentStderrEnv  = "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR"
 	LogFileMongoDBAuditEnv           = "MDB_LOG_FILE_MONGODB_AUDIT"
 	LogFileMongoDBEnv                = "MDB_LOG_FILE_MONGODB"
 	LogFileAgentMonitoringEnv        = "MDB_LOG_FILE_MONITORING_AGENT"
@@ -963,10 +962,8 @@ func getAutomationLogEnvVars(parameters mdbv1.StartupParameters) []corev1.EnvVar
 	logFileWithoutExt := logFileName[0 : len(logFileName)-len(logFileExt)]
 
 	verboseLogFile := fmt.Sprintf("%s%s-verbose%s", logFileDir, logFileWithoutExt, logFileExt)
-	stderrLogFile := fmt.Sprintf("%s%s-stderr%s", logFileDir, logFileWithoutExt, logFileExt)
 	return []corev1.EnvVar{
 		{Name: LogFileAutomationAgentVerboseEnv, Value: verboseLogFile},
-		{Name: LogFileAutomationAgentStderrEnv, Value: stderrLogFile},
 		{Name: LogFileAutomationAgentEnv, Value: automationLogFile},
 	}
 }

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -230,28 +230,25 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 	})
 
 	envVars := logConfigurationToEnvVars(parameters, additionalMongodConfig)
-	assert.Len(t, envVars, 7)
+	assert.Len(t, envVars, 6)
 
 	logFileAutomationAgentEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "log.file")}
 	logFileAutomationAgentVerboseEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "log-verbose.file")}
-	logFileAutomationAgentStderrEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: path.Join(util.PvcMountPathLogs, "log-stderr.file")}
 	logFileAutomationAgentDefaultEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")}
 	logFileAutomationAgentVerboseDefaultEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")}
-	logFileAutomationAgentStderrDefaultEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-stderr.log")}
 	logFileMongoDBAuditEnvVar := corev1.EnvVar{Name: LogFileMongoDBAuditEnv, Value: path.Join(util.PvcMountPathLogs, "audit.log")}
 	logFileMongoDBAuditDefaultEnvVar := corev1.EnvVar{Name: LogFileMongoDBAuditEnv, Value: path.Join(util.PvcMountPathLogs, "mongodb-audit.log")}
 	logFileMongoDBEnvVar := corev1.EnvVar{Name: LogFileMongoDBEnv, Value: path.Join(util.PvcMountPathLogs, "mongodb.log")}
 	logFileAgentMonitoringEnvVar := corev1.EnvVar{Name: LogFileAgentMonitoringEnv, Value: path.Join(util.PvcMountPathLogs, "monitoring-agent.log")}
 	logFileAgentBackupEnvVar := corev1.EnvVar{Name: LogFileAgentBackupEnv, Value: path.Join(util.PvcMountPathLogs, "backup-agent.log")}
 
-	numberOfLogFilesInEnvVars := 7
+	numberOfLogFilesInEnvVars := 6
 
 	t.Run("automation log is changed and audit log is changed", func(t *testing.T) {
 		envVars := logConfigurationToEnvVars(parameters, additionalMongodConfig)
 		assert.Len(t, envVars, numberOfLogFilesInEnvVars)
 		assert.Contains(t, envVars, logFileAutomationAgentEnvVar)
 		assert.Contains(t, envVars, logFileAutomationAgentVerboseEnvVar)
-		assert.Contains(t, envVars, logFileAutomationAgentStderrEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBAuditEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBEnvVar)
 		assert.Contains(t, envVars, logFileAgentMonitoringEnvVar)
@@ -263,7 +260,6 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 		assert.Len(t, envVars, numberOfLogFilesInEnvVars)
 		assert.Contains(t, envVars, logFileAutomationAgentEnvVar)
 		assert.Contains(t, envVars, logFileAutomationAgentVerboseEnvVar)
-		assert.Contains(t, envVars, logFileAutomationAgentStderrEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBAuditEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBEnvVar)
 		assert.Contains(t, envVars, logFileAgentMonitoringEnvVar)
@@ -275,7 +271,6 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 		assert.Len(t, envVars, numberOfLogFilesInEnvVars)
 		assert.Contains(t, envVars, logFileAutomationAgentDefaultEnvVar)
 		assert.Contains(t, envVars, logFileAutomationAgentVerboseDefaultEnvVar)
-		assert.Contains(t, envVars, logFileAutomationAgentStderrDefaultEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBAuditEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBEnvVar)
 		assert.Contains(t, envVars, logFileAgentMonitoringEnvVar)
@@ -287,7 +282,6 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 		assert.Len(t, envVars, numberOfLogFilesInEnvVars)
 		assert.Contains(t, envVars, logFileAutomationAgentDefaultEnvVar)
 		assert.Contains(t, envVars, logFileAutomationAgentVerboseDefaultEnvVar)
-		assert.Contains(t, envVars, logFileAutomationAgentStderrDefaultEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBAuditDefaultEnvVar)
 		assert.Contains(t, envVars, logFileMongoDBEnvVar)
 		assert.Contains(t, envVars, logFileAgentMonitoringEnvVar)
@@ -300,34 +294,29 @@ func TestGetAutomationLogEnvVars(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": "path/to/log.file"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: "path/to/log.file"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: "path/to/log-verbose.file"})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: "path/to/log-stderr.file"})
 	})
 
 	t.Run("automation log file without extension", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": "path/to/logfile"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: "path/to/logfile"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: "path/to/logfile-verbose"})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: "path/to/logfile-stderr"})
 	})
 	t.Run("invalid automation log file is not crashing", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": "path/to/"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: "path/to/"})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: "path/to/-verbose"})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: "path/to/-stderr"})
 	})
 
 	t.Run("empty automation log file is falling back to default names", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": ""})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-stderr.log")})
 	})
 
 	t.Run("not set logFile cause falling back to default names", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")})
 		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentStderrEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-stderr.log")})
 	})
 }
 

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -25,7 +25,6 @@ source /opt/scripts/agent-launcher-lib.sh
 
 # all the following MDB_LOG_FILE_* env var should be defined in container's env vars
 tail -F -n0 "${MDB_LOG_FILE_AUTOMATION_AGENT_VERBOSE}" 2> /dev/null | json_log 'automation-agent-verbose' &
-tail -F -n0 "${MDB_LOG_FILE_AUTOMATION_AGENT_STDERR}" 2> /dev/null | json_log 'automation-agent-stderr' &
 tail -F -n0 "${MDB_LOG_FILE_AUTOMATION_AGENT}" 2> /dev/null | json_log 'automation-agent' &
 tail -F -n0 "${MDB_LOG_FILE_MONITORING_AGENT}" 2> /dev/null | json_log 'monitoring-agent' &
 tail -F -n0 "${MDB_LOG_FILE_BACKUP_AGENT}" 2> /dev/null | json_log 'backup-agent' &
@@ -227,7 +226,7 @@ else
 fi
 
 # Note, that we do logging in subshell - this allows us to save the correct PID to variable (not the logging one)
-"${AGENT_BINARY_PATH}" "${agentOpts[@]}" "${splittedAgentFlags[@]}" 2>> "${MDB_LOG_FILE_AUTOMATION_AGENT_STDERR}" >> >(json_log "automation-agent-stdout") &
+"${AGENT_BINARY_PATH}" "${agentOpts[@]}" "${splittedAgentFlags[@]}" 2> >(json_log "automation-agent-stderr") >> >(json_log "automation-agent-stdout") &
 
 export agentPid=$!
 script_log "Launched automation agent, pid=${agentPid}"

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
@@ -588,7 +588,6 @@ def assert_container_env_vars(namespace: str, pod_name: str):
             "SSL_REQUIRE_VALID_MMS_CERTIFICATES",
             "MULTI_CLUSTER_MODE",
             "MDB_LOG_FILE_AUTOMATION_AGENT_VERBOSE",
-            "MDB_LOG_FILE_AUTOMATION_AGENT_STDERR",
             "MDB_LOG_FILE_AUTOMATION_AGENT",
             "MDB_LOG_FILE_MONITORING_AGENT",
             "MDB_LOG_FILE_BACKUP_AGENT",

--- a/scripts/evergreen/e2e/dump_diagnostic_information.sh
+++ b/scripts/evergreen/e2e/dump_diagnostic_information.sh
@@ -188,9 +188,6 @@ dump_pod_logs() {
 
     done
 
-    if kubectl --context="${context}" exec "${pod}" -n "${namespace}" -- ls /var/log/mongodb-mms-automation/automation-agent-stderr.log &>/dev/null; then
-        kubectl --context="${context}" cp "${namespace}/${pod}:/var/log/mongodb-mms-automation/automation-agent-stderr.log" "logs/${prefix}${pod}-agent-stderr.log" &> /dev/null
-    fi
 }
 
 # dump_pod_readiness_state dumps readiness and agent-health-status files.

--- a/scripts/evergreen/e2e/test_summary/collector.py
+++ b/scripts/evergreen/e2e/test_summary/collector.py
@@ -380,7 +380,6 @@ class TestSummaryGenerator:
           - {prefix}{pod}-pod-describe.txt          (kubectl describe)
           - {prefix}{pod}-agent-verbose.log          (automation agent verbose log)
           - {prefix}{pod}-agent.log                  (automation agent log)
-          - {prefix}{pod}-agent-stderr.log           (agent stderr)
           - {prefix}{pod}-monitoring-agent-verbose.log
           - {prefix}{pod}-monitoring-agent.log
           - {prefix}{pod}-monitoring-agent-stdout.log
@@ -423,7 +422,6 @@ class TestSummaryGenerator:
                 for a in (
                     "agent-verbose",
                     "agent.",
-                    "agent-stderr",
                     "monitoring-agent",
                 )
             ):
@@ -852,7 +850,6 @@ class TestSummaryGenerator:
 
         known_suffixes = [
             "-agent-verbose",
-            "-agent-stderr",
             "-agent",
             "-monitoring-agent-verbose",
             "-monitoring-agent-stdout",


### PR DESCRIPTION
# Summary

<!-- Enter your PR summary here. Try to emphasize on WHY this change is needed, followed by what's being done in the PR. -->

- automation-agent-stderr.log was written to a file on the PVC, with no rotation or size limit
- Under certain conditions the PVC was filled and crashing the pod
- This fix redirects the automation agent's stderr directly to the pod's stdout stream, eliminating the unbounded file growth

example output in `agent-container.log` in the evg patch (random test chosen): [link](https://operator-e2e-artifacts.s3.us-east-1.amazonaws.com/logs/mongodb_kubernetes_e2e_static_mdb_kind_ubi_cloudqa_e2e_replica_set_recovery_patch_5a7307c621ce7cc55804e74cffd84cfb5134c909_6a463aed6695cc000771e89f_26_07_02_10_18_24/0/_a-1782987932-61ydkruq1gz_my-invalid-replica-set-0-mongodb-agent-container.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Checksum-Mode=ENABLED&X-Amz-Credential=AKIAT5B2QITEKCB6K6KZ%2F20260702%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260702T103611Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=774bf5397e1eb6e0a8625313e50c40667f8261c2dc015bd7c7d16151e665ac99)

```
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.653+0000] [.debug] [util/distros/distros.go:LinuxFlavorAndVersionUncached:112] Detected linux flavor rhel version 9.8"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.656+0000] [.debug] [src/mmsserverappender/backendmmsserverappender.go:func2:405] Started BackendMmsServerAppender with postPeriod=1m0s"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.info] [src/logrotator/maintainer.go:mainLoop:84] <Log Rotation> [10:30:56.716] Starting log rotation maintainer main loop"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/maintainers/externalmaintainer.go:mainLoop:762] [10:30:56.717] Maintenence round completed with status={false 0 {true false 0  true false true true -1 [] map[]}} in 830ns"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/mmsserverappender/backendmmsserverappender.go:func4:405] BackendMmsServerAppender received flush request.  Flushing..."}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/maintainers/externalmaintainer.go:mainLoop:769] [10:30:56.717] Resetting maintainTimer to 9.325s"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/maintainers/externalmaintainer.go:mainLoop:762] [10:30:56.717] Maintenence round completed with status={false 0 {true false 0  true false true true -1 [] map[]}} in 1.288Âµs"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/maintainers/externalmaintainer.go:mainLoop:762] [10:30:56.717] Maintenence round completed with status={false 0 {true false 0  true false true true -1 [] map[]}} in 894ns"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/maintainers/externalmaintainer.go:mainLoop:769] [10:30:56.717] Resetting maintainTimer to 9.969s"}
{"logType":"automation-agent-stderr","contents":"[2026-07-02T10:30:56.717+0000] [.debug] [src/maintainers/externalmaintainer.go:mainLoop:769] [10:30:56.717] Resetting maintainTimer to 9.395s"}
{"logType":"automation-agent-st
```

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
