### PR TITLE
KUBE-148 Disable Search metrics forwarding in OM <8.0.25

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -911,8 +911,9 @@ task_groups:
       - e2e_search_replicaset_external_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_mongot_replicaset_x509_auth
-      - e2e_search_enterprise_metrics_forwarder_replicaset
-      - e2e_search_external_metrics_forwarder_replicaset
+      # Disabled in KUBE-148, restore once OM 8.0.25 is out
+      # - e2e_search_enterprise_metrics_forwarder_replicaset
+      # - e2e_search_external_metrics_forwarder_replicaset
     <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_large_task_group but for om80 variants.
@@ -938,8 +939,9 @@ task_groups:
       - e2e_search_cds_hot_reload
       - e2e_search_envoy_retry_policy
       - e2e_search_auto_embedding_rolling_restart
-      - e2e_search_enterprise_metrics_forwarder_sharded
-      - e2e_search_external_metrics_forwarder_sharded
+      # Disabled in KUBE-148, restore once OM 8.0.25 is out
+      # - e2e_search_enterprise_metrics_forwarder_sharded
+      # - e2e_search_external_metrics_forwarder_sharded
     <<: *teardown_group
 
   # this task group contains just a one task, which is smoke testing whether the operator

--- a/changelog/20260702_fix_ops_manager_search_awareness_minimum_version.md
+++ b/changelog/20260702_fix_ops_manager_search_awareness_minimum_version.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-07-02
+---
+
+* **MongoDBSearch**: The minimum Ops Manager version required for Search metrics to be forwarded to Ops Manager is now 8.0.25 due to a bug in 8.0.24.

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -67,7 +67,7 @@ const (
 	// metricsForwarderMinOpsManagerVersion is the minimum self-hosted Ops Manager version that
 	// supports the metrics forwarding ingest endpoint. Versions below this do not expose the
 	// endpoint, so the forwarder cannot function correctly against them.
-	metricsForwarderMinOpsManagerVersion = "8.0.24"
+	metricsForwarderMinOpsManagerVersion = "8.0.25"
 
 	// how long to wait before re-checking whether removed mongot
 	// pods have terminated so their Ops Manager hosts can be safely deregistered.
@@ -561,7 +561,7 @@ func (r omHTTPAgentRequester) GetOMVersion(projectConfig mdbv1.ProjectConfig) (v
 }
 
 // checkOMVersionForMetricsEndpoint verifies that the Ops Manager instance reachable via projectConfig
-// supports the metrics forwarding ingest endpoint (requires >= 8.0.24). It returns (false, status)
+// supports the metrics forwarding ingest endpoint (requires >= 8.0.25). It returns (false, status)
 // when the forwarder must not proceed, and (true, workflow.OK()) when it may.
 //
 // The connection is "explicit" when the user directly populated .spec.observability.metricsForwarder.opsManager
@@ -572,7 +572,7 @@ func (r omHTTPAgentRequester) GetOMVersion(projectConfig mdbv1.ProjectConfig) (v
 //   - OM unreachable (fetch error):          Pending — retries on the next reconcile.
 //   - Unknown version or unparseable semver: Implicit → Unsupported; Explicit → Failed.
 //   - Cloud Manager connection:              Implicit → Unsupported; Explicit → Failed.
-//   - Self-hosted OM version < 8.0.24:      Implicit → Unsupported; Explicit → Failed.
+//   - Self-hosted OM version < 8.0.25:      Implicit → Unsupported; Explicit → Failed.
 func (r *MongoDBSearchMetricsForwarderReconciler) checkOMVersionForMetricsEndpoint(mdbSearch *searchv1.MongoDBSearch, projectConfig mdbv1.ProjectConfig, log *zap.SugaredLogger) (bool, workflow.Status) {
 	explicit := mdbSearch.MetricsForwarderHasExplicitProjectConfig()
 

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -145,7 +145,7 @@ func (s stubOMAgentRequester) GetOMVersion(projectConfig mdbv1.ProjectConfig) (v
 
 // newStubOMAgentRequester returns a requester that resolves the group API to the given groupID and
 // treats every host deletion as a no-op success. The OM version defaults to the minimum supported
-// version (8.0.24) so existing tests are unaffected.
+// version (8.0.25) so existing tests are unaffected.
 func newStubOMAgentRequester(groupID string) stubOMAgentRequester {
 	return stubOMAgentRequester{
 		fn: func(_ mdbv1.ProjectConfig, method, path, _ string, _ any) ([]byte, error) {
@@ -1413,7 +1413,7 @@ func TestMetricsForwarder_OMVersionTooOld_ImplicitConnection(t *testing.T) {
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
 	assert.Equal(t, status.PhaseUnsupported, updatedSearch.Status.MetricsForwarder.Phase)
-	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "8.0.24")
+	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, metricsForwarderMinOpsManagerVersion)
 
 	// No Deployment must exist.
 	dep := &appsv1.Deployment{}
@@ -1438,7 +1438,7 @@ func TestMetricsForwarder_OMVersionTooOld_ExplicitConnection(t *testing.T) {
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
 	assert.Equal(t, status.PhaseFailed, updatedSearch.Status.MetricsForwarder.Phase)
-	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "8.0.24")
+	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, metricsForwarderMinOpsManagerVersion)
 
 	dep := &appsv1.Deployment{}
 	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
@@ -1461,7 +1461,7 @@ func TestMetricsForwarder_ExternalSource_OMVersionTooOld(t *testing.T) {
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
 	assert.Equal(t, status.PhaseFailed, updatedSearch.Status.MetricsForwarder.Phase)
-	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "8.0.24")
+	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, metricsForwarderMinOpsManagerVersion)
 }
 
 // TestMetricsForwarder_CloudManager_ImplicitConnection: implicit connection pointing at Cloud Manager.
@@ -1519,8 +1519,8 @@ func TestMetricsForwarder_OMVersionSupported(t *testing.T) {
 	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
 
 	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
-	// Default stub already returns 8.0.24; being explicit here for clarity.
-	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: "8.0.24"})
+	// Default stub already returns 8.0.25; being explicit here for clarity.
+	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: metricsForwarderMinOpsManagerVersion})
 
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 


### PR DESCRIPTION
# Summary
Ops Manager 8.0.24 has a bug that causes its preflight checks to fail on startup if mongot hosts are registered. This disables Search metrics forwarding against 8.0.24 - the fix is in 8.0.25.

## Proof of Work
[e2e tests running against 8.0.24 fail because the metrics forwarder phase is disabled](https://spruce.corp.mongodb.com/version/6a463eeb33e3dc00078aa4ac/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
