### PR TITLE
Regenerate multi-cluster GitOps RBAC samples to match generator output

### DIFF
--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml
@@ -13,6 +13,7 @@ rules:
   - clustermongodbroles
   verbs:
   - '*'
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -113,6 +114,7 @@ rules:
   verbs:
   - list
   - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -140,6 +142,7 @@ rules:
   - /version
   verbs:
   - get
+
 ---
 # Central Cluster, cluster-scoped resources
 apiVersion: rbac.authorization.k8s.io/v1
@@ -157,6 +160,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -173,6 +177,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -189,6 +194,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 # Central Cluster, cluster-scoped resources
 apiVersion: v1
@@ -199,5 +205,5 @@ metadata:
     multi-cluster: "true"
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
----
 
+---

--- a/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
+++ b/public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml
@@ -92,6 +92,7 @@ rules:
   - watch
   - delete
   - deletecollection
+
 ---
 # Central Cluster, namespace-scoped resources
 apiVersion: rbac.authorization.k8s.io/v1
@@ -110,6 +111,7 @@ subjects:
 - kind: ServiceAccount
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
+
 ---
 # Central Cluster, namespace-scoped resources
 apiVersion: v1
@@ -120,5 +122,5 @@ metadata:
     multi-cluster: "true"
   name: mongodb-kubernetes-operator-multicluster
   namespace: central-namespace
----
 
+---


### PR DESCRIPTION
# Summary

The public multi-cluster RBAC samples are generated by TestPrintingOutRolesServiceAccountsAndRoleBindings, which only runs under `make precommit-full` (MDB_REGENERATE_RBAC=true).

The checked-in files were stale relative to the generator's current formatting (blank line before each `---` separator), so `make precommit-full` left a dirty tree while `make precommit` passed clean.

Commit the regenerated (whitespace-only) output so both targets agree.

## Proof of Work

CI passes

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
 