### PR TITLE
CLOUDP-411215: Cleanup - remove mention of `multiCluster.clusterClientTimeout`

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -93,7 +93,6 @@ def _install_simulated_operator(
         "operator.watchNamespace",
         "multiCluster.clusters",
         "multiCluster.kubeConfigSecretName",
-        "multiCluster.clusterClientTimeout",
         "multiCluster.performFailover",
     ):
         helm_args.pop(k, None)


### PR DESCRIPTION
# Summary

Addresses feedback from https://github.com/mongodb/mongodb-kubernetes/pull/1314#issuecomment-4867046753

## Proof of Work

N/A

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
