### PR TITLE
Create the release tag with the explicit commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,11 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git tag -a $VERSION -m "Release of MCK $VERSION"
+          git tag -a $VERSION -m "Release of MCK $VERSION" $COMMIT_SHA
           git push origin $VERSION
         env:
           VERSION: ${{ github.event.inputs.version }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_release:


### PR DESCRIPTION
# Summary
Specifying the explicit commit SHA in the `git tag` command prevents tagging the wrong commit if newer commits made their way into the target branch after the release candidate commit has been selected.

## Proof of Work
[Workflow run](https://github.com/mongodb/mongodb-kubernetes/actions/runs/28655077731/job/84982631416) against the `fealebenpae/release-workflow-tagging` branch (https://github.com/mongodb/mongodb-kubernetes/commit/fd091caff010e675bbda643187be984445ac7ab0 being the tip of the branch) with https://github.com/mongodb/mongodb-kubernetes/commit/f935a71a503c0c98f8caf517d7bfed09c4c691e2 as the commit sha and `1.9.1-test` as the version.
The `1.9.1-test` tag was created from the requested commit, not the tip of the branch:
<img width="207" height="78" alt="image" src="https://github.com/user-attachments/assets/17cbd5d8-c471-4b21-82fb-b58bcfd1193f" />

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
