### PR TITLE
Fix Evergreen operator performance test variant setup

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -732,6 +732,11 @@ functions:
         binary: scripts/evergreen/e2e/e2e.sh
 
   e2e_test_perf:
+    # Perf tasks provision and roll many deployments; the 300-deployment task exceeds the
+    # global 2h exec_timeout_secs. Raise the limit for perf tasks only.
+    - command: timeout.update
+      params:
+        exec_timeout_secs: 14400
     - command: subprocess.exec
       type: test
       retry_on_failure: true

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -564,6 +564,7 @@ tasks:
     commands:
       - func: clone
       - func: switch_context
+      - func: python_venv
       - func: generate_perf_tests_tasks
         vars:
           variant: e2e_operator_perf_one_thread
@@ -573,6 +574,7 @@ tasks:
     commands:
       - func: clone
       - func: switch_context
+      - func: python_venv
       - func: generate_perf_tests_tasks
         vars:
           variant: e2e_operator_perf
@@ -582,6 +584,7 @@ tasks:
     commands:
       - func: clone
       - func: switch_context
+      - func: python_venv
       - func: generate_perf_tests_tasks
         vars:
           variant: e2e_operator_perf_thirty
@@ -1975,7 +1978,7 @@ buildvariants:
     tags: [ "manual_patch", "e2e_perf_test_suite" ]
     allowed_requesters: [ "patch" ]
     run_on:
-      - ubuntu1804-xlarge
+      - ubuntu2404-xlarge
     <<: *base_om7_dependency
     tasks:
       - name: generate_perf_tasks_10_thread
@@ -1985,7 +1988,7 @@ buildvariants:
     tags: [ "manual_patch", "e2e_perf_test_suite" ]
     allowed_requesters: [ "patch" ]
     run_on:
-      - ubuntu1804-xlarge
+      - ubuntu2404-xlarge
     <<: *base_om7_dependency
     tasks:
       - name: generate_perf_tasks_one_thread
@@ -1995,7 +1998,7 @@ buildvariants:
     tags: [ "manual_patch", "e2e_perf_test_suite" ]
     allowed_requesters: [ "patch" ]
     run_on:
-      - ubuntu1804-xlarge
+      - ubuntu2404-xlarge
     <<: *base_om7_dependency
     tasks:
       - name: generate_perf_tasks_30_thread

--- a/scripts/evergreen/e2e/performance/create_variants.py
+++ b/scripts/evergreen/e2e/performance/create_variants.py
@@ -37,6 +37,7 @@ group = TaskGroup(
     setup_group=[
         FunctionCall("clone"),
         FunctionCall("download_kube_tools"),
+        FunctionCall("switch_context"),
         FunctionCall("setup_building_host"),
     ],
     setup_task=[

--- a/scripts/evergreen/e2e/performance/create_variants.py
+++ b/scripts/evergreen/e2e/performance/create_variants.py
@@ -50,7 +50,7 @@ group = TaskGroup(
         FunctionCall("teardown_kubernetes_environment"),
         FunctionCall("teardown_cloud_qa"),
     ],
-    teardown_group=[FunctionCall("prune_docker_resources"), FunctionCall("run_retry_script")],
+    teardown_group=[FunctionCall("prune_docker_resources")],
 )
 
 build_variant = BuildVariant(variant).display_task(variant)


### PR DESCRIPTION
# Summary

The operator performance test Evergreen variants (`e2e_operator_perf` and its one-/thirty-thread siblings) had bit-rotted and could not run. This PR fixes the accumulated issues so the variant runs end-to-end again. All are pre-existing infrastructure problems, independent of any operator behaviour change:

- **Distro:** moved the perf variants off the EOL `ubuntu1804-xlarge` (curl 7.58 rejects `--retry-all-errors` / `--fail-with-body` used by the shared download helper) to `ubuntu2404-xlarge`.
- **Missing venv:** the `generate_perf_tasks_*` generator tasks never created the Python venv, so `run_python.sh` wrote an error into the generated tasks JSON and `generate.tasks` could not parse it. Added `python_venv`.
- **Dangling function:** `create_variants.py` referenced a non-existent `run_retry_script` function in the task group teardown, which `generate.tasks` rejected. Removed it.
- **Single-node cluster:** the generated perf task group was missing `switch_context` in its `setup_group`, so the `performance` context was not applied and a single-node kind cluster was built instead of the intended 6-node one — capping pod capacity and stalling the test partway. Added `switch_context`.
- **Task timeout:** the 300-deployment task needs more than the global 2h `exec_timeout_secs` to roll updates across all deployments. Raised the perf tasks' exec timeout to 4h via `timeout.update`.

## Proof of Work

- Baseline on unmodified master (ubuntu1804) — fails at host setup, confirming the variant was already broken on master: https://spruce.mongodb.com/version/6a477b6fc08dd000078f8e15
- All four generated perf tasks pass (`perf_180d_1r`, `perf_300d_1r`, `perf_60d_3r`, `perf_90d_2r`): https://spruce.mongodb.com/version/6a4ba9eb99e0640007c9264a
- Re-verified after rebasing on master: https://spruce.mongodb.com/version/6a4bd97642cf280007aea3ea
- e2e: N/A (Evergreen CI/tooling change only; no operator runtime code touched)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details