### PR TITLE
CLOUDP-411215: Move telemetry settings to OperatorConfig

### DIFF
--- a/api/operator/v1/operatorconfig_types.go
+++ b/api/operator/v1/operatorconfig_types.go
@@ -136,6 +136,13 @@ type TelemetryCollectionConfig struct {
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1m')",message="frequency must be at least 1m"
 	Frequency *metav1.Duration `json:"frequency,omitempty"`
 
+	// KubeTimeout is the timeout for Kubernetes API calls made while collecting telemetry.
+	// Duration using h (hours), m (minutes) and s (seconds) units, e.g. "30s", "5m". Must be at least 1s; defaults to 5m when omitted.
+	// +optional
+	// +kubebuilder:default="5m"
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="kubeTimeout must be at least 1s"
+	KubeTimeout *metav1.Duration `json:"kubeTimeout,omitempty"`
+
 	// Clusters controls collection of cluster-level telemetry.
 	// +optional
 	Clusters *TelemetryCollectionClustersConfig `json:"clusters,omitempty"`

--- a/api/operator/v1/zz_generated.deepcopy.go
+++ b/api/operator/v1/zz_generated.deepcopy.go
@@ -348,6 +348,11 @@ func (in *TelemetryCollectionConfig) DeepCopyInto(out *TelemetryCollectionConfig
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.KubeTimeout != nil {
+		in, out := &in.KubeTimeout, &out.KubeTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.Clusters != nil {
 		in, out := &in.Clusters, &out.Clusters
 		*out = new(TelemetryCollectionClustersConfig)

--- a/changelog/20260706_breaking_telemetry_moved_to_operatorconfig.md
+++ b/changelog/20260706_breaking_telemetry_moved_to_operatorconfig.md
@@ -1,0 +1,6 @@
+---
+kind: breaking
+date: 2026-07-06
+---
+
+* **Operator**: The `operator.telemetry.*` Helm values and the `MDB_OPERATOR_TELEMETRY_ENABLED`, `MDB_OPERATOR_TELEMETRY_SEND_ENABLED`, `MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY`, `MDB_OPERATOR_TELEMETRY_COLLECTION_CLUSTERS_ENABLED`, `MDB_OPERATOR_TELEMETRY_COLLECTION_DEPLOYMENTS_ENABLED`, `MDB_OPERATOR_TELEMETRY_COLLECTION_OPERATORS_ENABLED`, `MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY` and `MDB_OPERATOR_TELEMETRY_KUBE_TIMEOUT` environment variables have been removed. Configure telemetry using the `.spec.telemetry` block in the `OperatorConfig` CR instead: `.spec.telemetry.mode` (master switch, `Enabled`/`Disabled`), `.spec.telemetry.collection.frequency`, `.spec.telemetry.collection.kubeTimeout`, `.spec.telemetry.collection.{clusters,deployments,operators}.mode`, `.spec.telemetry.send.mode` and `.spec.telemetry.send.frequency`. Telemetry remains opt-out: absence of any telemetry configuration keeps telemetry enabled, and all default values are unchanged.

--- a/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.mongodb.com_operatorconfigs.yaml
@@ -212,6 +212,15 @@ spec:
                         x-kubernetes-validations:
                         - message: frequency must be at least 1m
                           rule: duration(self) >= duration('1m')
+                      kubeTimeout:
+                        default: 5m
+                        description: |-
+                          KubeTimeout is the timeout for Kubernetes API calls made while collecting telemetry.
+                          Duration using h (hours), m (minutes) and s (seconds) units, e.g. "30s", "5m". Must be at least 1s; defaults to 5m when omitted.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: kubeTimeout must be at least 1s
+                          rule: duration(self) >= duration('1s')
                       operators:
                         description: Operators controls collection of operator-level
                           telemetry.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,10 +51,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: MANAGED_SECURITY_CONTEXT
               value: 'true'
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY
-              value: "1h"
-            - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
-              value: "168h"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -144,7 +144,12 @@ def build_operator_config_spec_from_test_env() -> dict:
     # dedicated telemetry variant (MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true, which also points the
     # operator at a cloud-dev endpoint via MDB_OPERATOR_TELEMETRY_SEND_BASEURL). Setting
     # MDB_OPERATOR_TELEMETRY_ENABLED=false disables telemetry entirely (master switch).
-    telemetry: dict = {"send": {"mode": "Disabled"}}
+    #
+    # Collection frequency is set to the minimum (1m) so telemetry tests observe fresh, populated
+    # payloads quickly: the operator collects once immediately at startup (before any deployment
+    # exists) and then on this interval, so a short interval is needed to pick up resources created
+    # later in the test within its polling window.
+    telemetry: dict = {"send": {"mode": "Disabled"}, "collection": {"frequency": "1m"}}
     if os.getenv("MDB_OPERATOR_TELEMETRY_SEND_ENABLED", "false") == "true":
         telemetry["send"]["mode"] = "Enabled"
     if os.getenv("MDB_OPERATOR_TELEMETRY_ENABLED", "true") == "false":
@@ -176,6 +181,29 @@ def get_operator_pod_restart_count(namespace: str, name: str, api_client=None) -
     if operator_status is None:
         return None
     return operator_status.restart_count
+
+
+def wait_for_operator_pod_present(namespace: str, name: str, api_client=None, retries: int = 120) -> int:
+    """Polls until exactly one operator pod with started containers is present and returns its restart
+    count. Raises AssertionError if the pod does not appear within the timeout.
+
+    Some install paths report readiness before the operator Deployment has finished rolling out its
+    pod (notably OLM, which signals readiness via the CSV phase, and rolling upgrades where the old
+    and new pods coexist transiently). Polling avoids a one-shot read racing that rollout.
+    """
+    timeout_seconds = retries
+    while retries > 0:
+        count = get_operator_pod_restart_count(namespace, name, api_client=api_client)
+        if count is not None:
+            return count
+        time.sleep(1)
+        retries -= 1
+
+    raise AssertionError(
+        f"Operator pod '{name}' in namespace '{namespace}' did not appear within {timeout_seconds} "
+        "seconds before applying OperatorConfig. Ensure the operator is running before calling "
+        "apply_operator_config_from_test_env."
+    )
 
 
 def wait_for_operator_pod_restart(
@@ -244,20 +272,21 @@ def apply_operator_config_from_test_env(
     if not spec:
         return False
 
-    previous_restart_count = get_operator_pod_restart_count(namespace, name, api_client=api_client)
+    if local_operator():
+        # No operator pod in the cluster — the operator process reads OperatorConfig directly from the
+        # API server, so there is no pod restart to wait for.
+        create_operator_config(namespace, spec, api_client=api_client)
+        return True
+
+    # Snapshot the operator pod's restart count before applying the CR. Poll for the pod to be present
+    # first: some install paths report readiness before the operator Deployment has finished rolling
+    # out (e.g. OLM's CSV phase, or a rolling upgrade where the old pod is still terminating).
+    previous_restart_count = wait_for_operator_pod_present(namespace, name, api_client=api_client)
+
     if not create_operator_config(namespace, spec, api_client=api_client):
         # The CR already existed, so the operator already loaded this config and will not restart.
         return False
 
-    if local_operator():
-        # No operator pod in the cluster — the operator process reads OperatorConfig directly from the
-        # API server, so no restart to wait for.
-        return True
-
-    assert previous_restart_count is not None, (
-        f"Operator pod '{name}' in namespace '{namespace}' was not found before OperatorConfig was applied. "
-        "Ensure the operator is running before calling apply_operator_config_from_test_env."
-    )
     wait_for_operator_pod_restart(namespace, name, previous_restart_count, api_client=api_client)
     if wait_for_ready is not None:
         wait_for_ready()

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -138,6 +138,19 @@ def build_operator_config_spec_from_test_env() -> dict:
     max_concurrent_reconciles = os.getenv("MDB_MAX_CONCURRENT_RECONCILES")
     if max_concurrent_reconciles:
         spec["maxConcurrentReconciles"] = int(max_concurrent_reconciles)
+
+    # Telemetry. The OperatorConfig default is send Enabled (opt-out), but e2e operators must NOT
+    # ship telemetry to cloud, so we default send to Disabled here and only enable it for the
+    # dedicated telemetry variant (MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true, which also points the
+    # operator at a cloud-dev endpoint via MDB_OPERATOR_TELEMETRY_SEND_BASEURL). Setting
+    # MDB_OPERATOR_TELEMETRY_ENABLED=false disables telemetry entirely (master switch).
+    telemetry: dict = {"send": {"mode": "Disabled"}}
+    if os.getenv("MDB_OPERATOR_TELEMETRY_SEND_ENABLED", "false") == "true":
+        telemetry["send"]["mode"] = "Enabled"
+    if os.getenv("MDB_OPERATOR_TELEMETRY_ENABLED", "true") == "false":
+        telemetry["mode"] = "Disabled"
+    spec["telemetry"] = telemetry
+
     return spec
 
 

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_meko_operator_upgrade_with_resources.py
@@ -70,6 +70,8 @@ def meko_subscription(namespace: str, catalog_source: CustomObject, operator_ins
         {"name": "MANAGED_SECURITY_CONTEXT", "value": "false"},
         {"name": "OPERATOR_ENV", "value": "dev"},
         {"name": "MDB_DEFAULT_ARCHITECTURE", "value": static_value},
+        # MEKO is the legacy operator and still reads telemetry env vars directly, so keep send
+        # disabled here. The MCK subscription below configures this via the OperatorConfig CR instead.
         {"name": "MDB_OPERATOR_TELEMETRY_SEND_ENABLED", "value": "false"},
     ]
     # Add registry env vars for patch builds (ECR registries for unreleased images)
@@ -99,10 +101,11 @@ def get_mck_subscription_object(
     Create a subscription object for the MCK operator.
     This is a separate function (not a fixture) so it can be called after uninstalling MEKO.
     """
+    # This installs the MCK (branch) operator, which no longer reads telemetry env vars; telemetry
+    # send is kept disabled via the OperatorConfig CR (apply_operator_config_from_test_env).
     base_env_vars = [
         {"name": "MANAGED_SECURITY_CONTEXT", "value": "false"},
         {"name": "OPERATOR_ENV", "value": "dev"},
-        {"name": "MDB_OPERATOR_TELEMETRY_SEND_ENABLED", "value": "false"},
     ]
     # Add registry env vars for patch builds (ECR registries for unreleased images)
     registry_env_vars = get_registry_env_vars_for_subscription(operator_installation_config)

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade.py
@@ -47,6 +47,9 @@ def test_upgrade_operator_only(namespace: str, version_id: str):
                 "env": [
                     {"name": "MANAGED_SECURITY_CONTEXT", "value": "false"},
                     {"name": "OPERATOR_ENV", "value": "dev"},
+                    # The upgrade starts from the released operator, which still reads telemetry env
+                    # vars directly, so keep send disabled here. After the upgrade to the branch build,
+                    # apply_operator_config_from_test_env keeps it disabled via the OperatorConfig CR.
                     {"name": "MDB_OPERATOR_TELEMETRY_SEND_ENABLED", "value": "false"},
                 ]
             },

--- a/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
+++ b/docker/mongodb-kubernetes-tests/tests/olm/olm_operator_upgrade_with_resources.py
@@ -59,6 +59,9 @@ def subscription(namespace: str, catalog_source: CustomObject, operator_installa
     base_env_vars = [
         {"name": "MANAGED_SECURITY_CONTEXT", "value": "false"},
         {"name": "OPERATOR_ENV", "value": "dev"},
+        # The upgrade starts from the released operator, which still reads telemetry env vars
+        # directly, so keep send disabled here. After the upgrade to the branch build,
+        # apply_operator_config_from_test_env keeps it disabled via the OperatorConfig CR.
         {"name": "MDB_OPERATOR_TELEMETRY_SEND_ENABLED", "value": "false"},
     ]
     # Add registry env vars for patch builds (ECR registries for unreleased images)

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
@@ -97,6 +97,8 @@ def test_install_latest_official_operator(
         helm_chart_path=LEGACY_OPERATOR_CHART,  # We are testing the upgrade from version fixing appdb hostnames, introduced in MEKO
         operator_name=LEGACY_OPERATOR_NAME,
         operator_image=LEGACY_OPERATOR_IMAGE_NAME,
+        # The legacy operator does not ship the OperatorConfig CRD, so the CR cannot be created here.
+        create_operator_config=False,
     )
     operator.wait_for_operator_ready()
 

--- a/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
+++ b/helm_chart/crds/operator.mongodb.com_operatorconfigs.yaml
@@ -212,6 +212,15 @@ spec:
                         x-kubernetes-validations:
                         - message: frequency must be at least 1m
                           rule: duration(self) >= duration('1m')
+                      kubeTimeout:
+                        default: 5m
+                        description: |-
+                          KubeTimeout is the timeout for Kubernetes API calls made while collecting telemetry.
+                          Duration using h (hours), m (minutes) and s (seconds) units, e.g. "30s", "5m". Must be at least 1s; defaults to 5m when omitted.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: kubeTimeout must be at least 1s
+                          rule: duration(self) >= duration('1s')
                       operators:
                         description: Operators controls collection of operator-level
                           telemetry.

--- a/helm_chart/templates/operator-roles-telemetry.yaml
+++ b/helm_chart/templates/operator-roles-telemetry.yaml
@@ -1,9 +1,11 @@
 {{- $clusterRoleName := printf "%s-cluster-telemetry" .Values.operator.name }}
 {{- $telemetry := default dict .Values.operator.telemetry }}
 
-{{/* We can't use default here, as 0, false and nil as determined as unset and thus set the default value */}}
-{{- if ne $telemetry.enabled false }}
-  {{- if ne $telemetry.installClusterRole false}}
+{{/* Whether telemetry is enabled/disabled is a runtime setting on the OperatorConfig CR, so the RBAC
+     is always deployed (the base deployment can toggle telemetry without redeploying). Deployment of
+     the ClusterRole itself remains an installation-stage choice via operator.telemetry.installClusterRole.
+     We can't use default here, as 0, false and nil are determined as unset and thus set the default value */}}
+{{- if ne $telemetry.installClusterRole false}}
 
 ---
 # Additional ClusterRole for clusterVersionDetection
@@ -46,5 +48,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.operator.name }}
     namespace: {{ include "mongodb-kubernetes-operator.namespace" . }}
-  {{- end}}{{/* if ne $telemetry.installClusterRole false */}}
-{{- end }}{{/* if ne $telemetry.enabled false */}}
+{{- end}}{{/* if ne $telemetry.installClusterRole false */}}

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -106,38 +106,14 @@ spec:
             - name: MANAGED_SECURITY_CONTEXT
               value: 'true'
     {{- end }}
-    {{- $telemetry := default dict .Values.operator.telemetry }}
-    {{- if eq $telemetry.enabled false }}
-            - name: MDB_OPERATOR_TELEMETRY_ENABLED
-              value: "false"
-    {{- end }}
-    {{- if eq $telemetry.collection.clusters.enabled false }}
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_CLUSTERS_ENABLED
-              value: "false"
-    {{- end }}
-    {{- if eq $telemetry.collection.deployments.enabled false }}
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_DEPLOYMENTS_ENABLED
-              value: "false"
-    {{- end }}
-    {{- if eq $telemetry.collection.operators.enabled false }}
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_OPERATORS_ENABLED
-              value: "false"
-    {{- end }}
-    {{- if $telemetry.collection.frequency}}
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY
-              value: "{{ $telemetry.collection.frequency }}"
-    {{- end }}
-    {{- if eq $telemetry.send.enabled false }}
-            - name: MDB_OPERATOR_TELEMETRY_SEND_ENABLED
-              value: "false"
-    {{- end }}
-    {{- if $telemetry.send.frequency}}
-            - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
-              value: "{{ .Values.operator.telemetry.send.frequency }}"
-    {{- end }}
-    {{- if $telemetry.send.baseUrl}}
+    {{- /* Telemetry is configured via the OperatorConfig CR (operator.mongodb.com). The only
+           remaining Helm-configurable telemetry setting is operator.telemetry.send.baseUrl, an
+           internal, undocumented knob used to point telemetry at a mock endpoint in tests. dig
+           traverses the (optional) path nil-safely and returns "" when it is unset. */}}
+    {{- $telemetryBaseUrl := dig "telemetry" "send" "baseUrl" "" .Values.operator }}
+    {{- if $telemetryBaseUrl }}
             - name: MDB_OPERATOR_TELEMETRY_SEND_BASEURL
-              value: "{{ $telemetry.send.baseUrl }}"
+              value: "{{ $telemetryBaseUrl }}"
     {{- end }}
     {{- $mongodbEnterpriseDatabaseImageEnv := "MONGODB_ENTERPRISE_DATABASE_IMAGE" -}}
     {{- $initDatabaseImageRepositoryEnv := "INIT_DATABASE_IMAGE_REPOSITORY" -}}

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -104,19 +104,6 @@ operator:
     #   name: "mdbpolicy.my-namespace.mongodb.com"
     name: ''
 
-  telemetry:
-    collection:
-      clusters: {}
-      deployments: {}
-      operators: {}
-      # Valid time units are "m", "h". Anything less than one minute defaults to 1h
-      frequency: 1h
-    # Enables sending the collected telemetry to MongoDB
-    send:
-      # 168 hours is one week
-      # Valid time units are "h". Anything less than one hours defaults to 168h
-      frequency: 168h
-
 ## Database
 database:
   name: mongodb-kubernetes-database

--- a/main.go
+++ b/main.go
@@ -225,6 +225,20 @@ func run() error {
 
 	propagateProxyEnv := operatorCfg.Spec.Proxy.EnvPropagationPolicy == operatorv1.ProxyEnvPropagationPolicyPropagate
 
+	// Telemetry is configured via OperatorConfig.spec.telemetry. operatorconfig.Load guarantees
+	// Telemetry and its nested blocks are non-nil and defaulted, so the pointers below are safe to
+	// dereference. Absence of any telemetry configuration implies telemetry is enabled (opt-out model).
+	telemetryEnabled := operatorCfg.Spec.Telemetry.Mode == operatorv1.FeatureModeEnabled
+	telemetryConfig := telemetry.Config{
+		CollectionFrequency: operatorCfg.Spec.Telemetry.Collection.Frequency.Duration,
+		KubeTimeout:         operatorCfg.Spec.Telemetry.Collection.KubeTimeout.Duration,
+		CollectClusters:     operatorCfg.Spec.Telemetry.Collection.Clusters.Mode == operatorv1.FeatureModeEnabled,
+		CollectDeployments:  operatorCfg.Spec.Telemetry.Collection.Deployments.Mode == operatorv1.FeatureModeEnabled,
+		CollectOperators:    operatorCfg.Spec.Telemetry.Collection.Operators.Mode == operatorv1.FeatureModeEnabled,
+		SendEnabled:         operatorCfg.Spec.Telemetry.Send.Mode == operatorv1.FeatureModeEnabled,
+		SendFrequency:       operatorCfg.Spec.Telemetry.Send.Frequency.Duration,
+	}
+
 	// The CRDs the operator reconciles are configured via OperatorConfig.spec.watchedResources
 	watchedResources := make([]string, len(operatorCfg.Spec.WatchedResources))
 	for i, r := range operatorCfg.Spec.WatchedResources {
@@ -353,10 +367,10 @@ func run() error {
 		}
 	}
 
-	if telemetry.IsTelemetryActivated() {
+	if telemetryEnabled {
 		log.Info("Running telemetry component!")
 		installerMethod := env.ReadOrDefault(telemetry.InstallerEnvVar, "")
-		telemetryRunnable, err := telemetry.NewLeaderRunnable(mgr, memberClusterObjectsMap, currentNamespace, imageUrls[util.MongodbImageEnv], imageUrls[util.NonStaticDatabaseEnterpriseImage], installerMethod, getOperatorEnv(), defaultArchitecture)
+		telemetryRunnable, err := telemetry.NewLeaderRunnable(mgr, memberClusterObjectsMap, currentNamespace, imageUrls[util.MongodbImageEnv], imageUrls[util.NonStaticDatabaseEnterpriseImage], installerMethod, getOperatorEnv(), defaultArchitecture, telemetryConfig)
 		if err != nil {
 			log.Errorf("Unable to enable telemetry; err: %s", err)
 		}

--- a/pkg/operatorconfig/operatorconfig.go
+++ b/pkg/operatorconfig/operatorconfig.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
 )
@@ -72,6 +74,52 @@ func withDefaults(cfg operatorv1.OperatorConfig) operatorv1.OperatorConfig {
 	}
 	if cfg.Spec.Proxy.EnvPropagationPolicy == "" {
 		cfg.Spec.Proxy.EnvPropagationPolicy = operatorv1.ProxyEnvPropagationPolicyNoPropagation
+	}
+	// Telemetry is a pointer tree, so an omitted block leaves the API server's nested defaults
+	// unapplied. Absence of any telemetry configuration must imply telemetry is enabled (opt-out
+	// model), so ensure every nested block exists and its fields are defaulted to Enabled with the
+	// documented frequencies/timeout.
+	if cfg.Spec.Telemetry == nil {
+		cfg.Spec.Telemetry = &operatorv1.TelemetryConfig{}
+	}
+	if cfg.Spec.Telemetry.Mode == "" {
+		cfg.Spec.Telemetry.Mode = operatorv1.FeatureModeEnabled
+	}
+	if cfg.Spec.Telemetry.Collection == nil {
+		cfg.Spec.Telemetry.Collection = &operatorv1.TelemetryCollectionConfig{}
+	}
+	if cfg.Spec.Telemetry.Collection.Frequency == nil {
+		cfg.Spec.Telemetry.Collection.Frequency = &metav1.Duration{Duration: time.Hour}
+	}
+	if cfg.Spec.Telemetry.Collection.KubeTimeout == nil {
+		cfg.Spec.Telemetry.Collection.KubeTimeout = &metav1.Duration{Duration: 5 * time.Minute}
+	}
+	if cfg.Spec.Telemetry.Collection.Clusters == nil {
+		cfg.Spec.Telemetry.Collection.Clusters = &operatorv1.TelemetryCollectionClustersConfig{}
+	}
+	if cfg.Spec.Telemetry.Collection.Clusters.Mode == "" {
+		cfg.Spec.Telemetry.Collection.Clusters.Mode = operatorv1.FeatureModeEnabled
+	}
+	if cfg.Spec.Telemetry.Collection.Deployments == nil {
+		cfg.Spec.Telemetry.Collection.Deployments = &operatorv1.TelemetryCollectionDeploymentsConfig{}
+	}
+	if cfg.Spec.Telemetry.Collection.Deployments.Mode == "" {
+		cfg.Spec.Telemetry.Collection.Deployments.Mode = operatorv1.FeatureModeEnabled
+	}
+	if cfg.Spec.Telemetry.Collection.Operators == nil {
+		cfg.Spec.Telemetry.Collection.Operators = &operatorv1.TelemetryCollectionOperatorsConfig{}
+	}
+	if cfg.Spec.Telemetry.Collection.Operators.Mode == "" {
+		cfg.Spec.Telemetry.Collection.Operators.Mode = operatorv1.FeatureModeEnabled
+	}
+	if cfg.Spec.Telemetry.Send == nil {
+		cfg.Spec.Telemetry.Send = &operatorv1.TelemetrySendConfig{}
+	}
+	if cfg.Spec.Telemetry.Send.Mode == "" {
+		cfg.Spec.Telemetry.Send.Mode = operatorv1.FeatureModeEnabled
+	}
+	if cfg.Spec.Telemetry.Send.Frequency == nil {
+		cfg.Spec.Telemetry.Send.Frequency = &metav1.Duration{Duration: 168 * time.Hour}
 	}
 	return cfg
 }

--- a/pkg/operatorconfig/operatorconfig_test.go
+++ b/pkg/operatorconfig/operatorconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,25 @@ func TestLoad_AbsentCR(t *testing.T) {
 	// Proxy is a pointer; withDefaults must materialise it and default the policy
 	require.NotNil(t, cfg.Spec.Proxy)
 	assert.Equal(t, operatorv1.ProxyEnvPropagationPolicyNoPropagation, cfg.Spec.Proxy.EnvPropagationPolicy)
+	// Telemetry is a pointer tree; withDefaults must materialise every block and default to Enabled
+	// with the documented frequencies/timeout (opt-out model).
+	require.NotNil(t, cfg.Spec.Telemetry)
+	assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Mode)
+	require.NotNil(t, cfg.Spec.Telemetry.Collection)
+	require.NotNil(t, cfg.Spec.Telemetry.Collection.Frequency)
+	assert.Equal(t, time.Hour, cfg.Spec.Telemetry.Collection.Frequency.Duration)
+	require.NotNil(t, cfg.Spec.Telemetry.Collection.KubeTimeout)
+	assert.Equal(t, 5*time.Minute, cfg.Spec.Telemetry.Collection.KubeTimeout.Duration)
+	require.NotNil(t, cfg.Spec.Telemetry.Collection.Clusters)
+	assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Collection.Clusters.Mode)
+	require.NotNil(t, cfg.Spec.Telemetry.Collection.Deployments)
+	assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Collection.Deployments.Mode)
+	require.NotNil(t, cfg.Spec.Telemetry.Collection.Operators)
+	assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Collection.Operators.Mode)
+	require.NotNil(t, cfg.Spec.Telemetry.Send)
+	assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Send.Mode)
+	require.NotNil(t, cfg.Spec.Telemetry.Send.Frequency)
+	assert.Equal(t, 168*time.Hour, cfg.Spec.Telemetry.Send.Frequency.Duration)
 }
 
 func TestLoad_Proxy(t *testing.T) {
@@ -228,6 +248,79 @@ func TestLoad_MemberClusterRequiredHealthyStreak(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cfg.Spec.MultiCluster)
 		assert.Equal(t, 7, cfg.Spec.MultiCluster.MemberClusterRequiredHealthyStreak)
+	})
+}
+
+func TestLoad_Telemetry(t *testing.T) {
+	t.Run("explicit Disabled master mode is preserved", func(t *testing.T) {
+		cr := &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.DefaultOperatorConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: operatorv1.OperatorConfigSpec{
+				Telemetry: &operatorv1.TelemetryConfig{
+					Mode: operatorv1.FeatureModeDisabled,
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+		cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Spec.Telemetry)
+		assert.Equal(t, operatorv1.FeatureModeDisabled, cfg.Spec.Telemetry.Mode)
+		// Nested blocks are still materialised and defaulted even when the master switch is off.
+		require.NotNil(t, cfg.Spec.Telemetry.Collection)
+		require.NotNil(t, cfg.Spec.Telemetry.Collection.Frequency)
+		assert.Equal(t, time.Hour, cfg.Spec.Telemetry.Collection.Frequency.Duration)
+		require.NotNil(t, cfg.Spec.Telemetry.Send)
+		assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Send.Mode)
+	})
+
+	t.Run("explicit nested values are preserved and omitted siblings defaulted", func(t *testing.T) {
+		cr := &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.DefaultOperatorConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: operatorv1.OperatorConfigSpec{
+				Telemetry: &operatorv1.TelemetryConfig{
+					Collection: &operatorv1.TelemetryCollectionConfig{
+						Frequency: &metav1.Duration{Duration: 30 * time.Minute},
+						Clusters: &operatorv1.TelemetryCollectionClustersConfig{
+							Mode: operatorv1.FeatureModeDisabled,
+						},
+					},
+					Send: &operatorv1.TelemetrySendConfig{
+						Mode: operatorv1.FeatureModeDisabled,
+					},
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cr).Build()
+
+		cfg, err := Load(context.Background(), c, testNamespace, util.DefaultOperatorConfigName)
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Spec.Telemetry)
+		// Master switch defaults to Enabled when omitted.
+		assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Mode)
+		// Explicit collection frequency and clusters mode are preserved.
+		assert.Equal(t, 30*time.Minute, cfg.Spec.Telemetry.Collection.Frequency.Duration)
+		assert.Equal(t, operatorv1.FeatureModeDisabled, cfg.Spec.Telemetry.Collection.Clusters.Mode)
+		// Omitted siblings are materialised and defaulted.
+		require.NotNil(t, cfg.Spec.Telemetry.Collection.KubeTimeout)
+		assert.Equal(t, 5*time.Minute, cfg.Spec.Telemetry.Collection.KubeTimeout.Duration)
+		require.NotNil(t, cfg.Spec.Telemetry.Collection.Deployments)
+		assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Collection.Deployments.Mode)
+		require.NotNil(t, cfg.Spec.Telemetry.Collection.Operators)
+		assert.Equal(t, operatorv1.FeatureModeEnabled, cfg.Spec.Telemetry.Collection.Operators.Mode)
+		// Explicit send mode preserved; send frequency defaulted.
+		assert.Equal(t, operatorv1.FeatureModeDisabled, cfg.Spec.Telemetry.Send.Mode)
+		require.NotNil(t, cfg.Spec.Telemetry.Send.Frequency)
+		assert.Equal(t, 168*time.Hour, cfg.Spec.Telemetry.Send.Frequency.Duration)
 	})
 }
 

--- a/pkg/telemetry/cluster.go
+++ b/pkg/telemetry/cluster.go
@@ -10,8 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
 
 const (
@@ -38,7 +36,7 @@ var kubernetesFlavourAnnotationsMapping = map[string]string{
 }
 
 // detectClusterInfo detects the Kubernetes version and cluster flavor
-func detectClusterInfos(ctx context.Context, memberClusterMap map[string]ConfigClient) []KubernetesClusterUsageSnapshotProperties {
+func detectClusterInfos(ctx context.Context, memberClusterMap map[string]ConfigClient, kubeTimeout time.Duration) []KubernetesClusterUsageSnapshotProperties {
 	var clusterProperties []KubernetesClusterUsageSnapshotProperties
 
 	for _, mgr := range memberClusterMap {
@@ -46,7 +44,7 @@ func detectClusterInfos(ctx context.Context, memberClusterMap map[string]ConfigC
 		if err != nil {
 			Logger.Debugf("failed to create discovery client: %s, sending Unknown as version", err)
 		}
-		clusterProperty := getKubernetesClusterProperty(ctx, discoveryClient, mgr.GetAPIReader())
+		clusterProperty := getKubernetesClusterProperty(ctx, discoveryClient, mgr.GetAPIReader(), kubeTimeout)
 		clusterProperties = append(clusterProperties, clusterProperty)
 	}
 
@@ -59,9 +57,9 @@ func detectClusterInfos(ctx context.Context, memberClusterMap map[string]ConfigC
 // - kubernetes cluster uid
 // Notes: We are using a non-cached client to ensure we are properly timing out in case we don't have the
 // necessary RBACs.
-func getKubernetesClusterProperty(ctx context.Context, discoveryClient discovery.DiscoveryInterface, uncachedClient kubeclient.Reader) KubernetesClusterUsageSnapshotProperties {
+func getKubernetesClusterProperty(ctx context.Context, discoveryClient discovery.DiscoveryInterface, uncachedClient kubeclient.Reader, kubeTimeout time.Duration) KubernetesClusterUsageSnapshotProperties {
 	kubernetesAPIVersion := unknown
-	kubeClusterUUID := getKubernetesClusterUUID(ctx, uncachedClient)
+	kubeClusterUUID := getKubernetesClusterUUID(ctx, uncachedClient, kubeTimeout)
 
 	if discoveryClient != nil {
 		if versionInfo := getServerVersion(discoveryClient); versionInfo != nil {
@@ -136,18 +134,19 @@ func detectKubernetesFlavour(ctx context.Context, uncachedClient kubeclient.Read
 // getKubernetesClusterUUID retrieves the UUID from the kube-system namespace.
 // We are using a non-cached client to ensure we are properly timing out in case we don't have the
 // necessary RBACs.
-func getKubernetesClusterUUID(ctx context.Context, uncachedClient kubeclient.Reader) string {
-	timeoutLengthStr := env.ReadOrDefault(KubeTimeout, "5m") // nolint:forbidigo
-	duration, err := time.ParseDuration(timeoutLengthStr)
-	if err != nil {
-		Logger.Warnf("Failed converting %s to a duration, using default 5m", KubeTimeout)
-		duration = 5 * time.Minute
+func getKubernetesClusterUUID(ctx context.Context, uncachedClient kubeclient.Reader, kubeTimeout time.Duration) string {
+	// The timeout comes pre-validated and defaulted from the OperatorConfig CR. Guard against a
+	// non-positive value as a defensive measure so we never disable the timeout entirely.
+	duration := kubeTimeout
+	if duration <= 0 {
+		Logger.Warnf("Telemetry kube timeout is not positive (%s), using default %s", duration, DefaultKubeTimeout)
+		duration = DefaultKubeTimeout
 	}
 	nonCachedClientTimeout, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 
 	namespace := &corev1.Namespace{}
-	err = uncachedClient.Get(nonCachedClientTimeout, kubeclient.ObjectKey{Name: "kube-system"}, namespace)
+	err := uncachedClient.Get(nonCachedClientTimeout, kubeclient.ObjectKey{Name: "kube-system"}, namespace)
 	if err != nil {
 		Logger.Debugf("failed to fetch kube-system namespace: %s", err)
 		return unknown

--- a/pkg/telemetry/cluster_test.go
+++ b/pkg/telemetry/cluster_test.go
@@ -157,7 +157,7 @@ func TestGetKubernetesClusterProperty(t *testing.T) {
 	// Run test cases
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			property := getKubernetesClusterProperty(ctx, tt.discoveryClient, tt.uncachedClient)
+			property := getKubernetesClusterProperty(ctx, tt.discoveryClient, tt.uncachedClient, DefaultKubeTimeout)
 
 			assert.Equal(t, tt.expectedClusterID, property.KubernetesClusterID, "Cluster ID mismatch")
 			assert.Equal(t, tt.expectedAPIVersion, property.KubernetesAPIVersion, "API version mismatch")
@@ -223,7 +223,7 @@ func TestGetKubernetesClusterUUID(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithObjects(namespace).Build()
-	uuid := getKubernetesClusterUUID(ctx, fakeClient)
+	uuid := getKubernetesClusterUUID(ctx, fakeClient, DefaultKubeTimeout)
 
 	assert.Equal(t, "fake-uuid", uuid)
 }

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"runtime"
 	"slices"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -26,7 +25,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/images"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/versionutil"
 )
 
@@ -57,13 +55,14 @@ type LeaderRunnable struct {
 	installerMethod         string
 	configuredOperatorEnv   util.OperatorEnvironment
 	defaultArchitecture     architectures.DefaultArchitecture
+	config                  Config
 }
 
 func (l *LeaderRunnable) NeedLeaderElection() bool {
 	return true
 }
 
-func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[string]cluster.Cluster, currentNamespace, mongodbImage, databaseNonStaticImage, installerMethod string, operatorEnv util.OperatorEnvironment, defaultArchitecture architectures.DefaultArchitecture) (*LeaderRunnable, error) {
+func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[string]cluster.Cluster, currentNamespace, mongodbImage, databaseNonStaticImage, installerMethod string, operatorEnv util.OperatorEnvironment, defaultArchitecture architectures.DefaultArchitecture, config Config) (*LeaderRunnable, error) {
 	atlasClient, err := NewClient(nil)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed creating atlas telemetry client: %w", err)
@@ -78,12 +77,13 @@ func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[
 		databaseNonStaticImage:  databaseNonStaticImage,
 		installerMethod:         installerMethod,
 		defaultArchitecture:     defaultArchitecture,
+		config:                  config,
 	}, nil
 }
 
 func (l *LeaderRunnable) Start(ctx context.Context) error {
 	Logger.Debug("Starting leader-only telemetry goroutine")
-	RunTelemetry(ctx, l.mongodbImage, l.databaseNonStaticImage, l.currentNamespace, l.installerMethod, l.operatorMgr, l.memberClusterObjectsMap, l.atlasClient, l.configuredOperatorEnv, l.defaultArchitecture)
+	RunTelemetry(ctx, l.mongodbImage, l.databaseNonStaticImage, l.currentNamespace, l.installerMethod, l.operatorMgr, l.memberClusterObjectsMap, l.atlasClient, l.configuredOperatorEnv, l.defaultArchitecture, l.config)
 
 	return nil
 }
@@ -91,7 +91,7 @@ func (l *LeaderRunnable) Start(ctx context.Context) error {
 type snapshotCollector func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event
 
 // RunTelemetry lists the specified CRDs and sends them as events to Segment
-func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticImage, namespace, installerMethod string, operatorClusterMgr manager.Manager, clusterMap map[string]cluster.Cluster, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment, defaultArchitecture architectures.DefaultArchitecture) {
+func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticImage, namespace, installerMethod string, operatorClusterMgr manager.Manager, clusterMap map[string]cluster.Cluster, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment, defaultArchitecture architectures.DefaultArchitecture, cfg Config) {
 	Logger.Debug("Collecting telemetry!")
 	ctx, span := TRACER.Start(leaderTrace, "RunTelemetry")
 	span.SetAttributes(
@@ -99,13 +99,14 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 	)
 	defer span.End()
 
-	intervalStr := env.ReadOrDefault(CollectionFrequency, DefaultCollectionFrequencyStr) // nolint:forbidigo
-	duration, err := time.ParseDuration(intervalStr)
-	if err != nil || duration < time.Minute {
-		Logger.Warn("Failed converting %s to a duration or value is too small (minimum is one minute), using default 1h", CollectionFrequency)
+	// The collection frequency comes pre-validated and defaulted from the OperatorConfig CR.
+	// Guard against a non-positive value as a defensive measure since time.NewTicker panics on <= 0.
+	duration := cfg.CollectionFrequency
+	if duration <= 0 {
+		Logger.Warnf("Telemetry collection frequency is not positive (%s), using default %s", duration, DefaultCollectionFrequency)
 		duration = DefaultCollectionFrequency
 	}
-	Logger.Debugf("%s is set to: %s", CollectionFrequency, duration)
+	Logger.Debugf("Telemetry collection frequency is set to: %s", duration)
 
 	// converting to a smaller interface for better testing and clearer responsibilities
 	cc := map[string]ConfigClient{}
@@ -117,10 +118,10 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 	// The functions are not 100% identical, this map takes care of that
 	snapshotCollectors := map[EventType]func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event{
 		Operators: func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, _, _ string) []Event {
-			return collectOperatorSnapshot(ctx, memberClusterMap, operatorClusterMgr, operatorUUID, installerMethod)
+			return collectOperatorSnapshot(ctx, memberClusterMap, operatorClusterMgr, operatorUUID, installerMethod, cfg.KubeTimeout)
 		},
 		Clusters: func(ctx context.Context, cc map[string]ConfigClient, operatorClusterMgr manager.Manager, _, _, _ string) []Event {
-			return collectClustersSnapshot(ctx, cc, operatorClusterMgr)
+			return collectClustersSnapshot(ctx, cc, operatorClusterMgr, cfg.KubeTimeout)
 		},
 		Deployments: func(ctx context.Context, _ map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event {
 			return collectDeploymentsSnapshot(ctx, operatorClusterMgr, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture)
@@ -134,7 +135,7 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 		operatorUUID := getOrGenerateOperatorUUID(ctx, operatorClusterMgr.GetClient(), namespace)
 
 		for eventType, f := range snapshotCollectors {
-			collectAndSendSnapshot(ctx, eventType, f, cc, operatorClusterMgr, operatorUUID, mongodbImage, databaseNonStaticImage, namespace, atlasClient, configuredOperatorEnv)
+			collectAndSendSnapshot(ctx, eventType, f, cc, operatorClusterMgr, operatorUUID, mongodbImage, databaseNonStaticImage, namespace, atlasClient, configuredOperatorEnv, cfg)
 		}
 	}
 
@@ -154,9 +155,8 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 	}
 }
 
-func collectAndSendSnapshot(ctx context.Context, eventType EventType, cf snapshotCollector, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage, namespace string, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment) {
-	telemetryIsEnabled := ReadBoolWithTrueAsDefault(EventTypeMappingToEnvVar[eventType])
-	if !telemetryIsEnabled {
+func collectAndSendSnapshot(ctx context.Context, eventType EventType, cf snapshotCollector, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage, namespace string, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment, cfg Config) {
+	if !cfg.collectionEnabled(eventType) {
 		return
 	}
 
@@ -167,13 +167,13 @@ func collectAndSendSnapshot(ctx context.Context, eventType EventType, cf snapsho
 		event.Properties["operatorEnvironment"] = configuredOperatorEnv.String()
 	}
 
-	handleEvents(ctx, atlasClient, events, eventType, namespace, operatorClusterMgr.GetClient())
+	handleEvents(ctx, atlasClient, events, eventType, namespace, operatorClusterMgr.GetClient(), cfg.SendEnabled, cfg.SendFrequency)
 }
 
-func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, installerMethod string) []Event {
+func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, installerMethod string, kubeTimeout time.Duration) []Event {
 	var kubeClusterUUIDList []string
 	uncachedClient := operatorClusterMgr.GetAPIReader()
-	kubeClusterOperatorUUID := getKubernetesClusterUUID(ctx, uncachedClient)
+	kubeClusterOperatorUUID := getKubernetesClusterUUID(ctx, uncachedClient, kubeTimeout)
 
 	// in single cluster we don't fill the memberClusterMap
 	if len(memberClusterMap) == 0 {
@@ -182,7 +182,7 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 
 	for _, c := range memberClusterMap {
 		uncachedClient := c.GetAPIReader()
-		uid := getKubernetesClusterUUID(ctx, uncachedClient)
+		uid := getKubernetesClusterUUID(ctx, uncachedClient, kubeTimeout)
 		kubeClusterUUIDList = append(kubeClusterUUIDList, uid)
 	}
 
@@ -454,23 +454,18 @@ func getMaxNumberOfClustersSCIsDeployedOn(item mdbv1.MongoDB) int {
 	return numberOfClustersUsed
 }
 
-func ReadBoolWithTrueAsDefault(envVarName string) bool {
-	envVar := env.ReadOrDefault(envVarName, "true") // nolint:forbidigo
-	return strings.TrimSpace(strings.ToLower(envVar)) == "true"
-}
-
-func handleEvents(ctx context.Context, atlasClient *Client, events []Event, eventType EventType, namespace string, operatorClusterClient kubeclient.Client) {
+func handleEvents(ctx context.Context, atlasClient *Client, events []Event, eventType EventType, namespace string, operatorClusterClient kubeclient.Client, sendEnabled bool, sendFrequency time.Duration) {
 	if err := updateTelemetryConfigMapPayload(ctx, operatorClusterClient, events, namespace, OperatorConfigMapTelemetryConfigMapName, eventType); err != nil {
 		Logger.Debugf("Failed to save last collected events: %s. Not sending data", err)
 		return
 	}
 
-	if sendTelemetry := ReadBoolWithTrueAsDefault(SendEnabled); !sendTelemetry {
+	if !sendEnabled {
 		Logger.Debugf("Telemetry deactivated, not sending it for eventType: %s", string(eventType))
 		return
 	}
 
-	isOlder, err := isTimestampOlderThanConfiguredFrequency(ctx, operatorClusterClient, namespace, OperatorConfigMapTelemetryConfigMapName, eventType)
+	isOlder, err := isTimestampOlderThanConfiguredFrequency(ctx, operatorClusterClient, namespace, OperatorConfigMapTelemetryConfigMapName, eventType, sendFrequency)
 	if err != nil {
 		Logger.Debugf("Failed to check for timestamp in configmap; not sending data: %s", err)
 		return
@@ -490,8 +485,8 @@ func handleEvents(ctx context.Context, atlasClient *Client, events []Event, even
 	}
 }
 
-func collectClustersSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager) []Event {
-	allClusterDetails := getClusterProperties(ctx, memberClusterMap, operatorClusterMgr)
+func collectClustersSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, kubeTimeout time.Duration) []Event {
+	allClusterDetails := getClusterProperties(ctx, memberClusterMap, operatorClusterMgr, kubeTimeout)
 	now := time.Now()
 
 	var events []Event
@@ -505,9 +500,9 @@ func collectClustersSnapshot(ctx context.Context, memberClusterMap map[string]Co
 	return events
 }
 
-func getClusterProperties(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager) []KubernetesClusterUsageSnapshotProperties {
-	operatorMemberClusterProperties := detectClusterInfos(ctx, map[string]ConfigClient{"operator": operatorClusterMgr})
-	memberClustersProperties := detectClusterInfos(ctx, memberClusterMap)
+func getClusterProperties(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, kubeTimeout time.Duration) []KubernetesClusterUsageSnapshotProperties {
+	operatorMemberClusterProperties := detectClusterInfos(ctx, map[string]ConfigClient{"operator": operatorClusterMgr}, kubeTimeout)
+	memberClustersProperties := detectClusterInfos(ctx, memberClusterMap, kubeTimeout)
 
 	uniqueProperties := make(map[string]KubernetesClusterUsageSnapshotProperties)
 	for _, property := range append(operatorMemberClusterProperties, memberClustersProperties...) {

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1533,7 +1533,7 @@ func TestCollectOperatorSnapshot(t *testing.T) {
 
 			ctx := context.Background()
 
-			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, test.expectedProps.OperatorInstaller)
+			events := collectOperatorSnapshot(ctx, test.memberClusterMap, mgr, testOperatorUUID, test.expectedProps.OperatorInstaller, DefaultKubeTimeout)
 
 			require.Len(t, events, 1, "expected exactly one operator event")
 			event := events[0]

--- a/pkg/telemetry/config.go
+++ b/pkg/telemetry/config.go
@@ -2,28 +2,47 @@ package telemetry
 
 import "time"
 
-// Helm Chart Settings
+// BaseUrl is an internal, undocumented env var used only to point telemetry at a mock
+// endpoint in tests. Production uses the Atlas SDK default (https://cloud.mongodb.com/).
+// All other telemetry settings are configured via the OperatorConfig CR.
 const (
-	Enabled             = "MDB_OPERATOR_TELEMETRY_ENABLED"
-	BaseUrl             = "MDB_OPERATOR_TELEMETRY_SEND_BASEURL"
-	KubeTimeout         = "MDB_OPERATOR_TELEMETRY_KUBE_TIMEOUT"
-	CollectionFrequency = "MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY"
-	SendEnabled         = "MDB_OPERATOR_TELEMETRY_SEND_ENABLED"
-	SendFrequency       = "MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY"
+	BaseUrl = "MDB_OPERATOR_TELEMETRY_SEND_BASEURL"
 )
 
-// Default Settings
+// Default Settings. These are only used as defensive fallbacks in the runtime; the
+// authoritative defaults are applied when loading the OperatorConfig CR.
 const (
-	DefaultCollectionFrequency    = 1 * time.Hour
-	DefaultCollectionFrequencyStr = "1h"
-	DefaultSendFrequencyStr       = "168h"
-	DefaultSendFrequency          = time.Hour * 168
+	DefaultCollectionFrequency = 1 * time.Hour
+	DefaultSendFrequency       = time.Hour * 168
+	DefaultKubeTimeout         = 5 * time.Minute
 )
 
 const (
 	OperatorConfigMapTelemetryConfigMapName = "mongodb-enterprise-operator-telemetry"
 )
 
-func IsTelemetryActivated() bool {
-	return ReadBoolWithTrueAsDefault(Enabled)
+// Config is the resolved telemetry configuration sourced from the OperatorConfig CR
+// (OperatorConfig.spec.telemetry). It is passed into the telemetry runnable at startup.
+type Config struct {
+	CollectionFrequency time.Duration
+	KubeTimeout         time.Duration
+	CollectClusters     bool
+	CollectDeployments  bool
+	CollectOperators    bool
+	SendEnabled         bool
+	SendFrequency       time.Duration
+}
+
+// collectionEnabled reports whether collection of the given event type is enabled.
+func (c Config) collectionEnabled(eventType EventType) bool {
+	switch eventType {
+	case Clusters:
+		return c.CollectClusters
+	case Deployments:
+		return c.CollectDeployments
+	case Operators:
+		return c.CollectOperators
+	default:
+		return false
+	}
 }

--- a/pkg/telemetry/config.go
+++ b/pkg/telemetry/config.go
@@ -3,7 +3,7 @@ package telemetry
 import "time"
 
 // BaseUrl is an internal, undocumented env var used only to point telemetry at a mock
-// endpoint in tests. Production uses the Atlas SDK default (https://cloud.mongodb.com/).
+// endpoint in tests. Production uses the Atlas SDK default.
 // All other telemetry settings are configured via the OperatorConfig CR.
 const (
 	BaseUrl = "MDB_OPERATOR_TELEMETRY_SEND_BASEURL"

--- a/pkg/telemetry/config_test.go
+++ b/pkg/telemetry/config_test.go
@@ -1,0 +1,20 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_collectionEnabled(t *testing.T) {
+	cfg := Config{
+		CollectClusters:    true,
+		CollectDeployments: false,
+		CollectOperators:   true,
+	}
+
+	assert.True(t, cfg.collectionEnabled(Clusters))
+	assert.False(t, cfg.collectionEnabled(Deployments))
+	assert.True(t, cfg.collectionEnabled(Operators))
+	assert.False(t, cfg.collectionEnabled(EventType("Unknown")))
+}

--- a/pkg/telemetry/configmap.go
+++ b/pkg/telemetry/configmap.go
@@ -15,8 +15,6 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	v2 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
 
 const (
@@ -121,16 +119,17 @@ func createInitialConfigmap(namespace string) (string, *corev1.ConfigMap) {
 
 // isTimestampOlderThanConfiguredFrequency is used to get the timestamp from the ConfigMap and check whether it's time to
 // send the data to atlas.
-func isTimestampOlderThanConfiguredFrequency(ctx context.Context, k8sClient kubeclient.Client, namespace string, OperatorConfigMapTelemetryConfigMapName string, et EventType) (bool, error) {
-	durationStr := env.ReadOrDefault(SendFrequency, DefaultSendFrequencyStr) // nolint:forbidigo
-	duration, err := time.ParseDuration(durationStr)
-	if err != nil || duration < 10*time.Minute {
-		Logger.Warn("Failed to parse or given durationString: %s too low (min: 10 minutes), defaulting to one week", durationStr)
+func isTimestampOlderThanConfiguredFrequency(ctx context.Context, k8sClient kubeclient.Client, namespace string, OperatorConfigMapTelemetryConfigMapName string, et EventType, sendFrequency time.Duration) (bool, error) {
+	// The send frequency comes pre-validated and defaulted from the OperatorConfig CR. Guard against
+	// a non-positive value as a defensive measure.
+	duration := sendFrequency
+	if duration <= 0 {
+		Logger.Warnf("Telemetry send frequency is not positive (%s), using default %s", duration, DefaultSendFrequency)
 		duration = DefaultSendFrequency
 	}
 
 	cm := &corev1.ConfigMap{}
-	err = k8sClient.Get(ctx, types.NamespacedName{Name: OperatorConfigMapTelemetryConfigMapName, Namespace: namespace}, cm)
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: OperatorConfigMapTelemetryConfigMapName, Namespace: namespace}, cm)
 	if err != nil {
 		return false, fmt.Errorf("failed to get ConfigMap: %w", err)
 	}

--- a/pkg/telemetry/configmap_test.go
+++ b/pkg/telemetry/configmap_test.go
@@ -223,15 +223,16 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 	et := Deployments
 
 	tests := []struct {
-		name             string
-		frequencySetting string
-		configMapData    map[string]string
-		shouldCollect    bool
-		expectedErr      bool
-		description      string
+		name          string
+		frequency     time.Duration
+		configMapData map[string]string
+		shouldCollect bool
+		expectedErr   bool
+		description   string
 	}{
 		{
-			name: "Default one-week check - outdated",
+			name:      "One-week frequency - outdated",
+			frequency: 168 * time.Hour,
 			configMapData: map[string]string{
 				et.GetTimeStampKey(): strconv.FormatInt(time.Now().Add(-8*24*time.Hour).Unix(), 10), // 8 days ago
 			},
@@ -240,7 +241,8 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 			description:   "Timestamp is older than one week",
 		},
 		{
-			name: "Default one-week check - recent",
+			name:      "One-week frequency - recent",
+			frequency: 168 * time.Hour,
 			configMapData: map[string]string{
 				et.GetTimeStampKey(): strconv.FormatInt(time.Now().Add(-6*24*time.Hour).Unix(), 10), // 6 days ago
 			},
@@ -249,37 +251,42 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 			description:   "Timestamp is within one week",
 		},
 		{
-			name:             "Custom duration from env - below minimum, will default to 1h",
-			frequencySetting: "5m",
+			// The function uses the supplied frequency verbatim (no runtime floor); the OperatorConfig
+			// CEL validation enforces the real minimum of 1h before a value ever reaches here, so a
+			// sub-hour value like 5m cannot occur in production. This case only pins the pure-function
+			// contract: any positive duration is honoured as-is.
+			name:      "Positive frequency honoured verbatim - outdated",
+			frequency: 5 * time.Minute,
+			configMapData: map[string]string{
+				et.GetTimeStampKey(): strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10),
+			},
+			shouldCollect: true,
+			expectedErr:   false,
+			description:   "Timestamp is older than the supplied 5-minute frequency",
+		},
+		{
+			name:      "Custom frequency - recent",
+			frequency: 30 * time.Minute,
 			configMapData: map[string]string{
 				et.GetTimeStampKey(): strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10),
 			},
 			shouldCollect: false,
 			expectedErr:   false,
-			description:   "Timestamp is older than configured 5-minute threshold",
+			description:   "Timestamp is within the configured 30-minute threshold",
 		},
 		{
-			name:             "Custom duration from env - recent",
-			frequencySetting: "30m",
+			name:      "Non-positive frequency defaults to one week",
+			frequency: 0,
 			configMapData: map[string]string{
 				et.GetTimeStampKey(): strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10),
 			},
 			shouldCollect: false,
 			expectedErr:   false,
-			description:   "Timestamp is within configured 30-minute threshold",
+			description:   "A non-positive frequency falls back to the 168h default, so a recent timestamp is not collected",
 		},
 		{
-			name:             "Invalid duration format",
-			frequencySetting: "invalid",
-			configMapData: map[string]string{
-				et.GetTimeStampKey(): strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10),
-			},
-			shouldCollect: false,
-			expectedErr:   false,
-			description:   "Should default to 168h",
-		},
-		{
-			name: "Missing timestamp key",
+			name:      "Missing timestamp key",
+			frequency: 168 * time.Hour,
 			configMapData: map[string]string{
 				"someOtherKey": "1650000000",
 			},
@@ -288,7 +295,8 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 			description:   "Should return error due to missing timestamp key",
 		},
 		{
-			name: "Initial timestamp value",
+			name:      "Initial timestamp value",
+			frequency: 168 * time.Hour,
 			configMapData: map[string]string{
 				et.GetTimeStampKey(): TimestampInitialValue,
 			},
@@ -297,7 +305,8 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 			description:   "Should return true for initial timestamp",
 		},
 		{
-			name: "Invalid timestamp format",
+			name:      "Invalid timestamp format",
+			frequency: 168 * time.Hour,
 			configMapData: map[string]string{
 				et.GetTimeStampKey(): "invalid_timestamp",
 			},
@@ -309,8 +318,6 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv(SendFrequency, test.frequencySetting)
-
 			fakeClient := fake.NewClientBuilder().
 				WithObjects(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -321,7 +328,7 @@ func TestIsTimestampOlderThanConfiguredFrequency(t *testing.T) {
 				}).
 				Build()
 
-			result, err := isTimestampOlderThanConfiguredFrequency(ctx, fakeClient, namespace, configMapName, et)
+			result, err := isTimestampOlderThanConfiguredFrequency(ctx, fakeClient, namespace, configMapName, et, test.frequency)
 
 			assert.Equal(t, test.shouldCollect, result, test.description)
 

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -117,12 +117,6 @@ var AllEventTypes = []EventType{
 	Clusters,
 }
 
-var EventTypeMappingToEnvVar = map[EventType]string{
-	Deployments: "MDB_OPERATOR_TELEMETRY_COLLECTION_DEPLOYMENTS_ENABLED",
-	Clusters:    "MDB_OPERATOR_TELEMETRY_COLLECTION_CLUSTERS_ENABLED",
-	Operators:   "MDB_OPERATOR_TELEMETRY_COLLECTION_OPERATORS_ENABLED",
-}
-
 func (e EventType) GetPayloadKey() string {
 	return fmt.Sprintf("%s%s", LastSendPayloadKey, e)
 }

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -9135,6 +9135,15 @@ spec:
                         x-kubernetes-validations:
                         - message: frequency must be at least 1m
                           rule: duration(self) >= duration('1m')
+                      kubeTimeout:
+                        default: 5m
+                        description: |-
+                          KubeTimeout is the timeout for Kubernetes API calls made while collecting telemetry.
+                          Duration using h (hours), m (minutes) and s (seconds) units, e.g. "30s", "5m". Must be at least 1s; defaults to 5m when omitted.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: kubeTimeout must be at least 1s
+                          rule: duration(self) >= duration('1s')
                       operators:
                         description: Operators controls collection of operator-level
                           telemetry.

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -384,10 +384,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY
-              value: "1h"
-            - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
-              value: "168h"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -374,10 +374,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: MANAGED_SECURITY_CONTEXT
               value: 'true'
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY
-              value: "1h"
-            - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
-              value: "168h"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -382,10 +382,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY
-              value: "1h"
-            - name: MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY
-              value: "168h"
             - name: IMAGE_PULL_POLICY
               value: Always
             # Database

--- a/scripts/dev/contexts/e2e_om70_kind_ubi
+++ b/scripts/dev/contexts/e2e_om70_kind_ubi
@@ -11,5 +11,6 @@ source "${script_dir}/variables/om70"
 export KUBE_ENVIRONMENT_NAME=kind
 
 # this is the only variant to fully deactivate telemetry.
-# this is mostly used to verify that deactivation works on the helm chart level
+# the test harness translates this into OperatorConfig.spec.telemetry.mode=Disabled, exercising the
+# telemetry master switch.
 export MDB_OPERATOR_TELEMETRY_ENABLED=false

--- a/scripts/dev/contexts/e2e_om70_kind_ubi
+++ b/scripts/dev/contexts/e2e_om70_kind_ubi
@@ -9,8 +9,3 @@ source "${script_dir}/root-context"
 source "${script_dir}/variables/om70"
 
 export KUBE_ENVIRONMENT_NAME=kind
-
-# this is the only variant to fully deactivate telemetry.
-# the test harness translates this into OperatorConfig.spec.telemetry.mode=Disabled, exercising the
-# telemetry master switch.
-export MDB_OPERATOR_TELEMETRY_ENABLED=false

--- a/scripts/dev/contexts/e2e_operator_race_ubi_with_telemetry
+++ b/scripts/dev/contexts/e2e_operator_race_ubi_with_telemetry
@@ -16,6 +16,9 @@ export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
 export BUILD_WITH_RACE_DETECTION=true
+# Telemetry send is enabled for this variant (translated into OperatorConfig.spec.telemetry.send.mode
+# by the test harness); the operator ships to the cloud-dev endpoint via the retained baseUrl env var.
+# Send/collection frequency are not configured in tests: the first collection and send happen at
+# operator startup, so the telemetry ConfigMap is populated regardless of frequency.
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 export MDB_OPERATOR_TELEMETRY_SEND_BASEURL="https://cloud-dev.mongodb.com/"
-export MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY="10m"

--- a/scripts/dev/contexts/e2e_operator_race_ubi_with_telemetry
+++ b/scripts/dev/contexts/e2e_operator_race_ubi_with_telemetry
@@ -18,7 +18,5 @@ export ops_manager_version="cloud_qa"
 export BUILD_WITH_RACE_DETECTION=true
 # Telemetry send is enabled for this variant (translated into OperatorConfig.spec.telemetry.send.mode
 # by the test harness); the operator ships to the cloud-dev endpoint via the retained baseUrl env var.
-# Send/collection frequency are not configured in tests: the first collection and send happen at
-# operator startup, so the telemetry ConfigMap is populated regardless of frequency.
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 export MDB_OPERATOR_TELEMETRY_SEND_BASEURL="https://cloud-dev.mongodb.com/"

--- a/scripts/dev/contexts/manual_telemetry_multi_cluster_dev
+++ b/scripts/dev/contexts/manual_telemetry_multi_cluster_dev
@@ -17,8 +17,7 @@ export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
 # Telemetry is configured via the OperatorConfig CR now. Send is translated into
 # OperatorConfig.spec.telemetry.send.mode by the test harness; the operator ships to cloud-dev via
-# the retained baseUrl env var. Frequencies are not configurable in tests (first collect/send are
-# immediate at startup).
+# the retained baseUrl env var.
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 export MDB_OPERATOR_TELEMETRY_SEND_BASEURL="https://cloud-dev.mongodb.com/"
 

--- a/scripts/dev/contexts/manual_telemetry_multi_cluster_dev
+++ b/scripts/dev/contexts/manual_telemetry_multi_cluster_dev
@@ -15,10 +15,12 @@ export CENTRAL_CLUSTER=kind-e2e-operator
 export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
+# Telemetry is configured via the OperatorConfig CR now. Send is translated into
+# OperatorConfig.spec.telemetry.send.mode by the test harness; the operator ships to cloud-dev via
+# the retained baseUrl env var. Frequencies are not configurable in tests (first collect/send are
+# immediate at startup).
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 export MDB_OPERATOR_TELEMETRY_SEND_BASEURL="https://cloud-dev.mongodb.com/"
-export MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY="10m" # let's send frequently
-export MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY="1m" # let's collect as often as we can
 
 # MCK is capable of deploying a webhook (optional).
 # To do so it needs know which pods to select for routing traffic

--- a/scripts/dev/contexts/manual_telemetry_multi_cluster_prod
+++ b/scripts/dev/contexts/manual_telemetry_multi_cluster_prod
@@ -15,9 +15,10 @@ export CENTRAL_CLUSTER=kind-e2e-operator
 export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
+# Telemetry is configured via the OperatorConfig CR now. Send is translated into
+# OperatorConfig.spec.telemetry.send.mode by the test harness. Frequencies are not configurable in
+# tests (first collect/send are immediate at startup).
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
-export MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY="10m" # let's send frequently
-export MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY="1m" # let's collect as often as we can
 
 # MCK is capable of deploying a webhook (optional).
 # To do so it needs know which pods to select for routing traffic

--- a/scripts/dev/contexts/manual_telemetry_multi_cluster_prod
+++ b/scripts/dev/contexts/manual_telemetry_multi_cluster_prod
@@ -16,8 +16,7 @@ export TEST_POD_CLUSTER=kind-e2e-cluster-1
 export test_pod_cluster=kind-e2e-cluster-1
 export ops_manager_version="cloud_qa"
 # Telemetry is configured via the OperatorConfig CR now. Send is translated into
-# OperatorConfig.spec.telemetry.send.mode by the test harness. Frequencies are not configurable in
-# tests (first collect/send are immediate at startup).
+# OperatorConfig.spec.telemetry.send.mode by the test harness.
 export MDB_OPERATOR_TELEMETRY_SEND_ENABLED=true
 
 # MCK is capable of deploying a webhook (optional).

--- a/scripts/dev/print_operator_env.sh
+++ b/scripts/dev/print_operator_env.sh
@@ -50,10 +50,6 @@ OPERATOR_NAME=\"${OPERATOR_NAME}\"
     echo "KUBECONFIG=${KUBECONFIG}"
   fi
 
-  # Telemetry enable/send/frequency are configured via the OperatorConfig CR, not env vars. Only the
-  # internal SEND_BASEURL knob (used to point telemetry at a mock/cloud-dev endpoint) is still an
-  # env var read by the operator. Note: when running the operator locally without an OperatorConfig
-  # CR in the target cluster, telemetry defaults to enabled (opt-out model).
   if [[ "${MDB_OPERATOR_TELEMETRY_SEND_BASEURL:-""}" != "" ]]; then
     echo "MDB_OPERATOR_TELEMETRY_SEND_BASEURL=${MDB_OPERATOR_TELEMETRY_SEND_BASEURL}"
   fi

--- a/scripts/dev/print_operator_env.sh
+++ b/scripts/dev/print_operator_env.sh
@@ -25,8 +25,6 @@ MONGODB_IMAGE=\"mongodb-enterprise-server\"
 MONGODB_AGENT_VERSION=\"${MONGODB_AGENT_VERSION:-}\"
 MONGODB_REPO_URL=\"${MONGODB_REPO_URL:-}\"
 IMAGE_PULL_SECRETS=\"image-registries-secret\"
-MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY=\"${MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY:-1m}\"
-MDB_OPERATOR_TELEMETRY_SEND_ENABLED=\"${MDB_OPERATOR_TELEMETRY_SEND_ENABLED:-false}\"
 MDB_COMMUNITY_IMAGE=\"${MDB_COMMUNITY_IMAGE}\"
 MDB_COMMUNITY_REPO_URL=\"${MDB_COMMUNITY_REPO_URL}\"
 MDB_COMMUNITY_AGENT_IMAGE=\"${MDB_COMMUNITY_AGENT_IMAGE}\"
@@ -52,10 +50,10 @@ OPERATOR_NAME=\"${OPERATOR_NAME}\"
     echo "KUBECONFIG=${KUBECONFIG}"
   fi
 
-  if [[ "${MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY:-""}" != "" ]]; then
-    echo "MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY=${MDB_OPERATOR_TELEMETRY_SEND_FREQUENCY}"
-  fi
-
+  # Telemetry enable/send/frequency are configured via the OperatorConfig CR, not env vars. Only the
+  # internal SEND_BASEURL knob (used to point telemetry at a mock/cloud-dev endpoint) is still an
+  # env var read by the operator. Note: when running the operator locally without an OperatorConfig
+  # CR in the target cluster, telemetry defaults to enabled (opt-out model).
   if [[ "${MDB_OPERATOR_TELEMETRY_SEND_BASEURL:-""}" != "" ]]; then
     echo "MDB_OPERATOR_TELEMETRY_SEND_BASEURL=${MDB_OPERATOR_TELEMETRY_SEND_BASEURL}"
   fi

--- a/scripts/evergreen/deployments/test-app/templates/mongodb-enterprise-tests.yaml
+++ b/scripts/evergreen/deployments/test-app/templates/mongodb-enterprise-tests.yaml
@@ -185,6 +185,10 @@ spec:
     - name: MDB_MAX_CONCURRENT_RECONCILES
       value: "{{ .Values.maxConcurrentReconciles }}"
     {{ end }}
+    - name: MDB_OPERATOR_TELEMETRY_SEND_ENABLED
+      value: "{{ .Values.mdbOperatorTelemetrySendEnabled }}"
+    - name: MDB_OPERATOR_TELEMETRY_ENABLED
+      value: "{{ .Values.mdbOperatorTelemetryEnabled }}"
     - name: CLUSTER_DOMAIN
       value: "{{ .Values.clusterDomain }}"
     {{ if .Values.omDebugHttp }}

--- a/scripts/evergreen/deployments/test-app/values.yaml
+++ b/scripts/evergreen/deployments/test-app/values.yaml
@@ -41,6 +41,12 @@ otel_resource_attributes:
 pytestOtelEnabled: true
 mdbDefaultArchitecture: "non-static"
 
+# Telemetry signals read by build_operator_config_spec_from_test_env() to configure the
+# OperatorConfig CR for the operator under test. Send is disabled by default so e2e operators
+# do not ship telemetry to cloud; the telemetry variant sets sendEnabled=true.
+mdbOperatorTelemetrySendEnabled: "false"
+mdbOperatorTelemetryEnabled: "true"
+
 # set to "true" to set OM_DEBUG_HTTP=true for the operator
 omDebugHttp:
 

--- a/scripts/evergreen/deployments/test-app/values.yaml
+++ b/scripts/evergreen/deployments/test-app/values.yaml
@@ -41,7 +41,7 @@ otel_resource_attributes:
 pytestOtelEnabled: true
 mdbDefaultArchitecture: "non-static"
 
-# Telemetry signals read by build_operator_config_spec_from_test_env() to configure the
+# Telemetry signals read by test harness to configure the
 # OperatorConfig CR for the operator under test. Send is disabled by default so e2e operators
 # do not ship telemetry to cloud; the telemetry variant sets sendEnabled=true.
 mdbOperatorTelemetrySendEnabled: "false"

--- a/scripts/evergreen/e2e/single_e2e.sh
+++ b/scripts/evergreen/e2e/single_e2e.sh
@@ -74,6 +74,8 @@ deploy_test_app() {
         "--set" "managedSecurityContext=${MANAGED_SECURITY_CONTEXT:-false}"
         "--set" "registry=${REGISTRY}"
         "--set" "mdbDefaultArchitecture=${MDB_DEFAULT_ARCHITECTURE:-'non-static'}"
+        "--set" "mdbOperatorTelemetrySendEnabled=${MDB_OPERATOR_TELEMETRY_SEND_ENABLED:-'false'}"
+        "--set" "mdbOperatorTelemetryEnabled=${MDB_OPERATOR_TELEMETRY_ENABLED:-'true'}"
         "--set" "clusterDomain=${CLUSTER_DOMAIN:-'cluster.local'}"
         "--set" "cognito_user_pool_id=${cognito_user_pool_id}"
         "--set" "cognito_workload_federation_client_id=${cognito_workload_federation_client_id}"

--- a/scripts/funcs/operator_deployment
+++ b/scripts/funcs/operator_deployment
@@ -30,10 +30,9 @@ get_operator_helm_values() {
     "versionUpgradeHook.version=${VERSION_UPGRADE_HOOK_VERSION}"
     "mongodb.name=mongodb-enterprise-server"
     "operator.mdbDefaultArchitecture=${MDB_DEFAULT_ARCHITECTURE:-non-static}"
-    # only send the telemetry to the backend on a specific variant, thus default to false
-    "operator.telemetry.send.enabled=${MDB_OPERATOR_TELEMETRY_SEND_ENABLED:-false}"
-    # lets collect and save in the configmap as frequently as we can
-    "operator.telemetry.collection.frequency=${MDB_OPERATOR_TELEMETRY_COLLECTION_FREQUENCY:-1m}"
+    # Telemetry send/collection are configured via the OperatorConfig CR (see
+    # build_operator_config_spec_from_test_env); they are no longer Helm values. The retained
+    # operator.telemetry.send.baseUrl knob is set further below.
     "search.repo=${MDB_SEARCH_REPO_URL}"
     "search.name=${MDB_SEARCH_NAME}"
     "search.version=${MDB_SEARCH_VERSION}"
@@ -67,13 +66,6 @@ get_operator_helm_values() {
     if [[ -n "${otel_collector_endpoint:-}" ]]; then
       config+=("operator.opentelemetry.tracing.collectorEndpoint=${otel_collector_endpoint}")
     fi
-  fi
-
-  if [[ "${MDB_OPERATOR_TELEMETRY_ENABLED:-true}" == "false" ]]; then
-    config+=("operator.telemetry.enabled=false")
-    config+=("operator.telemetry.collection.clusters.enabled=false")
-    config+=("operator.telemetry.collection.deployments.enabled=false")
-    config+=("operator.telemetry.collection.operators.enabled=false")
   fi
 
   # shellcheck disable=SC2154

--- a/scripts/funcs/operator_deployment
+++ b/scripts/funcs/operator_deployment
@@ -30,9 +30,6 @@ get_operator_helm_values() {
     "versionUpgradeHook.version=${VERSION_UPGRADE_HOOK_VERSION}"
     "mongodb.name=mongodb-enterprise-server"
     "operator.mdbDefaultArchitecture=${MDB_DEFAULT_ARCHITECTURE:-non-static}"
-    # Telemetry send/collection are configured via the OperatorConfig CR (see
-    # build_operator_config_spec_from_test_env); they are no longer Helm values. The retained
-    # operator.telemetry.send.baseUrl knob is set further below.
     "search.repo=${MDB_SEARCH_REPO_URL}"
     "search.name=${MDB_SEARCH_NAME}"
     "search.version=${MDB_SEARCH_VERSION}"


### PR DESCRIPTION
# Summary

Part of the Installation UX epic: operator settings are being moved off Helm
values and environment variables onto the `OperatorConfig` CR so a single base
deployment can be reconfigured post-installation across Helm, OLM and raw YAML.
This PR migrates the telemetry configuration.

Telemetry is now configured via `OperatorConfig.spec.telemetry`: master `mode`,
`collection.frequency`, `collection.kubeTimeout`, per-type
`collection.{clusters,deployments,operators}.mode`, `send.mode` and
`send.frequency`. The `operator.telemetry.*` Helm values and the
`MDB_OPERATOR_TELEMETRY_*` environment variables are removed; the operator reads
the resolved config once at startup and the existing OperatorConfig watcher
restarts it on change. Telemetry remains opt-out (absence of config keeps it
enabled) and all default values are unchanged. `MDB_OPERATOR_TELEMETRY_KUBE_TIMEOUT`
is promoted to `spec.telemetry.collection.kubeTimeout`;
`MDB_OPERATOR_TELEMETRY_SEND_BASEURL` is retained as an internal, test-only knob
(settable via `operator.telemetry.send.baseUrl`).

## Proof of Work

- Unit tests `go test ./pkg/telemetry/... ./pkg/operatorconfig/...` pass, covering
  telemetry defaulting in `withDefaults`, the resolved `Config` threading, and the
  send-frequency / kube-timeout behaviour.
- `helm template` renders with no telemetry env vars by default, emits
  `MDB_OPERATOR_TELEMETRY_SEND_BASEURL` only when `operator.telemetry.send.baseUrl`
  is set, and still deploys the telemetry ClusterRole.
- e2e: pending — to be exercised via a targeted Evergreen patch on this draft.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->