### PR TITLE
add makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,16 @@ usage:
 prerequisites:
 	@ scripts/dev/install.sh
 
-precommit:
+PREK := $(shell pwd)/bin/prek
+
+.PHONY: prek
+prek:
+	@[ -f "$(PREK)" ] || scripts/evergreen/setup_prek.sh
+
+precommit: prek
 	@ source scripts/dev/set_env_context.sh && prek -a
 
-precommit-full:
+precommit-full: prek
 	@ source scripts/dev/set_env_context.sh && MDB_UPDATE_LICENSES=true MDB_REGENERATE_RBAC=true prek -a
 
 switch:


### PR DESCRIPTION
# Summary

This pull request improves the reliability of the `precommit` and `precommit-full` Makefile targets by ensuring the `prek` binary is available before running them. The changes introduce a new `prek` target that checks for the existence of the `prek` binary and runs a setup script if it's missing.

**Build process improvements:**

* Added a `.PHONY` `prek` target to the `Makefile` that checks for the presence of the `prek` binary and runs `scripts/evergreen/setup_prek.sh` if it's not found, ensuring the required tool is available.
* Updated the `precommit` and `precommit-full` targets to depend on the new `prek` target, improving robustness and reducing the chance of missing dependencies during pre-commit checks.

## Proof of Work

```
~/projects/mongodb-kubernetes use-prefk-markfiletarget *4                                                                                                                                                                                                                                                                                                               󰌠 3.13.7 (mongodb-kubernetes)  1.26.4 󱃾 docker-desktop   19:19:
❯ make precommit
update-mongodb-operator-version..........................................
generate-manifests................
```

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
