### PR TITLE
[KUBE-162] Add E2E test for multi cluster status in search resource

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -907,6 +907,11 @@ func (r *MongoDBSearchReconcileHelper) deploymentReadiness(ctx context.Context, 
 	if dep.Status.ReadyReplicas < desired {
 		return workflow.Pending("%s deployment %s not ready: %d/%d replicas ready", kind, name, dep.Status.ReadyReplicas, desired)
 	}
+	// UpdatedReplicas and ReadyReplicas both reach desired even during a stuck rollout (new-spec pod created but unschedulable
+	// while the old pod stays Ready); only UnavailableReplicas reflects the pending surge pod.
+	if dep.Status.UnavailableReplicas > 0 {
+		return workflow.Pending("%s deployment %s rollout in progress: %d unavailable replica(s)", kind, name, dep.Status.UnavailableReplicas)
+	}
 	return workflow.OK()
 }
 

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -101,20 +101,20 @@ class MongoDBSearch(MongoDB, CustomObject):
             logger.info(f"MongoDBSearch {self.name}: loadBalancer status correctly absent")
 
     def get_cluster_statuses(self) -> list[dict]:
-        """Returns the status.clusterStatuses list, or [] if absent.
+        """Returns the status.clusters list, or [] if absent.
 
         The search controller is the sole writer and recomputes the whole list
-        every reconcile (one entry per spec.clusters[], keyed by clusterIndex).
+        every reconcile (one entry per spec.clusters[], keyed by index).
         """
         try:
-            return list(self["status"]["clusterStatuses"] or [])
+            return list(self["status"]["clusters"] or [])
         except KeyError:
             return []
 
     def get_cluster_status(self, cluster_index: int) -> Optional[dict]:
-        """Returns the per-cluster status entry with the given clusterIndex, or None."""
+        """Returns the per-cluster status entry with the given index, or None."""
         for cs in self.get_cluster_statuses():
-            if cs.get("clusterIndex") == cluster_index:
+            if cs.get("index") == cluster_index:
                 return cs
         return None
 
@@ -123,35 +123,40 @@ class MongoDBSearch(MongoDB, CustomObject):
         clusters = self["spec"].get("clusters", []) or []
         return [c.get("index", i) for i, c in enumerate(clusters)]
 
-    def assert_cluster_statuses(self, expected_count: Optional[int] = None, expect_managed_lb: Optional[bool] = None):
-        """Assert status.clusterStatuses is well-formed for a healthy (Running) deployment.
+    def assert_cluster_statuses(
+        self,
+        expected_count: Optional[int] = None,
+        expect_managed_lb: Optional[bool] = None,
+        expect_metrics_forwarder: bool = False,
+    ):
+        """Assert status.clusters is well-formed for a healthy (Running) deployment.
 
         - One entry per spec.clusters[], no more, no less (expected_count overrides).
-        - clusterIndex values exactly match the spec pins and are unique.
+        - index values exactly match the spec pins and are unique.
         - Every entry's search phase is Running with an empty searchMessage.
         - loadBalancer phase is Running (empty message) iff managed LB, else absent/empty
           (expect_managed_lb overrides is_lb_mode_managed()).
+        - metricsForwarder phase is Running (empty message) iff expect_metrics_forwarder,
+          else absent/empty.
         """
         self.load()
         statuses = self.get_cluster_statuses()
         spec_indexes = self._spec_cluster_indexes()
 
         want_count = expected_count if expected_count is not None else len(spec_indexes)
-        assert (
-            len(statuses) == want_count
-        ), f"expected {want_count} clusterStatuses entries, got {len(statuses)}: {statuses}"
+        assert len(statuses) == want_count, f"expected {want_count} clusters entries, got {len(statuses)}: {statuses}"
 
-        got_indexes = [cs.get("clusterIndex") for cs in statuses]
-        assert len(set(got_indexes)) == len(got_indexes), f"duplicate clusterIndex in clusterStatuses: {got_indexes}"
+        got_indexes = [cs.get("index") for cs in statuses]
+        assert len(set(got_indexes)) == len(got_indexes), f"duplicate index in status.clusters: {got_indexes}"
         if expected_count is None:
             assert sorted(got_indexes) == sorted(
                 spec_indexes
-            ), f"clusterStatuses indexes {sorted(got_indexes)} != spec.clusters indexes {sorted(spec_indexes)}"
+            ), f"status.clusters indexes {sorted(got_indexes)} != spec.clusters indexes {sorted(spec_indexes)}"
 
         managed_lb = expect_managed_lb if expect_managed_lb is not None else self.is_lb_mode_managed()
 
         for cs in statuses:
-            ci = cs.get("clusterIndex")
+            ci = cs.get("index")
             assert (
                 cs.get("search") == "Running"
             ), f"cluster {ci}: search phase is {cs.get('search')!r}, expected Running"
@@ -171,7 +176,24 @@ class MongoDBSearch(MongoDB, CustomObject):
                     "loadBalancer"
                 ), f"cluster {ci}: loadBalancer should be absent for non-managed LB, got {cs.get('loadBalancer')!r}"
 
-        logger.info(f"MongoDBSearch {self.name}: clusterStatuses OK ({len(statuses)} entries, managed_lb={managed_lb})")
+            if expect_metrics_forwarder:
+                assert (
+                    cs.get("metricsForwarder") == "Running"
+                ), f"cluster {ci}: metricsForwarder phase is {cs.get('metricsForwarder')!r}, expected Running"
+                assert not cs.get("metricsForwarderMessage"), (
+                    f"cluster {ci}: metricsForwarderMessage should be empty when Running, "
+                    f"got {cs.get('metricsForwarderMessage')!r}"
+                )
+            else:
+                assert not cs.get("metricsForwarder"), (
+                    f"cluster {ci}: metricsForwarder should be absent when forwarder disabled, "
+                    f"got {cs.get('metricsForwarder')!r}"
+                )
+
+        logger.info(
+            f"MongoDBSearch {self.name}: status.clusters OK ({len(statuses)} entries, "
+            f"managed_lb={managed_lb}, metrics_forwarder={expect_metrics_forwarder})"
+        )
 
     def wait_for_cluster_search_phase(
         self,
@@ -203,6 +225,21 @@ class MongoDBSearch(MongoDB, CustomObject):
             "loadBalancer", "loadBalancerMessage", cluster_index, expected_phase, expect_message, timeout
         )
 
+    def wait_for_cluster_metrics_forwarder_phase(
+        self,
+        cluster_index: int,
+        expected_phase: Phase,
+        expect_message: bool,
+        timeout: int = 300,
+    ):
+        """Poll until the given cluster's per-cluster METRICS FORWARDER phase reaches expected_phase.
+
+        Same message semantics as wait_for_cluster_search_phase, on metricsForwarderMessage.
+        """
+        self._wait_for_cluster_phase(
+            "metricsForwarder", "metricsForwarderMessage", cluster_index, expected_phase, expect_message, timeout
+        )
+
     def _wait_for_cluster_phase(
         self,
         phase_key: str,
@@ -220,7 +257,7 @@ class MongoDBSearch(MongoDB, CustomObject):
             if cs is None:
                 return (
                     False,
-                    f"no clusterStatuses entry for clusterIndex {cluster_index}: {self.get_cluster_statuses()}",
+                    f"no status.clusters entry for index {cluster_index}: {self.get_cluster_statuses()}",
                 )
             phase = cs.get(phase_key)
             msg = cs.get(message_key) or ""

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -123,6 +123,11 @@ class MongoDBSearch(MongoDB, CustomObject):
         clusters = self["spec"].get("clusters", []) or []
         return [c.get("index", i) for i, c in enumerate(clusters)]
 
+    def _spec_cluster_pairs(self) -> list[tuple[str, int]]:
+        """The (name, index) pairs from spec.clusters[], index defaulting to positional."""
+        clusters = self["spec"].get("clusters", []) or []
+        return [(c.get("name", ""), c.get("index", i)) for i, c in enumerate(clusters)]
+
     def assert_cluster_statuses(
         self,
         expected_count: Optional[int] = None,
@@ -130,23 +135,30 @@ class MongoDBSearch(MongoDB, CustomObject):
         expect_metrics_forwarder: Optional[bool] = None,
     ):
         """Assert status.clusters is well-formed for a healthy (Running) deployment:
-        one entry per spec.clusters[] (unique, matching index pins), each with search
-        Running. loadBalancer is Running iff managed LB (else absent). metricsForwarder:
-        None (default) skips the check; True requires Running, False requires absent.
+        one entry per spec.clusters[] with the exact (name, index) pairs matching spec,
+        each with search Running. loadBalancer is Running iff managed LB (else absent).
+        metricsForwarder: None (default) skips the check; True requires Running, False
+        requires absent. expected_count, when given, is an extra count assertion.
         """
         self.load()
         statuses = self.get_cluster_statuses()
-        spec_indexes = self._spec_cluster_indexes()
+        spec_cluster_name_index_pairs = self._spec_cluster_pairs()
 
-        want_count = expected_count if expected_count is not None else len(spec_indexes)
-        assert len(statuses) == want_count, f"expected {want_count} clusters entries, got {len(statuses)}: {statuses}"
+        assert len(statuses) == len(
+            spec_cluster_name_index_pairs
+        ), f"expected {len(spec_cluster_name_index_pairs)} clusters entries (one per spec.clusters[]), got {len(statuses)}: {statuses}"
+        if expected_count is not None:
+            assert (
+                len(statuses) == expected_count
+            ), f"expected {expected_count} clusters entries, got {len(statuses)}: {statuses}"
 
         got_indexes = [cs.get("index") for cs in statuses]
         assert len(set(got_indexes)) == len(got_indexes), f"duplicate index in status.clusters: {got_indexes}"
-        if expected_count is None:
-            assert sorted(got_indexes) == sorted(
-                spec_indexes
-            ), f"status.clusters indexes {sorted(got_indexes)} != spec.clusters indexes {sorted(spec_indexes)}"
+
+        got_pairs = [(cs.get("name", ""), cs.get("index")) for cs in statuses]
+        assert sorted(got_pairs) == sorted(
+            spec_cluster_name_index_pairs
+        ), f"status.clusters (name, index) pairs {sorted(got_pairs)} != spec.clusters {sorted(spec_cluster_name_index_pairs)}"
 
         managed_lb = expect_managed_lb if expect_managed_lb is not None else self.is_lb_mode_managed()
 

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -127,17 +127,12 @@ class MongoDBSearch(MongoDB, CustomObject):
         self,
         expected_count: Optional[int] = None,
         expect_managed_lb: Optional[bool] = None,
-        expect_metrics_forwarder: bool = False,
+        expect_metrics_forwarder: Optional[bool] = None,
     ):
-        """Assert status.clusters is well-formed for a healthy (Running) deployment.
-
-        - One entry per spec.clusters[], no more, no less (expected_count overrides).
-        - index values exactly match the spec pins and are unique.
-        - Every entry's search phase is Running with an empty searchMessage.
-        - loadBalancer phase is Running (empty message) iff managed LB, else absent/empty
-          (expect_managed_lb overrides is_lb_mode_managed()).
-        - metricsForwarder phase is Running (empty message) iff expect_metrics_forwarder,
-          else absent/empty.
+        """Assert status.clusters is well-formed for a healthy (Running) deployment:
+        one entry per spec.clusters[] (unique, matching index pins), each with search
+        Running. loadBalancer is Running iff managed LB (else absent). metricsForwarder:
+        None (default) skips the check; True requires Running, False requires absent.
         """
         self.load()
         statuses = self.get_cluster_statuses()
@@ -176,7 +171,7 @@ class MongoDBSearch(MongoDB, CustomObject):
                     "loadBalancer"
                 ), f"cluster {ci}: loadBalancer should be absent for non-managed LB, got {cs.get('loadBalancer')!r}"
 
-            if expect_metrics_forwarder:
+            if expect_metrics_forwarder is True:
                 assert (
                     cs.get("metricsForwarder") == "Running"
                 ), f"cluster {ci}: metricsForwarder phase is {cs.get('metricsForwarder')!r}, expected Running"
@@ -184,11 +179,12 @@ class MongoDBSearch(MongoDB, CustomObject):
                     f"cluster {ci}: metricsForwarderMessage should be empty when Running, "
                     f"got {cs.get('metricsForwarderMessage')!r}"
                 )
-            else:
+            elif expect_metrics_forwarder is False:
                 assert not cs.get("metricsForwarder"), (
                     f"cluster {ci}: metricsForwarder should be absent when forwarder disabled, "
                     f"got {cs.get('metricsForwarder')!r}"
                 )
+            # expect_metrics_forwarder is None → do not assert on metricsForwarder
 
         logger.info(
             f"MongoDBSearch {self.name}: status.clusters OK ({len(statuses)} entries, "

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -100,6 +100,148 @@ class MongoDBSearch(MongoDB, CustomObject):
             assert lb is None, f"status.loadBalancer should be absent for non-managed LB, got: {lb}"
             logger.info(f"MongoDBSearch {self.name}: loadBalancer status correctly absent")
 
+    def get_cluster_statuses(self) -> list[dict]:
+        """Returns the status.clusterStatuses list, or [] if absent.
+
+        The search controller is the sole writer and recomputes the whole list
+        every reconcile (one entry per spec.clusters[], keyed by clusterIndex).
+        """
+        try:
+            return list(self["status"]["clusterStatuses"] or [])
+        except KeyError:
+            return []
+
+    def get_cluster_status(self, cluster_index: int) -> Optional[dict]:
+        """Returns the per-cluster status entry with the given clusterIndex, or None."""
+        for cs in self.get_cluster_statuses():
+            if cs.get("clusterIndex") == cluster_index:
+                return cs
+        return None
+
+    def _spec_cluster_indexes(self) -> list[int]:
+        """The pinned spec.clusters[].index values, defaulting to positional index."""
+        clusters = self["spec"].get("clusters", []) or []
+        return [c.get("index", i) for i, c in enumerate(clusters)]
+
+    def assert_cluster_statuses(self, expected_count: Optional[int] = None, expect_managed_lb: Optional[bool] = None):
+        """Assert status.clusterStatuses is well-formed for a healthy (Running) deployment.
+
+        - One entry per spec.clusters[], no more, no less (expected_count overrides).
+        - clusterIndex values exactly match the spec pins and are unique.
+        - Every entry's search phase is Running with an empty searchMessage.
+        - loadBalancer phase is Running (empty message) iff managed LB, else absent/empty
+          (expect_managed_lb overrides is_lb_mode_managed()).
+        """
+        self.load()
+        statuses = self.get_cluster_statuses()
+        spec_indexes = self._spec_cluster_indexes()
+
+        want_count = expected_count if expected_count is not None else len(spec_indexes)
+        assert (
+            len(statuses) == want_count
+        ), f"expected {want_count} clusterStatuses entries, got {len(statuses)}: {statuses}"
+
+        got_indexes = [cs.get("clusterIndex") for cs in statuses]
+        assert len(set(got_indexes)) == len(got_indexes), f"duplicate clusterIndex in clusterStatuses: {got_indexes}"
+        if expected_count is None:
+            assert sorted(got_indexes) == sorted(
+                spec_indexes
+            ), f"clusterStatuses indexes {sorted(got_indexes)} != spec.clusters indexes {sorted(spec_indexes)}"
+
+        managed_lb = expect_managed_lb if expect_managed_lb is not None else self.is_lb_mode_managed()
+
+        for cs in statuses:
+            ci = cs.get("clusterIndex")
+            assert (
+                cs.get("search") == "Running"
+            ), f"cluster {ci}: search phase is {cs.get('search')!r}, expected Running"
+            assert not cs.get(
+                "searchMessage"
+            ), f"cluster {ci}: searchMessage should be empty when Running, got {cs.get('searchMessage')!r}"
+            if managed_lb:
+                assert (
+                    cs.get("loadBalancer") == "Running"
+                ), f"cluster {ci}: loadBalancer phase is {cs.get('loadBalancer')!r}, expected Running"
+                assert not cs.get("loadBalancerMessage"), (
+                    f"cluster {ci}: loadBalancerMessage should be empty when Running, "
+                    f"got {cs.get('loadBalancerMessage')!r}"
+                )
+            else:
+                assert not cs.get(
+                    "loadBalancer"
+                ), f"cluster {ci}: loadBalancer should be absent for non-managed LB, got {cs.get('loadBalancer')!r}"
+
+        logger.info(f"MongoDBSearch {self.name}: clusterStatuses OK ({len(statuses)} entries, managed_lb={managed_lb})")
+
+    def wait_for_cluster_search_phase(
+        self,
+        cluster_index: int,
+        expected_phase: Phase,
+        expect_message: bool,
+        timeout: int = 300,
+    ):
+        """Poll until the given cluster's per-cluster SEARCH phase reaches expected_phase.
+
+        When expect_message is True, also require a non-empty searchMessage (the phase is
+        not Running so it must explain why); when False, require an empty searchMessage.
+        Raises on timeout with the last-seen entry for diagnostics.
+        """
+        self._wait_for_cluster_phase("search", "searchMessage", cluster_index, expected_phase, expect_message, timeout)
+
+    def wait_for_cluster_lb_phase(
+        self,
+        cluster_index: int,
+        expected_phase: Phase,
+        expect_message: bool,
+        timeout: int = 300,
+    ):
+        """Poll until the given cluster's per-cluster LOAD BALANCER phase reaches expected_phase.
+
+        Same message semantics as wait_for_cluster_search_phase, on loadBalancerMessage.
+        """
+        self._wait_for_cluster_phase(
+            "loadBalancer", "loadBalancerMessage", cluster_index, expected_phase, expect_message, timeout
+        )
+
+    def _wait_for_cluster_phase(
+        self,
+        phase_key: str,
+        message_key: str,
+        cluster_index: int,
+        expected_phase: Phase,
+        expect_message: bool,
+        timeout: int,
+    ):
+        from kubetester.kubetester import run_periodically
+
+        def check() -> tuple:
+            self.load()
+            cs = self.get_cluster_status(cluster_index)
+            if cs is None:
+                return (
+                    False,
+                    f"no clusterStatuses entry for clusterIndex {cluster_index}: {self.get_cluster_statuses()}",
+                )
+            phase = cs.get(phase_key)
+            msg = cs.get(message_key) or ""
+            if phase != expected_phase.name:
+                return (
+                    False,
+                    f"cluster {cluster_index}: {phase_key}={phase!r}, want {expected_phase.name!r} (msg={msg!r})",
+                )
+            if expect_message and not msg:
+                return False, f"cluster {cluster_index}: {phase_key}={phase!r} but {message_key} is empty"
+            if not expect_message and msg:
+                return False, f"cluster {cluster_index}: {phase_key}={phase!r} but {message_key} not cleared: {msg!r}"
+            return True, f"cluster {cluster_index}: {phase_key}={phase} (msg={msg!r}) as expected"
+
+        run_periodically(
+            check,
+            timeout=timeout,
+            sleep_time=10,
+            msg=f"cluster {cluster_index} {phase_key} -> {expected_phase.name}",
+        )
+
     def get_metrics_forwarder_status(self) -> Optional[dict]:
         """Returns the status.metricsForwarder substatus dict, or None if absent."""
         try:

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -215,8 +215,7 @@ class MongoDBSearch(MongoDB, CustomObject):
         expect_message: bool,
         timeout: int = 300,
     ):
-        """Poll until the given cluster's per-cluster LOAD BALANCER phase reaches expected_phase.
-        """
+        """Poll until the given cluster's per-cluster LOAD BALANCER phase reaches expected_phase."""
         self._wait_for_cluster_phase(
             "loadBalancer", "loadBalancerMessage", cluster_index, expected_phase, expect_message, timeout
         )
@@ -228,8 +227,7 @@ class MongoDBSearch(MongoDB, CustomObject):
         expect_message: bool,
         timeout: int = 300,
     ):
-        """Poll until the given cluster's per-cluster METRICS FORWARDER phase reaches expected_phase.
-        """
+        """Poll until the given cluster's per-cluster METRICS FORWARDER phase reaches expected_phase."""
         self._wait_for_cluster_phase(
             "metricsForwarder", "metricsForwarderMessage", cluster_index, expected_phase, expect_message, timeout
         )

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_search.py
@@ -204,9 +204,7 @@ class MongoDBSearch(MongoDB, CustomObject):
     ):
         """Poll until the given cluster's per-cluster SEARCH phase reaches expected_phase.
 
-        When expect_message is True, also require a non-empty searchMessage (the phase is
-        not Running so it must explain why); when False, require an empty searchMessage.
-        Raises on timeout with the last-seen entry for diagnostics.
+        When expect_message is True, also require a non-empty searchMessage when False, require an empty searchMessage.
         """
         self._wait_for_cluster_phase("search", "searchMessage", cluster_index, expected_phase, expect_message, timeout)
 
@@ -218,8 +216,6 @@ class MongoDBSearch(MongoDB, CustomObject):
         timeout: int = 300,
     ):
         """Poll until the given cluster's per-cluster LOAD BALANCER phase reaches expected_phase.
-
-        Same message semantics as wait_for_cluster_search_phase, on loadBalancerMessage.
         """
         self._wait_for_cluster_phase(
             "loadBalancer", "loadBalancerMessage", cluster_index, expected_phase, expect_message, timeout
@@ -233,8 +229,6 @@ class MongoDBSearch(MongoDB, CustomObject):
         timeout: int = 300,
     ):
         """Poll until the given cluster's per-cluster METRICS FORWARDER phase reaches expected_phase.
-
-        Same message semantics as wait_for_cluster_search_phase, on metricsForwarderMessage.
         """
         self._wait_for_cluster_phase(
             "metricsForwarder", "metricsForwarderMessage", cluster_index, expected_phase, expect_message, timeout

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -1177,11 +1177,8 @@ def _set_envoy_memory_request(mdbs: MongoDBSearch, list_pos: int, memory: str | 
     """Set (memory != None) or clear the managed Envoy resourceRequirements.requests.memory
     for spec.clusters[list_pos].
 
-    The Envoy Deployment defaults to RollingUpdate; with maxUnavailable rounding to 0 the
-    old Ready pods would keep readyReplicas == desired and MASK an unschedulable surge pod,
-    so envoyDeploymentStatus never reports Pending. We pin strategy.type=Recreate via the
-    deployment override alongside the bad request: Recreate tears the old pod(s) down first,
-    driving readyReplicas to 0 so the fault reliably surfaces. Reverting clears both."""
+    We need this to set unreasonable memeory request to simulate the faulty envoy deployment to test the search status.
+    """
     mdbs.load()
     managed = mdbs["spec"]["clusters"][list_pos]["loadBalancer"]["managed"]
     if memory is None:

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -1154,6 +1154,25 @@ def _set_mongot_memory_request(mdbs: MongoDBSearch, list_pos: int, memory: str |
     mdbs.update()
 
 
+def _delete_mongot_pods_for_cluster(
+    mdbs: MongoDBSearch,
+    cluster_index: int,
+    member_cluster_clients: List[MultiClusterClient],
+) -> None:
+    """Delete the mongot StatefulSet pods for a cluster so the STS recreates them from the
+    current template, if the pods are stuck in pending STS would not updated them."""
+    sts_prefix = f"{MDBS_RESOURCE_NAME}-search-{cluster_index}-"
+    for mcc in member_cluster_clients:
+        if mcc.cluster_index != cluster_index:
+            continue
+        core = mcc.core_v1_api()
+        for pod in core.list_namespaced_pod(mdbs.namespace).items:
+            name = pod.metadata.name
+            if name.startswith(sts_prefix) and not name.startswith(f"{sts_prefix}lb"):
+                logger.info(f"deleting wedged mongot pod {name} in cluster {mcc.cluster_name}")
+                core.delete_namespaced_pod(name, mdbs.namespace)
+
+
 def _set_envoy_memory_request(mdbs: MongoDBSearch, list_pos: int, memory: str | None) -> None:
     """Set (memory != None) or clear the managed Envoy resourceRequirements.requests.memory
     for spec.clusters[list_pos].
@@ -1202,11 +1221,13 @@ def test_mongot_fault_degrades_only_that_clusters_search(mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_q2_mc_rs_steady
-def test_mongot_fault_recovers(mdbs: MongoDBSearch):
+def test_mongot_fault_recovers(mdbs: MongoDBSearch, member_cluster_clients: List[MultiClusterClient]):
     """Reverting the mongot request transitions the fault cluster's `search` sub-phase back
-    to Running and clears its message automatically."""
+    to Running and clears its message.
+    """
     faulted_ci = _cluster_index_at(mdbs, MONGOT_FAULT_POS)
     _set_mongot_memory_request(mdbs, MONGOT_FAULT_POS, None)
+    _delete_mongot_pods_for_cluster(mdbs, faulted_ci, member_cluster_clients)
     mdbs.wait_for_cluster_search_phase(faulted_ci, Phase.Running, expect_message=False, timeout=STATUS_RECOVER_TIMEOUT)
     mdbs.assert_reaches_phase(Phase.Running, timeout=STATUS_RECOVER_TIMEOUT)
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -1174,19 +1174,16 @@ def _delete_mongot_pods_for_cluster(
 
 
 def _set_envoy_memory_request(mdbs: MongoDBSearch, list_pos: int, memory: str | None) -> None:
-    """Set (memory != None) or clear the managed Envoy resourceRequirements.requests.memory
-    for spec.clusters[list_pos].
-
-    We need this to set unreasonable memeory request to simulate the faulty envoy deployment to test the search status.
+    """Set (memory != None) or clear the managed Envoy memory request for spec.clusters[list_pos]
+    to simulate a faulty envoy deployment. Keeps the default RollingUpdate strategy so the test
+    exercises the production rollout case (old pod Ready while the new one is unschedulable).
     """
     mdbs.load()
     managed = mdbs["spec"]["clusters"][list_pos]["loadBalancer"]["managed"]
     if memory is None:
         managed.pop("resourceRequirements", None)
-        managed.pop("deployment", None)
     else:
         managed["resourceRequirements"] = {"requests": {"memory": memory}}
-        managed["deployment"] = {"spec": {"strategy": {"type": "Recreate"}}}
     mdbs.update()
 
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -768,6 +768,14 @@ def test_verify_lb_status(mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_q2_mc_rs_steady
+def test_verify_per_cluster_status(mdbs: MongoDBSearch):
+    """Real multi-cluster: status.clusterStatuses has ONE entry per member cluster, each
+    with search and loadBalancer sub-phases Running, and clusterIndex values matching the
+    spec.clusters[] pins."""
+    mdbs.assert_cluster_statuses(expected_count=len(MEMBERS_PER_CLUSTER), expect_managed_lb=True)
+
+
+@mark.e2e_search_q2_mc_rs_steady
 def test_patch_per_cluster_mongot_host(
     mdb: MongoDBMulti,
     helper: MCSearchDeploymentHelper,
@@ -924,6 +932,7 @@ SEARCH_INDEX_READY_TIMEOUT = 300
 SEARCH_QUERY_RETRY_TIMEOUT = 60
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
     """mongorestore the sample_mflix.archive into the source RS."""
@@ -935,6 +944,7 @@ def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
     )
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_create_search_index(
     mdb: MongoDBMulti,
@@ -952,6 +962,7 @@ def test_create_search_index(
     tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_execute_text_search_query(
     mdb: MongoDBMulti,
@@ -985,6 +996,7 @@ def test_execute_text_search_query(
     )
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_create_vector_search_index(
     mdb: MongoDBMulti,
@@ -1005,6 +1017,7 @@ def test_create_vector_search_index(
     embedded.wait_for_vector_search_index(timeout=SEARCH_INDEX_READY_TIMEOUT)
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_execute_vector_search_query(
     mdb: MongoDBMulti,
@@ -1042,6 +1055,7 @@ def test_execute_vector_search_query(
     )
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_per_cluster_search_query(
     mdb: MongoDBMulti,
@@ -1077,6 +1091,7 @@ def test_per_cluster_search_query(
         )
 
 
+@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_per_cluster_vector_search_query(
     mdb: MongoDBMulti,
@@ -1116,3 +1131,126 @@ def test_per_cluster_vector_search_query(
             sleep_time=5,
             msg=f"cluster {cluster_index}: $vectorSearch query to succeed",
         )
+
+# Larger than any node in the e2e kind clusters — guarantees Unschedulable.
+UNSCHEDULABLE_MEMORY = "10000Gi"
+STATUS_DEGRADE_TIMEOUT = 300
+STATUS_RECOVER_TIMEOUT = 600
+
+# Fault targets are spec.clusters[] LIST POSITIONS.
+MONGOT_FAULT_POS = 0
+ENVOY_FAULT_POS = 1
+
+
+def _cluster_index_at(mdbs: MongoDBSearch, list_pos: int) -> int:
+    """The clusterIndex pin of the spec.clusters[] entry at the given list position."""
+    mdbs.load()
+    clusters = mdbs["spec"]["clusters"]
+    return clusters[list_pos].get("index", list_pos)
+
+
+def _set_mongot_memory_request(mdbs: MongoDBSearch, list_pos: int, memory: str | None) -> None:
+    """Set (memory != None) or clear spec.clusters[list_pos].resourceRequirements.requests.memory."""
+    mdbs.load()
+    cluster = mdbs["spec"]["clusters"][list_pos]
+    if memory is None:
+        cluster.pop("resourceRequirements", None)
+    else:
+        cluster["resourceRequirements"] = {"requests": {"memory": memory}}
+    mdbs.update()
+
+
+def _set_envoy_memory_request(mdbs: MongoDBSearch, list_pos: int, memory: str | None) -> None:
+    """Set (memory != None) or clear the managed Envoy resourceRequirements.requests.memory
+    for spec.clusters[list_pos].
+
+    The Envoy Deployment defaults to RollingUpdate; with maxUnavailable rounding to 0 the
+    old Ready pods would keep readyReplicas == desired and MASK an unschedulable surge pod,
+    so envoyDeploymentStatus never reports Pending. We pin strategy.type=Recreate via the
+    deployment override alongside the bad request: Recreate tears the old pod(s) down first,
+    driving readyReplicas to 0 so the fault reliably surfaces. Reverting clears both."""
+    mdbs.load()
+    managed = mdbs["spec"]["clusters"][list_pos]["loadBalancer"]["managed"]
+    if memory is None:
+        managed.pop("resourceRequirements", None)
+        managed.pop("deployment", None)
+    else:
+        managed["resourceRequirements"] = {"requests": {"memory": memory}}
+        managed["deployment"] = {"spec": {"strategy": {"type": "Recreate"}}}
+    mdbs.update()
+
+
+@mark.e2e_search_q2_mc_rs_steady
+def test_mongot_fault_degrades_only_that_clusters_search(mdbs: MongoDBSearch):
+    """Unschedulable mongot on the specific cluster -> only that cluster's `search` sub-phase leaves
+    Running with a message; its `loadBalancer` sub-phase and the other cluster stay Running."""
+    faulted_ci = _cluster_index_at(mdbs, MONGOT_FAULT_POS)
+    other_ci = _cluster_index_at(mdbs, ENVOY_FAULT_POS)
+    _set_mongot_memory_request(mdbs, MONGOT_FAULT_POS, UNSCHEDULABLE_MEMORY)
+
+    # Affected cluster's SEARCH half degrades and carries a message.
+    mdbs.wait_for_cluster_search_phase(faulted_ci, Phase.Pending, expect_message=True, timeout=STATUS_DEGRADE_TIMEOUT)
+
+    # Independence: the SAME cluster's LB half is untouched (still Running, no message)...
+    lb = mdbs.get_cluster_status(faulted_ci) or {}
+    assert (
+        lb.get("loadBalancer") == "Running"
+    ), f"cluster {faulted_ci}: loadBalancer should stay Running during a mongot fault, got {lb.get('loadBalancer')!r}"
+    assert not lb.get("loadBalancerMessage"), f"cluster {faulted_ci}: loadBalancerMessage should stay empty"
+
+    # ...and the OTHER cluster is fully Running — no cross-cluster bleed.
+    other = mdbs.get_cluster_status(other_ci) or {}
+    assert other.get("search") == "Running", (
+        f"cluster {other_ci}: search should stay Running while only cluster "
+        f"{faulted_ci} is faulted, got {other.get('search')!r}"
+    )
+    assert other.get("loadBalancer") == "Running", f"cluster {other_ci}: loadBalancer should stay Running"
+
+
+@mark.e2e_search_q2_mc_rs_steady
+def test_mongot_fault_recovers(mdbs: MongoDBSearch):
+    """Reverting the mongot request transitions the fault cluster's `search` sub-phase back
+    to Running and clears its message automatically."""
+    faulted_ci = _cluster_index_at(mdbs, MONGOT_FAULT_POS)
+    _set_mongot_memory_request(mdbs, MONGOT_FAULT_POS, None)
+    mdbs.wait_for_cluster_search_phase(faulted_ci, Phase.Running, expect_message=False, timeout=STATUS_RECOVER_TIMEOUT)
+    mdbs.assert_reaches_phase(Phase.Running, timeout=STATUS_RECOVER_TIMEOUT)
+
+
+@mark.e2e_search_q2_mc_rs_steady
+def test_envoy_fault_degrades_only_that_clusters_lb(mdbs: MongoDBSearch):
+    """Unschedulable Envoy on the fault cluster -> that cluster's `loadBalancer` sub-phase
+    leaves Running with a message; its `search` sub-phase and the other cluster stay Running."""
+    faulted_ci = _cluster_index_at(mdbs, ENVOY_FAULT_POS)
+    other_ci = _cluster_index_at(mdbs, MONGOT_FAULT_POS)
+    _set_envoy_memory_request(mdbs, ENVOY_FAULT_POS, UNSCHEDULABLE_MEMORY)
+
+    # Affected cluster's LB half degrades and carries a message.
+    mdbs.wait_for_cluster_lb_phase(faulted_ci, Phase.Pending, expect_message=True, timeout=STATUS_DEGRADE_TIMEOUT)
+
+    # Independence: the SAME cluster's search half is untouched (still Running, no message)...
+    search = mdbs.get_cluster_status(faulted_ci) or {}
+    assert (
+        search.get("search") == "Running"
+    ), f"cluster {faulted_ci}: search should stay Running during an Envoy fault, got {search.get('search')!r}"
+    assert not search.get("searchMessage"), f"cluster {faulted_ci}: searchMessage should stay empty"
+
+    # ...and the OTHER cluster is fully Running.
+    other = mdbs.get_cluster_status(other_ci) or {}
+    assert other.get("search") == "Running", f"cluster {other_ci}: search should stay Running"
+    assert other.get("loadBalancer") == "Running", (
+        f"cluster {other_ci}: loadBalancer should stay Running while only cluster "
+        f"{faulted_ci} Envoy is faulted, got {other.get('loadBalancer')!r}"
+    )
+
+
+@mark.e2e_search_q2_mc_rs_steady
+def test_envoy_fault_recovers(mdbs: MongoDBSearch):
+    """Reverting the Envoy request transitions the fault cluster's `loadBalancer` sub-phase
+    back to Running and clears its message; the whole resource returns to Running."""
+    faulted_ci = _cluster_index_at(mdbs, ENVOY_FAULT_POS)
+    _set_envoy_memory_request(mdbs, ENVOY_FAULT_POS, None)
+    mdbs.wait_for_cluster_lb_phase(faulted_ci, Phase.Running, expect_message=False, timeout=STATUS_RECOVER_TIMEOUT)
+    mdbs.assert_reaches_phase(Phase.Running, timeout=STATUS_RECOVER_TIMEOUT)
+    # Final: every cluster fully Running again.
+    mdbs.assert_cluster_statuses(expected_count=len(MEMBERS_PER_CLUSTER), expect_managed_lb=True)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -769,8 +769,8 @@ def test_verify_lb_status(mdbs: MongoDBSearch):
 
 @mark.e2e_search_q2_mc_rs_steady
 def test_verify_per_cluster_status(mdbs: MongoDBSearch):
-    """Real multi-cluster: status.clusterStatuses has ONE entry per member cluster, each
-    with search and loadBalancer sub-phases Running, and clusterIndex values matching the
+    """Real multi-cluster: status.clusters has ONE entry per member cluster, each
+    with search and loadBalancer sub-phases Running, and index values matching the
     spec.clusters[] pins."""
     mdbs.assert_cluster_statuses(expected_count=len(MEMBERS_PER_CLUSTER), expect_managed_lb=True)
 
@@ -932,7 +932,6 @@ SEARCH_INDEX_READY_TIMEOUT = 300
 SEARCH_QUERY_RETRY_TIMEOUT = 60
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
     """mongorestore the sample_mflix.archive into the source RS."""
@@ -944,7 +943,6 @@ def test_restore_sample_database(mdb: MongoDBMulti, tools_pod):
     )
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_create_search_index(
     mdb: MongoDBMulti,
@@ -962,7 +960,6 @@ def test_create_search_index(
     tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_execute_text_search_query(
     mdb: MongoDBMulti,
@@ -996,7 +993,6 @@ def test_execute_text_search_query(
     )
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_create_vector_search_index(
     mdb: MongoDBMulti,
@@ -1017,7 +1013,6 @@ def test_create_vector_search_index(
     embedded.wait_for_vector_search_index(timeout=SEARCH_INDEX_READY_TIMEOUT)
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_execute_vector_search_query(
     mdb: MongoDBMulti,
@@ -1055,7 +1050,6 @@ def test_execute_vector_search_query(
     )
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_per_cluster_search_query(
     mdb: MongoDBMulti,
@@ -1091,7 +1085,6 @@ def test_per_cluster_search_query(
         )
 
 
-@pytest.mark.skip(reason="LOCAL-DATAPLANE-SKIP: direct pymongo to in-cluster mongod DNS unreachable from host")
 @mark.e2e_search_q2_mc_rs_steady
 def test_per_cluster_vector_search_query(
     mdb: MongoDBMulti,
@@ -1132,6 +1125,7 @@ def test_per_cluster_vector_search_query(
             msg=f"cluster {cluster_index}: $vectorSearch query to succeed",
         )
 
+
 # Larger than any node in the e2e kind clusters — guarantees Unschedulable.
 UNSCHEDULABLE_MEMORY = "10000Gi"
 STATUS_DEGRADE_TIMEOUT = 300
@@ -1143,7 +1137,7 @@ ENVOY_FAULT_POS = 1
 
 
 def _cluster_index_at(mdbs: MongoDBSearch, list_pos: int) -> int:
-    """The clusterIndex pin of the spec.clusters[] entry at the given list position."""
+    """The index pin of the spec.clusters[] entry at the given list position."""
     mdbs.load()
     clusters = mdbs["spec"]["clusters"]
     return clusters[list_pos].get("index", list_pos)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -1198,17 +1198,17 @@ def test_mongot_fault_degrades_only_that_clusters_search(mdbs: MongoDBSearch):
     other_ci = _cluster_index_at(mdbs, ENVOY_FAULT_POS)
     _set_mongot_memory_request(mdbs, MONGOT_FAULT_POS, UNSCHEDULABLE_MEMORY)
 
-    # Affected cluster's SEARCH half degrades and carries a message.
+    # Affected cluster's SEARCH degrades and carries a message.
     mdbs.wait_for_cluster_search_phase(faulted_ci, Phase.Pending, expect_message=True, timeout=STATUS_DEGRADE_TIMEOUT)
 
-    # Independence: the SAME cluster's LB half is untouched (still Running, no message)...
+    # The SAME cluster's LB is untouched (still Running, no message)...
     lb = mdbs.get_cluster_status(faulted_ci) or {}
     assert (
         lb.get("loadBalancer") == "Running"
     ), f"cluster {faulted_ci}: loadBalancer should stay Running during a mongot fault, got {lb.get('loadBalancer')!r}"
     assert not lb.get("loadBalancerMessage"), f"cluster {faulted_ci}: loadBalancerMessage should stay empty"
 
-    # ...and the OTHER cluster is fully Running — no cross-cluster bleed.
+    # Other cluster is fully Running — making sure statuses are reflected per cluster properly.
     other = mdbs.get_cluster_status(other_ci) or {}
     assert other.get("search") == "Running", (
         f"cluster {other_ci}: search should stay Running while only cluster "
@@ -1240,14 +1240,14 @@ def test_envoy_fault_degrades_only_that_clusters_lb(mdbs: MongoDBSearch):
     # Affected cluster's LB half degrades and carries a message.
     mdbs.wait_for_cluster_lb_phase(faulted_ci, Phase.Pending, expect_message=True, timeout=STATUS_DEGRADE_TIMEOUT)
 
-    # Independence: the SAME cluster's search half is untouched (still Running, no message)...
+    # The SAME cluster's search is untouched (still Running, no message)...
     search = mdbs.get_cluster_status(faulted_ci) or {}
     assert (
         search.get("search") == "Running"
     ), f"cluster {faulted_ci}: search should stay Running during an Envoy fault, got {search.get('search')!r}"
     assert not search.get("searchMessage"), f"cluster {faulted_ci}: searchMessage should stay empty"
 
-    # ...and the OTHER cluster is fully Running.
+    # The OTHER cluster is fully Running.
     other = mdbs.get_cluster_status(other_ci) or {}
     assert other.get("search") == "Running", f"cluster {other_ci}: search should stay Running"
     assert other.get("loadBalancer") == "Running", (

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -86,6 +86,13 @@ def test_create_search_resource(mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_community_basic
+def test_verify_per_cluster_status(mdbs: MongoDBSearch):
+    """Single-cluster deployment: status.clusterStatuses has exactly one Running entry
+    and no loadBalancer sub-phase (unmanaged/no LB)."""
+    mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=False)
+
+
+@mark.e2e_search_community_basic
 def test_advanced_mongot_configs_rendered(namespace: str, mdbs: MongoDBSearch):
     data = read_configmap(namespace, search_resource_names.mongot_configmap_name(mdbs.name))
     config = yaml.safe_load(data["config.yml"])

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -87,7 +87,7 @@ def test_create_search_resource(mdbs: MongoDBSearch):
 
 @mark.e2e_search_community_basic
 def test_verify_per_cluster_status(mdbs: MongoDBSearch):
-    """Single-cluster deployment: status.clusterStatuses has exactly one Running entry
+    """Single-cluster deployment: status.clusters has exactly one Running entry
     and no loadBalancer sub-phase (unmanaged/no LB)."""
     mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=False)
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
@@ -133,6 +133,10 @@ def test_metrics_forwarder_status(om: MongoDBOpsManager, mdbs: MongoDBSearch):
 
     run_periodically(check_metrics_forwarder_status, timeout=120, interval=10)
 
+    # Per-cluster surface: single-cluster + managed LB + metrics forwarder enabled, so the
+    # one status.clusters entry must report search, loadBalancer AND metricsForwarder Running.
+    mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True, expect_metrics_forwarder=True)
+
     tester = om.get_om_tester(project_name=MDB_RESOURCE_NAME)
     tester.assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
 
@@ -188,6 +192,16 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
             return e.status == 404
 
     run_periodically(check_configmap_deleted, timeout=60, interval=5)
+
+    # Per-cluster surface: with the forwarder disabled, the metricsForwarder sub-phase must
+    # drop out of status.clusters (search + loadBalancer stay Running).
+    def check_per_cluster_metrics_forwarder_absent():
+        mdbs.reload()
+        cs = mdbs.get_cluster_status(0)
+        return cs is not None and not cs.get("metricsForwarder")
+
+    run_periodically(check_per_cluster_metrics_forwarder_absent, timeout=120, interval=10)
+    mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True, expect_metrics_forwarder=False)
 
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_internal_mongodb_multi_mongot_managed_lb.py
@@ -237,6 +237,9 @@ def test_verify_search_resource_status(mdbs: MongoDBSearch):
     phase = mdbs.get_status_phase()
     assert phase == Phase.Running, f"MongoDBSearch phase is {phase}, expected Running"
     mdbs.assert_lb_status()
+    # Single-cluster managed LB: exactly one per-cluster entry, both search and
+    # loadBalancer sub-phases Running.
+    mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True)
     logger.info(f"MongoDBSearch {mdbs.name} is in Running phase")
 
 


### PR DESCRIPTION
# Summary

This PR adds [E2E test](https://github.com/mongodb/mongodb-kubernetes/pull/1285) for the change that add a field `status.clusters` in `MongoDBSearch` CR to have cluster level status of search components.

## Proof of Work

Successful CI.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
