### PR TITLE
(Cleanup) Reenable quarantined scram tests after HELP-96015 fix

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -702,21 +702,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
-  # Quarantined: blocked on HELP-96015 (upstream Automation Agent 13.53 regression stalling
-  # mongos recovery after a project switch). github_pr_aliases selects task: ".*" for every
-  # pr_patch variant, so tags alone can't exclude this from PR runs — patchable:false is the
-  # mechanism that actually keeps it out of PR/manual patches while still letting it run (and
-  # gate releasability) on master merge commits. See EVERGREEN.md#quarantined-tests.
   - name: e2e_sharded_cluster_scram_sha_256_switch_project
     tags: [ "patch-run" ]
     commands:
       - func: "e2e_test"
 
-  # Quarantined: blocked on HELP-96015 (upstream Automation Agent 13.53 regression stalling
-  # mongos recovery after a project switch). github_pr_aliases selects task: ".*" for every
-  # pr_patch variant, so tags alone can't exclude this from PR runs — patchable:false is the
-  # mechanism that actually keeps it out of PR/manual patches while still letting it run (and
-  # gate releasability) on master merge commits. See EVERGREEN.md#quarantined-tests.
   - name: e2e_sharded_cluster_scram_sha_1_switch_project
     tags: [ "patch-run" ]
     commands:

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_1_switch_project.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_1_switch_project.py
@@ -10,12 +10,6 @@ from .helper_switch_project import SwitchProjectHelper
 
 MDB_RESOURCE_NAME = "sharded-cluster-scram-sha-1-switch-project"
 
-# Quarantined: blocked on an upstream Cloud Manager Automation Agent 13.53 regression that
-# stalls mongos recovery after a sharded cluster project switch. See HELP-96015.
-# The Evergreen task for this file is patchable:false, so it only runs on master merge commits
-# (never in PR/manual patches) and its result still gates master's releasability.
-# See EVERGREEN.md#quarantined-tests.
-
 
 @pytest.fixture(scope="function")
 def sharded_cluster(namespace: str) -> MongoDB:

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_256_switch_project.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_256_switch_project.py
@@ -10,12 +10,6 @@ from .helper_switch_project import SwitchProjectHelper
 
 MDB_RESOURCE_NAME = "sharded-cluster-scram-sha-256-switch-project"
 
-# Quarantined: blocked on an upstream Cloud Manager Automation Agent 13.53 regression that
-# stalls mongos recovery after a sharded cluster project switch. See HELP-96015.
-# The Evergreen task for this file is patchable:false, so it only runs on master merge commits
-# (never in PR/manual patches) and its result still gates master's releasability.
-# See EVERGREEN.md#quarantined-tests.
-
 
 @pytest.fixture(scope="function")
 def sharded_cluster(namespace: str) -> MongoDB:


### PR DESCRIPTION
# Summary

As HELP-96015 has been fixed, we expect we can reenable the scram tests we had quarantined at #1313

## Proof of Work

CI must pass those tests not quarantined.

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
