### PR TITLE
KUBE-157: sweep stale per-shard TLS secrets on member clusters

### DIFF
--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -802,10 +802,11 @@ func (r *MongoDBSearchReconcileHelper) pruneRoutingReady(ctx context.Context, li
 }
 
 // cleanupStaleShardResources reaps the per-shard mongot resources of shards that no
-// longer exist (shard scale-down): proxy Service, headless Service, ConfigMap, and the
-// mongot StatefulSet — whose whenDeleted=Delete policy then cascades its PVC. For every
-// live shard it rebuilds the expected resource names; anything we own carrying the
-// matching scope label but not in those sets belongs to a removed shard and is deleted.
+// longer exist (shard scale-down): proxy Service, headless Service, ConfigMap, ingress
+// TLS Secret, and the mongot StatefulSet — whose whenDeleted=Delete policy then cascades
+// its PVC. For every live shard it rebuilds the expected resource names; anything we own
+// carrying the matching scope label but not in those sets belongs to a removed shard and
+// is deleted.
 //
 // It fans out over the central client and every member client; per-kind/per-cluster
 // failures are best-effort — aggregated and retried next reconcile.
@@ -822,12 +823,14 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 	expectedHeadless := map[string]bool{}
 	expectedSTS := map[string]bool{}
 	expectedConfig := map[string]bool{}
+	expectedTLSSecret := map[string]bool{}
 	seenClusters := map[int]bool{}
 	for _, w := range r.buildShardedWorkList(currentShardNames) {
 		expectedProxy[r.mdbSearch.ProxyServiceNameForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
 		expectedHeadless[r.mdbSearch.MongotServiceForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
 		expectedSTS[r.mdbSearch.MongotStatefulSetForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
 		expectedConfig[r.mdbSearch.MongotConfigMapForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
+		expectedTLSSecret[r.mdbSearch.TLSOperatorSecretForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
 		if !seenClusters[w.ClusterIndex] {
 			seenClusters[w.ClusterIndex] = true
 			expectedProxy[r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex).Name] = true
@@ -841,7 +844,8 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 
 	// The mongot StatefulSet is the only StatefulSet we own, so it's scoped by owner
 	// label; proxy and headless Services share a kind but carry distinct component
-	// labels; the mongot ConfigMap carries the mongot component label.
+	// labels; the mongot ConfigMap and per-shard ingress TLS Secret carry the mongot
+	// component label (the only Secret kind stamped with it).
 	sweeps := []struct {
 		newList  func() client.ObjectList
 		selector client.MatchingLabels
@@ -852,6 +856,7 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: proxyServiceComponent}, expectedProxy, "proxy Service"},
 		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedHeadless, "headless Service"},
 		{func() client.ObjectList { return &corev1.ConfigMapList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedConfig, "ConfigMap"},
+		{func() client.ObjectList { return &corev1.SecretList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedTLSSecret, "TLS Secret"},
 	}
 
 	var errs error
@@ -1539,7 +1544,11 @@ func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Contex
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
 
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource, clusterName)
+	ingressTlsSecretLabels := map[string]string{componentLabelKey: mongotComponent}
+	for k, v := range searchOwnerLabels(r.mdbSearch, clusterName) {
+		ingressTlsSecretLabels[k] = v
+	}
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource, clusterName, ingressTlsSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1626,7 +1635,7 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 	}
 
 	x509Resource := &x509AuthResource{MongoDBSearch: r.mdbSearch}
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource, clusterName)
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource, clusterName, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1734,7 +1743,7 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 	scramKeyPasswordSecret := r.mdbSearch.ScramKeyFilePasswordSecret()
 	if r.mdbSearch.HasScramClientCert() {
 		scramCertResource := &scramClientCertResource{MongoDBSearch: r.mdbSearch}
-		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource, clusterName)
+		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource, clusterName, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3035,6 +3035,11 @@ func TestCleanupStaleShardResources(t *testing.T) {
 			Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
 		}}
 	}
+	mongotTLSSecret := func(shard string, owned bool) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: search.TLSOperatorSecretForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
+		}}
+	}
 
 	fakeClient := newTestFakeClient(search,
 		proxySvc("shard-0", true),  // active, owned
@@ -3044,6 +3049,7 @@ func TestCleanupStaleShardResources(t *testing.T) {
 		mongotSTS("shard-1", true), mongotSTS("shard-2", true),
 		mongotHeadless("shard-1", true), mongotHeadless("shard-2", true), mongotHeadless("shard-x", false),
 		mongotCM("shard-1", true), mongotCM("shard-2", true), mongotCM("shard-x", false),
+		mongotTLSSecret("shard-1", true), mongotTLSSecret("shard-2", true), mongotTLSSecret("shard-x", false),
 		// Name collision: live shard "x"'s headless Svc name == stale "x-svc"'s STS name.
 		// Separate per-kind expected sets keep them apart; a merged set would leak the stale STS.
 		mongotHeadless("x", true), mongotSTS("x-svc", true),
@@ -3074,6 +3080,9 @@ func TestCleanupStaleShardResources(t *testing.T) {
 	present(search.MongotConfigMapForClusterShard(0, "shard-1"), &corev1.ConfigMap{}, "active shard ConfigMap preserved")
 	gone(search.MongotConfigMapForClusterShard(0, "shard-2"), &corev1.ConfigMap{}, "stale shard ConfigMap deleted")
 	present(search.MongotConfigMapForClusterShard(0, "shard-x"), &corev1.ConfigMap{}, "different-owner ConfigMap untouched")
+	present(search.TLSOperatorSecretForClusterShard(0, "shard-1"), &corev1.Secret{}, "active shard TLS Secret preserved")
+	gone(search.TLSOperatorSecretForClusterShard(0, "shard-2"), &corev1.Secret{}, "stale shard TLS Secret deleted")
+	present(search.TLSOperatorSecretForClusterShard(0, "shard-x"), &corev1.Secret{}, "different-owner TLS Secret untouched")
 
 	present(search.MongotServiceForClusterShard(0, "x"), &corev1.Service{}, "live shard x headless Service preserved despite name-collision with stale x-svc STS")
 	gone(search.MongotStatefulSetForClusterShard(0, "x-svc"), &appsv1.StatefulSet{}, "stale x-svc STS reaped despite name-collision with live x headless Service")
@@ -4015,6 +4024,11 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 			Name: search.MongotConfigMapForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
 		}}
 	}
+	memberTLSSecret := func(idx int, shard string, owned bool) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: search.TLSOperatorSecretForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
+		}}
+	}
 
 	// cluster-a (idx 0): keep shard-0 + cluster-level; sh-stale should be deleted.
 	clusterA := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(
@@ -4025,6 +4039,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		memberSTS(0, "sh-0", true), memberSTS(0, "sh-stale", true),
 		memberMongotSvc(0, "sh-0", true), memberMongotSvc(0, "sh-stale", true), memberMongotSvc(0, "sh-foreign", false),
 		memberCM(0, "sh-0", true), memberCM(0, "sh-stale", true),
+		memberTLSSecret(0, "sh-0", true), memberTLSSecret(0, "sh-stale", true),
 	).Build())
 	// cluster-b (idx 1): same pattern, plus an unrelated owned-by-other-CR svc
 	// to guard the label-name check.
@@ -4087,6 +4102,8 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 	present(search.MongotServiceForClusterShard(0, "sh-foreign").Name, &corev1.Service{}, "unowned headless Service")
 	present(search.MongotConfigMapForClusterShard(0, "sh-0").Name, &corev1.ConfigMap{}, "active mongot ConfigMap")
 	gone(search.MongotConfigMapForClusterShard(0, "sh-stale").Name, &corev1.ConfigMap{}, "stale mongot ConfigMap")
+	present(search.TLSOperatorSecretForClusterShard(0, "sh-0").Name, &corev1.Secret{}, "active mongot TLS Secret")
+	gone(search.TLSOperatorSecretForClusterShard(0, "sh-stale").Name, &corev1.Secret{}, "stale mongot TLS Secret")
 }
 
 // Empty GetShardNames() yields an empty work list. The reconciler must not fail

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
@@ -103,13 +103,18 @@ def verify_shard_resources_exist(namespace: str, mdbs_name: str, shard_name: str
     assert proxy_svc is not None, f"Proxy Service {proxy_svc_name} not found"
     logger.info(f"Proxy Service {proxy_svc_name} exists")
 
-    # Assert the ConfigMap and PVC(s) exist too, so the matching absence checks in
-    # verify_shard_resources_deleted can't pass vacuously if a future rename drifts
-    # the expected names.
+    # Assert the ConfigMap, operator TLS Secret, and PVC(s) exist too, so the matching
+    # absence checks in verify_shard_resources_deleted can't pass vacuously if a future
+    # rename drifts the expected names.
     cm_name = search_resource_names.shard_configmap_name(mdbs_name, shard_name)
     cm = core_v1.read_namespaced_config_map(cm_name, namespace)
     assert cm is not None, f"mongot ConfigMap {cm_name} not found"
     logger.info(f"mongot ConfigMap {cm_name} exists")
+
+    tls_secret_name = f"{mdbs_name}-search-0-{shard_name}-certificate-key"
+    tls_secret = core_v1.read_namespaced_secret(tls_secret_name, namespace)
+    assert tls_secret is not None, f"operator TLS Secret {tls_secret_name} not found"
+    logger.info(f"operator TLS Secret {tls_secret_name} exists")
 
     pvc_prefix = f"data-{sts_name}-"
     pvcs = core_v1.list_namespaced_persistent_volume_claim(namespace)
@@ -139,7 +144,7 @@ def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: s
     """Assert FULL teardown of a removed shard's mongot resources.
 
     The stale-resource sweep deletes the per-shard mongot StatefulSet, headless
-    Service, proxy Service, and mongot ConfigMap; the StatefulSet's
+    Service, proxy Service, mongot ConfigMap, and operator TLS Secret; the StatefulSet's
     ``persistentVolumeClaimRetentionPolicy.whenDeleted: Delete`` then reaps the
     backing PVC(s). Each kind is polled independently so a partial sweep surfaces
     the specific resource that leaked. We poll until 404 (or empty list for PVCs)
@@ -152,6 +157,9 @@ def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: s
     sts_name = search_resource_names.shard_statefulset_name(mdbs_name, shard_name)
     svc_name = search_resource_names.shard_service_name(mdbs_name, shard_name)
     cm_name = search_resource_names.shard_configmap_name(mdbs_name, shard_name)
+    # Operator-managed cert+key Secret: TLSOperatorSecretForClusterShard
+    # (mongodbsearch_types.go) -> "<name>-search-<clusterIndex>-<shardName>-certificate-key".
+    tls_secret_name = f"{mdbs_name}-search-0-{shard_name}-certificate-key"
     # PVCs are named "<volumeClaimName>-<sts-name>-<ordinal>"; the mongot data
     # volume claim is "data" (search_construction.go), so the prefix is "data-<sts>-".
     pvc_prefix = f"data-{sts_name}-"
@@ -183,6 +191,15 @@ def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: s
                 return True, f"mongot ConfigMap {cm_name} deleted"
             raise
 
+    def tls_secret_gone():
+        try:
+            core_v1.read_namespaced_secret(tls_secret_name, namespace)
+            return False, f"operator TLS Secret {tls_secret_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"operator TLS Secret {tls_secret_name} deleted"
+            raise
+
     def pvcs_gone():
         pvcs = core_v1.list_namespaced_persistent_volume_claim(namespace)
         leftover = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
@@ -191,11 +208,12 @@ def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: s
         return True, f"no PVCs with prefix {pvc_prefix!r} remain"
 
     # Proxy Service is covered by verify_shard_proxy_service_deleted; here we
-    # add the StatefulSet, headless Service, ConfigMap, and PVCs.
+    # add the StatefulSet, headless Service, ConfigMap, TLS Secret, and PVCs.
     for check, label in (
         (sts_gone, f"StatefulSet {sts_name}"),
         (headless_svc_gone, f"headless Service {svc_name}"),
         (configmap_gone, f"mongot ConfigMap {cm_name}"),
+        (tls_secret_gone, f"operator TLS Secret {tls_secret_name}"),
         (pvcs_gone, f"PVCs {pvc_prefix}*"),
     ):
         run_periodically(check, timeout=300, sleep_time=10, msg=f"{label} deletion")

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
@@ -207,8 +207,7 @@ def verify_shard_resources_deleted(namespace: str, mdbs_name: str, shard_name: s
             return False, f"PVC(s) for removed shard still exist: {leftover}"
         return True, f"no PVCs with prefix {pvc_prefix!r} remain"
 
-    # Proxy Service is covered by verify_shard_proxy_service_deleted; here we
-    # add the StatefulSet, headless Service, ConfigMap, TLS Secret, and PVCs.
+    # Proxy Service is covered by verify_shard_proxy_service_deleted.
     for check, label in (
         (sts_gone, f"StatefulSet {sts_name}"),
         (headless_svc_gone, f"headless Service {svc_name}"),

--- a/pkg/tls/tls_secret.go
+++ b/pkg/tls/tls_secret.go
@@ -34,7 +34,7 @@ type TLSConfigurableResource interface {
 //
 // An OwnerReference is set only when writing into the central cluster
 // (clusterName == ""): Kubernetes GC does not span clusters.
-func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource, clusterName string) (string, error) {
+func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource, clusterName string, labels map[string]string) (string, error) {
 	certKey, err := getPemOrConcatenatedCrtAndKey(ctx, getUpdateCreator, resource.TLSSecretNamespacedName())
 	if err != nil {
 		return "", err
@@ -45,7 +45,8 @@ func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreat
 	secretBuilder := secret.Builder().
 		SetName(resource.TLSOperatorSecretNamespacedName().Name).
 		SetNamespace(resource.TLSOperatorSecretNamespacedName().Namespace).
-		SetField(fileName, certKey)
+		SetField(fileName, certKey).
+		SetLabels(labels)
 	if clusterName == "" {
 		secretBuilder = secretBuilder.SetOwnerReferences(resource.GetOwnerReferences())
 	}


### PR DESCRIPTION
## Summary

Stacked on top of #1344 (KUBE-154).

Found during code review of KUBE-154: the stale-shard sweep (`cleanupStaleShardResources`) reaps per-shard StatefulSet/Service/ConfigMap left behind by shard scale-down, but not `Secret`. Now that KUBE-154 correctly stops setting a cross-cluster owner reference on member-cluster resources, the per-shard ingress TLS secret (built via `pkg/tls/tls_secret.go`'s `EnsureTLSSecret`, `perShardTLSResource` adapter) has no cleanup path left on member clusters when its shard is removed:

- Before KUBE-154: a dangling owner reference meant the member cluster's own GC controller eventually deleted the secret as a side effect of the crash-loop bug.
- After KUBE-154: that's correctly gone, but nothing replaced it — the secret leaks permanently on shard removal.

This PR closes that gap the same way ConfigMap already is: stamp the secret with the owner + component labels (`searchOwnerLabels` + `componentLabelKey: mongotComponent`), and add it as a 5th entry to the `sweeps` slice.

Scoped to the per-shard **ingress** TLS secret only — the x509 client-cert and SCRAM client-cert secrets are single, CR-scoped (not per-shard-named), so shard-removal sweeping doesn't apply to them; both call sites now pass `nil` labels and are otherwise unaffected.

Fixes KUBE-157.

## Test plan

- [x] `go build ./...`
- [x] `go test ./controllers/searchcontroller/... ./pkg/tls/... ./controllers/operator/...` — all green
- [x] `gofmt -l` / `go vet` — clean
- [x] Extended `TestCleanupStaleShardResources` (single-cluster) and `TestCleanupStaleShardResources_MCFanOut` (2-cluster MC) with a stale/live/different-owner TLS secret fixture, mirroring the existing ConfigMap assertions
- [x] e2e coverage: `e2e_search_sharded_scale_shards_managed_lb`'s `verify_shard_resources_deleted` now also polls the removed shard's operator TLS secret (`<name>-search-0-<shard>-certificate-key`, per `TLSOperatorSecretForClusterShard`) to 404, with a matching existence assertion after scale-up so the absence check can't pass vacuously

## CI

Rebased onto the new #1344 head (changelog entry + comment trim) and force-pushed, which retriggers the Evergreen run — the previous run was aborted.

Restacked again onto the latest #1344 head (`9e7ed3dec`, vanilla cluster-name normalization); no changes to this PR's own three commits.

skip-ci

