### PR TITLE
CLOUDP-420747: Track backport branches

### DIFF
--- a/ci/backporting.yaml
+++ b/ci/backporting.yaml
@@ -1,0 +1,10 @@
+# Backporting branches information
+branches:
+  - name: master
+    description: Master branch for latest version
+    version: 1.x
+  - name: old-master
+    description: Test backporting branch
+    version: 0.x
+    internal-only: true
+

--- a/ci/config.go
+++ b/ci/config.go
@@ -1,0 +1,11 @@
+// Package ci embeds repo-level CI configuration so mckci can read it without
+// resolving filesystem paths at runtime. The embedded data reflects the commit
+// the binary was built from.
+package ci
+
+import _ "embed"
+
+// BackportingYAML is the raw contents of ci/backporting.yaml.
+//
+//go:embed backporting.yaml
+var BackportingYAML []byte

--- a/ci/internal/backport/backport.go
+++ b/ci/internal/backport/backport.go
@@ -1,0 +1,82 @@
+// Package backport models the backporting-branch chain declared in
+// ci/backporting.yaml and answers the one question the backporting automation
+// needs: given the branch a fix merged into, which branch does it flow to next.
+//
+// The automation is triggered by a merge event that already carries the branch
+// name, so no git/ancestry discovery is required here; the logic is pure and
+// fully unit-testable from the parsed config alone.
+package backport
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrUntracked is returned when a branch is not present in the config.
+var ErrUntracked = errors.New("branch is not a tracked backporting branch")
+
+// Branch is a single entry in the backporting chain. Order in the config
+// defines the chain: a fix merged into one branch is backported to the next.
+type Branch struct {
+	Name        string `yaml:"name" json:"name"`
+	Description string `yaml:"description" json:"description"`
+	Version     string `yaml:"version" json:"version"`
+	// InternalOnly marks branches used only for testing the automation; they
+	// are still part of the chain but automation may choose not to open real PRs.
+	InternalOnly bool `yaml:"internal-only" json:"internal-only"`
+}
+
+// Config is the parsed backporting.yaml. Branches are ordered newest-first
+// (master, then progressively older maintenance branches).
+type Config struct {
+	Branches []Branch `yaml:"branches"`
+}
+
+// Parse decodes and validates a backporting.yaml document.
+func Parse(data []byte) (*Config, error) {
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing backporting config: %w", err)
+	}
+	if len(cfg.Branches) == 0 {
+		return nil, errors.New("backporting config declares no branches")
+	}
+	seen := make(map[string]struct{}, len(cfg.Branches))
+	for i, b := range cfg.Branches {
+		if b.Name == "" {
+			return nil, fmt.Errorf("branch at index %d has no name", i)
+		}
+		if _, dup := seen[b.Name]; dup {
+			return nil, fmt.Errorf("duplicate branch name %q", b.Name)
+		}
+		seen[b.Name] = struct{}{}
+	}
+	return &cfg, nil
+}
+
+// NextBranch returns the full entry a fix in `branch` should be backported to
+// next. It returns nil (and no error) when `branch` is the last in the chain,
+// and wraps ErrUntracked when `branch` is not tracked in the config.
+func (c *Config) NextBranch(branch string) (*Branch, error) {
+	for i, b := range c.Branches {
+		if b.Name == branch {
+			if i+1 < len(c.Branches) {
+				return &c.Branches[i+1], nil
+			}
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("%q: %w", branch, ErrUntracked)
+}
+
+// Next returns the name of the branch NextBranch resolves to, or "" when
+// `branch` is the last in the chain.
+func (c *Config) Next(branch string) (string, error) {
+	next, err := c.NextBranch(branch)
+	if err != nil || next == nil {
+		return "", err
+	}
+	return next.Name, nil
+}

--- a/ci/internal/backport/backport_test.go
+++ b/ci/internal/backport/backport_test.go
@@ -1,0 +1,172 @@
+package backport_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mongodb/mongodb-kubernetes/ci/internal/backport"
+)
+
+const sampleYAML = `
+branches:
+  - name: master
+    description: Master branch for latest version
+    version: 3.x
+  - name: v2
+    description: Maintenance branch for 2.x
+    version: 2.x
+  - name: v1
+    description: Maintenance branch for 1.x
+    version: 1.x
+  - name: old-master
+    description: Test backporting branch
+    version: 0.x
+    internal-only: true
+`
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr bool
+		want    []backport.Branch
+	}{
+		{
+			name: "valid config",
+			data: sampleYAML,
+			want: []backport.Branch{
+				{Name: "master", Description: "Master branch for latest version", Version: "3.x"},
+				{Name: "v2", Description: "Maintenance branch for 2.x", Version: "2.x"},
+				{Name: "v1", Description: "Maintenance branch for 1.x", Version: "1.x"},
+				{Name: "old-master", Description: "Test backporting branch", Version: "0.x", InternalOnly: true},
+			},
+		},
+		{
+			name:    "invalid yaml",
+			data:    "branches: [this is: not valid",
+			wantErr: true,
+		},
+		{
+			name:    "duplicate branch names",
+			data:    "branches:\n  - name: master\n    version: 3.x\n  - name: master\n    version: 2.x\n",
+			wantErr: true,
+		},
+		{
+			name:    "branch without name",
+			data:    "branches:\n  - version: 3.x\n",
+			wantErr: true,
+		},
+		{
+			name:    "no branches",
+			data:    "branches: []\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := backport.Parse([]byte(tt.data))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse() unexpected error: %v", err)
+			}
+			if len(cfg.Branches) != len(tt.want) {
+				t.Fatalf("Parse() got %d branches, want %d", len(cfg.Branches), len(tt.want))
+			}
+			for i, b := range cfg.Branches {
+				if b != tt.want[i] {
+					t.Errorf("branch[%d] = %+v, want %+v", i, b, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConfig_NextBranch(t *testing.T) {
+	cfg, err := backport.Parse([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		from    string
+		want    *backport.Branch
+		wantErr error
+	}{
+		{
+			name: "returns full target entry",
+			from: "v1",
+			want: &backport.Branch{Name: "old-master", Description: "Test backporting branch", Version: "0.x", InternalOnly: true},
+		},
+		{name: "last branch returns nil", from: "old-master", want: nil},
+		{name: "untracked branch errors", from: "nope", wantErr: backport.ErrUntracked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cfg.NextBranch(tt.from)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("NextBranch(%q) error = %v, want %v", tt.from, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NextBranch(%q) unexpected error: %v", tt.from, err)
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("NextBranch(%q) = %+v, want nil", tt.from, got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Errorf("NextBranch(%q) = %+v, want %+v", tt.from, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_Next(t *testing.T) {
+	cfg, err := backport.Parse([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		from    string
+		want    string
+		wantErr error
+	}{
+		{name: "master to v2", from: "master", want: "v2"},
+		{name: "v2 to v1", from: "v2", want: "v1"},
+		{name: "v1 to old-master", from: "v1", want: "old-master"},
+		{name: "last branch has no next", from: "old-master", want: ""},
+		{name: "untracked branch errors", from: "nope", wantErr: backport.ErrUntracked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cfg.Next(tt.from)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Next(%q) error = %v, want %v", tt.from, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Next(%q) unexpected error: %v", tt.from, err)
+			}
+			if got != tt.want {
+				t.Errorf("Next(%q) = %q, want %q", tt.from, got, tt.want)
+			}
+		})
+	}
+}

--- a/ci/internal/cli/backport.go
+++ b/ci/internal/cli/backport.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mongodb/mongodb-kubernetes/ci"
+	"github.com/mongodb/mongodb-kubernetes/ci/internal/backport"
+)
+
+func newBackportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backport",
+		Short: "Query the backporting-branch chain declared in ci/backporting.yaml",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newBackportFromCmd())
+	return cmd
+}
+
+func newBackportFromCmd() *cobra.Command {
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "from <branch>",
+		Short: "Print the branch a fix in <branch> should be backported to next",
+		Long: "Prints the next branch in the backporting chain after <branch> " +
+			"(nothing if <branch> is the last one). Errors if <branch> is not tracked. " +
+			"With --json, prints the full target branch entry instead of just its name.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := backport.Parse(ci.BackportingYAML)
+			if err != nil {
+				return err
+			}
+			next, err := cfg.NextBranch(args[0])
+			if err != nil {
+				return err
+			}
+			if next == nil {
+				return nil
+			}
+			if asJSON {
+				encoded, err := json.Marshal(next)
+				if err != nil {
+					return err
+				}
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), string(encoded))
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), next.Name)
+			return err
+		},
+	}
+
+	cmd.Flags().BoolVar(&asJSON, "json", false, "print the full target branch entry as JSON instead of just its name")
+
+	return cmd
+}

--- a/ci/internal/cli/backport_test.go
+++ b/ci/internal/cli/backport_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBackportFromCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		json    bool
+		want    string
+		wantErr bool
+	}{
+		{name: "master prints next", arg: "master", want: "old-master"},
+		{name: "last in chain prints nothing", arg: "old-master", want: ""},
+		{name: "untracked errors", arg: "does-not-exist", wantErr: true},
+		{
+			name: "json prints full target entry",
+			arg:  "master",
+			json: true,
+			want: `{"name":"old-master","description":"Test backporting branch","version":"0.x","internal-only":true}`,
+		},
+		{name: "json last in chain prints nothing", arg: "old-master", json: true, want: ""},
+		{name: "json untracked errors", arg: "does-not-exist", json: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := NewRoot()
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+			args := []string{"backport", "from", tt.arg}
+			if tt.json {
+				args = append(args, "--json")
+			}
+			root.SetArgs(args)
+
+			err := root.Execute()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.arg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := strings.TrimSpace(out.String()); got != tt.want {
+				t.Errorf("backport from %q = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewRoot_RegistersBackport(t *testing.T) {
+	root := NewRoot()
+	found := false
+	for _, sub := range root.Commands() {
+		if sub.Name() == "backport" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("backport subcommand not registered on root")
+	}
+}

--- a/ci/internal/cli/root.go
+++ b/ci/internal/cli/root.go
@@ -28,6 +28,7 @@ func NewRoot() *cobra.Command {
 
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newReleaseCmd())
+	root.AddCommand(newBackportCmd())
 
 	return root
 }


### PR DESCRIPTION
# Summary

Add initial backporting track info and supporting command.

The YAML allows us to track our backporting branches and the tool queries it.

**Note**: old-master is totally fictional at this point. Still it might be used later on for testing before we actually have a real public backport branch to go to.

## Proof of Work

CI unit tests included and:

```shell
$ ./scripts/mckci backport from master
old-master

$ ./scripts/mckci backport from old-master
$

$ ./scripts/mckci backport from main
Error: "main": branch is not a tracked backporting branch

$ ./scripts/mckci backport from master --json |jq .
{
  "name": "old-master",
  "description": "Test backporting branch",
  "version": "0.x",
  "internal-only": true
}

```

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
