### PR TITLE
KUBE-122: Cap default mongot JVM heap at 30GB

### DIFF
--- a/changelog/20260707_fix_mongodbsearch_default_jvm_heap_capped_at_30gb.md
+++ b/changelog/20260707_fix_mongodbsearch_default_jvm_heap_capped_at_30gb.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-07-07
 ---
 
-* **MongoDBSearch**: The default JVM heap size (half of the memory request) is now capped at 30GB, following the [mongot sizing guidance](https://www.mongodb.com/docs/manual/tutorial/mongot-sizing/advanced-guidance/hardware/#jvm-heap-sizing). Heap sizes above ~30GB prevent the JVM from using compressed object pointers and degrade performance. User-provided heap flags are not affected.
+* **MongoDBSearch**: The default JVM heap size (half of the memory request) is now capped at 30GB, following the [mongot sizing guidance](https://www.mongodb.com/docs/manual/tutorial/mongot-sizing/advanced-guidance/hardware/#jvm-heap-sizing). Heap sizes above ~30GB prevent the JVM from using compressed object pointers and degrade performance. User-provided heap flags are not affected, if more than 30GB heap is required, we recommend using jvmFlags.

--- a/changelog/20260707_fix_mongodbsearch_default_jvm_heap_capped_at_30gb.md
+++ b/changelog/20260707_fix_mongodbsearch_default_jvm_heap_capped_at_30gb.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-07-07
+---
+
+* **MongoDBSearch**: The default JVM heap size (half of the memory request) is now capped at 30GB, following the [mongot sizing guidance](https://www.mongodb.com/docs/manual/tutorial/mongot-sizing/advanced-guidance/hardware/#jvm-heap-sizing). Heap sizes above ~30GB prevent the JVM from using compressed object pointers and degrade performance. User-provided heap flags are not affected.

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -60,6 +60,10 @@ const (
 	GrpcKeyPasswordMountPath = "/mongot/grpc-key-password"           // #nosec G101 -- path, not a password
 	TempGrpcKeyPasswordPath  = tempVolumePath + "/grpc-key-password" // #nosec G101 -- path, not a password
 
+	// maxDefaultHeapMB caps the default JVM heap at 30GB, matching Atlas Search sizing guidance:
+	// https://www.mongodb.com/docs/manual/tutorial/mongot-sizing/advanced-guidance/hardware/#jvm-heap-sizing
+	maxDefaultHeapMB = 30 * 1024
+
 	ScramClientCertOperatorMountPath = "/var/lib/tls/scram-client/"
 	ScramKeyPasswordMountPath        = "/mongot/scram-key-password"           // #nosec G101 -- path, not a password
 	TempScramKeyPasswordPath         = tempVolumePath + "/scram-key-password" // #nosec G101 -- path, not a password
@@ -258,6 +262,10 @@ func jvmFlags(userJVMFlags []string, resourceRequirements corev1.ResourceRequire
 		memRequest := resourceRequirements.Requests.Memory()
 		halfBytes := memRequest.Value() / 2
 		halfMB := halfBytes / (1024 * 1024)
+		// The same document recommends staying under ~30GB so the JVM keeps compressed object pointers.
+		if halfMB > maxDefaultHeapMB {
+			halfMB = maxDefaultHeapMB
+		}
 		flags = append(flags, fmt.Sprintf("-Xmx%dm", halfMB))
 		flags = append(flags, fmt.Sprintf("-Xms%dm", halfMB))
 	}

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -86,6 +86,22 @@ func TestCreateSearchStatefulSetFunc_JVMFlags(t *testing.T) {
 			userProvidedMemory: "8Gi",
 			expectedJVMFlags:   `--jvm-flags "-Xmx4096m -Xms4096m"`,
 		},
+		{
+			name:               "60Gi memory - half is exactly the 30GB cap",
+			userProvidedMemory: "60Gi",
+			expectedJVMFlags:   `--jvm-flags "-Xmx30720m -Xms30720m"`,
+		},
+		{
+			name:               "128Gi memory - auto heap capped at 30GB",
+			userProvidedMemory: "128Gi",
+			expectedJVMFlags:   `--jvm-flags "-Xmx30720m -Xms30720m"`,
+		},
+		{
+			name:                 "128Gi memory with user heap flags above the cap - not capped",
+			userProvidedJVMFlags: []string{"-Xmx64g", "-Xms64g"},
+			userProvidedMemory:   "128Gi",
+			expectedJVMFlags:     `--jvm-flags "-Xmx64g -Xms64g"`,
+		},
 		// Custom memory + user JVM flags combined
 		{
 			name:                 "8Gi memory with non-heap user flags - auto heap from custom memory",


### PR DESCRIPTION
## Summary

The default JVM heap for mongot (half of the memory request) is now capped at 30GB, per the [mongot sizing guidance](https://www.mongodb.com/docs/manual/tutorial/mongot-sizing/advanced-guidance/hardware/#jvm-heap-sizing). Above ~30GB the JVM loses compressed object pointers and mongot takes a performance hit.

User-provided heap flags are not affected.

## Proof of work

Unit tests pass, including new cases at and above the cap.