### PR TITLE
KUBE-161: Quarantine e2e search_connectivity_tool_mc_sharded

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1467,8 +1467,14 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  # Quarantined: flaky, producing unreliable results in CI and slowing down development.
+  # See KUBE-161. github_pr_aliases selects task: ".*" for every pr_patch variant, so tags
+  # alone can't exclude this from PR runs — patchable:false is the mechanism that actually
+  # keeps it out of PR/manual patches while still letting it run (and gate releasability) on
+  # master merge commits. See EVERGREEN.md#quarantined-tests.
   - name: e2e_search_connectivity_tool_mc_sharded
-    tags: [ "patch-run" ]
+    tags: [ "quarantined" ]
+    patchable: false
     commands:
       - func: "e2e_test"
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
@@ -1,4 +1,8 @@
-"""E2E for the search connectivity tool against a MultiCluster sharded source.x"""
+"""E2E for the search connectivity tool against a MultiCluster sharded source.x
+
+Quarantined: flaky, producing unreliable results in CI. Tracking ticket: KUBE-161.
+See EVERGREEN.md#quarantined-tests.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
# Summary

Quarantine flaky e2e search test `search_connectivity_tool_mc_sharded` from variant `e2e_multi_cluster_2_clusters` until we can fix it to run reliably.

## Proof of Work

CI should pass skipping such test at PR time.

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
