### PR TITLE
KUBE-160: derive previous operator version from release tags in CSV update

### DIFF
--- a/scripts/evergreen/release/update_helm_values_files.py
+++ b/scripts/evergreen/release/update_helm_values_files.py
@@ -12,6 +12,7 @@ import sys
 from typing import List
 
 from agent_matrix import get_supported_version_for_image
+from git import Repo
 from helm_files_handler import (
     get_value_in_yaml_file,
     set_value_in_yaml_file,
@@ -19,6 +20,9 @@ from helm_files_handler import (
     update_community_agent_image_in_file,
     update_community_agent_image_in_go_file,
 )
+
+from scripts.release.constants import DEFAULT_RELEASE_INITIAL_VERSION, DEFAULT_REPOSITORY_PATH
+from scripts.release.version import find_previous_version
 
 RELEASE_JSON_TO_HELM_KEY = {
     "mongodbOperator": "operator",
@@ -46,6 +50,11 @@ def main() -> int:
 
     operator_version = release["mongodbOperator"]
 
+    repo = Repo(DEFAULT_REPOSITORY_PATH)
+    old_operator_version = find_previous_version(
+        repo=repo, initial_commit_sha=None, initial_version=DEFAULT_RELEASE_INITIAL_VERSION
+    ).name
+
     for k in release:
         if k in RELEASE_JSON_TO_HELM_KEY:
             update_all_helm_values_files(RELEASE_JSON_TO_HELM_KEY[k], release[k])
@@ -54,7 +63,7 @@ def main() -> int:
 
     update_helm_charts(operator_version, release, agent_version)
     update_community_manifests(agent_version)
-    update_cluster_service_version(operator_version)
+    update_cluster_service_version(operator_version, old_operator_version)
 
     return 0
 
@@ -99,14 +108,13 @@ def update_helm_charts(operator_version, release, agent_version):
     set_value_in_yaml_file("helm_chart/values.yaml", "community.agent.version", agent_version)
 
 
-def update_cluster_service_version(operator_version):
+def update_cluster_service_version(operator_version: str, old_operator_version: str):
     container_image_value = get_value_in_yaml_file(
         "config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml",
         "metadata.annotations.containerImage",
     )
 
     image_parts = container_image_value.split(":")
-    old_operator_version = image_parts[-1]
     image_repo = ":".join(image_parts[:-1])
 
     if old_operator_version != operator_version:

--- a/scripts/release/version.py
+++ b/scripts/release/version.py
@@ -10,6 +10,7 @@ from scripts.release.changelog import ChangeEntry, ChangeKind, get_changelog_ent
 class VersionTag:
     name: str
     commit: Commit
+    is_initial: bool = False
 
 
 def calculate_next_version(
@@ -20,37 +21,41 @@ def calculate_next_version(
 
 def calculate_next_version_with_changelog(
     repo: Repo, changelog_sub_path: str, initial_commit_sha: str | None, initial_version: str | None
-) -> (str, list[ChangeEntry]):
-    previous_version_tag, previous_version_commit = find_previous_version(repo, initial_commit_sha)
+) -> tuple[str, list[ChangeEntry]]:
+    previous_version_tag = find_previous_version(
+        repo=repo,
+        initial_commit_sha=initial_commit_sha,
+        initial_version=initial_version,
+    )
 
-    changelog: list[ChangeEntry] = get_changelog_entries(previous_version_commit, repo, changelog_sub_path)
+    changelog: list[ChangeEntry] = get_changelog_entries(previous_version_tag.commit, repo, changelog_sub_path)
     changelog_kinds = list(set(entry.kind for entry in changelog))
 
-    # If there is no previous version tag, we start with the initial version tag
-    if not previous_version_tag:
-        if not initial_version:
-            raise ValueError("No previous version tag found and no initial version provided.")
-        version = initial_version
+    # If we start with the initial version tag, do not increment it
+    if previous_version_tag.is_initial:
+        version = previous_version_tag.name
     else:
         version = increment_previous_version(previous_version_tag.name, changelog_kinds)
 
     return version, changelog
 
 
-def find_previous_version(repo: Repo, initial_commit_sha: str = None) -> (VersionTag | None, Commit):
+def find_previous_version(repo: Repo, initial_commit_sha: str = None, initial_version: str = None) -> VersionTag:
     """Find the most recent version that is an ancestor of the current HEAD commit."""
 
     previous_version_tag = find_previous_version_tag(repo)
+    if previous_version_tag:
+        return previous_version_tag
 
     # If there is no previous version tag, we start with the initial commit
-    if not previous_version_tag:
-        # If no initial commit SHA provided, use the first commit in the repository
-        if not initial_commit_sha:
-            initial_commit_sha = list(repo.iter_commits(reverse=True))[0].hexsha
+    # If no initial commit SHA provided, use the first commit in the repository
+    if not initial_commit_sha:
+        initial_commit_sha = list(repo.iter_commits(reverse=True))[0].hexsha
 
-        return None, repo.commit(initial_commit_sha)
+    if not initial_version:
+        raise ValueError("No previous version tag found and no initial version provided.")
 
-    return previous_version_tag, previous_version_tag.commit
+    return VersionTag(initial_version, repo.commit(initial_commit_sha), True)
 
 
 def find_previous_version_tag(repo: Repo) -> VersionTag | None:


### PR DESCRIPTION
# Summary

The release automation derived the *previous* operator version by string-parsing the `containerImage` annotation in the ClusterServiceVersion base manifest. That value is rewritten by this same script on every run, so `spec.replaces` was coupled to a field the script mutates rather than to an actual released version. This change derives the previous version from the most recent release git tag reachable from HEAD instead.

- `update_helm_values_files.py` now looks up the old operator version via `find_previous_version` (using `DEFAULT_REPOSITORY_PATH` / `DEFAULT_RELEASE_INITIAL_VERSION`) and passes it into `update_cluster_service_version`, which writes `spec.replaces: mongodb-kubernetes.v<old_version>`.

Additional code improvements:

- `find_previous_version` now returns a single `VersionTag` (adding an `is_initial` flag) and accepts an `initial_version`, replacing the old `(VersionTag | None, Commit)` tuple return. When no prior tag exists it returns the configured initial version rather than `None`.
- `calculate_next_version_with_changelog` uses the `is_initial` flag to decide whether to increment.

## Proof of Work

**Tests / lint**
- `pytest scripts/release/tests/version_test.py` — 17 passed
- Full `scripts/release/tests/` suite — 72 passed (1 unrelated failure in `release_info_test.py` from a `quay.io` network call via skopeo)
- `pre-commit` black + isort on both changed files — passed

**`spec.replaces` resolves from the git tag, on the real repo**

```
$ python -c "from git import Repo; from scripts.release.version import find_previous_version; \
    v=find_previous_version(repo=Repo('.'), initial_commit_sha=None, initial_version='1.0.0'); \
    print(f'spec.replaces -> mongodb-kubernetes.v{v.name}')"
spec.replaces -> mongodb-kubernetes.v1.9.1
```

**`spec.replaces` is stable and only changes when a new tag is present**

Reproduced in a throwaway repo with an `origin` remote (tags are read via `git ls-remote origin`). `spec.replaces` = `mongodb-kubernetes.v<old_version>` where `<old_version>` is the newest SemVer tag that is a *strict ancestor* of HEAD:

```
HEAD past tag 1.9.1 (1.9.1 is a strict ancestor):
  run 1: mongodb-kubernetes.v1.9.1  (is_initial=False)
  run 2: mongodb-kubernetes.v1.9.1  (is_initial=False)
  run 3: mongodb-kubernetes.v1.9.1  (is_initial=False) <- stable across re-runs

New tag 1.10.0 cut on HEAD (equals HEAD, excluded until HEAD advances):
  run:   mongodb-kubernetes.v1.9.1  (is_initial=False) <- still 1.9.1

HEAD advanced one commit past 1.10.0:
  run:   mongodb-kubernetes.v1.10.0  (is_initial=False) <- now flips to 1.10.0
```

This demonstrates:
1. **Idempotent** — re-running the release script at the same HEAD produces the same `spec.replaces` (previously it drifted, since the value was parsed back out of the `containerImage` annotation the script overwrites).
2. **Changes only on a new tag** — the value flips only once a new release tag exists in the repo and is an ancestor of HEAD; simply re-running or moving HEAD without a new tag leaves it unchanged.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
