### PR TITLE
Configurable OM JVM heap percentage and opt-in native auto-heap

### DIFF
--- a/changelog/20260708_feature_configurable_om_jvm_heap_percentage_and_opt_in.md
+++ b/changelog/20260708_feature_configurable_om_jvm_heap_percentage_and_opt_in.md
@@ -1,0 +1,7 @@
+---
+kind: feature
+date: 2026-07-08
+---
+
+* **OpsManager**: The JVM heap percentage for Ops Manager pods is now configurable via the `MDB_OM_JVM_HEAP_PERCENTAGE` environment variable. The default has changed from 90% to 75% (the MongoDB internal standard), reducing the risk of container OOM kills. Users who need the previous value can set `MDB_OM_JVM_HEAP_PERCENTAGE=90`.
+* **OpsManager**: Added opt-in support for Ops Manager's native cgroup-aware heap sizing via the `MDB_OM_AUTO_HEAP` environment variable. When enabled, the operator skips setting `-Xmx`/`-Xms` and delegates heap sizing to Ops Manager's built-in logic. This requires OM pods with at least 16Gi of memory.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -103,6 +103,8 @@ spec:
               value: "false"
             - name: MDB_MAX_CONCURRENT_RECONCILES
               value: "1"
+            - name: MDB_OM_JVM_HEAP_PERCENTAGE
+              value: "75"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/controllers/operator/construct/jvm.go
+++ b/controllers/operator/construct/jvm.go
@@ -2,6 +2,8 @@ package construct
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -16,9 +18,8 @@ import (
 )
 
 const (
-	opsManagerPodMemPercentage = 90
-	oneMB                      = 1048576
-	backupDaemonHealthPort     = 8090
+	oneMB                  = 1048576
+	backupDaemonHealthPort = 8090
 )
 
 // setJvmArgsEnvVars sets the correct environment variables for JVM size parameters.
@@ -45,31 +46,37 @@ func buildJvmParamsEnvVars(m omv1.MongoDBOpsManagerSpec, containerName string, t
 	backupJvmEnvVar := corev1.EnvVar{Name: util.BackupDaemonJvmParamEnvVar}
 
 	omContainer := container.GetByName(containerName, template.Spec.Containers)
-	// calculate xmx from container's memory limit
-	memLimits := omContainer.Resources.Limits.Memory()
-	maxPodMem, err := getPercentOfQuantityAsInt(*memLimits, opsManagerPodMemPercentage)
-	if err != nil {
-		return []corev1.EnvVar{}, xerrors.Errorf("error calculating xmx from pod mem: %w", err)
-	}
 
-	// calculate xms from container's memory request if it is set, otherwise xms=xmx
-	memRequests := omContainer.Resources.Requests.Memory()
-	minPodMem, err := getPercentOfQuantityAsInt(*memRequests, opsManagerPodMemPercentage)
-	if err != nil {
-		return []corev1.EnvVar{}, xerrors.Errorf("error calculating xms from pod mem: %w", err)
-	}
+	if !isOmAutoHeapEnabled() {
+		// calculate xmx from container's memory limit
+		memLimits := omContainer.Resources.Limits.Memory()
+		maxPodMem, err := getPercentOfQuantityAsInt(*memLimits, getOpsManagerPodMemPercentage())
+		if err != nil {
+			return []corev1.EnvVar{}, xerrors.Errorf("error calculating xmx from pod mem: %w", err)
+		}
 
-	// if only one of mem limits/requests is set, use that value for both xmx & xms
-	if minPodMem == 0 {
-		minPodMem = maxPodMem
-	}
-	if maxPodMem == 0 {
-		maxPodMem = minPodMem
-	}
+		// calculate xms from container's memory request if it is set, otherwise xms=xmx
+		memRequests := omContainer.Resources.Requests.Memory()
+		minPodMem, err := getPercentOfQuantityAsInt(*memRequests, getOpsManagerPodMemPercentage())
+		if err != nil {
+			return []corev1.EnvVar{}, xerrors.Errorf("error calculating xms from pod mem: %w", err)
+		}
 
-	memParams := fmt.Sprintf("-Xmx%dm -Xms%dm", maxPodMem, minPodMem)
-	mmsJvmEnvVar.Value = buildJvmEnvVar(m.JVMParams, memParams)
-	backupJvmEnvVar.Value = buildJvmEnvVar(m.Backup.JVMParams, memParams)
+		// if only one of mem limits/requests is set, use that value for both xmx & xms
+		if minPodMem == 0 {
+			minPodMem = maxPodMem
+		}
+		if maxPodMem == 0 {
+			maxPodMem = minPodMem
+		}
+
+		memParams := fmt.Sprintf("-Xmx%dm -Xms%dm", maxPodMem, minPodMem)
+		mmsJvmEnvVar.Value = buildJvmEnvVar(m.JVMParams, memParams)
+		backupJvmEnvVar.Value = buildJvmEnvVar(m.Backup.JVMParams, memParams)
+	} else {
+		mmsJvmEnvVar.Value = buildJvmEnvVar(m.JVMParams, "")
+		backupJvmEnvVar.Value = buildJvmEnvVar(m.Backup.JVMParams, "")
+	}
 
 	// If a debug port is set, add the JVM debug agent to the JVM parameters
 	if debugPort := getDebugPort(omContainer.Ports); debugPort > 0 {
@@ -116,6 +123,22 @@ func getPercentOfQuantityAsInt(q resource.Quantity, percent int) (int, error) {
 	return int(float64(quantityAsInt)*percentage) / oneMB, nil
 }
 
+func getOpsManagerPodMemPercentage() int {
+	val := os.Getenv(util.OmJvmHeapPercentageEnv)
+	if val == "" {
+		return util.DefaultOmJvmHeapPercentage
+	}
+	pct, err := strconv.Atoi(val)
+	if err != nil || pct <= 0 || pct > 100 {
+		return util.DefaultOmJvmHeapPercentage
+	}
+	return pct
+}
+
+func isOmAutoHeapEnabled() bool {
+	return os.Getenv(util.OmAutoHeapEnv) == util.EnvVarTrue
+}
+
 // buildJvmEnvVar returns the string representation of the JVM environment variable
 func buildJvmEnvVar(customParams []string, containerMemParams string) string {
 	jvmParams := strings.Join(customParams, " ")
@@ -129,7 +152,7 @@ func buildJvmEnvVar(customParams []string, containerMemParams string) string {
 		return jvmParams
 	}
 
-	if jvmParams != "" {
+	if jvmParams != "" && containerMemParams != "" {
 		jvmParams += " "
 	}
 

--- a/controllers/operator/construct/jvm_test.go
+++ b/controllers/operator/construct/jvm_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 func TestBuildJvmEnvVar(t *testing.T) {
@@ -30,4 +32,46 @@ func TestBuildJvmEnvVar(t *testing.T) {
 			assert.Equalf(t, tt.want, buildJvmEnvVar(tt.args.customParams, tt.args.containerMemParams), "buildJvmEnvVar(%v, %v)", tt.args.customParams, tt.args.containerMemParams)
 		})
 	}
+}
+
+func TestGetOpsManagerPodMemPercentage(t *testing.T) {
+	t.Run("default when env var not set", func(t *testing.T) {
+		assert.Equal(t, util.DefaultOmJvmHeapPercentage, getOpsManagerPodMemPercentage())
+	})
+
+	t.Run("returns value from env var", func(t *testing.T) {
+		t.Setenv(util.OmJvmHeapPercentageEnv, "80")
+		assert.Equal(t, 80, getOpsManagerPodMemPercentage())
+	})
+
+	t.Run("returns default for invalid value", func(t *testing.T) {
+		t.Setenv(util.OmJvmHeapPercentageEnv, "invalid")
+		assert.Equal(t, util.DefaultOmJvmHeapPercentage, getOpsManagerPodMemPercentage())
+	})
+
+	t.Run("returns default for zero", func(t *testing.T) {
+		t.Setenv(util.OmJvmHeapPercentageEnv, "0")
+		assert.Equal(t, util.DefaultOmJvmHeapPercentage, getOpsManagerPodMemPercentage())
+	})
+
+	t.Run("returns default for over 100", func(t *testing.T) {
+		t.Setenv(util.OmJvmHeapPercentageEnv, "101")
+		assert.Equal(t, util.DefaultOmJvmHeapPercentage, getOpsManagerPodMemPercentage())
+	})
+}
+
+func TestIsOmAutoHeapEnabled(t *testing.T) {
+	t.Run("disabled when env var not set", func(t *testing.T) {
+		assert.False(t, isOmAutoHeapEnabled())
+	})
+
+	t.Run("disabled when env var is false", func(t *testing.T) {
+		t.Setenv(util.OmAutoHeapEnv, "false")
+		assert.False(t, isOmAutoHeapEnabled())
+	})
+
+	t.Run("enabled when env var is true", func(t *testing.T) {
+		t.Setenv(util.OmAutoHeapEnv, "true")
+		assert.True(t, isOmAutoHeapEnabled())
+	})
 }

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
@@ -450,6 +451,7 @@ func backupAndOpsManagerSharedConfiguration(opts OpsManagerStatefulSetOptions) s
 	omVolumes, omVolumeMounts = getNonPersistentOpsManagerVolumeMounts(omVolumes, omVolumeMounts, opts)
 
 	opts.EnvVars = append(opts.EnvVars, kmipEnvVars(opts)...)
+	opts.EnvVars = append(opts.EnvVars, omAutoHeapEnvVars()...)
 	omVolumes, omVolumeMounts = appendKmipVolumes(omVolumes, omVolumeMounts, opts)
 
 	initContainerMod := podtemplatespec.NOOP()
@@ -534,6 +536,15 @@ func kmipEnvVars(opts OpsManagerStatefulSetOptions) []corev1.EnvVar {
 		}
 	}
 	return nil
+}
+
+func omAutoHeapEnvVars() []corev1.EnvVar {
+	if os.Getenv(util.OmAutoHeapEnv) != util.EnvVarTrue {
+		return nil
+	}
+	return []corev1.EnvVar{
+		{Name: "OM_AUTO_HEAP", Value: util.EnvVarTrue},
+	}
 }
 
 // opsManagerReadinessProbe creates the readiness probe.

--- a/controllers/operator/construct/opsmanager_construction_test.go
+++ b/controllers/operator/construct/opsmanager_construction_test.go
@@ -276,8 +276,8 @@ func TestBuildOpsManagerStatefulSet(t *testing.T) {
 		assert.NoError(t, err)
 		expectedVars := []corev1.EnvVar{
 			{Name: "ENABLE_IRP", Value: "true"},
-			{Name: "CUSTOM_JAVA_MMS_UI_OPTS", Value: "-Xmx5149m -Xms343m"},
-			{Name: "CUSTOM_JAVA_DAEMON_OPTS", Value: "-Xmx5149m -Xms343m -DDAEMON.DEBUG.PORT=8090"},
+			{Name: "CUSTOM_JAVA_MMS_UI_OPTS", Value: "-Xmx4291m -Xms286m"},
+			{Name: "CUSTOM_JAVA_DAEMON_OPTS", Value: "-Xmx4291m -Xms286m -DDAEMON.DEBUG.PORT=8090"},
 		}
 		env := sts.Spec.Template.Spec.Containers[0].Env
 		assert.Equal(t, expectedVars, env)

--- a/controllers/operator/construct/opsmanager_construction_test.go
+++ b/controllers/operator/construct/opsmanager_construction_test.go
@@ -86,12 +86,12 @@ func TestBuildJvmParamsEnvVars_FromCustomContainerResource(t *testing.T) {
 	envVarsNoLimitsOrReqs, err := buildJvmParamsEnvVars(om.Spec, util.OpsManagerContainerName, template)
 	assert.NoError(t, err)
 
-	// if only memory requests are configured, xms and xmx should be 90% of mem request
-	assert.Equal(t, "-DFakeOptionEnabled -Xmx187m -Xms187m", envVarReqsOnly[0].Value)
-	// both are configured, xms should be 90% of mem request, and xmx 90% of mem limit
-	assert.Equal(t, "-DFakeOptionEnabled -Xmx230m -Xms187m", envVarLimitsAndReqs[0].Value)
-	// if only memory limits are configured, xms and xmx should be 90% of mem limits
-	assert.Equal(t, "-DFakeOptionEnabled -Xmx230m -Xms230m", envVarLimitsOnly[0].Value)
+	// if only memory requests are configured, xms and xmx should be 75% of mem request
+	assert.Equal(t, "-DFakeOptionEnabled -Xmx156m -Xms156m", envVarReqsOnly[0].Value)
+	// both are configured, xms should be 75% of mem request, and xmx 75% of mem limit
+	assert.Equal(t, "-DFakeOptionEnabled -Xmx192m -Xms156m", envVarLimitsAndReqs[0].Value)
+	// if only memory limits are configured, xms and xmx should be 75% of mem limits
+	assert.Equal(t, "-DFakeOptionEnabled -Xmx192m -Xms192m", envVarLimitsOnly[0].Value)
 	// if neither is configured, xms/xmx params should not be added to JVM params, keeping OM defaults
 	assert.Equal(t, "-DFakeOptionEnabled", envVarsNoLimitsOrReqs[0].Value)
 }
@@ -167,10 +167,63 @@ func TestBuildJvmParamsEnvVars_FromDefaultPodSpec(t *testing.T) {
 	assert.NoError(t, err)
 	// xmx and xms based calculated from  default container memory, requests.mem=limits.mem=5GB
 	assert.Equal(t, "CUSTOM_JAVA_MMS_UI_OPTS", envVar[0].Name)
-	assert.Equal(t, "-Xmx4291m -Xms4291m", envVar[0].Value)
+	assert.Equal(t, "-Xmx3576m -Xms3576m", envVar[0].Value)
 
 	assert.Equal(t, "CUSTOM_JAVA_DAEMON_OPTS", envVar[1].Name)
-	assert.Equal(t, "-Xmx4291m -Xms4291m -DDAEMON.DEBUG.PORT=8090", envVar[1].Value)
+	assert.Equal(t, "-Xmx3576m -Xms3576m -DDAEMON.DEBUG.PORT=8090", envVar[1].Value)
+}
+
+func TestOmAutoHeapEnvVars(t *testing.T) {
+	t.Run("disabled when env var not set", func(t *testing.T) {
+		assert.Nil(t, omAutoHeapEnvVars())
+	})
+
+	t.Run("enabled returns OM_AUTO_HEAP env var", func(t *testing.T) {
+		t.Setenv(util.OmAutoHeapEnv, "true")
+		vars := omAutoHeapEnvVars()
+		assert.NotNil(t, vars)
+		assert.Len(t, vars, 1)
+		assert.Equal(t, "OM_AUTO_HEAP", vars[0].Name)
+		assert.Equal(t, "true", vars[0].Value)
+	})
+}
+
+func TestBuildJvmParamsEnvVars_WithAutoHeap(t *testing.T) {
+	t.Setenv(util.OmAutoHeapEnv, "true")
+
+	ctx := context.Background()
+	om := omv1.NewOpsManagerBuilderDefault().
+		AddConfiguration(util.MmsCentralUrlPropKey, "http://om-svc").
+		Build()
+	om.Spec.JVMParams = []string{"-DFakeOptionEnabled"}
+
+	omSts, err := createOpsManagerStatefulset(ctx, om)
+	assert.NoError(t, err)
+	template := omSts.Spec.Template
+
+	envVar, err := buildJvmParamsEnvVars(om.Spec, util.OpsManagerContainerName, template)
+	assert.NoError(t, err)
+	assert.Equal(t, "-DFakeOptionEnabled", envVar[0].Value)
+	assert.NotContains(t, envVar[0].Value, "-Xmx")
+	assert.NotContains(t, envVar[0].Value, "-Xms")
+}
+
+func TestBuildJvmParamsEnvVars_WithCustomPercentage(t *testing.T) {
+	t.Setenv(util.OmJvmHeapPercentageEnv, "80")
+
+	ctx := context.Background()
+	om := omv1.NewOpsManagerBuilderDefault().
+		AddConfiguration(util.MmsCentralUrlPropKey, "http://om-svc").
+		Build()
+
+	omSts, err := createOpsManagerStatefulset(ctx, om)
+	assert.NoError(t, err)
+	template := omSts.Spec.Template
+
+	envVar, err := buildJvmParamsEnvVars(om.Spec, util.OpsManagerContainerName, template)
+	assert.NoError(t, err)
+	assert.Contains(t, envVar[0].Value, "-Xmx3814m")
+	assert.Contains(t, envVar[0].Value, "-Xms3814m")
 }
 
 func TestBuildOpsManagerStatefulSet(t *testing.T) {
@@ -190,8 +243,8 @@ func TestBuildOpsManagerStatefulSet(t *testing.T) {
 			{Name: "ENABLE_IRP", Value: "true"},
 			{Name: "OM_PROP_mms_adminEmailAddr", Value: "cloud-manager-support@mongodb.com"},
 			{Name: "OM_PROP_mms_centralUrl", Value: "http://om-svc"},
-			{Name: "CUSTOM_JAVA_MMS_UI_OPTS", Value: "-Xmx4291m -Xms4291m"},
-			{Name: "CUSTOM_JAVA_DAEMON_OPTS", Value: "-Xmx4291m -Xms4291m -DDAEMON.DEBUG.PORT=8090"},
+			{Name: "CUSTOM_JAVA_MMS_UI_OPTS", Value: "-Xmx3576m -Xms3576m"},
+			{Name: "CUSTOM_JAVA_DAEMON_OPTS", Value: "-Xmx3576m -Xms3576m -DDAEMON.DEBUG.PORT=8090"},
 		}
 		env := sts.Spec.Template.Spec.Containers[0].Env
 		assert.Equal(t, expectedVars, env)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_jvm_params.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_jvm_params.py
@@ -76,8 +76,8 @@ class TestOpsManagerCreationWithJvmParams:
                 api_client=api_client,
             )
             java_params = self.parse_java_params(result, JAVA_MMS_UI_OPTS)
-            assert "-Xmx4291m" in java_params
-            assert "-Xms343m" in java_params
+            assert "-Xmx3576m" in java_params
+            assert "-Xms286m" in java_params
 
     def test_om_process_mem_scales(self, ops_manager: MongoDBOpsManager):
         for api_client, pod in ops_manager.read_om_pods():

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -221,6 +221,12 @@ spec:
             - name: MDB_MAX_CONCURRENT_RECONCILES
               value: "{{ .Values.operator.maxConcurrentReconciles }}"
     {{- end }}
+            - name: MDB_OM_JVM_HEAP_PERCENTAGE
+              value: {{ .Values.operator.omJvmHeapPercentage | default 75 | quote }}
+    {{- if .Values.operator.omAutoHeap }}
+            - name: MDB_OM_AUTO_HEAP
+              value: "true"
+    {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -73,6 +73,15 @@ operator:
   # 4*4=20 workers in total. Memory usage depends on the actual number of resources reconciles in parallel and is not allocated upfront.
   maxConcurrentReconciles: 1
 
+  # Percentage of the OM container memory limit to use for JVM heap (-Xmx).
+  # Default: 75 (MongoDB internal standard). Previous default was 90%.
+  omJvmHeapPercentage: 75
+
+  # Use OM's native cgroup-aware heap sizing instead of operator's percentage-based approach.
+  # WARNING: Only use with OM pods having ≥16Gi memory. OM_AUTO_HEAP has an 8GB lower bound
+  # that will cause OOM on smaller pods (default 5Gi).
+  omAutoHeap: false
+
   # Create operator service account and roles
   # if false, then operator RBAC will not be provided by the chart
   createOperatorServiceAccount: true

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -263,8 +263,11 @@ const (
 	OmPropertyPrefix                   = "OM_PROP_"
 	MmsJvmParamEnvVar                  = "CUSTOM_JAVA_MMS_UI_OPTS"
 	BackupDaemonJvmParamEnvVar         = "CUSTOM_JAVA_DAEMON_OPTS"
+	OmJvmHeapPercentageEnv             = "MDB_OM_JVM_HEAP_PERCENTAGE"
+	DefaultOmJvmHeapPercentage         = 75
+	OmAutoHeapEnv                      = "MDB_OM_AUTO_HEAP"
+	EnvVarTrue                          = "true"
 	GenKeyPath                         = "/mongodb-ops-manager/.mongodb-mms"
-	LatestOmVersion                    = "5.0"
 	AppDBAutomationConfigKey           = "cluster-config.json"
 	AppDBMonitoringAutomationConfigKey = "monitoring-cluster-config.json"
 	DefaultAppDbPasswordKey            = "password"

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -427,6 +427,8 @@ spec:
               value: 'true'
             - name: MDB_MAX_CONCURRENT_RECONCILES
               value: "1"
+            - name: MDB_OM_JVM_HEAP_PERCENTAGE
+              value: "75"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -416,6 +416,8 @@ spec:
               value: 'true'
             - name: MDB_MAX_CONCURRENT_RECONCILES
               value: "1"
+            - name: MDB_OM_JVM_HEAP_PERCENTAGE
+              value: "75"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -424,6 +424,8 @@ spec:
               value: 'true'
             - name: MDB_MAX_CONCURRENT_RECONCILES
               value: "1"
+            - name: MDB_OM_JVM_HEAP_PERCENTAGE
+              value: "75"
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Summary

The OM JVM heap was hardcoded to 90% of the container memory limit — an arbitrary value with no design rationale (traced to CLOUDP-82600, Feb 2021). This left insufficient headroom for non-heap JVM memory (metaspace, thread stacks, direct buffers), causing real customer OOM kills:

- **[HELP-90788](https://jira.mongodb.org/browse/HELP-90788)**: Customer with 20Gi limit got `-Xmx18432m` (90%), leaving only 2GB headroom. Support confirmed "the 2gb headroom is definitely not sufficient" and recommended increasing to 24Gi. At 75%, the same pod would have 5GB headroom.


This PR:
- Makes the percentage configurable via `MDB_OM_JVM_HEAP_PERCENTAGE` env var (default changed from 90% to 75%, the MongoDB internal standard per CLOUDP-373541)
- Adds opt-in support for OM's native cgroup-aware heap sizing via `MDB_OM_AUTO_HEAP` env var — when enabled, the operator skips `-Xmx`/`-Xms` and delegates to OM's built-in logic

**Before:** OM pods got `-Xmx4291m -Xms4291m` (90% of default 5Gi). **After:** OM pods get `-Xmx3576m -Xms3576m` (75% of 5Gi), unless overridden.

## Proof of Work

- `controllers/operator/construct/jvm_test.go` — `TestGetOpsManagerPodMemPercentage` (5 subtests), `TestIsOmAutoHeapEnabled` (3 subtests)
- `controllers/operator/construct/opsmanager_construction_test.go` — `TestOmAutoHeapEnvVars`, `TestBuildJvmParamsEnvVars_WithAutoHeap`, `TestBuildJvmParamsEnvVars_WithCustomPercentage`, updated existing tests for new 75% default
- `docker/mongodb-kubernetes-tests/tests/opsmanager/om_jvm_params.py` — e2e test updated for new 75% expectations
- All unit tests pass: `go test ./controllers/operator/construct/ -run "Jvm|AutoHeap|CustomPercentage|OmAutoHeap|GetOpsManager" -v -count=1`

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---