### PR TITLE
fix: unify make precommit targets via check_precommit.sh

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -311,7 +311,7 @@ functions:
           - ${workdir}/bin
           - ${workdir}/venv/bin
         working_dir: src/github.com/mongodb/mongodb-kubernetes
-        binary: scripts/evergreen/check_precommit.sh
+        binary: scripts/evergreen/check_precommit.sh --full
 
   # Configures docker authentication to ECR and RH registries.
   setup_building_host:

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1,5 +1,5 @@
 
-cel.dev/expr,v0.25.1,https://github.com/google/cel-spec/blob/v0.25.1/LICENSE,Apache-2.0
+cel.dev/expr,v0.25.1,Unknown,Apache-2.0
 github.com/Masterminds/semver/v3,v3.5.0,https://github.com/Masterminds/semver/blob/v3.5.0/LICENSE.txt,MIT
 github.com/beorn7/perks/quantile,v1.0.1,https://github.com/beorn7/perks/blob/v1.0.1/LICENSE,MIT
 github.com/blang/semver,v3.5.1,https://github.com/blang/semver/blob/v3.5.1/LICENSE,MIT

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1,5 +1,5 @@
 
-cel.dev/expr,v0.25.1,Unknown,Apache-2.0
+cel.dev/expr,v0.25.1,https://github.com/google/cel-spec/blob/v0.25.1/LICENSE,Apache-2.0
 github.com/Masterminds/semver/v3,v3.5.0,https://github.com/Masterminds/semver/blob/v3.5.0/LICENSE.txt,MIT
 github.com/beorn7/perks/quantile,v1.0.1,https://github.com/beorn7/perks/blob/v1.0.1/LICENSE,MIT
 github.com/blang/semver,v3.5.1,https://github.com/blang/semver/blob/v3.5.1/LICENSE,MIT

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ prek:
 	@[ -f "$(PREK)" ] || scripts/evergreen/setup_prek.sh
 
 precommit: prek
-	@ source scripts/dev/set_env_context.sh && prek -a
+	@ scripts/evergreen/check_precommit.sh
 
 precommit-full: prek
-	@ source scripts/dev/set_env_context.sh && MDB_UPDATE_LICENSES=true MDB_REGENERATE_RBAC=true prek -a
+	@ scripts/evergreen/check_precommit.sh --full
 
 switch:
 	@ scripts/dev/switch_context.sh $(context) $(additional_override)

--- a/scripts/evergreen/check_precommit.sh
+++ b/scripts/evergreen/check_precommit.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 #
-# CI script to run prek checks in Evergreen.
-# This script is called by the Evergreen CI pipeline.
+# Run prek checks locally (make precommit / make precommit-full) or in Evergreen CI.
 #
 
 set -Eeou pipefail
+
+full_mode=false
+if [[ "${1:-}" == "--full" ]]; then
+  full_mode=true
+fi
 
 source scripts/dev/set_env_context.sh
 source scripts/funcs/printing
@@ -22,8 +26,10 @@ fi
 
 title "Running pre-commit checks"
 
-# Set EVERGREEN_MODE to signal we're in CI
-export EVERGREEN_MODE=true
+if [[ "${full_mode}" == true ]]; then
+  export MDB_UPDATE_LICENSES=true
+  export MDB_REGENERATE_RBAC=true
+fi
 
 # Store the current state of the index and working directory
 initial_index_state=$(git diff --name-only --cached --diff-filter=AM)

--- a/scripts/evergreen/precommit_bump.sh
+++ b/scripts/evergreen/precommit_bump.sh
@@ -43,7 +43,7 @@ echo "Detected a branch that should be bumped."
 git checkout "${ORIGINAL_BRANCH}"
 
 # Run pre-commit - allow failure (exit 1 means files were modified)
-EVERGREEN_MODE=true .githooks/pre-commit || true
+.githooks/pre-commit || true
 
 git add .
 


### PR DESCRIPTION
# Summary

`make precommit` and `make precommit-full` duplicated logic that already lived in `scripts/evergreen/check_precommit.sh` (venv activation, prek invocation, git index verification). The Makefile targets also diverged from what Evergreen runs in CI.

This PR routes both Makefile targets through `check_precommit.sh`, with a `--full` flag that enables the heavier generation hooks (`MDB_UPDATE_LICENSES`, `MDB_REGENERATE_RBAC`). Regular `make precommit` stays fast; `make precommit-full` and Evergreen CI use `--full`. `EVERGREEN_MODE` is removed — it was set in two places but never read anywhere in the repo (old leftover when we did things differently in the past).

**Note:** Running `make precommit-full` locally regenerated `LICENSE-THIRD-PARTY` and `go-licenses` wrote `Unknown` for `cel.dev/expr` (vanity import path — no `go-import` meta tags).
## Proof of Work

- `bash -n scripts/evergreen/check_precommit.sh` passes
- `make precommit` and `make precommit-full` both delegate to `check_precommit.sh` (with/without `--full`)
- Evergreen precommit task updated to `check_precommit.sh --full`

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
