### PR TITLE
CLOUDP-407997: Publish MCK promoted MCK images

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -657,7 +657,7 @@ tasks:
           working_dir: src/github.com/mongodb/mongodb-kubernetes
           script: |
             source .generated/context.export.env
-            scripts/mckci release promote images --commit "${revision}"
+            scripts/mckci release promote images --commit "${revision}" --latest-marker latest
 
   # Notify Slack about build failures
   # On patches: stdout only. On mainline: stdout + Slack

--- a/ci/internal/cli/release.go
+++ b/ci/internal/cli/release.go
@@ -11,5 +11,6 @@ func newReleaseCmd() *cobra.Command {
 		},
 	}
 	cmd.AddCommand(newPromoteReleaseCmd())
+	cmd.AddCommand(newPublishReleaseCmd())
 	return cmd
 }

--- a/ci/internal/cli/release_promote.go
+++ b/ci/internal/cli/release_promote.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -23,19 +24,29 @@ func newPromoteReleaseCmd() *cobra.Command {
 
 func newPromoteImageCmd() *cobra.Command {
 	var (
-		image       string
-		commit      string
-		version     string
-		registryURL string
-		repo        string
-		dryRun      bool
+		image        string
+		commit       string
+		version      string
+		registryURL  string
+		repo         string
+		latestMarker string
+		force        bool
+		dryRun       bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Promote a single candidate image",
+		Long: `Promotes a single candidate image, tagging it promoted-{commit}-{version}
+and promoted-{latest-marker} (--latest-marker is required).
+
+The promoted-{latest-marker} tag is a mutable pointer that always moves.
+When promoting a backport (e.g. patching an older release branch after a
+newer version has already been promoted), pass a distinct --latest-marker
+(e.g. "latestv1") so the backport doesn't steal the "latest" pointer away
+from the newest promoted version.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return promoteImage(cmd, image, commit, version, registryURL, repo, dryRun)
+			return promoteImage(cmd, image, commit, version, registryURL, repo, latestMarker, force, dryRun)
 		},
 	}
 
@@ -44,53 +55,76 @@ func newPromoteImageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&version, "version", "", "version to encode in the promoted tag")
 	cmd.Flags().StringVar(&registryURL, "registry", "https://quay.io", "target OCI registry base URL")
 	cmd.Flags().StringVar(&repo, "repo", "mongodb/mongodb-kubernetes-operator", "target image repository")
+	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite the promoted-{commit}-{version} tag even if it already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 
 	MustNotErr(cmd.MarkFlagRequired("image"))
 	MustNotErr(cmd.MarkFlagRequired("commit"))
 	MustNotErr(cmd.MarkFlagRequired("version"))
+	MustNotErr(cmd.MarkFlagRequired("latest-marker"))
 
 	return cmd
 }
 
 func newPromoteImagesCmd() *cobra.Command {
 	var (
-		buildInfo   string
-		releaseJSON string
-		commit      string
-		dryRun      bool
+		buildInfo    string
+		releaseJSON  string
+		commit       string
+		latestMarker string
+		force        bool
+		dryRun       bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "images",
 		Short: "Promote every release image defined in build_info.json at the given commit",
+		Long: `Promotes every release image in build_info.json at the given commit.
+
+Every image's immutable promoted-{commit}-{version} tag is checked for
+conflicts BEFORE any writes happen. If any image would overwrite an existing
+tag with different content, the whole set is refused untouched — use
+--force to promote anyway.
+
+Every image also gets a promoted-{latest-marker} mutable pointer tag
+(--latest-marker is required). When promoting a backport (e.g.
+patching an older release branch after a newer version has already been
+promoted), pass a distinct --latest-marker (e.g. "latestv1") so the backport
+doesn't steal the "latest" pointer away from the newest promoted version.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return promoteAllImages(cmd, buildInfo, releaseJSON, commit, dryRun)
+			return promoteAllImages(cmd, buildInfo, releaseJSON, commit, latestMarker, force, dryRun)
 		},
 	}
 
 	cmd.Flags().StringVar(&buildInfo, "build-info", "build_info.json", "path to build_info.json")
 	cmd.Flags().StringVar(&releaseJSON, "release-json", "release.json", "path to release.json")
 	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to encode in the promoted tags")
+	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().BoolVar(&force, "force", false, "promote every image even if any promoted tag already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 
 	MustNotErr(cmd.MarkFlagRequired("commit"))
+	MustNotErr(cmd.MarkFlagRequired("latest-marker"))
 
 	return cmd
 }
 
 // promoteAllImages promotes every release image in build_info.json at the given
 // commit, writing promoted tags to each image's primary staging repository.
-func promoteAllImages(cmd *cobra.Command, buildInfo, releaseJSON, commit string, dryRun bool) error {
+func promoteAllImages(cmd *cobra.Command, buildInfo, releaseJSON, commit, latestMarker string, force, dryRun bool) error {
 	images, err := release.LoadReleaseImages(buildInfo, releaseJSON)
 	if err != nil {
 		return err
 	}
-	results, err := release.PromoteImages(images, commit, dryRun, release.DefaultRegistryConnector)
+	results, err := release.PromoteImages(images, commit, latestMarker, force, dryRun, release.DefaultRegistryConnector)
 	if err != nil {
 		return err
 	}
 	for _, r := range results {
+		if err := printNotices(cmd, r.Name, r.Infos, r.Warnings); err != nil {
+			return err
+		}
 		for _, tag := range r.Tags {
 			verb := "promoted"
 			if dryRun {
@@ -104,18 +138,24 @@ func promoteAllImages(cmd *cobra.Command, buildInfo, releaseJSON, commit string,
 	return nil
 }
 
-func promoteImage(cmd *cobra.Command, image, commit, version, registryURL, repo string, dryRun bool) error {
-	tags, err := release.Promote(release.PromoteInputs{
-		Image:   image,
-		Commit:  commit,
-		Version: version,
-		Repo:    repo,
-		DryRun:  dryRun,
-	}, release.DefaultRegistryConnector(registryURL))
+func promoteImage(cmd *cobra.Command, image, commit, version, registryURL, repo, latestMarker string, force, dryRun bool) error {
+	host := strings.TrimPrefix(strings.TrimPrefix(registryURL, "https://"), "http://")
+	result, err := release.Promote(release.PromoteInputs{
+		Image:        image,
+		Commit:       commit,
+		Version:      version,
+		Repo:         repo,
+		LatestMarker: latestMarker,
+		Force:        force,
+		DryRun:       dryRun,
+	}, host, release.DefaultRegistryConnector(registryURL))
 	if err != nil {
 		return err
 	}
-	for _, tag := range tags {
+	if err := printNotices(cmd, "", result.Infos, result.Warnings); err != nil {
+		return err
+	}
+	for _, tag := range result.Tags {
 		var line string
 		if dryRun {
 			line = fmt.Sprintf("dry-run: would copy %s → %s/%s:%s\n", image, registryURL, repo, tag)
@@ -123,6 +163,26 @@ func promoteImage(cmd *cobra.Command, image, commit, version, registryURL, repo 
 			line = fmt.Sprintf("promoted: %s/%s:%s\n", registryURL, repo, tag)
 		}
 		if _, err := fmt.Fprint(cmd.OutOrStdout(), line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// printNotices writes infos to stdout and warnings to stderr, each prefixed
+// with name (if non-empty) to identify which image a result belongs to.
+func printNotices(cmd *cobra.Command, name string, infos, warnings []string) error {
+	prefix := ""
+	if name != "" {
+		prefix = name + ": "
+	}
+	for _, i := range infos {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "info: %s%s\n", prefix, i); err != nil {
+			return err
+		}
+	}
+	for _, w := range warnings {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s%s\n", prefix, w); err != nil {
 			return err
 		}
 	}

--- a/ci/internal/cli/release_publish.go
+++ b/ci/internal/cli/release_publish.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mongodb/mongodb-kubernetes/ci/internal/release"
+)
+
+func newPublishReleaseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "publish",
+		Short: "Publish promoted candidate(s) to the production registry",
+	}
+
+	cmd.AddCommand(newPublishImageCmd())
+	cmd.AddCommand(newPublishImagesCmd())
+
+	return cmd
+}
+
+func newPublishImageCmd() *cobra.Command {
+	var (
+		stagingImage string
+		commit       string
+		registryURL  string
+		prodRepo     string
+		latestMarker string
+		force        bool
+		dryRun       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Publish a single promoted candidate image",
+		Long: `Resolves the promoted candidate for the given commit (or the promoted
+candidate matching promoted-{latest-marker} in staging if --commit is
+omitted), then retags it in the production registry as :{version} and
+:{latest-marker}. The version is derived from the promoted-{commit}-{version}
+tag already present in the staging registry — no --version flag is needed.
+
+The immutable :{version} tag is checked for conflicts before it is
+overwritten: if it already exists at a different digest, the publish is
+refused unless --force is given. :{latest-marker} always moves.
+
+--latest-marker is required. When publishing a backport (e.g.
+patching an older release branch after a newer version has already been
+published), pass a distinct --latest-marker (e.g. "latestv1") so the
+backport doesn't steal the ":latest" tag away from the newest published
+version.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			host := strings.TrimPrefix(strings.TrimPrefix(registryURL, "https://"), "http://")
+			result, err := release.Publish(release.PublishInputs{
+				StagingImage: stagingImage,
+				Commit:       commit,
+				ProdRepo:     prodRepo,
+				LatestMarker: latestMarker,
+				Force:        force,
+				DryRun:       dryRun,
+			}, host, release.DefaultRegistryConnector(registryURL))
+			if err != nil {
+				return err
+			}
+			if err := printNotices(cmd, "", result.Infos, result.Warnings); err != nil {
+				return err
+			}
+			src := fmt.Sprintf("%s:%s", stagingImage, release.PromotedTagFor(result.Commit, result.Version))
+			for _, tag := range result.AppliedTags {
+				dst := fmt.Sprintf("%s/%s:%s", registryURL, prodRepo, tag)
+				var line string
+				if dryRun {
+					line = fmt.Sprintf("dry-run: would copy %s → %s\n", src, dst)
+				} else {
+					line = fmt.Sprintf("published: %s → %s\n", src, dst)
+				}
+				if _, err := fmt.Fprint(cmd.OutOrStdout(), line); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	// Staging and production must share the --registry host; the host in
+	// --staging-image is only used to derive the repo path.
+	cmd.Flags().StringVar(&stagingImage, "staging-image", "", "staging image repo, e.g. quay.io/mongodb/staging/mongodb-kubernetes (required)")
+	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to publish (default: latest promoted)")
+	cmd.Flags().StringVar(&registryURL, "registry", "https://quay.io", "production OCI registry base URL")
+	cmd.Flags().StringVar(&prodRepo, "prod-repo", "mongodb/mongodb-kubernetes-operator", "production image repository")
+	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite the :{version} production tag even if it already points at a different digest")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+
+	MustNotErr(cmd.MarkFlagRequired("staging-image"))
+	MustNotErr(cmd.MarkFlagRequired("latest-marker"))
+
+	return cmd
+}
+
+func newPublishImagesCmd() *cobra.Command {
+	var (
+		buildInfo    string
+		releaseJSON  string
+		commit       string
+		latestMarker string
+		force        bool
+		dryRun       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Publish every promoted release image defined in build_info.json at the given commit",
+		Long: `Resolves the release image set from build_info.json and release.json, then
+for each image retags its promoted-{commit}-{version} candidate (read from
+the image's primary staging repository) as :{version} and :{latest-marker}
+in the image's production (release.repository) registry. --commit is
+required: a multi-image publish always publishes one specific,
+already-promoted commit consistently across every image, rather than
+resolving promoted-{latest-marker} independently per image.
+
+Every image's immutable :{version} production tag is checked for conflicts
+BEFORE any writes happen. If any image would overwrite an existing tag with
+different content, the whole set is refused untouched — use --force to
+publish anyway. :{latest-marker} always moves.
+
+--latest-marker is required. When publishing a backport across
+every image (e.g. patching an older release branch after a newer version has
+already been published), pass a distinct --latest-marker (e.g. "latestv1")
+so the backport doesn't steal the ":latest" tag away from the newest
+published version.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			images, err := release.LoadReleaseImages(buildInfo, releaseJSON)
+			if err != nil {
+				return err
+			}
+			results, err := release.PublishImages(images, commit, latestMarker, force, dryRun, release.DefaultRegistryConnector)
+			if err != nil {
+				return err
+			}
+			for _, r := range results {
+				if err := printNotices(cmd, r.Name, r.Infos, r.Warnings); err != nil {
+					return err
+				}
+				src := fmt.Sprintf("%s:%s", r.StagingRepo, release.PromotedTagFor(r.Commit, r.Version))
+				for _, tag := range r.Tags {
+					dst := fmt.Sprintf("%s:%s", r.ProdRepo, tag)
+					verb := "published"
+					if dryRun {
+						verb = "dry-run: would publish"
+					}
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s: %s → %s\n", verb, src, dst); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&buildInfo, "build-info", "build_info.json", "path to build_info.json")
+	cmd.Flags().StringVar(&releaseJSON, "release-json", "release.json", "path to release.json")
+	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to publish")
+	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().BoolVar(&force, "force", false, "publish every image even if any production tag already points at a different digest")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+
+	MustNotErr(cmd.MarkFlagRequired("commit"))
+	MustNotErr(cmd.MarkFlagRequired("latest-marker"))
+
+	return cmd
+}

--- a/ci/internal/release/images_promote.go
+++ b/ci/internal/release/images_promote.go
@@ -8,10 +8,12 @@ import (
 
 // ImagesPromoteResult records what was (or would be) promoted for one image.
 type ImagesPromoteResult struct {
-	Name    string
-	Repo    string
-	Version string
-	Tags    []string
+	Name     string
+	Repo     string
+	Version  string
+	Tags     []string
+	Warnings []string
+	Infos    []string
 }
 
 // shortCommit mirrors the COMMIT_SHA_SHORT computed in
@@ -28,7 +30,7 @@ func shortCommit(commit string) string {
 }
 
 // PromoteImages promotes every image at the given commit, writing
-// promoted-{commit}-{version} and promoted-latest to each image's PRIMARY
+// promoted-{commit}-{version} and promoted-{latestMarker} to each image's PRIMARY
 // staging repository only (secondary repositories are intentionally left
 // untouched for now). The source image is the short-commit-tagged image the
 // staging build already pushed, e.g. <staging-repo>:<short-commit> (matching the
@@ -39,34 +41,70 @@ func shortCommit(commit string) string {
 // commit-tagged source image is missing), so a broken merge build does not
 // silently promote a partial image set. connect resolves a Registry for an image's
 // host; the CLI passes DefaultRegistryConnector and tests inject a fake.
-func PromoteImages(images []ReleaseImage, commit string, dryRun bool, connect RegistryConnector) ([]ImagesPromoteResult, error) {
+func PromoteImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, connect RegistryConnector) ([]ImagesPromoteResult, error) {
 	if commit == "" {
 		return nil, errors.New("commit is required")
 	}
 	if len(images) == 0 {
 		return nil, errors.New("no images to promote")
 	}
-
+	if latestMarker == "" {
+		return nil, errors.New("latest-marker is required")
+	}
 	srcTag := shortCommit(commit)
-	results := make([]ImagesPromoteResult, 0, len(images))
+
+	type prepared struct {
+		img        ReleaseImage
+		reg        Registry
+		host       string
+		repoPath   string
+		srcRef     string
+		versionTag string
+	}
+
+	prep := make([]prepared, 0, len(images))
+	var conflicts []string
 	for _, img := range images {
 		host, path := splitHostRepo(img.StagingRepo)
-		src := fmt.Sprintf("%s:%s", img.StagingRepo, srcTag)
-		tags, err := Promote(PromoteInputs{
-			Image:   src,
-			Commit:  commit,
-			Version: img.Version,
-			Repo:    path,
-			DryRun:  dryRun,
-		}, connect(host))
+		reg := connect(host)
+		srcRef := fmt.Sprintf("%s:%s", img.StagingRepo, srcTag)
+		versionTag := PromotedTagFor(commit, img.Version)
+
+		dstVersionRef := fmt.Sprintf("%s/%s:%s", host, path, versionTag)
+		conflict, _, err := checkStomp(reg, srcRef, dstVersionRef)
 		if err != nil {
-			return nil, fmt.Errorf("promote %s (%s): %w", img.Name, src, err)
+			return nil, fmt.Errorf("check %s (%s): %w", img.Name, srcRef, err)
+		}
+		if conflict != "" {
+			conflicts = append(conflicts, fmt.Sprintf("%s: %s", img.Name, conflict))
+		}
+		prep = append(prep, prepared{img: img, reg: reg, host: host, repoPath: path, srcRef: srcRef, versionTag: versionTag})
+	}
+	if len(conflicts) > 0 && !force {
+		return nil, fmt.Errorf("refusing to promote images; tag conflicts found (use --force if the tags needs overwriting):\n%s", strings.Join(conflicts, "\n"))
+	}
+
+	results := make([]ImagesPromoteResult, 0, len(images))
+	for _, p := range prep {
+		result, err := Promote(PromoteInputs{
+			Image:        p.srcRef,
+			Commit:       commit,
+			Version:      p.img.Version,
+			Repo:         p.repoPath,
+			LatestMarker: latestMarker,
+			Force:        true,
+			DryRun:       dryRun,
+		}, p.host, p.reg)
+		if err != nil {
+			return nil, fmt.Errorf("promote %s (%s): %w", p.img.Name, p.srcRef, err)
 		}
 		results = append(results, ImagesPromoteResult{
-			Name:    img.Name,
-			Repo:    img.StagingRepo,
-			Version: img.Version,
-			Tags:    tags,
+			Name:     p.img.Name,
+			Repo:     p.img.StagingRepo,
+			Version:  p.img.Version,
+			Tags:     result.Tags,
+			Warnings: result.Warnings,
+			Infos:    result.Infos,
 		})
 	}
 	return results, nil

--- a/ci/internal/release/images_promote_test.go
+++ b/ci/internal/release/images_promote_test.go
@@ -2,8 +2,14 @@ package release
 
 import (
 	"errors"
+	"fmt"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 type copyCall struct {
@@ -25,6 +31,20 @@ func (f *fakeRegistry) CopyWithTags(srcRef, dstRepo string, tags []string) error
 	return nil
 }
 
+func (f *fakeRegistry) ListTags(repo string) ([]string, error) {
+	return nil, errors.New("fakeRegistry.ListTags not implemented")
+}
+
+func (f *fakeRegistry) Digest(ref string) (string, error) {
+	if err := f.fail[ref]; err != nil {
+		return "", err
+	}
+	if strings.Contains(ref, PromotedTagPrefix) {
+		return "", ErrTagNotFound
+	}
+	return "digest:" + ref, nil
+}
+
 func TestPromoteImages(t *testing.T) {
 	fake := &fakeRegistry{}
 	connect := func(url string) Registry { return fake }
@@ -34,7 +54,7 @@ func TestPromoteImages(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: "quay.io/staging/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
 	}
 
-	results, err := PromoteImages(images, "abc1234", false, connect)
+	results, err := PromoteImages(images, "abc1234", "latest", false, false, connect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,12 +66,22 @@ func TestPromoteImages(t *testing.T) {
 		{
 			srcRef:  "quay.io/staging/mongodb-kubernetes:abc1234",
 			dstRepo: "staging/mongodb-kubernetes",
-			tags:    []string{PromotedTagFor("abc1234", "1.9.2"), promotedLatestTag()},
+			tags:    []string{PromotedTagFor("abc1234", "1.9.2")},
+		},
+		{
+			srcRef:  "quay.io/staging/mongodb-kubernetes:abc1234",
+			dstRepo: "staging/mongodb-kubernetes",
+			tags:    []string{promotedLatestTag()},
 		},
 		{
 			srcRef:  "quay.io/staging/mongodb-kubernetes-readinessprobe:abc1234",
 			dstRepo: "staging/mongodb-kubernetes-readinessprobe",
-			tags:    []string{PromotedTagFor("abc1234", "1.0.24"), promotedLatestTag()},
+			tags:    []string{PromotedTagFor("abc1234", "1.0.24")},
+		},
+		{
+			srcRef:  "quay.io/staging/mongodb-kubernetes-readinessprobe:abc1234",
+			dstRepo: "staging/mongodb-kubernetes-readinessprobe",
+			tags:    []string{promotedLatestTag()},
 		},
 	}
 	if len(fake.copies) != len(want) {
@@ -78,7 +108,7 @@ func TestPromoteImagesHardFailsOnMissingSource(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: "quay.io/staging/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
 	}
 
-	_, err := PromoteImages(images, "abc1234", false, connect)
+	_, err := PromoteImages(images, "abc1234", "latest", false, false, connect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected hard failure mentioning readiness-probe, got %v", err)
 	}
@@ -93,7 +123,9 @@ func TestPromoteImagesUsesShortCommitAsSourceTag(t *testing.T) {
 	}
 	fullCommit := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 
-	results, err := PromoteImages(images, fullCommit, false, connect)
+	force := false
+	dryrun := false
+	results, err := PromoteImages(images, fullCommit, "latest", force, dryrun, connect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,11 +135,14 @@ func TestPromoteImagesUsesShortCommitAsSourceTag(t *testing.T) {
 
 	// Source tag must be the first 8 chars of the full commit.
 	wantSrcRef := "quay.io/staging/mongodb-kubernetes:a1b2c3d4"
-	if len(fake.copies) != 1 {
-		t.Fatalf("copies: got %d, want 1", len(fake.copies))
+	if len(fake.copies) != 2 {
+		t.Fatalf("copies: got %d, want 2", len(fake.copies))
 	}
 	if fake.copies[0].srcRef != wantSrcRef {
 		t.Errorf("srcRef: got %q, want %q", fake.copies[0].srcRef, wantSrcRef)
+	}
+	if fake.copies[1].srcRef != wantSrcRef {
+		t.Errorf("srcRef (latest call): got %q, want %q", fake.copies[1].srcRef, wantSrcRef)
 	}
 	// Destination tag must still use the FULL commit.
 	wantDstTag := PromotedTagFor(fullCommit, "2.0.0")
@@ -122,10 +157,47 @@ func TestPromoteImagesCommitRequired(t *testing.T) {
 		return nil
 	}
 	images := []ReleaseImage{{Name: "operator", StagingRepo: "h/staging/op", Version: "1.9.2"}}
-	_, err := PromoteImages(images, "", false, connect)
+	_, err := PromoteImages(images, "", "", false, false, connect)
 	if err == nil || !strings.Contains(err.Error(), "commit") {
 		t.Fatalf("expected commit error, got %v", err)
 	}
+}
+
+func TestPromoteImagesRefusesAllOnAnyConflict(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	opRepo := host + "/staging/mongodb-kubernetes"
+	rpRepo := host + "/staging/mongodb-kubernetes-readinessprobe"
+	pushImage(t, opRepo+":abc1234", name.Insecure)
+	pushImage(t, rpRepo+":abc1234", name.Insecure)
+
+	pushImage(t, rpRepo+":"+PromotedTagFor("abc1234", "1.0.24"), name.Insecure)
+
+	images := []ReleaseImage{
+		{Name: "operator", StagingRepo: opRepo, Version: "1.9.2", IsAnchor: true},
+		{Name: "readiness-probe", StagingRepo: rpRepo, Version: "1.0.24"},
+	}
+
+	_, err := PromoteImages(images, "abc1234", "latest", false, false, insecureConnect)
+	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
+		t.Fatalf("expected conflict error mentioning readiness-probe, got %v", err)
+	}
+
+	if _, err := remote.Get(mustTagRef(t, opRepo, PromotedTagFor("abc1234", "1.9.2"))); err == nil {
+		t.Error("operator promoted tag should not exist: images must be refused before any writes")
+	}
+
+	results, err := PromoteImages(images, "abc1234", "latest", true, false, insecureConnect)
+	if err != nil {
+		t.Fatalf("force: unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("force: results: got %d, want 2", len(results))
+	}
+	opDigest := mustDigest(t, opRepo, "abc1234")
+	assertTagDigest(t, opRepo, PromotedTagFor("abc1234", "1.9.2"), opDigest)
 }
 
 func TestSplitHostRepo(t *testing.T) {
@@ -136,4 +208,41 @@ func TestSplitHostRepo(t *testing.T) {
 	if h, p := splitHostRepo("norepo"); h != "" || p != "norepo" {
 		t.Errorf("no-slash: got (%q, %q)", h, p)
 	}
+}
+
+func insecureConnect(host string) Registry {
+	return DefaultRegistryConnector("http://" + host)
+}
+
+func assertTagDigest(t *testing.T, repo, tag, wantDigest string) {
+	t.Helper()
+	ref, err := name.NewTag(fmt.Sprintf("%s:%s", repo, tag), name.Insecure)
+	if err != nil {
+		t.Fatalf("parse tag %s:%s: %v", repo, tag, err)
+	}
+	desc, err := remote.Get(ref)
+	if err != nil {
+		t.Fatalf("tag %s:%s not found: %v", repo, tag, err)
+	}
+	if desc.Digest.String() != wantDigest {
+		t.Errorf("%s:%s digest got %q, want %q", repo, tag, desc.Digest, wantDigest)
+	}
+}
+
+func mustTagRef(t *testing.T, repo, tag string) name.Reference {
+	t.Helper()
+	ref, err := name.NewTag(fmt.Sprintf("%s:%s", repo, tag), name.Insecure)
+	if err != nil {
+		t.Fatalf("parse tag %s:%s: %v", repo, tag, err)
+	}
+	return ref
+}
+
+func mustDigest(t *testing.T, repo, tag string) string {
+	t.Helper()
+	desc, err := remote.Get(mustTagRef(t, repo, tag))
+	if err != nil {
+		t.Fatalf("get %s:%s: %v", repo, tag, err)
+	}
+	return desc.Digest.String()
 }

--- a/ci/internal/release/images_publish.go
+++ b/ci/internal/release/images_publish.go
@@ -1,0 +1,90 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type ImagesPublishResult struct {
+	Name        string
+	StagingRepo string
+	ProdRepo    string
+	Commit      string
+	Version     string
+	Tags        []string
+	Warnings    []string
+	Infos       []string
+}
+
+func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, connect RegistryConnector) ([]ImagesPublishResult, error) {
+	if commit == "" {
+		return nil, errors.New("commit is required")
+	}
+	if len(images) == 0 {
+		return nil, errors.New("no images to publish")
+	}
+	if latestMarker == "" {
+		return nil, errors.New("latest-marker is required")
+	}
+
+	type prepared struct {
+		img      ReleaseImage
+		reg      Registry
+		host     string
+		prodPath string
+		version  string
+	}
+
+	prep := make([]prepared, 0, len(images))
+	var conflicts []string
+	for _, img := range images {
+		host, path := splitHostRepo(img.ReleaseRepo)
+		reg := connect(host)
+
+		_, version, err := resolvePromoted(img.StagingRepo, commit, latestMarker, reg)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s (%s): %w", img.Name, img.StagingRepo, err)
+		}
+		srcRef := fmt.Sprintf("%s:%s", img.StagingRepo, PromotedTagFor(commit, version))
+		dstVersionRef := fmt.Sprintf("%s/%s:%s", host, path, version)
+
+		conflict, _, err := checkStomp(reg, srcRef, dstVersionRef)
+		if err != nil {
+			return nil, fmt.Errorf("check %s (%s): %w", img.Name, srcRef, err)
+		}
+		if conflict != "" {
+			conflicts = append(conflicts, fmt.Sprintf("%s: %s", img.Name, conflict))
+		}
+		prep = append(prep, prepared{img: img, reg: reg, host: host, prodPath: path, version: version})
+	}
+	if len(conflicts) > 0 && !force {
+		return nil, fmt.Errorf("refusing to publish images; tag conflicts found (use --force to override):\n%s", strings.Join(conflicts, "\n"))
+	}
+
+	results := make([]ImagesPublishResult, 0, len(images))
+	for _, p := range prep {
+		result, err := Publish(PublishInputs{
+			StagingImage: p.img.StagingRepo,
+			Commit:       commit,
+			ProdRepo:     p.prodPath,
+			LatestMarker: latestMarker,
+			Force:        true,
+			DryRun:       dryRun,
+		}, p.host, p.reg)
+		if err != nil {
+			return nil, fmt.Errorf("publish %s (%s): %w", p.img.Name, p.img.StagingRepo, err)
+		}
+		results = append(results, ImagesPublishResult{
+			Name:        p.img.Name,
+			StagingRepo: p.img.StagingRepo,
+			ProdRepo:    p.img.ReleaseRepo,
+			Commit:      result.Commit,
+			Version:     result.Version,
+			Tags:        result.AppliedTags,
+			Warnings:    result.Warnings,
+			Infos:       result.Infos,
+		})
+	}
+	return results, nil
+}

--- a/ci/internal/release/images_publish_test.go
+++ b/ci/internal/release/images_publish_test.go
@@ -1,0 +1,121 @@
+package release
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestPublishImages(t *testing.T) {
+	stagingSrv := httptest.NewServer(registry.New())
+	defer stagingSrv.Close()
+	prodSrv := httptest.NewServer(registry.New())
+	defer prodSrv.Close()
+
+	stagingHost := strings.TrimPrefix(stagingSrv.URL, "http://")
+	prodHost := strings.TrimPrefix(prodSrv.URL, "http://")
+
+	opStaging := stagingHost + "/staging/mongodb-kubernetes"
+	opProd := prodHost + "/mongodb/mongodb-kubernetes"
+	rpStaging := stagingHost + "/staging/mongodb-kubernetes-readinessprobe"
+	rpProd := prodHost + "/mongodb/mongodb-kubernetes-readinessprobe"
+
+	opDigest := pushImage(t, fmt.Sprintf("%s:%s", opStaging, PromotedTagFor("abc1234", "1.9.2")), name.Insecure)
+	rpDigest := pushImage(t, fmt.Sprintf("%s:%s", rpStaging, PromotedTagFor("abc1234", "1.0.24")), name.Insecure)
+
+	images := []ReleaseImage{
+		{Name: "operator", StagingRepo: opStaging, ReleaseRepo: opProd, Version: "1.9.2", IsAnchor: true},
+		{Name: "readiness-probe", StagingRepo: rpStaging, ReleaseRepo: rpProd, Version: "1.0.24"},
+	}
+
+	results, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results: got %d, want 2", len(results))
+	}
+
+	assertTagDigest(t, opProd, "1.9.2", opDigest)
+	assertTagDigest(t, opProd, "latest", opDigest)
+	assertTagDigest(t, rpProd, "1.0.24", rpDigest)
+	assertTagDigest(t, rpProd, "latest", rpDigest)
+}
+
+func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
+	stagingSrv := httptest.NewServer(registry.New())
+	defer stagingSrv.Close()
+	prodSrv := httptest.NewServer(registry.New())
+	defer prodSrv.Close()
+
+	stagingHost := strings.TrimPrefix(stagingSrv.URL, "http://")
+	prodHost := strings.TrimPrefix(prodSrv.URL, "http://")
+
+	opStaging := stagingHost + "/staging/mongodb-kubernetes"
+	pushImage(t, fmt.Sprintf("%s:%s", opStaging, PromotedTagFor("abc1234", "1.9.2")), name.Insecure)
+
+	images := []ReleaseImage{
+		{Name: "operator", StagingRepo: opStaging, ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes", Version: "1.9.2", IsAnchor: true},
+		{Name: "readiness-probe", StagingRepo: stagingHost + "/staging/mongodb-kubernetes-readinessprobe", ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
+	}
+
+	_, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)
+	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
+		t.Fatalf("expected hard failure mentioning readiness-probe, got %v", err)
+	}
+}
+
+func TestPublishImagesCommitRequired(t *testing.T) {
+	images := []ReleaseImage{{Name: "operator", StagingRepo: "h/staging/op", ReleaseRepo: "h/op"}}
+	_, err := PublishImages(images, "", "", false, false, insecureConnect)
+	if err == nil || !strings.Contains(err.Error(), "commit") {
+		t.Fatalf("expected commit error, got %v", err)
+	}
+}
+
+func TestPublishImagesRefusesAllOnAnyConflict(t *testing.T) {
+	stagingSrv := httptest.NewServer(registry.New())
+	defer stagingSrv.Close()
+	prodSrv := httptest.NewServer(registry.New())
+	defer prodSrv.Close()
+
+	stagingHost := strings.TrimPrefix(stagingSrv.URL, "http://")
+	prodHost := strings.TrimPrefix(prodSrv.URL, "http://")
+
+	opStaging := stagingHost + "/staging/mongodb-kubernetes"
+	opProd := prodHost + "/mongodb/mongodb-kubernetes"
+	rpStaging := stagingHost + "/staging/mongodb-kubernetes-readinessprobe"
+	rpProd := prodHost + "/mongodb/mongodb-kubernetes-readinessprobe"
+
+	pushImage(t, fmt.Sprintf("%s:%s", opStaging, PromotedTagFor("abc1234", "1.9.2")), name.Insecure)
+	pushImage(t, fmt.Sprintf("%s:%s", rpStaging, PromotedTagFor("abc1234", "1.0.24")), name.Insecure)
+
+	pushImage(t, rpProd+":1.0.24", name.Insecure)
+
+	images := []ReleaseImage{
+		{Name: "operator", StagingRepo: opStaging, ReleaseRepo: opProd, Version: "1.9.2", IsAnchor: true},
+		{Name: "readiness-probe", StagingRepo: rpStaging, ReleaseRepo: rpProd, Version: "1.0.24"},
+	}
+
+	_, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)
+	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
+		t.Fatalf("expected conflict error mentioning readiness-probe, got %v", err)
+	}
+
+	if _, err := remote.Get(mustTagRef(t, opProd, "1.9.2")); err == nil {
+		t.Error("operator production tag should not exist: images must be refused before any writes")
+	}
+
+	results, err := PublishImages(images, "abc1234", "latest", true, false, insecureConnect)
+	if err != nil {
+		t.Fatalf("force: unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("force: results: got %d, want 2", len(results))
+	}
+}

--- a/ci/internal/release/promote.go
+++ b/ci/internal/release/promote.go
@@ -12,8 +12,14 @@ func PromotedTagFor(commit, version string) string {
 	return PromotedTagPrefix + commit + "-" + version
 }
 
+// promotedTagFor builds the mutable promoted-{marker} pointer tag, e.g.
+// "promoted-latest" or "promoted-latestv1" for a backport marker.
+func promotedTagFor(marker string) string {
+	return PromotedTagPrefix + marker
+}
+
 func promotedLatestTag() string {
-	return PromotedTagPrefix + "latest"
+	return promotedTagFor("latest")
 }
 
 // PromoteInputs are the parameters for a promote operation.
@@ -22,34 +28,86 @@ type PromoteInputs struct {
 	Commit  string // commit SHA for the promoted tag name (required)
 	Version string // version for the promoted tag name (required)
 	Repo    string // target repository under the registry host (required)
-	DryRun  bool
+	// LatestMarker customizes the mutable promoted-{marker} pointer tag that
+	// is moved alongside the immutable promoted-{commit}-{version} tag
+	// (required; the CLI defaults it to "latest" via the --latest-marker
+	// flag). Backport releases (e.g. patching an older branch after a newer
+	// version has already been released) should pass a distinct marker
+	// (e.g. "latestv1") so they don't steal the "latest" pointer away from
+	// the newest release.
+	LatestMarker string
+	// Force allows overwriting the immutable promoted-{commit}-{version} tag
+	// even if it already points at a different digest. Without it, such a
+	// conflict is a hard error (image stomping protection).
+	Force  bool
+	DryRun bool
+}
+
+// PromoteResult holds the tags applied (or that would be applied), any
+// non-fatal warnings surfaced along the way, and informational notices.
+type PromoteResult struct {
+	Tags     []string
+	Warnings []string
+	Infos    []string
 }
 
 // Promote copies the source image to promoted-{commit}-{version} and
 // promoted-latest in the target repo, using reg to talk to the registry.
-func Promote(inputs PromoteInputs, reg Registry) ([]string, error) {
+// host is the destination registry host (e.g. "quay.io"); inputs.Repo is a
+// path relative to it, matching Registry.CopyWithTags' own convention. It is
+// needed to build a fully-qualified destination ref for the stomp check,
+// since Registry.Digest (like ListTags) never prefixes a host itself.
+func Promote(inputs PromoteInputs, host string, reg Registry) (PromoteResult, error) {
 	if inputs.Image == "" {
-		return nil, errors.New("image is required")
+		return PromoteResult{}, errors.New("image is required")
 	}
 	if inputs.Commit == "" {
-		return nil, errors.New("commit is required")
+		return PromoteResult{}, errors.New("commit is required")
 	}
 	if inputs.Version == "" {
-		return nil, errors.New("version is required")
+		return PromoteResult{}, errors.New("version is required")
 	}
 	if inputs.Repo == "" {
-		return nil, errors.New("repo is required")
+		return PromoteResult{}, errors.New("repo is required")
+	}
+	if inputs.LatestMarker == "" {
+		return PromoteResult{}, errors.New("latest-marker is required")
 	}
 
-	tags := []string{
-		PromotedTagFor(inputs.Commit, inputs.Version),
-		promotedLatestTag(),
+	versionTag := PromotedTagFor(inputs.Commit, inputs.Version)
+	latestTag := promotedTagFor(inputs.LatestMarker)
+	dstVersionRef := fmt.Sprintf("%s/%s:%s", host, inputs.Repo, versionTag)
+
+	// Only the immutable per-version tag is stomp-checked; promoted-latest is
+	// a mutable pointer that is meant to move on every promotion.
+	conflict, upToDate, err := checkStomp(reg, inputs.Image, dstVersionRef)
+	if err != nil {
+		return PromoteResult{}, err
 	}
+	if conflict != "" && !inputs.Force {
+		return PromoteResult{}, fmt.Errorf("refusing to promote: %s (use --force is the tag needs overwriting)", conflict)
+	}
+
+	var warnings, infos []string
+	if upToDate {
+		infos = append(infos, fmt.Sprintf("%s is already in place", dstVersionRef))
+	} else if conflict != "" {
+		warnings = append(warnings, fmt.Sprintf("overwriting due to --force: %s", conflict))
+	}
+
+	result := PromoteResult{Tags: []string{versionTag, latestTag}, Warnings: warnings, Infos: infos}
 	if inputs.DryRun {
-		return tags, nil
+		return result, nil
 	}
-	if err := reg.CopyWithTags(inputs.Image, inputs.Repo, tags); err != nil {
-		return nil, fmt.Errorf("promote %s: %w", inputs.Image, err)
+
+	// Immutable tag first: only once that succeeds do we move the mutable
+	// latest pointer, so a failure never leaves latest ahead of the
+	// version-tagged image it's supposed to point at.
+	if err := reg.CopyWithTags(inputs.Image, inputs.Repo, []string{versionTag}); err != nil {
+		return PromoteResult{}, fmt.Errorf("promote %s: %w", inputs.Image, err)
 	}
-	return tags, nil
+	if err := reg.CopyWithTags(inputs.Image, inputs.Repo, []string{latestTag}); err != nil {
+		return PromoteResult{}, fmt.Errorf("promote %s (latest): %w", inputs.Image, err)
+	}
+	return result, nil
 }

--- a/ci/internal/release/promote_test.go
+++ b/ci/internal/release/promote_test.go
@@ -3,12 +3,12 @@ package release
 import (
 	"fmt"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
-	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -29,7 +29,7 @@ func TestPromote(t *testing.T) {
 	}{
 		{
 			name:   "happy path",
-			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo},
+			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest"},
 		},
 		{
 			name:    "image required",
@@ -55,7 +55,7 @@ func TestPromote(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, err := Promote(tt.inputs, DefaultRegistryConnector(srv.URL))
+			result, err := Promote(tt.inputs, host, DefaultRegistryConnector(srv.URL))
 
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
@@ -67,7 +67,7 @@ func TestPromote(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			for _, tag := range tags {
+			for _, tag := range result.Tags {
 				ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, tag), name.Insecure)
 				if err != nil {
 					t.Errorf("parse tag %s: %v", tag, err)
@@ -86,23 +86,184 @@ func TestPromote(t *testing.T) {
 	}
 }
 
-// pushImage pushes a random image to the given reference and returns its digest string.
-func pushImage(t *testing.T, ref string, opts ...name.Option) string {
-	t.Helper()
-	img, err := random.Image(1024, 1)
+func TestPromoteDryRun(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const repo = "myorg/myimage"
+
+	srcRef := fmt.Sprintf("%s/%s:nightly-abc1234", host, repo)
+	pushImage(t, srcRef, name.Insecure)
+
+	result, err := Promote(PromoteInputs{
+		Image:        srcRef,
+		Commit:       "abc1234",
+		Version:      "9.9.9",
+		Repo:         repo,
+		LatestMarker: "latest",
+		DryRun:       true,
+	}, host, DefaultRegistryConnector(srv.URL))
 	if err != nil {
-		t.Fatalf("random image: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	d, err := img.Digest()
+
+	want := []string{PromotedTagFor("abc1234", "9.9.9"), promotedLatestTag()}
+	if !slices.Equal(result.Tags, want) {
+		t.Errorf("tags: got %v, want %v", result.Tags, want)
+	}
+
+	// Dry-run must not write anything to the registry.
+	for _, tag := range result.Tags {
+		ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, tag), name.Insecure)
+		if err != nil {
+			t.Fatalf("parse tag %s: %v", tag, err)
+		}
+		if _, err := remote.Get(ref); err == nil {
+			t.Errorf("tag %s should not exist after dry-run", tag)
+		}
+	}
+}
+
+func TestPromoteCustomLatestMarker(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const repo = "myorg/backport"
+
+	srcRef := fmt.Sprintf("%s/%s:nightly-abc1234", host, repo)
+	srcDigest := pushImage(t, srcRef, name.Insecure)
+
+	result, err := Promote(PromoteInputs{
+		Image:        srcRef,
+		Commit:       "abc1234",
+		Version:      "1.10.1",
+		Repo:         repo,
+		LatestMarker: "latestv1",
+	}, host, DefaultRegistryConnector(srv.URL))
 	if err != nil {
-		t.Fatalf("image digest: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	r, err := name.ParseReference(ref, opts...)
+
+	want := []string{PromotedTagFor("abc1234", "1.10.1"), promotedTagFor("latestv1")}
+	if !slices.Equal(result.Tags, want) {
+		t.Errorf("tags: got %v, want %v", result.Tags, want)
+	}
+
+	// The custom marker tag must exist and point at the promoted image...
+	markerRef, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, promotedTagFor("latestv1")), name.Insecure)
 	if err != nil {
-		t.Fatalf("parse ref %s: %v", ref, err)
+		t.Fatalf("parse tag: %v", err)
 	}
-	if err := remote.Write(r, img); err != nil {
-		t.Fatalf("push %s: %v", ref, err)
+	desc, err := remote.Get(markerRef)
+	if err != nil {
+		t.Fatalf("tag %s not found after promote: %v", promotedTagFor("latestv1"), err)
 	}
-	return d.String()
+	if desc.Digest.String() != srcDigest {
+		t.Errorf("marker tag digest got %q, want %q", desc.Digest, srcDigest)
+	}
+
+	// ...while the default promoted-latest tag must remain untouched.
+	defaultLatestRef, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, promotedLatestTag()), name.Insecure)
+	if err != nil {
+		t.Fatalf("parse tag: %v", err)
+	}
+	if _, err := remote.Get(defaultLatestRef); err == nil {
+		t.Errorf("promoted-latest should not be moved when a custom --latest-marker is used")
+	}
+}
+
+func TestPromoteRefusesStompedTag(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const repo = "myorg/stomp"
+
+	newSrc := fmt.Sprintf("%s/%s:nightly-new", host, repo)
+	pushImage(t, newSrc, name.Insecure)
+
+	// A different image already sits at the exact promoted tag we're about to write.
+	pushImage(t, fmt.Sprintf("%s/%s:%s", host, repo, PromotedTagFor("abc1234", "1.9.0")), name.Insecure)
+
+	reg := DefaultRegistryConnector(srv.URL)
+
+	t.Run("refused without force", func(t *testing.T) {
+		_, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest"}, host, reg)
+		if err == nil || !strings.Contains(err.Error(), "already exists at a different digest") {
+			t.Fatalf("expected stomp error, got %v", err)
+		}
+	})
+
+	t.Run("proceeds with force", func(t *testing.T) {
+		result, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", Force: true}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ref, _ := name.NewTag(fmt.Sprintf("%s/%s:%s", host, repo, PromotedTagFor("abc1234", "1.9.0")), name.Insecure)
+		desc, err := remote.Get(ref)
+		if err != nil {
+			t.Fatalf("get promoted tag: %v", err)
+		}
+		newDigest, err := name.NewTag(newSrc, name.Insecure)
+		if err != nil {
+			t.Fatalf("parse src: %v", err)
+		}
+		srcDesc, err := remote.Get(newDigest)
+		if err != nil {
+			t.Fatalf("get src: %v", err)
+		}
+		if desc.Digest.String() != srcDesc.Digest.String() {
+			t.Errorf("promoted tag digest got %q, want %q (forced overwrite)", desc.Digest, srcDesc.Digest)
+		}
+		if len(result.Warnings) == 0 {
+			t.Error("expected a warning when force-overwriting a conflicting tag")
+		}
+	})
+}
+
+func TestPromoteRequiresLatestMarker(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const repo = "myorg/myimage"
+	srcRef := fmt.Sprintf("%s/%s:nightly-abc1234", host, repo)
+	pushImage(t, srcRef, name.Insecure)
+
+	_, err := Promote(PromoteInputs{
+		Image:   srcRef,
+		Commit:  "abc1234",
+		Version: "1.9.0",
+		Repo:    repo,
+	}, host, DefaultRegistryConnector(srv.URL))
+	if err == nil || !strings.Contains(err.Error(), "latest-marker is required") {
+		t.Fatalf("expected 'latest-marker is required' error, got %v", err)
+	}
+}
+
+func TestPromoteInfosOnIdempotentRerun(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const repo = "myorg/idempotent"
+
+	srcRef := fmt.Sprintf("%s/%s:nightly-abc1234", host, repo)
+	pushImage(t, srcRef, name.Insecure)
+
+	reg := DefaultRegistryConnector(srv.URL)
+	inputs := PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest"}
+
+	if _, err := Promote(inputs, host, reg); err != nil {
+		t.Fatalf("first promote: unexpected error: %v", err)
+	}
+
+	// Re-running promote for the exact same source/commit/version is a safe
+	// no-op (same digest): it must not fail, but should surface an info notice.
+	result, err := Promote(inputs, host, reg)
+	if err != nil {
+		t.Fatalf("second promote: unexpected error: %v", err)
+	}
+	if len(result.Infos) == 0 {
+		t.Error("expected an info notice for a same-digest re-promote")
+	}
 }

--- a/ci/internal/release/publish.go
+++ b/ci/internal/release/publish.go
@@ -1,0 +1,158 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// PublishInputs are the parameters for a publish operation.
+type PublishInputs struct {
+	// StagingImage is the base repo path for the staging registry,
+	// e.g. "quay.io/mongodb/staging/mongodb-kubernetes". Must not include a tag.
+	StagingImage string
+	// ProdRepo is the target repository in the production registry,
+	// e.g. "mongodb/mongodb-kubernetes-operator".
+	ProdRepo string
+	// Commit is the SHA of the promoted commit to publish.
+	// If empty, it is resolved from the promoted-{marker} tag (see LatestMarker).
+	Commit string
+	// LatestMarker customizes the mutable :{marker} production tag (and,
+	// correspondingly, which promoted-{marker} staging tag is used to
+	// resolve Commit when it is empty). Required; the CLI defaults it to
+	// "latest" via the --latest-marker flag. Backport releases (e.g.
+	// publishing a patch on an older branch after a newer version has
+	// already been published) should pass a distinct marker (e.g.
+	// "latestv1") so they don't move ":latest" away from the newest release.
+	LatestMarker string
+	// Force allows overwriting the immutable :{version} production tag even if
+	// it already points at a different digest. Without it, such a conflict is
+	// a hard error (image stomping protection).
+	Force bool
+	// DryRun prints what would happen without copying any images.
+	DryRun bool
+}
+
+// PublishResult holds the resolved inputs and the tags that were (or would be) applied.
+type PublishResult struct {
+	Commit      string
+	Version     string
+	AppliedTags []string
+	Warnings    []string
+	Infos       []string
+}
+
+// Publish retags a promoted staging candidate as :{version} and :{marker}
+// (marker defaults to "latest", see PublishInputs.LatestMarker) in the
+// production registry. host is the destination (production) registry
+// host (e.g. "quay.io"); inputs.ProdRepo is a path relative to it, matching
+// Registry.CopyWithTags' own convention. StagingImage, by contrast, is always
+// fully-qualified (may live on a different host, e.g. ECR staging vs quay.io
+// production).
+func Publish(inputs PublishInputs, host string, reg Registry) (PublishResult, error) {
+	if inputs.StagingImage == "" {
+		return PublishResult{}, errors.New("staging-image is required")
+	}
+	if inputs.ProdRepo == "" {
+		return PublishResult{}, errors.New("prod-repo is required")
+	}
+	if inputs.LatestMarker == "" {
+		return PublishResult{}, errors.New("latest-marker is required")
+	}
+
+	marker := inputs.LatestMarker
+	commit, version, err := resolvePromoted(inputs.StagingImage, inputs.Commit, marker, reg)
+	if err != nil {
+		return PublishResult{}, err
+	}
+
+	srcRef := fmt.Sprintf("%s:%s", inputs.StagingImage, PromotedTagFor(commit, version))
+	dstVersionRef := fmt.Sprintf("%s/%s:%s", host, inputs.ProdRepo, version)
+
+	// Only the immutable :{version} tag is stomp-checked; :latest is a mutable
+	// pointer that is meant to move on every publish.
+	conflict, upToDate, err := checkStomp(reg, srcRef, dstVersionRef)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	if conflict != "" && !inputs.Force {
+		return PublishResult{}, fmt.Errorf("refusing to publish: %s (use --force to override)", conflict)
+	}
+
+	var warnings, infos []string
+	if upToDate {
+		infos = append(infos, fmt.Sprintf("%s is already in place", dstVersionRef))
+	} else if conflict != "" {
+		warnings = append(warnings, fmt.Sprintf("overwriting due to --force: %s", conflict))
+	}
+
+	tags := []string{version, marker}
+	result := PublishResult{Commit: commit, Version: version, AppliedTags: tags, Warnings: warnings, Infos: infos}
+
+	if inputs.DryRun {
+		return result, nil
+	}
+
+	// Immutable tag first: only once that succeeds do we move :{marker}, so a
+	// failure never leaves it ahead of the version it's supposed to point at.
+	if err := reg.CopyWithTags(srcRef, inputs.ProdRepo, []string{version}); err != nil {
+		return PublishResult{}, fmt.Errorf("publish %s: %w", srcRef, err)
+	}
+	if err := reg.CopyWithTags(srcRef, inputs.ProdRepo, []string{marker}); err != nil {
+		return PublishResult{}, fmt.Errorf("publish %s (%s): %w", srcRef, marker, err)
+	}
+	return result, nil
+}
+
+func resolvePromoted(stagingImage, commit, marker string, reg Registry) (string, string, error) {
+	tags, err := reg.ListTags(stagingImage)
+	if err != nil {
+		return "", "", fmt.Errorf("list tags for %s: %w", stagingImage, err)
+	}
+
+	if commit == "" {
+		latestRef := fmt.Sprintf("%s:%s", stagingImage, promotedTagFor(marker))
+		latestDigest, err := reg.Digest(latestRef)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve promoted-%s: %w", marker, err)
+		}
+		for _, tag := range tags {
+			if !isPromotedVersionTag(tag, marker) {
+				continue
+			}
+			d, err := reg.Digest(fmt.Sprintf("%s:%s", stagingImage, tag))
+			if err != nil {
+				continue
+			}
+			if d == latestDigest {
+				return parsePromotedTag(tag)
+			}
+		}
+		return "", "", fmt.Errorf("no promoted-{commit}-{version} tag matches promoted-%s in %s", marker, stagingImage)
+	}
+
+	prefix := PromotedTagPrefix + commit + "-"
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, prefix) && isPromotedVersionTag(tag, marker) {
+			return parsePromotedTag(tag)
+		}
+	}
+	return "", "", fmt.Errorf("no promoted tag found for commit %s in %s", commit, stagingImage)
+}
+
+func isPromotedVersionTag(tag, marker string) bool {
+	return strings.HasPrefix(tag, PromotedTagPrefix) && tag != promotedTagFor(marker)
+}
+
+func parsePromotedTag(tag string) (string, string, error) {
+	rest := strings.TrimPrefix(tag, PromotedTagPrefix)
+	// A commit SHA is hex, so the first dash after the prefix separates the
+	// commit from the version. Splitting here (rather than at a fixed 40-char
+	// offset) accepts commits of any length and versions that contain dashes
+	// (e.g. "1.0.0-rc1").
+	commit, version, found := strings.Cut(rest, "-")
+	if !found || commit == "" || version == "" {
+		return "", "", fmt.Errorf("malformed promoted tag: %q", tag)
+	}
+	return commit, version, nil
+}

--- a/ci/internal/release/publish_test.go
+++ b/ci/internal/release/publish_test.go
@@ -1,0 +1,373 @@
+package release
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestPublish(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const (
+		stagingRepo = "myorg/staging/myimage"
+		prodRepo    = "myorg/myimage"
+		commit      = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+		version     = "1.10.0"
+	)
+
+	stagingBase := fmt.Sprintf("%s/%s", host, stagingRepo)
+	promotedTag := PromotedTagFor(commit, version)
+
+	srcRef := fmt.Sprintf("%s:%s", stagingBase, promotedTag)
+	srcDigest := pushImage(t, srcRef, name.Insecure)
+	tagAs(t, srcRef, fmt.Sprintf("%s:%s", stagingBase, promotedLatestTag()), name.Insecure)
+
+	reg := DefaultRegistryConnector(srv.URL)
+
+	t.Run("publish with explicit commit", func(t *testing.T) {
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Commit != commit {
+			t.Errorf("commit: got %q, want %q", result.Commit, commit)
+		}
+		if result.Version != version {
+			t.Errorf("version: got %q, want %q", result.Version, version)
+		}
+		for _, tag := range result.AppliedTags {
+			ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, prodRepo, tag), name.Insecure)
+			if err != nil {
+				t.Fatalf("parse prod tag %s: %v", tag, err)
+			}
+			desc, err := remote.Get(ref)
+			if err != nil {
+				t.Errorf("prod tag %s not found: %v", tag, err)
+				continue
+			}
+			if desc.Digest.String() != srcDigest {
+				t.Errorf("prod tag %s: digest got %q, want %q", tag, desc.Digest, srcDigest)
+			}
+		}
+	})
+
+	t.Run("publish with custom latest marker resolves and moves its own pointer", func(t *testing.T) {
+		const (
+			backportCommit  = "b1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+			backportVersion = "1.10.1"
+			marker          = "latestv1"
+		)
+		backportSrcRef := fmt.Sprintf("%s:%s", stagingBase, PromotedTagFor(backportCommit, backportVersion))
+		backportDigest := pushImage(t, backportSrcRef, name.Insecure)
+		tagAs(t, backportSrcRef, fmt.Sprintf("%s:%s", stagingBase, promotedTagFor(marker)), name.Insecure)
+
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, ProdRepo: prodRepo, LatestMarker: marker}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Commit != backportCommit {
+			t.Errorf("commit: got %q, want %q", result.Commit, backportCommit)
+		}
+		if result.Version != backportVersion {
+			t.Errorf("version: got %q, want %q", result.Version, backportVersion)
+		}
+
+		// The custom marker tag must point at the backport image.
+		markerRef, err := name.NewTag(fmt.Sprintf("%s/%s:%s", host, prodRepo, marker), name.Insecure)
+		if err != nil {
+			t.Fatalf("parse marker tag: %v", err)
+		}
+		desc, err := remote.Get(markerRef)
+		if err != nil {
+			t.Fatalf("marker tag %s not found: %v", marker, err)
+		}
+		if desc.Digest.String() != backportDigest {
+			t.Errorf("marker tag digest got %q, want %q", desc.Digest, backportDigest)
+		}
+
+		// The default :latest tag from the earlier subtest must be untouched
+		// (still pointing at the newer, non-backport release).
+		latestRef, err := name.NewTag(fmt.Sprintf("%s/%s:latest", host, prodRepo), name.Insecure)
+		if err != nil {
+			t.Fatalf("parse latest tag: %v", err)
+		}
+		latestDesc, err := remote.Get(latestRef)
+		if err != nil {
+			t.Fatalf("latest tag not found: %v", err)
+		}
+		if latestDesc.Digest.String() != srcDigest {
+			t.Errorf(":latest digest got %q, want %q (should be untouched by backport publish)", latestDesc.Digest, srcDigest)
+		}
+	})
+
+	t.Run("publish resolves latest when commit omitted", func(t *testing.T) {
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Commit != commit {
+			t.Errorf("commit: got %q, want %q", result.Commit, commit)
+		}
+		if result.Version != version {
+			t.Errorf("version: got %q, want %q", result.Version, version)
+		}
+	})
+
+	t.Run("dry-run returns result without copying", func(t *testing.T) {
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", DryRun: true}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Version != version {
+			t.Errorf("version: got %q, want %q", result.Version, version)
+		}
+	})
+
+	t.Run("staging-image required", func(t *testing.T) {
+		_, err := Publish(PublishInputs{Commit: commit, ProdRepo: prodRepo}, host, reg)
+		if err == nil || !strings.Contains(err.Error(), "staging-image") {
+			t.Errorf("expected error containing %q, got %v", "staging-image", err)
+		}
+	})
+
+	t.Run("prod-repo required", func(t *testing.T) {
+		_, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit}, host, reg)
+		if err == nil || !strings.Contains(err.Error(), "prod-repo") {
+			t.Errorf("expected error containing %q, got %v", "prod-repo", err)
+		}
+	})
+
+	t.Run("unknown commit returns error", func(t *testing.T) {
+		_, err := Publish(PublishInputs{
+			StagingImage: stagingBase,
+			Commit:       "0000000000000000000000000000000000000000",
+			ProdRepo:     prodRepo,
+			LatestMarker: "latest",
+		}, host, reg)
+		if err == nil {
+			t.Error("expected error for unknown commit, got nil")
+		}
+	})
+
+	t.Run("resolves the candidate matching promoted-latest among several", func(t *testing.T) {
+		// A dedicated staging repo with two distinct promoted candidates
+		// (different digests). promoted-latest points at the second one; publish
+		// with no --commit must resolve that commit/version, not the other.
+		multiBase := fmt.Sprintf("%s/%s", host, "myorg/staging/multi")
+		const (
+			oldCommit  = "1111111111111111111111111111111111111111"
+			oldVersion = "1.0.0"
+			newCommit  = "2222222222222222222222222222222222222222"
+			newVersion = "2.0.0"
+		)
+		pushImage(t, fmt.Sprintf("%s:%s", multiBase, PromotedTagFor(oldCommit, oldVersion)), name.Insecure)
+		newRef := fmt.Sprintf("%s:%s", multiBase, PromotedTagFor(newCommit, newVersion))
+		pushImage(t, newRef, name.Insecure)
+		tagAs(t, newRef, fmt.Sprintf("%s:%s", multiBase, promotedLatestTag()), name.Insecure)
+
+		result, err := Publish(PublishInputs{StagingImage: multiBase, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Commit != newCommit {
+			t.Errorf("commit: got %q, want %q", result.Commit, newCommit)
+		}
+		if result.Version != newVersion {
+			t.Errorf("version: got %q, want %q", result.Version, newVersion)
+		}
+	})
+
+	t.Run("promoted-latest matching no version tag returns error", func(t *testing.T) {
+		// promoted-latest exists but points at a digest no promoted-{c}-{v}
+		// version tag shares, so resolution must fail.
+		orphanBase := fmt.Sprintf("%s/%s", host, "myorg/staging/orphan")
+		pushImage(t, fmt.Sprintf("%s:%s", orphanBase, promotedLatestTag()), name.Insecure)
+
+		_, err := Publish(PublishInputs{StagingImage: orphanBase, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		if err == nil || !strings.Contains(err.Error(), "matches promoted-latest") {
+			t.Errorf("expected 'matches promoted-latest' error, got %v", err)
+		}
+	})
+}
+
+func TestPublishRefusesStompedVersionTag(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	const (
+		stagingRepo = "myorg/staging/stomp"
+		prodRepo    = "myorg/stomp"
+		commit      = "abc1234"
+		version     = "1.9.0"
+	)
+	stagingBase := fmt.Sprintf("%s/%s", host, stagingRepo)
+	srcRef := fmt.Sprintf("%s:%s", stagingBase, PromotedTagFor(commit, version))
+	pushImage(t, srcRef, name.Insecure)
+
+	// Production already has a DIFFERENT image at the immutable :version tag.
+	prodBase := fmt.Sprintf("%s/%s", host, prodRepo)
+	pushImage(t, fmt.Sprintf("%s:%s", prodBase, version), name.Insecure)
+
+	reg := DefaultRegistryConnector(srv.URL)
+
+	t.Run("refused without force", func(t *testing.T) {
+		_, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		if err == nil || !strings.Contains(err.Error(), "already exists at a different digest") {
+			t.Fatalf("expected stomp error, got %v", err)
+		}
+	})
+
+	t.Run("proceeds with force", func(t *testing.T) {
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", Force: true}, host, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Warnings) == 0 {
+			t.Error("expected a warning when force-overwriting a conflicting tag")
+		}
+		ref, _ := name.NewTag(fmt.Sprintf("%s:%s", prodBase, version), name.Insecure)
+		desc, err := remote.Get(ref)
+		if err != nil {
+			t.Fatalf("get prod tag: %v", err)
+		}
+		srcRefParsed, _ := name.NewTag(srcRef, name.Insecure)
+		srcDesc, err := remote.Get(srcRefParsed)
+		if err != nil {
+			t.Fatalf("get src: %v", err)
+		}
+		if desc.Digest.String() != srcDesc.Digest.String() {
+			t.Errorf("prod tag digest got %q, want %q (forced overwrite)", desc.Digest, srcDesc.Digest)
+		}
+	})
+}
+
+func TestPublishRequiresLatestMarker(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+	const stagingRepo = "myorg/staging/myimage"
+	const prodRepo = "myorg/myimage"
+	stagingBase := fmt.Sprintf("%s/%s", host, stagingRepo)
+
+	_, err := Publish(PublishInputs{
+		StagingImage: stagingBase,
+		ProdRepo:     prodRepo,
+	}, host, DefaultRegistryConnector(srv.URL))
+	if err == nil || !strings.Contains(err.Error(), "latest-marker is required") {
+		t.Fatalf("expected 'latest-marker is required' error, got %v", err)
+	}
+}
+
+func TestParsePromotedTag(t *testing.T) {
+	const commit = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	tests := []struct {
+		tag         string
+		wantCommit  string
+		wantVersion string
+		wantErr     string
+	}{
+		{
+			tag:         "promoted-" + commit + "-1.10.0",
+			wantCommit:  commit,
+			wantVersion: "1.10.0",
+		},
+		{
+			// Short commits are valid — promote does not require a full 40-char SHA.
+			tag:         "promoted-abc1234-1.9.0",
+			wantCommit:  "abc1234",
+			wantVersion: "1.9.0",
+		},
+		{
+			// Versions may themselves contain dashes; only the first dash splits.
+			tag:         "promoted-" + commit + "-1.0.0-rc1",
+			wantCommit:  commit,
+			wantVersion: "1.0.0-rc1",
+		},
+		{
+			// No version separator at all.
+			tag:     "promoted-" + commit,
+			wantErr: "malformed",
+		},
+		{
+			// Empty version.
+			tag:     "promoted-" + commit + "-",
+			wantErr: "malformed",
+		},
+		{
+			// Empty commit.
+			tag:     "promoted--1.10.0",
+			wantErr: "malformed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			c, v, err := parsePromotedTag(tt.tag)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c != tt.wantCommit {
+				t.Errorf("commit: got %q, want %q", c, tt.wantCommit)
+			}
+			if v != tt.wantVersion {
+				t.Errorf("version: got %q, want %q", v, tt.wantVersion)
+			}
+		})
+	}
+}
+
+// pushImage pushes a random image to the given reference and returns its digest string.
+func pushImage(t *testing.T, ref string, opts ...name.Option) string {
+	t.Helper()
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	d, err := img.Digest()
+	if err != nil {
+		t.Fatalf("image digest: %v", err)
+	}
+	r, err := name.ParseReference(ref, opts...)
+	if err != nil {
+		t.Fatalf("parse ref %s: %v", ref, err)
+	}
+	if err := remote.Write(r, img); err != nil {
+		t.Fatalf("push %s: %v", ref, err)
+	}
+	return d.String()
+}
+
+// tagAs creates an additional tag on an existing image.
+func tagAs(t *testing.T, existingRef, newRef string, opts ...name.Option) {
+	t.Helper()
+	src, err := name.ParseReference(existingRef, opts...)
+	if err != nil {
+		t.Fatalf("parse src ref: %v", err)
+	}
+	desc, err := remote.Get(src)
+	if err != nil {
+		t.Fatalf("get %s: %v", existingRef, err)
+	}
+	dst, err := name.NewTag(newRef, opts...)
+	if err != nil {
+		t.Fatalf("parse dst tag: %v", err)
+	}
+	if err := remote.Tag(dst, desc); err != nil {
+		t.Fatalf("tag %s: %v", newRef, err)
+	}
+}

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -1,19 +1,31 @@
 package release
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
+
+// ErrTagNotFound is returned by Registry.Digest when the reference does not
+// exist yet (as opposed to a real registry-access failure).
+var ErrTagNotFound = errors.New("tag not found")
 
 // Registry is the abstracted OCI interface. The default implementation talks to
 // a real registry via go-containerregistry; tests can substitute a fake.
 type Registry interface {
 	// CopyWithTags copies srcRef to dstRepo under each of the given tags.
 	CopyWithTags(srcRef string, dstRepo string, tags []string) error
+	// ListTags returns all tags for the given image repository reference.
+	ListTags(repo string) ([]string, error)
+	// Digest returns the manifest digest for ref (a full "host/repo:tag"
+	// reference), or ErrTagNotFound if it doesn't exist.
+	Digest(ref string) (string, error)
 }
 
 // RegistryConnector builds a Registry for a registry base URL. The CLI passes
@@ -55,6 +67,41 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 		}
 	}
 	return nil
+}
+
+func (t *cRegistry) ListTags(repo string) ([]string, error) {
+	// repo always arrives as a full reference (host/path); it may live on a
+	// different host than the registry's own (e.g. listing an ECR staging repo
+	// via a registry connected for the quay.io production host), so it must be
+	// parsed as-is rather than reassembled under t.host.
+	repoPath := strings.TrimPrefix(repo, "https://")
+	repoPath = strings.TrimPrefix(repoPath, "http://")
+
+	r, err := name.NewRepository(repoPath, t.nameOpts()...)
+	if err != nil {
+		return nil, fmt.Errorf("parse repo %s: %w", repo, err)
+	}
+	tags, err := remote.List(r, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return nil, fmt.Errorf("list tags %s: %w", r, err)
+	}
+	return tags, nil
+}
+
+func (t *cRegistry) Digest(ref string) (string, error) {
+	r, err := name.ParseReference(ref, t.nameOpts()...)
+	if err != nil {
+		return "", fmt.Errorf("parse ref %s: %w", ref, err)
+	}
+	desc, err := remote.Get(r, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			return "", ErrTagNotFound
+		}
+		return "", fmt.Errorf("get %s: %w", ref, err)
+	}
+	return desc.Digest.String(), nil
 }
 
 func (t *cRegistry) nameOpts() []name.Option {

--- a/ci/internal/release/stomp.go
+++ b/ci/internal/release/stomp.go
@@ -1,0 +1,42 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+)
+
+// checkStomp resolves the existing digest (if any) of dstRef and compares it
+// against the digest of srcRef. Both must be fully-qualified references
+// (host/repo:tag) — callers are responsible for prefixing a host-relative
+// repo path with the destination registry's host before calling this, since
+// Registry.Digest (like ListTags) never does that itself. It never mutates
+// the registry.
+//
+// This only applies to an immutable per-version tag (promoted-{commit}-{version}
+// or a production :{version} tag); a mutable "latest" pointer is expected to
+// move on every run and is never checked.
+//
+//   - tag absent: free to write, returns ("", false, nil).
+//   - tag present, same digest as src: safe no-op re-run, returns ("", true, nil)
+//     so the caller can warn without blocking.
+//   - tag present, different digest: a real conflict (image stomping), returns
+//     a human-readable description; the caller must refuse unless forced.
+func checkStomp(reg Registry, srcRef, dstRef string) (conflict string, alreadyUpToDate bool, err error) {
+	srcDigest, err := reg.Digest(srcRef)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve source %s: %w", srcRef, err)
+	}
+
+	existingDigest, err := reg.Digest(dstRef)
+	if err != nil {
+		if errors.Is(err, ErrTagNotFound) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("resolve existing %s: %w", dstRef, err)
+	}
+
+	if existingDigest == srcDigest {
+		return "", true, nil
+	}
+	return fmt.Sprintf("%s already exists at a different digest (existing=%s, new=%s)", dstRef, existingDigest, srcDigest), false, nil
+}


### PR DESCRIPTION
# Summary

Prepare CI tool to publish previously promoted images and unify naming.

New `mckci release publish` and `mckci release publish images` commands for publishing single and all release images at a specific commit (or promoted-latest). Stomp protection added to `mckci release promote images`.

## Stomp protection (both promote images + publish images)

Every image's immutable tag is checked for conflicts BEFORE any writes. If any image conflicts and `--force` is not set, the entire operation is refused — no partial writes.

## Latest Marker

To support backport branches you might want to use different "latest" markers with `--latestMarker` such as `latest`, `latest-v1`, etc.

## Examples

```bash
# Publish all release images from latest promoted image/commit
mckci release publish images 

# Publish all release images at a specific commit
mckci release publish images \
  --commit a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2

# Publish single image (omit --commit for promoted-latest)
mckci release publish \
  --staging-image quay.io/mongodb/staging/mongodb-kubernetes \
  --commit a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2

# Promote all release images with force override
mckci release promote images --commit a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2 --force

# Dry-run all images
mckci release promote images --commit a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2 --dry-run
```

## Proof of Work

CI must pass, changes fully self tested.

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
