### PR TITLE
KUBE-161: Deflake three search/sharded e2e tests and bump Go to 1.26.5

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1467,14 +1467,8 @@ tasks:
     commands:
       - func: "e2e_test"
 
-  # Quarantined: flaky, producing unreliable results in CI and slowing down development.
-  # See KUBE-161. github_pr_aliases selects task: ".*" for every pr_patch variant, so tags
-  # alone can't exclude this from PR runs — patchable:false is the mechanism that actually
-  # keeps it out of PR/manual patches while still letting it run (and gate releasability) on
-  # master merge commits. See EVERGREEN.md#quarantined-tests.
   - name: e2e_search_connectivity_tool_mc_sharded
-    tags: [ "quarantined" ]
-    patchable: false
+    tags: [ "patch-run" ]
     commands:
       - func: "e2e_test"
 

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1467,8 +1467,14 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  # Quarantined: flaky, producing unreliable results in CI and slowing down development.
+  # See KUBE-161. github_pr_aliases selects task: ".*" for every pr_patch variant, so tags
+  # alone can't exclude this from PR runs — patchable:false is the mechanism that actually
+  # keeps it out of PR/manual patches while still letting it run (and gate releasability) on
+  # master merge commits. See EVERGREEN.md#quarantined-tests.
   - name: e2e_search_connectivity_tool_mc_sharded
-    tags: [ "patch-run" ]
+    tags: [ "quarantined" ]
+    patchable: false
     commands:
       - func: "e2e_test"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -228,8 +228,8 @@ repos:
       # staticcheck) see the full codebase and pre-existing violations are not silently skipped.
       - id: golangci-lint-full
         args: [--timeout=10m]
-        language_version: 1.26.4
+        language_version: 1.26.5
         priority: 6
       - id: golangci-lint-fmt
-        language_version: 1.26.4
+        language_version: 1.26.5
         priority: 6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.4
+golang 1.26.5

--- a/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_and_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/sharded_cluster_scram_sha_and_x509.py
@@ -75,7 +75,7 @@ def x509_user(sharded_cluster: MongoDB, namespace: str) -> MongoDBUser:
 @pytest.mark.e2e_sharded_cluster_scram_sha_and_x509
 def test_sharded_cluster_running(sharded_cluster: MongoDB):
     sharded_cluster.update()
-    sharded_cluster.assert_reaches_phase(Phase.Running, timeout=400)
+    sharded_cluster.assert_reaches_phase(Phase.Running, timeout=600)
 
 
 @pytest.mark.e2e_sharded_cluster_scram_sha_and_x509

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -838,14 +838,17 @@ def wait_for_mongot_statefulset_drained(
     timeout: int = 180,
     sleep_time: int = 5,
 ) -> None:
-    """Wait until the mongot StatefulSet has 0 ready replicas or is deleted.
+    """Wait until the mongot StatefulSet has 0 replicas or is deleted.
 
     On ``spec.clusters[].replicas`` -> 0 the operator keeps the StatefulSet but
-    scales it to 0, so ``ready == desired == 0`` is the normal terminal state; a
-    404 is also accepted for callers that remove the STS outright (e.g. CR
-    delete). ``api_client`` must target the cluster that hosts the STS — for
-    multi-cluster the mongot StatefulSets live on the member clusters, not the
-    operator/default cluster.
+    scales it to 0, so ``replicas == ready == desired == 0`` is the normal
+    terminal state. ``status.replicas`` (not just ``readyReplicas``) must reach 0:
+    a Terminating pod is unready but still counted, and only its full deletion
+    means the drain completed (the PVC GC under ``WhenScaled: Delete`` starts
+    after that — see ``wait_for_mongot_pvcs_deleted``). A 404 is also accepted
+    for callers that remove the STS outright (e.g. CR delete). ``api_client``
+    must target the cluster that hosts the STS — for multi-cluster the mongot
+    StatefulSets live on the member clusters, not the operator/default cluster.
     """
     apps_v1 = client.AppsV1Api(api_client=api_client)
 
@@ -856,9 +859,13 @@ def wait_for_mongot_statefulset_drained(
             if exc.status == 404:
                 return True, f"{sts_name} deleted by reconciler"
             raise
+        replicas = sts.status.replicas or 0
         ready = sts.status.ready_replicas or 0
         desired = (sts.spec.replicas if sts.spec else 0) or 0
-        return ready == 0 and desired == 0, f"ready={ready}, desired={desired}"
+        return (
+            replicas == 0 and ready == 0 and desired == 0,
+            f"replicas={replicas}, ready={ready}, desired={desired}",
+        )
 
     run_periodically(
         drained,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
@@ -30,6 +30,7 @@ from tests.common.search.connectivity import (
     FAILURE_TRANSIENT_NETWORK,
     SearchConnectivityTool,
     cluster_tagged_read_preference,
+    wait_for_mongot_pvcs_deleted,
     wait_for_mongot_statefulset_drained,
 )
 from tests.common.search.sharded_search_helper import mc_sharded_search_tester
@@ -190,6 +191,11 @@ class TestSearchConnectivityToolMcSharded:
                     wait_for_mongot_statefulset_drained(
                         sts_name, namespace, api_client=faulted_mcc.api_client, timeout=300
                     )
+                # The operator must converge on the faulted spec too: IsReady() demands
+                # status.replicas == spec.replicas on every mongot STS, so Running here
+                # proves all condemned pods are fully deleted (but says nothing about
+                # the async PVC GC — see the wait_for_mongot_pvcs_deleted in finally).
+                mdbs.assert_reaches_phase(Phase.Running, timeout=300)
 
                 healthy_res = tool.oneshot_search(read_preference=cluster_tagged_read_preference(healthy_name))
                 logger.info(f"[{faulted_name} down] tag->{healthy_name} (healthy): {healthy_res}")
@@ -210,10 +216,21 @@ class TestSearchConnectivityToolMcSharded:
                     f"{faulted_res.failure_class} ({faulted_res.error_class}): {faulted_res.error_message}"
                 )
             finally:
+                # Wait out the async PVC GC before restoring replicas (see
+                # wait_for_mongot_pvcs_deleted docstring for the STS-controller race).
+                for sts_name in faulted_stses:
+                    wait_for_mongot_pvcs_deleted(
+                        namespace,
+                        sts_name,
+                        api_client=faulted_mcc.api_client,
+                        timeout=300,
+                    )
                 mdbs.load()
                 mdbs["spec"]["clusters"] = [dict(c) for c in original_clusters]
                 mdbs.update()
-                mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+                # The fresh per-shard replicas must reindex from mongod before they
+                # report Ready, so allow a generous window.
+                mdbs.assert_reaches_phase(Phase.Running, timeout=1200)
                 # re-index the restored cluster's mongots before the next iteration
                 tool.wait_for_sentinel_indexed(timeout=300)
                 logger.info(f"restored cluster {faulted_index} ({faulted_name}) mongots; MDBS Running")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
@@ -213,7 +213,7 @@ class TestSearchConnectivityToolMcSharded:
                 mdbs.load()
                 mdbs["spec"]["clusters"] = [dict(c) for c in original_clusters]
                 mdbs.update()
-                mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+                mdbs.assert_reaches_phase(Phase.Running, timeout=1800)
                 # re-index the restored cluster's mongots before the next iteration
                 tool.wait_for_sentinel_indexed(timeout=300)
                 logger.info(f"restored cluster {faulted_index} ({faulted_name}) mongots; MDBS Running")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
@@ -213,7 +213,7 @@ class TestSearchConnectivityToolMcSharded:
                 mdbs.load()
                 mdbs["spec"]["clusters"] = [dict(c) for c in original_clusters]
                 mdbs.update()
-                mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+                mdbs.assert_reaches_phase(Phase.Running, timeout=900)
                 # re-index the restored cluster's mongots before the next iteration
                 tool.wait_for_sentinel_indexed(timeout=300)
                 logger.info(f"restored cluster {faulted_index} ({faulted_name}) mongots; MDBS Running")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/search_connectivity_tool_mc_sharded.py
@@ -213,7 +213,7 @@ class TestSearchConnectivityToolMcSharded:
                 mdbs.load()
                 mdbs["spec"]["clusters"] = [dict(c) for c in original_clusters]
                 mdbs.update()
-                mdbs.assert_reaches_phase(Phase.Running, timeout=1800)
+                mdbs.assert_reaches_phase(Phase.Running, timeout=600)
                 # re-index the restored cluster's mongots before the next iteration
                 tool.wait_for_sentinel_indexed(timeout=300)
                 logger.info(f"restored cluster {faulted_index} ({faulted_name}) mongots; MDBS Running")

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
@@ -93,7 +93,7 @@ def test_create_ops_manager(namespace: str):
 @mark.e2e_search_enterprise_basic
 def test_create_database_resource(mdb: MongoDB):
     mdb.update()
-    mdb.assert_reaches_phase(Phase.Running, timeout=300)
+    mdb.assert_reaches_phase(Phase.Running, timeout=600)
 
 
 @mark.e2e_search_enterprise_basic

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
@@ -118,10 +118,9 @@ def test_create_search_resource(mdbs: MongoDBSearch):
 
 @mark.e2e_search_enterprise_basic
 def test_wait_for_database_resource_ready(mdb: MongoDB):
-    # The search wiring lands on the mongods asynchronously; the resulting
-    # Running->reconciling->Running transition can complete faster than phase polling or
-    # without a visible phase change, so wait for the mongot parameters to appear on every
-    # member rather than trying to catch the transition.
+    # The mongot wiring is applied as an in-memory automation-config override and does not bump
+    # the MongoDB generation, so there is no phase/generation transition to wait on; poll the
+    # mongods for the search parameters directly.
     def mongot_params_wired(m: MongoDB) -> bool:
         if m.get_status_phase() != Phase.Running:
             return False

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_basic.py
@@ -93,7 +93,7 @@ def test_create_ops_manager(namespace: str):
 @mark.e2e_search_enterprise_basic
 def test_create_database_resource(mdb: MongoDB):
     mdb.update()
-    mdb.assert_reaches_phase(Phase.Running, timeout=600)
+    mdb.assert_reaches_phase(Phase.Running, timeout=300)
 
 
 @mark.e2e_search_enterprise_basic
@@ -118,19 +118,25 @@ def test_create_search_resource(mdbs: MongoDBSearch):
 
 @mark.e2e_search_enterprise_basic
 def test_wait_for_database_resource_ready(mdb: MongoDB):
-    mdb.assert_abandons_phase(Phase.Running, timeout=300)
-    mdb.assert_reaches_phase(Phase.Running, timeout=300)
-
-    for idx in range(mdb.get_members()):
-        mongod_config = yaml.safe_load(
-            KubernetesTester.run_command_in_pod_container(
-                f"{mdb.name}-{idx}", mdb.namespace, ["cat", "/data/automation-mongod.conf"]
+    # The search wiring lands on the mongods asynchronously; the resulting
+    # Running->reconciling->Running transition can complete faster than phase polling or
+    # without a visible phase change, so wait for the mongot parameters to appear on every
+    # member rather than trying to catch the transition.
+    def mongot_params_wired(m: MongoDB) -> bool:
+        if m.get_status_phase() != Phase.Running:
+            return False
+        for idx in range(m.get_members()):
+            mongod_config = yaml.safe_load(
+                KubernetesTester.run_command_in_pod_container(
+                    f"{m.name}-{idx}", m.namespace, ["cat", "/data/automation-mongod.conf"]
+                )
             )
-        )
-        setParameter = mongod_config.get("setParameter", {})
-        assert (
-            "mongotHost" in setParameter and "searchIndexManagementHostAndPort" in setParameter
-        ), "mongot parameters not found in mongod config"
+            set_parameter = mongod_config.get("setParameter", {})
+            if "mongotHost" not in set_parameter or "searchIndexManagementHostAndPort" not in set_parameter:
+                return False
+        return True
+
+    mdb.wait_for(mongot_params_wired, timeout=600, should_raise=True)
 
 
 @fixture(scope="function")

--- a/go.mod
+++ b/go.mod
@@ -161,6 +161,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
 
-go 1.26.4
+go 1.26.5
 
 tool gotest.tools/gotestsum


### PR DESCRIPTION
Deflake three intermittently-failing e2e tests and bump the Go toolchain for a stdlib security fix.

| Test | Change |
|------|--------|
| `e2e_sharded_cluster_scram_sha_and_x509` / `test_sharded_cluster_running` | `assert_reaches_phase(Running)` 400s → 600s. Genuine slow convergence — CI failures land just past the old budget (e.g. 432s) and pass on retry. |
| `e2e_search_enterprise_basic` / `test_wait_for_database_resource_ready` | Replace the racy `assert_abandons_phase(Running)` with a wait for the search wiring to actually land (`mongotHost` / `searchIndexManagementHostAndPort` present on every mongod, resource `Running`). The mongot wiring is applied as an in-memory automation-config override and does not bump the MongoDB generation, so there is no phase transition to observe. |
| `e2e_search_connectivity_tool_mc_sharded` / `test_cluster_tagged_search_routes_in_cluster` | Wait for the per-shard mongot PVCs to be fully deleted before restoring replicas, and require `status.replicas == 0` (not just `readyReplicas`) in the drain check. Un-quarantined (KUBE-161). |

### mc_sharded flake

The mongot StatefulSets use `persistentVolumeClaimRetentionPolicy: {whenScaled: Delete}`. The test faults a cluster by scaling its per-shard mongots to 0, then restores them. When the restore (scale 0→N) lands while the condemned pod/PVC from the scale-to-0 is still terminating, the StatefulSet controller wedges: the old pod finishes terminating, its PVC is GC'd, and no replacement pod is ever created (`spec.replicas=1, status.replicas=0`, no events) — so `MongoDBSearch` stays `Pending` indefinitely and no timeout recovers it. This is the same race `search_connectivity_tool_mc_rs.py` already guards against with `wait_for_mongot_pvcs_deleted`; this test was simply missing the guard. Operator-side hardening (serialize mongot scale-up until the old pod and PVC are gone) is tracked separately.

### Go 1.26.5

`govulncheck` flags GO-2026-5856 (Encrypted Client Hello privacy leak in `crypto/tls`), present in the go1.26.4 standard library and fixed in go1.26.5. Bump the `go.mod` directive (source of truth) and propagate to `.tool-versions` and the golangci-lint pre-commit `language_version`.

### Proof of Work
- Floor (unit) + lint + scram — https://spruce.mongodb.com/version/6a4ecff5114ab0000728627a — all green, including `lint_repo` (confirms the GO-2026-5856 fix in CI).
- mc_sharded (dynamic + static) + enterprise_basic, restarted in place 4× — https://spruce.mongodb.com/version/6a4ec9d5fcb33c0007e94a22 — mc_sharded 4/4 green on both variants; enterprise_basic 4/4 test-green (one infrastructure setup-failure auto-retried).
- Earlier scram + enterprise_basic run — https://spruce.mongodb.com/version/6a4eb089ddfdae0007e99511 — both green (`lint_repo` there failed only on the base CVE now fixed here).

### Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
