### PR TITLE
KUBE-154: establish MongoDBSearch lifecycle identity

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -861,7 +861,7 @@ func (s *MongoDBSearch) GetOwnerReferences() []metav1.OwnerReference {
 	ownerReference := *metav1.NewControllerRef(s, schema.GroupVersionKind{
 		Group:   v1.SchemeGroupVersion.Group,
 		Version: v1.SchemeGroupVersion.Version,
-		Kind:    s.Kind,
+		Kind:    s.GetKind(),
 	})
 	return []metav1.OwnerReference{ownerReference}
 }

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -189,7 +189,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		// A concurrent writer bumped the ConfigMap between read and update; retry
 		// instead of marking the CR Failed over a transient race.
 		if apierrors.IsConflict(err) {
-			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Pending("Search state was modified concurrently, retrying").Requeue(), log)
+			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Pending("Search state was modified concurrently, re-queuing ").Requeue(), log)
 		}
 		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("failed to read or repair search state: %w", err)), log)
 	}

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -180,9 +180,18 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		}
 	}
 
-	state, err := searchcontroller.ReadSearchState(ctx, r.kubeClient, mdbSearch)
+	// The no-op mutation reads the state and, as a side effect, repairs legacy
+	// owner labels on the state ConfigMap.
+	state, err := searchcontroller.MutateSearchState(ctx, r.kubeClient, mdbSearch, func(*searchcontroller.SearchDeploymentState) bool {
+		return false
+	})
 	if err != nil {
-		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("failed to read search state: %w", err)), log)
+		// A concurrent writer bumped the ConfigMap between read and update; retry
+		// instead of marking the CR Failed over a transient race.
+		if apierrors.IsConflict(err) {
+			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Pending("Search state was modified concurrently, retrying").Requeue(), log)
+		}
+		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("failed to read or repair search state: %w", err)), log)
 	}
 
 	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig, r.memberClusterClientsMap, state)

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -299,6 +301,37 @@ func TestMongoDBSearchReconcile_Success(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+
+	t.Run("state write conflict requeues instead of failing", func(t *testing.T) {
+		ctx := context.Background()
+		search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+		mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+		// A state CM without owner labels forces the pre-reconcile no-op state
+		// mutation to attempt a metadata-repair update, which conflicts here.
+		stateCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: searchcontroller.SearchStateCMName(search), Namespace: search.Namespace},
+		}
+		c := mock.NewEmptyFakeClientBuilder().
+			WithObjects(search, mdbc, stateCM).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if obj.GetName() == stateCM.Name {
+						return apiErrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, stateCM.Name, nil)
+					}
+					return cl.Update(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		reconciler := newMongoDBSearchReconciler(c, searchcontroller.OperatorSearchConfig{}, map[string]client.Client{}, "")
+
+		res, err := reconciler.Reconcile(ctx, requestFromObject(search))
+		require.NoError(t, err)
+		assert.True(t, res.Requeue, "conflict must requeue, not fail")
+
+		updated := &searchv1.MongoDBSearch{}
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, updated))
+		assert.Equal(t, status.PhasePending, updated.Status.Phase)
+	})
 }
 
 func checkSearchReconcileFailed(

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -1008,6 +1008,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployme
 			dep.Labels = merge.StringToStringMap(dep.Labels, deploymentOverride.MetadataWrapper.Labels)
 			dep.Annotations = merge.StringToStringMap(dep.Annotations, deploymentOverride.MetadataWrapper.Annotations)
 		}
+		// Identity labels are merged after user label overrides so users cannot
+		// detach the Deployment from its owning MongoDBSearch.
+		dep.Labels = merge.StringToStringMap(dep.Labels, labels)
 
 		if clusterName == "" {
 			return controllerutil.SetOwnerReference(search, dep, c.Scheme())
@@ -1123,16 +1126,7 @@ func metricsForwarderResourceRequirements(search *searchv1.MongoDBSearch) corev1
 // metricsForwarderLabelsForCluster returns resource labels including cross-cluster enqueue labels.
 // clusterName=="" (single-cluster/central): cluster-name label is omitted.
 func metricsForwarderLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
-	labels := map[string]string{
-		"app":                                search.MetricsForwarderDeploymentNameForCluster(clusterIndex),
-		"component":                          metricsForwarderLabelName,
-		khandler.MongoDBSearchOwnerNameLabel: search.Name,
-		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
-	}
-	if clusterName != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
-	}
-	return labels
+	return khandler.SearchManagedLabels(search, search.MetricsForwarderDeploymentNameForCluster(clusterIndex), metricsForwarderLabelName, clusterName)
 }
 
 func metricsForwarderPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterIndex int) map[string]string {

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -1126,7 +1126,7 @@ func metricsForwarderResourceRequirements(search *searchv1.MongoDBSearch) corev1
 // metricsForwarderLabelsForCluster returns resource labels including cross-cluster enqueue labels.
 // clusterName=="" (single-cluster/central): cluster-name label is omitted.
 func metricsForwarderLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
-	return khandler.SearchManagedLabels(search, search.MetricsForwarderDeploymentNameForCluster(clusterIndex), metricsForwarderLabelName, clusterName)
+	return khandler.SearchOwnershipLabels(search, search.MetricsForwarderDeploymentNameForCluster(clusterIndex), metricsForwarderLabelName, clusterName)
 }
 
 func metricsForwarderPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterIndex int) map[string]string {

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1" //nolint:depguard
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
@@ -367,11 +368,16 @@ func TestMetricsForwarderLabels(t *testing.T) {
 
 	labels := metricsForwarderLabels(search)
 	assert.Equal(t, "my-search-search-metrics-forwarder-0", labels["app"])
-	assert.Equal(t, metricsForwarderLabelName, labels["component"])
+	assert.Equal(t, metricsForwarderLabelName, labels[khandler.MongoDBSearchComponentLabel])
+	assert.NotContains(t, labels, khandler.MongoDBSearchClusterNameLabel)
+
+	memberLabels := metricsForwarderLabelsForCluster(search, "us-east", 3)
+	assert.Equal(t, search.MetricsForwarderDeploymentNameForCluster(3), memberLabels["app"])
+	assert.Equal(t, "us-east", memberLabels[khandler.MongoDBSearchClusterNameLabel])
 
 	podLabels := metricsForwarderPodLabels(search)
 	assert.Equal(t, "my-search-search-metrics-forwarder-0", podLabels["app"])
-	assert.NotContains(t, podLabels, "component")
+	assert.NotContains(t, podLabels, khandler.MongoDBSearchComponentLabel)
 }
 
 func TestMetricsForwarderResourceRequirements_Defaults(t *testing.T) {

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -1677,11 +1677,17 @@ func newTestMongoDBSearchWithReplicas(name, namespace, mdbName string, replicas 
 }
 
 // TestReconcileTopologyState_FirstReconcile_RecordsCurrentReplicas verifies that the first call
-// creates a state ConfigMap recording the current replica count and returns pending=false.
+// records the current replica count in the state ConfigMap and returns pending=false. The
+// pre-existing ConfigMap carries nil Data (as after a hand-edit): it must read as fresh state
+// and must not panic the state write.
 func TestReconcileTopologyState_FirstReconcile_RecordsCurrentReplicas(t *testing.T) {
 	search := newTestMongoDBSearchWithReplicas(testSearchName, testNamespace, testMDBName, 2)
 	agentSecret := newTestAgentKeySecret("agent-key-secret", testNamespace)
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, search, agentSecret)
+	emptyStateCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      fmt.Sprintf("%s-metrics-forwarder-state", search.Name),
+		Namespace: testNamespace,
+	}}
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, search, agentSecret, emptyStateCM)
 
 	var deletedHostIDs []string
 	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -555,6 +555,9 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 			dep.Labels = merge.StringToStringMap(dep.Labels, managedLB.Deployment.MetadataWrapper.Labels)
 			dep.Annotations = merge.StringToStringMap(dep.Annotations, managedLB.Deployment.MetadataWrapper.Annotations)
 		}
+		// Identity labels are merged after user label overrides so users cannot
+		// detach the Deployment from its owning MongoDBSearch.
+		dep.Labels = merge.StringToStringMap(dep.Labels, labels)
 
 		if clusterName == "" {
 			return controllerutil.SetOwnerReference(search, dep, c.Scheme())
@@ -780,17 +783,7 @@ func defaultEnvoyResourceRequirements() corev1.ResourceRequirements {
 // clusterIndex is used for the "app" label (resource name); clusterName is used
 // for the cluster-name label so label selectors remain name-keyed.
 func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
-	labels := map[string]string{
-		"app":                                search.LoadBalancerDeploymentNameForCluster(clusterIndex),
-		"component":                          labelName,
-		khandler.MongoDBSearchOwnerNameLabel: search.Name,
-		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
-	}
-	// In single-cluster legacy mode (clusterName==""), omit the per-cluster label so existing watchers continue to match.
-	if clusterName != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
-	}
-	return labels
+	return khandler.SearchManagedLabels(search, search.LoadBalancerDeploymentNameForCluster(clusterIndex), labelName, clusterName)
 }
 
 // envoyReplicas returns the cluster's desired Envoy replica count.

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -783,7 +783,7 @@ func defaultEnvoyResourceRequirements() corev1.ResourceRequirements {
 // clusterIndex is used for the "app" label (resource name); clusterName is used
 // for the cluster-name label so label selectors remain name-keyed.
 func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
-	return khandler.SearchManagedLabels(search, search.LoadBalancerDeploymentNameForCluster(clusterIndex), labelName, clusterName)
+	return khandler.SearchOwnershipLabels(search, search.LoadBalancerDeploymentNameForCluster(clusterIndex), labelName, clusterName)
 }
 
 // envoyReplicas returns the cluster's desired Envoy replica count.

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -922,6 +922,7 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 	single := envoyLabelsForCluster(search, "", 0)
 	assert.Equal(t, "mdb-search", single[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", single[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, labelName, single[khandler.MongoDBSearchComponentLabel])
 	_, hasCluster := single[khandler.MongoDBSearchClusterNameLabel]
 	assert.False(t, hasCluster)
 	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(0), single["app"])
@@ -930,6 +931,7 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 	mc := envoyLabelsForCluster(search, "us-east-k8s", 3)
 	assert.Equal(t, "mdb-search", mc[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", mc[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, labelName, mc[khandler.MongoDBSearchComponentLabel])
 	assert.Equal(t, "us-east-k8s", mc[khandler.MongoDBSearchClusterNameLabel])
 	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(3), mc["app"])
 }

--- a/controllers/operator/state_store.go
+++ b/controllers/operator/state_store.go
@@ -57,6 +57,11 @@ func (s *StateStore[S]) read(ctx context.Context) error {
 	}
 
 	s.data = cm.Data
+	// An empty or hand-edited ConfigMap can carry nil Data; setDataValue would
+	// panic writing into a nil map.
+	if s.data == nil {
+		s.data = map[string]string{}
+	}
 	return nil
 }
 

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -46,6 +46,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
 )
 
 const (
@@ -126,27 +127,16 @@ func NewMongoDBSearchReconcileHelper(
 // don't cross cluster boundaries; labels are the only path back from a member
 // resource to its central CR (for watch routing and label-based GC).
 func searchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) map[string]string {
-	labels := map[string]string{
-		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
-		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
-	}
-	if clusterName != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
-	}
-	return labels
+	return khandler.SearchManagedLabels(search, "", "", clusterName)
 }
 
-// withSearchOwnerLabels merges the search-owner labels into the STS ObjectMeta
-// labels. It does NOT touch the selector/pod-template (which is immutable on
-// existing STS); the pod-routing labels stay in the unit's podLabels.
+// withSearchOwnerLabels adds the managed identity labels to the StatefulSet
+// labels. It runs last in the modification chain so user labels merged earlier
+// cannot win over them. It does not touch the selector/pod-template (immutable
+// on an existing STS); the pod-routing labels stay in the unit's podLabels.
 func withSearchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) statefulset.Modification {
 	return func(set *appsv1.StatefulSet) {
-		if set.Labels == nil {
-			set.Labels = map[string]string{}
-		}
-		for k, v := range searchOwnerLabels(search, clusterName) {
-			set.Labels[k] = v
-		}
+		set.Labels = merge.StringToStringMap(set.Labels, khandler.SearchManagedLabels(search, "", mongotComponent, clusterName))
 	}
 }
 
@@ -668,22 +658,25 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		}
 	}
 
+	tlsSecretLabels := searchOwnerLabels(r.mdbSearch, unit.clusterName)
+	ingressTLSSecretLabels := khandler.SearchManagedLabels(r.mdbSearch, "", mongotComponent, unit.clusterName)
+
 	// Per-unit ingress TLS: each shard may have its own secret, so this cannot
 	// be hoisted out of the loop.
-	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource)
+	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource, ingressTLSSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit egress TLS (SCRAM CA + optional client cert): uses unitClient so the
 	// operator-managed secret is created on the cluster where mongot pods run.
-	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient)
+	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient, tlsSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit x509 client cert: uses unitClient for the same reason as egress TLS.
-	x509MongotModification, x509StsModification, err := r.ensureX509ClientCertConfig(ctx, unitClient)
+	x509MongotModification, x509StsModification, err := r.ensureX509ClientCertConfig(ctx, unitClient, tlsSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -730,7 +723,6 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		unitClient,
 		unit.stsName,
 		stsFunc,
-		withSearchOwnerLabels(r.mdbSearch, unit.clusterName),
 		mods.passwordAuthSts,
 		configHashModification,
 		mods.keyfileSts,
@@ -738,7 +730,8 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		egressTlsStsModification,
 		x509StsModification,
 		mods.embeddingConfigSts,
-		stsOverride, // must be last: see StatefulSetOverrideModification
+		stsOverride,
+		withSearchOwnerLabels(r.mdbSearch, unit.clusterName),
 	)
 	if err != nil {
 		return nil, nil, err
@@ -1029,7 +1022,10 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 		expected map[string]bool
 		kind     string
 	}{
-		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels(searchOwnerLabels(r.mdbSearch, "")), expectedSTS, "StatefulSet"},
+		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels{
+			khandler.MongoDBSearchOwnerNameLabel:      r.mdbSearch.Name,
+			khandler.MongoDBSearchOwnerNamespaceLabel: r.mdbSearch.Namespace,
+		}, expectedSTS, "StatefulSet"},
 		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: proxyServiceComponent}, expectedProxy, "proxy Service"},
 		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedHeadless, "headless Service"},
 		{func() client.ObjectList { return &corev1.ConfigMapList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedConfig, "ConfigMap"},
@@ -1383,7 +1379,7 @@ func mongotServicePorts(search *searchv1.MongoDBSearch) []corev1.ServicePort {
 const (
 	appLabelKey           = "app"
 	shardLabelKey         = "shard"
-	componentLabelKey     = "component"
+	componentLabelKey     = khandler.MongoDBSearchComponentLabel
 	proxyServiceComponent = "search-proxy"
 	// mongotComponent is the component-label value on the per-shard mongot headless
 	// Service and ConfigMap (the StatefulSet is swept by owner label instead).
@@ -1696,12 +1692,12 @@ func setupMongotContainerArgsForAPIKeys() container.Modification {
 // ensureIngressTlsConfig processes TLS configuration for any mongot deployment.
 // For non-sharded deployments, pass r.mdbSearch as the tlsResource.
 // For sharded deployments, pass a perShardTLSResource adapter.
-func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
 	if r.mdbSearch.Spec.Security.TLS == nil {
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
 
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource)
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource, labels, tlsResource.GetOwnerReferences())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1775,7 +1771,7 @@ func (x *x509AuthResource) TLSOperatorSecretNamespacedName() types.NamespacedNam
 
 // ensureX509ClientCertConfig processes x509 client certificate configuration for the sync source in case of mongot to mongod communication.
 // When x509 is configured, it replaces username/password auth with x509 certificate auth.
-func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
 	if !r.mdbSearch.IsX509Auth() {
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
@@ -1788,7 +1784,7 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 	}
 
 	x509Resource := &x509AuthResource{MongoDBSearch: r.mdbSearch}
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource)
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource, labels, x509Resource.GetOwnerReferences())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1884,7 +1880,7 @@ func (p *perShardTLSResource) TLSOperatorSecretNamespacedName() types.Namespaced
 	return p.TLSOperatorSecretForClusterShard(p.clusterIndex, p.shardName)
 }
 
-func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
 	tlsSourceConfig := r.db.TLSConfig()
 	if tlsSourceConfig == nil {
 		return mongot.NOOP(), statefulset.NOOP(), nil
@@ -1896,7 +1892,7 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 	scramKeyPasswordSecret := r.mdbSearch.ScramKeyFilePasswordSecret()
 	if r.mdbSearch.HasScramClientCert() {
 		scramCertResource := &scramClientCertResource{MongoDBSearch: r.mdbSearch}
-		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource)
+		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource, labels, scramCertResource.GetOwnerReferences())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -127,7 +127,7 @@ func NewMongoDBSearchReconcileHelper(
 // don't cross cluster boundaries; labels are the only path back from a member
 // resource to its central CR (for watch routing and label-based GC).
 func searchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) map[string]string {
-	return khandler.SearchManagedLabels(search, "", "", clusterName)
+	return khandler.SearchOwnershipLabels(search, "", "", clusterName)
 }
 
 // withSearchOwnerLabels adds the managed identity labels to the StatefulSet
@@ -136,7 +136,7 @@ func searchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) map[s
 // on an existing STS); the pod-routing labels stay in the unit's podLabels.
 func withSearchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) statefulset.Modification {
 	return func(set *appsv1.StatefulSet) {
-		set.Labels = merge.StringToStringMap(set.Labels, khandler.SearchManagedLabels(search, "", mongotComponent, clusterName))
+		set.Labels = merge.StringToStringMap(set.Labels, khandler.SearchOwnershipLabels(search, "", mongotComponent, clusterName))
 	}
 }
 
@@ -659,7 +659,7 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 	}
 
 	tlsSecretLabels := searchOwnerLabels(r.mdbSearch, unit.clusterName)
-	ingressTLSSecretLabels := khandler.SearchManagedLabels(r.mdbSearch, "", mongotComponent, unit.clusterName)
+	ingressTLSSecretLabels := khandler.SearchOwnershipLabels(r.mdbSearch, "", mongotComponent, unit.clusterName)
 
 	// Per-unit ingress TLS: each shard may have its own secret, so this cannot
 	// be hoisted out of the loop.

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -33,6 +33,7 @@ import (
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/mongot"
+	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 )
 
@@ -104,6 +105,25 @@ func newTestFakeClient(objects ...client.Object) kubernetesClient.Client {
 
 	clientBuilder.WithObjects(objects...)
 	return kubernetesClient.NewClient(clientBuilder.Build())
+}
+
+// assertSearchManagedLabels asserts the managed identity on every local
+// mongot resource: owner labels, component, cluster-name label presence,
+// and the owner reference back to the MongoDBSearch CR.
+func assertSearchManagedLabels(t *testing.T, obj client.Object, search *searchv1.MongoDBSearch, clusterName string) {
+	t.Helper()
+	labels := obj.GetLabels()
+	assert.Equal(t, search.Name, labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, mongotComponent, labels[khandler.MongoDBSearchComponentLabel])
+	if clusterName == "" {
+		assert.NotContains(t, labels, khandler.MongoDBSearchClusterNameLabel)
+	} else {
+		assert.Equal(t, clusterName, labels[khandler.MongoDBSearchClusterNameLabel])
+	}
+	assert.True(t, slices.ContainsFunc(obj.GetOwnerReferences(), func(ref metav1.OwnerReference) bool {
+		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name && ref.UID == search.UID
+	}), "expected owner reference back to the MongoDBSearch CR")
 }
 
 func reconcileMongoDBSearch(ctx context.Context, fakeClient kubernetesClient.Client, mdbSearch *searchv1.MongoDBSearch, mdbc *mdbcv1.MongoDBCommunity, operatorConfig OperatorSearchConfig) workflow.Status {
@@ -613,6 +633,49 @@ func TestMongoDBSearchReconcileHelper_ServiceCreation(t *testing.T) {
 
 			assertServiceBasicProperties(t, svc, mdbSearch)
 			assertServicePorts(t, svc, tc.expectedPorts)
+		})
+	}
+}
+
+func TestSearchManagedLabelsWinOverOverrides(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+	}{
+		{name: "member cluster", clusterName: "member-a"},
+		{name: "legacy single cluster"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			overrideLabels := map[string]string{
+				"custom-label":                            "custom-value",
+				khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
+				khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
+				khandler.MongoDBSearchComponentLabel:      "wrong-component",
+			}
+			if tc.clusterName != "" {
+				overrideLabels[khandler.MongoDBSearchClusterNameLabel] = "wrong-cluster"
+			}
+			search := newTestMongoDBSearch("test-search", "test-ns", func(search *searchv1.MongoDBSearch) {
+				search.UID = "search-uid"
+				search.Spec.Clusters = []searchv1.ClusterSpec{{
+					Name: tc.clusterName,
+					StatefulSetConfiguration: &v1.StatefulSetConfiguration{
+						MetadataWrapper: v1.StatefulSetMetadataWrapper{
+							Labels: overrideLabels,
+						},
+					},
+				}}
+			})
+			sizing := search.EffectiveClusters()[0]
+			sts := statefulset.New(
+				CreateSearchStatefulSetFunc(search, sizing, "test-search-search-0", search.Namespace, "test-search-search-0-svc", "test-search-search-0-config", map[string]string{"app": "test-search-search-0"}, "mongot:latest", false),
+				StatefulSetOverrideModification(sizing.StatefulSetConfiguration),
+				withSearchOwnerLabels(search, tc.clusterName),
+			)
+
+			assert.Equal(t, "custom-value", sts.Labels["custom-label"])
+			assertSearchManagedLabels(t, &sts, search, tc.clusterName)
 		})
 	}
 }
@@ -2600,7 +2663,7 @@ func TestEnsureX509ClientCertConfig_NoopWhenNotConfigured(t *testing.T) {
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.NoError(t, err)
 
 	// Apply modifications and verify no changes
@@ -2641,13 +2704,14 @@ func TestEnsureX509ClientCertConfig_ErrorWhenTLSNotConfigured(t *testing.T) {
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
-	_, _, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	_, _, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tls must be enabled")
 }
 
 func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+		s.UID = "search-uid"
 		s.Spec.Source.X509 = &searchv1.X509Auth{
 			ClientCertificateSecret: corev1.LocalObjectReference{Name: "x509-cert"},
 		}
@@ -2666,8 +2730,11 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	fakeClient := newTestFakeClient(search, x509Secret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.NoError(t, err)
+	operatorSecret, err := fakeClient.GetSecret(t.Context(), search.X509OperatorManagedSecret())
+	require.NoError(t, err)
+	assert.Subset(t, operatorSecret.Labels, searchOwnerLabels(search, ""))
 
 	// Apply mongot modification to a config with both ReplicaSet and Router (sharded scenario)
 	config := &mongot.Config{
@@ -2765,7 +2832,7 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	fakeClient := newTestFakeClient(search, x509Secret, keyPasswordSecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.NoError(t, err)
 
 	// Verify mongot config has key password path
@@ -3071,8 +3138,14 @@ func TestCleanupStaleShardResources(t *testing.T) {
 
 func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
+	search.UID = "search-uid"
+	search.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "my-prefix"}}
 	mdbc := newTestMongoDBCommunity("test-mongodb", "test-ns")
-	fakeClient := newTestFakeClient(search, mdbc)
+	sourceTLSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: search.TLSSecretNamespacedName().Name, Namespace: search.Namespace},
+		Data:       map[string][]byte{"tls.crt": []byte("cert-data"), "tls.key": []byte("key-data")},
+	}
+	fakeClient := newTestFakeClient(search, mdbc, sourceTLSSecret)
 
 	helper := NewMongoDBSearchReconcileHelper(
 		fakeClient,
@@ -3103,6 +3176,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-search-search-0-svc", svc.Spec.Selector["app"])
 	assert.Equal(t, "test-search-search-0-svc", svc.Labels["app"])
 	assert.Empty(t, svc.Labels["shard"])
+	assertSearchManagedLabels(t, &svc, search, "")
 
 	portMap := make(map[string]int32)
 	for _, p := range svc.Spec.Ports {
@@ -3120,11 +3194,8 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-ns", sts.Namespace)
 	assert.Equal(t, "test-search-search-0-svc", sts.Labels["app"])
 	assert.Empty(t, sts.Labels["shard"])
-
 	// Owner-ref back to the MongoDBSearch CR drives PVC reclaim via GC on CR delete.
-	assert.True(t, slices.ContainsFunc(sts.OwnerReferences, func(ref metav1.OwnerReference) bool {
-		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name
-	}))
+	assertSearchManagedLabels(t, &sts, search, "")
 
 	// Verify ConfigMap
 	cmNsName := search.MongotConfigConfigMapNameForCluster(0)
@@ -3133,6 +3204,12 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 
 	assert.Equal(t, "test-search-search-0-config", cm.Name)
 	assert.Contains(t, cm.Data, MongotConfigFilename)
+	assertSearchManagedLabels(t, &cm, search, "")
+
+	// Verify operator-managed ingress TLS Secret identity
+	ingressSecret, err := fakeClient.GetSecret(t.Context(), search.TLSOperatorSecretNamespacedName())
+	require.NoError(t, err)
+	assertSearchManagedLabels(t, &ingressSecret, search, "")
 }
 
 type fakeExternalSource struct {

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3102,9 +3102,9 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	search.Spec.Clusters[0].StatefulSetConfiguration = &v1.StatefulSetConfiguration{
 		MetadataWrapper: v1.StatefulSetMetadataWrapper{
 			Labels: map[string]string{
-				"app":                                     "test-search-search-0-svc",
-				"custom-label":                            "custom-value",
-				khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
+				"app":                                "test-search-search-0-svc",
+				"custom-label":                       "custom-value",
+				khandler.MongoDBSearchOwnerNameLabel: "wrong-name",
 				khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
 				khandler.MongoDBSearchComponentLabel:      "wrong-component",
 			},

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -33,7 +33,6 @@ import (
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/mongot"
-	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 )
 
@@ -107,10 +106,10 @@ func newTestFakeClient(objects ...client.Object) kubernetesClient.Client {
 	return kubernetesClient.NewClient(clientBuilder.Build())
 }
 
-// assertSearchManagedLabels asserts the managed identity on every local
+// assertSearchOwnershipLabels asserts the managed identity on every local
 // mongot resource: owner labels, component, cluster-name label presence,
 // and the owner reference back to the MongoDBSearch CR.
-func assertSearchManagedLabels(t *testing.T, obj client.Object, search *searchv1.MongoDBSearch, clusterName string) {
+func assertSearchOwnershipLabels(t *testing.T, obj client.Object, search *searchv1.MongoDBSearch, clusterName string) {
 	t.Helper()
 	labels := obj.GetLabels()
 	assert.Equal(t, search.Name, labels[khandler.MongoDBSearchOwnerNameLabel])
@@ -633,49 +632,6 @@ func TestMongoDBSearchReconcileHelper_ServiceCreation(t *testing.T) {
 
 			assertServiceBasicProperties(t, svc, mdbSearch)
 			assertServicePorts(t, svc, tc.expectedPorts)
-		})
-	}
-}
-
-func TestSearchManagedLabelsWinOverOverrides(t *testing.T) {
-	tests := []struct {
-		name        string
-		clusterName string
-	}{
-		{name: "member cluster", clusterName: "member-a"},
-		{name: "legacy single cluster"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			overrideLabels := map[string]string{
-				"custom-label":                            "custom-value",
-				khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
-				khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
-				khandler.MongoDBSearchComponentLabel:      "wrong-component",
-			}
-			if tc.clusterName != "" {
-				overrideLabels[khandler.MongoDBSearchClusterNameLabel] = "wrong-cluster"
-			}
-			search := newTestMongoDBSearch("test-search", "test-ns", func(search *searchv1.MongoDBSearch) {
-				search.UID = "search-uid"
-				search.Spec.Clusters = []searchv1.ClusterSpec{{
-					Name: tc.clusterName,
-					StatefulSetConfiguration: &v1.StatefulSetConfiguration{
-						MetadataWrapper: v1.StatefulSetMetadataWrapper{
-							Labels: overrideLabels,
-						},
-					},
-				}}
-			})
-			sizing := search.EffectiveClusters()[0]
-			sts := statefulset.New(
-				CreateSearchStatefulSetFunc(search, sizing, "test-search-search-0", search.Namespace, "test-search-search-0-svc", "test-search-search-0-config", map[string]string{"app": "test-search-search-0"}, "mongot:latest", false),
-				StatefulSetOverrideModification(sizing.StatefulSetConfiguration),
-				withSearchOwnerLabels(search, tc.clusterName),
-			)
-
-			assert.Equal(t, "custom-value", sts.Labels["custom-label"])
-			assertSearchManagedLabels(t, &sts, search, tc.clusterName)
 		})
 	}
 }
@@ -3140,6 +3096,20 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
 	search.UID = "search-uid"
 	search.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "my-prefix"}}
+	// User label overrides must survive on the StatefulSet, but never displace
+	// the ownership labels applied after them. The override replaces the object
+	// labels wholesale, so it re-supplies the app label asserted below.
+	search.Spec.Clusters[0].StatefulSetConfiguration = &v1.StatefulSetConfiguration{
+		MetadataWrapper: v1.StatefulSetMetadataWrapper{
+			Labels: map[string]string{
+				"app":                                     "test-search-search-0-svc",
+				"custom-label":                            "custom-value",
+				khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
+				khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
+				khandler.MongoDBSearchComponentLabel:      "wrong-component",
+			},
+		},
+	}
 	mdbc := newTestMongoDBCommunity("test-mongodb", "test-ns")
 	sourceTLSSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: search.TLSSecretNamespacedName().Name, Namespace: search.Namespace},
@@ -3176,7 +3146,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-search-search-0-svc", svc.Spec.Selector["app"])
 	assert.Equal(t, "test-search-search-0-svc", svc.Labels["app"])
 	assert.Empty(t, svc.Labels["shard"])
-	assertSearchManagedLabels(t, &svc, search, "")
+	assertSearchOwnershipLabels(t, &svc, search, "")
 
 	portMap := make(map[string]int32)
 	for _, p := range svc.Spec.Ports {
@@ -3194,8 +3164,11 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-ns", sts.Namespace)
 	assert.Equal(t, "test-search-search-0-svc", sts.Labels["app"])
 	assert.Empty(t, sts.Labels["shard"])
+	assert.Equal(t, "custom-value", sts.Labels["custom-label"])
 	// Owner-ref back to the MongoDBSearch CR drives PVC reclaim via GC on CR delete.
-	assertSearchManagedLabels(t, &sts, search, "")
+	// assertSearchOwnershipLabels also pins that the "wrong-*" user overrides above
+	// did not displace the ownership labels.
+	assertSearchOwnershipLabels(t, &sts, search, "")
 
 	// Verify ConfigMap
 	cmNsName := search.MongotConfigConfigMapNameForCluster(0)
@@ -3204,12 +3177,12 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 
 	assert.Equal(t, "test-search-search-0-config", cm.Name)
 	assert.Contains(t, cm.Data, MongotConfigFilename)
-	assertSearchManagedLabels(t, &cm, search, "")
+	assertSearchOwnershipLabels(t, &cm, search, "")
 
 	// Verify operator-managed ingress TLS Secret identity
 	ingressSecret, err := fakeClient.GetSecret(t.Context(), search.TLSOperatorSecretNamespacedName())
 	require.NoError(t, err)
-	assertSearchManagedLabels(t, &ingressSecret, search, "")
+	assertSearchOwnershipLabels(t, &ingressSecret, search, "")
 }
 
 type fakeExternalSource struct {

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -196,12 +196,13 @@ func nodeAffinityModification(nodeAffinity *corev1.NodeAffinity) podtemplatespec
 
 // StatefulSetOverrideModification applies the resolved clusters[].statefulSet, with any
 // shardOverrides[].statefulSet already deep-merged in (see ResolveSizingForClusterShard).
-// It must run LAST in the modification chain, over the fully built StatefulSet: the override
+// It must run after the fully built StatefulSet: the override
 // merge sorts volumes by name, so merging mid-pipeline (before the password/TLS
 // volume modifications append) yields a different volume order on the create and
 // update paths — the first reconcile after STS creation then sees a spurious
 // template diff and rolls every mongot pod. Applying last also makes the user
-// override win over operator-set fields, as the CRD field documents.
+// override win over operator-set fields, as the CRD field documents. Only the
+// managed identity labels are applied afterward, without changing the merged spec.
 func StatefulSetOverrideModification(stsConfig *v1.StatefulSetConfiguration) statefulset.Modification {
 	if stsConfig == nil {
 		return statefulset.NOOP()

--- a/controllers/searchcontroller/search_state.go
+++ b/controllers/searchcontroller/search_state.go
@@ -73,7 +73,8 @@ func ReadSearchState(
 // search state ConfigMap: a stale base yields 409 Conflict and the reconcile
 // requeues, instead of silently losing a concurrent write (do NOT replace this
 // with configmap.CreateOrUpdate — that is a blind no-RV Update). mutate returns
-// true when the state changed and must be persisted.
+// true when the state changed and must be persisted. Every update also repairs
+// owner labels missing from ConfigMaps written by released 1.9.x operators.
 func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, mutate func(*SearchDeploymentState) bool) (*SearchDeploymentState, error) {
 	cmName := SearchStateCMName(search)
 	cm := &corev1.ConfigMap{}
@@ -90,7 +91,7 @@ func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *s
 		newCM := configmap.Builder().
 			SetName(cmName).
 			SetNamespace(search.Namespace).
-			SetLabels(search.GetOwnerLabels()).
+			SetLabels(searchOwnerLabels(search, "")).
 			SetOwnerReferences(kube.BaseOwnerReference(search)).
 			SetDataField(searchStateKey, string(data)).
 			Build()
@@ -103,9 +104,23 @@ func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *s
 	if err != nil {
 		return nil, err
 	}
-	if !mutate(state) {
+
+	stateChanged := mutate(state)
+	metadataChanged := false
+	if cm.Labels == nil {
+		cm.Labels = map[string]string{}
+	}
+	for key, value := range searchOwnerLabels(search, "") {
+		if cm.Labels[key] != value {
+			cm.Labels[key] = value
+			metadataChanged = true
+		}
+	}
+
+	if !stateChanged && !metadataChanged {
 		return state, nil
 	}
+
 	data, err := json.Marshal(state)
 	if err != nil {
 		return nil, err

--- a/controllers/searchcontroller/search_state_test.go
+++ b/controllers/searchcontroller/search_state_test.go
@@ -15,8 +15,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/mock"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 )
 
@@ -29,8 +31,9 @@ func decodeStateJSON(cm *corev1.ConfigMap, dst interface{}) error {
 }
 
 // The routing-ready switch persists through RV-checked read-modify-writes on the
-// state ConfigMap: creation with owner metadata, monotonic appends, no-op
-// rewrites, pruning, and 409 Conflict on a stale base instead of a silent lost update.
+// state ConfigMap: creation with owner identity, monotonic appends, legacy label
+// repair, no-op rewrites, pruning, and 409 Conflict on a stale base instead of a
+// silent lost update.
 func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 	ctx := context.Background()
 	search := newTestMongoDBSearch("mysearch", mock.TestNamespace)
@@ -52,7 +55,7 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 		return st
 	}
 
-	t.Run("first mark creates the state CM with owner metadata", func(t *testing.T) {
+	t.Run("first mark creates the state CM with owner identity", func(t *testing.T) {
 		c := mock.NewEmptyFakeClientBuilder().Build()
 		helper := newHelper(c)
 		require.NoError(t, helper.markRoutingReady(ctx, "sh-0"))
@@ -63,7 +66,7 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 		assert.Equal(t, []string{"sh-0"}, readState(t, c).RoutingReadyMongotGroups)
 		require.Len(t, cm.OwnerReferences, 1)
 		assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
-		for k, v := range search.GetOwnerLabels() {
+		for k, v := range searchOwnerLabels(search, "") {
 			assert.Equal(t, v, cm.Labels[k], "owner label %s", k)
 		}
 	})
@@ -78,6 +81,43 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 
 		require.NoError(t, newHelper(c).markRoutingReady(ctx, "sh-1"))
 		assert.Equal(t, []string{"sh-0", "sh-1"}, readState(t, c).RoutingReadyMongotGroups)
+	})
+
+	t.Run("mark repairs owner labels on a legacy state CM", func(t *testing.T) {
+		raw, err := json.Marshal(SearchDeploymentState{RoutingReadyMongotGroups: []string{"legacy-shard"}})
+		require.NoError(t, err)
+		legacyCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            SearchStateCMName(search),
+				Namespace:       search.Namespace,
+				Labels:          search.GetOwnerLabels(),
+				OwnerReferences: kube.BaseOwnerReference(search),
+			},
+			Data: map[string]string{searchStateKey: string(raw)},
+		}
+		c := mock.NewEmptyFakeClientBuilder().WithObjects(legacyCM).Build()
+		helper := newHelper(c)
+		require.NoError(t, helper.markRoutingReady(ctx, "sh-0"))
+		assert.Equal(t, []string{"legacy-shard", "sh-0"}, helper.state.RoutingReadyMongotGroups)
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, c.Get(ctx, stateCMName, cm))
+		for k, v := range searchOwnerLabels(search, "") {
+			assert.Equal(t, v, cm.Labels[k], "owner label %s", k)
+		}
+		require.Len(t, cm.OwnerReferences, 1, "current-CR owner reference must not be duplicated")
+	})
+
+	t.Run("no-op mutation does not create missing state", func(t *testing.T) {
+		c := mock.NewEmptyFakeClientBuilder().Build()
+		state, err := MutateSearchState(ctx, kubernetesClient.NewClient(c), search, func(*SearchDeploymentState) bool {
+			return false
+		})
+		require.NoError(t, err)
+		assert.Empty(t, state.RoutingReadyMongotGroups)
+
+		err = c.Get(ctx, stateCMName, &corev1.ConfigMap{})
+		assert.True(t, apierrors.IsNotFound(err), "no-op mutation must not create the state CM")
 	})
 
 	t.Run("already-on switch is a no-op write", func(t *testing.T) {

--- a/pkg/handler/labels_search.go
+++ b/pkg/handler/labels_search.go
@@ -6,19 +6,39 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Cross-cluster enqueue labels for search-owned member-cluster resources.
-// Owner references do not cross cluster boundaries; both the search controller
-// and the Envoy controller stamp these labels on every member-cluster write so
-// mappers / predicates can enqueue the central MongoDBSearch request.
+// Search resource identity labels used for routing and cleanup.
 const (
 	MongoDBSearchOwnerNameLabel      = "mongodb.com/search-name"
 	MongoDBSearchOwnerNamespaceLabel = "mongodb.com/search-namespace"
-	// MongoDBSearchClusterNameLabel records the owning member cluster on
-	// per-cluster member resources (Envoy Deployment + ConfigMap).
+	MongoDBSearchComponentLabel      = "component"
+	// MongoDBSearchClusterNameLabel records the target member cluster.
 	MongoDBSearchClusterNameLabel = "mongodb.com/cluster-name"
 )
+
+// SearchManagedLabels returns the managed identity labels shared by Search
+// resource writers, cleanup selectors, and event routing. Writers merge user
+// labels first and apply these labels last so user metadata overrides can
+// never detach a resource from its owning MongoDBSearch.
+func SearchManagedLabels(search metav1.Object, app, component, clusterName string) map[string]string {
+	labels := map[string]string{
+		MongoDBSearchOwnerNameLabel:      search.GetName(),
+		MongoDBSearchOwnerNamespaceLabel: search.GetNamespace(),
+	}
+	if app != "" {
+		labels["app"] = app
+	}
+	if component != "" {
+		labels[MongoDBSearchComponentLabel] = component
+	}
+	if clusterName != "" {
+		labels[MongoDBSearchClusterNameLabel] = clusterName
+	}
+	return labels
+}
 
 // MapMemberClusterObjectToSearch reads the search-owner labels off a watched
 // member-cluster object and returns the reconcile request for the central

--- a/pkg/handler/labels_search.go
+++ b/pkg/handler/labels_search.go
@@ -19,11 +19,11 @@ const (
 	MongoDBSearchClusterNameLabel = "mongodb.com/cluster-name"
 )
 
-// SearchManagedLabels returns the managed identity labels shared by Search
+// SearchOwnershipLabels returns the managed identity labels shared by Search
 // resource writers, cleanup selectors, and event routing. Writers merge user
 // labels first and apply these labels last so user metadata overrides can
 // never detach a resource from its owning MongoDBSearch.
-func SearchManagedLabels(search metav1.Object, app, component, clusterName string) map[string]string {
+func SearchOwnershipLabels(search metav1.Object, app, component, clusterName string) map[string]string {
 	labels := map[string]string{
 		MongoDBSearchOwnerNameLabel:      search.GetName(),
 		MongoDBSearchOwnerNamespaceLabel: search.GetNamespace(),

--- a/pkg/tls/tls_secret.go
+++ b/pkg/tls/tls_secret.go
@@ -28,10 +28,10 @@ type TLSConfigurableResource interface {
 	TLSOperatorSecretNamespacedName() types.NamespacedName
 }
 
-// ensureTLSSecret will create or update the operator-managed Secret containing
+// EnsureTLSSecret will create or update the operator-managed Secret containing
 // the concatenated certificate and key from the user-provided Secret.
 // Returns the file name of the concatenated certificate and key
-func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource) (string, error) {
+func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource, labels map[string]string, ownerReferences []metav1.OwnerReference) (string, error) {
 	certKey, err := getPemOrConcatenatedCrtAndKey(ctx, getUpdateCreator, resource.TLSSecretNamespacedName())
 	if err != nil {
 		return "", err
@@ -43,7 +43,8 @@ func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreat
 		SetName(resource.TLSOperatorSecretNamespacedName().Name).
 		SetNamespace(resource.TLSOperatorSecretNamespacedName().Namespace).
 		SetField(fileName, certKey).
-		SetOwnerReferences(resource.GetOwnerReferences()).
+		SetLabels(labels).
+		SetOwnerReferences(ownerReferences).
 		Build()
 
 	return fileName, secret.CreateOrUpdate(ctx, getUpdateCreator, operatorSecret)


### PR DESCRIPTION
# Summary

MongoDBSearch resources need durable identity so reconciliation, watch routing, state adoption, and cleanup remain safe across the resource lifecycle. This PR stamps owner name, namespace, cluster, and component labels on operator-managed workloads and copies. Writers merge user/override labels first and stamp the managed labels last — the managed set always wins, with no separate restore/reapply pass.


## Proof of Work

- `go build ./...` clean; unit suites for `controllers/operator`, `controllers/searchcontroller`, `pkg/handler`, `pkg/tls`, `api/mongodb/v1/search` pass; each of the 2 commits builds and passes its package tests in isolation.
- **Round-10 gates** at head `c59f3392a`: `go build ./...` + unit suites for the operator, searchcontroller, and handler trees green (17 packages ok across the stack tip); golangci-lint unchanged (one pre-existing finding in a file untouched by the stack).
- Race suite (`gotestsum -- -race` over controllers/api/pkg): 2,537 tests, 0 failures, 0 data races.
- `golangci-lint` clean on the diff (2 pre-existing findings in untouched files); black-box verified: the nil-map fix is load-bearing (test panics without it).
- Label precedence pinned by the compact table test (member + single-cluster rows); adoption semantics pinned at the `MutateSearchState` boundary (legacy label repair; no-op mutate does not create state). Test delta vs master: +164 lines.
- Evergreen: the canonical 68-task matrix at this head `486dea11c` concluded **green** — [`6a6752e80286710007f64f21`](https://spruce.corp.mongodb.com/version/6a6752e80286710007f64f21): 68/68, all at execution 0, zero restarts. The stack's current topmost matrix (round 7, at #1393's `4352719aa`, built on this head) also concluded **green** — [`6a67d2fb23f20c000767e00e`](https://spruce.corp.mongodb.com/version/6a67d2fb23f20c000767e00e): 69/69 at execution 0, zero restarts. Prior revision `bee40edd2` also concluded green — [`6a6364f9e0037d000798157f`](https://spruce.corp.mongodb.com/version/6a6364f9e0037d000798157f): 68/68, 67 at execution 0, the one auto-restart environmental (OpenShift autoscaler double scale-up, triaged in the review thread).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` label retained

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->

