### PR TITLE
chore(e2e): Add transport-level retry for Kubernetes API calls on 5xx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -228,8 +228,8 @@ repos:
       # staticcheck) see the full codebase and pre-existing violations are not silently skipped.
       - id: golangci-lint-full
         args: [--timeout=10m]
-        language_version: 1.26.4
+        language_version: 1.26.5
         priority: 6
       - id: golangci-lint-fmt
-        language_version: 1.26.4
+        language_version: 1.26.5
         priority: 6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.4
+golang 1.26.5

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -90,6 +90,18 @@ try:
 except Exception:
     kubernetes.config.load_incluster_config()
 
+from urllib3.util.retry import Retry
+
+_K8S_RETRY = Retry(
+    total=3,
+    backoff_factor=1,
+    status_forcelist=[500, 502, 503, 504],
+)
+
+_default_cfg = kubernetes.client.Configuration.get_default_copy()
+_default_cfg.retries = _K8S_RETRY
+kubernetes.client.Configuration.set_default(_default_cfg)
+
 logger = test_logger.get_test_logger(__name__)
 
 
@@ -1224,6 +1236,7 @@ def _get_client_for_cluster(
 
     configuration.verify_ssl = False
     configuration.api_key = {"authorization": f"Bearer {token}"}
+    configuration.retries = _K8S_RETRY
     return kubernetes.client.api_client.ApiClient(configuration=configuration)
 
 

--- a/go.mod
+++ b/go.mod
@@ -161,6 +161,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
 
-go 1.26.4
+go 1.26.5
 
 tool gotest.tools/gotestsum


### PR DESCRIPTION
## Summary

E2E tests run ~40 minutes. Transient Kubernetes API failures (connection refused, timeout, 5xx) kill tests mid-run, forcing expensive re-runs. This PR adds transport-level retry to the Kubernetes client so ALL API reads get automatic retry on transient failures with zero per-function overhead.

## What

### Why transport-level

- **Catches the actual failure at the actual boundary.** The thing that fails is the network call, not the Python function.
- **Safe by default.** `allowed_methods` stays at urllib3 default (GET/HEAD/OPTIONS only). Writes are never retried at transport — no double-create risk.


## Proof of Work

- `make precommit`: black, isort, ty all pass
- ci


## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? (skip-changelog label applied — E2E test infra only)
