### PR TITLE
CLOUDP-420746: automate RedHat operator bundle publishing

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -691,6 +691,33 @@ functions:
           - ${workdir}/bin
         command: scripts/evergreen/operator-sdk/prepare-openshift-bundles.sh
 
+  # Downloads the certified openshift bundle from S3 and pushes a branch containing it
+  # to the mongodb-forks certified-operators and community-operators repos. It does NOT
+  # open the PRs: the script prints the "create PR" URLs and the manual review checklist.
+  # Only one Evergreen-managed GitHub App can be installed per project (already used by CI),
+  # so this does NOT use the built-in github.generate_token command. Instead the script mints
+  # its own token from a dedicated GitHub App installed on the mongodb-forks org, via
+  # `scripts/mckci github app-token` (see scripts/release/publish-openshift-bundles-to-rh.sh).
+  # Requires three EVG project variables: rh_gh_app_id and rh_gh_app_installation_id (plain,
+  # public variables), and rh_gh_app_pem_b64 (must be configured as a Private project variable).
+  publish_openshift_bundles_to_rh:
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        include_expansions_in_env:
+          - mongodbOperator
+          - rh_gh_app_id
+          - rh_gh_app_installation_id
+          - rh_gh_app_pem_b64
+        env:
+          VERSION: ${mongodbOperator}
+          RH_DRYRUN: ${rh_dryrun|true}
+          RH_GH_APP_ID: ${rh_gh_app_id}
+          RH_GH_APP_INSTALLATION_ID: ${rh_gh_app_installation_id}
+          RH_GH_APP_PEM_B64: ${rh_gh_app_pem_b64}
+        binary: scripts/release/publish-openshift-bundles-to-rh.sh
+
   # Performs some AWS cleanup
   cleanup_aws:
     - *setup_jq

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -213,7 +213,7 @@ buildvariants:
     tags: [ "release" ]
     run_on:
       - ubuntu2404-small
-    allowed_requesters: [ "patch", "github_tag" ]
+    allowed_requesters: [ "github_tag" ]
     depends_on:
       - name: run_conditionally_prepare_and_upload_openshift_bundles
         variant: prepare_openshift_bundles

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -94,6 +94,14 @@ tasks:
           variant: prepare_openshift_bundles
           task: prepare_and_upload_openshift_bundles
 
+  - name: publish_openshift_bundles_to_rh
+    tags: [ "openshift_bundles" ]
+    allowed_requesters: [ "patch", "github_tag" ]
+    commands:
+      - func: clone
+      - func: update_evergreen_expansions
+      - func: publish_openshift_bundles_to_rh
+
   - name: release_kubectl_mongodb_plugin
     tags: [ "binary_release" ]
     allowed_requesters: [ "patch", "github_tag" ]
@@ -196,6 +204,21 @@ buildvariants:
         variant: preflight_release_images
     tasks:
       - name: run_conditionally_prepare_and_upload_openshift_bundles
+
+  # Publishing to the RedHat forks is a separate, manually-triggered variant: the bundle is
+  # pulled from S3, so it does not need to share a host with the prepare task, and the PRs
+  # are draft + human-reviewed so we do not auto-chain it after every release build.
+  - name: publish_openshift_bundles_to_rh
+    display_name: publish_openshift_bundles_to_rh
+    tags: [ "release" ]
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: run_conditionally_prepare_and_upload_openshift_bundles
+        variant: prepare_openshift_bundles
+    tasks:
+      - name: publish_openshift_bundles_to_rh
 
   - name: prerelease_kind_code_snippets
     display_name: prerelease_kind_code_snippets

--- a/ci/internal/cli/github.go
+++ b/ci/internal/cli/github.go
@@ -1,0 +1,15 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func newGitHubCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "github",
+		Short: "Github integration commands",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newGHAppTokenCmd())
+	return cmd
+}

--- a/ci/internal/cli/github_apptoken.go
+++ b/ci/internal/cli/github_apptoken.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mongodb/mongodb-kubernetes/ci/internal/github"
+)
+
+func newGHAppTokenCmd() *cobra.Command {
+	var (
+		appID          string
+		installationID string
+		pemBase64      string
+		pemFile        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "app-token",
+		Short: "Mint a short-lived GitHub App installation access token and print it to stdout",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if appID == "" || installationID == "" || (pemBase64 == "" && pemFile == "") {
+				return fmt.Errorf("--app-id, --installation-id, and --pem-base64 (or --pem-file) are required")
+			}
+
+			pem, err := resolvePEM(pemFile, pemBase64)
+			if err != nil {
+				return err
+			}
+
+			token, err := github.MintInstallationToken(cmd.Context(), github.AppTokenInputs{
+				AppID:          appID,
+				InstallationID: installationID,
+				PEM:            pem,
+			})
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), token)
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "GitHub App ID")
+	cmd.Flags().StringVar(&installationID, "installation-id", "", "installation ID the token is scoped to")
+	cmd.Flags().StringVar(&pemBase64, "pem-base64", "", "base64-encoded PEM private key")
+	cmd.Flags().StringVar(&pemFile, "pem-file", "", "path to a PEM private key file")
+
+	return cmd
+}
+
+func resolvePEM(pemFile, pemBase64 string) ([]byte, error) {
+	if pemFile != "" {
+		return os.ReadFile(pemFile)
+	}
+	if pemBase64 == "" {
+		return nil, fmt.Errorf("no private key provided: pass --pem-file or --pem-base64")
+	}
+	pem, err := base64.StdEncoding.DecodeString(strings.TrimSpace(pemBase64))
+	if err != nil {
+		return nil, fmt.Errorf("decode --pem-base64: %w", err)
+	}
+	return pem, nil
+}

--- a/ci/internal/cli/root.go
+++ b/ci/internal/cli/root.go
@@ -28,6 +28,7 @@ func NewRoot() *cobra.Command {
 
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newReleaseCmd())
+	root.AddCommand(newGitHubCmd())
 
 	return root
 }

--- a/ci/internal/github/apptoken.go
+++ b/ci/internal/github/apptoken.go
@@ -1,0 +1,146 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const GitHubAPIBaseURL = "https://api.github.com"
+
+// AppTokenInputs are the parameters needed to mint an installation token.
+type AppTokenInputs struct {
+	AppID          string
+	InstallationID string
+	PEM            []byte
+
+	APIBaseURL string // override for tests
+	HTTPClient *http.Client
+}
+
+// MintInstallationToken exchanges an app JWT for an installation access token.
+func MintInstallationToken(ctx context.Context, in AppTokenInputs) (string, error) {
+	if in.AppID == "" {
+		return "", errors.New("app-id is required")
+	}
+	if in.InstallationID == "" {
+		return "", errors.New("installation-id is required")
+	}
+	if len(in.PEM) == 0 {
+		return "", errors.New("pem is required")
+	}
+
+	key, err := parseRSAPrivateKey(in.PEM)
+	if err != nil {
+		return "", fmt.Errorf("parse private key: %w", err)
+	}
+
+	jwt, err := buildAppJWT(in.AppID, key, time.Now())
+	if err != nil {
+		return "", fmt.Errorf("build app jwt: %w", err)
+	}
+
+	baseURL := in.APIBaseURL
+	if baseURL == "" {
+		baseURL = GitHubAPIBaseURL
+	}
+	client := in.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	url := fmt.Sprintf("%s/app/installations/%s/access_tokens", baseURL, in.InstallationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("exchange jwt for installation token: %s: %s", resp.Status, bytes.TrimSpace(body))
+	}
+
+	var out struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if out.Token == "" {
+		return "", errors.New("token missing from GitHub response")
+	}
+	return out.Token, nil
+}
+
+// parseRSAPrivateKey accepts PKCS#1 or PKCS#8 PEM.
+func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("no PEM block found (is the key base64-decoded correctly?)")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("not a valid PKCS#1 or PKCS#8 RSA key: %w", err)
+	}
+	key, ok := keyAny.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("unexpected key type %T, want RSA", keyAny)
+	}
+	return key, nil
+}
+
+// buildAppJWT signs a 10-minute RS256 JWT, backdated 60s for clock skew.
+func buildAppJWT(appID string, key *rsa.PrivateKey, now time.Time) (string, error) {
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	claims := map[string]any{
+		"iat": now.Add(-60 * time.Second).Unix(),
+		"exp": now.Add(9 * time.Minute).Unix(),
+		"iss": appID,
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+
+	enc := base64.RawURLEncoding
+	signingInput := enc.EncodeToString(headerJSON) + "." + enc.EncodeToString(claimsJSON)
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + enc.EncodeToString(sig), nil
+}

--- a/ci/internal/github/apptoken_test.go
+++ b/ci/internal/github/apptoken_test.go
@@ -1,0 +1,169 @@
+package github
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return key
+}
+
+func pkcs1PEM(t *testing.T, key *rsa.PrivateKey) []byte {
+	t.Helper()
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+}
+
+func pkcs8PEM(t *testing.T, key *rsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func TestParseRSAPrivateKey(t *testing.T) {
+	key := testKey(t)
+
+	t.Run("pkcs1", func(t *testing.T) {
+		if _, err := parseRSAPrivateKey(pkcs1PEM(t, key)); err != nil {
+			t.Fatalf("pkcs1: %v", err)
+		}
+	})
+	t.Run("pkcs8", func(t *testing.T) {
+		if _, err := parseRSAPrivateKey(pkcs8PEM(t, key)); err != nil {
+			t.Fatalf("pkcs8: %v", err)
+		}
+	})
+	t.Run("garbage", func(t *testing.T) {
+		if _, err := parseRSAPrivateKey([]byte("not a pem")); err == nil {
+			t.Fatal("expected error for non-PEM input")
+		}
+	})
+}
+
+func TestBuildAppJWT(t *testing.T) {
+	key := testKey(t)
+	now := time.Unix(1_700_000_000, 0)
+
+	jwt, err := buildAppJWT("12345", key, now)
+	if err != nil {
+		t.Fatalf("buildAppJWT: %v", err)
+	}
+
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT segments, got %d", len(parts))
+	}
+	enc := base64.RawURLEncoding
+
+	// Verify the signature against the header.payload signing input.
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	sig, err := enc.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	if err := rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sig); err != nil {
+		t.Fatalf("signature does not verify: %v", err)
+	}
+
+	// Verify the claims: iss, and iat backdated 60s, exp 9m out.
+	claimsJSON, err := enc.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode claims: %v", err)
+	}
+	var claims struct {
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+		Iss string `json:"iss"`
+	}
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+	if claims.Iss != "12345" {
+		t.Errorf("iss = %q, want 12345", claims.Iss)
+	}
+	if want := now.Add(-60 * time.Second).Unix(); claims.Iat != want {
+		t.Errorf("iat = %d, want %d", claims.Iat, want)
+	}
+	if want := now.Add(9 * time.Minute).Unix(); claims.Exp != want {
+		t.Errorf("exp = %d, want %d", claims.Exp, want)
+	}
+}
+
+func TestMintInstallationToken(t *testing.T) {
+	key := testKey(t)
+
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/app/installations/678/access_tokens" {
+				t.Errorf("unexpected path %q", r.URL.Path)
+			}
+			if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+				t.Errorf("missing bearer auth, got %q", auth)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"ghs_faketoken"}`))
+		}))
+		defer srv.Close()
+
+		token, err := MintInstallationToken(context.Background(), AppTokenInputs{
+			AppID:          "12345",
+			InstallationID: "678",
+			PEM:            pkcs1PEM(t, key),
+			APIBaseURL:     srv.URL,
+		})
+		if err != nil {
+			t.Fatalf("MintInstallationToken: %v", err)
+		}
+		if token != "ghs_faketoken" {
+			t.Errorf("token = %q, want ghs_faketoken", token)
+		}
+	})
+
+	t.Run("http error surfaces body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"bad creds"}`))
+		}))
+		defer srv.Close()
+
+		_, err := MintInstallationToken(context.Background(), AppTokenInputs{
+			AppID:          "12345",
+			InstallationID: "678",
+			PEM:            pkcs1PEM(t, key),
+			APIBaseURL:     srv.URL,
+		})
+		if err == nil || !strings.Contains(err.Error(), "bad creds") {
+			t.Fatalf("expected error containing response body, got %v", err)
+		}
+	})
+
+	t.Run("missing inputs", func(t *testing.T) {
+		_, err := MintInstallationToken(context.Background(), AppTokenInputs{})
+		if err == nil {
+			t.Fatal("expected error for empty inputs")
+		}
+	})
+}

--- a/scripts/release/publish-openshift-bundles-to-rh.sh
+++ b/scripts/release/publish-openshift-bundles-to-rh.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # Publishes the OpenShift OLM bundle to the RedHat operator repositories.
 #
-# It downloads the unified certified bundle tarball (produced and uploaded by the
+# It downloads the unified bundle tarball (produced and uploaded by the
 # prepare_and_upload_openshift_bundles Evergreen task) and, for each RedHat fork,
 # pushes a branch containing the bundle laid out under operators/<package>/<version>/.
+#
 # It intentionally does NOT open the pull requests: it prints the "create PR" URLs and
 # the manual review checklist so a human can raise the DRAFT PRs and drive the review.
 #
-# The same certified bundle is used for both the certified-operators and the
+# The same bundle is used for both the certified-operators and the
 # community-operators repositories (the file contents are identical between them).
+# The "certified" term is used in the tarball file for historical reasons.
 #
 # Usage (runnable standalone from a CLI or from Evergreen):
 #   GH_TOKEN=<token-with-write-to-forks> VERSION=1.3.0 RH_DRYRUN=true \

--- a/scripts/release/publish-openshift-bundles-to-rh.sh
+++ b/scripts/release/publish-openshift-bundles-to-rh.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Publishes the OpenShift OLM bundle to the RedHat operator repositories.
+#
+# It downloads the unified certified bundle tarball (produced and uploaded by the
+# prepare_and_upload_openshift_bundles Evergreen task) and, for each RedHat fork,
+# pushes a branch containing the bundle laid out under operators/<package>/<version>/.
+# It intentionally does NOT open the pull requests: it prints the "create PR" URLs and
+# the manual review checklist so a human can raise the DRAFT PRs and drive the review.
+#
+# The same certified bundle is used for both the certified-operators and the
+# community-operators repositories (the file contents are identical between them).
+#
+# Usage (runnable standalone from a CLI or from Evergreen):
+#   GH_TOKEN=<token-with-write-to-forks> VERSION=1.3.0 RH_DRYRUN=true \
+#     scripts/release/publish-openshift-bundles-to-rh.sh
+#
+# Environment:
+#   GH_TOKEN    (optional) token with write access to the mongodb-forks repos. If unset, it is
+#               resolved in order from: 1) the gh CLI's cached login (`gh auth token`), then
+#               2) minting a fresh installation token from a dedicated GitHub App via
+#               `scripts/mckci github app-token` (see RH_GH_APP_* below). If none of these
+#               resolve a token, the script falls back to ambient git credentials.
+#   RH_GH_APP_ID                (required for App-token fallback) GitHub App ID.
+#   RH_GH_APP_INSTALLATION_ID   (required for App-token fallback) installation ID for the app
+#                                on the mongodb-forks org.
+#   RH_GH_APP_PEM_B64           (required for App-token fallback) base64-encoded PEM private
+#                                key for the app. In Evergreen this comes from the Private
+#                                project variable `rh_gh_app_pem_b64`.
+#   VERSION     (optional) operator version; defaults to .mongodbOperator in release.json.
+#   RH_DRYRUN   (optional) "true" (default) performs a --dry-run push; "false" pushes.
+#   S3_BUNDLES_URL (optional) base URL of the bundles bucket.
+#   PACKAGE     (optional) operator package dir name; defaults to mongodb-kubernetes.
+
+set -Eeou pipefail
+# Opt-in command tracing for debugging: MDB_DEBUG=1
+test "${MDB_DEBUG:-0}" -eq 1 && set -x
+
+VERSION="${VERSION:-$(jq -r .mongodbOperator < release.json)}"
+RH_DRYRUN="${RH_DRYRUN:-true}"
+PACKAGE="${PACKAGE:-mongodb-kubernetes}"
+S3_BUNDLES_URL="${S3_BUNDLES_URL:-https://operator-e2e-bundles.s3.amazonaws.com/bundles}"
+
+# GH_TOKEN is optional: if unset we fall back, in order, to 1) the gh CLI token (if available),
+# 2) minting a fresh installation token from a dedicated GitHub App (see RH_GH_APP_* below), and
+# ultimately to the ambient git credentials (credential helper / cached login). This keeps
+# the script usable from a logged-in CLI while still accepting an explicit token in Evergreen.
+GH_TOKEN="${GH_TOKEN:-}"
+if [[ -z "${GH_TOKEN}" ]] && command -v gh >/dev/null 2>&1; then
+  GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
+RH_GH_APP_ID="${RH_GH_APP_ID:-}"
+RH_GH_APP_INSTALLATION_ID="${RH_GH_APP_INSTALLATION_ID:-}"
+RH_GH_APP_PEM_B64="${RH_GH_APP_PEM_B64:-}"
+if [[ -z "${GH_TOKEN}" && -n "${RH_GH_APP_PEM_B64}" ]]; then
+  GH_TOKEN="$(scripts/mckci github app-token \
+    --app-id "${RH_GH_APP_ID}" \
+    --installation-id "${RH_GH_APP_INSTALLATION_ID}" \
+    --pem-base64 "${RH_GH_APP_PEM_B64}")"
+fi
+if [[ -z "${VERSION}" || "${VERSION}" == "null" ]]; then
+  echo "could not determine VERSION (pass VERSION or ensure release.json has .mongodbOperator)"
+  exit 1
+fi
+
+branch="mongodb-kubernetes-${VERSION}"
+bundle_file="mck-operator-certified-${VERSION}.tgz"
+
+# Each mongodb-forks repo and its upstream owner ("repo owner"). The same bundle is published
+# to both. A plain indexed array is used for portability (macOS ships bash 3.2, which has no
+# associative arrays).
+REPO_UPSTREAMS=(
+  "certified-operators redhat-openshift-ecosystem"
+  "community-operators k8s-operatorhub"
+)
+
+# On a dry run we keep the workdir so the prepared checkouts/branches can be inspected;
+# on a real run we clean up. Override with KEEP_WORKDIR=true/false.
+workdir="$(mktemp -d)"
+echo "Workdir: ${workdir}"
+if [[ "${RH_DRYRUN}" == "false" ]]; then
+  KEEP_WORKDIR="${KEEP_WORKDIR:-false}"
+else
+  KEEP_WORKDIR="${KEEP_WORKDIR:-true}"
+fi
+cleanup() {
+  if [[ "${KEEP_WORKDIR}" == "false" ]]; then
+    rm -rf "${workdir}"
+  else
+    echo "Workdir kept for inspection: ${workdir}"
+  fi
+}
+trap cleanup EXIT
+
+echo "Downloading ${bundle_file} from ${S3_BUNDLES_URL}"
+curl -fsSL "${S3_BUNDLES_URL}/${bundle_file}" -o "${workdir}/${bundle_file}"
+
+# The tarball contains ./bundle/<version>/{bundle.Dockerfile,manifests,metadata,...}.
+tar -xzf "${workdir}/${bundle_file}" -C "${workdir}"
+bundle_src="${workdir}/bundle/${VERSION}"
+if [[ ! -d "${bundle_src}" ]]; then
+  echo "unexpected tarball layout: ${bundle_src} not found after extracting ${bundle_file}"
+  exit 1
+fi
+
+# Prepares (and, unless dry-run, pushes) the branch for a single fork.
+publish_repo() {
+  local repo="$1" owner="$2"
+  local repo_dir="${workdir}/${repo}"
+  local clone_url
+
+  if [[ -n "${GH_TOKEN}" ]]; then
+    clone_url="https://x-access-token:${GH_TOKEN}@github.com/mongodb-forks/${repo}.git"
+  else
+    # No explicit token: rely on ambient git credentials (credential helper / cached login).
+    clone_url="https://github.com/mongodb-forks/${repo}.git"
+  fi
+  git clone "${clone_url}" "${repo_dir}"
+  git -C "${repo_dir}" remote add upstream "https://github.com/${owner}/${repo}.git"
+  git -C "${repo_dir}" fetch upstream
+  git -C "${repo_dir}" checkout -B "${branch}" upstream/main
+
+  # Lay the bundle into the RedHat repo layout: operators/<package>/<version>/.
+  local dest="${repo_dir}/operators/${PACKAGE}/${VERSION}"
+  mkdir -p "$(dirname "${dest}")"
+  rm -rf "${dest}"
+  cp -r "${bundle_src}" "${dest}"
+
+  git -C "${repo_dir}" add "operators/${PACKAGE}/${VERSION}"
+  git -C "${repo_dir}" commit --quiet --signoff -m "operator ${PACKAGE} (${VERSION})"
+
+  if [[ "${RH_DRYRUN}" == "false" ]]; then
+    git -C "${repo_dir}" push -fu origin "${branch}"
+  else
+    echo "RH_DRYRUN=${RH_DRYRUN}: skipping push (branch prepared locally at ${repo_dir})"
+  fi
+}
+
+pr_urls=()
+failed=()
+for entry in "${REPO_UPSTREAMS[@]}"; do
+  # shellcheck disable=SC2086
+  set -- ${entry}
+  repo="$1"
+  owner="$2"
+
+  echo "=== ${repo} (upstream: ${owner}/${repo}) ==="
+  # Attempt every repo even if a previous one failed, so one broken fork does not hide the rest.
+  if publish_repo "${repo}" "${owner}"; then
+    # Cross-fork compare link: opens the upstream PR form pre-filled from our fork branch.
+    pr_urls+=("https://github.com/${owner}/${repo}/compare/main...mongodb-forks:${repo}:${branch}?expand=1")
+  else
+    echo "FAILED preparing ${repo} (see error above)"
+    failed+=("${repo}")
+  fi
+done
+
+echo
+if [[ ${#pr_urls[@]} -gt 0 ]]; then
+  echo "Release branches prepared (RH_DRYRUN=${RH_DRYRUN})."
+  echo "Click the links below to open the upstream PR (mark it as a DRAFT), then ask the team"
+  echo "for a quick look; certified merges on green CI, community may need a close/re-open:"
+  for url in "${pr_urls[@]}"; do
+    echo "  ${url}"
+  done
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+  echo
+  echo "The following repos failed: ${failed[*]}"
+  exit 1
+fi


### PR DESCRIPTION
# Summary

Add scripts/release/publish-openshift-bundles-to-rh.sh:
- Downloads the certified OLM bundle from S3
- Prepares/pushes a branch on the mongodb-forks certified-operators and community-operators repos
- Prints the upstream PR links (PR creation stays manual).

Wire it into Evergreen via a new publish_openshift_bundles_to_rh func, task, and variant using github.generate_token.

## Proof of Work

CI must pass.

✅ Local run passes


```shell
% KEEP_WORKDIR=true VERSION=1.8.1 RH_DRYRUN=true scripts/release/publish-openshift-bundles-to-rh.sh
...
Click the links below to open the upstream PR (mark it as a DRAFT), then ask the team
for a quick look; certified merges on green CI, community may need a close/re-open:
  https://github.com/redhat-openshift-ecosystem/certified-operators/compare/main...mongodb-forks:certified-operators:mongodb-kubernetes-1.8.1?expand=1
  https://github.com/k8s-operatorhub/community-operators/compare/main...mongodb-forks:community-operators:mongodb-kubernetes-1.8.1?expand=1
Workdir kept for inspection: /var/folders/8g/h28ztw4j64x4msqcmg4p9t0h0000gp/T/tmp.GbC0n9rGUb
```


## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
