### PR TITLE
CLOUD 407997: Add release process to publish artifacts from staging to release MCK

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -967,6 +967,45 @@ functions:
           unzip -u macos-notary.zip
           chmod 755 ./linux_amd64/macnotary
 
+  # Strips the "old-"/"new-" trigger-tag prefix (see .evergreen.yml
+  # git_tag_aliases) and publishes the bare version as the RELEASE_VERSION
+  # expansion, for tasks that need the real version rather than the literal
+  # trigger tag. A no-op (identity) for any other triggered_by_git_tag shape.
+  compute_release_version:
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        shell: bash
+        script: |
+          set -e
+          VERSION="${triggered_by_git_tag}"
+          VERSION="${VERSION#old-}"
+          VERSION="${VERSION#new-}"
+          echo "RELEASE_VERSION: ${VERSION}" > release_version_expansion.yaml
+    - command: expansions.update
+      params:
+        file: src/github.com/mongodb/mongodb-kubernetes/release_version_expansion.yaml
+
+  # Strips the trigger-tag prefix (${prefix}), pushes bare "X.Y.Z" at the
+  # triggering commit, and deletes the trigger tag. Runs after the release
+  # pipeline succeeds; "X.Y.Z" is not itself a git_tag_aliases trigger.
+  push_release_tag:
+    - command: github.generate_token
+      params:
+        expansion_name: GH_TOKEN
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        include_expansions_in_env:
+          - GH_TOKEN
+          - triggered_by_git_tag
+          - revision
+        env:
+          GH_TOKEN: ${GH_TOKEN}
+        binary: scripts/evergreen/push_release_tag.sh ${prefix}
+
   create_chart_release_pr:
     - command: github.generate_token
       params:
@@ -982,7 +1021,7 @@ functions:
           - OPERATOR_VERSION
         env:
           GH_TOKEN: ${GH_TOKEN}
-        binary: scripts/dev/run_python.sh scripts/release/create_chart_release_pr.py --chart_version ${OPERATOR_VERSION|*triggered_by_git_tag}
+        binary: scripts/dev/run_python.sh scripts/release/create_chart_release_pr.py --chart_version ${OPERATOR_VERSION|*RELEASE_VERSION}
 
   add_releaseinfo_to_github_assets:
     - command: github.generate_token
@@ -996,7 +1035,7 @@ functions:
           - OPERATOR_VERSION
         env:
           GH_TOKEN: ${GH_TOKEN}
-        binary: scripts/dev/run_python.sh scripts/release/release_info.py --version ${OPERATOR_VERSION|*triggered_by_git_tag}
+        binary: scripts/dev/run_python.sh scripts/release/release_info.py --version ${OPERATOR_VERSION|*RELEASE_VERSION}
 
   release_kubectl_mongodb_plugin:
     - command: github.generate_token

--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -1,0 +1,181 @@
+# New release process, triggered by tags shaped "new-X.Y.Z" (see .evergreen.yml
+# git_tag_aliases). Unlike the legacy process (.evergreen-release.yml, deprecated),
+# this does not rebuild or retest images: it publishes the images already
+# promoted for the tagged commit (via the mainline mckci_release_promote task)
+# straight to production. Everything else the legacy process does that is NOT
+# an image rebuild/retest — preflight+submit, OpenShift bundle prep + RH
+# release branches, prerelease code snippet generation, chart release PR,
+# chart-to-OCI release, kubectl plugin release, and GitHub release info —
+# still runs here, gated on release_publish instead of on rebuilding images.
+include:
+  - filename: .evergreen-functions.yml
+
+tasks:
+  - name: mckci_release_publish_group
+    allowed_requesters: [ "patch", "github_tag" ]
+    commands:
+      - func: clone
+      - func: setup_building_host
+      - command: shell.exec
+        type: test
+        params:
+          shell: bash
+          working_dir: src/github.com/mongodb/mongodb-kubernetes
+          script: |
+            source .generated/context.export.env
+            scripts/mckci release publish group --commit "${revision}"
+
+  # Runs after the publish task succeeds: pushes the final "X.Y.Z" tag (which
+  # is not itself a trigger) and deletes "new-X.Y.Z".
+  - name: retag_new_release
+    commands:
+      - func: clone
+      - func: push_release_tag
+        vars:
+          prefix: "new-"
+
+buildvariants:
+  - name: release_publish
+    display_name: release_publish
+    tags: [ "release-publish" ]
+    run_on:
+      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
+    allowed_requesters: [ "patch", "github_tag" ]
+    tasks:
+      - name: mckci_release_publish_group
+
+  # Preflight/RH certification against the images just published to
+  # quay.io/mongodb/*:{version} — reuses the task defined in
+  # .evergreen-release.yml (globally available once both files are included
+  # by .evergreen.yml). No rebuild: preflight only reads existing images.
+  - name: preflight_released_images
+    display_name: preflight_released_images
+    tags: [ "release-publish" ]
+    run_on:
+      - rhel90-large
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: release_publish
+    expansions:
+      preflight_submit: true
+    tasks:
+      - name: preflight_release_operator_images_task_group
+
+  # Prepares the OpenShift bundle for this version if it doesn't already
+  # exist in S3 (see should_prepare_openshift_bundles.sh). No image rebuild:
+  # reads the version from release.json.
+  - name: prepare_openshift_bundles_publish
+    display_name: prepare_openshift_bundles_publish
+    tags: [ "release-publish" ]
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: release_publish
+      - name: "*"
+        variant: preflight_released_images
+    tasks:
+      - name: run_conditionally_prepare_and_upload_openshift_bundles
+
+  # Opens the draft PR against the Red Hat forks with the bundle prepared
+  # above. Human-reviewed, so github_tag only (not run on patches).
+  - name: prepare_openshift_bundles_to_rh
+    display_name: prepare_openshift_bundles_to_rh
+    tags: [ "release-publish" ]
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "github_tag" ]
+    depends_on:
+      - name: run_conditionally_prepare_and_upload_openshift_bundles
+        variant: prepare_openshift_bundles_publish
+    tasks:
+      - name: publish_openshift_bundles_to_rh
+
+  # Doc code-snippet generation against the images just published — this is
+  # generation, not testing: it deploys the operator using already-published
+  # images and captures snippet output for docs.
+  - name: prerelease_kind_code_snippets_publish
+    display_name: prerelease_kind_code_snippets_publish
+    tags: [ "release-publish", "prerelease_code_snippets" ]
+    run_on:
+      - ubuntu2404-large
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: release_publish
+    tasks:
+      - name: kind_code_snippets_task_group
+
+  - name: prerelease_gke_code_snippets_publish
+    display_name: prerelease_gke_code_snippets_publish
+    tags: [ "release-publish", "prerelease_code_snippets" ]
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: release_publish
+    tasks:
+      - name: gke_code_snippets_task_group
+
+  # File-copy + GitHub PR only; needs just the version string, no images.
+  - name: create_chart_release_pr_publish
+    display_name: create_chart_release_pr_publish
+    tags: [ "release-publish" ]
+    run_on:
+      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
+    allowed_requesters: [ "patch", "github_tag" ]
+    tasks:
+      - name: create_chart_release_pr
+
+  # helm package + push to OCI; gated on release_publish so the chart never
+  # references an operator image that hasn't been published yet.
+  - name: release_chart_to_oci_registry_publish
+    display_name: release_chart_to_oci_registry_publish
+    tags: [ "release-publish" ]
+    run_on:
+      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: release_publish
+    tasks:
+      - name: release_chart_to_oci_registry
+
+  # Publishes/notarizes the kubectl-mongodb plugin binary; needs only the
+  # version + already-published assets, no image rebuild.
+  - name: release_kubectl_mongodb_plugin_publish
+    display_name: release_kubectl_mongodb_plugin_publish
+    tags: [ "release-publish" ]
+    run_on:
+      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
+    allowed_requesters: [ "patch", "github_tag" ]
+    tasks:
+      - name: release_kubectl_mongodb_plugin
+
+  # Attaches release metadata to the GitHub release; version-only, no images.
+  - name: add_releaseinfo_to_github_assets_publish
+    display_name: add_releaseinfo_to_github_assets_publish
+    tags: [ "release-publish" ]
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "patch", "github_tag" ]
+    tasks:
+      - name: add_releaseinfo_to_github_assets
+
+  # Not tagged "release-publish" itself (it depends on every "release-publish"-
+  # tagged variant succeeding, which would otherwise create a self-dependency).
+  - name: retag_new_release
+    display_name: retag_new_release
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: ".release-publish"
+        status: "success"
+    tasks:
+      - name: retag_new_release
+

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -1,3 +1,18 @@
+# DEPRECATED: this is the legacy release process (rebuilds and retests every
+# image before publishing), triggered by tags shaped "old-X.Y.Z". It is kept
+# running alongside the new publish-only process (.evergreen-release-publish.yml,
+# triggered by "new-X.Y.Z") until the new process fully replaces it. Do not
+# add new functionality here — add it to the new process instead.
+#
+# Cleanup once retired:
+# 1. Delete this file; rename .evergreen-release-publish.yml to
+#    .evergreen-release.yml in its place.
+# 2. In .evergreen.yml: remove the "old-*" git_tag_aliases entry, remove the
+#    "deprecated-release" patch alias, remove this file from the include:
+#    block, and update the remaining git_tag_aliases entry/comment to point
+#    at the renamed file. Every buildvariant tagged "deprecated-release" in
+#    this file goes away with it — nothing tagged "deprecated-release" is
+#    used anywhere else, so there is nothing else to clean up.
 include:
   - filename: .evergreen-functions.yml
 
@@ -115,6 +130,7 @@ tasks:
   - name: add_releaseinfo_to_github_assets
     commands:
       - func: clone
+      - func: compute_release_version
       - func: python_venv
       - func: add_releaseinfo_to_github_assets
 
@@ -122,8 +138,18 @@ tasks:
     tags: [ "helm_chart_release_pr" ]
     commands:
       - func: clone
+      - func: compute_release_version
       - func: python_venv
       - func: create_chart_release_pr
+
+  # Runs after every task in a "deprecated-release"-tagged variant succeeds: pushes the
+  # final "X.Y.Z" tag (which is not itself a trigger) and deletes "old-X.Y.Z".
+  - name: retag_legacy_release
+    commands:
+      - func: clone
+      - func: push_release_tag
+        vars:
+          prefix: "old-"
 
   - name: release_chart_to_oci_registry
     tags: [ "release_chart_to_oci_registry" ]
@@ -140,7 +166,7 @@ buildvariants:
 
   - name: release_images
     display_name: release_images
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     allowed_requesters: [ "patch", "github_tag" ]
@@ -155,7 +181,7 @@ buildvariants:
 
   - name: add_releaseinfo_to_github_assets
     display_name: add_releaseinfo_to_github_assets
-    tags: ["release"]
+    tags: ["deprecated-release"]
     run_on:
       - ubuntu2404-small
     allowed_requesters: ["patch", "github_tag"]
@@ -168,7 +194,7 @@ buildvariants:
   # Preflight on git tag: images built in release_images (+ enterprise server on Quay). OM/agent preflight runs on master (see preflight_om_and_agents variant).
   - name: preflight_release_images
     display_name: preflight_release_images
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - rhel90-large
     allowed_requesters: [ "patch", "github_tag" ]
@@ -194,7 +220,7 @@ buildvariants:
 
   - name: prepare_openshift_bundles
     display_name: prepare_openshift_bundles
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - ubuntu2404-small
     allowed_requesters: [ "patch", "github_tag" ]
@@ -211,7 +237,7 @@ buildvariants:
   # are draft + human-reviewed so we do not auto-chain it after every release build.
   - name: publish_openshift_bundles_to_rh
     display_name: publish_openshift_bundles_to_rh
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - ubuntu2404-small
     allowed_requesters: [ "github_tag" ]
@@ -223,7 +249,7 @@ buildvariants:
 
   - name: prerelease_kind_code_snippets
     display_name: prerelease_kind_code_snippets
-    tags: [ "release", "prerelease_code_snippets" ]
+    tags: [ "deprecated-release", "prerelease_code_snippets" ]
     run_on:
       - ubuntu2404-large
     allowed_requesters: [ "patch", "github_tag" ]
@@ -236,7 +262,7 @@ buildvariants:
 
   - name: prerelease_gke_code_snippets
     display_name: prerelease_gke_code_snippets
-    tags: [ "release", "prerelease_code_snippets" ]
+    tags: [ "deprecated-release", "prerelease_code_snippets" ]
     run_on:
       - ubuntu2404-small
     allowed_requesters: ["patch", "github_tag"]
@@ -249,7 +275,7 @@ buildvariants:
 
   - name: init_test_run_release
     display_name: init_test_run
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     allowed_requesters: [ "patch", "github_tag" ]
@@ -264,7 +290,7 @@ buildvariants:
   - name: init_smoke_tests_ibm_power_release
     display_name: init_smoke_tests_ibm_power
     max_hosts: -1
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - release-rhel9-power-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
       - release-rhel9-power-large # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
@@ -280,7 +306,7 @@ buildvariants:
   - name: init_smoke_tests_ibm_z_release
     display_name: init_smoke_tests_ibm_z
     max_hosts: -1
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - release-rhel9-zseries-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
       - release-rhel9-zseries-large # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
@@ -296,7 +322,7 @@ buildvariants:
   - name: init_smoke_tests_arm_release
     display_name: init_smoke_tests_arm
     max_hosts: -1
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     allowed_requesters: [ "patch", "github_tag" ]
@@ -310,7 +336,7 @@ buildvariants:
 
   - name: e2e_smoke_release
     display_name: e2e_smoke
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - ubuntu2404-large
     allowed_requesters: [ "patch", "github_tag" ]
@@ -324,7 +350,7 @@ buildvariants:
 
   - name: e2e_static_smoke_release
     display_name: e2e_static_smoke
-    tags: [ "release", "e2e_smoke_release_test_suite", "static" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite", "static" ]
     run_on:
       - ubuntu2404-large
     allowed_requesters: [ "patch", "github_tag" ]
@@ -338,7 +364,7 @@ buildvariants:
 
   - name: e2e_smoke_ibm_power_release
     display_name: e2e_smoke_ibm_power
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - rhel9-power-small
       - rhel9-power-large
@@ -353,7 +379,7 @@ buildvariants:
 
   - name: e2e_static_smoke_ibm_power_release
     display_name: e2e_static_smoke_ibm_power
-    tags: [ "release", "e2e_smoke_release_test_suite", "static" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite", "static" ]
     run_on:
       - rhel9-power-small
       - rhel9-power-large
@@ -368,7 +394,7 @@ buildvariants:
 
   - name: e2e_smoke_ibm_z_release
     display_name: e2e_smoke_ibm_z
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
@@ -383,7 +409,7 @@ buildvariants:
 
   - name: e2e_static_smoke_ibm_z_release
     display_name: e2e_static_smoke_ibm_z
-    tags: [ "release", "e2e_smoke_release_test_suite", "static" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite", "static" ]
     run_on:
       - rhel9-zseries-small
       - rhel9-zseries-large
@@ -398,7 +424,7 @@ buildvariants:
 
   - name: e2e_smoke_arm_release
     display_name: e2e_smoke_arm
-    tags: [ "release", "e2e_smoke_release_test_suite" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite" ]
     run_on:
       - ubuntu2404-arm64-large
     allowed_requesters: [ "patch", "github_tag" ]
@@ -412,7 +438,7 @@ buildvariants:
 
   - name: e2e_static_smoke_arm_release
     display_name: e2e_static_smoke_arm
-    tags: [ "release", "e2e_smoke_release_test_suite", "static" ]
+    tags: [ "deprecated-release", "e2e_smoke_release_test_suite", "static" ]
     run_on:
       - ubuntu2404-arm64-large
     allowed_requesters: [ "patch", "github_tag" ]
@@ -426,7 +452,7 @@ buildvariants:
 
   - name: release_kubectl_mongodb_plugin
     display_name: release_kubectl_mongodb_plugin
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     allowed_requesters: [ "patch", "github_tag" ]
@@ -435,7 +461,7 @@ buildvariants:
 
   - name: create_chart_release_pr
     display_name: create_chart_release_pr
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     allowed_requesters: [ "patch", "github_tag" ]
@@ -444,7 +470,7 @@ buildvariants:
 
   - name: release_chart_to_oci_registry
     display_name: release_chart_to_oci_registry
-    tags: [ "release" ]
+    tags: [ "deprecated-release" ]
     run_on:
       - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
     allowed_requesters: [ "patch", "github_tag" ]
@@ -458,3 +484,17 @@ buildvariants:
         patch_optional: true
     tasks:
       - name: release_chart_to_oci_registry
+
+  # Not tagged "deprecated-release" itself (it depends on every "deprecated-release"-tagged variant
+  # succeeding, which would otherwise create a self-dependency).
+  - name: retag_legacy_release
+    display_name: retag_legacy_release
+    run_on:
+      - ubuntu2404-small
+    allowed_requesters: [ "patch", "github_tag" ]
+    depends_on:
+      - name: "*"
+        variant: ".deprecated-release"
+        status: "success"
+    tasks:
+      - name: retag_legacy_release

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -20,6 +20,7 @@ include:
   - filename: .evergreen-mco.yml
   - filename: .evergreen-snippets.yml
   - filename: .evergreen-release.yml
+  - filename: .evergreen-release-publish.yml
 
 variables:
   # NOTE: This is a denylist to prevent missing changes that shoudl trigger e2e.
@@ -253,8 +254,11 @@ patch_aliases:
   - alias: "patch-run-cloudqa"
     variant_tags: [ "cloudqa_non_static" ]
     task: ".*"
-  - alias: "release"
-    variant_tags: [ "release" ]
+  - alias: "deprecated-release"
+    variant_tags: [ "deprecated-release" ]
+    task: ".*"
+  - alias: "release-publish"
+    variant_tags: [ "release-publish" ]
     task: ".*"
   - alias: "preflight_release_test"
     description: "Release-style preflight only (no image release, no Pyxis submit); patch-only. See EVERGREEN.md."
@@ -292,10 +296,19 @@ github_checks_aliases:
   - variant: ".*"
     task: ".*"
 
-# Triggered on git tag
+# Triggered on git tag. The plain "X.Y.Z" shape is intentionally NOT a trigger:
+# it's applied by the release pipelines themselves as the final, human-facing
+# tag once their trigger tag's pipeline succeeds, and must not re-trigger anything.
 git_tag_aliases:
-  - git_tag: "^(\\d+\\.)?(\\d+\\.)?(\\d+)$"
-    variant_tags: [ "release" ]
+  # Legacy process (deprecated, still supported): rebuilds and retests images
+  # before publishing. See .evergreen-release.yml.
+  - git_tag: "^old-(\\d+\\.)?(\\d+\\.)?(\\d+)$"
+    variant_tags: [ "deprecated-release" ]
+    task: ".*"
+  # New process: publishes the already-promoted images for the given commit
+  # without rebuilding or retesting. See .evergreen-release-publish.yml.
+  - git_tag: "^new-(\\d+\\.)?(\\d+\\.)?(\\d+)$"
+    variant_tags: [ "release-publish" ]
     task: ".*"
 
 tasks:

--- a/.github/workflows/deprecated-release.yml
+++ b/.github/workflows/deprecated-release.yml
@@ -1,0 +1,90 @@
+# DEPRECATED: legacy release process (rebuilds and retests before publishing).
+# To be deleted soon
+#
+# Pushes an "old-X.Y.Z" tag, which Evergreen's git_tag_aliases (.evergreen.yml)
+# routes to the legacy pipeline (.evergreen-release.yml).
+# That pipeline's own retag_legacy_release task also pushes the final "X.Y.Z"
+name: Deprecated Legacy Release MCK version (slow with rebuild and retesting)
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'SHA of the commit to release'
+        type: string
+        required: true
+      version:
+        description: 'Version to release'
+        required: true
+        type: string
+
+jobs:
+  crate_draft_release_notes:
+    name: Create draft release with Release Notes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: '0'
+      - name: Setup host
+        uses: ./.github/actions/setup-ubuntu-host
+        with:
+          python-version: '${{ vars.PYTHON_VERSION }}'
+      - name: Generate Release Notes
+        id: generate_release_notes
+        run: python -m scripts.release.release_notes -s $INITIAL_COMMIT_SHA -v $INITIAL_VERSION -o release_notes_final.md
+        env:
+          INITIAL_COMMIT_SHA: ${{ vars.RELEASE_INITIAL_COMMIT_SHA }}
+          INITIAL_VERSION: ${{ vars.RELEASE_INITIAL_VERSION }}
+      - name: Generate draft release
+        run: |
+          gh release create $VERSION --target $COMMIT_SHA --draft --latest --notes-file release_notes_final.md --title "Release of MCK $VERSION"
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  approve_release:
+    name: Create Git Tag + start Evergreen jobs
+    environment: production
+    runs-on: ubuntu-latest
+    needs: crate_draft_release_notes
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: '0'
+      - name: Create git tag
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "old-$VERSION" -m "Release of MCK $VERSION" $COMMIT_SHA
+          git push origin "old-$VERSION"
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish_release:
+    name: Publish Release
+    environment: production
+    runs-on: ubuntu-latest
+    needs: approve_release
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: '0'
+      - name: Publish Release Notes
+        run: |
+          gh release edit $VERSION --draft=false --verify-tag --latest
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,32 @@
-name: Release MCK version
+# Release process: publishes the images already promoted for a given commit
+#
+# Pushes a "new-X.Y.Z" tag, which Evergreen's git_tag_aliases (.evergreen.yml)
+# routes to the publish-only pipeline (.evergreen-release-publish.yml).
+name: Release MCK version (publish-only)
+
+permissions:
+  contents: read
+  checks: read
 
 on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: 'SHA of the commit to release'
+        description: 'Commit hash of the promoted commit to release. Must have a corresponding promoted-{commit}-{version} tag in the staging registry.'
         type: string
         required: true
       version:
-        description: 'Version to release'
+        description: 'Expected release version implied by the given commit (version at release.json .mongodbOperator field). The release fails if they do not match.'
         required: true
         type: string
 
 jobs:
-  crate_draft_release_notes:
-    name: Create draft release with Release Notes
+  create_tag_and_draft_release:
+    name: Create Draft Release & Push Tag
     runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.verify_release_commit.outputs.commit }}
+      version: ${{ steps.verify_release_commit.outputs.version }}
     permissions:
       contents: write
     steps:
@@ -23,52 +34,99 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: '0'
+
       - name: Setup host
         uses: ./.github/actions/setup-ubuntu-host
         with:
           python-version: '${{ vars.PYTHON_VERSION }}'
+
+      - name: Log in to quay.io (staging)
+        run: scripts/release/quay_staging_login.sh
+        env:
+          QUAY_STAGING_USERNAME: ${{ secrets.QUAY_STAGING_USERNAME }}
+          QUAY_STAGING_PASSWORD: ${{ secrets.QUAY_STAGING_ROBOT_TOKEN }}
+
+      - name: Verify Release Commit
+        id: verify_release_commit
+        run: |
+          output=$(scripts/evergreen/release/verify_release_commit.sh \
+            --commit "${{ github.event.inputs.commit_sha }}" \
+            --version "${{ github.event.inputs.version }}")
+          echo "$output" | while IFS= read -r line; do
+            echo "$line" >> "$GITHUB_OUTPUT"
+          done
+
       - name: Generate Release Notes
         id: generate_release_notes
         run: python -m scripts.release.release_notes -s $INITIAL_COMMIT_SHA -v $INITIAL_VERSION -o release_notes_final.md
         env:
           INITIAL_COMMIT_SHA: ${{ vars.RELEASE_INITIAL_COMMIT_SHA }}
           INITIAL_VERSION: ${{ vars.RELEASE_INITIAL_VERSION }}
+
       - name: Generate draft release
         run: |
           gh release create $VERSION --target $COMMIT_SHA --draft --latest --notes-file release_notes_final.md --title "Release of MCK $VERSION"
         env:
-          VERSION: ${{ github.event.inputs.version }}
-          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+          VERSION: ${{ steps.verify_release_commit.outputs.version }}
+          COMMIT_SHA: ${{ steps.verify_release_commit.outputs.commit }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  approve_release:
-    name: Create Git Tag + start Evergreen jobs
-    environment: production
-    runs-on: ubuntu-latest
-    needs: crate_draft_release_notes
-    permissions:
-      contents: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: '0'
       - name: Create git tag
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git tag -a $VERSION -m "Release of MCK $VERSION" $COMMIT_SHA
-          git push origin $VERSION
+          git tag -a "new-$VERSION" -m "Release of MCK $VERSION" $COMMIT_SHA
+          git push origin "new-$VERSION"
         env:
-          VERSION: ${{ github.event.inputs.version }}
-          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+          VERSION: ${{ steps.verify_release_commit.outputs.version }}
+          COMMIT_SHA: ${{ steps.verify_release_commit.outputs.commit }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  wait_for_evergreen_and_prep_pr:
+    name: Wait for Evergreen & Synthesize PR Link
+    runs-on: ubuntu-latest
+    needs: create_tag_and_draft_release
+    permissions:
+      contents: read
+      checks: read
+    steps:
+      - name: Wait for Evergreen build to complete
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
+        id: wait_for_evg
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "evergreen" # Ensure this matches the status check context EVG posts
+          ref: ${{ needs.create_tag_and_draft_release.outputs.commit }}
+          timeoutSeconds: 1800
+          intervalSeconds: 30
+
+      - name: Fail if Evergreen failed
+        if: steps.wait_for_evg.outputs.conclusion != 'success'
+        run: |
+          echo "Evergreen publish pipeline failed or timed out!"
+          exit 1
+
+      - name: Generate RedHat PR Links in Job Summary
+        run: |
+          RH_FORK_ORG="mongodb-forks"
+          COMMUNITY_REPO="community-operators"
+          CERTIFIED_REPO="certified-operators"
+          VERSION="${{ needs.create_tag_and_draft_release.outputs.version }}"
+          RH_BRANCH="mck-release-${VERSION}"
+
+          COMMUNITY_PR_CREATION_URL="https://github.com/k8s-operatorhub/community-operators/compare/main...${RH_FORK_ORG}:${COMMUNITY_REPO}:${RH_BRANCH}?quick_pull=1"
+          CERTIFIED_PR_CREATION_URL="https://github.com/redhat-openshift-ecosystem/certified-operators/compare/main...${RH_FORK_ORG}:${CERTIFIED_REPO}:${RH_BRANCH}?quick_pull=1"
+          echo "## 🚀 Evergreen Finished: RedHat PR Ready" >> $GITHUB_STEP_SUMMARY
+          echo "Evergreen successfully created the release branches on the RedHat fork." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "👉 **[Click here to create the RedHat Community Operators PR](${COMMUNITY_PR_CREATION_URL})**" >> $GITHUB_STEP_SUMMARY
+          echo "👉 **[Click here to createi the RedHat Certified Operators PR](${CERTIFIED_PR_CREATION_URL})**" >> $GITHUB_STEP_SUMMARY
 
   publish_release:
     name: Publish Release
-    environment: production
+    environment: production # Manual gate
     runs-on: ubuntu-latest
-    needs: approve_release
+    needs: wait_for_evergreen_and_prep_pr
     permissions:
       contents: write
     steps:
@@ -76,9 +134,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: '0'
+
       - name: Publish Release Notes
         run: |
           gh release edit $VERSION --draft=false --verify-tag --latest
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ needs.create_tag_and_draft_release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/EVERGREEN.md
+++ b/EVERGREEN.md
@@ -3,7 +3,8 @@
 Each variant needs to be tagged with one or more tags referencing related build scenario:
  - pr_patch: for patches created by GitHub PRs
  - staging: for builds triggered when merging to master or release branch
- - release: for builds triggered on git tags
+ - deprecated-release: legacy release process (rebuilds/retests everything), triggered by "old-X.Y.Z" git tags. To be removed soon — see .evergreen-release.yml.
+ - release-publish: new release process (publish-only, no rebuild/retest), triggered by "new-X.Y.Z" git tags. See .evergreen-release-publish.yml.
 
 For variants that are **only** triggered manually (patch) or by PCT we should use "manual_patch" tag.
 Examples: `migrate_all_agents`, `e2e_operator_perf` or `publish_om80_images`.
@@ -36,10 +37,20 @@ evergreen patch -p mongodb-kubernetes -a pr_patch -d "Test PR patch build" -f -y
 evergreen patch -p mongodb-kubernetes -a staging -d "Test staging build" -f -y -u --path .evergreen.yml --param BUILD_SCENARIO=staging
 ```
 
-### Release scenario:
+### Legacy release scenario (deprecated, to be removed soon):
+
+Rebuilds and retests every image before publishing. Triggered normally by pushing an "old-X.Y.Z" git tag; the command below runs the same variants via patch. See .evergreen-release.yml.
 
 ```shell
-evergreen patch -p mongodb-kubernetes -a release -d "Test release build" -f -y -u --path .evergreen.yml --param BUILD_SCENARIO=release --param OPERATOR_VERSION=1.3.0-rc
+evergreen patch -p mongodb-kubernetes -a deprecated-release -d "Test release build" -f -y -u --path .evergreen.yml --param BUILD_SCENARIO=release --param OPERATOR_VERSION=1.3.0-rc
+```
+
+### New release-publish scenario:
+
+Publishes already-promoted images straight to production — no rebuild, no retest. Triggered normally by pushing a "new-X.Y.Z" git tag; the command below runs the same variants via patch. See .evergreen-release-publish.yml.
+
+```shell
+evergreen patch -p mongodb-kubernetes -a release-publish -d "Test release-publish build" -f -y -u --path .evergreen.yml --param BUILD_SCENARIO=release --param OPERATOR_VERSION=1.3.0-rc
 ```
 
 ### Release-style preflight only (no image push, no Pyxis submit)

--- a/scripts/dev/contexts/evg-private-context
+++ b/scripts/dev/contexts/evg-private-context
@@ -77,7 +77,12 @@ export BUILD_ID="${build_id:-"unknown"}"
 export EXECUTION="${execution:-"unknown"}"
 export BUILD_VARIANT="${build_variant:-"unknown"}"
 export VERSION_ID="${version_id:-"unknown"}"
-export GIT_TAG="${triggered_by_git_tag:-}"
+# Strip the "old-"/"new-" release-trigger-tag prefix "new-" or "old-"
+# everything downstream expects GIT_TAG as "X.Y.Z" version
+GIT_TAG="${triggered_by_git_tag:-}"
+GIT_TAG="${GIT_TAG#old-}"
+GIT_TAG="${GIT_TAG#new-}"
+export GIT_TAG
 
 # var used in pipeline.py to determine if we're running on EVG host
 # used to discern between local pipeline image build and the build in pipeline

--- a/scripts/evergreen/push_release_tag.sh
+++ b/scripts/evergreen/push_release_tag.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Strips the trigger-tag prefix (old-/new-, see .evergreen.yml git_tag_aliases)
+# off triggered_by_git_tag, pushes bare "X.Y.Z" at the triggering commit, and
+# deletes the trigger tag. "X.Y.Z" is not itself a trigger, so this is safe.
+#
+# Usage: push_release_tag.sh <trigger-tag-prefix>
+# Expects GH_TOKEN, triggered_by_git_tag, and revision.
+
+set -Eeou pipefail
+
+prefix="${1:?usage: push_release_tag.sh <trigger-tag-prefix>}"
+trigger_tag="${triggered_by_git_tag:?triggered_by_git_tag is not set}"
+revision="${revision:?revision is not set}"
+
+version="${trigger_tag#"${prefix}"}"
+if [[ "${version}" == "${trigger_tag}" ]]; then
+  echo "triggered_by_git_tag '${trigger_tag}' does not start with expected prefix '${prefix}', aborting" >&2
+  exit 1
+fi
+
+remote="https://x-access-token:${GH_TOKEN:-}@github.com/mongodb/mongodb-kubernetes.git"
+
+git tag -a "${version}" -m "Release of MCK ${version}" "${revision}"
+git push "${remote}" "refs/tags/${version}"
+git push "${remote}" ":refs/tags/${trigger_tag}"
+

--- a/scripts/evergreen/release/verify_release_commit.sh
+++ b/scripts/evergreen/release/verify_release_commit.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Verify a promoted commit+version pair; emits commit=<sha> version=<ver> on stdout.
+# Usage: verify_release_commit.sh --commit <sha> --version <ver> [--staging-repo <repo>]
+# All errors (with explanations) go to stderr; exit code 0 on success.
+
+set -Eeou pipefail
+
+staging_repo="${MCK_STAGING_REPO:-quay.io/mongodb/staging/mongodb-kubernetes}"
+commit_sha=""
+input_version=""
+
+usage() { echo "Usage: $(basename "$0") --commit <sha> --version <ver> [--staging-repo <repo>]" >&2; exit "${1:-1}"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --commit=*) commit_sha="${1#*=}" ;;
+    --commit) commit_sha="$2"; shift ;;
+    --version=*) input_version="${1#*=}" ;;
+    --version) input_version="$2"; shift ;;
+    --staging-repo=*) staging_repo="${1#*=}" ;;
+    --staging-repo) staging_repo="$2"; shift ;;
+    --help|-h) usage 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+  shift
+done
+
+: "${commit_sha:?--commit is required}"
+: "${input_version:?--version is required}"
+
+full_sha=$(git rev-parse "${commit_sha}" 2>/dev/null || true)
+if [[ -z "${full_sha}" ]]; then
+  echo "ERROR: could not resolve commit ${commit_sha} in the local repository. Is it a valid commit SHA and is your clone up to date (fetch-depth 0)?" >&2
+  exit 1
+fi
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+promoted_tag="promoted-${commit_sha}-${input_version}"
+if ! docker manifest inspect "${staging_repo}:${promoted_tag}" >/dev/null 2>&1; then
+  cat >&2 <<-EOF
+	ERROR: commit "${commit_sha}" is not promoted, please check if the merge can be fixed or the promotion can be enforced manually:
+	https://spruce.corp.mongodb.com/version/mongodb_kubernetes_${full_sha}/tasks
+	This usually means the commit was not promoted, most likely due to failed or flaky tests at merge time.
+	EOF
+  exit 1
+fi
+
+release_json_version=$(git show "${commit_sha}:release.json" 2>/dev/null | jq -r '.mongodbOperator' 2>/dev/null || true)
+if [[ -z "${release_json_version}" ]]; then
+  echo "ERROR: could not read release.json at commit ${commit_sha}: is the commit valid and is your local clone up to date (fetch-depth 0)?" >&2
+  exit 1
+fi
+
+if [[ "${release_json_version}" != "${input_version}" ]]; then
+  echo "ERROR: release.json at commit ${commit_sha} declares mongodbOperator=${release_json_version} but requested version is ${input_version}" >&2
+  exit 1
+fi
+
+echo "commit=${commit_sha}"
+echo "version=${input_version}"
+

--- a/scripts/release/release_om_and_agents.py
+++ b/scripts/release/release_om_and_agents.py
@@ -16,6 +16,7 @@ Usage:
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -183,6 +184,11 @@ def main():
     parser = argparse.ArgumentParser(description="Release all images on merge")
     parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
     args = parser.parse_args()
+
+    branch_name = os.environ.get("branch_name")
+    if branch_name != "master":
+        logger.info(f"Skipping release_om_and_agents: only runs on master (branch_name={branch_name})")
+        return 0
 
     release_data = load_release_json()
     ops_manager_mapping = get_ops_manager_mapping(release_data)


### PR DESCRIPTION
# Summary

This adds a new release process backed by the new promote/publish CI tooling that allows us to skip rebuilding and retesting at release time.

The new process just takes the promoted images from a tagged commit that was previously promoted, usually only after having passed all tests, and mimics the rest of the process except rebuilding and retesting images. Instead the promoted images are directly copied over to the official release registries.

The old release process is kept as deprecated. Will be removed once the new release process proves to be reliable.

Note that this change also changes the tigger tags from GH to Evergreen:
- The old release process now issues a tag such as `old-X.Y.Z`
- The new release process now issues a tag such as `new-X.Y.Z`
- Both processes tags the commit finally as `X.Y.Z`, which no longer triggers further actions.

Also includes the DX for the releaser to be ablr to create the PRs against RH, right after the evergreen automation has prepared the branches in `mongodb-forks`.

## Proof of Work

TBD

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
