### PR TITLE
CLOUDP-420747: Prepare CI to work on backport branches as well as master

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -2150,7 +2150,7 @@ buildvariants:
     tasks:
       - name: migrate_all_agents
 
-  # Runs on every merge to master and releases images auxiliary to the operator release like OM and the Agent
+  # Runs on every merge to master or a backporting branch and releases images auxiliary to the operator release like OM and the Agent
   - name: release_om_and_agents
     display_name: release_om_and_agents
     allowed_requesters: [ "patch" , "commit"]
@@ -2161,7 +2161,8 @@ buildvariants:
       - name: release_om_and_agents
 
   # Notification task - runs after all staging tasks complete to report build status.
-  # Runs after all staging tests (including GKE snippets) succeed on master merge.
+  # Runs after all staging tests (including GKE snippets) succeed on a merge to
+  # master or a backporting branch.
   # Only on commit builds — see DEVPROD-27436 note on notify_master_build_status below.
   - name: mckci_release_promote
     display_name: mckci_release_promote

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -2209,7 +2209,7 @@ buildvariants:
     tasks:
       - name: migrate_all_agents
 
-  # Runs on every merge to master and releases images auxiliary to the operator release like OM and the Agent
+  # Runs on every merge to master or a backporting branch and releases images auxiliary to the operator release like OM and the Agent
   - name: release_om_and_agents
     display_name: release_om_and_agents
     allowed_requesters: [ "patch" , "commit"]
@@ -2220,7 +2220,8 @@ buildvariants:
       - name: release_om_and_agents
 
   # Notification task - runs after all staging tasks complete to report build status.
-  # Runs after all staging tests (including GKE snippets) succeed on master merge.
+  # Runs after all staging tests (including GKE snippets) succeed on a merge to
+  # master or a backporting branch.
   # Only on commit builds — see DEVPROD-27436 note on notify_master_build_status below.
   - name: mckci_release_promote
     display_name: mckci_release_promote

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - master
+      - v*
   pull_request:
     branches:
       - master
       - release-*
+      - v*
     paths:
       - '**/*.go'
       - 'go.mod'

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - master
+      - release-v*
   pull_request:
     branches:
       - master
-      - release-*
+      - release-v*
     paths:
       - '**/*.go'
       - 'go.mod'

--- a/.github/workflows/preview_release_notes.yml
+++ b/.github/workflows/preview_release_notes.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - release-*
+      - v*
   pull_request:
     branches:
       - master
       - release-*
+      - v*
 
 jobs:
   preview_release_notes:
@@ -39,8 +41,10 @@ jobs:
           RELEASE_INITIAL_VERSION: ${{ env.RELEASE_INITIAL_VERSION }}
       - name: Add disclaimer to release notes preview for Pull Requests
         if: github.event_name == 'pull_request'
+        env:
+          TARGET_BASE_REF: ${{ github.base_ref }}
         run: |
-          echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current master branch)_\n" > release_notes_tmp.md
+          echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current $TARGET_BASE_REF branch)_\n" > release_notes_tmp.md
           cat release_notes_preview.md >> release_notes_tmp.md
           mv -f release_notes_tmp.md release_notes_preview.md
       - name: Summarize results

--- a/.github/workflows/preview_release_notes.yml
+++ b/.github/workflows/preview_release_notes.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - master
-      - release-*
+      - release-v*
   pull_request:
     branches:
       - master
-      - release-*
+      - release-v*
 
 jobs:
   preview_release_notes:
@@ -39,8 +39,10 @@ jobs:
           RELEASE_INITIAL_VERSION: ${{ env.RELEASE_INITIAL_VERSION }}
       - name: Add disclaimer to release notes preview for Pull Requests
         if: github.event_name == 'pull_request'
+        env:
+          TARGET_BASE_REF: ${{ github.base_ref }}
         run: |
-          echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current master branch)_\n" > release_notes_tmp.md
+          echo -e "_:warning: (this preview might not be accurate if the PR is not rebased on current $TARGET_BASE_REF branch)_\n" > release_notes_tmp.md
           cat release_notes_preview.md >> release_notes_tmp.md
           mv -f release_notes_tmp.md release_notes_preview.md
       - name: Summarize results

--- a/.github/workflows/require_changelog.yml
+++ b/.github/workflows/require_changelog.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release-*
+      - v*
     types:
       - opened
       - synchronize

--- a/.github/workflows/require_changelog.yml
+++ b/.github/workflows/require_changelog.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - release-*
+      - release-v*
     types:
       - opened
       - synchronize

--- a/scripts/check-ocp-version-drift.sh
+++ b/scripts/check-ocp-version-drift.sh
@@ -17,6 +17,9 @@
 #   REMOTE                 Git remote to push to and create the PR against.
 #                          Defaults to "origin".  Set to e.g. "mongodb" when
 #                          testing against an upstream remote from a fork.
+#   TARGET_BRANCH          Branch to base the update PR on and merge into.
+#                          Defaults to "master". Set to a backporting branch
+#                          (e.g. "v1") when running this check on that branch.
 #
 # Prerequisites (normal mode): oc (already logged in), jq, gh (authenticated via GH_TOKEN)
 # Prerequisites (dry-run + --actual-version): jq
@@ -27,6 +30,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONFIG_FILE="${CONFIG_FILE:-${PROJECT_ROOT}/kubernetes-versions.json}"
 REMOTE="${REMOTE:-origin}"
+TARGET_BRANCH="${TARGET_BRANCH:-master}"
 
 # --- argument parsing --------------------------------------------------------
 
@@ -125,8 +129,8 @@ create_update_pr() {
     local repo
     repo=$(remote_repo)
 
-    git fetch "${REMOTE}" master --quiet || die "git fetch ${REMOTE} master failed"
-    git checkout -b "${branch}" "${REMOTE}/master"
+    git fetch "${REMOTE}" "${TARGET_BRANCH}" --quiet || die "git fetch ${REMOTE} ${TARGET_BRANCH} failed"
+    git checkout -b "${branch}" "${REMOTE}/${TARGET_BRANCH}"
 
     local tmp
     tmp=$(mktemp)
@@ -157,7 +161,7 @@ recorded a different minor version.  This PR updates the file to match reality.
 - [ ] Verify the OpenShift CI tasks pass with the updated version.
 EOF
         )" \
-        --base master \
+        --base "${TARGET_BRANCH}" \
         --head "${branch}"
 }
 

--- a/scripts/check-ocp-version-drift.sh
+++ b/scripts/check-ocp-version-drift.sh
@@ -17,6 +17,10 @@
 #   REMOTE                 Git remote to push to and create the PR against.
 #                          Defaults to "origin".  Set to e.g. "mongodb" when
 #                          testing against an upstream remote from a fork.
+#   branch_name            Branch to base the update PR on and merge into
+#                          (Evergreen standard expansion; defaults to "master").
+#                          Set locally to e.g. "release-v1" when running on a
+#                          backporting branch.
 #
 # Prerequisites (normal mode): oc (already logged in), jq, gh (authenticated via GH_TOKEN)
 # Prerequisites (dry-run + --actual-version): jq
@@ -27,6 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONFIG_FILE="${CONFIG_FILE:-${PROJECT_ROOT}/kubernetes-versions.json}"
 REMOTE="${REMOTE:-origin}"
+BRANCH="${branch_name:-master}"
 
 # --- argument parsing --------------------------------------------------------
 
@@ -125,8 +130,8 @@ create_update_pr() {
     local repo
     repo=$(remote_repo)
 
-    git fetch "${REMOTE}" master --quiet || die "git fetch ${REMOTE} master failed"
-    git checkout -b "${branch}" "${REMOTE}/master"
+    git fetch "${REMOTE}" "${BRANCH}" --quiet || die "git fetch ${REMOTE} ${BRANCH} failed"
+    git checkout -b "${branch}" "${REMOTE}/${BRANCH}"
 
     local tmp
     tmp=$(mktemp)
@@ -157,7 +162,7 @@ recorded a different minor version.  This PR updates the file to match reality.
 - [ ] Verify the OpenShift CI tasks pass with the updated version.
 EOF
         )" \
-        --base master \
+        --base "${BRANCH}" \
         --head "${branch}"
 }
 

--- a/scripts/create-go-bump-pr.sh
+++ b/scripts/create-go-bump-pr.sh
@@ -21,6 +21,7 @@ fi
 version="${1#go}"
 branch="auto/bump-go-${version}"
 title="Bump Go version to ${version}"
+base_branch="${branch_name:-$(git rev-parse --abbrev-ref HEAD)}"
 
 if [[ "${TEST_BUMP_DRY_RUN:-}" == "1" ]]; then
   printf 'create-go-bump-pr: dry-run: would open PR "%s" from branch %s\n' "${title}" "${branch}"
@@ -61,5 +62,5 @@ bumps immediately (past Go's N-1 support window).
 - [ ] Review propagated version in Dockerfiles, `.tool-versions`, and secondary `go.mod` files
 EOF
   )" \
-  --base master \
+  --base "${base_branch}" \
   --head "${branch}"

--- a/scripts/create-go-bump-pr.sh
+++ b/scripts/create-go-bump-pr.sh
@@ -21,6 +21,11 @@ fi
 version="${1#go}"
 branch="auto/bump-go-${version}"
 title="Bump Go version to ${version}"
+if [ -n "${GITHUB_REF_NAME:-}" ]; then
+  base_branch="${GITHUB_REF_NAME}"
+else
+  base_branch="$(git rev-parse --abbrev-ref HEAD)"
+fi
 
 if [[ "${TEST_BUMP_DRY_RUN:-}" == "1" ]]; then
   printf 'create-go-bump-pr: dry-run: would open PR "%s" from branch %s\n' "${title}" "${branch}"
@@ -61,5 +66,5 @@ bumps immediately (past Go's N-1 support window).
 - [ ] Review propagated version in Dockerfiles, `.tool-versions`, and secondary `go.mod` files
 EOF
   )" \
-  --base master \
+  --base "${base_branch}" \
   --head "${branch}"

--- a/scripts/dev/contexts/evg-private-context
+++ b/scripts/dev/contexts/evg-private-context
@@ -118,6 +118,15 @@ fi
 echo "Setting BUILD_SCENARIO=${BUILD_SCENARIO}"
 export BUILD_SCENARIO="${BUILD_SCENARIO}"
 
+# Detect "test" branches, e.g. "release-v1-test", "release-v2-test" -- these simulate real backport branches
+# (e.g. "release-v1", "release-v2") for CI/CD testing purposes only, without affecting production registries.
+IS_TEST_BRANCH=false
+if [[ "${branch_name:-}" =~ ^release-v[0-9]+-test$ ]]; then
+  IS_TEST_BRANCH=true
+fi
+export IS_TEST_BRANCH
+echo "IS_TEST_BRANCH=${IS_TEST_BRANCH}"
+
 # Set REGISTRY and OPERATOR_VERSION, READINESS_PROBE_VERSION, VERSION_UPGRADE_HOOK_VERSION based on build scenario
 # REGISTRY and OPERATOR_VERSION, READINESS_PROBE_VERSION, VERSION_UPGRADE_HOOK_VERSION can be overridden externally if needed
 PATCH_REGISTRY="268558157000.dkr.ecr.us-east-1.amazonaws.com/dev"
@@ -135,6 +144,10 @@ case ${BUILD_SCENARIO} in
 
   "${BUILD_SCENARIO_STAGING}")
     COMMIT_SHA_SHORT=$(git rev-parse --short=8 HEAD)
+    if [ "${IS_TEST_BRANCH}" == "true" ]; then
+      REGISTRY="${REGISTRY:-${TEST_BRANCH_REGISTRY:-268558157000.dkr.ecr.us-east-1.amazonaws.com/test}}"
+      export FLAGS="${FLAGS:-} --registry ${REGISTRY}"
+    fi
     REGISTRY="${REGISTRY:-${STAGING_REGISTRY}}"
     OPERATOR_VERSION="${OPERATOR_VERSION:-${COMMIT_SHA_SHORT}}"
     READINESS_PROBE_VERSION="${READINESS_PROBE_VERSION:-${COMMIT_SHA_SHORT}}"

--- a/scripts/dev/contexts/evg-private-context
+++ b/scripts/dev/contexts/evg-private-context
@@ -120,6 +120,15 @@ fi
 echo "Setting BUILD_SCENARIO=${BUILD_SCENARIO}"
 export BUILD_SCENARIO="${BUILD_SCENARIO}"
 
+# Detect "test" branches, e.g. "v1-test", "v2-test" -- these simulate real backport branches
+# (e.g. "v1", "v2") for CI/CD testing purposes only, without affecting production registries.
+IS_TEST_BRANCH=false
+if [[ "${branch_name:-}" =~ ^v[0-9]+-test$ ]]; then
+  IS_TEST_BRANCH=true
+fi
+export IS_TEST_BRANCH
+echo "IS_TEST_BRANCH=${IS_TEST_BRANCH}"
+
 # Set REGISTRY and OPERATOR_VERSION, READINESS_PROBE_VERSION, VERSION_UPGRADE_HOOK_VERSION based on build scenario
 # REGISTRY and OPERATOR_VERSION, READINESS_PROBE_VERSION, VERSION_UPGRADE_HOOK_VERSION can be overridden externally if needed
 PATCH_REGISTRY="268558157000.dkr.ecr.us-east-1.amazonaws.com/dev"
@@ -137,6 +146,10 @@ case ${BUILD_SCENARIO} in
 
   "${BUILD_SCENARIO_STAGING}")
     COMMIT_SHA_SHORT=$(git rev-parse --short=8 HEAD)
+    if [ "${IS_TEST_BRANCH}" == "true" ]; then
+      REGISTRY="${REGISTRY:-${TEST_BRANCH_REGISTRY:-268558157000.dkr.ecr.us-east-1.amazonaws.com/test}}"
+      export FLAGS="${FLAGS:-} --registry ${REGISTRY}"
+    fi
     REGISTRY="${REGISTRY:-${STAGING_REGISTRY}}"
     OPERATOR_VERSION="${OPERATOR_VERSION:-${COMMIT_SHA_SHORT}}"
     READINESS_PROBE_VERSION="${READINESS_PROBE_VERSION:-${COMMIT_SHA_SHORT}}"

--- a/scripts/dev/regenerate_multicluster_rbac.sh
+++ b/scripts/dev/regenerate_multicluster_rbac.sh
@@ -8,7 +8,7 @@ set -Eeou pipefail
 source scripts/dev/set_env_context.sh
 source scripts/funcs/printing
 
-git_last_changed=$(git ls-tree -r origin/master --name-only)
+git_last_changed=$(git ls-tree -r "origin/${branch_name:-master}" --name-only)
 
 if echo "${git_last_changed}" | grep -q -e 'cmd/kubectl-mongodb' -e 'pkg/kubectl-mongodb'; then
   echo 'regenerating multicluster RBAC public example'

--- a/scripts/dev/regenerate_multicluster_rbac.sh
+++ b/scripts/dev/regenerate_multicluster_rbac.sh
@@ -7,8 +7,9 @@ set -Eeou pipefail
 
 source scripts/dev/set_env_context.sh
 source scripts/funcs/printing
+BRANCH="${branch_name:-master}"
 
-git_last_changed=$(git ls-tree -r origin/master --name-only)
+git_last_changed=$(git ls-tree -r "origin/${BRANCH}" --name-only)
 
 if echo "${git_last_changed}" | grep -q -e 'cmd/kubectl-mongodb' -e 'pkg/kubectl-mongodb'; then
   echo 'regenerating multicluster RBAC public example'

--- a/scripts/evergreen/notify_master_failures.py
+++ b/scripts/evergreen/notify_master_failures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Slack notification script for master build failures.
+Slack notification script for master or backporting-branch build failures.
 
 This script queries the Evergreen API to find failed tasks in a build version
 and sends a Slack notification to #k8s-enterprise-builds with failure details
@@ -277,17 +277,20 @@ def format_slack_message(
     # <@author_id> format works with Slack's GitHub integration
     author_mention = f"<@{version_info.author_id}>" if version_info.author_id else version_info.author
 
+    branch = getattr(version_info, "branch", None) or "master"
+    branch_label = "Master" if branch == "master" else branch
+
     if is_failure:
-        header_text = "🔴 Master Build Failures"
+        header_text = f"🔴 {branch_label} Build Failures"
         button_style = "danger"
         run_prefix = f"Run #{run_number}: " if run_number else ""
-        summary_text = f"{run_prefix}Master build failed: {num_failures} tasks failed for commit {version_info.revision[:8]} by {version_info.author}"
+        summary_text = f"{run_prefix}{branch_label} build failed: {num_failures} tasks failed for commit {version_info.revision[:8]} by {version_info.author}"
     else:
-        header_text = "✅ Master Build Passed"
+        header_text = f"✅ {branch_label} Build Passed"
         button_style = None
         run_prefix = f"Run #{run_number}: " if run_number else ""
         summary_text = (
-            f"{run_prefix}Master build passed for commit {version_info.revision[:8]} by {version_info.author}"
+            f"{run_prefix}{branch_label} build passed for commit {version_info.revision[:8]} by {version_info.author}"
         )
 
     # how to format Slack messages: https://docs.slack.dev/block-kit/
@@ -452,7 +455,7 @@ def print_stdout_report(
 def main() -> None:
     start_time = time.time()
 
-    parser = argparse.ArgumentParser(description="Notify about master build failures")
+    parser = argparse.ArgumentParser(description="Notify about master or backporting-branch build failures")
     parser.add_argument("--dry-run", action="store_true", help="Print Slack JSON payload (for debugging)")
     parser.add_argument("--version-id", help="Evergreen version ID (overrides env var)")
     args = parser.parse_args()

--- a/scripts/evergreen/should_release_agents_on_ecr.sh
+++ b/scripts/evergreen/should_release_agents_on_ecr.sh
@@ -8,20 +8,20 @@ no_local_changes() {
   git diff --quiet -- release.json
 }
 
-no_changes_vs_master() {
-  git diff --quiet origin/master -- release.json
+no_changes_vs_branch() {
+  git diff --quiet "origin/${branch_name:-master}" -- release.json
 }
 
 git fetch origin
 
-if no_local_changes && no_changes_vs_master; then
+if no_local_changes && no_changes_vs_branch; then
   echo "skipping since release.json has not changed"
   exit 1
 else
   echo "release.json has changed, triggering ecr agent release"
   echo "git diff"
   git diff -- release.json
-  echo "git diff master"
-  git diff origin/master -- release.json
+  echo "git diff ${branch_name:-master}"
+  git diff "origin/${branch_name:-master}" -- release.json
   exit 0
 fi

--- a/scripts/evergreen/should_release_agents_on_ecr.sh
+++ b/scripts/evergreen/should_release_agents_on_ecr.sh
@@ -4,24 +4,26 @@
 
 set -Eeou pipefail
 
+BRANCH="${branch_name:-master}"
+
 no_local_changes() {
   git diff --quiet -- release.json
 }
 
-no_changes_vs_master() {
-  git diff --quiet origin/master -- release.json
+no_changes_vs_branch() {
+  git diff --quiet "origin/${BRANCH}" -- release.json
 }
 
 git fetch origin
 
-if no_local_changes && no_changes_vs_master; then
+if no_local_changes && no_changes_vs_branch; then
   echo "skipping since release.json has not changed"
   exit 1
 else
   echo "release.json has changed, triggering ecr agent release"
   echo "git diff"
   git diff -- release.json
-  echo "git diff master"
-  git diff origin/master -- release.json
+  echo "git diff ${BRANCH}"
+  git diff "origin/${BRANCH}" -- release.json
   exit 0
 fi

--- a/scripts/evergreen/tests/test_notify_master_failures.py
+++ b/scripts/evergreen/tests/test_notify_master_failures.py
@@ -41,6 +41,7 @@ def make_mock_version(
     message: str = "Test commit",
     status: str = "succeeded",
     order: int = 100,
+    branch: str = "master",
 ) -> VersionInfo:
     """Create a mock VersionInfo for testing."""
     mock_version = MagicMock()
@@ -50,6 +51,7 @@ def make_mock_version(
     mock_version.message = message
     mock_version.status = status
     mock_version.order = order
+    mock_version.branch = branch
     mock_version.json = {"author_id": author_id}
     mock_version.build_variants_status = []
     return VersionInfo(version=mock_version)
@@ -84,6 +86,16 @@ class TestFormatSlackMessage:
         assert "Run #6411" in message["text"]
         run_block = message["blocks"][1]["fields"][0]["text"]
         assert "#6411" in run_block
+
+    def test_backport_branch_failure_message(self):
+        message = make_message(failed_tasks=FEW_TASKS, branch="v1")
+        assert "v1 build failed" in message["text"]
+        assert "v1 Build Failures" in message["blocks"][0]["text"]["text"]
+
+    def test_backport_branch_success_message(self):
+        message = make_message(branch="v2")
+        assert "v2 build passed" in message["text"]
+        assert "v2 Build Passed" in message["blocks"][0]["text"]["text"]
 
     def test_groups_failures_by_variant(self):
         message = make_message(failed_tasks=FEW_TASKS)

--- a/scripts/evergreen/tests/test_notify_master_failures.py
+++ b/scripts/evergreen/tests/test_notify_master_failures.py
@@ -41,6 +41,7 @@ def make_mock_version(
     message: str = "Test commit",
     status: str = "succeeded",
     order: int = 100,
+    branch: str = "master",
 ) -> VersionInfo:
     """Create a mock VersionInfo for testing."""
     mock_version = MagicMock()
@@ -50,6 +51,7 @@ def make_mock_version(
     mock_version.message = message
     mock_version.status = status
     mock_version.order = order
+    mock_version.branch = branch
     mock_version.json = {"author_id": author_id}
     mock_version.build_variants_status = []
     return VersionInfo(version=mock_version)
@@ -84,6 +86,16 @@ class TestFormatSlackMessage:
         assert "Run #6411" in message["text"]
         run_block = message["blocks"][1]["fields"][0]["text"]
         assert "#6411" in run_block
+
+    def test_backport_branch_failure_message(self):
+        message = make_message(failed_tasks=FEW_TASKS, branch="release-v1")
+        assert "release-v1 build failed" in message["text"]
+        assert "release-v1 Build Failures" in message["blocks"][0]["text"]["text"]
+
+    def test_backport_branch_success_message(self):
+        message = make_message(branch="release-v2")
+        assert "release-v2 build passed" in message["text"]
+        assert "release-v2 Build Passed" in message["blocks"][0]["text"]["text"]
 
     def test_groups_failures_by_variant(self):
         message = make_message(failed_tasks=FEW_TASKS)

--- a/scripts/release/agent/agents_to_rebuild.py
+++ b/scripts/release/agent/agents_to_rebuild.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Detects changes to opsManagerMapping in release.json for triggering agent releases.
-Relies on git origin/master vs local release.json
+Relies on should_release_agents_on_ecr.sh diffing local release.json against the branch's remote state.
 """
 import json
 import logging

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -74,6 +74,8 @@ def build_image(
             tags.append(tag)
             if build_configuration.latest_tag:
                 tags.append(f"{registry}:latest{arch_suffix}")
+            if build_configuration.branch_latest_tag:
+                tags.append(f"{registry}:{build_configuration.branch_latest_tag}{arch_suffix}")
             if build_configuration.olm_tag:
                 olm_tag = create_olm_version_tag(build_configuration.version)
                 tags.append(f"{registry}:{olm_tag}{arch_suffix}")

--- a/scripts/release/build/image_build_configuration.py
+++ b/scripts/release/build/image_build_configuration.py
@@ -26,6 +26,9 @@ class ImageBuildConfiguration:
     architecture_suffix: bool = False
     agent_tools_version: Optional[str] = None  # Explicit tools version for agent builds
     custom_agent_url: Optional[str] = None  # Custom agent URL for testing (overrides prod download)
+    # Extra "latest" tag for backport branches (e.g. "latest-v1"), mirroring
+    # latest_tag which only ever applies on master.
+    branch_latest_tag: Optional[str] = None
 
     def is_release_scenario(self) -> bool:
         return self.scenario == BuildScenario.RELEASE

--- a/scripts/release/build/image_build_configuration.py
+++ b/scripts/release/build/image_build_configuration.py
@@ -26,6 +26,9 @@ class ImageBuildConfiguration:
     architecture_suffix: bool = False
     agent_tools_version: Optional[str] = None  # Explicit tools version for agent builds
     custom_agent_url: Optional[str] = None  # Custom agent URL for testing (overrides prod download)
+    # Extra "latest" tag for backport branches (e.g. "latest-release-v1"), mirroring
+    # latest_tag which only ever applies on master.
+    branch_latest_tag: Optional[str] = None
 
     def is_release_scenario(self) -> bool:
         return self.scenario == BuildScenario.RELEASE

--- a/scripts/release/build_cache.py
+++ b/scripts/release/build_cache.py
@@ -5,8 +5,8 @@ This module consolidates all caching logic: cache write decisions,
 ECR repository management, and BuildKit cache configuration generation.
 
 Cache Strategy:
-- All builds read from the master cache
-- Only mainline merges (gitter_request) write to master cache
+- Each branch (master, v1, v2, ...) has its own cache, keyed by branch_name
+- Only mainline merges (gitter_request) write to their branch's cache
 - PRs, manual patches, and other builds are read-only to prevent cache pollution
 """
 
@@ -26,7 +26,7 @@ _LIFECYCLE_POLICY_PATH = Path(__file__).parent / "cache_lifecycle_policy.json"
 
 def should_write_cache() -> bool:
     """
-    Determine if this build should write to the master cache.
+    Determine if this build should write to its branch's cache.
 
     Only mainline merges (gitter_request) write to cache.
     All other builds (PRs, manual patches, etc.) are read-only.
@@ -37,6 +37,11 @@ def should_write_cache() -> bool:
     should_write = requester == "gitter_request"
     logger.debug(f"Cache write decision: requester={requester}, write={should_write}")
     return should_write
+
+
+def _cache_branch() -> str:
+    """The branch whose cache this build reads from and (maybe) writes to."""
+    return os.environ.get("branch_name", "master")
 
 
 def get_cache_lifecycle_policy() -> dict:
@@ -113,8 +118,8 @@ def build_cache_configuration(
     """
     Build cache configuration for BuildKit remote cache.
 
-    All builds read from the master cache.
-    Only mainline merges and merge queue builds write to the master cache.
+    All builds read from their branch's cache (master, v1, v2, ...).
+    Only mainline merges and merge queue builds write to that cache.
 
     Uses mode=max to cache all intermediate layers (not just final), oci-mediatypes for
     broad registry compatibility, and image-manifest to store cache as a proper manifest.
@@ -122,23 +127,24 @@ def build_cache_configuration(
     :param base_registry: Base registry URL for cache
     :return: tuple of (cache_from_refs, cache_to_refs) where cache_to_refs may be None
     """
-    master_ref = f"{base_registry}:master"
+    branch = _cache_branch()
+    branch_ref = f"{base_registry}:{branch}"
 
-    # All builds read from master cache
-    cache_from_refs = [{"type": "registry", "ref": master_ref}]
+    # All builds read from their branch's cache
+    cache_from_refs = [{"type": "registry", "ref": branch_ref}]
 
-    # Only mainline merges write to master cache
+    # Only mainline merges write to their branch's cache
     if should_write_cache():
         cache_to_refs = {
             "type": "registry",
-            "ref": master_ref,
+            "ref": branch_ref,
             "mode": "max",
             "oci-mediatypes": "true",
             "image-manifest": "true",
         }
-        logger.info("Cache config: read from master, write to master")
+        logger.info(f"Cache config: read from {branch}, write to {branch}")
     else:
         cache_to_refs = None
-        logger.info("Cache config: read from master (read-only)")
+        logger.info(f"Cache config: read from {branch} (read-only)")
 
     return cache_from_refs, cache_to_refs

--- a/scripts/release/build_cache.py
+++ b/scripts/release/build_cache.py
@@ -5,8 +5,8 @@ This module consolidates all caching logic: cache write decisions,
 ECR repository management, and BuildKit cache configuration generation.
 
 Cache Strategy:
-- All builds read from the master cache
-- Only mainline merges (gitter_request) write to master cache
+- Each branch (master, release-v1, release-v2, ...) has its own cache, keyed by branch_name
+- Only mainline merges (gitter_request) write to their branch's cache
 - PRs, manual patches, and other builds are read-only to prevent cache pollution
 """
 
@@ -26,7 +26,7 @@ _LIFECYCLE_POLICY_PATH = Path(__file__).parent / "cache_lifecycle_policy.json"
 
 def should_write_cache() -> bool:
     """
-    Determine if this build should write to the master cache.
+    Determine if this build should write to its branch's cache.
 
     Only mainline merges (gitter_request) write to cache.
     All other builds (PRs, manual patches, etc.) are read-only.
@@ -37,6 +37,11 @@ def should_write_cache() -> bool:
     should_write = requester == "gitter_request"
     logger.debug(f"Cache write decision: requester={requester}, write={should_write}")
     return should_write
+
+
+def _cache_branch() -> str:
+    """The branch whose cache this build reads from and (maybe) writes to."""
+    return os.environ.get("branch_name", "master")
 
 
 def get_cache_lifecycle_policy() -> dict:
@@ -113,8 +118,8 @@ def build_cache_configuration(
     """
     Build cache configuration for BuildKit remote cache.
 
-    All builds read from the master cache.
-    Only mainline merges and merge queue builds write to the master cache.
+    All builds read from their branch's cache (master, v1, v2, ...).
+    Only mainline merges and merge queue builds write to that cache.
 
     Uses mode=max to cache all intermediate layers (not just final), oci-mediatypes for
     broad registry compatibility, and image-manifest to store cache as a proper manifest.
@@ -122,23 +127,24 @@ def build_cache_configuration(
     :param base_registry: Base registry URL for cache
     :return: tuple of (cache_from_refs, cache_to_refs) where cache_to_refs may be None
     """
-    master_ref = f"{base_registry}:master"
+    branch = _cache_branch()
+    branch_ref = f"{base_registry}:{branch}"
 
-    # All builds read from master cache
-    cache_from_refs = [{"type": "registry", "ref": master_ref}]
+    # All builds read from their branch's cache
+    cache_from_refs = [{"type": "registry", "ref": branch_ref}]
 
-    # Only mainline merges write to master cache
+    # Only mainline merges write to their branch's cache
     if should_write_cache():
         cache_to_refs = {
             "type": "registry",
-            "ref": master_ref,
+            "ref": branch_ref,
             "mode": "max",
             "oci-mediatypes": "true",
             "image-manifest": "true",
         }
-        logger.info("Cache config: read from master, write to master")
+        logger.info(f"Cache config: read from {branch}, write to {branch}")
     else:
         cache_to_refs = None
-        logger.info("Cache config: read from master (read-only)")
+        logger.info(f"Cache config: read from {branch} (read-only)")
 
     return cache_from_refs, cache_to_refs

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -1,7 +1,8 @@
 import argparse
 import os
+import re
 from functools import partial
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional
 
 from opentelemetry import context, trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -93,6 +94,20 @@ def build_image(image_name: str, build_configuration: ImageBuildConfiguration):
     get_builder_function_for_image_name()[image_name](build_configuration)
 
 
+_BACKPORT_BRANCH_RE = re.compile(r"^v(\d+)(-test)?$")
+
+
+def branch_latest_tag_for(branch_name: str) -> Optional[str]:
+    """
+    The "latest" tag equivalent for a backport branch, e.g. "v1" -> "latest-v1", "v1-test" -> "latest-v1-test".
+    Master has no branch_latest_tag: it uses the plain "latest" tag instead.
+    Returns None for master and any untracked/non-backport branch.
+    """
+    if _BACKPORT_BRANCH_RE.match(branch_name or ""):
+        return f"latest-{branch_name}"
+    return None
+
+
 def image_build_config_from_args(args) -> ImageBuildConfiguration:
     image = args.image
 
@@ -109,11 +124,10 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
     version = args.version
     dockerfile_path = image_build_info.dockerfile_path
     builder = get_image_builder_from_arg(image_build_info.builder)
-    latest_tag = (
-        image_build_info.latest_tag
-        and os.environ.get("requester", "") == "commit"
-        and os.environ.get("branch_name") == "master"
-    )
+    branch_name = os.environ.get("branch_name")
+    is_mainline_commit = image_build_info.latest_tag and os.environ.get("requester", "") == "commit"
+    latest_tag = is_mainline_commit and branch_name == "master"
+    branch_latest_tag = branch_latest_tag_for(branch_name) if is_mainline_commit else None
     olm_tag = image_build_info.olm_tag
     if args.registry:
         registries = [args.registry]
@@ -160,6 +174,7 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
         scenario=build_scenario,
         version=version,
         latest_tag=latest_tag,
+        branch_latest_tag=branch_latest_tag,
         olm_tag=olm_tag,
         registries=registries,
         dockerfile_path=dockerfile_path,

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -1,7 +1,8 @@
 import argparse
 import os
+import re
 from functools import partial
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional
 
 from opentelemetry import context, trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -93,6 +94,20 @@ def build_image(image_name: str, build_configuration: ImageBuildConfiguration):
     get_builder_function_for_image_name()[image_name](build_configuration)
 
 
+_BACKPORT_BRANCH_RE = re.compile(r"^release-v(\d+)(-test)?$")
+
+
+def branch_latest_tag_for(branch_name: str) -> Optional[str]:
+    """
+    The "latest" tag equivalent for a backport branch, e.g. "release-v1" -> "latest-release-v1", "release-v1-test" -> "latest-release-v1-test".
+    Master has no branch_latest_tag: it uses the plain "latest" tag instead.
+    Returns None for master and any untracked/non-backport branch.
+    """
+    if _BACKPORT_BRANCH_RE.match(branch_name or ""):
+        return f"latest-{branch_name}"
+    return None
+
+
 def image_build_config_from_args(args) -> ImageBuildConfiguration:
     image = args.image
 
@@ -109,11 +124,10 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
     version = args.version
     dockerfile_path = image_build_info.dockerfile_path
     builder = get_image_builder_from_arg(image_build_info.builder)
-    latest_tag = (
-        image_build_info.latest_tag
-        and os.environ.get("requester", "") == "commit"
-        and os.environ.get("branch_name") == "master"
-    )
+    branch_name = os.environ.get("branch_name")
+    is_mainline_commit = image_build_info.latest_tag and os.environ.get("requester", "") == "commit"
+    latest_tag = is_mainline_commit and branch_name == "master"
+    branch_latest_tag = branch_latest_tag_for(branch_name) if is_mainline_commit else None
     olm_tag = image_build_info.olm_tag
     if args.registry:
         registries = [args.registry]
@@ -160,6 +174,7 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
         scenario=build_scenario,
         version=version,
         latest_tag=latest_tag,
+        branch_latest_tag=branch_latest_tag,
         olm_tag=olm_tag,
         registries=registries,
         dockerfile_path=dockerfile_path,

--- a/scripts/release/tests/build_cache_test.py
+++ b/scripts/release/tests/build_cache_test.py
@@ -16,10 +16,10 @@ class TestShouldWriteCache:
 
 
 class TestBuildCacheConfiguration:
-    """Test cache config: always read master, only gitter_request writes."""
+    """Test cache config: read/write the current branch's own cache, only gitter_request writes."""
 
     @patch.dict("os.environ", {"requester": "gitter_request"}, clear=True)
-    def test_gitter_request_reads_and_writes_master(self):
+    def test_gitter_request_reads_and_writes_master_by_default(self):
         base_registry = "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/cache/test"
         cache_from, cache_to = build_cache_configuration(base_registry)
 
@@ -33,4 +33,20 @@ class TestBuildCacheConfiguration:
         cache_from, cache_to = build_cache_configuration(base_registry)
 
         assert cache_from == [{"type": "registry", "ref": f"{base_registry}:master"}]
+        assert cache_to is None
+
+    @patch.dict("os.environ", {"requester": "gitter_request", "branch_name": "v1"}, clear=True)
+    def test_backport_branch_reads_and_writes_its_own_cache(self):
+        base_registry = "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/cache/test"
+        cache_from, cache_to = build_cache_configuration(base_registry)
+
+        assert cache_from == [{"type": "registry", "ref": f"{base_registry}:v1"}]
+        assert cache_to["ref"] == f"{base_registry}:v1"
+
+    @patch.dict("os.environ", {"requester": "github_pull_request", "branch_name": "v2"}, clear=True)
+    def test_backport_branch_pr_does_not_pollute_master_cache(self):
+        base_registry = "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/cache/test"
+        cache_from, cache_to = build_cache_configuration(base_registry)
+
+        assert cache_from == [{"type": "registry", "ref": f"{base_registry}:v2"}]
         assert cache_to is None

--- a/scripts/release/tests/build_cache_test.py
+++ b/scripts/release/tests/build_cache_test.py
@@ -16,10 +16,10 @@ class TestShouldWriteCache:
 
 
 class TestBuildCacheConfiguration:
-    """Test cache config: always read master, only gitter_request writes."""
+    """Test cache config: read/write the current branch's own cache, only gitter_request writes."""
 
     @patch.dict("os.environ", {"requester": "gitter_request"}, clear=True)
-    def test_gitter_request_reads_and_writes_master(self):
+    def test_gitter_request_reads_and_writes_master_by_default(self):
         base_registry = "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/cache/test"
         cache_from, cache_to = build_cache_configuration(base_registry)
 
@@ -33,4 +33,20 @@ class TestBuildCacheConfiguration:
         cache_from, cache_to = build_cache_configuration(base_registry)
 
         assert cache_from == [{"type": "registry", "ref": f"{base_registry}:master"}]
+        assert cache_to is None
+
+    @patch.dict("os.environ", {"requester": "gitter_request", "branch_name": "release-v1"}, clear=True)
+    def test_backport_branch_reads_and_writes_its_own_cache(self):
+        base_registry = "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/cache/test"
+        cache_from, cache_to = build_cache_configuration(base_registry)
+
+        assert cache_from == [{"type": "registry", "ref": f"{base_registry}:release-v1"}]
+        assert cache_to["ref"] == f"{base_registry}:release-v1"
+
+    @patch.dict("os.environ", {"requester": "github_pull_request", "branch_name": "release-v2"}, clear=True)
+    def test_backport_branch_pr_does_not_pollute_master_cache(self):
+        base_registry = "268558157000.dkr.ecr.us-east-1.amazonaws.com/dev/cache/test"
+        cache_from, cache_to = build_cache_configuration(base_registry)
+
+        assert cache_from == [{"type": "registry", "ref": f"{base_registry}:release-v2"}]
         assert cache_to is None

--- a/scripts/release/tests/pipeline_test.py
+++ b/scripts/release/tests/pipeline_test.py
@@ -1,0 +1,30 @@
+from scripts.release.pipeline import branch_latest_tag_for
+
+
+class TestBranchLatestTagFor:
+    def test_master_has_no_branch_latest_tag(self):
+        assert branch_latest_tag_for("master") is None
+
+    def test_v1_branch(self):
+        assert branch_latest_tag_for("v1") == "latest-v1"
+
+    def test_v2_branch(self):
+        assert branch_latest_tag_for("v2") == "latest-v2"
+
+    def test_untracked_branch(self):
+        assert branch_latest_tag_for("some-feature-branch") is None
+
+    def test_none_branch(self):
+        assert branch_latest_tag_for(None) is None
+
+    def test_v1_test_branch(self):
+        assert branch_latest_tag_for("v1-test") == "latest-v1-test"
+
+    def test_v2_test_branch(self):
+        assert branch_latest_tag_for("v2-test") == "latest-v2-test"
+
+    def test_v_test_no_number(self):
+        assert branch_latest_tag_for("v-test") is None
+
+    def test_missing_v_prefix(self):
+        assert branch_latest_tag_for("1-test") is None

--- a/scripts/release/tests/pipeline_test.py
+++ b/scripts/release/tests/pipeline_test.py
@@ -1,0 +1,30 @@
+from scripts.release.pipeline import branch_latest_tag_for
+
+
+class TestBranchLatestTagFor:
+    def test_master_has_no_branch_latest_tag(self):
+        assert branch_latest_tag_for("master") is None
+
+    def test_v1_branch(self):
+        assert branch_latest_tag_for("release-v1") == "latest-release-v1"
+
+    def test_v2_branch(self):
+        assert branch_latest_tag_for("release-v2") == "latest-release-v2"
+
+    def test_untracked_branch(self):
+        assert branch_latest_tag_for("some-feature-branch") is None
+
+    def test_none_branch(self):
+        assert branch_latest_tag_for(None) is None
+
+    def test_v1_test_branch(self):
+        assert branch_latest_tag_for("release-v1-test") == "latest-release-v1-test"
+
+    def test_v2_test_branch(self):
+        assert branch_latest_tag_for("release-v2-test") == "latest-release-v2-test"
+
+    def test_v_test_no_number(self):
+        assert branch_latest_tag_for("v-test") is None
+
+    def test_missing_v_prefix(self):
+        assert branch_latest_tag_for("1-test") is None

--- a/scripts/test/bash/backport_branch/test_backport_branch_ci.bats
+++ b/scripts/test/bash/backport_branch/test_backport_branch_ci.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+#
+# Regression tests for CI scripts that must diff against the current branch's
+# own remote state instead of a hardcoded origin/master. Builds a throwaway
+# local git remote with master + v1 branches so the origin/v1 comparison can
+# be exercised without a real GitHub push or Evergreen project.
+#
+# Run via: scripts/test/bash/run.sh backport_branch
+
+setup() {
+    PROJECT_DIR="$(git rev-parse --show-toplevel)"
+    SCRIPT="${PROJECT_DIR}/scripts/evergreen/should_release_agents_on_ecr.sh"
+    RBAC_SCRIPT="${PROJECT_DIR}/scripts/dev/regenerate_multicluster_rbac.sh"
+
+    WORK_DIR="$(mktemp -d)"
+    REMOTE_DIR="${WORK_DIR}/remote.git"
+    CLONE_DIR="${WORK_DIR}/clone"
+
+    git init --bare -q "${REMOTE_DIR}"
+    git clone -q "${REMOTE_DIR}" "${CLONE_DIR}"
+
+    cd "${CLONE_DIR}"
+    git config user.email "test@example.com"
+    git config user.name "test"
+
+    echo '{"marker": "master-value"}' > release.json
+    git add release.json
+    git commit -q -m "master release.json"
+    git branch -m master
+    git push -q origin master
+
+    git checkout -q -b v1
+    echo '{"marker": "v1-value"}' > release.json
+    git add release.json
+    git commit -q -m "v1 release.json diverges from master"
+    git push -q origin v1
+}
+
+teardown() {
+    rm -rf "${WORK_DIR}"
+}
+
+@test "should_release_agents_on_ecr: skips when release.json unchanged vs its own branch" {
+    cd "${CLONE_DIR}"
+    git checkout -q v1
+
+    run env branch_name=v1 "${SCRIPT}"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"has not changed"* ]]
+}
+
+@test "should_release_agents_on_ecr: does NOT false-trigger just because v1 differs from master" {
+    cd "${CLONE_DIR}"
+    git checkout -q v1
+
+    # release.json on v1 differs from master's, but nothing has changed
+    # *within* v1 itself — comparing against origin/master (the old bug)
+    # would incorrectly report a change here.
+    run env branch_name=v1 "${SCRIPT}"
+
+    [ "$status" -eq 1 ]
+}
+
+@test "should_release_agents_on_ecr: triggers when release.json changes on v1" {
+    cd "${CLONE_DIR}"
+    git checkout -q v1
+    echo '{"marker": "v1-value-modified"}' > release.json
+
+    run env branch_name=v1 "${SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"has changed"* ]]
+}
+
+@test "regenerate_multicluster_rbac: lists v1's own tree, not master's" {
+    cd "${CLONE_DIR}"
+    git checkout -q v1
+    mkdir -p pkg/kubectl-mongodb
+    echo "marker" > pkg/kubectl-mongodb/only_on_v1.go
+    git add pkg/kubectl-mongodb
+    git commit -q -m "add kubectl-mongodb path only on v1"
+    git push -q origin v1
+
+    tree_listing=$(env branch_name=v1 git ls-tree -r "origin/v1" --name-only)
+
+    [[ "${tree_listing}" == *"pkg/kubectl-mongodb/only_on_v1.go"* ]]
+
+    master_tree_listing=$(git ls-tree -r "origin/master" --name-only)
+    [[ "${master_tree_listing}" != *"pkg/kubectl-mongodb/only_on_v1.go"* ]]
+}

--- a/scripts/test/bash/backport_branch/test_backport_branch_ci.bats
+++ b/scripts/test/bash/backport_branch/test_backport_branch_ci.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+#
+# Regression tests for CI scripts that must diff against the current branch's
+# own remote state instead of a hardcoded origin/master. Builds a throwaway
+# local git remote with master + release-v1 branches so the origin/release-v1 comparison can
+# be exercised without a real GitHub push or Evergreen project.
+#
+# Run via: scripts/test/bash/run.sh backport_branch
+
+setup() {
+    PROJECT_DIR="$(git rev-parse --show-toplevel)"
+    SCRIPT="${PROJECT_DIR}/scripts/evergreen/should_release_agents_on_ecr.sh"
+    WORK_DIR="$(mktemp -d)"
+    REMOTE_DIR="${WORK_DIR}/remote.git"
+    CLONE_DIR="${WORK_DIR}/clone"
+
+    git init --bare -q "${REMOTE_DIR}"
+    git clone -q "${REMOTE_DIR}" "${CLONE_DIR}"
+
+    cd "${CLONE_DIR}"
+    git config user.email "test@example.com"
+    git config user.name "test"
+
+    echo '{"marker": "master-value"}' > release.json
+    git add release.json
+    git commit -q -m "master release.json"
+    git branch -m master
+    git push -q origin master
+
+    git checkout -q -b release-v1
+    echo '{"marker": "release-v1-value"}' > release.json
+    git add release.json
+    git commit -q -m "release-v1 release.json diverges from master"
+    git push -q origin release-v1
+}
+
+teardown() {
+    rm -rf "${WORK_DIR}"
+}
+
+@test "should_release_agents_on_ecr: skips when release.json unchanged vs its own branch" {
+    cd "${CLONE_DIR}"
+    git checkout -q release-v1
+
+    run env branch_name=release-v1 "${SCRIPT}"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"has not changed"* ]]
+}
+
+@test "should_release_agents_on_ecr: triggers when release.json changes on release-v1" {
+    cd "${CLONE_DIR}"
+    git checkout -q release-v1
+    echo '{"marker": "release-v1-value-modified"}' > release.json
+
+    run env branch_name=release-v1 "${SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"has changed"* ]]
+}
+
+@test "git ls-tree: lists release-v1's own tree, not master's" {
+    cd "${CLONE_DIR}"
+    git checkout -q release-v1
+    mkdir -p pkg/kubectl-mongodb
+    echo "marker" > pkg/kubectl-mongodb/only_on_v1.go
+    git add pkg/kubectl-mongodb
+    git commit -q -m "add kubectl-mongodb path only on release-v1"
+    git push -q origin release-v1
+
+    tree_listing=$(git ls-tree -r "origin/release-v1" --name-only)
+
+    [[ "${tree_listing}" == *"pkg/kubectl-mongodb/only_on_v1.go"* ]]
+
+    master_tree_listing=$(git ls-tree -r "origin/master" --name-only)
+    [[ "${master_tree_listing}" != *"pkg/kubectl-mongodb/only_on_v1.go"* ]]
+}


### PR DESCRIPTION
# Summary

Ensure the CI keeps working the same on `master` than on future back-porting branches v1, v2, v3, pattern `v*`. For testing `v*-test` branches are also supported, but they publish to test registries.

## Proof of Work

TBD

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
