### PR TITLE
KUBE-307: Auto-trigger docs snippets after release publish

### DIFF
--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -26,13 +26,23 @@ tasks:
             scripts/mckci release publish group --commit "${revision}"
 
   # Runs after the publish task succeeds: pushes the final "X.Y.Z" tag (which
-  # is not itself a trigger) and deletes "new-X.Y.Z".
+  # is not itself a trigger) and deletes "new-X.Y.Z", then triggers the public
+  # docs-snippet refresh.
   - name: retag_new_release
     commands:
       - func: clone
       - func: push_release_tag
         vars:
           prefix: "new-"
+      - func: compute_release_version
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src/github.com/mongodb/mongodb-kubernetes
+          include_expansions_in_env:
+            - revision
+            - RELEASE_VERSION
+          binary: scripts/dev/trigger_public_docs_snippets.sh
 
 buildvariants:
   - name: release_publish

--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -26,13 +26,23 @@ tasks:
             scripts/mckci release publish images --commit "${revision}" --latest-marker latest
 
   # Runs after the publish task succeeds: pushes the final "X.Y.Z" tag (which
-  # is not itself a trigger) and deletes "new-X.Y.Z".
+  # is not itself a trigger) and deletes "new-X.Y.Z", then triggers the public
+  # docs-snippet refresh.
   - name: retag_new_release
     commands:
       - func: clone
       - func: push_release_tag
         vars:
           prefix: "new-"
+      - func: compute_release_version
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src/github.com/mongodb/mongodb-kubernetes
+          include_expansions_in_env:
+            - revision
+            - RELEASE_VERSION
+          binary: scripts/dev/trigger_public_docs_snippets.sh
 
 buildvariants:
   - name: release_publish

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -6,7 +6,8 @@
 #
 # Cleanup once retired:
 # 1. Delete this file; rename .evergreen-release-publish.yml to
-#    .evergreen-release.yml in its place.
+#    .evergreen-release.yml in its place. Also remove redundant "_publish"
+#    suffixes.
 # 2. In .evergreen.yml: remove the "old-*" git_tag_aliases entry, remove the
 #    "deprecated-release" patch alias, remove this file from the include:
 #    block, and update the remaining git_tag_aliases entry/comment to point

--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -225,7 +225,10 @@ task_groups:
       - test_kind_search_sharded_multi_cluster_snippets.sh
 
 buildvariants:
-  # These variants are used to test the code snippets and each one can be used in patches
+  # NOTE: public_gke|kind_code_snippets are docs-publishing jobs, not release-gating tests - they run
+  # the released public Helm chart and feed output to docs-mongodb-internal (update_docs_snippets.sh).
+  # They can only succeed once a release is public, so never add them to a ".staging"/"e2e_test_suite"
+  # group. Auto-triggered post-release (master only) by trigger_public_docs_snippets.sh.
   # More details in the TD: https://docs.google.com/document/d/1fuTxfRtP8QPtn7sKYxQM_AGcD6xycTZH8svngGxyKhc/edit?tab=t.0#bookmark=id.e8uva0393mbe
   - name: public_gke_code_snippets
     display_name: public_gke_code_snippets

--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -238,7 +238,10 @@ task_groups:
       - test_kind_search_sharded_multi_cluster_snippets.sh
 
 buildvariants:
-  # These variants are used to test the code snippets and each one can be used in patches
+  # NOTE: public_gke|kind_code_snippets are docs-publishing jobs, not release-gating tests - they run
+  # the released public Helm chart and feed output to docs-mongodb-internal (update_docs_snippets.sh).
+  # They can only succeed once a release is public, so never add them to a ".staging"/"e2e_test_suite"
+  # group. Auto-triggered post-release (master only) by trigger_public_docs_snippets.sh.
   # More details in the TD: https://docs.google.com/document/d/1fuTxfRtP8QPtn7sKYxQM_AGcD6xycTZH8svngGxyKhc/edit?tab=t.0#bookmark=id.e8uva0393mbe
   - name: public_gke_code_snippets
     display_name: public_gke_code_snippets

--- a/scripts/dev/trigger_public_docs_snippets.sh
+++ b/scripts/dev/trigger_public_docs_snippets.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Triggers the public docs-snippet refresh after retag_new_release confirms a release is public.
+# Master only (backports don't change snippet content); checked via ${revision} vs origin/master
+# rather than branch_name, since a tag/workflow_dispatch build's branch_name isn't reliable here.
+# Manual fallback for backports:
+#   evergreen patch -p mongodb-kubernetes -v public_kind_code_snippets -v public_gke_code_snippets -t all -f -y -u --browse
+
+set -Eeou pipefail
+
+: "${revision:?revision must be set (Evergreen expansion)}"
+: "${RELEASE_VERSION:?RELEASE_VERSION must be set (from compute_release_version)}"
+
+git fetch origin master --quiet
+
+if ! git merge-base --is-ancestor "${revision}" origin/master; then
+  echo "trigger_public_docs_snippets: ${revision} is not on master (backport release ${RELEASE_VERSION}) - skipping"
+  exit 0
+fi
+
+echo "trigger_public_docs_snippets: triggering public snippet refresh for released version ${RELEASE_VERSION}"
+evergreen patch \
+  -p mongodb-kubernetes \
+  -v public_kind_code_snippets \
+  -v public_gke_code_snippets \
+  -t all \
+  -d "public docs snippets refresh for ${RELEASE_VERSION}" \
+  -f -y -u


### PR DESCRIPTION
# Summary

Reclassifies `public_gke`/`kind_code_snippets` as post-release docs-publishing jobs rather than release-gating tests, and adds an automated trigger off retag_new_release (master only, backports stay manual).

## Proof of Work

TBD

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
 