### PR TITLE
KUBE-171: Add sharded multi-cluster Search snippets

### DIFF
--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -191,6 +191,12 @@ tasks:
       - func: test_code_snippets
       - func: archive_snippets_output
 
+  - name: test_kind_search_sharded_multi_cluster_snippets.sh
+    tags: [ "code_snippets", "patch-run" ]
+    commands:
+      - func: test_code_snippets
+      - func: archive_snippets_output
+
 task_groups:
   - name: gke_code_snippets_task_group
     <<: *setup_and_teardown_group_gke_code_snippets
@@ -216,6 +222,7 @@ task_groups:
     max_hosts: -1
     tasks:
       - test_kind_search_rs_multi_cluster_snippets.sh
+      - test_kind_search_sharded_multi_cluster_snippets.sh
 
 buildvariants:
   # These variants are used to test the code snippets and each one can be used in patches

--- a/docs/search/13-search-sharded-multi-cluster/README.md
+++ b/docs/search/13-search-sharded-multi-cluster/README.md
@@ -1,0 +1,115 @@
+# Multi-cluster MongoDB Search with a sharded cluster
+
+This scenario deploys a multi-cluster `MongoDBSearch` resource for an existing
+Ops Manager-managed sharded cluster. The shell snippets do not create or
+reconfigure the source MongoDB deployment.
+
+## Prerequisites
+
+- A MongoDB 8.2 or later sharded cluster managed by Ops Manager. MongoDB 8.3 or
+  later is recommended. The `mongos` and shard members must be reachable from
+  both Kubernetes clusters.
+- Two Kubernetes contexts connected by a service mesh that provides
+  cross-cluster Service DNS and connectivity.
+- The namespace snippets use Istio's injection label. Adjust that label when
+  using another service mesh.
+- `kubectl`, Helm, the `kubectl-mongodb` plugin, `jq`, and cert-manager.
+- A `search-sync-source` user on the source deployment with the
+  `searchCoordinator` role. Set `MDB_SEARCH_SYNC_USER_PASSWORD` to that user's
+  password.
+- A cert-manager `ClusterIssuer` named by `MDB_TLS_CA_ISSUER` on the central
+  cluster. It must issue certificates trusted by the source MongoDB deployment.
+- A ConfigMap named by `MDB_TLS_CA_CONFIGMAP` in `MDB_NS` on both clusters. It
+  must contain the source deployment's CA certificate under the `ca-pem` and
+  `ca.crt` keys.
+
+## Configure the source deployment in Ops Manager
+
+The source `mongos` and each shard `mongod` must route Search traffic to cluster
+0's managed proxy for that process role.
+
+1. Edit `env_variables.sh`, then load and validate it:
+
+   ```bash
+   source env_variables.sh
+   bash code_snippets/13_0040_validate_env.sh
+   ```
+
+   `MDB_EXTERNAL_CLUSTER_NAME` defaults to `mdb-mc-sh`. Change it to the
+   existing deployment name. Also set the existing shard names and every
+   `MDB_EXTERNAL_*_HOST_*` endpoint to match the source deployment.
+
+2. In Ops Manager, open **Deployment > Processes** and click **Modify** for
+   each process listed below.
+3. Under **Advanced Configuration Options**, click **Add Option**, select
+   `setParameter`, and add these parameters to every `mongos` and shard
+   `mongod`:
+
+   | Parameter | Value |
+   |-----------|-------|
+   | `searchTLSMode` | `requireTLS` |
+   | `useGrpcForSearch` | `true` |
+   | `skipAuthenticationToMongot` | `false` |
+   | `skipAuthenticationToSearchIndexManagementServer` | `false` |
+
+   Set `mongotHost` and `searchIndexManagementHostAndPort` according to the
+   process role:
+
+   | Process | Value for both parameters |
+   |---------|---------------------------|
+   | Every `mongos` | `${MDB_PROXY_HOST_0}` |
+   | Every shard 0 `mongod` | `${MDB_PROXY_HOST_SHARD_0}` |
+   | Every shard 1 `mongod` | `${MDB_PROXY_HOST_SHARD_1}` |
+   | Every shard 2 `mongod` | `${MDB_PROXY_HOST_SHARD_2}` |
+
+   Enter the expanded values from `env_variables.sh`, not the variable names.
+4. Click **Save**, review the changes, and deploy the updated configuration.
+   Do not add these Search parameters to config server processes.
+
+Ops Manager applies `setParameter` startup options to the processes it manages.
+See [Advanced Options for MongoDB Deployments](https://www.mongodb.com/docs/ops-manager/current/reference/deployment-advanced-options/).
+
+These snippets deliberately use one stable Search target per process role.
+Processes in cluster 1 send Search traffic across the service mesh to cluster
+0's proxies, and cluster 1's Search stack is a warm standby. Ops Manager's
+per-process configuration can instead target each process at its local cluster
+proxy.
+
+## Deploy MongoDB Search
+
+Run only the customer steps listed below:
+
+```bash
+bash code_snippets/13_0045_create_namespaces.sh
+bash code_snippets/13_0100_install_operator.sh
+bash code_snippets/13_0301_install_cert_manager.sh
+bash code_snippets/13_0316_create_search_sync_secret.sh
+bash code_snippets/13_0316a_create_mongot_tls_certificates.sh
+bash code_snippets/13_0316b_create_lb_tls_certificates.sh
+bash code_snippets/13_0317_replicate_search_secrets.sh
+bash code_snippets/13_0320_create_mongodb_search_resource.sh
+bash code_snippets/13_0325_wait_for_search_resource.sh
+bash code_snippets/13_0330_show_running_pods.sh
+```
+
+The password Secret is created on cluster 0 and then replicated with the TLS
+Secrets to cluster 1. The `MongoDBSearch` resource uses the `mongos` and shard
+hostnames from `env_variables.sh`.
+
+## Run Search queries
+
+Use the shared sharded-cluster query snippets; a separate multi-cluster query
+is not required because applications connect through `mongos` normally. Set
+both optional connection strings in `env_variables.sh` before running the query
+snippets:
+
+- `MDB_ADMIN_CONNECTION_STRING` must be authorized to restore data, enable
+  sharding, create indexes, and shard collections in `sample_mflix`.
+- `MDB_USER_CONNECTION_STRING` must have `readWrite` access to `sample_mflix`,
+  including permission to create and manage Search indexes.
+
+```bash
+export K8S_CTX="${K8S_CTX_0}"
+
+( cd ../08-search-sharded-query-usage && ./test.sh )
+```

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0040_validate_env.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0040_validate_env.sh
@@ -1,0 +1,67 @@
+echo "Validating environment variables..."
+
+required_vars=(
+  "K8S_CTX_0"
+  "K8S_CTX_1"
+  "MDB_NS"
+  "MDB_EXTERNAL_CLUSTER_NAME"
+  "MDB_SEARCH_RESOURCE_NAME"
+  "MDB_VERSION"
+  "MDB_SEARCH_SYNC_USER_PASSWORD"
+  "MDB_MONGOT_REPLICAS_PER_CLUSTER"
+  "MDB_PROXY_HOST_0"
+  "MDB_PROXY_HOST_SHARD_0"
+  "MDB_PROXY_HOST_SHARD_1"
+  "MDB_PROXY_HOST_SHARD_2"
+  "MDB_EXTERNAL_MONGOS_HOST_0"
+  "MDB_EXTERNAL_MONGOS_HOST_1"
+  "MDB_EXTERNAL_SHARD_0_NAME"
+  "MDB_EXTERNAL_SHARD_1_NAME"
+  "MDB_EXTERNAL_SHARD_2_NAME"
+  "MDB_EXTERNAL_SHARD_0_HOST_CL0"
+  "MDB_EXTERNAL_SHARD_0_HOST_CL1"
+  "MDB_EXTERNAL_SHARD_1_HOST_CL0"
+  "MDB_EXTERNAL_SHARD_1_HOST_CL1"
+  "MDB_EXTERNAL_SHARD_2_HOST_CL0"
+  "MDB_EXTERNAL_SHARD_2_HOST_CL1"
+)
+
+missing_vars=()
+for var in "${required_vars[@]}"; do
+  [[ -n "${!var:-}" ]] && [[ "${!var}" != "<"* ]] || missing_vars+=("${var}")
+done
+
+has_error=false
+if (( ${#missing_vars[@]} )); then
+  echo "ERROR: Missing required environment variables:" >&2
+  for m in "${missing_vars[@]}"; do echo "  - ${m}" >&2; done
+  echo "Please edit env_variables.sh and set these values before proceeding." >&2
+  has_error=true
+fi
+
+missing_contexts=()
+for ctx in "${K8S_CTX_0:-}" "${K8S_CTX_1:-}"; do
+  if [[ -n "${ctx}" ]] && [[ "${ctx}" != "<"* ]] && ! kubectl config get-contexts "${ctx}" &>/dev/null; then
+    missing_contexts+=("${ctx}")
+  fi
+done
+
+if (( ${#missing_contexts[@]} )); then
+  echo "ERROR: Kubernetes context(s) not found:" >&2
+  for ctx in "${missing_contexts[@]}"; do echo "  - ${ctx}" >&2; done
+  echo "Available contexts:" >&2
+  kubectl config get-contexts -o name >&2
+  has_error=true
+fi
+
+if [[ "${has_error}" == "true" ]]; then
+  false
+else
+  echo "[ok] All required environment variables are set"
+  echo "  Kubernetes contexts: ${K8S_CTX_0}, ${K8S_CTX_1}"
+  echo "  Namespace: ${MDB_NS}"
+  echo "  External sharded cluster: ${MDB_EXTERNAL_CLUSTER_NAME}"
+  echo "  Search resource name: ${MDB_SEARCH_RESOURCE_NAME}"
+  echo "  Mongot replicas per (cluster, shard): ${MDB_MONGOT_REPLICAS_PER_CLUSTER}"
+  echo "  Cluster 0 mongos proxy host: ${MDB_PROXY_HOST_0}"
+fi

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0045_create_namespaces.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0045_create_namespaces.sh
@@ -1,0 +1,7 @@
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  kubectl create namespace "${MDB_NS}" --context "${ctx}" --dry-run=client -o yaml | \
+    kubectl apply --context "${ctx}" -f -
+  kubectl label namespace "${MDB_NS}" istio-injection=enabled --overwrite --context "${ctx}"
+done
+
+echo "[ok] Namespace '${MDB_NS}' ready in every member cluster"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0046_internal_create_image_pull_secrets.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0046_internal_create_image_pull_secrets.sh
@@ -1,0 +1,17 @@
+if [[ -z "${IMAGE_PULL_SECRET_NAME:-}" ]]; then
+  echo "No IMAGE_PULL_SECRET_NAME configured, skipping image pull secret creation"
+elif [[ -z "${IMAGE_PULL_SECRET_DATA:-}" ]]; then
+  echo "No IMAGE_PULL_SECRET_DATA configured, skipping image pull secret creation"
+else
+  for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+    kubectl create secret docker-registry "${IMAGE_PULL_SECRET_NAME}" \
+      --docker-server="${DOCKER_REGISTRY:-quay.io}" \
+      --docker-username="${DOCKER_USERNAME:-}" \
+      --docker-password="${DOCKER_PASSWORD:-}" \
+      --namespace="${MDB_NS}" \
+      --context "${ctx}" \
+      --dry-run=client -o yaml | kubectl apply --context "${ctx}" -f -
+  done
+
+  echo "[ok] Image pull secret '${IMAGE_PULL_SECRET_NAME}' created in every member cluster"
+fi

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0100_install_operator.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0100_install_operator.sh
@@ -1,0 +1,32 @@
+echo "Configuring multi-cluster service accounts and roles..."
+
+kubectl mongodb multicluster setup \
+  --central-cluster="${K8S_CTX_0}" \
+  --member-clusters="${K8S_CTX_0},${K8S_CTX_1}" \
+  --member-cluster-namespace="${MDB_NS}" \
+  --central-cluster-namespace="${MDB_NS}" \
+  --create-service-account-secrets \
+  --install-database-roles=true \
+  ${IMAGE_PULL_SECRET_NAME:+--image-pull-secrets="${IMAGE_PULL_SECRET_NAME}"}
+
+echo "[ok] Multi-cluster service accounts and roles configured"
+
+echo "Installing the operator in multi-cluster mode..."
+
+helm upgrade --install --debug --kube-context "${K8S_CTX_0}" \
+  --create-namespace --namespace="${MDB_NS}" \
+  mongodb-kubernetes-operator-multi-cluster \
+  --set namespace="${MDB_NS}" \
+  --set operator.namespace="${MDB_NS}" \
+  --set operator.watchNamespace="${MDB_NS}" \
+  --set operator.name=mongodb-kubernetes-operator-multi-cluster \
+  --set operator.createOperatorServiceAccount=false \
+  --set operator.createResourcesServiceAccountsAndRoles=false \
+  --set "multiCluster.clusters={${K8S_CTX_0},${K8S_CTX_1}}" \
+  ${OPERATOR_ADDITIONAL_HELM_VALUES:+--set ${OPERATOR_ADDITIONAL_HELM_VALUES}} \
+  "${OPERATOR_HELM_CHART}"
+
+kubectl --context "${K8S_CTX_0}" -n "${MDB_NS}" rollout status \
+  --timeout=2m deployment/mongodb-kubernetes-operator-multi-cluster
+
+echo "[ok] Operator installed in multi-cluster mode"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0300_internal_create_ops_manager_resources.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0300_internal_create_ops_manager_resources.sh
@@ -1,0 +1,24 @@
+echo "Creating Ops Manager connection resources..."
+
+
+kubectl create secret generic om-credentials \
+  --from-literal="user=${OPS_MANAGER_API_USER}" \
+  --from-literal="publicApiKey=${OPS_MANAGER_API_KEY}" \
+  --namespace="${MDB_NS}" \
+  --context "${K8S_CTX_0}" \
+  --dry-run=client -o yaml | kubectl apply --context "${K8S_CTX_0}" -f -
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: om-project
+data:
+  baseUrl: "${OPS_MANAGER_API_URL}"
+  orgId: "${OPS_MANAGER_ORG_ID}"
+  projectName: "${OPS_MANAGER_PROJECT_NAME}"
+EOF
+
+echo "[ok] Ops Manager resources created"
+echo "  - Secret: om-credentials"
+echo "  - ConfigMap: om-project"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0301_install_cert_manager.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0301_install_cert_manager.sh
@@ -1,0 +1,18 @@
+echo "Installing cert-manager..."
+
+if kubectl get namespace "${CERT_MANAGER_NAMESPACE}" --context "${K8S_CTX_0}" &>/dev/null \
+  && kubectl get deployment cert-manager -n "${CERT_MANAGER_NAMESPACE}" --context "${K8S_CTX_0}" &>/dev/null; then
+  echo "cert-manager is already installed, skipping installation"
+  kubectl rollout status deployment/cert-manager -n "${CERT_MANAGER_NAMESPACE}" --context "${K8S_CTX_0}" --timeout=60s
+  echo "[ok] cert-manager is ready"
+else
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml \
+    --context "${K8S_CTX_0}"
+
+  echo "Waiting for cert-manager to be ready..."
+  kubectl rollout status deployment/cert-manager -n "${CERT_MANAGER_NAMESPACE}" --context "${K8S_CTX_0}" --timeout=300s
+  kubectl rollout status deployment/cert-manager-webhook -n "${CERT_MANAGER_NAMESPACE}" --context "${K8S_CTX_0}" --timeout=300s
+  kubectl rollout status deployment/cert-manager-cainjector -n "${CERT_MANAGER_NAMESPACE}" --context "${K8S_CTX_0}" --timeout=300s
+
+  echo "[ok] cert-manager installed and ready"
+fi

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0302_internal_configure_tls_prerequisites.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0302_internal_configure_tls_prerequisites.sh
@@ -1,0 +1,53 @@
+echo "Configuring TLS prerequisites..."
+
+kubectl apply --context "${K8S_CTX_0}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${MDB_TLS_SELF_SIGNED_ISSUER}
+spec:
+  selfSigned: {}
+EOF
+
+echo "  [ok] Self-signed ClusterIssuer created"
+
+kubectl apply --context "${K8S_CTX_0}" -n "${CERT_MANAGER_NAMESPACE}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${MDB_TLS_CA_CERT_NAME}
+spec:
+  isCA: true
+  commonName: mongodb-ca
+  secretName: ${MDB_TLS_CA_SECRET_NAME}
+  duration: 87600h
+  renewBefore: 8760h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: ${MDB_TLS_SELF_SIGNED_ISSUER}
+    kind: ClusterIssuer
+EOF
+
+echo "  [ok] CA Certificate requested"
+
+echo "  Waiting for CA certificate..."
+kubectl wait --for=condition=Ready certificate/"${MDB_TLS_CA_CERT_NAME}" \
+  -n "${CERT_MANAGER_NAMESPACE}" \
+  --context "${K8S_CTX_0}" \
+  --timeout=60s
+
+kubectl apply --context "${K8S_CTX_0}" -n "${CERT_MANAGER_NAMESPACE}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${MDB_TLS_CA_ISSUER}
+spec:
+  ca:
+    secretName: ${MDB_TLS_CA_SECRET_NAME}
+EOF
+
+echo "  [ok] CA Issuer created"
+
+echo "[ok] TLS prerequisites configured"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0302a_internal_configure_tls_prerequisites_mongod.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0302a_internal_configure_tls_prerequisites_mongod.sh
@@ -1,0 +1,19 @@
+echo "Configuring CA certificate (ConfigMap) for mongod..."
+
+mkdir -p certs
+
+kubectl get secret "${MDB_TLS_CA_SECRET_NAME}" \
+  -n "${CERT_MANAGER_NAMESPACE}" \
+  --context "${K8S_CTX_0}" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/ca-pem
+
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  kubectl create configmap "${MDB_TLS_CA_CONFIGMAP}" \
+    --from-file=ca-pem=certs/ca-pem \
+    --from-file=ca.crt=certs/ca-pem \
+    -n "${MDB_NS}" \
+    --context "${ctx}" \
+    --dry-run=client -o yaml | kubectl apply --context "${ctx}" -f -
+done
+
+echo "[ok] CA ConfigMap configured for mongod in every member cluster"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0304_internal_generate_tls_certificates.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0304_internal_generate_tls_certificates.sh
@@ -1,0 +1,41 @@
+echo "Generating TLS certificates for the MongoDB sharded cluster..."
+
+for component in "${MDB_SHARD_0_NAME}" "${MDB_SHARD_1_NAME}" "${MDB_SHARD_2_NAME}" \
+  "${MDB_RESOURCE_NAME}-config" "${MDB_RESOURCE_NAME}-mongos"; do
+  cert_name="${MDB_TLS_CERT_SECRET_PREFIX}-${component}-cert"
+  echo "Creating certificate ${cert_name}..."
+  kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${cert_name}
+spec:
+  secretName: ${cert_name}
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - "*.${MDB_NS}.svc.cluster.local"
+  issuerRef:
+    name: ${MDB_TLS_CA_ISSUER}
+    kind: ClusterIssuer
+EOF
+  echo "  [ok] Certificate requested: ${cert_name}"
+done
+
+echo ""
+echo "Waiting for certificates to be ready..."
+for component in "${MDB_SHARD_0_NAME}" "${MDB_SHARD_1_NAME}" "${MDB_SHARD_2_NAME}" \
+  "${MDB_RESOURCE_NAME}-config" "${MDB_RESOURCE_NAME}-mongos"; do
+  kubectl wait --for=condition=Ready certificate/"${MDB_TLS_CERT_SECRET_PREFIX}-${component}-cert" \
+    -n "${MDB_NS}" \
+    --context "${K8S_CTX_0}" \
+    --timeout=60s
+done
+
+echo "[ok] MongoDB sharded cluster TLS certificates created"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0310_internal_create_mongodb_mc_sharded.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0310_internal_create_mongodb_mc_sharded.sh
@@ -1,0 +1,91 @@
+echo "Creating operator-managed multi-cluster MongoDB sharded cluster..."
+echo "  Shards: ${MDB_SHARD_COUNT}"
+echo "  mongods per shard per cluster: ${MDB_MONGODS_PER_SHARD_PER_CLUSTER}"
+echo "  mongos per cluster: ${MDB_MONGOS_PER_CLUSTER}"
+echo "  Config servers per cluster: ${MDB_CONFIG_SERVERS_PER_CLUSTER}"
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  name: ${MDB_RESOURCE_NAME}
+spec:
+  shardCount: ${MDB_SHARD_COUNT}
+  topology: MultiCluster
+  type: ShardedCluster
+  version: ${MDB_VERSION}
+  opsManager:
+    configMapRef:
+      name: om-project
+  credentials: om-credentials
+  persistent: true
+  security:
+    certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
+    tls:
+      ca: ${MDB_TLS_CA_CONFIGMAP}
+    authentication:
+      enabled: true
+      modes: ["SCRAM"]
+  mongos:
+    clusterSpecList:
+      - clusterName: ${K8S_CTX_0}
+        members: ${MDB_MONGOS_PER_CLUSTER}
+      - clusterName: ${K8S_CTX_1}
+        members: ${MDB_MONGOS_PER_CLUSTER}
+    additionalMongodConfig:
+      setParameter:
+        searchTLSMode: requireTLS
+        useGrpcForSearch: true
+        skipAuthenticationToMongot: false
+        skipAuthenticationToSearchIndexManagementServer: false
+        mongotHost: "${MDB_PROXY_HOST_0}"
+        searchIndexManagementHostAndPort: "${MDB_PROXY_HOST_0}"
+  configSrv:
+    clusterSpecList:
+      - clusterName: ${K8S_CTX_0}
+        members: ${MDB_CONFIG_SERVERS_PER_CLUSTER}
+      - clusterName: ${K8S_CTX_1}
+        members: ${MDB_CONFIG_SERVERS_PER_CLUSTER}
+  shard:
+    clusterSpecList:
+      - clusterName: ${K8S_CTX_0}
+        members: ${MDB_MONGODS_PER_SHARD_PER_CLUSTER}
+      - clusterName: ${K8S_CTX_1}
+        members: ${MDB_MONGODS_PER_SHARD_PER_CLUSTER}
+    additionalMongodConfig:
+      setParameter:
+        searchTLSMode: requireTLS
+        useGrpcForSearch: true
+        skipAuthenticationToMongot: false
+        skipAuthenticationToSearchIndexManagementServer: false
+  shardOverrides:
+    - shardNames: ["${MDB_SHARD_0_NAME}"]
+      additionalMongodConfig:
+        setParameter:
+          searchTLSMode: requireTLS
+          useGrpcForSearch: true
+          skipAuthenticationToMongot: false
+          skipAuthenticationToSearchIndexManagementServer: false
+          mongotHost: "${MDB_PROXY_HOST_SHARD_0}"
+          searchIndexManagementHostAndPort: "${MDB_PROXY_HOST_SHARD_0}"
+    - shardNames: ["${MDB_SHARD_1_NAME}"]
+      additionalMongodConfig:
+        setParameter:
+          searchTLSMode: requireTLS
+          useGrpcForSearch: true
+          skipAuthenticationToMongot: false
+          skipAuthenticationToSearchIndexManagementServer: false
+          mongotHost: "${MDB_PROXY_HOST_SHARD_1}"
+          searchIndexManagementHostAndPort: "${MDB_PROXY_HOST_SHARD_1}"
+    - shardNames: ["${MDB_SHARD_2_NAME}"]
+      additionalMongodConfig:
+        setParameter:
+          searchTLSMode: requireTLS
+          useGrpcForSearch: true
+          skipAuthenticationToMongot: false
+          skipAuthenticationToSearchIndexManagementServer: false
+          mongotHost: "${MDB_PROXY_HOST_SHARD_2}"
+          searchIndexManagementHostAndPort: "${MDB_PROXY_HOST_SHARD_2}"
+EOF
+
+echo "[ok] Multi-cluster MongoDB sharded cluster resource created"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0315_internal_wait_for_sharded_cluster.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0315_internal_wait_for_sharded_cluster.sh
@@ -1,0 +1,17 @@
+echo "Waiting for the multi-cluster MongoDB sharded cluster to be ready..."
+echo "This may take several minutes..."
+
+kubectl wait --for=jsonpath='{.status.phase}'=Running \
+  mongodb/"${MDB_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CTX_0}" \
+  --timeout=1500s
+
+echo "[ok] Multi-cluster MongoDB sharded cluster is Running"
+
+echo ""
+echo "Sharded cluster StatefulSets per member cluster:"
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  echo "== ${ctx} =="
+  kubectl get statefulsets -n "${MDB_NS}" --context "${ctx}"
+done

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0315a_internal_create_mongodb_users.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0315a_internal_create_mongodb_users.sh
@@ -1,0 +1,108 @@
+echo "Creating password secrets for MongoDB users..."
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mdb-admin-user-password
+type: Opaque
+stringData:
+  password: ${MDB_ADMIN_USER_PASSWORD}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mdb-user-password
+type: Opaque
+stringData:
+  password: ${MDB_USER_PASSWORD}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${MDB_RESOURCE_NAME}-search-sync-source-password
+type: Opaque
+stringData:
+  password: ${MDB_SEARCH_SYNC_USER_PASSWORD}
+EOF
+
+echo "  [ok] Password secrets created"
+
+echo "Creating MongoDBUser CRDs..."
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: mdb-admin-user
+spec:
+  username: mdb-admin
+  db: admin
+  mongodbResourceRef:
+    name: ${MDB_RESOURCE_NAME}
+  passwordSecretKeyRef:
+    name: mdb-admin-user-password
+    key: password
+  roles:
+  - name: root
+    db: admin
+EOF
+echo "  [ok] Admin user CRD created"
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: mdb-user
+spec:
+  username: mdb-user
+  db: admin
+  mongodbResourceRef:
+    name: ${MDB_RESOURCE_NAME}
+  passwordSecretKeyRef:
+    name: mdb-user-password
+    key: password
+  roles:
+  - name: readWrite
+    db: sample_mflix
+EOF
+echo "  [ok] Application user CRD created"
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: ${MDB_RESOURCE_NAME}-search-sync-source
+spec:
+  username: search-sync-source
+  db: admin
+  mongodbResourceRef:
+    name: ${MDB_RESOURCE_NAME}
+  passwordSecretKeyRef:
+    name: ${MDB_RESOURCE_NAME}-search-sync-source-password
+    key: password
+  roles:
+  - name: searchCoordinator
+    db: admin
+EOF
+echo "  [ok] Search sync source user CRD created"
+
+echo "Waiting for admin user to be ready..."
+kubectl wait --context "${K8S_CTX_0}" -n "${MDB_NS}" \
+  --for=jsonpath='{.status.phase}'=Updated \
+  mongodbuser/mdb-admin-user \
+  --timeout=300s
+
+echo "Waiting for regular user to be ready..."
+kubectl wait --context "${K8S_CTX_0}" -n "${MDB_NS}" \
+  --for=jsonpath='{.status.phase}'=Updated \
+  mongodbuser/mdb-user \
+  --timeout=300s
+
+echo "Waiting for search sync user to be ready..."
+kubectl wait --context "${K8S_CTX_0}" -n "${MDB_NS}" \
+  --for=jsonpath='{.status.phase}'=Updated \
+  "mongodbuser/${MDB_RESOURCE_NAME}-search-sync-source" \
+  --timeout=300s
+
+echo "[ok] All MongoDB users created successfully"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0316_create_search_sync_secret.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0316_create_search_sync_secret.sh
@@ -1,0 +1,5 @@
+kubectl --context "${K8S_CTX_0}" -n "${MDB_NS}" create secret generic \
+  "${MDB_SEARCH_RESOURCE_NAME}-search-sync-source-password" \
+  --from-literal=password="${MDB_SEARCH_SYNC_USER_PASSWORD}" \
+  --dry-run=client -o yaml \
+  | kubectl --context "${K8S_CTX_0}" -n "${MDB_NS}" apply -f -

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0316a_create_mongot_tls_certificates.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0316a_create_mongot_tls_certificates.sh
@@ -1,0 +1,43 @@
+echo "Creating TLS certificates for MongoDB Search (mongot) pods..."
+
+for ci in 0 1; do
+  for shard_name in "${MDB_EXTERNAL_SHARD_0_NAME}" "${MDB_EXTERNAL_SHARD_1_NAME}" "${MDB_EXTERNAL_SHARD_2_NAME}"; do
+    cert_name="${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-${ci}-${shard_name}-cert"
+    echo "  Creating certificate: ${cert_name}"
+    kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${cert_name}
+spec:
+  secretName: ${cert_name}
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - "*.${MDB_NS}.svc.cluster.local"
+  issuerRef:
+    name: ${MDB_TLS_CA_ISSUER}
+    kind: ClusterIssuer
+EOF
+    echo "  [ok] Certificate requested: ${cert_name}"
+  done
+done
+
+echo "Waiting for mongot certificates to be ready..."
+for ci in 0 1; do
+  for shard_name in "${MDB_EXTERNAL_SHARD_0_NAME}" "${MDB_EXTERNAL_SHARD_1_NAME}" "${MDB_EXTERNAL_SHARD_2_NAME}"; do
+    kubectl wait --for=condition=Ready \
+      certificate/"${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-${ci}-${shard_name}-cert" \
+      -n "${MDB_NS}" \
+      --context "${K8S_CTX_0}" \
+      --timeout=60s
+  done
+done
+
+echo "[ok] All MongoDB Search (mongot) TLS certificates created"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0316b_create_lb_tls_certificates.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0316b_create_lb_tls_certificates.sh
@@ -1,0 +1,68 @@
+echo "Creating TLS certificates for managed load balancer (Envoy)..."
+
+for ci in 0 1; do
+  lb_server_cert="${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-lb-${ci}-cert"
+  lb_client_cert="${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-lb-${ci}-client-cert"
+
+  echo "Creating LB server certificate for cluster ${ci}..."
+  kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${lb_server_cert}
+spec:
+  secretName: ${lb_server_cert}
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  usages:
+    - server auth
+  dnsNames:
+    - "*.${MDB_NS}.svc.cluster.local"
+  issuerRef:
+    name: ${MDB_TLS_CA_ISSUER}
+    kind: ClusterIssuer
+EOF
+  echo "  [ok] LB server certificate requested: ${lb_server_cert}"
+
+  echo "Creating LB client certificate for cluster ${ci}..."
+  kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${lb_client_cert}
+spec:
+  secretName: ${lb_client_cert}
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  usages:
+    - client auth
+  dnsNames:
+    - "*.${MDB_NS}.svc.cluster.local"
+  issuerRef:
+    name: ${MDB_TLS_CA_ISSUER}
+    kind: ClusterIssuer
+EOF
+  echo "  [ok] LB client certificate requested: ${lb_client_cert}"
+done
+
+echo "Waiting for LB certificates to be ready..."
+for ci in 0 1; do
+  lb_server_cert="${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-lb-${ci}-cert"
+  lb_client_cert="${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-lb-${ci}-client-cert"
+  kubectl wait --for=condition=Ready certificate/"${lb_server_cert}" \
+    -n "${MDB_NS}" \
+    --context "${K8S_CTX_0}" \
+    --timeout=60s
+  kubectl wait --for=condition=Ready certificate/"${lb_client_cert}" \
+    -n "${MDB_NS}" \
+    --context "${K8S_CTX_0}" \
+    --timeout=60s
+done
+
+echo "[ok] All managed load balancer (Envoy) TLS certificates created"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0317_replicate_search_secrets.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0317_replicate_search_secrets.sh
@@ -1,0 +1,17 @@
+echo "Replicating Search Secrets to the member clusters..."
+
+replicate_secret() {
+  local name="$1" dst_ctx="$2"
+  kubectl --context "${K8S_CTX_0}" -n "${MDB_NS}" get secret "${name}" -o json \
+    | jq 'del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.namespace, .metadata.ownerReferences, .metadata.managedFields, .status)' \
+    | kubectl --context "${dst_ctx}" -n "${MDB_NS}" apply -f -
+}
+
+for shard_name in "${MDB_EXTERNAL_SHARD_0_NAME}" "${MDB_EXTERNAL_SHARD_1_NAME}" "${MDB_EXTERNAL_SHARD_2_NAME}"; do
+  replicate_secret "${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-1-${shard_name}-cert" "${K8S_CTX_1}"
+done
+replicate_secret "${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-lb-1-cert" "${K8S_CTX_1}"
+replicate_secret "${MDB_TLS_CERT_SECRET_PREFIX}-${MDB_SEARCH_RESOURCE_NAME}-search-lb-1-client-cert" "${K8S_CTX_1}"
+replicate_secret "${MDB_SEARCH_RESOURCE_NAME}-search-sync-source-password" "${K8S_CTX_1}"
+
+echo "[ok] Search Secrets replicated to member clusters"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0320_create_mongodb_search_resource.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0320_create_mongodb_search_resource.sh
@@ -1,0 +1,71 @@
+echo "Creating MongoDBSearch resource (multi-cluster sharded, managed Envoy LB)..."
+echo "  Configuring ${MDB_MONGOT_REPLICAS_PER_CLUSTER} mongot replica(s) per (cluster, shard)"
+
+kubectl apply --context "${K8S_CTX_0}" -n "${MDB_NS}" -f - <<EOF
+apiVersion: mongodb.com/v1
+kind: MongoDBSearch
+metadata:
+  name: ${MDB_SEARCH_RESOURCE_NAME}
+spec:
+  source:
+    username: search-sync-source
+    passwordSecretRef:
+      name: ${MDB_SEARCH_RESOURCE_NAME}-search-sync-source-password
+      key: password
+    external:
+      shardedCluster:
+        router:
+          hosts:
+            - "${MDB_EXTERNAL_MONGOS_HOST_0}"
+            - "${MDB_EXTERNAL_MONGOS_HOST_1}"
+        shards:
+          - shardName: ${MDB_EXTERNAL_SHARD_0_NAME}
+            hosts:
+              - "${MDB_EXTERNAL_SHARD_0_HOST_CL0}"
+              - "${MDB_EXTERNAL_SHARD_0_HOST_CL1}"
+          - shardName: ${MDB_EXTERNAL_SHARD_1_NAME}
+            hosts:
+              - "${MDB_EXTERNAL_SHARD_1_HOST_CL0}"
+              - "${MDB_EXTERNAL_SHARD_1_HOST_CL1}"
+          - shardName: ${MDB_EXTERNAL_SHARD_2_NAME}
+            hosts:
+              - "${MDB_EXTERNAL_SHARD_2_HOST_CL0}"
+              - "${MDB_EXTERNAL_SHARD_2_HOST_CL1}"
+      tls:
+        ca:
+          name: ${MDB_TLS_CA_CONFIGMAP}
+  security:
+    tls:
+      certsSecretPrefix: ${MDB_TLS_CERT_SECRET_PREFIX}
+  clusters:
+    - name: ${K8S_CTX_0}
+      index: 0
+      replicas: ${MDB_MONGOT_REPLICAS_PER_CLUSTER}
+      loadBalancer:
+        managed:
+          externalHostname: "${MDB_SEARCH_RESOURCE_NAME}-search-0-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local"
+          routerHostname: "${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local"
+      resourceRequirements:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
+    - name: ${K8S_CTX_1}
+      index: 1
+      replicas: ${MDB_MONGOT_REPLICAS_PER_CLUSTER}
+      loadBalancer:
+        managed:
+          externalHostname: "${MDB_SEARCH_RESOURCE_NAME}-search-1-{shardName}-proxy-svc.${MDB_NS}.svc.cluster.local"
+          routerHostname: "${MDB_SEARCH_RESOURCE_NAME}-search-1-proxy-svc.${MDB_NS}.svc.cluster.local"
+      resourceRequirements:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
+EOF
+
+echo "[ok] MongoDBSearch resource '${MDB_SEARCH_RESOURCE_NAME}' created"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0325_wait_for_search_resource.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0325_wait_for_search_resource.sh
@@ -1,0 +1,22 @@
+echo "Waiting for MongoDBSearch to be ready..."
+echo "This may take several minutes while mongot syncs data..."
+
+kubectl wait --for=jsonpath='{.status.phase}'=Running \
+  mongodbsearch/"${MDB_SEARCH_RESOURCE_NAME}" \
+  -n "${MDB_NS}" \
+  --context "${K8S_CTX_0}" \
+  --timeout=900s
+
+echo "[ok] MongoDBSearch '${MDB_SEARCH_RESOURCE_NAME}' is Running"
+
+echo ""
+echo "MongoDBSearch pods per member cluster:"
+ci=0
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  echo "== ${ctx} =="
+  for shard_name in "${MDB_EXTERNAL_SHARD_0_NAME}" "${MDB_EXTERNAL_SHARD_1_NAME}" "${MDB_EXTERNAL_SHARD_2_NAME}"; do
+    kubectl get pods -n "${MDB_NS}" --context "${ctx}" \
+      -l "app=${MDB_SEARCH_RESOURCE_NAME}-search-${ci}-${shard_name}"
+  done
+  ci=$((ci + 1))
+done

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0326_internal_verify_envoy_deployment.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0326_internal_verify_envoy_deployment.sh
@@ -1,0 +1,62 @@
+echo "Verifying operator-managed per-cluster mongot and Envoy resources..."
+
+has_error=false
+ci=0
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  envoy_deployment="${MDB_SEARCH_RESOURCE_NAME}-search-lb-${ci}"
+
+  echo "== cluster ${ci} (${ctx}) =="
+
+  echo "Checking per-shard mongot StatefulSets..."
+  for shard_name in "${MDB_SHARD_0_NAME}" "${MDB_SHARD_1_NAME}" "${MDB_SHARD_2_NAME}"; do
+    mongot_sts="${MDB_SEARCH_RESOURCE_NAME}-search-${ci}-${shard_name}"
+    if kubectl get statefulset "${mongot_sts}" -n "${MDB_NS}" --context "${ctx}" &>/dev/null; then
+      echo "  [ok] StatefulSet '${mongot_sts}' exists"
+    else
+      echo "  [FAIL] StatefulSet '${mongot_sts}' NOT FOUND" >&2
+      has_error=true
+    fi
+  done
+
+  echo "Checking Envoy Deployment..."
+  if kubectl get deployment "${envoy_deployment}" -n "${MDB_NS}" --context "${ctx}" &>/dev/null; then
+    if kubectl rollout status deployment/"${envoy_deployment}" -n "${MDB_NS}" --context "${ctx}" --timeout=120s; then
+      echo "  [ok] Deployment '${envoy_deployment}' is ready"
+    else
+      echo "  [FAIL] Deployment '${envoy_deployment}' is not ready" >&2
+      has_error=true
+    fi
+  else
+    echo "  [FAIL] Deployment '${envoy_deployment}' NOT FOUND" >&2
+    has_error=true
+  fi
+
+  echo "Checking router proxy Service..."
+  router_proxy_service="${MDB_SEARCH_RESOURCE_NAME}-search-${ci}-proxy-svc"
+  if kubectl get service "${router_proxy_service}" -n "${MDB_NS}" --context "${ctx}" &>/dev/null; then
+    echo "  [ok] Service '${router_proxy_service}' exists"
+  else
+    echo "  [FAIL] Service '${router_proxy_service}' NOT FOUND" >&2
+    has_error=true
+  fi
+
+  echo "Checking per-shard proxy Services..."
+  for shard_name in "${MDB_SHARD_0_NAME}" "${MDB_SHARD_1_NAME}" "${MDB_SHARD_2_NAME}"; do
+    proxy_service="${MDB_SEARCH_RESOURCE_NAME}-search-${ci}-${shard_name}-proxy-svc"
+    if kubectl get service "${proxy_service}" -n "${MDB_NS}" --context "${ctx}" &>/dev/null; then
+      echo "  [ok] Service '${proxy_service}' exists"
+    else
+      echo "  [FAIL] Service '${proxy_service}' NOT FOUND" >&2
+      has_error=true
+    fi
+  done
+
+  ci=$((ci + 1))
+done
+
+if [[ "${has_error}" == "true" ]]; then
+  false
+else
+  echo ""
+  echo "[ok] Operator-managed per-cluster Envoy proxies are deployed and healthy"
+fi

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0330_show_running_pods.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_0330_show_running_pods.sh
@@ -1,0 +1,15 @@
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  echo "== ${ctx} =="
+  echo "Pods in namespace '${MDB_NS}':"
+  echo ""
+
+  kubectl get pods -n "${MDB_NS}" --context "${ctx}" -o wide
+
+  echo ""
+  echo "Services in namespace '${MDB_NS}':"
+  kubectl get services -n "${MDB_NS}" --context "${ctx}"
+  echo ""
+done
+
+echo "MongoDBSearch resources:"
+kubectl get mongodbsearch -n "${MDB_NS}" --context "${K8S_CTX_0}"

--- a/docs/search/13-search-sharded-multi-cluster/code_snippets/13_9010_internal_delete_namespace.sh
+++ b/docs/search/13-search-sharded-multi-cluster/code_snippets/13_9010_internal_delete_namespace.sh
@@ -1,0 +1,14 @@
+echo "WARNING: This will delete namespace '${MDB_NS}' and all its resources in every member cluster."
+echo ""
+
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  echo "Deleting namespace '${MDB_NS}' in ${ctx}..."
+  kubectl delete namespace "${MDB_NS}" --context "${ctx}" --wait=false
+done
+
+echo ""
+echo "Namespace deletion initiated."
+echo "Resources may take a few minutes to fully terminate."
+echo ""
+echo "To monitor cleanup progress:"
+echo "  kubectl get pods -n ${MDB_NS} --context ${K8S_CTX_0} --watch"

--- a/docs/search/13-search-sharded-multi-cluster/env_variables.sh
+++ b/docs/search/13-search-sharded-multi-cluster/env_variables.sh
@@ -1,0 +1,57 @@
+# Kubernetes contexts for the two member clusters. Cluster 0 is also the
+# central cluster where the operator and MongoDBSearch resource run.
+export K8S_CTX_0="<central/member-0 cluster context>"
+export K8S_CTX_1="<member-1 cluster context>"
+export MDB_NS="mongodb"
+
+# Existing external sharded cluster and the MongoDBSearch resource to create.
+export MDB_EXTERNAL_CLUSTER_NAME="mdb-mc-sh"
+export MDB_SEARCH_RESOURCE_NAME="ext-sh"
+
+# Existing shard replica-set names. Change these defaults when your deployment
+# uses different names.
+export MDB_EXTERNAL_SHARD_0_NAME="${MDB_EXTERNAL_CLUSTER_NAME}-0"
+export MDB_EXTERNAL_SHARD_1_NAME="${MDB_EXTERNAL_CLUSTER_NAME}-1"
+export MDB_EXTERNAL_SHARD_2_NAME="${MDB_EXTERNAL_CLUSTER_NAME}-2"
+
+# MongoDB version used by the optional query tools pod.
+export MDB_VERSION="8.2.6-ent"
+
+# Existing search-sync-source user password.
+export MDB_SEARCH_SYNC_USER_PASSWORD="<search-sync-source password>"
+
+# Operator installation.
+export OPERATOR_HELM_CHART="oci://quay.io/mongodb/helm-charts/mongodb-kubernetes"
+export OPERATOR_ADDITIONAL_HELM_VALUES=""
+
+# Existing TLS resources. Keep the issuer and CA ConfigMap aligned with the
+# source deployment's trusted CA.
+export CERT_MANAGER_NAMESPACE="cert-manager"
+export MDB_TLS_CERT_SECRET_PREFIX="certs"
+export MDB_TLS_CA_CONFIGMAP="${MDB_EXTERNAL_CLUSTER_NAME}-ca"
+export MDB_TLS_CA_ISSUER="my-ca-issuer"
+
+# MongoDB Search configuration.
+export MDB_MONGOT_REPLICAS_PER_CLUSTER=1
+# Managed Envoy port (operator default; do not change).
+export ENVOY_PROXY_PORT="27028"
+export MDB_PROXY_HOST_0="${MDB_SEARCH_RESOURCE_NAME}-search-0-proxy-svc.${MDB_NS}.svc.cluster.local:${ENVOY_PROXY_PORT}"
+export MDB_PROXY_HOST_SHARD_0="${MDB_SEARCH_RESOURCE_NAME}-search-0-${MDB_EXTERNAL_SHARD_0_NAME}-proxy-svc.${MDB_NS}.svc.cluster.local:${ENVOY_PROXY_PORT}"
+export MDB_PROXY_HOST_SHARD_1="${MDB_SEARCH_RESOURCE_NAME}-search-0-${MDB_EXTERNAL_SHARD_1_NAME}-proxy-svc.${MDB_NS}.svc.cluster.local:${ENVOY_PROXY_PORT}"
+export MDB_PROXY_HOST_SHARD_2="${MDB_SEARCH_RESOURCE_NAME}-search-0-${MDB_EXTERNAL_SHARD_2_NAME}-proxy-svc.${MDB_NS}.svc.cluster.local:${ENVOY_PROXY_PORT}"
+
+# Existing mongos and shard endpoints reachable from the Kubernetes clusters.
+export MDB_EXTERNAL_MONGOS_HOST_0="<cluster-0 mongos host:27017>"
+export MDB_EXTERNAL_MONGOS_HOST_1="<cluster-1 mongos host:27017>"
+export MDB_EXTERNAL_SHARD_0_HOST_CL0="<cluster-0 shard-0 host:27017>"
+export MDB_EXTERNAL_SHARD_0_HOST_CL1="<cluster-1 shard-0 host:27017>"
+export MDB_EXTERNAL_SHARD_1_HOST_CL0="<cluster-0 shard-1 host:27017>"
+export MDB_EXTERNAL_SHARD_1_HOST_CL1="<cluster-1 shard-1 host:27017>"
+export MDB_EXTERNAL_SHARD_2_HOST_CL0="<cluster-0 shard-2 host:27017>"
+export MDB_EXTERNAL_SHARD_2_HOST_CL1="<cluster-1 shard-2 host:27017>"
+
+# Optional sample query flow. The admin connection must be able to restore and
+# shard sample_mflix; the user connection must be able to manage Search indexes
+# and run queries in that database.
+export MDB_ADMIN_CONNECTION_STRING="<MongoDB admin connection string>"
+export MDB_USER_CONNECTION_STRING="<MongoDB user connection string>"

--- a/docs/search/13-search-sharded-multi-cluster/env_variables_e2e_private.sh
+++ b/docs/search/13-search-sharded-multi-cluster/env_variables_e2e_private.sh
@@ -1,0 +1,58 @@
+# E2E Test Environment Overrides (Enterprise with Ops Manager, multi-cluster kind)
+#
+# This file is sourced by the test runner to override environment variables
+# for automated E2E testing. Do not use this file for manual testing.
+# NOTE: This uses the 2-cluster kind context with cloud-qa Ops Manager.
+
+source "${PROJECT_DIR}/scripts/funcs/operator_deployment"
+source "${PROJECT_DIR}/scripts/dev/contexts/e2e_multi_cluster_2_clusters"
+source "${PROJECT_DIR}/scripts/dev/contexts/variables/mongodb_search_dev"
+
+# Member cluster contexts come from the e2e context: CENTRAL_CLUSTER is also
+# member 0, the second word of MEMBER_CLUSTERS is member 1.
+export K8S_CTX_0="${CENTRAL_CLUSTER}"
+K8S_CTX_1=$(echo "${MEMBER_CLUSTERS}" | awk '{print $2}')
+export K8S_CTX_1
+
+# kind API server endpoints (127.0.0.1:<port>) are not reachable from pods, so
+# the kubeconfig Secret created by `kubectl mongodb multicluster setup` would
+# leave the operator unable to reach the member clusters. Build a kubeconfig
+# variant pointing at each cluster's node container IP on the shared docker
+# network (port 6443). Unlike the kubernetes Service clusterIP that the e2e
+# test-pod flow uses, the node IP is reachable BOTH from pods (the kind
+# interconnect routes via node IPs) and from this host (docker bridge) -- the
+# plugin itself talks to the API servers from the host while it runs.
+plugin_kubeconfig="${PROJECT_DIR}/.generated/snippets_plugin_kubeconfig"
+cp "${KUBECONFIG:-${HOME}/.kube/config}" "${plugin_kubeconfig}"
+for ctx in "${K8S_CTX_0}" "${K8S_CTX_1}"; do
+  node_ip=$(kubectl get nodes --context "${ctx}" -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+  kubectl config --kubeconfig "${plugin_kubeconfig}" set "clusters.${ctx}.server" "https://${node_ip}:6443"
+done
+export KUBECONFIG="${plugin_kubeconfig}"
+
+OPERATOR_ADDITIONAL_HELM_VALUES="$(get_operator_helm_values | tr ' ' ',')"
+export OPERATOR_ADDITIONAL_HELM_VALUES
+export OPERATOR_HELM_CHART="${PROJECT_DIR}/helm_chart"
+
+# we need project name with a timestamp (NAMESPACE in evg is randomized) to allow for cloud-qa cleanups
+export OPS_MANAGER_PROJECT_NAME="${NAMESPACE}-${MDB_RESOURCE_NAME}"
+export OPS_MANAGER_API_URL="${OM_BASE_URL}"
+export OPS_MANAGER_API_USER="${OM_USER}"
+export OPS_MANAGER_API_KEY="${OM_API_KEY}"
+export OPS_MANAGER_ORG_ID="${OM_ORGID}"
+
+# Override the user-supplied mongos and shard host placeholders with the
+# operator-managed Services created by the internal_ steps.
+# mongos naming: <resource>-mongos-<clusterIndex>-<memberIndex>-svc
+export MDB_EXTERNAL_MONGOS_HOST_0="${MDB_RESOURCE_NAME}-mongos-0-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_EXTERNAL_MONGOS_HOST_1="${MDB_RESOURCE_NAME}-mongos-1-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_ADMIN_CONNECTION_STRING="mongodb://mdb-admin:${MDB_ADMIN_USER_PASSWORD}@${MDB_EXTERNAL_MONGOS_HOST_0},${MDB_EXTERNAL_MONGOS_HOST_1}/?tls=true&tlsCAFile=/tls/ca.crt&authSource=admin&authMechanism=SCRAM-SHA-256"
+export MDB_USER_CONNECTION_STRING="mongodb://mdb-user:${MDB_USER_PASSWORD}@${MDB_EXTERNAL_MONGOS_HOST_0},${MDB_EXTERNAL_MONGOS_HOST_1}/?tls=true&tlsCAFile=/tls/ca.crt&authSource=admin&authMechanism=SCRAM-SHA-256"
+
+# Shard member host naming: <resource>-<shardIndex>-<clusterIndex>-<memberIndex>-svc
+export MDB_EXTERNAL_SHARD_0_HOST_CL0="${MDB_RESOURCE_NAME}-0-0-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_EXTERNAL_SHARD_0_HOST_CL1="${MDB_RESOURCE_NAME}-0-1-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_EXTERNAL_SHARD_1_HOST_CL0="${MDB_RESOURCE_NAME}-1-0-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_EXTERNAL_SHARD_1_HOST_CL1="${MDB_RESOURCE_NAME}-1-1-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_EXTERNAL_SHARD_2_HOST_CL0="${MDB_RESOURCE_NAME}-2-0-0-svc.${MDB_NS}.svc.cluster.local:27017"
+export MDB_EXTERNAL_SHARD_2_HOST_CL1="${MDB_RESOURCE_NAME}-2-1-0-svc.${MDB_NS}.svc.cluster.local:27017"

--- a/docs/search/13-search-sharded-multi-cluster/env_variables_internal.sh
+++ b/docs/search/13-search-sharded-multi-cluster/env_variables_internal.sh
@@ -1,0 +1,24 @@
+# Internal source-deployment settings used only by automated tests.
+export MDB_RESOURCE_NAME="${MDB_EXTERNAL_CLUSTER_NAME}"
+export MDB_SHARD_COUNT=3
+export MDB_MONGODS_PER_SHARD_PER_CLUSTER=1
+export MDB_MONGOS_PER_CLUSTER=1
+export MDB_CONFIG_SERVERS_PER_CLUSTER=1
+
+export MDB_SHARD_0_NAME="${MDB_EXTERNAL_SHARD_0_NAME}"
+export MDB_SHARD_1_NAME="${MDB_EXTERNAL_SHARD_1_NAME}"
+export MDB_SHARD_2_NAME="${MDB_EXTERNAL_SHARD_2_NAME}"
+
+export OPS_MANAGER_PROJECT_NAME="<arbitrary project name>"
+export OPS_MANAGER_API_URL="<SET API URL>"
+export OPS_MANAGER_API_USER="<SET API USER>"
+export OPS_MANAGER_API_KEY="<SET API KEY>"
+export OPS_MANAGER_ORG_ID="<SET ORG ID>"
+
+export MDB_ADMIN_USER_PASSWORD="admin-user-password-CHANGE-ME"
+export MDB_USER_PASSWORD="mdb-user-password-CHANGE-ME"
+export MDB_SEARCH_SYNC_USER_PASSWORD="search-sync-user-password-CHANGE-ME"
+
+export MDB_TLS_SELF_SIGNED_ISSUER="selfsigned-bootstrap-issuer"
+export MDB_TLS_CA_CERT_NAME="my-selfsigned-ca"
+export MDB_TLS_CA_SECRET_NAME="root-secret"

--- a/docs/search/13-search-sharded-multi-cluster/test.sh
+++ b/docs/search/13-search-sharded-multi-cluster/test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Test runner script for MongoDB Search with a multi-cluster (topology:
+# MultiCluster) sharded MongoDB source + per-cluster managed Envoy LB
+#
+# This script executes all code snippets in order to test the full deployment flow.
+# It can be run manually or as part of automated E2E testing.
+#
+# Usage:
+#   source env_variables.sh
+#   source env_variables_internal.sh
+#   ./test.sh
+#
+# For E2E testing, env_variables_e2e_private.sh is sourced automatically
+# by the test runner.
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+project_dir="${script_dir}/../../.."
+
+source "${project_dir}/scripts/code_snippets/sample_test_runner.sh"
+
+cd "${script_dir}" || exit 1
+
+prepare_snippets
+
+# ============================================================================
+# PREREQUISITES
+# ============================================================================
+
+run 13_0040_validate_env.sh
+run 13_0045_create_namespaces.sh
+run 13_0046_internal_create_image_pull_secrets.sh
+
+run_for_output 13_0100_install_operator.sh
+
+# Ops Manager resources (for the simulated external cluster)
+run 13_0300_internal_create_ops_manager_resources.sh
+
+# ============================================================================
+# TLS CONFIGURATION
+# ============================================================================
+
+run_for_output 13_0301_install_cert_manager.sh
+run 13_0302_internal_configure_tls_prerequisites.sh
+run 13_0302a_internal_configure_tls_prerequisites_mongod.sh
+run 13_0304_internal_generate_tls_certificates.sh
+
+# ============================================================================
+# SIMULATED EXTERNAL MULTI-CLUSTER MONGODB SHARDED CLUSTER
+# ============================================================================
+
+# Create simulated external multi-cluster sharded cluster
+run 13_0310_internal_create_mongodb_mc_sharded.sh
+run_for_output 13_0315_internal_wait_for_sharded_cluster.sh
+
+# Create users AFTER the cluster is ready (MongoDBUser CRDs reference it)
+run 13_0315a_internal_create_mongodb_users.sh
+run 13_0316_create_search_sync_secret.sh
+
+# ============================================================================
+# MONGODB SEARCH WITH PER-CLUSTER MANAGED ENVOY LB
+# ============================================================================
+
+# Create TLS certificates for the per-(cluster,shard) mongot pods
+run 13_0316a_create_mongot_tls_certificates.sh
+
+# Create TLS certificates for the managed load balancer (Envoy)
+run 13_0316b_create_lb_tls_certificates.sh
+
+# Replicate the Search Secrets to the member clusters (the operator does not)
+run 13_0317_replicate_search_secrets.sh
+
+# Create MongoDBSearch with the external multi-cluster sharded source
+run 13_0320_create_mongodb_search_resource.sh
+run_for_output 13_0325_wait_for_search_resource.sh
+
+# ============================================================================
+# VERIFICATION
+# ============================================================================
+
+# Verify the per-(cluster,shard) mongot StatefulSets and operator-managed Envoys
+run_for_output 13_0326_internal_verify_envoy_deployment.sh
+
+# Show all running pods
+run_for_output 13_0330_show_running_pods.sh
+
+echo "To clean up, run: ./code_snippets/13_9010_internal_delete_namespace.sh"
+
+cd - || true

--- a/scripts/code_snippets/tests/test_kind_search_sharded_multi_cluster_snippets.sh
+++ b/scripts/code_snippets/tests/test_kind_search_sharded_multi_cluster_snippets.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+test "${MDB_BASH_DEBUG:-0}" -eq 1 && set -x
+
+source scripts/dev/set_env_context.sh
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+
+_SNIPPETS_OUTPUT_DIR="$(dirname "${script_name}")/outputs/$(basename "${script_name%.*}")"
+export _SNIPPETS_OUTPUT_DIR
+mkdir -p "${_SNIPPETS_OUTPUT_DIR}"
+
+dump_logs() {
+  if [[ "${SKIP_DUMP:-"false"}" != "true" ]]; then
+    for context in "${K8S_CTX_0:-}" "${K8S_CTX_1:-}"; do
+      if [[ -n "${context}" ]]; then
+        scripts/evergreen/e2e/dump_diagnostic_information_from_all_namespaces.sh "${context}"
+      fi
+    done
+  fi
+}
+trap dump_logs EXIT
+
+# Phase 1: Infrastructure (scenario 13 — multi-cluster sharded + managed LB)
+test_dir="./docs/search/13-search-sharded-multi-cluster"
+source "${test_dir}/env_variables.sh"
+# shellcheck disable=SC1091
+source "${test_dir}/env_variables_internal.sh"
+echo "Sourcing env variables for ${CODE_SNIPPETS_FLAVOR} flavor"
+# shellcheck disable=SC1090
+test -f "${test_dir}/env_variables_${CODE_SNIPPETS_FLAVOR}.sh" && source "${test_dir}/env_variables_${CODE_SNIPPETS_FLAVOR}.sh"
+${test_dir}/test.sh
+
+# No restart sleep is needed here (unlike the single-cluster scenarios): on
+# multi-cluster the search setParameters are part of the initial resource spec,
+# so the mongod processes never restart after MongoDBSearch is created.
+
+# Phase 2: Sharded queries (scenario 08) — runs against cluster 0
+test_dir="./docs/search/08-search-sharded-query-usage"
+echo "Sourcing env variables for ${CODE_SNIPPETS_FLAVOR} flavor"
+# shellcheck disable=SC1090
+test -f "${test_dir}/env_variables_${CODE_SNIPPETS_FLAVOR}.sh" && source "${test_dir}/env_variables_${CODE_SNIPPETS_FLAVOR}.sh"
+
+# The query module is single-context: point it at the central cluster, where
+# the tools pod and the CA ConfigMap live. MDB_ADMIN_CONNECTION_STRING and
+# MDB_USER_CONNECTION_STRING are exported by scenario 13's env_variables.sh.
+export K8S_CTX="${K8S_CTX_0}"
+
+${test_dir}/test.sh
+
+assert_search_results() {
+  kubectl exec -i mongodb-tools -n "${MDB_NS}" --context "${K8S_CTX}" -- \
+    mongosh --quiet "${MDB_USER_CONNECTION_STRING}" <<'MONGOSH'
+const sampleDb = db.getSiblingDB("sample_mflix");
+const textResults = sampleDb.movies.aggregate([
+  { $search: { text: { query: "baseball", path: "plot" } } },
+  { $limit: 1 }
+]);
+if (!textResults.hasNext()) {
+  throw new Error("internal text search assertion returned no documents");
+}
+
+const queryVector = sampleDb.embedded_movies.findOne(
+  { plot_embedding_voyage_3_large: { $exists: true } },
+  { plot_embedding_voyage_3_large: 1 }
+).plot_embedding_voyage_3_large;
+const vectorResults = sampleDb.embedded_movies.aggregate([
+  {
+    $vectorSearch: {
+      index: "vector_index",
+      path: "plot_embedding_voyage_3_large",
+      queryVector,
+      numCandidates: 50,
+      limit: 1
+    }
+  }
+]);
+if (!vectorResults.hasNext()) {
+  throw new Error("internal vector search assertion returned no documents");
+}
+MONGOSH
+}
+
+# Phase 3 proves that a mongos in each cluster can execute Search queries
+# through cluster 0's stable proxy targets. The cluster-0 tools pod reaches
+# both mongos processes over the mesh. K8S_CTX stays K8S_CTX_0 because the
+# tools pod and CA live there.
+# Invoke via 'bash -e' rather than the run/run_for_output framework: its skip-log
+# is keyed on snippet name, so a second run() of the same snippet would no-op.
+for ci in 0 1; do
+  mongos_var="MDB_EXTERNAL_MONGOS_HOST_${ci}"
+  mongos="${!mongos_var}"
+  export MDB_USER_CONNECTION_STRING="mongodb://mdb-user:${MDB_USER_PASSWORD}@${mongos}/?directConnection=true&tls=true&tlsCAFile=/tls/ca.crt&authSource=admin&authMechanism=SCRAM-SHA-256"
+  echo "Phase 3: verifying search from cluster ${ci} mongos (${mongos})"
+  bash -e ./docs/search/08-search-sharded-query-usage/code_snippets/08_0450_execute_search_query.sh
+  bash -e ./docs/search/08-search-sharded-query-usage/code_snippets/08_0455_execute_vector_search_query.sh
+  assert_search_results
+done


### PR DESCRIPTION
## Summary

- Add the complete sharded multi-cluster MongoDB Search snippet scenario.
- Add its kind test runner and register it alongside the replica-set task in the multi-cluster Evergreen task group.

## Customer/internal split

- **Customer-facing:** scenario 13 README, environment contract, and public steps for attaching Search to an existing multi-cluster sharded deployment.
- **Internal CI:** source-deployment helpers, private E2E overrides, kind runner, and Evergreen task wiring.

## Validation

- Bash syntax and ShellCheck pass for all changed shell files.
- Evergreen validation and evaluation pass; the multi-cluster variant retains all 11 required dependencies and registers both replica-set and sharded tasks.
- `git diff --check`, patch-equivalence, and the strict changed-path allowlist pass.

## Evergreen proof

[Final surgical Search snippets patch](https://spruce.mongodb.com/version/6a5f6f941a1f9e00076950d1) passed all nine requested Search snippet tasks and ten required dependency builds. Its downloaded logs and output artifacts confirm the selected query flows executed successfully on both clusters.

## Tracking

- Jira: [KUBE-171](https://jira.mongodb.org/browse/KUBE-171)
- Epic: [KUBE-155](https://jira.mongodb.org/browse/KUBE-155)