### PR TITLE
KUBE-180: validate MongoDBSearch lifecycle recovery

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -23,6 +23,7 @@ from tests.common.search.search_tester import SearchTester
 
 if TYPE_CHECKING:
     from kubetester.mongodb_search import MongoDBSearch
+    from kubetester.multicluster_client import MultiClusterClient
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -984,6 +985,101 @@ def wait_for_resource_deleted(read_fn: Callable[[], Any], what: str, timeout: in
 
 def wait_for_search_deleted(mdbs: "MongoDBSearch", timeout: int = 300) -> None:
     wait_for_resource_deleted(mdbs.load, f"MongoDBSearch {mdbs.name}", timeout=timeout)
+
+
+def protected_search_input_uids(
+    core_v1: Any,
+    namespace: str,
+    source_tls_secret_name: str,
+    sync_user_secret_name: str,
+    ca_configmap_name: str,
+    *,
+    additional_secret_names: tuple[str, ...] = (),
+) -> dict[str, str]:
+    def uid(resource: Any, what: str) -> str:
+        value = resource.metadata.uid
+        assert value, f"{what} has no UID"
+        return value
+
+    uids = {
+        "source_tls_secret": uid(
+            core_v1.read_namespaced_secret(source_tls_secret_name, namespace),
+            f"Secret {source_tls_secret_name}",
+        ),
+        "sync_user_secret": uid(
+            core_v1.read_namespaced_secret(sync_user_secret_name, namespace),
+            f"Secret {sync_user_secret_name}",
+        ),
+        "ca_configmap": uid(
+            core_v1.read_namespaced_config_map(ca_configmap_name, namespace),
+            f"ConfigMap {ca_configmap_name}",
+        ),
+    }
+    uids.update(
+        {
+            f"secret/{name}": uid(core_v1.read_namespaced_secret(name, namespace), f"Secret {name}")
+            for name in additional_secret_names
+        }
+    )
+    return uids
+
+
+def search_artifact_uids(
+    mcc: "MultiClusterClient",
+    namespace: str,
+    names: dict[str, str],
+) -> dict[str, str]:
+    apps = mcc.apps_v1_api()
+    core = mcc.core_v1_api()
+    resources = {
+        f"StatefulSet/{names['sts']}": mcc.read_namespaced_stateful_set(names["sts"], namespace),
+        f"Service/{names['svc']}": mcc.read_namespaced_service(names["svc"], namespace),
+        f"Service/{names['proxy']}": mcc.read_namespaced_service(names["proxy"], namespace),
+        f"ConfigMap/{names['mongot_cm']}": mcc.read_namespaced_config_map(names["mongot_cm"], namespace),
+        f"Deployment/{names['envoy_deployment']}": apps.read_namespaced_deployment(
+            names["envoy_deployment"], namespace
+        ),
+        f"ConfigMap/{names['envoy_cm']}": mcc.read_namespaced_config_map(names["envoy_cm"], namespace),
+        f"Secret/{names['operator_tls_secret']}": core.read_namespaced_secret(names["operator_tls_secret"], namespace),
+    }
+    pvc_names = mongot_data_pvc_names(namespace, names["sts"], api_client=mcc.api_client)
+    assert pvc_names, f"[{mcc.cluster_name}] expected mongot data PVCs for {names['sts']}"
+    resources.update(
+        {
+            f"PersistentVolumeClaim/{name}": core.read_namespaced_persistent_volume_claim(name, namespace)
+            for name in pvc_names
+        }
+    )
+
+    uids = {what: resource.metadata.uid for what, resource in resources.items()}
+    assert all(uids.values()), f"[{mcc.cluster_name}] Search artifact without UID: {uids}"
+    return uids
+
+
+def wait_for_search_artifacts_deleted(
+    mcc: "MultiClusterClient",
+    namespace: str,
+    sts_name: str,
+    search_name: str,
+    *,
+    timeout: int = 600,
+) -> None:
+    """Label-scoped absence is the authoritative cleanup assertion; the exact-name
+    STS check on top catches accidental label stripping on the primary artifact."""
+    wait_for_resource_deleted(
+        lambda: mcc.read_namespaced_stateful_set(sts_name, namespace),
+        f"STS {sts_name} in {mcc.cluster_name}",
+        timeout=timeout,
+    )
+    wait_for_mongot_pvcs_deleted(namespace, sts_name, api_client=mcc.api_client, timeout=300)
+    wait_for_search_owned_resources_deleted(
+        mcc.apps_v1_api(),
+        mcc.core_v1_api(),
+        namespace,
+        search_name,
+        where=mcc.cluster_name,
+        timeout=timeout,
+    )
 
 
 def hard_kill_pods_by_label(

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -10,7 +10,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import pymongo
 import pymongo.errors
@@ -20,6 +20,9 @@ from kubetester.kubetester import run_periodically
 from pymongo.read_preferences import Nearest
 from tests import test_logger
 from tests.common.search.search_tester import SearchTester
+
+if TYPE_CHECKING:
+    from kubetester.mongodb_search import MongoDBSearch
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -39,6 +42,9 @@ FAILURE_SEARCH_NOT_ENABLED = "search_not_enabled"
 # only an explicit index-state rejection proves the bad Ready-while-syncing mode.
 FAILURE_MONGOT_UNREACHABLE = "mongot_unreachable"
 FAILURE_OTHER = "other"
+
+SEARCH_OWNER_NAME_LABEL = "mongodb.com/search-name"
+SEARCH_OWNER_NAMESPACE_LABEL = "mongodb.com/search-namespace"
 
 _CURSOR_LOST_MESSAGE_RE = re.compile(
     r"cursor id .*?(not found|was killed)|remote error from mongot|rst_stream",
@@ -894,14 +900,9 @@ def wait_for_mongot_pvcs_deleted(
     named ``<template>-<sts>-<ordinal>``, so we match on the ``-<sts>-`` infix.
     ``api_client`` must target the cluster hosting the STS.
     """
-    core = client.CoreV1Api(api_client=api_client)
 
     def deleted() -> tuple[bool, str]:
-        remaining = [
-            pvc.metadata.name
-            for pvc in core.list_namespaced_persistent_volume_claim(namespace).items
-            if f"-{sts_name}-" in f"-{pvc.metadata.name}"
-        ]
+        remaining = mongot_data_pvc_names(namespace, sts_name, api_client=api_client)
         return not remaining, ("all deleted" if not remaining else f"remaining={remaining}")
 
     run_periodically(
@@ -910,6 +911,79 @@ def wait_for_mongot_pvcs_deleted(
         sleep_time=sleep_time,
         msg=f"mongot PVCs for STS {sts_name} to be deleted",
     )
+
+
+def _search_owned_top_level_resources(
+    apps_v1: Any,
+    core_v1: Any,
+    namespace: str,
+    search_name: str,
+) -> dict[str, list[Any]]:
+    selector = f"{SEARCH_OWNER_NAME_LABEL}={search_name},{SEARCH_OWNER_NAMESPACE_LABEL}={namespace}"
+    return {
+        "StatefulSet": apps_v1.list_namespaced_stateful_set(namespace, label_selector=selector).items,
+        "Deployment": apps_v1.list_namespaced_deployment(namespace, label_selector=selector).items,
+        "Service": core_v1.list_namespaced_service(namespace, label_selector=selector).items,
+        "ConfigMap": core_v1.list_namespaced_config_map(namespace, label_selector=selector).items,
+        "Secret": core_v1.list_namespaced_secret(namespace, label_selector=selector).items,
+    }
+
+
+def wait_for_search_owned_resources_deleted(
+    apps_v1: Any,
+    core_v1: Any,
+    namespace: str,
+    search_name: str,
+    *,
+    where: str,
+    timeout: int = 600,
+) -> None:
+    def deleted() -> tuple[bool, str]:
+        resources = _search_owned_top_level_resources(apps_v1, core_v1, namespace, search_name)
+        remaining = [
+            f"{kind}/{resource.metadata.name}(uid={resource.metadata.uid})"
+            for kind, items in resources.items()
+            for resource in items
+        ]
+        return not remaining, f"{where}: remaining={remaining}"
+
+    run_periodically(
+        deleted,
+        timeout=timeout,
+        sleep_time=5,
+        msg=f"{where} Search-owned top-level resource cleanup",
+    )
+
+
+def mongot_data_pvc_names(
+    namespace: str,
+    sts_name: str,
+    *,
+    api_client: Optional[client.ApiClient] = None,
+) -> list[str]:
+    core = client.CoreV1Api(api_client=api_client)
+    return [
+        pvc.metadata.name
+        for pvc in core.list_namespaced_persistent_volume_claim(namespace).items
+        if f"-{sts_name}-" in f"-{pvc.metadata.name}"
+    ]
+
+
+def wait_for_resource_deleted(read_fn: Callable[[], Any], what: str, timeout: int = 300) -> None:
+    def deleted() -> tuple[bool, str]:
+        try:
+            read_fn()
+            return False, f"{what} still present"
+        except client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                return True, f"{what} deleted"
+            raise
+
+    run_periodically(deleted, timeout=timeout, sleep_time=5, msg=f"{what} cleanup")
+
+
+def wait_for_search_deleted(mdbs: "MongoDBSearch", timeout: int = 300) -> None:
+    wait_for_resource_deleted(mdbs.load, f"MongoDBSearch {mdbs.name}", timeout=timeout)
 
 
 def hard_kill_pods_by_label(

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -1029,6 +1029,15 @@ def protected_search_input_uids(
     *,
     additional_secret_names: tuple[str, ...] = (),
 ) -> dict[str, str]:
+    """Snapshot the UIDs of customer-provided ("protected") Search inputs.
+
+    These are resources the customer creates (source TLS Secret, sync-user password
+    Secret, CA ConfigMap, ...) that the operator consumes but must never delete or
+    recreate — cleanup sweeps only remove operator-owned artifacts. Tests capture
+    these UIDs before a lifecycle transition and assert afterwards that they are
+    unchanged, proving the inputs survived untouched.
+    """
+
     def uid(resource: Any, what: str) -> str:
         value = resource.metadata.uid
         assert value, f"{what} has no UID"

--- a/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/connectivity.py
@@ -24,6 +24,7 @@ from tests.common.search.search_tester import SearchTester
 if TYPE_CHECKING:
     from kubetester.mongodb_search import MongoDBSearch
     from kubetester.multicluster_client import MultiClusterClient
+    from kubetester.phase import Phase
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -987,6 +988,38 @@ def wait_for_search_deleted(mdbs: "MongoDBSearch", timeout: int = 300) -> None:
     wait_for_resource_deleted(mdbs.load, f"MongoDBSearch {mdbs.name}", timeout=timeout)
 
 
+def wait_for_deployment_recreated(apps: Any, namespace: str, name: str, previous_uid: str, timeout: int = 300) -> None:
+    """Poll until Deployment `name` exists with a NEW uid and all desired replicas ready."""
+
+    def recreated_and_ready() -> tuple[bool, str]:
+        try:
+            deployment = apps.read_namespaced_deployment(name, namespace)
+        except client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                return False, f"{name} absent"
+            raise
+        desired = deployment.spec.replicas or 0
+        ready = deployment.status.ready_replicas or 0
+        replaced = deployment.metadata.uid != previous_uid
+        return replaced and desired > 0 and ready == desired, f"replaced={replaced}, ready={ready}/{desired}"
+
+    run_periodically(recreated_and_ready, timeout=timeout, sleep_time=5, msg=f"Deployment {name} recreation")
+
+
+def wait_for_metrics_forwarder_phase(mdbs: "MongoDBSearch", phase: "Phase", timeout: int = 120) -> None:
+    def reached() -> bool:
+        mdbs.reload()
+        status = mdbs.get_metrics_forwarder_status()
+        return status is not None and status.get("phase") == phase.name
+
+    run_periodically(
+        reached,
+        timeout=timeout,
+        sleep_time=10,
+        msg=f"metrics forwarder status to reach {phase.name}",
+    )
+
+
 def protected_search_input_uids(
     core_v1: Any,
     namespace: str,
@@ -1024,24 +1057,37 @@ def protected_search_input_uids(
     return uids
 
 
+def _mc_search_artifact_readers(
+    mcc: "MultiClusterClient",
+    namespace: str,
+    names: dict[str, str],
+) -> dict[str, Callable[[], Any]]:
+    """Direct readers for the concrete (kind, name) identities of one cluster's
+    Search artifact set (keys match `mc_search_artifact_names`)."""
+    apps = mcc.apps_v1_api()
+    core = mcc.core_v1_api()
+    return {
+        f"StatefulSet/{names['sts']}": lambda: mcc.read_namespaced_stateful_set(names["sts"], namespace),
+        f"Service/{names['svc']}": lambda: mcc.read_namespaced_service(names["svc"], namespace),
+        f"Service/{names['proxy']}": lambda: mcc.read_namespaced_service(names["proxy"], namespace),
+        f"ConfigMap/{names['mongot_cm']}": lambda: mcc.read_namespaced_config_map(names["mongot_cm"], namespace),
+        f"Deployment/{names['envoy_deployment']}": lambda: apps.read_namespaced_deployment(
+            names["envoy_deployment"], namespace
+        ),
+        f"ConfigMap/{names['envoy_cm']}": lambda: mcc.read_namespaced_config_map(names["envoy_cm"], namespace),
+        f"Secret/{names['operator_tls_secret']}": lambda: core.read_namespaced_secret(
+            names["operator_tls_secret"], namespace
+        ),
+    }
+
+
 def search_artifact_uids(
     mcc: "MultiClusterClient",
     namespace: str,
     names: dict[str, str],
 ) -> dict[str, str]:
-    apps = mcc.apps_v1_api()
     core = mcc.core_v1_api()
-    resources = {
-        f"StatefulSet/{names['sts']}": mcc.read_namespaced_stateful_set(names["sts"], namespace),
-        f"Service/{names['svc']}": mcc.read_namespaced_service(names["svc"], namespace),
-        f"Service/{names['proxy']}": mcc.read_namespaced_service(names["proxy"], namespace),
-        f"ConfigMap/{names['mongot_cm']}": mcc.read_namespaced_config_map(names["mongot_cm"], namespace),
-        f"Deployment/{names['envoy_deployment']}": apps.read_namespaced_deployment(
-            names["envoy_deployment"], namespace
-        ),
-        f"ConfigMap/{names['envoy_cm']}": mcc.read_namespaced_config_map(names["envoy_cm"], namespace),
-        f"Secret/{names['operator_tls_secret']}": core.read_namespaced_secret(names["operator_tls_secret"], namespace),
-    }
+    resources = {what: read() for what, read in _mc_search_artifact_readers(mcc, namespace, names).items()}
     pvc_names = mongot_data_pvc_names(namespace, names["sts"], api_client=mcc.api_client)
     assert pvc_names, f"[{mcc.cluster_name}] expected mongot data PVCs for {names['sts']}"
     resources.update(
@@ -1059,19 +1105,36 @@ def search_artifact_uids(
 def wait_for_search_artifacts_deleted(
     mcc: "MultiClusterClient",
     namespace: str,
-    sts_name: str,
+    names: dict[str, str],
     search_name: str,
     *,
     timeout: int = 600,
 ) -> None:
-    """Label-scoped absence is the authoritative cleanup assertion; the exact-name
-    STS check on top catches accidental label stripping on the primary artifact."""
-    wait_for_resource_deleted(
-        lambda: mcc.read_namespaced_stateful_set(sts_name, namespace),
-        f"STS {sts_name} in {mcc.cluster_name}",
+    """Identity-based absence is the authoritative cleanup assertion: every concrete
+    (kind, name) captured before deletion must read back 404 — a resource that loses
+    its owner labels drops out of a label selector but not out of this poll. The
+    label-scoped emptiness List stays as a secondary check for labeled orphans
+    outside the captured inventory."""
+    readers = _mc_search_artifact_readers(mcc, namespace, names)
+
+    def identities_deleted() -> tuple[bool, str]:
+        remaining = []
+        for what, read in readers.items():
+            try:
+                read()
+                remaining.append(what)
+            except client.exceptions.ApiException as exc:
+                if exc.status != 404:
+                    raise
+        return not remaining, f"{mcc.cluster_name}: remaining={remaining}"
+
+    run_periodically(
+        identities_deleted,
         timeout=timeout,
+        sleep_time=5,
+        msg=f"{mcc.cluster_name} Search artifact identity cleanup",
     )
-    wait_for_mongot_pvcs_deleted(namespace, sts_name, api_client=mcc.api_client, timeout=300)
+    wait_for_mongot_pvcs_deleted(namespace, names["sts"], api_client=mcc.api_client, timeout=300)
     wait_for_search_owned_resources_deleted(
         mcc.apps_v1_api(),
         mcc.core_v1_api(),

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -98,6 +98,11 @@ def mongot_tls_cert_name(search_name: str, certs_secret_prefix: str = "") -> str
     return f"{search_name}-search-cert"
 
 
+def operator_managed_tls_secret_name(search_name: str) -> str:
+    """Operator-created copy of the RS mongot TLS certificate Secret."""
+    return f"{search_name}-search-certificate-key"
+
+
 # ============================================================================
 # Sharded cluster resources
 # ============================================================================
@@ -130,6 +135,11 @@ def shard_tls_cert_name(
     if certs_secret_prefix:
         return f"{certs_secret_prefix}-{search_name}-search-{cluster_index}-{shard_name}-cert"
     return f"{search_name}-search-{cluster_index}-{shard_name}-cert"
+
+
+def shard_operator_managed_tls_secret_name(search_name: str, shard_name: str, cluster_index: int = 0) -> str:
+    """Operator-created copy of a shard mongot TLS certificate Secret."""
+    return f"{search_name}-search-{cluster_index}-{shard_name}-certificate-key"
 
 
 def shard_proxy_service_name(search_name: str, shard_name: str, cluster_index: int = 0) -> str:

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -270,29 +270,17 @@ def metrics_forwarder_deployment_name(search_name: str, cluster_index: int = 0) 
 
 
 def metrics_forwarder_configmap_name(search_name: str, cluster_index: int = 0) -> str:
-    """ConfigMap name for the metrics forwarder config. Mirrors MetricsForwarderConfigMapNameForCluster().
-
-    cluster_index defaults to 0 for single-cluster callers; pass the cluster
-    position explicitly for multi-cluster tests.
-    """
+    """ConfigMap name for the metrics forwarder config. Mirrors MetricsForwarderConfigMapNameForCluster()."""
     return f"{search_name}-search-metrics-forwarder-{cluster_index}-config"
 
 
 def metrics_forwarder_agent_key_secret_name(search_name: str, cluster_index: int = 0) -> str:
-    """Secret name for the forwarder-owned agent-key replica. Mirrors MetricsForwarderAgentKeySecretNameForCluster().
-
-    cluster_index defaults to 0 for single-cluster callers; pass the cluster
-    position explicitly for multi-cluster tests.
-    """
+    """Secret name for the forwarder-owned agent-key replica. Mirrors MetricsForwarderAgentKeySecretNameForCluster()."""
     return f"{search_name}-search-metrics-forwarder-{cluster_index}-agent-key"
 
 
 def metrics_forwarder_ca_configmap_name(search_name: str, cluster_index: int = 0) -> str:
-    """ConfigMap name for the forwarder-owned OM CA replica. Mirrors MetricsForwarderCACertConfigMapNameForCluster().
-
-    cluster_index defaults to 0 for single-cluster callers; pass the cluster
-    position explicitly for multi-cluster tests.
-    """
+    """ConfigMap name for the forwarder-owned OM CA replica. Mirrors MetricsForwarderCACertConfigMapNameForCluster()."""
     return f"{search_name}-search-metrics-forwarder-{cluster_index}-ca-cert"
 
 

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -189,6 +189,19 @@ def shard_proxy_svc_hostname_template(search_name: str, namespace: str, cluster_
     return f"{search_name}-search-{cluster_index}-{{shardName}}-proxy-svc.{namespace}.svc.cluster.local"
 
 
+def mc_search_artifact_names(search_name: str, cluster_index: int) -> dict[str, str]:
+    """Names of the operator-managed per-cluster Search artifacts (RS-MC managed-LB set)."""
+    return {
+        "sts": mongot_statefulset_name_for_cluster(search_name, cluster_index),
+        "svc": mongot_service_name_for_cluster(search_name, cluster_index),
+        "proxy": mc_proxy_svc_name(search_name, cluster_index),
+        "mongot_cm": mongot_configmap_name_for_cluster(search_name, cluster_index),
+        "envoy_deployment": lb_deployment_name(search_name, cluster_index),
+        "envoy_cm": lb_configmap_name(search_name, cluster_index),
+        "operator_tls_secret": operator_managed_tls_secret_name(search_name),
+    }
+
+
 # ============================================================================
 # Managed load balancer resources
 # ============================================================================
@@ -263,3 +276,8 @@ def metrics_forwarder_configmap_name(search_name: str, cluster_index: int = 0) -
     position explicitly for multi-cluster tests.
     """
     return f"{search_name}-search-metrics-forwarder-{cluster_index}-config"
+
+
+def metrics_forwarder_state_configmap_name(search_name: str) -> str:
+    """ConfigMap name for the persisted metrics forwarder topology state (one per CR, central cluster)."""
+    return f"{search_name}-metrics-forwarder-state"

--- a/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/search_resource_names.py
@@ -278,6 +278,24 @@ def metrics_forwarder_configmap_name(search_name: str, cluster_index: int = 0) -
     return f"{search_name}-search-metrics-forwarder-{cluster_index}-config"
 
 
+def metrics_forwarder_agent_key_secret_name(search_name: str, cluster_index: int = 0) -> str:
+    """Secret name for the forwarder-owned agent-key replica. Mirrors MetricsForwarderAgentKeySecretNameForCluster().
+
+    cluster_index defaults to 0 for single-cluster callers; pass the cluster
+    position explicitly for multi-cluster tests.
+    """
+    return f"{search_name}-search-metrics-forwarder-{cluster_index}-agent-key"
+
+
+def metrics_forwarder_ca_configmap_name(search_name: str, cluster_index: int = 0) -> str:
+    """ConfigMap name for the forwarder-owned OM CA replica. Mirrors MetricsForwarderCACertConfigMapNameForCluster().
+
+    cluster_index defaults to 0 for single-cluster callers; pass the cluster
+    position explicitly for multi-cluster tests.
+    """
+    return f"{search_name}-search-metrics-forwarder-{cluster_index}-ca-cert"
+
+
 def metrics_forwarder_state_configmap_name(search_name: str) -> str:
     """ConfigMap name for the persisted metrics forwarder topology state (one per CR, central cluster)."""
     return f"{search_name}-metrics-forwarder-state"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/conftest.py
@@ -30,6 +30,7 @@ from pytest import fixture
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import search_resource_names
+from tests.common.search.connectivity import protected_search_input_uids
 from tests.conftest import get_multi_cluster_operator
 
 logger = test_logger.get_test_logger(__name__)
@@ -379,6 +380,27 @@ def assert_cross_cluster_isolation(
 # ---------------------------------------------------------------------------
 # Comprehensive happy-path helpers (shared by RS + sharded variants)
 # ---------------------------------------------------------------------------
+
+
+def mc_search_customer_input_uids(
+    mcc: MultiClusterClient,
+    namespace: str,
+    search_name: str,
+    ca_configmap_name: str,
+    cluster_index: int,
+) -> Dict[str, str]:
+    """UIDs of the customer-provided Search inputs on one cluster (must survive cleanup)."""
+    return protected_search_input_uids(
+        mcc.core_v1_api(),
+        namespace,
+        search_resource_names.mongot_tls_cert_name(search_name, MDBS_TLS_CERT_PREFIX),
+        f"{search_name}-{MONGOT_USER_NAME}-password",
+        ca_configmap_name,
+        additional_secret_names=(
+            search_resource_names.lb_server_cert_name(search_name, MDBS_TLS_CERT_PREFIX, cluster_index),
+            search_resource_names.lb_client_cert_name(search_name, MDBS_TLS_CERT_PREFIX, cluster_index),
+        ),
+    )
 
 
 def assert_per_cluster_count(per_cluster: List, expected: int = 2) -> None:

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -1321,6 +1321,45 @@ def test_remove_and_readd_search_cluster_entry(
         timeout=600,
     )
 
+    # Multi-cluster MongoDBSearch requires a managed load balancer on every cluster
+    # entry: flipping managed->none must be rejected by validation without touching
+    # the deployed per-cluster artifacts. Managed->none teardown is single-cluster
+    # behavior, covered by the single-cluster managed-LB tests.
+    def artifact_uids(mcc: MultiClusterClient) -> dict[str, str]:
+        return search_artifact_uids(
+            mcc, namespace, search_resource_names.mc_search_artifact_names(MDBS_RESOURCE_NAME, _idx(mcc))
+        )
+
+    mdbs.load()
+    managed_lb_entries = deepcopy(mdbs["spec"]["clusters"])
+    pre_flip_uids = {mcc.cluster_name: artifact_uids(mcc) for mcc in member_cluster_clients}
+    for entry in mdbs["spec"]["clusters"]:
+        entry.pop("loadBalancer", None)
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Failed, msg_regexp=".*requires a managed load balancer.*", timeout=300)
+    for mcc in member_cluster_clients:
+        assert (
+            artifact_uids(mcc) == pre_flip_uids[mcc.cluster_name]
+        ), f"[{mcc.cluster_name}] managed artifact UIDs changed after rejected managed->none flip"
+
+    # Revert to managed: the CR must recover from the rejected spec, so the
+    # fault-injection and delete tests below see the exact pre-flip world.
+    mdbs.load()
+    mdbs["spec"]["clusters"] = managed_lb_entries
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_lb_status()
+    mdbs.assert_cluster_statuses(expected_count=2, expect_managed_lb=True)
+    for mcc in member_cluster_clients:
+        names = search_resource_names.mc_search_artifact_names(MDBS_RESOURCE_NAME, _idx(mcc))
+        assert_workload_ready_in_cluster(
+            mcc,
+            namespace,
+            {names["sts"]: MONGOT_REPLICAS_PER_CLUSTER},
+            names["envoy_deployment"],
+            timeout=600,
+        )
+
 
 # Larger than any node in the e2e kind clusters — guarantees Unschedulable.
 UNSCHEDULABLE_MEMORY = "10000Gi"

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -16,6 +16,7 @@ is exercised opportunistically when the deployed mongot image supports replicati
 import json
 import os
 import re
+from copy import deepcopy
 from typing import Dict, List
 
 import kubernetes
@@ -23,6 +24,7 @@ import pymongo.errors
 import pytest
 import yaml
 from kubernetes.client import CoreV1Api
+from kubernetes.client.rest import ApiException
 from kubetester import create_or_update_configmap, create_or_update_secret, read_secret, try_load
 from kubetester.certs import create_tls_certs
 from kubetester.certs_mongodb_multi import create_multi_cluster_mongodb_tls_certs
@@ -37,9 +39,19 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
-from tests.common.multicluster.multicluster_utils import assert_deployment_ready_in_cluster
+from tests.common.multicluster.multicluster_utils import (
+    assert_deployment_ready_in_cluster,
+    assert_workload_ready_in_cluster,
+)
 from tests.common.search import search_resource_names
-from tests.common.search.connectivity import CLUSTER_LOCATION_TAG_KEY
+from tests.common.search.connectivity import (
+    CLUSTER_LOCATION_TAG_KEY,
+    mongot_data_pvc_names,
+    protected_search_input_uids,
+    search_artifact_uids,
+    wait_for_search_artifacts_deleted,
+    wait_for_search_deleted,
+)
 from tests.common.search.movies_search_helper import (
     EMBEDDING_QUERY_KEY_ENV_VAR,
     EmbeddedMoviesSearchHelper,
@@ -495,19 +507,9 @@ def test_create_search_resource(mdbs: MongoDBSearch):
     mdbs.assert_reaches_phase(Phase.Running, timeout=900)
 
 
-def _per_cluster_mongot_config_name(mdbs_name: str, cluster_index: int) -> str:
-    """Mirror MongotConfigConfigMapNameForCluster."""
-    return f"{mdbs_name}-search-{cluster_index}-config"
-
-
-def _per_cluster_envoy_deployment_name(mdbs_name: str, cluster_index: int) -> str:
-    """Mirror LoadBalancerDeploymentNameForCluster: `{name}-search-lb-{clusterIndex}`."""
-    return f"{mdbs_name}-search-lb-{cluster_index}"
-
-
-def _per_cluster_envoy_configmap_name(mdbs_name: str, cluster_index: int) -> str:
-    """Mirror LoadBalancerConfigMapNameForCluster: `{name}-search-lb-{clusterIndex}-config`."""
-    return f"{mdbs_name}-search-lb-{cluster_index}-config"
+def _assert_no_owner_refs(owner_refs: list | None, where: str) -> None:
+    owner_refs = owner_refs or []
+    assert not owner_refs, f"{where} must have no ownerReferences in multi-cluster mode, got {owner_refs}"
 
 
 def _read_mongod_set_parameter(
@@ -604,7 +606,7 @@ def test_verify_per_cluster_mongot_resources(
         idx = helper.cluster_index(mcc.cluster_name)
         sts_name = f"{MDBS_RESOURCE_NAME}-search-{idx}"
         svc_name = f"{MDBS_RESOURCE_NAME}-search-{idx}-svc"
-        cm_name = _per_cluster_mongot_config_name(MDBS_RESOURCE_NAME, idx)
+        cm_name = search_resource_names.mongot_configmap_name_for_cluster(MDBS_RESOURCE_NAME, idx)
         proxy_svc_name = f"{MDBS_RESOURCE_NAME}-search-{idx}-proxy-svc"
 
         sts = mcc.read_namespaced_stateful_set(sts_name, namespace)
@@ -741,8 +743,8 @@ def test_verify_per_cluster_envoy_deployment(
     """
     for mcc in member_cluster_clients:
         cluster_idx = helper.cluster_index(mcc.cluster_name)
-        envoy_deployment_name = _per_cluster_envoy_deployment_name(MDBS_RESOURCE_NAME, cluster_idx)
-        envoy_cm_name = _per_cluster_envoy_configmap_name(MDBS_RESOURCE_NAME, cluster_idx)
+        envoy_deployment_name = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_idx)
+        envoy_cm_name = search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_idx)
         apps = mcc.apps_v1_api()
         assert_deployment_ready_in_cluster(apps, name=envoy_deployment_name, namespace=namespace)
         envoy_deploy = apps.read_namespaced_deployment(name=envoy_deployment_name, namespace=namespace)
@@ -751,6 +753,103 @@ def test_verify_per_cluster_envoy_deployment(
         _assert_search_owner_labels(envoy_cm.metadata.labels or {}, f"Envoy CM {envoy_cm_name}")
 
         logger.info(f"Envoy Deployment {envoy_deployment_name} ready in cluster {mcc.cluster_name} (idx={cluster_idx})")
+
+
+@mark.e2e_search_q2_mc_rs_steady
+def test_named_single_cluster_shape_no_owner_refs_and_cleanup(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDBMulti,
+    mdbs: MongoDBSearch,
+    ca_configmap: str,
+):
+    target_cluster = member_cluster_clients[0]
+    target_cluster_name = target_cluster.cluster_name
+    target_cluster_index = _idx(target_cluster)
+    named_single_name = f"{MDBS_RESOURCE_NAME}-named-single"
+
+    named_single = MongoDBSearch.from_yaml(
+        yaml_fixture("search-q2-mc-rs-search.yaml"),
+        name=named_single_name,
+        namespace=namespace,
+    )
+    named_single.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(named_single)
+
+    seeds = [f"{svc}.{namespace}.svc.cluster.local:27017" for svc in mdb.service_names()]
+    named_single["spec"]["source"] = {
+        "username": MONGOT_USER_NAME,
+        "passwordSecretRef": {
+            "name": f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+            "key": "password",
+        },
+        "external": {
+            "hostAndPorts": seeds,
+            "tls": {"ca": {"name": ca_configmap}},
+        },
+    }
+    named_single["spec"]["security"] = {
+        "tls": {
+            "certificateKeySecretRef": {
+                "name": search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
+            }
+        },
+    }
+    named_single["spec"]["clusters"] = [
+        {
+            "name": target_cluster_name,
+            "index": target_cluster_index,
+            "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+            "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: target_cluster_name}]},
+        }
+    ]
+
+    named_single.update()
+    named_single.assert_reaches_phase(Phase.Running, timeout=900)
+
+    named_single.load()
+    assert len(named_single["spec"]["clusters"]) == 1
+    assert named_single["spec"]["clusters"][0]["name"] == target_cluster_name
+
+    sts_name = search_resource_names.mongot_statefulset_name_for_cluster(named_single_name, target_cluster_index)
+    svc_name = search_resource_names.mongot_service_name_for_cluster(named_single_name, target_cluster_index)
+    cm_name = search_resource_names.mongot_configmap_name_for_cluster(named_single_name, target_cluster_index)
+    operator_tls_secret = search_resource_names.operator_managed_tls_secret_name(named_single_name)
+
+    sts = target_cluster.read_namespaced_stateful_set(sts_name, namespace)
+    svc = target_cluster.read_namespaced_service(svc_name, namespace)
+    cm = target_cluster.read_namespaced_config_map(cm_name, namespace)
+    tls_secret = target_cluster.core_v1_api().read_namespaced_secret(operator_tls_secret, namespace)
+    _assert_no_owner_refs(sts.metadata.owner_references, f"STS {sts_name} ({target_cluster_name})")
+    _assert_no_owner_refs(svc.metadata.owner_references, f"Service {svc_name} ({target_cluster_name})")
+    _assert_no_owner_refs(cm.metadata.owner_references, f"ConfigMap {cm_name} ({target_cluster_name})")
+    _assert_no_owner_refs(tls_secret.metadata.owner_references, f"Secret {operator_tls_secret} ({target_cluster_name})")
+
+    for other_cluster in member_cluster_clients:
+        if other_cluster.cluster_name == target_cluster_name:
+            continue
+        try:
+            other_cluster.read_namespaced_stateful_set(sts_name, namespace)
+            raise AssertionError(
+                f"[{other_cluster.cluster_name}] unexpectedly found {sts_name}; "
+                f"named single-cluster spec should only materialize resources on {target_cluster_name}"
+            )
+        except ApiException as exc:
+            assert exc.status == 404, f"[{other_cluster.cluster_name}] unexpected error while reading {sts_name}: {exc}"
+
+    pvcs_before = mongot_data_pvc_names(namespace, sts_name, api_client=target_cluster.api_client)
+    assert pvcs_before, f"expected at least one mongot data PVC for {sts_name} before delete"
+
+    main_sts_name = search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, target_cluster_index)
+    main_sts_uid = target_cluster.read_namespaced_stateful_set(main_sts_name, namespace).metadata.uid
+
+    named_single.delete()
+    wait_for_search_deleted(named_single, timeout=600)
+    wait_for_search_artifacts_deleted(target_cluster, namespace, sts_name, named_single_name)
+    assert (
+        target_cluster.read_namespaced_stateful_set(main_sts_name, namespace).metadata.uid == main_sts_uid
+    ), f"main Search STS {main_sts_name} must be untouched by the {named_single_name} cleanup"
 
 
 @mark.e2e_search_q2_mc_rs_steady
@@ -848,7 +947,7 @@ def test_per_cluster_envoy_sni_observed(
     """
     for mcc in member_cluster_clients:
         cluster_idx = helper.cluster_index(mcc.cluster_name)
-        cm_name = _per_cluster_envoy_configmap_name(MDBS_RESOURCE_NAME, cluster_idx)
+        cm_name = search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_idx)
         expected_fqdn = search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, cluster_idx)
 
         cm = mcc.core_v1_api().read_namespaced_config_map(name=cm_name, namespace=namespace)
@@ -1119,6 +1218,127 @@ def test_per_cluster_vector_search_query(
         )
 
 
+@mark.e2e_search_q2_mc_rs_steady
+def test_remove_and_readd_search_cluster_entry(
+    namespace: str,
+    mdb: MongoDBMulti,
+    mdbs: MongoDBSearch,
+    helper: MCSearchDeploymentHelper,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    def artifact_names(cluster_index: int) -> dict[str, str]:
+        return {
+            "sts": search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index),
+            "svc": search_resource_names.mongot_service_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index),
+            "proxy": search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, cluster_index),
+            "mongot_cm": search_resource_names.mongot_configmap_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index),
+            "envoy_deployment": search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_index),
+            "envoy_cm": search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_index),
+            "operator_tls_secret": search_resource_names.operator_managed_tls_secret_name(MDBS_RESOURCE_NAME),
+        }
+
+    def assert_cluster_query(cluster_name: str, cluster_index: int) -> None:
+        tester = _direct_search_tester_for_cluster(mdb, cluster_index, USER_NAME, USER_PASSWORD)
+        movies = SampleMoviesSearchHelper(search_tester=tester)
+
+        def execute_search() -> tuple[bool, str]:
+            try:
+                results = movies.text_search_movies("Star Wars")
+                return bool(results), f"[{cluster_name}] $search returned {len(results)} results"
+            except pymongo.errors.PyMongoError as exc:
+                return False, f"[{cluster_name}] $search error: {exc}"
+
+        run_periodically(
+            execute_search,
+            timeout=SEARCH_INDEX_READY_TIMEOUT,
+            sleep_time=5,
+            msg=f"[{cluster_name}] $search query after cluster-entry update",
+        )
+
+    assert (
+        len(member_cluster_clients) == 2
+    ), f"cluster-entry lifecycle requires exactly two member clusters, got {len(member_cluster_clients)}"
+    mdbs.load()
+    cluster_entries = {entry["name"]: deepcopy(entry) for entry in mdbs["spec"]["clusters"]}
+    clients = {mcc.cluster_name: mcc for mcc in member_cluster_clients}
+    assert set(cluster_entries) == set(
+        clients
+    ), f"spec.clusters names {sorted(cluster_entries)} do not match member clients {sorted(clients)}"
+
+    source_tls_secret_name = search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
+    sync_user_secret_name = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
+
+    def customer_input_uids(mcc: MultiClusterClient, cluster_index: int) -> dict[str, str]:
+        return protected_search_input_uids(
+            mcc.core_v1_api(),
+            namespace,
+            source_tls_secret_name,
+            sync_user_secret_name,
+            CA_CONFIGMAP_NAME,
+            additional_secret_names=(
+                search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+                search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+            ),
+        )
+
+    snapshots: dict[str, tuple[dict[str, str], dict[str, str], dict[str, str]]] = {}
+    for cluster_name, entry in cluster_entries.items():
+        cluster_index = entry["index"]
+        assert cluster_index == helper.cluster_index(cluster_name), (
+            f"{cluster_name}: spec index {cluster_index} differs from stable mapping "
+            f"{helper.cluster_index(cluster_name)}"
+        )
+        mcc = clients[cluster_name]
+        names = artifact_names(cluster_index)
+        snapshots[cluster_name] = (
+            names,
+            search_artifact_uids(mcc, namespace, names),
+            customer_input_uids(mcc, cluster_index),
+        )
+
+    retained_name = member_cluster_clients[0].cluster_name
+    removed_name = member_cluster_clients[1].cluster_name
+    retained_entry = cluster_entries[retained_name]
+    removed_entry = cluster_entries[removed_name]
+    retained = clients[retained_name]
+    removed = clients[removed_name]
+    retained_names, retained_uids, _ = snapshots[retained_name]
+    removed_names, _, removed_protected_uids = snapshots[removed_name]
+
+    mdbs["spec"]["clusters"] = [deepcopy(retained_entry)]
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True)
+    wait_for_search_artifacts_deleted(removed, namespace, removed_names["sts"], mdbs.name)
+    assert customer_input_uids(removed, removed_entry["index"]) == removed_protected_uids
+    assert (
+        search_artifact_uids(retained, namespace, retained_names) == retained_uids
+    ), f"[{retained_name}] managed artifact UIDs changed when {removed_name} was removed"
+    assert_workload_ready_in_cluster(
+        retained,
+        namespace,
+        {retained_names["sts"]: MONGOT_REPLICAS_PER_CLUSTER},
+        retained_names["envoy_deployment"],
+        timeout=300,
+    )
+    assert_cluster_query(retained_name, retained_entry["index"])
+
+    # Restore the two-cluster topology for the tests that follow. Re-adding the
+    # entry is ordinary reconciliation, so no lifecycle assertions are made here.
+    mdbs.load()
+    mdbs["spec"]["clusters"].append(deepcopy(removed_entry))
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_cluster_statuses(expected_count=2, expect_managed_lb=True)
+    assert_workload_ready_in_cluster(
+        removed,
+        namespace,
+        {removed_names["sts"]: MONGOT_REPLICAS_PER_CLUSTER},
+        removed_names["envoy_deployment"],
+        timeout=600,
+    )
+
+
 # Larger than any node in the e2e kind clusters — guarantees Unschedulable.
 UNSCHEDULABLE_MEMORY = "10000Gi"
 STATUS_DEGRADE_TIMEOUT = 300
@@ -1256,3 +1476,52 @@ def test_envoy_fault_recovers(mdbs: MongoDBSearch):
     mdbs.assert_reaches_phase(Phase.Running, timeout=STATUS_RECOVER_TIMEOUT)
     # Final: every cluster fully Running again.
     mdbs.assert_cluster_statuses(expected_count=len(MEMBERS_PER_CLUSTER), expect_managed_lb=True)
+
+
+@mark.e2e_search_q2_mc_rs_steady
+def test_delete_search_resource_cleans_all_member_cluster_artifacts(
+    namespace: str,
+    mdbs: MongoDBSearch,
+    helper: MCSearchDeploymentHelper,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    resource_by_cluster: List[tuple[MultiClusterClient, int, dict[str, str], dict[str, str]]] = []
+    source_tls_secret_name = search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
+    sync_user_secret_name = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
+
+    def customer_input_uids(mcc: MultiClusterClient, cluster_index: int) -> dict[str, str]:
+        return protected_search_input_uids(
+            mcc.core_v1_api(),
+            namespace,
+            source_tls_secret_name,
+            sync_user_secret_name,
+            CA_CONFIGMAP_NAME,
+            additional_secret_names=(
+                search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+                search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+            ),
+        )
+
+    for mcc in member_cluster_clients:
+        cluster_idx = helper.cluster_index(mcc.cluster_name)
+        names = {
+            "sts": search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_idx),
+            "svc": search_resource_names.mongot_service_name_for_cluster(MDBS_RESOURCE_NAME, cluster_idx),
+            "proxy": search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, cluster_idx),
+            "mongot_cm": search_resource_names.mongot_configmap_name_for_cluster(MDBS_RESOURCE_NAME, cluster_idx),
+            "envoy_deployment": search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_idx),
+            "envoy_cm": search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_idx),
+            "operator_tls_secret": search_resource_names.operator_managed_tls_secret_name(MDBS_RESOURCE_NAME),
+        }
+
+        search_artifact_uids(mcc, namespace, names)
+        protected_uids = customer_input_uids(mcc, cluster_idx)
+
+        resource_by_cluster.append((mcc, cluster_idx, names, protected_uids))
+
+    mdbs.delete()
+    wait_for_search_deleted(mdbs, timeout=600)
+
+    for mcc, cluster_idx, names, protected_uids in resource_by_cluster:
+        wait_for_search_artifacts_deleted(mcc, namespace, names["sts"], mdbs.name)
+        assert customer_input_uids(mcc, cluster_idx) == protected_uids

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q2_mc_rs_steady.py
@@ -47,8 +47,8 @@ from tests.common.search import search_resource_names
 from tests.common.search.connectivity import (
     CLUSTER_LOCATION_TAG_KEY,
     mongot_data_pvc_names,
-    protected_search_input_uids,
     search_artifact_uids,
+    wait_for_deployment_recreated,
     wait_for_search_artifacts_deleted,
     wait_for_search_deleted,
 )
@@ -62,6 +62,7 @@ from tests.common.search.search_tester import SearchTester
 from tests.common.search.sharded_search_helper import create_issuer_ca
 from tests.conftest import get_issuer_ca_filepath
 from tests.multicluster.conftest import cluster_spec_list
+from tests.multicluster_search.conftest import mc_search_customer_input_uids
 
 logger = test_logger.get_test_logger(__name__)
 
@@ -111,6 +112,10 @@ MDBS_TLS_CERT_PREFIX = "certs"
 CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
 SOURCE_CERT_PREFIX = "clustercert"
 SOURCE_BUNDLE_SECRET = f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-cert"
+
+
+def _customer_input_uids(mcc: MultiClusterClient, namespace: str, cluster_index: int) -> dict[str, str]:
+    return mc_search_customer_input_uids(mcc, namespace, MDBS_RESOURCE_NAME, CA_CONFIGMAP_NAME, cluster_index)
 
 
 # =============================================================================
@@ -846,7 +851,12 @@ def test_named_single_cluster_shape_no_owner_refs_and_cleanup(
 
     named_single.delete()
     wait_for_search_deleted(named_single, timeout=600)
-    wait_for_search_artifacts_deleted(target_cluster, namespace, sts_name, named_single_name)
+    wait_for_search_artifacts_deleted(
+        target_cluster,
+        namespace,
+        search_resource_names.mc_search_artifact_names(named_single_name, target_cluster_index),
+        named_single_name,
+    )
     assert (
         target_cluster.read_namespaced_stateful_set(main_sts_name, namespace).metadata.uid == main_sts_uid
     ), f"main Search STS {main_sts_name} must be untouched by the {named_single_name} cleanup"
@@ -1226,17 +1236,6 @@ def test_remove_and_readd_search_cluster_entry(
     helper: MCSearchDeploymentHelper,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    def artifact_names(cluster_index: int) -> dict[str, str]:
-        return {
-            "sts": search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index),
-            "svc": search_resource_names.mongot_service_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index),
-            "proxy": search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, cluster_index),
-            "mongot_cm": search_resource_names.mongot_configmap_name_for_cluster(MDBS_RESOURCE_NAME, cluster_index),
-            "envoy_deployment": search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_index),
-            "envoy_cm": search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_index),
-            "operator_tls_secret": search_resource_names.operator_managed_tls_secret_name(MDBS_RESOURCE_NAME),
-        }
-
     def assert_cluster_query(cluster_name: str, cluster_index: int) -> None:
         tester = _direct_search_tester_for_cluster(mdb, cluster_index, USER_NAME, USER_PASSWORD)
         movies = SampleMoviesSearchHelper(search_tester=tester)
@@ -1265,22 +1264,6 @@ def test_remove_and_readd_search_cluster_entry(
         clients
     ), f"spec.clusters names {sorted(cluster_entries)} do not match member clients {sorted(clients)}"
 
-    source_tls_secret_name = search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
-    sync_user_secret_name = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
-
-    def customer_input_uids(mcc: MultiClusterClient, cluster_index: int) -> dict[str, str]:
-        return protected_search_input_uids(
-            mcc.core_v1_api(),
-            namespace,
-            source_tls_secret_name,
-            sync_user_secret_name,
-            CA_CONFIGMAP_NAME,
-            additional_secret_names=(
-                search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
-                search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
-            ),
-        )
-
     snapshots: dict[str, tuple[dict[str, str], dict[str, str], dict[str, str]]] = {}
     for cluster_name, entry in cluster_entries.items():
         cluster_index = entry["index"]
@@ -1289,11 +1272,11 @@ def test_remove_and_readd_search_cluster_entry(
             f"{helper.cluster_index(cluster_name)}"
         )
         mcc = clients[cluster_name]
-        names = artifact_names(cluster_index)
+        names = search_resource_names.mc_search_artifact_names(MDBS_RESOURCE_NAME, cluster_index)
         snapshots[cluster_name] = (
             names,
             search_artifact_uids(mcc, namespace, names),
-            customer_input_uids(mcc, cluster_index),
+            _customer_input_uids(mcc, namespace, cluster_index),
         )
 
     retained_name = member_cluster_clients[0].cluster_name
@@ -1309,8 +1292,8 @@ def test_remove_and_readd_search_cluster_entry(
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=900)
     mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True)
-    wait_for_search_artifacts_deleted(removed, namespace, removed_names["sts"], mdbs.name)
-    assert customer_input_uids(removed, removed_entry["index"]) == removed_protected_uids
+    wait_for_search_artifacts_deleted(removed, namespace, removed_names, mdbs.name)
+    assert _customer_input_uids(removed, namespace, removed_entry["index"]) == removed_protected_uids
     assert (
         search_artifact_uids(retained, namespace, retained_names) == retained_uids
     ), f"[{retained_name}] managed artifact UIDs changed when {removed_name} was removed"
@@ -1479,6 +1462,62 @@ def test_envoy_fault_recovers(mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_q2_mc_rs_steady
+def test_unregistered_cluster_entry_skips_only_that_cluster(
+    namespace: str,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """A spec.clusters entry naming a cluster with no registered client must not stall
+    the others: the CR turns Pending naming the missing cluster, while the healthy
+    clusters keep being reconciled (drift on one is repaired mid-Pending). Removing the
+    entry restores Running. Adding an entry removes nothing, so this is non-destructive."""
+    mdbs.load()
+    real_entries = deepcopy(mdbs["spec"]["clusters"])
+    healthy_indexes = [entry["index"] for entry in real_entries]
+
+    mdbs["spec"]["clusters"] = deepcopy(real_entries) + [
+        {
+            "name": "no-such-cluster",
+            "index": 2,
+            "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+            "loadBalancer": {
+                "managed": {
+                    "externalHostname": search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, 2),
+                },
+            },
+            "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: "no-such-cluster"}]},
+        }
+    ]
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Pending, msg_regexp=".*no-such-cluster.*", timeout=STATUS_DEGRADE_TIMEOUT)
+
+    # Drift-repair probe: under the released abort-on-first-miss behavior the healthy
+    # clusters would stop being reconciled entirely, so this recreation would hang.
+    probe_cluster = member_cluster_clients[0]
+    apps = probe_cluster.apps_v1_api()
+    envoy_name = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, _idx(probe_cluster))
+    old_envoy_uid = apps.read_namespaced_deployment(envoy_name, namespace).metadata.uid
+    apps.delete_namespaced_deployment(envoy_name, namespace)
+    wait_for_deployment_recreated(apps, namespace, envoy_name, old_envoy_uid)
+
+    mdbs.load()
+    for ci in healthy_indexes:
+        cs = mdbs.get_cluster_status(ci) or {}
+        assert (
+            cs.get("loadBalancer") == "Running"
+        ), f"cluster {ci}: loadBalancer={cs.get('loadBalancer')!r} during partial miss, expected Running"
+        assert not cs.get(
+            "loadBalancerMessage"
+        ), f"cluster {ci}: loadBalancerMessage should stay empty, got {cs.get('loadBalancerMessage')!r}"
+
+    mdbs.load()
+    mdbs["spec"]["clusters"] = real_entries
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_cluster_statuses(expected_count=2, expect_managed_lb=True)
+
+
+@mark.e2e_search_q2_mc_rs_steady
 def test_delete_search_resource_cleans_all_member_cluster_artifacts(
     namespace: str,
     mdbs: MongoDBSearch,
@@ -1486,36 +1525,12 @@ def test_delete_search_resource_cleans_all_member_cluster_artifacts(
     member_cluster_clients: List[MultiClusterClient],
 ):
     resource_by_cluster: List[tuple[MultiClusterClient, int, dict[str, str], dict[str, str]]] = []
-    source_tls_secret_name = search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX)
-    sync_user_secret_name = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
-
-    def customer_input_uids(mcc: MultiClusterClient, cluster_index: int) -> dict[str, str]:
-        return protected_search_input_uids(
-            mcc.core_v1_api(),
-            namespace,
-            source_tls_secret_name,
-            sync_user_secret_name,
-            CA_CONFIGMAP_NAME,
-            additional_secret_names=(
-                search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
-                search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
-            ),
-        )
-
     for mcc in member_cluster_clients:
         cluster_idx = helper.cluster_index(mcc.cluster_name)
-        names = {
-            "sts": search_resource_names.mongot_statefulset_name_for_cluster(MDBS_RESOURCE_NAME, cluster_idx),
-            "svc": search_resource_names.mongot_service_name_for_cluster(MDBS_RESOURCE_NAME, cluster_idx),
-            "proxy": search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, cluster_idx),
-            "mongot_cm": search_resource_names.mongot_configmap_name_for_cluster(MDBS_RESOURCE_NAME, cluster_idx),
-            "envoy_deployment": search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_idx),
-            "envoy_cm": search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, cluster_idx),
-            "operator_tls_secret": search_resource_names.operator_managed_tls_secret_name(MDBS_RESOURCE_NAME),
-        }
+        names = search_resource_names.mc_search_artifact_names(MDBS_RESOURCE_NAME, cluster_idx)
 
         search_artifact_uids(mcc, namespace, names)
-        protected_uids = customer_input_uids(mcc, cluster_idx)
+        protected_uids = _customer_input_uids(mcc, namespace, cluster_idx)
 
         resource_by_cluster.append((mcc, cluster_idx, names, protected_uids))
 
@@ -1523,5 +1538,5 @@ def test_delete_search_resource_cleans_all_member_cluster_artifacts(
     wait_for_search_deleted(mdbs, timeout=600)
 
     for mcc, cluster_idx, names, protected_uids in resource_by_cluster:
-        wait_for_search_artifacts_deleted(mcc, namespace, names["sts"], mdbs.name)
-        assert customer_input_uids(mcc, cluster_idx) == protected_uids
+        wait_for_search_artifacts_deleted(mcc, namespace, names, mdbs.name)
+        assert _customer_input_uids(mcc, namespace, cluster_idx) == protected_uids

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -5,7 +5,8 @@ StatefulSet, Service, ConfigMap, and proxy Service; each cluster also gets a clu
 proxy Service (for mongos) and an Envoy Deployment.
 """
 
-from typing import List
+from copy import deepcopy
+from typing import Callable, Dict, List
 
 import kubernetes
 import pymongo.errors
@@ -23,9 +24,20 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
-from tests.common.multicluster.multicluster_utils import assert_deployment_ready_in_cluster
+from tests.common.multicluster.multicluster_utils import (
+    assert_deployment_ready_in_cluster,
+    assert_workload_ready_in_cluster,
+)
 from tests.common.search import search_resource_names
-from tests.common.search.connectivity import CLUSTER_LOCATION_TAG_KEY
+from tests.common.search.connectivity import (
+    CLUSTER_LOCATION_TAG_KEY,
+    mongot_data_pvc_names,
+    protected_search_input_uids,
+    wait_for_mongot_pvcs_deleted,
+    wait_for_resource_deleted,
+    wait_for_search_deleted,
+    wait_for_search_owned_resources_deleted,
+)
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_tester import SearchTester
 from tests.common.search.sharded_search_helper import (
@@ -650,3 +662,203 @@ def test_per_cluster_search_query(
             sleep_time=5,
             msg=f"cluster {cluster_index}: $search via mongos",
         )
+
+
+# =============================================================================
+# Lifecycle: cluster-entry removal and CR deletion
+# =============================================================================
+
+
+def _shard_sts_names(cluster_index: int) -> List[str]:
+    return [
+        search_resource_names.shard_statefulset_name(
+            MDBS_RESOURCE_NAME, f"{MDB_RESOURCE_NAME}-{shard_idx}", cluster_index
+        )
+        for shard_idx in range(SHARD_COUNT)
+    ]
+
+
+def _local_artifact_readers(mcc: MultiClusterClient, namespace: str) -> Dict[str, Callable[[], object]]:
+    """Direct readers for the concrete (kind, name) identities of one cluster's Search
+    artifact set: per-(cluster, shard) mongot resources plus the cluster-level proxy
+    Service and Envoy Deployment/ConfigMap."""
+    ci = _idx(mcc)
+    apps = mcc.apps_v1_api()
+    core = mcc.core_v1_api()
+    readers: Dict[str, Callable[[], object]] = {}
+    for shard_idx in range(SHARD_COUNT):
+        shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+        sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
+        svc = search_resource_names.shard_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+        proxy = search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+        cm = search_resource_names.shard_configmap_name(MDBS_RESOURCE_NAME, shard_name, ci)
+        secret = search_resource_names.shard_operator_managed_tls_secret_name(MDBS_RESOURCE_NAME, shard_name, ci)
+        readers[f"StatefulSet/{sts}"] = lambda n=sts: mcc.read_namespaced_stateful_set(n, namespace)
+        readers[f"Service/{svc}"] = lambda n=svc: mcc.read_namespaced_service(n, namespace)
+        readers[f"Service/{proxy}"] = lambda n=proxy: mcc.read_namespaced_service(n, namespace)
+        readers[f"ConfigMap/{cm}"] = lambda n=cm: mcc.read_namespaced_config_map(n, namespace)
+        readers[f"Secret/{secret}"] = lambda n=secret: core.read_namespaced_secret(n, namespace)
+    cluster_proxy = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, ci)
+    envoy_dep = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, ci)
+    envoy_cm = search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, ci)
+    readers[f"Service/{cluster_proxy}"] = lambda: mcc.read_namespaced_service(cluster_proxy, namespace)
+    readers[f"Deployment/{envoy_dep}"] = lambda: apps.read_namespaced_deployment(envoy_dep, namespace)
+    readers[f"ConfigMap/{envoy_cm}"] = lambda: mcc.read_namespaced_config_map(envoy_cm, namespace)
+    return readers
+
+
+def _customer_input_uids(mcc: MultiClusterClient, namespace: str, cluster_index: int) -> Dict[str, str]:
+    """UIDs of the customer-replicated Search inputs on one cluster (must survive cleanup)."""
+
+    def shard_cert(shard_idx: int) -> str:
+        return search_resource_names.shard_tls_cert_name(
+            MDBS_RESOURCE_NAME, f"{MDB_RESOURCE_NAME}-{shard_idx}", MDBS_TLS_CERT_PREFIX, cluster_index
+        )
+
+    return protected_search_input_uids(
+        mcc.core_v1_api(),
+        namespace,
+        shard_cert(0),
+        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+        CA_CONFIGMAP_NAME,
+        additional_secret_names=(
+            search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+            search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+            *(shard_cert(shard_idx) for shard_idx in range(1, SHARD_COUNT)),
+        ),
+    )
+
+
+def _wait_for_cluster_artifacts_swept(
+    mcc: MultiClusterClient, namespace: str, readers: Dict[str, Callable[[], object]]
+) -> None:
+    """Identity 404-polls for every captured artifact, then PVC reap, then the
+    label-scoped emptiness backstop for labeled orphans outside the inventory."""
+    for what, read in readers.items():
+        wait_for_resource_deleted(read, f"{what} in {mcc.cluster_name}")
+    for sts_name in _shard_sts_names(_idx(mcc)):
+        wait_for_mongot_pvcs_deleted(namespace, sts_name, api_client=mcc.api_client)
+    wait_for_search_owned_resources_deleted(
+        mcc.apps_v1_api(),
+        mcc.core_v1_api(),
+        namespace,
+        MDBS_RESOURCE_NAME,
+        where=mcc.cluster_name,
+    )
+
+
+@mark.e2e_search_q3_mc_sharded_external_mtls
+def test_remove_and_readd_search_cluster_entry(
+    namespace: str,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Dropping one cluster entry sweeps every per-(cluster, shard) artifact on that
+    cluster (main + Envoy sweeps), leaves the survivor byte-identical (UID-pinned) and
+    serving $search, and re-adding the entry reconverges the two-cluster topology.
+
+    The survivor must be cluster 0: the source's mongos and shardOverrides mongotHost
+    endpoints all point at cluster-0's proxy Services.
+    """
+    assert (
+        len(member_cluster_clients) == 2
+    ), f"cluster-entry lifecycle requires exactly two member clusters, got {len(member_cluster_clients)}"
+    survivor, removed = member_cluster_clients[0], member_cluster_clients[1]
+    assert _idx(survivor) == 0, f"survivor must be cluster index 0 (source endpoints pin it), got {_idx(survivor)}"
+
+    mdbs.load()
+    original_entries = deepcopy(mdbs["spec"]["clusters"])
+    surviving_entries = [deepcopy(entry) for entry in original_entries if entry["name"] == survivor.cluster_name]
+    assert len(surviving_entries) == 1, f"expected exactly one entry for {survivor.cluster_name}: {original_entries}"
+
+    # Presence guard + UID snapshot on BOTH clusters (a 404 or missing-PVC failure here
+    # fails the capture, so the deletion polls below can never pass vacuously).
+    survivor_uids = {what: read().metadata.uid for what, read in _local_artifact_readers(survivor, namespace).items()}
+    removed_readers = _local_artifact_readers(removed, namespace)
+    for read in removed_readers.values():
+        read()
+    for sts_name in _shard_sts_names(_idx(removed)):
+        assert mongot_data_pvc_names(
+            namespace, sts_name, api_client=removed.api_client
+        ), f"[{removed.cluster_name}] expected mongot data PVCs for {sts_name}"
+    removed_protected_uids = _customer_input_uids(removed, namespace, _idx(removed))
+
+    mdbs["spec"]["clusters"] = surviving_entries
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True)
+
+    _wait_for_cluster_artifacts_swept(removed, namespace, removed_readers)
+    assert _customer_input_uids(removed, namespace, _idx(removed)) == removed_protected_uids
+    assert {
+        what: read().metadata.uid for what, read in _local_artifact_readers(survivor, namespace).items()
+    } == survivor_uids, (
+        f"[{survivor.cluster_name}] managed artifact UIDs changed when {removed.cluster_name} was removed"
+    )
+    assert_workload_ready_in_cluster(
+        survivor,
+        namespace,
+        {sts_name: MONGOT_REPLICAS_PER_CLUSTER for sts_name in _shard_sts_names(_idx(survivor))},
+        search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, _idx(survivor)),
+        timeout=300,
+    )
+
+    tester = _per_cluster_mongos_search_tester(namespace, 0, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+
+    def execute_search() -> tuple:
+        try:
+            results = movies.text_search_movies("Star Wars")
+            return bool(results), f"$search returned {len(results)} results"
+        except pymongo.errors.PyMongoError as exc:
+            return False, f"$search error: {exc}"
+
+    run_periodically(
+        execute_search,
+        timeout=SEARCH_INDEX_READY_TIMEOUT,
+        sleep_time=5,
+        msg=f"[{survivor.cluster_name}] $search after cluster-entry removal",
+    )
+
+    # Restore the two-cluster topology for the tests that follow. Re-adding the
+    # entry is ordinary reconciliation, so no lifecycle assertions are made here.
+    mdbs.load()
+    mdbs["spec"]["clusters"] = original_entries
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_cluster_statuses(expected_count=2, expect_managed_lb=True)
+    assert_workload_ready_in_cluster(
+        removed,
+        namespace,
+        {sts_name: MONGOT_REPLICAS_PER_CLUSTER for sts_name in _shard_sts_names(_idx(removed))},
+        search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, _idx(removed)),
+        timeout=600,
+    )
+
+
+@mark.e2e_search_q3_mc_sharded_external_mtls
+def test_delete_search_resource_cleans_all_member_cluster_artifacts(
+    namespace: str,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """CR delete: the OnDelete label sweep must remove every per-(cluster, shard)
+    artifact on every member cluster while the customer-replicated inputs survive
+    untouched. Destroys the workload — keep it last."""
+    per_cluster = []
+    for mcc in member_cluster_clients:
+        readers = _local_artifact_readers(mcc, namespace)
+        for read in readers.values():
+            read()
+        for sts_name in _shard_sts_names(_idx(mcc)):
+            assert mongot_data_pvc_names(
+                namespace, sts_name, api_client=mcc.api_client
+            ), f"[{mcc.cluster_name}] expected mongot data PVCs for {sts_name}"
+        per_cluster.append((mcc, readers, _customer_input_uids(mcc, namespace, _idx(mcc))))
+
+    mdbs.delete()
+    wait_for_search_deleted(mdbs, timeout=600)
+
+    for mcc, readers, protected_uids in per_cluster:
+        _wait_for_cluster_artifacts_swept(mcc, namespace, readers)
+        assert _customer_input_uids(mcc, namespace, _idx(mcc)) == protected_uids

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -35,7 +35,6 @@ from tests.common.search.connectivity import (
     protected_search_input_uids,
     wait_for_mongot_pvcs_deleted,
     wait_for_resource_deleted,
-    wait_for_search_deleted,
     wait_for_search_owned_resources_deleted,
 )
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
@@ -834,31 +833,3 @@ def test_remove_and_readd_search_cluster_entry(
         search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, _idx(removed)),
         timeout=600,
     )
-
-
-@mark.e2e_search_q3_mc_sharded_external_mtls
-def test_delete_search_resource_cleans_all_member_cluster_artifacts(
-    namespace: str,
-    mdbs: MongoDBSearch,
-    member_cluster_clients: List[MultiClusterClient],
-):
-    """CR delete: the OnDelete label sweep must remove every per-(cluster, shard)
-    artifact on every member cluster while the customer-replicated inputs survive
-    untouched. Destroys the workload — keep it last."""
-    per_cluster = []
-    for mcc in member_cluster_clients:
-        readers = _local_artifact_readers(mcc, namespace)
-        for read in readers.values():
-            read()
-        for sts_name in _shard_sts_names(_idx(mcc)):
-            assert mongot_data_pvc_names(
-                namespace, sts_name, api_client=mcc.api_client
-            ), f"[{mcc.cluster_name}] expected mongot data PVCs for {sts_name}"
-        per_cluster.append((mcc, readers, _customer_input_uids(mcc, namespace, _idx(mcc))))
-
-    mdbs.delete()
-    wait_for_search_deleted(mdbs, timeout=600)
-
-    for mcc, readers, protected_uids in per_cluster:
-        _wait_for_cluster_artifacts_swept(mcc, namespace, readers)
-        assert _customer_input_uids(mcc, namespace, _idx(mcc)) == protected_uids

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/q3_mc_sharded_external_mtls.py
@@ -6,7 +6,7 @@ proxy Service (for mongos) and an Envoy Deployment.
 """
 
 from copy import deepcopy
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 
 import kubernetes
 import pymongo.errors
@@ -678,14 +678,14 @@ def _shard_sts_names(cluster_index: int) -> List[str]:
     ]
 
 
-def _local_artifact_readers(mcc: MultiClusterClient, namespace: str) -> Dict[str, Callable[[], object]]:
+def _local_artifact_readers(mcc: MultiClusterClient, namespace: str) -> Dict[str, Callable[[], Any]]:
     """Direct readers for the concrete (kind, name) identities of one cluster's Search
     artifact set: per-(cluster, shard) mongot resources plus the cluster-level proxy
     Service and Envoy Deployment/ConfigMap."""
     ci = _idx(mcc)
     apps = mcc.apps_v1_api()
     core = mcc.core_v1_api()
-    readers: Dict[str, Callable[[], object]] = {}
+    readers: Dict[str, Callable[[], Any]] = {}
     for shard_idx in range(SHARD_COUNT):
         shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
         sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
@@ -730,7 +730,7 @@ def _customer_input_uids(mcc: MultiClusterClient, namespace: str, cluster_index:
 
 
 def _wait_for_cluster_artifacts_swept(
-    mcc: MultiClusterClient, namespace: str, readers: Dict[str, Callable[[], object]]
+    mcc: MultiClusterClient, namespace: str, readers: Dict[str, Callable[[], Any]]
 ) -> None:
     """Identity 404-polls for every captured artifact, then PVC reap, then the
     label-scoped emptiness backstop for labeled orphans outside the inventory."""

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
@@ -7,6 +7,7 @@ member_cluster_clients[:2] / member_cluster_names[:2] slice appears in this modu
 from __future__ import annotations
 
 import os
+from copy import deepcopy
 from typing import List, Tuple
 
 import kubernetes
@@ -25,6 +26,10 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.multicluster.multicluster_utils import assert_workload_ready_in_cluster
 from tests.common.search import search_resource_names
+from tests.common.search.connectivity import (
+    search_artifact_uids,
+    wait_for_search_artifacts_deleted,
+)
 from tests.common.search.mc_search_helper import (
     _assert_mongot_host_on_disk,
     assert_mongot_sync_source_hosts,
@@ -60,6 +65,7 @@ from tests.multicluster_search.conftest import (
     create_search_users,
     install_central_mc_operator,
     install_simulated_operators_per_member,
+    mc_search_customer_input_uids,
 )
 
 logger = test_logger.get_test_logger(__name__)
@@ -571,3 +577,59 @@ def test_cross_cluster_isolation_absence(
     Confirms each simulated operator only materialises its own LocalizeToCluster slice.
     """
     assert_cross_cluster_isolation(namespace, per_cluster_mdbs_search, MDBS_RESOURCE_NAME)
+
+
+@mark.e2e_search_simulated_mc_rs
+def test_remove_own_cluster_entry_sweeps_local_resources(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Dropping the operator's OWN cluster entry from its local CR copy sweeps every
+    local operator-managed artifact, leaves customer inputs and the other cluster
+    untouched, and restoring the entry redeploys the local slice. (No search-state
+    ConfigMap here: the routing-ready latch that creates it never fires for an
+    RS source — the sharded simulated-MC module covers its lifecycle.)"""
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    (mcc_a, mdbs_a), (mcc_b, mdbs_b) = per_cluster_mdbs_search
+    idx_a, idx_b = _idx(mcc_a), _idx(mcc_b)
+
+    names_a = search_resource_names.mc_search_artifact_names(MDBS_RESOURCE_NAME, idx_a)
+    names_b = search_resource_names.mc_search_artifact_names(MDBS_RESOURCE_NAME, idx_b)
+
+    uids_a = search_artifact_uids(mcc_a, namespace, names_a)
+    search_artifact_uids(mcc_b, namespace, names_b)  # presence guard for the deletion poll below
+    protected_uids_b = mc_search_customer_input_uids(mcc_b, namespace, MDBS_RESOURCE_NAME, CA_CONFIGMAP_NAME, idx_b)
+
+    mdbs_b.load()
+    original_clusters = deepcopy(mdbs_b["spec"]["clusters"])
+    remaining_clusters = [deepcopy(entry) for entry in original_clusters if entry["name"] == mcc_a.cluster_name]
+    assert len(remaining_clusters) == 1, f"expected exactly one entry for {mcc_a.cluster_name}: {original_clusters}"
+    mdbs_b["spec"]["clusters"] = remaining_clusters
+    mdbs_b.update()
+
+    wait_for_search_artifacts_deleted(mcc_b, namespace, names_b, mdbs_b.name)
+    assert (
+        mc_search_customer_input_uids(mcc_b, namespace, MDBS_RESOURCE_NAME, CA_CONFIGMAP_NAME, idx_b)
+        == protected_uids_b
+    ), f"[{mcc_b.cluster_name}] customer-provided inputs must survive the local sweep"
+
+    mdbs_a.load()
+    phase_a = mdbs_a.get_status_phase()
+    assert (
+        phase_a == Phase.Running
+    ), f"[{mcc_a.cluster_name}] phase={phase_a} after {mcc_b.cluster_name} swept its local slice"
+    assert (
+        search_artifact_uids(mcc_a, namespace, names_a) == uids_a
+    ), f"[{mcc_a.cluster_name}] managed artifacts changed when {mcc_b.cluster_name} swept its local slice"
+
+    mdbs_b.load()
+    mdbs_b["spec"]["clusters"] = original_clusters
+    mdbs_b.update()
+    mdbs_b.assert_reaches_phase(Phase.Running, timeout=900)
+    assert_workload_ready_in_cluster(
+        mcc_b,
+        namespace,
+        {names_b["sts"]: MONGOT_REPLICAS_PER_CLUSTER},
+        names_b["envoy_deployment"],
+        timeout=600,
+    )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_rs.py
@@ -26,10 +26,7 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.multicluster.multicluster_utils import assert_workload_ready_in_cluster
 from tests.common.search import search_resource_names
-from tests.common.search.connectivity import (
-    search_artifact_uids,
-    wait_for_search_artifacts_deleted,
-)
+from tests.common.search.connectivity import search_artifact_uids, wait_for_search_artifacts_deleted
 from tests.common.search.mc_search_helper import (
     _assert_mongot_host_on_disk,
     assert_mongot_sync_source_hosts,

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
@@ -19,7 +19,8 @@ index systems never collide.
 from __future__ import annotations
 
 import os
-from typing import Dict, List, Tuple
+from copy import deepcopy
+from typing import Callable, Dict, List, Tuple
 
 import kubernetes
 import pymongo.errors
@@ -39,6 +40,12 @@ from tests import test_logger
 from tests.common.mongodb_tools_pod.mongodb_tools_pod import ToolsPod
 from tests.common.multicluster.multicluster_utils import assert_workload_ready_in_cluster
 from tests.common.search import search_resource_names
+from tests.common.search.connectivity import (
+    mongot_data_pvc_names,
+    wait_for_mongot_pvcs_deleted,
+    wait_for_resource_deleted,
+    wait_for_search_owned_resources_deleted,
+)
 from tests.common.search.mc_search_helper import (
     assert_mongot_sync_source_hosts,
     patch_mongot_host_via_ac,
@@ -800,3 +807,125 @@ def test_cross_cluster_isolation_absence(
     """
     shard_names = [f"{MDB_RESOURCE_NAME}-{shard_idx}" for shard_idx in range(SHARD_COUNT)]
     assert_cross_cluster_isolation(namespace, per_cluster_mdbs_search, MDBS_RESOURCE_NAME, shard_names=shard_names)
+
+
+@mark.e2e_search_simulated_mc_sharded
+def test_remove_own_cluster_entry_sweeps_local_resources(
+    namespace: str,
+    per_cluster_mdbs_search: List[Tuple[MultiClusterClient, MongoDBSearch]],
+):
+    """Dropping the operator's OWN cluster entry from its local CR copy sweeps every
+    local per-(cluster, shard) artifact INCLUDING the search-state ConfigMap (the
+    removed-operator-local sweep is the one path that reaps it), leaves the other
+    cluster untouched, and restoring the entry redeploys the local slice and
+    re-creates the state ConfigMap (fresh UID) once the routing-ready latch re-fires."""
+    assert_per_cluster_count(per_cluster_mdbs_search)
+    (mcc_a, mdbs_a), (mcc_b, mdbs_b) = per_cluster_mdbs_search
+
+    state_cm_name = search_resource_names.search_state_configmap_name(MDBS_RESOURCE_NAME)
+
+    def local_artifact_readers(mcc: MultiClusterClient) -> Dict[str, Callable[[], object]]:
+        """Direct readers for the concrete (kind, name) identities of one cluster's
+        Search artifact set: per-shard mongot resources plus the cluster-level
+        proxy Service, Envoy Deployment/ConfigMap, and the state ConfigMap."""
+        ci = _idx(mcc)
+        apps = mcc.apps_v1_api()
+        core = mcc.core_v1_api()
+        readers: Dict[str, Callable[[], object]] = {}
+        for shard_idx in range(SHARD_COUNT):
+            shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
+            sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            svc = search_resource_names.shard_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            proxy = search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            cm = search_resource_names.shard_configmap_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            secret = search_resource_names.shard_operator_managed_tls_secret_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            readers[f"StatefulSet/{sts}"] = lambda n=sts: mcc.read_namespaced_stateful_set(n, namespace)
+            readers[f"Service/{svc}"] = lambda n=svc: mcc.read_namespaced_service(n, namespace)
+            readers[f"Service/{proxy}"] = lambda n=proxy: mcc.read_namespaced_service(n, namespace)
+            readers[f"ConfigMap/{cm}"] = lambda n=cm: mcc.read_namespaced_config_map(n, namespace)
+            readers[f"Secret/{secret}"] = lambda n=secret: core.read_namespaced_secret(n, namespace)
+        cluster_proxy = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, ci)
+        envoy_dep = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, ci)
+        envoy_cm = search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, ci)
+        readers[f"Service/{cluster_proxy}"] = lambda: mcc.read_namespaced_service(cluster_proxy, namespace)
+        readers[f"Deployment/{envoy_dep}"] = lambda: apps.read_namespaced_deployment(envoy_dep, namespace)
+        readers[f"ConfigMap/{envoy_cm}"] = lambda: mcc.read_namespaced_config_map(envoy_cm, namespace)
+        readers[f"ConfigMap/{state_cm_name}"] = lambda: mcc.read_namespaced_config_map(state_cm_name, namespace)
+        return readers
+
+    # Presence guard + UID snapshot on BOTH clusters (a 404 or missing-PVC failure here
+    # fails the capture, so the deletion polls below can never pass vacuously).
+    uids_a = {what: read().metadata.uid for what, read in local_artifact_readers(mcc_a).items()}
+    readers_b = local_artifact_readers(mcc_b)
+    uids_b = {what: read().metadata.uid for what, read in readers_b.items()}
+    shard_sts_names_b = [
+        search_resource_names.shard_statefulset_name(
+            MDBS_RESOURCE_NAME, f"{MDB_RESOURCE_NAME}-{shard_idx}", _idx(mcc_b)
+        )
+        for shard_idx in range(SHARD_COUNT)
+    ]
+    for sts_name in shard_sts_names_b:
+        assert mongot_data_pvc_names(
+            namespace, sts_name, api_client=mcc_b.api_client
+        ), f"[{mcc_b.cluster_name}] expected mongot data PVCs for {sts_name}"
+
+    mdbs_b.load()
+    original_clusters = deepcopy(mdbs_b["spec"]["clusters"])
+    remaining_clusters = [deepcopy(entry) for entry in original_clusters if entry["name"] == mcc_a.cluster_name]
+    assert len(remaining_clusters) == 1, f"expected exactly one entry for {mcc_a.cluster_name}: {original_clusters}"
+    mdbs_b["spec"]["clusters"] = remaining_clusters
+    mdbs_b.update()
+
+    for what, read in readers_b.items():
+        wait_for_resource_deleted(read, f"{what} in {mcc_b.cluster_name}")
+    for sts_name in shard_sts_names_b:
+        wait_for_mongot_pvcs_deleted(namespace, sts_name, api_client=mcc_b.api_client)
+    wait_for_search_owned_resources_deleted(
+        mcc_b.apps_v1_api(),
+        mcc_b.core_v1_api(),
+        namespace,
+        MDBS_RESOURCE_NAME,
+        where=mcc_b.cluster_name,
+    )
+
+    mdbs_a.load()
+    phase_a = mdbs_a.get_status_phase()
+    assert (
+        phase_a == Phase.Running
+    ), f"[{mcc_a.cluster_name}] phase={phase_a} after {mcc_b.cluster_name} swept its local slice"
+    assert {what: read().metadata.uid for what, read in local_artifact_readers(mcc_a).items()} == uids_a, (
+        f"[{mcc_a.cluster_name}] managed artifacts (including the state ConfigMap) changed "
+        f"when {mcc_b.cluster_name} swept its local slice"
+    )
+
+    mdbs_b.load()
+    mdbs_b["spec"]["clusters"] = original_clusters
+    mdbs_b.update()
+    mdbs_b.assert_reaches_phase(Phase.Running, timeout=900)
+    assert_workload_ready_in_cluster(
+        mcc_b,
+        namespace,
+        {sts_name: MONGOT_REPLICAS_PER_CLUSTER for sts_name in shard_sts_names_b},
+        search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, _idx(mcc_b)),
+        timeout=600,
+    )
+
+    # Only markRoutingReady creates the state ConfigMap, so a fresh UID proves the
+    # routing-ready latch re-fired for the redeployed slice.
+    old_state_cm_uid_b = uids_b[f"ConfigMap/{state_cm_name}"]
+
+    def state_cm_recreated() -> tuple:
+        try:
+            cm = mcc_b.read_namespaced_config_map(state_cm_name, namespace)
+        except kubernetes.client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                return False, f"{state_cm_name} absent"
+            raise
+        return cm.metadata.uid != old_state_cm_uid_b, f"uid={cm.metadata.uid} (pre-sweep uid={old_state_cm_uid_b})"
+
+    run_periodically(
+        state_cm_recreated,
+        timeout=300,
+        sleep_time=5,
+        msg=f"state ConfigMap {state_cm_name} re-created in {mcc_b.cluster_name}",
+    )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/simulated_mc_sharded.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import os
 from copy import deepcopy
-from typing import Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import kubernetes
 import pymongo.errors
@@ -824,14 +824,14 @@ def test_remove_own_cluster_entry_sweeps_local_resources(
 
     state_cm_name = search_resource_names.search_state_configmap_name(MDBS_RESOURCE_NAME)
 
-    def local_artifact_readers(mcc: MultiClusterClient) -> Dict[str, Callable[[], object]]:
+    def local_artifact_readers(mcc: MultiClusterClient) -> Dict[str, Callable[[], Any]]:
         """Direct readers for the concrete (kind, name) identities of one cluster's
         Search artifact set: per-shard mongot resources plus the cluster-level
         proxy Service, Envoy Deployment/ConfigMap, and the state ConfigMap."""
         ci = _idx(mcc)
         apps = mcc.apps_v1_api()
         core = mcc.core_v1_api()
-        readers: Dict[str, Callable[[], object]] = {}
+        readers: Dict[str, Callable[[], Any]] = {}
         for shard_idx in range(SHARD_COUNT):
             shard_name = f"{MDB_RESOURCE_NAME}-{shard_idx}"
             sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_basic.py
@@ -10,7 +10,11 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import movies_search_helper, search_resource_names
-from tests.common.search.connectivity import wait_for_mongot_pvcs_deleted, wait_for_mongot_statefulset_drained
+from tests.common.search.connectivity import (
+    mongot_data_pvc_names,
+    wait_for_mongot_pvcs_deleted,
+    wait_for_mongot_statefulset_drained,
+)
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_tester import SearchTester
 from tests.conftest import get_default_operator
@@ -128,18 +132,6 @@ def test_search_assert_search_query(sample_movies_helper: SampleMoviesSearchHelp
     sample_movies_helper.assert_search_query(retry_timeout=60)
 
 
-def _mongot_data_pvc_names(namespace: str, sts_name: str) -> list[str]:
-    """Names of the data PVCs backing a mongot StatefulSet (volumeClaimTemplate
-    ``data`` -> ``data-<sts>-<ordinal>``)."""
-    core_v1 = client.CoreV1Api()
-    prefix = f"data-{sts_name}-"
-    return [
-        pvc.metadata.name
-        for pvc in core_v1.list_namespaced_persistent_volume_claim(namespace).items
-        if pvc.metadata.name.startswith(prefix)
-    ]
-
-
 @mark.e2e_search_community_basic
 def test_scale_mongot_offline_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     """whenScaled:Delete - scaling mongot to 0 keeps the CR and StatefulSet object
@@ -150,7 +142,7 @@ def test_scale_mongot_offline_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     # Presence guard: the STS and its data PVC must exist before scale-down, else
     # the reclaim assertion below passes vacuously.
     client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace)
-    assert _mongot_data_pvc_names(namespace, sts_name), f"expected a mongot data PVC for {sts_name} before scale-down"
+    assert mongot_data_pvc_names(namespace, sts_name), f"expected a mongot data PVC for {sts_name} before scale-down"
 
     mdbs.load()
     mdbs["spec"]["clusters"][0]["replicas"] = 0
@@ -177,7 +169,7 @@ def test_delete_search_cr_reclaims_pvc(namespace: str, mdbs: MongoDBSearch):
     # Presence guard: the STS and its data PVC must exist before delete, otherwise
     # the post-delete absence checks below could pass vacuously.
     client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace)
-    pvcs_before = _mongot_data_pvc_names(namespace, sts_name)
+    pvcs_before = mongot_data_pvc_names(namespace, sts_name)
     assert pvcs_before, f"expected at least one mongot data PVC for {sts_name} before delete"
     logger.info(f"pre-delete: STS {sts_name} present, data PVCs {pvcs_before}")
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_tls.py
@@ -1,6 +1,11 @@
-from kubetester import create_or_update_secret, try_load
+import base64
+import json
+
+from kubernetes import client
+from kubetester import create_or_update_secret, pod_is_ready, try_load
 from kubetester.certs import create_tls_certs
 from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
 from kubetester.mongodb_community import MongoDBCommunity
 from kubetester.mongodb_search import MongoDBSearch
 from kubetester.phase import Phase
@@ -8,8 +13,10 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import movies_search_helper, search_resource_names
+from tests.common.search.connectivity import wait_for_all_pods_replaced, wait_for_resource_deleted
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_tester import SearchTester
+from tests.common.search.tls_utils import create_keyfile_password_secret, encrypt_tls_key_with_password
 from tests.conftest import get_default_operator
 
 logger = test_logger.get_test_logger(__name__)
@@ -31,6 +38,8 @@ TLS_SECRET_NAME = "tls-secret"
 
 # MongoDBSearch TLS configuration -- convention: {name}-search-cert
 MDBS_TLS_SECRET_NAME = search_resource_names.mongot_tls_cert_name(MDBS_RESOURCE_NAME)
+GRPC_KEY_PASSWORD = "search-grpc-key-password"
+GRPC_KEY_PASSWORD_SECRET_NAME = f"{MDBS_RESOURCE_NAME}-grpc-key-password"
 
 
 @fixture(scope="function")
@@ -65,7 +74,12 @@ def mdbs(namespace: str) -> MongoDBSearch:
     if "spec" not in resource:
         resource["spec"] = {}
 
-    resource["spec"]["security"] = {"tls": {"certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME}}}
+    resource["spec"]["security"] = {
+        "tls": {
+            "certificateKeySecretRef": {"name": MDBS_TLS_SECRET_NAME},
+            "keyFilePasswordSecretRef": {"name": GRPC_KEY_PASSWORD_SECRET_NAME},
+        }
+    }
 
     try_load(resource)
     return resource
@@ -107,6 +121,8 @@ def test_install_tls_secrets_and_configmaps(namespace: str, mdbc: MongoDBCommuni
         ],
         secret_name=MDBS_TLS_SECRET_NAME,
     )
+    encrypt_tls_key_with_password(namespace, MDBS_TLS_SECRET_NAME, GRPC_KEY_PASSWORD)
+    create_keyfile_password_secret(namespace, GRPC_KEY_PASSWORD_SECRET_NAME, GRPC_KEY_PASSWORD)
 
 
 @mark.e2e_search_community_tls
@@ -147,3 +163,101 @@ def test_search_create_search_index(sample_movies_helper: SampleMoviesSearchHelp
 @mark.e2e_search_community_tls
 def test_search_assert_search_query(sample_movies_helper: SampleMoviesSearchHelper):
     sample_movies_helper.assert_search_query(retry_timeout=60)
+
+
+@mark.e2e_search_community_tls
+def test_disable_search_ingress_tls_cleans_generated_resources(
+    namespace: str,
+    mdbc: MongoDBCommunity,
+    mdbs: MongoDBSearch,
+    sample_movies_helper: SampleMoviesSearchHelper,
+):
+    apps = client.AppsV1Api()
+    core = client.CoreV1Api()
+    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
+    generated_tls_secret_name = search_resource_names.operator_managed_tls_secret_name(mdbs.name)
+    source_password_secret_name = f"{mdbs.name}-{MONGOT_USER_NAME}-password"
+    source_config_secret_name = f"{mdbc.name}-config"
+    source_pod_names = [f"{mdbc.name}-{i}" for i in range(mdbc["spec"]["members"])]
+
+    def read_source_automation_config() -> dict:
+        secret = core.read_namespaced_secret(source_config_secret_name, namespace)
+        assert secret.data
+        return json.loads(base64.b64decode(secret.data["cluster-config.json"]))
+
+    customer_secret_uids = {
+        name: core.read_namespaced_secret(name, namespace).metadata.uid
+        for name in (
+            TLS_SECRET_NAME,
+            MDBS_TLS_SECRET_NAME,
+            GRPC_KEY_PASSWORD_SECRET_NAME,
+            source_password_secret_name,
+        )
+    }
+
+    generated_tls_secret = core.read_namespaced_secret(generated_tls_secret_name, namespace)
+    assert generated_tls_secret.metadata.uid
+    sts = apps.read_namespaced_stateful_set(sts_name, namespace)
+    mongot = next(container for container in sts.spec.template.spec.containers if container.name == "mongot")
+    assert {"tls", "grpc-key-password", "password"} <= {volume.name for volume in sts.spec.template.spec.volumes}
+    assert {"tls", "grpc-key-password", "password"} <= {mount.name for mount in mongot.volume_mounts}
+    original_pod_uids = {
+        pod_name: core.read_namespaced_pod(pod_name, namespace).metadata.uid for pod_name in (f"{sts_name}-0",)
+    }
+
+    mdbs.load()
+    mdbs["spec"]["security"]["tls"] = None
+    old_source_config_version = read_source_automation_config()["version"]
+    mdbs.update()
+
+    wait_for_all_pods_replaced(namespace, original_pod_uids, timeout=600)
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+    wait_for_resource_deleted(
+        lambda: core.read_namespaced_secret(generated_tls_secret_name, namespace),
+        f"generated ingress TLS Secret {namespace}/{generated_tls_secret_name}",
+        timeout=300,
+    )
+
+    sts = apps.read_namespaced_stateful_set(sts_name, namespace)
+    mongot = next(container for container in sts.spec.template.spec.containers if container.name == "mongot")
+    volume_names = {volume.name for volume in sts.spec.template.spec.volumes}
+    mount_names = {mount.name for mount in mongot.volume_mounts}
+    assert "tls" not in volume_names
+    assert "grpc-key-password" not in volume_names
+    assert "tls" not in mount_names
+    assert "grpc-key-password" not in mount_names
+    assert "password" in volume_names
+    assert "password" in mount_names
+
+    assert {
+        name: core.read_namespaced_secret(name, namespace).metadata.uid for name in customer_secret_uids
+    } == customer_secret_uids
+
+    def source_reached_new_goal_state() -> tuple[bool, str]:
+        automation_config = read_source_automation_config()
+        version = automation_config["version"]
+        tls_modes = {process["args2_6"]["setParameter"]["searchTLSMode"] for process in automation_config["processes"]}
+        pods = [core.read_namespaced_pod(name, namespace) for name in source_pod_names]
+        pod_states = []
+        for pod in pods:
+            agent_version = (pod.metadata.annotations or {}).get("agent.mongodb.com/version")
+            ready = pod_is_ready(pod)
+            pod_states.append(f"{pod.metadata.name}=agent_version:{agent_version},ready:{ready}")
+        reached = (
+            version > old_source_config_version
+            and tls_modes == {"disabled"}
+            and all(
+                (pod.metadata.annotations or {}).get("agent.mongodb.com/version") == str(version) and pod_is_ready(pod)
+                for pod in pods
+            )
+        )
+        return reached, f"config_version={version}>{old_source_config_version}, tls_modes={tls_modes}, {pod_states}"
+
+    run_periodically(
+        source_reached_new_goal_state,
+        timeout=600,
+        sleep_time=3,
+        msg="source MongoDBCommunity agents to reach the new automation-config goal state",
+    )
+    mdbc.assert_reaches_phase(Phase.Running, timeout=600)
+    sample_movies_helper.assert_search_query(retry_timeout=120)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_community_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_community_tls.py
@@ -1,11 +1,6 @@
-import base64
-import json
-
-from kubernetes import client
-from kubetester import create_or_update_secret, pod_is_ready, try_load
+from kubetester import create_or_update_secret, try_load
 from kubetester.certs import create_tls_certs
 from kubetester.kubetester import fixture as yaml_fixture
-from kubetester.kubetester import run_periodically
 from kubetester.mongodb_community import MongoDBCommunity
 from kubetester.mongodb_search import MongoDBSearch
 from kubetester.phase import Phase
@@ -13,7 +8,6 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import movies_search_helper, search_resource_names
-from tests.common.search.connectivity import wait_for_all_pods_replaced, wait_for_resource_deleted
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_tester import SearchTester
 from tests.common.search.tls_utils import create_keyfile_password_secret, encrypt_tls_key_with_password
@@ -163,101 +157,3 @@ def test_search_create_search_index(sample_movies_helper: SampleMoviesSearchHelp
 @mark.e2e_search_community_tls
 def test_search_assert_search_query(sample_movies_helper: SampleMoviesSearchHelper):
     sample_movies_helper.assert_search_query(retry_timeout=60)
-
-
-@mark.e2e_search_community_tls
-def test_disable_search_ingress_tls_cleans_generated_resources(
-    namespace: str,
-    mdbc: MongoDBCommunity,
-    mdbs: MongoDBSearch,
-    sample_movies_helper: SampleMoviesSearchHelper,
-):
-    apps = client.AppsV1Api()
-    core = client.CoreV1Api()
-    sts_name = search_resource_names.mongot_statefulset_name(mdbs.name)
-    generated_tls_secret_name = search_resource_names.operator_managed_tls_secret_name(mdbs.name)
-    source_password_secret_name = f"{mdbs.name}-{MONGOT_USER_NAME}-password"
-    source_config_secret_name = f"{mdbc.name}-config"
-    source_pod_names = [f"{mdbc.name}-{i}" for i in range(mdbc["spec"]["members"])]
-
-    def read_source_automation_config() -> dict:
-        secret = core.read_namespaced_secret(source_config_secret_name, namespace)
-        assert secret.data
-        return json.loads(base64.b64decode(secret.data["cluster-config.json"]))
-
-    customer_secret_uids = {
-        name: core.read_namespaced_secret(name, namespace).metadata.uid
-        for name in (
-            TLS_SECRET_NAME,
-            MDBS_TLS_SECRET_NAME,
-            GRPC_KEY_PASSWORD_SECRET_NAME,
-            source_password_secret_name,
-        )
-    }
-
-    generated_tls_secret = core.read_namespaced_secret(generated_tls_secret_name, namespace)
-    assert generated_tls_secret.metadata.uid
-    sts = apps.read_namespaced_stateful_set(sts_name, namespace)
-    mongot = next(container for container in sts.spec.template.spec.containers if container.name == "mongot")
-    assert {"tls", "grpc-key-password", "password"} <= {volume.name for volume in sts.spec.template.spec.volumes}
-    assert {"tls", "grpc-key-password", "password"} <= {mount.name for mount in mongot.volume_mounts}
-    original_pod_uids = {
-        pod_name: core.read_namespaced_pod(pod_name, namespace).metadata.uid for pod_name in (f"{sts_name}-0",)
-    }
-
-    mdbs.load()
-    mdbs["spec"]["security"]["tls"] = None
-    old_source_config_version = read_source_automation_config()["version"]
-    mdbs.update()
-
-    wait_for_all_pods_replaced(namespace, original_pod_uids, timeout=600)
-    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
-    wait_for_resource_deleted(
-        lambda: core.read_namespaced_secret(generated_tls_secret_name, namespace),
-        f"generated ingress TLS Secret {namespace}/{generated_tls_secret_name}",
-        timeout=300,
-    )
-
-    sts = apps.read_namespaced_stateful_set(sts_name, namespace)
-    mongot = next(container for container in sts.spec.template.spec.containers if container.name == "mongot")
-    volume_names = {volume.name for volume in sts.spec.template.spec.volumes}
-    mount_names = {mount.name for mount in mongot.volume_mounts}
-    assert "tls" not in volume_names
-    assert "grpc-key-password" not in volume_names
-    assert "tls" not in mount_names
-    assert "grpc-key-password" not in mount_names
-    assert "password" in volume_names
-    assert "password" in mount_names
-
-    assert {
-        name: core.read_namespaced_secret(name, namespace).metadata.uid for name in customer_secret_uids
-    } == customer_secret_uids
-
-    def source_reached_new_goal_state() -> tuple[bool, str]:
-        automation_config = read_source_automation_config()
-        version = automation_config["version"]
-        tls_modes = {process["args2_6"]["setParameter"]["searchTLSMode"] for process in automation_config["processes"]}
-        pods = [core.read_namespaced_pod(name, namespace) for name in source_pod_names]
-        pod_states = []
-        for pod in pods:
-            agent_version = (pod.metadata.annotations or {}).get("agent.mongodb.com/version")
-            ready = pod_is_ready(pod)
-            pod_states.append(f"{pod.metadata.name}=agent_version:{agent_version},ready:{ready}")
-        reached = (
-            version > old_source_config_version
-            and tls_modes == {"disabled"}
-            and all(
-                (pod.metadata.annotations or {}).get("agent.mongodb.com/version") == str(version) and pod_is_ready(pod)
-                for pod in pods
-            )
-        )
-        return reached, f"config_version={version}>{old_source_config_version}, tls_modes={tls_modes}, {pod_states}"
-
-    run_periodically(
-        source_reached_new_goal_state,
-        timeout=600,
-        sleep_time=3,
-        msg="source MongoDBCommunity agents to reach the new automation-config goal state",
-    )
-    mdbc.assert_reaches_phase(Phase.Running, timeout=600)
-    sample_movies_helper.assert_search_query(retry_timeout=120)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
@@ -11,6 +11,7 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
+from tests.common.search.connectivity import wait_for_resource_deleted
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.search_resource_names import (
     metrics_forwarder_configmap_name,
@@ -131,7 +132,12 @@ def test_metrics_forwarder_status(om: MongoDBOpsManager, mdbs: MongoDBSearch):
         status = mdbs.get_metrics_forwarder_status()
         return status is not None and status.get("phase") == Phase.Running.name
 
-    run_periodically(check_metrics_forwarder_status, timeout=120, interval=10)
+    run_periodically(
+        check_metrics_forwarder_status,
+        timeout=120,
+        sleep_time=10,
+        msg="metrics forwarder status to reach Running",
+    )
 
     # Per-cluster surface: single-cluster + managed LB + metrics forwarder enabled, so the
     # one status.clusters entry must report search, loadBalancer AND metricsForwarder Running.
@@ -168,7 +174,12 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         status = mdbs.get_metrics_forwarder_status()
         return status is not None and status.get("phase") == Phase.Disabled.name
 
-    run_periodically(check_metrics_forwarder_status, timeout=120, interval=10)
+    run_periodically(
+        check_metrics_forwarder_status,
+        timeout=120,
+        sleep_time=10,
+        msg="metrics forwarder status to reach Disabled",
+    )
 
     # Verify resources are cleaned up
     def check_deployment_deleted():
@@ -180,7 +191,12 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         except ApiException as e:
             return e.status == 404
 
-    run_periodically(check_deployment_deleted, timeout=60, interval=5)
+    run_periodically(
+        check_deployment_deleted,
+        timeout=60,
+        sleep_time=5,
+        msg="metrics forwarder Deployment cleanup",
+    )
 
     def check_configmap_deleted():
         try:
@@ -191,7 +207,12 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         except ApiException as e:
             return e.status == 404
 
-    run_periodically(check_configmap_deleted, timeout=60, interval=5)
+    run_periodically(
+        check_configmap_deleted,
+        timeout=60,
+        sleep_time=5,
+        msg="metrics forwarder ConfigMap cleanup",
+    )
 
     # Per-cluster surface: with the forwarder disabled, the metricsForwarder sub-phase must
     # drop out of status.clusters (search + loadBalancer stay Running).
@@ -200,13 +221,50 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         cs = mdbs.get_cluster_status(0)
         return cs is not None and not cs.get("metricsForwarder")
 
-    run_periodically(check_per_cluster_metrics_forwarder_absent, timeout=120, interval=10)
+    run_periodically(
+        check_per_cluster_metrics_forwarder_absent,
+        timeout=120,
+        sleep_time=10,
+        msg="per-cluster metrics forwarder status cleanup",
+    )
     mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True, expect_metrics_forwarder=False)
 
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset
 def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: MongoDBSearch):
+    ensure_nested_objects(mdbs, ["spec", "observability", "metricsForwarder"])
+    mdbs["spec"]["observability"]["metricsForwarder"]["mode"] = "enabled"
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=300)
+
+    def metrics_forwarder_running():
+        mdbs.reload()
+        status = mdbs.get_metrics_forwarder_status()
+        return status is not None and status.get("phase") == Phase.Running.name
+
+    run_periodically(
+        metrics_forwarder_running,
+        timeout=120,
+        sleep_time=10,
+        msg="metrics forwarder status to reconverge before Search deletion",
+    )
+
+    deployment_name = metrics_forwarder_deployment_name(MDB_RESOURCE_NAME)
+    configmap_name = metrics_forwarder_configmap_name(MDB_RESOURCE_NAME)
+    apps = client.AppsV1Api()
+    core = client.CoreV1Api()
+    apps.read_namespaced_deployment(deployment_name, mdbs.namespace)
+    core.read_namespaced_config_map(configmap_name, mdbs.namespace)
+
     mdbs.delete()
 
     tester = om.get_om_tester(project_name=MDB_RESOURCE_NAME)
     tester.assert_mongot_hosts_converged(set())
+    wait_for_resource_deleted(
+        lambda: apps.read_namespaced_deployment(deployment_name, mdbs.namespace),
+        f"metrics-forwarder Deployment {mdbs.namespace}/{deployment_name}",
+    )
+    wait_for_resource_deleted(
+        lambda: core.read_namespaced_config_map(configmap_name, mdbs.namespace),
+        f"metrics-forwarder ConfigMap {mdbs.namespace}/{configmap_name}",
+    )

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
@@ -11,11 +11,12 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
-from tests.common.search.connectivity import wait_for_resource_deleted
+from tests.common.search.connectivity import wait_for_metrics_forwarder_phase, wait_for_resource_deleted
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.search_resource_names import (
     metrics_forwarder_configmap_name,
     metrics_forwarder_deployment_name,
+    metrics_forwarder_state_configmap_name,
 )
 from tests.conftest import get_default_operator
 from tests.search.om_deployment import get_ops_manager
@@ -127,17 +128,7 @@ def test_create_search_resource(mdbs: MongoDBSearch):
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset
 def test_metrics_forwarder_status(om: MongoDBOpsManager, mdbs: MongoDBSearch):
-    def check_metrics_forwarder_status():
-        mdbs.reload()
-        status = mdbs.get_metrics_forwarder_status()
-        return status is not None and status.get("phase") == Phase.Running.name
-
-    run_periodically(
-        check_metrics_forwarder_status,
-        timeout=120,
-        sleep_time=10,
-        msg="metrics forwarder status to reach Running",
-    )
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Running)
 
     # Per-cluster surface: single-cluster + managed LB + metrics forwarder enabled, so the
     # one status.clusters entry must report search, loadBalancer AND metricsForwarder Running.
@@ -163,23 +154,13 @@ def test_scaling_updates_hosts(om: MongoDBOpsManager, mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset
-def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
+def test_disable_metrics_forwarder(om: MongoDBOpsManager, mdbs: MongoDBSearch):
     """Disable the metrics forwarder and verify cleanup."""
     ensure_nested_objects(mdbs, ["spec", "observability", "metricsForwarder"])
     mdbs["spec"]["observability"]["metricsForwarder"]["mode"] = "disabled"
     mdbs.update()
 
-    def check_metrics_forwarder_status():
-        mdbs.update()
-        status = mdbs.get_metrics_forwarder_status()
-        return status is not None and status.get("phase") == Phase.Disabled.name
-
-    run_periodically(
-        check_metrics_forwarder_status,
-        timeout=120,
-        sleep_time=10,
-        msg="metrics forwarder status to reach Disabled",
-    )
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Disabled)
 
     # Verify resources are cleaned up
     def check_deployment_deleted():
@@ -229,6 +210,14 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
     )
     mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True, expect_metrics_forwarder=False)
 
+    # Disabling tears down the forwarder only: the persisted topology state and the
+    # Ops Manager host registrations must survive for a later re-enable.
+    client.CoreV1Api().read_namespaced_config_map(
+        metrics_forwarder_state_configmap_name(MDB_RESOURCE_NAME), mdbs.namespace
+    )
+    tester = om.get_om_tester(project_name=MDB_RESOURCE_NAME)
+    tester.assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
+
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset
 def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: MongoDBSearch):
@@ -237,17 +226,7 @@ def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: Mo
     mdbs.update()
     mdbs.assert_reaches_phase(Phase.Running, timeout=300)
 
-    def metrics_forwarder_running():
-        mdbs.reload()
-        status = mdbs.get_metrics_forwarder_status()
-        return status is not None and status.get("phase") == Phase.Running.name
-
-    run_periodically(
-        metrics_forwarder_running,
-        timeout=120,
-        sleep_time=10,
-        msg="metrics forwarder status to reconverge before Search deletion",
-    )
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Running)
 
     deployment_name = metrics_forwarder_deployment_name(MDB_RESOURCE_NAME)
     configmap_name = metrics_forwarder_configmap_name(MDB_RESOURCE_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
@@ -277,7 +277,6 @@ def test_deleting_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: Mon
     apps.read_namespaced_deployment(deployment_name, mdbs.namespace)
     core.read_namespaced_config_map(configmap_name, mdbs.namespace)
     core.read_namespaced_secret(agent_key_secret, mdbs.namespace)
-    core.read_namespaced_config_map(ca_configmap, mdbs.namespace)
 
     mdbs.delete()
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
@@ -11,9 +11,15 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
-from tests.common.search.connectivity import wait_for_metrics_forwarder_phase, wait_for_resource_deleted
+from tests.common.search.connectivity import (
+    wait_for_metrics_forwarder_phase,
+    wait_for_resource_deleted,
+    wait_for_search_deleted,
+)
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.search_resource_names import (
+    metrics_forwarder_agent_key_secret_name,
+    metrics_forwarder_ca_configmap_name,
     metrics_forwarder_configmap_name,
     metrics_forwarder_deployment_name,
     metrics_forwarder_state_configmap_name,
@@ -33,6 +39,21 @@ USER_NAME = "mdb-user"
 USER_PASSWORD = f"{USER_NAME}-password"
 
 MDB_RESOURCE_NAME = "mdb-rs"
+
+# Finalizer the metrics forwarder controller holds on the MongoDBSearch: it must survive a
+# forwarder disable (only CR deletion releases it, after Ops Manager host deregistration).
+METRICS_FORWARDER_FINALIZER = "mongodb.com/v1.searchMongotHostsRemovalFinalizer"
+
+# setParameter keys the search controller injects into the source's automation config
+# (controllers/searchcontroller buildSearchSetParameters); all must drop after CR delete.
+SEARCH_SET_PARAMETER_KEYS = (
+    "mongotHost",
+    "searchIndexManagementHostAndPort",
+    "skipAuthenticationToSearchIndexManagementServer",
+    "skipAuthenticationToMongot",
+    "searchTLSMode",
+    "useGrpcForSearch",
+)
 
 
 @fixture(scope="function")
@@ -195,6 +216,20 @@ def test_disable_metrics_forwarder(om: MongoDBOpsManager, mdbs: MongoDBSearch):
         msg="metrics forwarder ConfigMap cleanup",
     )
 
+    # Disable sweeps all four forwarder kinds: the replicated agent-key Secret and OM CA
+    # ConfigMap must go the same way as the Deployment and config ConfigMap.
+    core = client.CoreV1Api()
+    agent_key_secret = metrics_forwarder_agent_key_secret_name(MDB_RESOURCE_NAME)
+    ca_configmap = metrics_forwarder_ca_configmap_name(MDB_RESOURCE_NAME)
+    wait_for_resource_deleted(
+        lambda: core.read_namespaced_secret(agent_key_secret, mdbs.namespace),
+        f"metrics-forwarder agent-key Secret {mdbs.namespace}/{agent_key_secret}",
+    )
+    wait_for_resource_deleted(
+        lambda: core.read_namespaced_config_map(ca_configmap, mdbs.namespace),
+        f"metrics-forwarder CA ConfigMap {mdbs.namespace}/{ca_configmap}",
+    )
+
     # Per-cluster surface: with the forwarder disabled, the metricsForwarder sub-phase must
     # drop out of status.clusters (search + loadBalancer stay Running).
     def check_per_cluster_metrics_forwarder_absent():
@@ -210,13 +245,18 @@ def test_disable_metrics_forwarder(om: MongoDBOpsManager, mdbs: MongoDBSearch):
     )
     mdbs.assert_cluster_statuses(expected_count=1, expect_managed_lb=True, expect_metrics_forwarder=False)
 
-    # Disabling tears down the forwarder only: the persisted topology state and the
-    # Ops Manager host registrations must survive for a later re-enable.
+    # Disabling tears down the forwarder only: the persisted topology state, the
+    # Ops Manager host registrations, and the finalizer must survive for a later re-enable.
     client.CoreV1Api().read_namespaced_config_map(
         metrics_forwarder_state_configmap_name(MDB_RESOURCE_NAME), mdbs.namespace
     )
     tester = om.get_om_tester(project_name=MDB_RESOURCE_NAME)
     tester.assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
+    mdbs.reload()
+    finalizers = mdbs["metadata"].get("finalizers") or []
+    assert (
+        METRICS_FORWARDER_FINALIZER in finalizers
+    ), f"finalizer {METRICS_FORWARDER_FINALIZER} must survive a forwarder disable, got {finalizers}"
 
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset
@@ -230,10 +270,13 @@ def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: Mo
 
     deployment_name = metrics_forwarder_deployment_name(MDB_RESOURCE_NAME)
     configmap_name = metrics_forwarder_configmap_name(MDB_RESOURCE_NAME)
+    agent_key_secret = metrics_forwarder_agent_key_secret_name(MDB_RESOURCE_NAME)
+    ca_configmap = metrics_forwarder_ca_configmap_name(MDB_RESOURCE_NAME)
     apps = client.AppsV1Api()
     core = client.CoreV1Api()
     apps.read_namespaced_deployment(deployment_name, mdbs.namespace)
     core.read_namespaced_config_map(configmap_name, mdbs.namespace)
+    core.read_namespaced_secret(agent_key_secret, mdbs.namespace)
 
     mdbs.delete()
 
@@ -246,4 +289,35 @@ def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: Mo
     wait_for_resource_deleted(
         lambda: core.read_namespaced_config_map(configmap_name, mdbs.namespace),
         f"metrics-forwarder ConfigMap {mdbs.namespace}/{configmap_name}",
+    )
+    wait_for_resource_deleted(
+        lambda: core.read_namespaced_secret(agent_key_secret, mdbs.namespace),
+        f"metrics-forwarder agent-key Secret {mdbs.namespace}/{agent_key_secret}",
+    )
+    wait_for_resource_deleted(
+        lambda: core.read_namespaced_config_map(ca_configmap, mdbs.namespace),
+        f"metrics-forwarder CA ConfigMap {mdbs.namespace}/{ca_configmap}",
+    )
+
+    # The finalizer is released only after the cleanup above, so the CR reading back 404
+    # proves the whole pre-deletion path (host dereg + resource sweep) ran to completion.
+    wait_for_search_deleted(mdbs)
+
+    # The source picks up the Search deletion on its next reconcile and drops the injected
+    # setParameters from the automation config; until then mongods point at a dead proxy.
+    def search_parameters_dropped():
+        ac_tester = tester.get_automation_config_tester()
+        leftovers = []
+        for process in ac_tester.get_replica_set_processes(MDB_RESOURCE_NAME):
+            set_parameter = process.get("args2_6", {}).get("setParameter", {})
+            present = [key for key in SEARCH_SET_PARAMETER_KEYS if key in set_parameter]
+            if present:
+                leftovers.append(f"{process['name']}: {present}")
+        return not leftovers, f"search setParameters still in automation config: {leftovers}"
+
+    run_periodically(
+        search_parameters_dropped,
+        timeout=300,
+        sleep_time=10,
+        msg="source automation config to drop the search setParameters",
     )

--- a/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_enterprise_metrics_forwarder_replicaset.py
@@ -260,7 +260,7 @@ def test_disable_metrics_forwarder(om: MongoDBOpsManager, mdbs: MongoDBSearch):
 
 
 @mark.e2e_search_enterprise_metrics_forwarder_replicaset
-def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: MongoDBSearch):
+def test_deleting_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: MongoDBSearch):
     ensure_nested_objects(mdbs, ["spec", "observability", "metricsForwarder"])
     mdbs["spec"]["observability"]["metricsForwarder"]["mode"] = "enabled"
     mdbs.update()
@@ -277,6 +277,7 @@ def test_deleteing_search_resource_deletes_hosts(om: MongoDBOpsManager, mdbs: Mo
     apps.read_namespaced_deployment(deployment_name, mdbs.namespace)
     core.read_namespaced_config_map(configmap_name, mdbs.namespace)
     core.read_namespaced_secret(agent_key_secret, mdbs.namespace)
+    core.read_namespaced_config_map(ca_configmap, mdbs.namespace)
 
     mdbs.delete()
 

--- a/docker/mongodb-kubernetes-tests/tests/search/search_external_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_external_metrics_forwarder_replicaset.py
@@ -184,10 +184,49 @@ def test_metrics_forwarder_status(om: MongoDBOpsManager, mdbs: MongoDBSearch):
         status = mdbs.get_metrics_forwarder_status()
         return status is not None and status.get("phase") == Phase.Running.name
 
-    run_periodically(check_metrics_forwarder_status, timeout=120, interval=10)
+    run_periodically(
+        check_metrics_forwarder_status,
+        timeout=120,
+        sleep_time=10,
+        msg="metrics forwarder status to reach Running",
+    )
 
     tester = om.get_om_tester(project_name=MDB_RESOURCE_NAME)
     tester.assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
+
+
+@mark.e2e_search_external_metrics_forwarder_replicaset
+def test_metrics_forwarder_recreates_deleted_deployment(om: MongoDBOpsManager, mdbs: MongoDBSearch):
+    apps = client.AppsV1Api()
+    deployment_name = metrics_forwarder_deployment_name(MDBS_RESOURCE_NAME)
+    old_deployment_uid = apps.read_namespaced_deployment(deployment_name, mdbs.namespace).metadata.uid
+
+    apps.delete_namespaced_deployment(deployment_name, mdbs.namespace)
+
+    def deployment_recreated_and_ready():
+        try:
+            deployment = apps.read_namespaced_deployment(deployment_name, mdbs.namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return False
+            raise
+        desired = deployment.spec.replicas or 0
+        return (
+            deployment.metadata.uid != old_deployment_uid
+            and desired > 0
+            and (deployment.status.ready_replicas or 0) == desired
+        )
+
+    run_periodically(deployment_recreated_and_ready, timeout=300, sleep_time=5)
+    mdbs.assert_reaches_phase(Phase.Running, timeout=300)
+
+    def metrics_forwarder_running():
+        mdbs.reload()
+        status = mdbs.get_metrics_forwarder_status()
+        return status is not None and status.get("phase") == Phase.Running.name
+
+    run_periodically(metrics_forwarder_running, timeout=120, sleep_time=10)
+    om.get_om_tester(project_name=MDB_RESOURCE_NAME).assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
 
 
 @mark.e2e_search_external_metrics_forwarder_replicaset
@@ -217,7 +256,12 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         status = mdbs.get_metrics_forwarder_status()
         return status is not None and status.get("phase") == Phase.Disabled.name
 
-    run_periodically(check_metrics_forwarder_status, timeout=120, interval=10)
+    run_periodically(
+        check_metrics_forwarder_status,
+        timeout=120,
+        sleep_time=10,
+        msg="metrics forwarder status to reach Disabled",
+    )
 
     # Verify resources are cleaned up. The forwarder Deployment/ConfigMap are named after the
     # MongoDBSearch resource (not the source MongoDB).
@@ -230,7 +274,12 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         except ApiException as e:
             return e.status == 404
 
-    run_periodically(check_deployment_deleted, timeout=60, interval=5)
+    run_periodically(
+        check_deployment_deleted,
+        timeout=60,
+        sleep_time=5,
+        msg="metrics forwarder Deployment cleanup",
+    )
 
     def check_configmap_deleted():
         try:
@@ -241,4 +290,9 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
         except ApiException as e:
             return e.status == 404
 
-    run_periodically(check_configmap_deleted, timeout=60, interval=5)
+    run_periodically(
+        check_configmap_deleted,
+        timeout=60,
+        sleep_time=5,
+        msg="metrics forwarder ConfigMap cleanup",
+    )

--- a/docker/mongodb-kubernetes-tests/tests/search/search_external_metrics_forwarder_replicaset.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_external_metrics_forwarder_replicaset.py
@@ -28,6 +28,7 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
 from tests.common.search import search_resource_names
+from tests.common.search.connectivity import wait_for_deployment_recreated, wait_for_metrics_forwarder_phase
 from tests.common.search.rs_search_helper import create_rs_lb_certificates, create_rs_search_tls_cert
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
 from tests.common.search.search_resource_names import (
@@ -179,17 +180,7 @@ def test_create_search_resource(helper: SearchDeploymentHelper, mdb: MongoDB, md
 
 @mark.e2e_search_external_metrics_forwarder_replicaset
 def test_metrics_forwarder_status(om: MongoDBOpsManager, mdbs: MongoDBSearch):
-    def check_metrics_forwarder_status():
-        mdbs.reload()
-        status = mdbs.get_metrics_forwarder_status()
-        return status is not None and status.get("phase") == Phase.Running.name
-
-    run_periodically(
-        check_metrics_forwarder_status,
-        timeout=120,
-        sleep_time=10,
-        msg="metrics forwarder status to reach Running",
-    )
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Running)
 
     tester = om.get_om_tester(project_name=MDB_RESOURCE_NAME)
     tester.assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
@@ -202,30 +193,10 @@ def test_metrics_forwarder_recreates_deleted_deployment(om: MongoDBOpsManager, m
     old_deployment_uid = apps.read_namespaced_deployment(deployment_name, mdbs.namespace).metadata.uid
 
     apps.delete_namespaced_deployment(deployment_name, mdbs.namespace)
-
-    def deployment_recreated_and_ready():
-        try:
-            deployment = apps.read_namespaced_deployment(deployment_name, mdbs.namespace)
-        except ApiException as exc:
-            if exc.status == 404:
-                return False
-            raise
-        desired = deployment.spec.replicas or 0
-        return (
-            deployment.metadata.uid != old_deployment_uid
-            and desired > 0
-            and (deployment.status.ready_replicas or 0) == desired
-        )
-
-    run_periodically(deployment_recreated_and_ready, timeout=300, sleep_time=5)
+    wait_for_deployment_recreated(apps, mdbs.namespace, deployment_name, old_deployment_uid)
     mdbs.assert_reaches_phase(Phase.Running, timeout=300)
 
-    def metrics_forwarder_running():
-        mdbs.reload()
-        status = mdbs.get_metrics_forwarder_status()
-        return status is not None and status.get("phase") == Phase.Running.name
-
-    run_periodically(metrics_forwarder_running, timeout=120, sleep_time=10)
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Running)
     om.get_om_tester(project_name=MDB_RESOURCE_NAME).assert_mongot_hosts_converged(mdbs.mongot_pod_hostnames())
 
 
@@ -251,17 +222,7 @@ def test_disable_metrics_forwarder(mdbs: MongoDBSearch):
     mdbs["spec"]["observability"]["metricsForwarder"]["mode"] = "disabled"
     mdbs.update()
 
-    def check_metrics_forwarder_status():
-        mdbs.reload()
-        status = mdbs.get_metrics_forwarder_status()
-        return status is not None and status.get("phase") == Phase.Disabled.name
-
-    run_periodically(
-        check_metrics_forwarder_status,
-        timeout=120,
-        sleep_time=10,
-        msg="metrics forwarder status to reach Disabled",
-    )
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Disabled)
 
     # Verify resources are cleaned up. The forwarder Deployment/ConfigMap are named after the
     # MongoDBSearch resource (not the source MongoDB).

--- a/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_replicaset_external_mongodb_proxy_service.py
@@ -29,6 +29,7 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
 from tests.common.search import search_resource_names
+from tests.common.search.connectivity import wait_for_resource_deleted
 from tests.common.search.rs_search_helper import (
     create_rs_lb_certificates,
     create_rs_search_tls_cert,
@@ -452,9 +453,23 @@ def test_verify_proxy_service_after_scaledown(namespace: str):
 
 
 @mark.e2e_search_replicaset_external_mongodb_proxy_service
-def test_verify_envoy_cleanup(namespace: str):
-    """Envoy Deployment should be cleaned up (garbage collected via owner reference)."""
+def test_verify_envoy_cleanup(namespace: str, mdbs: MongoDBSearch):
+    """Envoy Deployment and ConfigMap are cleaned up, and status.loadBalancer clears."""
     assert_envoy_deployment_gone(namespace)
+
+    envoy_cm_name = search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME)
+    wait_for_resource_deleted(
+        lambda: k8s_client.CoreV1Api().read_namespaced_config_map(envoy_cm_name, namespace),
+        f"Envoy ConfigMap {envoy_cm_name}",
+    )
+
+    def check_lb_status_cleared():
+        mdbs.load()
+        lb = mdbs.get_lb_status()
+        return lb is None, f"status.loadBalancer={lb}"
+
+    run_periodically(check_lb_status_cleared, timeout=300, sleep_time=5, msg="status.loadBalancer clearing")
+    mdbs.assert_lb_status()
 
 
 @mark.e2e_search_replicaset_external_mongodb_proxy_service

--- a/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
+++ b/docker/mongodb-kubernetes-tests/tests/search/search_sharded_scale_shards_managed_lb.py
@@ -79,12 +79,17 @@ CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
 MARKER = mark.e2e_search_sharded_scale_shards_managed_lb
 
 
+@fixture(scope="module")
+def source_tls_secret_uids() -> dict[str, str]:
+    return {}
+
+
 # ---------------------------------------------------------------------------
 # Inline verification helpers for shard resource existence / deletion
 # ---------------------------------------------------------------------------
 
 
-def verify_shard_resources_exist(namespace: str, mdbs_name: str, shard_name: str):
+def verify_shard_resources_exist(namespace: str, mdbs_name: str, shard_name: str) -> str:
     apps_v1 = client.AppsV1Api()
     core_v1 = client.CoreV1Api()
 
@@ -116,6 +121,13 @@ def verify_shard_resources_exist(namespace: str, mdbs_name: str, shard_name: str
     matching = [p.metadata.name for p in pvcs.items if p.metadata.name.startswith(pvc_prefix)]
     assert matching, f"no PVC with prefix {pvc_prefix!r} found for shard {shard_name}"
     logger.info(f"PVC(s) {matching} exist for shard {shard_name}")
+
+    source_tls_secret_name = search_resource_names.shard_tls_cert_name(mdbs_name, shard_name, MDBS_TLS_CERT_PREFIX)
+    operator_tls_secret_name = search_resource_names.shard_operator_managed_tls_secret_name(mdbs_name, shard_name)
+    source_tls_secret = core_v1.read_namespaced_secret(source_tls_secret_name, namespace)
+    core_v1.read_namespaced_secret(operator_tls_secret_name, namespace)
+    assert source_tls_secret.metadata.uid
+    return source_tls_secret.metadata.uid
 
 
 def verify_shard_proxy_service_deleted(namespace: str, mdbs_name: str, shard_name: str):
@@ -479,10 +491,10 @@ def test_scale_up_wait_for_search_running(mdbs: MongoDBSearch):
 
 
 @MARKER
-def test_scale_up_verify_new_shard_resources(namespace: str):
+def test_scale_up_verify_new_shard_resources(namespace: str, source_tls_secret_uids: dict[str, str]):
     """Verify per-shard resources exist for the newly added shard."""
     new_shard_name = f"{MDB_RESOURCE_NAME}-{SCALED_UP_SHARD_COUNT - 1}"
-    verify_shard_resources_exist(namespace, MDBS_RESOURCE_NAME, new_shard_name)
+    source_tls_secret_uids[new_shard_name] = verify_shard_resources_exist(namespace, MDBS_RESOURCE_NAME, new_shard_name)
     logger.info(f"All resources verified for new shard {new_shard_name}")
 
 
@@ -542,7 +554,7 @@ def test_scale_down_wait_for_search_running(mdbs: MongoDBSearch):
 
 
 @MARKER
-def test_scale_down_verify_stale_resources_cleaned(namespace: str):
+def test_scale_down_verify_stale_resources_cleaned(namespace: str, source_tls_secret_uids: dict[str, str]):
     """Verify the removed shard's mongot resources are FULLY torn down by the operator.
 
     Beyond the proxy Service (the only kind the original sweep removed), the
@@ -553,6 +565,34 @@ def test_scale_down_verify_stale_resources_cleaned(namespace: str):
     removed_shard_name = f"{MDB_RESOURCE_NAME}-{SCALED_UP_SHARD_COUNT - 1}"
     verify_shard_proxy_service_deleted(namespace, MDBS_RESOURCE_NAME, removed_shard_name)
     verify_shard_resources_deleted(namespace, MDBS_RESOURCE_NAME, removed_shard_name)
+
+    core_v1 = client.CoreV1Api()
+    source_tls_secret_name = search_resource_names.shard_tls_cert_name(
+        MDBS_RESOURCE_NAME, removed_shard_name, MDBS_TLS_CERT_PREFIX
+    )
+    operator_tls_secret_name = search_resource_names.shard_operator_managed_tls_secret_name(
+        MDBS_RESOURCE_NAME, removed_shard_name
+    )
+
+    def operator_tls_secret_gone():
+        try:
+            core_v1.read_namespaced_secret(operator_tls_secret_name, namespace)
+            return False, f"operator-managed TLS Secret {operator_tls_secret_name} still exists"
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True, f"operator-managed TLS Secret {operator_tls_secret_name} deleted"
+            raise
+
+    run_periodically(
+        operator_tls_secret_gone,
+        timeout=300,
+        sleep_time=10,
+        msg=f"operator-managed TLS Secret {operator_tls_secret_name} deletion",
+    )
+    assert (
+        core_v1.read_namespaced_secret(source_tls_secret_name, namespace).metadata.uid
+        == source_tls_secret_uids[removed_shard_name]
+    )
     logger.info(f"Stale mongot resources for {removed_shard_name} confirmed fully deleted")
 
 


### PR DESCRIPTION
# Summary

End-to-end coverage for the MongoDBSearch lifecycle behaviors introduced by the identity layer (#1362) and the cleanup layer (#1382). Test-only (zero Go), targets master.

- **CR-delete cleanup**: full per-member-cluster artifact sweep with customer inputs surviving UID-unchanged (2-cluster RS, `q2_mc_rs_steady.py`); named single-cluster shape (q2); PVC reclaim (community); metrics-forwarder teardown incl. removal of all six controller-injected mongot `setParameter`s and `searchMongotHostsRemovalFinalizer` release, plus the disable-retention contract.
- **Cluster-entry remove/re-add** with survivor-UID pinning: RS (q2), sharded (`q3_mc_sharded_external_mtls.py`), and removed-own-entry sweeps on real clusters (`simulated_mc_rs.py` / `simulated_mc_sharded.py`, incl. central state-CM lifecycle).
- **Shard scale-down** reaping; **managed→none LB** both sides: single-cluster teardown vs the MC rejection contract (`validateMCRequiresManagedLB`); missing-client warn-skip policy.
- Deletion asserted via concrete (kind, name) identity polls first, label-scoped emptiness List as backstop; ownership via `mongodb.com/search-name`/`search-namespace` (+cluster/component) labels.

Notes:

- GC-with-operator-scaled-down coverage lives in #1393's upgrade suite, not this PR.

## Proof of Work

- **Head `eb6da7b25`: full PR patch green (28/28 checks)**, including the three previously red ones (`unit_tests`/lint, `e2e_multi_cluster_2_clusters`, `e2e_om80_kind_ubi_large`).
- Earlier validated lineage: full 69-task matrices green twice ([`6a67d2fb`](https://spruce.corp.mongodb.com/version/6a67d2fb23f20c000767e00e), [`6a678ef1`](https://spruce.corp.mongodb.com/version/6a678ef18e26f100074ce4d8)); targeted runs 16/16 ([`6a69c980`](https://spruce.corp.mongodb.com/version/6a69c980ea4e0e000783fce9)) and 12/12 ([`6a6a1a9b`](https://spruce.corp.mongodb.com/version/6a6a1a9b17eec10007b1083b)), all at execution 0.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` label retained

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
