### PR TITLE
KUBE-141: Remove stale mms.https.PEMKeyFile from Ops Manager config when TLS is disabled

### DIFF
--- a/changelog/20260716_fix_ops_manager_stale_properties_after_disabling_tls.md
+++ b/changelog/20260716_fix_ops_manager_stale_properties_after_disabling_tls.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-07-16
+---
+
+* **MongoDBOpsManager**: Fixed Ops Manager failing to start after TLS is disabled when the configuration directory is persisted (for example a PVC mounted over `/mongodb-ops-manager/conf`). Properties the operator no longer sets, such as `mms.https.PEMKeyFile`, are now removed from `conf-mms.properties` on container start instead of lingering forever.

--- a/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go
+++ b/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -25,6 +26,9 @@ const (
 	appDbConnectionStringFilePath = appDbConnectionStringPath + "/connectionString"
 	// keep in sync with MmsMongoUri constant from github.com/mongodb/mongodb-kubernetes/pkg/util
 	appDbUriKey = "mongo.mongoUri"
+
+	omPropertiesBlockBegin = "## BEGIN properties managed by the MongoDB Kubernetes Operator (rewritten on every container start, do not edit)"
+	omPropertiesBlockEnd   = "## END properties managed by the MongoDB Kubernetes Operator"
 )
 
 func updateConfFile(confFile string) error {
@@ -210,6 +214,13 @@ func getOmPropertiesFromEnvVars() map[string]string {
 }
 
 func updateMmsProperties(lines []string, newProperties map[string]string) []string {
+	// Drop the block written by a previous container start first: a property the
+	// operator no longer sets (e.g. mms.https.PEMKeyFile after TLS is disabled)
+	// must disappear from the file rather than linger forever. The conf directory
+	// can survive container recreation (in-place crash restarts, or a user PVC
+	// mounted over it), so this file cannot be assumed to be freshly templated.
+	lines = removeOperatorPropertiesBlocks(lines)
+
 	seenProperties := map[string]bool{}
 
 	// Overwrite existing properties
@@ -225,13 +236,43 @@ func updateMmsProperties(lines []string, newProperties map[string]string) []stri
 		}
 	}
 
-	// Add new properties
-	for key, val := range newProperties {
-		if _, ok := seenProperties[key]; !ok {
-			lines = append(lines, fmt.Sprintf("%s=%s", key, val))
+	// Add the remaining properties inside a delimited block so the next container
+	// start can strip and rewrite them.
+	var blockKeys []string
+	for key := range newProperties {
+		if !seenProperties[key] {
+			blockKeys = append(blockKeys, key)
 		}
 	}
-	return lines
+	if len(blockKeys) == 0 {
+		return lines
+	}
+	sort.Strings(blockKeys)
+
+	lines = append(lines, omPropertiesBlockBegin)
+	for _, key := range blockKeys {
+		lines = append(lines, fmt.Sprintf("%s=%s", key, newProperties[key]))
+	}
+	return append(lines, omPropertiesBlockEnd)
+}
+
+// removeOperatorPropertiesBlocks removes every operator-managed property block
+// (delimited by omPropertiesBlockBegin/omPropertiesBlockEnd) that a previous
+// container start wrote into the properties file.
+func removeOperatorPropertiesBlocks(lines []string) []string {
+	result := make([]string, 0, len(lines))
+	inBlock := false
+	for _, line := range lines {
+		switch {
+		case line == omPropertiesBlockBegin:
+			inBlock = true
+		case line == omPropertiesBlockEnd:
+			inBlock = false
+		case !inBlock:
+			result = append(result, line)
+		}
+	}
+	return result
 }
 
 func main() {

--- a/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration_test.go
+++ b/docker/mongodb-kubernetes-init-ops-manager/mmsconfiguration/edit_mms_configuration_test.go
@@ -129,8 +129,64 @@ func TestEditMmsConfiguration_UpdatePropertiesFile(t *testing.T) {
 	updatedContent := _readLinesFromFile(propFile)
 	assert.Equal(t, updatedContent[0], "mms.prop=1234")
 	assert.Equal(t, updatedContent[1], "mms.test.prop5=")
+	// Keys already present in the file are overwritten in place.
 	assert.Equal(t, updatedContent[2], "mms.test.prop=somethingNew")
-	assert.Equal(t, updatedContent[3], "mms.test.prop.new=400")
+	// New keys are appended inside the operator-managed block.
+	assert.Equal(t, updatedContent[3], omPropertiesBlockBegin)
+	assert.Equal(t, updatedContent[4], "mms.test.prop.new=400")
+	assert.Equal(t, updatedContent[5], omPropertiesBlockEnd)
+}
+
+// TestEditMmsConfiguration_UpdatePropertiesFile_Idempotent verifies that
+// repeated container starts do not accumulate duplicate operator-managed
+// property blocks in the file.
+func TestEditMmsConfiguration_UpdatePropertiesFile_Idempotent(t *testing.T) {
+	newProperties := map[string]string{
+		"mms.test.prop.new": "400",
+	}
+	propFile := _createTestPropertiesFile()
+
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, updatePropertiesFile(propFile, newProperties))
+	}
+
+	content := strings.Join(_readLinesFromFile(propFile), "\n")
+	assert.Equal(t, 1, strings.Count(content, omPropertiesBlockBegin))
+	assert.Equal(t, 1, strings.Count(content, "mms.test.prop.new=400"))
+	assert.Contains(t, content, "mms.prop=1234")
+}
+
+// TestEditMmsConfiguration_UpdatePropertiesFile_RemovesStaleProperties
+// simulates disabling TLS on a running Ops Manager whose conf directory
+// survives into the next container start (in-place crash restart, or a
+// user-supplied PVC over the data path). Cycle 1 runs with TLS enabled and
+// writes mms.https.PEMKeyFile; cycle 2 runs after TLS was disabled, so the
+// property is absent from the new set. The stale key must not survive cycle
+// 2: a leftover PEMKeyFile pointing at a no-longer-mounted secret path
+// prevents Ops Manager from booting (KUBE-141 / HELP-84463).
+func TestEditMmsConfiguration_UpdatePropertiesFile_RemovesStaleProperties(t *testing.T) {
+	propFile := _createTestPropertiesFile()
+
+	tlsEnabled := map[string]string{
+		"mms.https.PEMKeyFile": "/opt/mongodb/mms/secrets/PVNZRVHDZKLN2KXL5VKDNOP5QTOX2LBJ",
+		"mms.centralUrl":       "https://om-svc.mongodb.svc.cluster.local:8443",
+		"mongo.mongoUri":       "mongodb://om-db-0.om-db-svc.mongodb.svc.cluster.local:27017",
+	}
+	assert.NoError(t, updatePropertiesFile(propFile, tlsEnabled))
+
+	tlsDisabled := map[string]string{
+		"mms.centralUrl": "http://om-svc.mongodb.svc.cluster.local:8080",
+		"mongo.mongoUri": "mongodb://om-db-0.om-db-svc.mongodb.svc.cluster.local:27017",
+	}
+	assert.NoError(t, updatePropertiesFile(propFile, tlsDisabled))
+
+	content := strings.Join(_readLinesFromFile(propFile), "\n")
+	assert.NotContains(t, content, "mms.https.PEMKeyFile",
+		"stale TLS property from a previous cycle must not remain in the file")
+	assert.Contains(t, content, "mms.centralUrl=http://om-svc.mongodb.svc.cluster.local:8080")
+
+	// Pre-existing base properties must be preserved.
+	assert.Contains(t, content, "mms.prop=1234")
 }
 
 func _createTestConfFile() string {

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_https_enabled.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_https_enabled.yaml
@@ -18,6 +18,18 @@ spec:
 
   statefulSet:
     spec:
+      # Persist the conf directory on a PVC (documented override of the default
+      # emptyDir mount). This makes conf-mms.properties survive pod recreation,
+      # matching the customer topology of KUBE-141: disabling TLS must not leave
+      # a stale mms.https.PEMKeyFile behind or Ops Manager can never boot again.
+      volumeClaimTemplates:
+        - metadata:
+            name: om-conf
+          spec:
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+              requests:
+                storage: 1Gi
       template:
         spec:
           volumes:
@@ -28,6 +40,8 @@ spec:
               volumeMounts:
                 - name: mongodb-versions
                   mountPath: /mongodb-ops-manager/mongodb-releases
+                - name: om-conf
+                  mountPath: /mongodb-ops-manager/conf
 
           # The initContainers will download the require 4.2+ and 4.4+ versions of MongoDB
           # allowing Ops Manager to act as download endpoint for the automation agent

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_ops_manager_https.py
@@ -234,3 +234,24 @@ def test_change_appdb_certificate_with_sts_restarting(ops_manager: MongoDBOpsMan
     ops_manager.trigger_appdb_sts_restart()
     rotate_cert(namespace, certificate_name="appdb-om-with-https-db-cert")
     ops_manager.appdb_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@mark.e2e_om_ops_manager_https_enabled
+def test_disable_https_on_opsmanager(ops_manager: MongoDBOpsManager):
+    """Ops Manager has HTTPS disabled again by removing spec.security. It should come back up over plain HTTP."""
+    ops_manager.load()
+    # update() sends a JSON merge-patch: a key merely absent from the body is left untouched
+    # server-side, so the field must be explicitly nulled out to delete it.
+    ops_manager["spec"]["security"] = None
+    ops_manager.update()
+
+    ops_manager.om_status().assert_abandons_phase(Phase.Running, timeout=600)
+    ops_manager.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+    om_url = ops_manager.om_status().get_url()
+    assert om_url is not None
+    assert om_url.startswith("http://")
+    assert om_url.endswith(":8080")
+
+    # Beyond the reported phase/url, make sure Ops Manager is actually answering API calls over plain HTTP.
+    ops_manager.get_om_tester().assert_healthiness()


### PR DESCRIPTION
# Summary

Disabling TLS on a running Ops Manager (removing `spec.security`) left the instance unable to start whenever the conf directory outlives the container — most commonly a user PVC mounted over `/mongodb-ops-manager/conf`, which the operator supports as a StatefulSet override (HELP-84463). The operator builds the new StatefulSet correctly, but the `mmsconfiguration` binary in the init-ops-manager image only ever overwrote or appended `OM_PROP_*` properties in `conf-mms.properties`, never deleting one it stopped setting. The stale `mms.https.PEMKeyFile` then points at a certificate secret that is no longer mounted and Ops Manager crash-loops in preflight. With the default emptyDir layout the conf directory is recreated on every rollout, which is why this never reproduced on kind.

Solution: Operator-set properties not already present in the file are now written inside a BEGIN/END-delimited block that is stripped and rewritten on every container start, the same way custom JVM params are already handled in this binary. A property the operator stops setting disappears from the file instead of lingering forever.

**A note for reviewers**: this is admittedly a bit manual — operator-owned properties are tracked with custom BEGIN/END comment markers and rewritten by string manipulation, mirroring the existing JVM-params handling. The approach deserves a careful look; happy to discuss alternatives.

Deployments already broken by an older image have the stale property as a plain line outside any block; those still need the existing workaround (remove the line, or delete the conf PVC). The fix prevents the state from the first start on a fixed image.

## Proof of Work

- New unit test reproducing the stale-property bug (fails without the fix), plus idempotency coverage.
- The `om_ops_manager_https` e2e now runs with a PVC mounted over the conf directory and ends with a disable-TLS stage:
  - without the fix it fails on exactly that stage, with the customer's crash-loop signature in the OM pod log: [patch](https://spruce.corp.mongodb.com/version/6a58e665524bfc0007bc4d08)
  - with the fix the task is green: [patch](https://spruce.corp.mongodb.com/version/6a58eaf3e0b9f0000767f0ed)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
