### PR TITLE
CLOUDP-423293: Add multicluster generate-member-registration plugin command

### DIFF
--- a/changelog/20260716_feature_generate_member_registration.md
+++ b/changelog/20260716_feature_generate_member_registration.md
@@ -1,0 +1,6 @@
+---
+kind: feature
+date: 2026-07-16
+---
+
+* **kubectl-mongodb plugin**: Added the `kubectl mongodb multicluster generate-member-registration` command. It connects to a single member cluster using a kubeconfig context, reads the ServiceAccount token that `generate-member-resources` created on it, and writes a credential Secret (a single-context kubeconfig) and a `MemberCluster` CR referencing it to stdout. Apply the output to the operator's cluster with `kubectl apply` or commit it to Git for GitOps workflows. Together with `generate-member-resources`, this replaces the imperative `multicluster setup` flow for configuring member clusters.

--- a/cmd/kubectl-mongodb/LICENSE-THIRD-PARTY
+++ b/cmd/kubectl-mongodb/LICENSE-THIRD-PARTY
@@ -54,6 +54,7 @@ k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json,v0.0.0-2025
 k8s.io/kube-openapi/pkg/validation/spec,v0.0.0-20250318190949-c8a335a9a2ff,https://github.com/kubernetes/kube-openapi/blob/c8a335a9a2ff/pkg/validation/spec/LICENSE,Apache-2.0
 k8s.io/utils,v0.0.0-20241104100929-3ea5e8cea738,https://github.com/kubernetes/utils/blob/3ea5e8cea738/LICENSE,Apache-2.0
 k8s.io/utils/internal/third_party/forked/golang/net,v0.0.0-20241104100929-3ea5e8cea738,https://github.com/kubernetes/utils/blob/3ea5e8cea738/internal/third_party/forked/golang/LICENSE,BSD-3-Clause
+sigs.k8s.io/controller-runtime/pkg/scheme,v0.20.4,https://github.com/kubernetes-sigs/controller-runtime/blob/v0.20.4/LICENSE,Apache-2.0
 sigs.k8s.io/json,v0.0.0-20241010143419-9aa6b5e7a4b3,https://github.com/kubernetes-sigs/json/blob/9aa6b5e7a4b3/LICENSE,Apache-2.0
 sigs.k8s.io/json,v0.0.0-20241010143419-9aa6b5e7a4b3,https://github.com/kubernetes-sigs/json/blob/9aa6b5e7a4b3/LICENSE,BSD-3-Clause
 sigs.k8s.io/randfill,v1.0.0,https://github.com/kubernetes-sigs/randfill/blob/v1.0.0/LICENSE,Apache-2.0

--- a/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
+++ b/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
@@ -1,0 +1,93 @@
+package generatememberregistration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/mongodb/mongodb-kubernetes/pkg/kubectl-mongodb/memberregistration"
+)
+
+var flags struct {
+	memberCluster          string
+	memberClusterContext   string
+	memberClusterNamespace string
+	operatorNamespace      string
+	clusterName            string
+}
+
+func init() {
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberCluster, "member-cluster", "", "RFC 1123 name of the member cluster; used as the MemberCluster CR's metadata.name and the credential Secret name suffix. Must match the name passed to generate-member-resources. [required]")
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterContext, "member-cluster-context", "", "Kubeconfig context for the member cluster; the command reads the ServiceAccount token and API server URL from it. [required]")
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterNamespace, "member-cluster-namespace", "", "Namespace on the member cluster where the ServiceAccount token Secret lives. [required]")
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.operatorNamespace, "operator-namespace", "", "Namespace on the operator's cluster where the MemberCluster CR and credential Secret will be created. Must match the operator's installation namespace. [required]")
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.clusterName, "cluster-name", "", "Logical cluster name set as spec.clusterName on the MemberCluster CR, used to resolve clusterSpecList[].clusterName references in workload CRs. [optional, default: --member-cluster]")
+}
+
+// GenerateMemberRegistrationCmd reads a member cluster's ServiceAccount token and emits the
+// credential Secret + MemberCluster CR the operator needs to reach that cluster.
+var GenerateMemberRegistrationCmd = &cobra.Command{
+	Use:   "generate-member-registration",
+	Short: "Emit a credential Secret and MemberCluster CR for a single member cluster",
+	Long: `'generate-member-registration' connects to one member cluster, reads the ServiceAccount
+token that 'generate-member-resources' created on it, and writes a credential Secret (a
+single-context kubeconfig) and a MemberCluster CR as multi-document YAML to stdout.
+
+Apply the output to the operator's cluster with kubectl, or commit it to Git for GitOps.
+
+Example:
+
+kubectl-mongodb multicluster generate-member-registration --member-cluster=cluster-east --member-cluster-context=east-ctx --member-cluster-namespace=mongodb --operator-namespace=mongodb | kubectl apply --context=central-ctx -f -
+`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		opts, err := parseFlags()
+		if err != nil {
+			return err
+		}
+
+		restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{CurrentContext: flags.memberClusterContext},
+		).ClientConfig()
+		if err != nil {
+			return xerrors.Errorf("loading kubeconfig context %q: %w", flags.memberClusterContext, err)
+		}
+		client, err := kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return xerrors.Errorf("building client for context %q: %w", flags.memberClusterContext, err)
+		}
+
+		out, err := memberregistration.Generate(cmd.Context(), client, restConfig.Host, opts)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(os.Stdout, out)
+		return err
+	},
+}
+
+func parseFlags() (memberregistration.Options, error) {
+	if strings.TrimSpace(flags.memberCluster) == "" ||
+		strings.TrimSpace(flags.memberClusterContext) == "" ||
+		strings.TrimSpace(flags.memberClusterNamespace) == "" ||
+		strings.TrimSpace(flags.operatorNamespace) == "" {
+		return memberregistration.Options{}, xerrors.Errorf("non-empty values are required for [member-cluster, member-cluster-context, member-cluster-namespace, operator-namespace]")
+	}
+
+	clusterName := flags.clusterName
+	if strings.TrimSpace(clusterName) == "" {
+		clusterName = flags.memberCluster
+	}
+
+	return memberregistration.Options{
+		MemberClusterName:        flags.memberCluster,
+		MemberClusterNamespace:   flags.memberClusterNamespace,
+		OperatorNamespace:        flags.operatorNamespace,
+		MemberClusterLogicalName: clusterName,
+	}, nil
+}

--- a/cmd/kubectl-mongodb/multicluster/multicluster.go
+++ b/cmd/kubectl-mongodb/multicluster/multicluster.go
@@ -3,6 +3,7 @@ package multicluster
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/mongodb/mongodb-kubernetes/cmd/kubectl-mongodb/multicluster/generatememberregistration"
 	"github.com/mongodb/mongodb-kubernetes/cmd/kubectl-mongodb/multicluster/generatememberresources"
 	"github.com/mongodb/mongodb-kubernetes/cmd/kubectl-mongodb/multicluster/recover"
 	"github.com/mongodb/mongodb-kubernetes/cmd/kubectl-mongodb/multicluster/setup"
@@ -20,4 +21,5 @@ func init() {
 	MulticlusterCmd.AddCommand(setup.SetupCmd)
 	MulticlusterCmd.AddCommand(recover.RecoverCmd)
 	MulticlusterCmd.AddCommand(generatememberresources.GenerateMemberResourcesCmd)
+	MulticlusterCmd.AddCommand(generatememberregistration.GenerateMemberRegistrationCmd)
 }

--- a/docs/dev/multi-cluster-config-tooling.md
+++ b/docs/dev/multi-cluster-config-tooling.md
@@ -34,12 +34,23 @@ to consume `MemberCluster` CRs (keeping a legacy fallback), then the legacy path
 | 5 | Migrate MC E2E to new tooling | _tbd_ | todo | Switch the two `conftest.py` fixtures + direct callers. Apply the generated RBAC to **every** member cluster including central (do not `skip_central_cluster`) — validates the additive apply. |
 | 6 | Clean break | _tbd_ | todo | Remove `setup`/`recovery`, the legacy discovery + fallback, and dead `common.go` RBAC/kubeconfig code. |
 | 7 | Member-scoped workload ServiceAccounts | _tbd_ | todo | End-state so `generate-member-resources` output touches **nothing** from helm/OLM. Un-hardcode the workload pod SA names in the operator (`construct/appdb_construction.go:500`, `construct/opsmanager_construction.go:480`; database SA already per-CR overridable) so pods on member clusters run under member-scoped SAs; emit member-scoped workload RBAC instead of the interim fixed-name `database-roles.yaml`. Single-cluster keeps using the helm-install SAs. |
+| 8 | RBAC de-duplication | _tbd_ | todo | Single source of truth for the operator's shared workload rules (services/secrets/configmaps/statefulsets/deployments/pods) so extending a permission is one edit, not two. Aim for: base role = shared + central-only (CRDs/operatorconfigs); member role = shared + member extras (serviceaccounts get, nodes, kube-system, /version). Mechanism left open (shared partial, restructured/parameterised template, generating member from the same source, …). Deferred deliberately — see below. |
 
-**Dependencies:** 3 → {1, 2}; 4 → {1, 3}; 5 → {1, 2}; 6 → 5; 7 → 3 (needs multi-cluster reconcile working; can land any time after).
+**Dependencies:** 3 → {1, 2}; 4 → {1, 3}; 5 → {1, 2}; 6 → 5; 7 → 3 (needs multi-cluster reconcile working; can land any time after); 8 → {5, 7} (runs on the settled, E2E-covered shape).
 
 ## Interim vs end-state: workload RBAC
 
 Member RBAC must be **additive** and never touch helm/OLM-provided resources. The operator's own member RBAC (`mck-member-*`) already satisfies this. The **workload** pod SAs do not yet: they are fixed-name and hard-coded in pod construction, so slice 1's `generate-member-resources` emits `database-roles.yaml` (fixed names), which re-applies over the helm/OLM copies on the operator's own cluster — a harmless idempotent apply, but not truly additive. Slice 7 reaches the end-state by making the operator use member-scoped workload SAs on member clusters. Until then the interim is tagged `TODO(m1kola): slice-1` in `pkg/kubectl-mongodb/memberresources`.
+
+## RBAC de-duplication (slice 8, deferred)
+
+The operator's workload-management rules (services/secrets/configmaps/statefulsets/deployments/pods) live in **both** `helm_chart/templates/member-cluster-rbac.yaml` and `helm_chart/templates/operator-roles-base.yaml` — the operator needs them on its own cluster (single-cluster workloads) and on member clusters, so they're conceptually one set. They have **drifted**:
+- the member role adds `deletecollection` on secrets/configmaps/services/statefulsets/deployments; the base role has it only on pods;
+- PVCs are inline in the member role but in a separate `operator-roles-pvc-resize.yaml` role in the base install.
+
+So extending a permission today means editing two places, with re-drift risk. **Do not fix this until anyone edits both sides in the meantime — keep them in sync.**
+
+It is deferred to slice 8 (after 5 and 7) on purpose: the dedup's correctness is "the operator still has sufficient permissions on both cluster types", which is best proven by the **full E2E suite** (single-cluster exercises the base role; multi-cluster the member role) — not the current unit render tests, which only check YAML shape. Deferring until E2E runs against the new tooling also makes the proper single-canonical-set unification safe to apply to the **base** role (not just align the member role down), and lets the shape settle after slices 4/7 first. The Go source already models the target split (`getMemberRules()` shared; `buildCentralEntityRole` = central + shared; `buildMemberEntityRole` = shared + member extras) in `pkg/kubectl-mongodb/common/common.go`.
 
 ## Key decisions
 

--- a/docs/dev/multi-cluster-config-tooling.md
+++ b/docs/dev/multi-cluster-config-tooling.md
@@ -28,7 +28,7 @@ to consume `MemberCluster` CRs (keeping a legacy fallback), then the legacy path
 | # | Slice | Jira | Status | Notes |
 |---|-------|------|--------|-------|
 | 1 | `generate-member-resources` command | CLOUDP-423293 | in progress | Embeds the Helm chart (Helm SDK); gated member-cluster RBAC templates; renders to stdout. Front-loads the Helm-SDK dependency risk. |
-| 2 | `generate-member-registration` command | CLOUDP-423293 | todo | Reads an SA token from a member cluster; emits a credential Secret + `MemberCluster` CR. No Helm SDK. |
+| 2 | `generate-member-registration` command | CLOUDP-423293 | in progress | Reads an SA token from a member cluster; emits a credential Secret + `MemberCluster` CR. No Helm SDK. |
 | 3 | Operator `MemberCluster` wiring + watch | _tbd_ | todo | Build the per-cluster client map from `MemberCluster` CRs + credential Secrets. **End goal: reactive add/remove, no restart** (mechanism is an open question — feasibility spike at slice-3 planning). Keeps a legacy fallback tagged `TODO(m1kola): slice-3`. |
 | 4 | RBAC validation | _tbd_ | todo | `RBACValid` condition validated against the `mongodb.com/rbac-version` annotation emitted by slice 1; startup gate + periodic re-check. |
 | 5 | Migrate MC E2E to new tooling | _tbd_ | todo | Switch the two `conftest.py` fixtures + direct callers. Apply the generated RBAC to **every** member cluster including central (do not `skip_central_cluster`) — validates the additive apply. |

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration.go
@@ -1,0 +1,126 @@
+// Package memberregistration produces the registration a member cluster needs so the MCK
+// operator can reach it: a credential Secret (a single-context kubeconfig) and a MemberCluster
+// CR referencing that Secret. It reads the ServiceAccount token that
+// `generate-member-resources` created on the member cluster and writes both resources as a
+// multi-document YAML string. It holds the logic; the CLI wiring lives in cmd/kubectl-mongodb.
+package memberregistration
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+	"github.com/mongodb/mongodb-kubernetes/pkg/resourcenames"
+)
+
+const (
+	// credentialSecretKey is the single key in the credential Secret holding the kubeconfig.
+	credentialSecretKey = "kubeconfig"
+
+	// tokenSecretTokenKey and tokenSecretCAKey are the keys Kubernetes populates on a
+	// kubernetes.io/service-account-token Secret.
+	tokenSecretTokenKey = "token"
+	tokenSecretCAKey    = "ca.crt"
+)
+
+// Options carries the resolved flag values for a single member-cluster registration.
+type Options struct {
+	// MemberClusterName is the RFC 1123 name used for the MemberCluster CR's metadata.name and the
+	// credential Secret name suffix. It must match the name passed to generate-member-resources,
+	// which is how the token Secret (mck-member-<MemberClusterName>-token) is located.
+	MemberClusterName string
+	// MemberClusterLogicalName is the logical cluster identity set as spec.clusterName on the MemberCluster CR.
+	// Used to resolve clusterSpecList[].clusterName references in workload CRs.
+	MemberClusterLogicalName string
+	// MemberClusterNamespace is the namespace on the member cluster holding the SA token Secret.
+	MemberClusterNamespace string
+	// OperatorNamespace is the namespace on the operator's cluster where the emitted CR and
+	// credential Secret are placed.
+	OperatorNamespace string
+}
+
+// Generate reads the member ServiceAccount token Secret via client and builds the output using
+// serverURL as the kubeconfig API-server address. It is the entry point used by the CLI, which
+// builds client and serverURL from the member cluster's kubeconfig context.
+func Generate(ctx context.Context, memberClusterClient kubernetes.Interface, memberClusterServerURL string, opts Options) (string, error) {
+	tokenSecretName := resourcenames.MemberClusterTokenSecretName(opts.MemberClusterName)
+	tokenSecret, err := memberClusterClient.CoreV1().Secrets(opts.MemberClusterNamespace).Get(ctx, tokenSecretName, metav1.GetOptions{})
+	if err != nil {
+		return "", xerrors.Errorf("reading token secret %s/%s on the member cluster (was 'generate-member-resources' applied to it?): %w", opts.MemberClusterNamespace, tokenSecretName, err)
+	}
+
+	token, ok := tokenSecret.Data[tokenSecretTokenKey]
+	if !ok || len(token) == 0 {
+		return "", xerrors.Errorf("token secret %s/%s has no %q key yet; wait for Kubernetes to populate the ServiceAccount token", opts.MemberClusterNamespace, tokenSecretName, tokenSecretTokenKey)
+	}
+	ca, ok := tokenSecret.Data[tokenSecretCAKey]
+	if !ok || len(ca) == 0 {
+		return "", xerrors.Errorf("token secret %s/%s has no %q key yet; wait for Kubernetes to populate the ServiceAccount token", opts.MemberClusterNamespace, tokenSecretName, tokenSecretCAKey)
+	}
+
+	kubeconfig, err := buildKubeConfig(opts.MemberClusterName, memberClusterServerURL, opts.MemberClusterNamespace, ca, token)
+	if err != nil {
+		return "", xerrors.Errorf("building kubeconfig: %w", err)
+	}
+
+	credentialSecretName := resourcenames.MemberClusterCredentialSecretName(opts.MemberClusterName)
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credentialSecretName,
+			Namespace: opts.OperatorNamespace,
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{credentialSecretKey: string(kubeconfig)},
+	}
+
+	memberCluster := &operatorv1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{APIVersion: operatorv1.GroupVersion.String(), Kind: "MemberCluster"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.MemberClusterName,
+			Namespace: opts.OperatorNamespace,
+		},
+		Spec: operatorv1.MemberClusterSpec{
+			ClusterName:         opts.MemberClusterLogicalName,
+			CredentialSecretRef: corev1.LocalObjectReference{Name: credentialSecretName},
+		},
+	}
+
+	secretYAML, err := yaml.Marshal(secret)
+	if err != nil {
+		return "", xerrors.Errorf("marshalling credential secret: %w", err)
+	}
+	memberClusterYAML, err := yaml.Marshal(memberCluster)
+	if err != nil {
+		return "", xerrors.Errorf("marshalling MemberCluster CR: %w", err)
+	}
+
+	return string(secretYAML) + "---\n" + string(memberClusterYAML), nil
+}
+
+// buildKubeConfig returns a serialised single-context kubeconfig with bearer-token auth.
+func buildKubeConfig(clusterName, serverURL, namespace string, ca, token []byte) ([]byte, error) {
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                   serverURL,
+		CertificateAuthorityData: ca,
+	}
+	cfg.AuthInfos["mck-operator"] = &clientcmdapi.AuthInfo{
+		Token: string(token),
+	}
+	cfg.Contexts[clusterName] = &clientcmdapi.Context{
+		Cluster:   clusterName,
+		AuthInfo:  "mck-operator",
+		Namespace: namespace,
+	}
+	cfg.CurrentContext = clusterName
+	return clientcmd.Write(*cfg)
+}

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration.go
@@ -24,11 +24,6 @@ import (
 const (
 	// credentialSecretKey is the single key in the credential Secret holding the kubeconfig.
 	credentialSecretKey = "kubeconfig"
-
-	// tokenSecretTokenKey and tokenSecretCAKey are the keys Kubernetes populates on a
-	// kubernetes.io/service-account-token Secret.
-	tokenSecretTokenKey = "token"
-	tokenSecretCAKey    = "ca.crt"
 )
 
 // Options carries the resolved flag values for a single member-cluster registration.
@@ -57,13 +52,13 @@ func Generate(ctx context.Context, memberClusterClient kubernetes.Interface, mem
 		return "", xerrors.Errorf("reading token secret %s/%s on the member cluster (was 'generate-member-resources' applied to it?): %w", opts.MemberClusterNamespace, tokenSecretName, err)
 	}
 
-	token, ok := tokenSecret.Data[tokenSecretTokenKey]
+	token, ok := tokenSecret.Data[corev1.ServiceAccountTokenKey]
 	if !ok || len(token) == 0 {
-		return "", xerrors.Errorf("token secret %s/%s has no %q key yet; wait for Kubernetes to populate the ServiceAccount token", opts.MemberClusterNamespace, tokenSecretName, tokenSecretTokenKey)
+		return "", xerrors.Errorf("token secret %s/%s has no %q key yet; wait for Kubernetes to populate the ServiceAccount token", opts.MemberClusterNamespace, tokenSecretName, corev1.ServiceAccountTokenKey)
 	}
-	ca, ok := tokenSecret.Data[tokenSecretCAKey]
+	ca, ok := tokenSecret.Data[corev1.ServiceAccountRootCAKey]
 	if !ok || len(ca) == 0 {
-		return "", xerrors.Errorf("token secret %s/%s has no %q key yet; wait for Kubernetes to populate the ServiceAccount token", opts.MemberClusterNamespace, tokenSecretName, tokenSecretCAKey)
+		return "", xerrors.Errorf("token secret %s/%s has no %q key yet; wait for Kubernetes to populate the ServiceAccount token", opts.MemberClusterNamespace, tokenSecretName, corev1.ServiceAccountRootCAKey)
 	}
 
 	kubeconfig, err := buildKubeConfig(opts.MemberClusterName, memberClusterServerURL, opts.MemberClusterNamespace, ca, token)

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration.go
@@ -68,7 +68,7 @@ func Generate(ctx context.Context, memberClusterClient kubernetes.Interface, mem
 
 	credentialSecretName := resourcenames.MemberClusterCredentialSecretName(opts.MemberClusterName)
 	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Secret"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      credentialSecretName,
 			Namespace: opts.OperatorNamespace,

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
@@ -1,0 +1,218 @@
+package memberregistration
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+const (
+	testNamespace = "mongodb"
+	testServerURL = "https://api.cluster-east.example.com:6443"
+	testToken     = "eyJ-test-token"
+	testCA        = "test-ca-data"
+)
+
+// tokenSecret returns a ServiceAccount token Secret as generate-member-resources would have
+// created it on the member cluster, keyed by cluster name.
+func tokenSecret(clusterName, namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mck-member-" + clusterName + "-token",
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		Data: data,
+	}
+}
+
+// parseResources decodes a multi-document YAML manifest into unstructured objects.
+func parseResources(t *testing.T, manifest string) []*unstructured.Unstructured {
+	t.Helper()
+	var out []*unstructured.Unstructured
+	dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	for {
+		obj := &unstructured.Unstructured{}
+		err := dec.Decode(obj)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err, "failed to parse rendered manifest")
+		if obj.GetKind() == "" {
+			continue
+		}
+		out = append(out, obj)
+	}
+	return out
+}
+
+func findByKind(rs []*unstructured.Unstructured, kind string) *unstructured.Unstructured {
+	for _, r := range rs {
+		if r.GetKind() == kind {
+			return r
+		}
+	}
+	return nil
+}
+
+func TestGenerate(t *testing.T) {
+	const operatorNamespace = "mongodb-operator"
+
+	tests := map[string]struct {
+		memberClusterName string
+		logicalName       string
+	}{
+		"logical name matches member cluster name": {
+			memberClusterName: "cluster-east",
+			logicalName:       "cluster-east",
+		},
+		// metadata.name (member cluster name) is RFC 1123 compliant; the logical name differs
+		// (e.g. an MCK 1.x name with an underscore that must not be modified).
+		"logical name differs from member cluster name": {
+			memberClusterName: "cluster-legacy",
+			logicalName:       "legacy_cluster_name",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tokenSecret(tc.memberClusterName, testNamespace, map[string][]byte{
+				tokenSecretTokenKey: []byte(testToken),
+				tokenSecretCAKey:    []byte(testCA),
+			}))
+
+			out, err := Generate(context.Background(), client, testServerURL, Options{
+				MemberClusterName:        tc.memberClusterName,
+				MemberClusterNamespace:   testNamespace,
+				OperatorNamespace:        operatorNamespace,
+				MemberClusterLogicalName: tc.logicalName,
+			})
+			require.NoError(t, err)
+
+			resources := parseResources(t, out)
+
+			// Exactly a credential Secret and a MemberCluster CR, in that order.
+			require.Len(t, resources, 2)
+			assert.Equal(t, "Secret", resources[0].GetKind(), "credential Secret must come first")
+			assert.Equal(t, "MemberCluster", resources[1].GetKind())
+
+			wantCredentialSecretName := "mck-credential-" + tc.memberClusterName
+
+			secret := findByKind(resources, "Secret")
+			require.NotNil(t, secret)
+			assert.Equal(t, wantCredentialSecretName, secret.GetName())
+			assert.Equal(t, operatorNamespace, secret.GetNamespace())
+			assert.Equal(t, "v1", secret.GetAPIVersion())
+			secretType, _, _ := unstructured.NestedString(secret.Object, "type")
+			assert.Equal(t, string(corev1.SecretTypeOpaque), secretType)
+
+			mc := findByKind(resources, "MemberCluster")
+			require.NotNil(t, mc)
+			assert.Equal(t, tc.memberClusterName, mc.GetName(), "metadata.name comes from MemberClusterName")
+			assert.Equal(t, operatorNamespace, mc.GetNamespace())
+			assert.Equal(t, "operator.mongodb.com/v1", mc.GetAPIVersion())
+			clusterName, _, _ := unstructured.NestedString(mc.Object, "spec", "clusterName")
+			assert.Equal(t, tc.logicalName, clusterName, "spec.clusterName comes from MemberClusterLogicalName")
+			credRef, _, _ := unstructured.NestedString(mc.Object, "spec", "credentialSecretRef", "name")
+			assert.Equal(t, wantCredentialSecretName, credRef, "MemberCluster must reference the credential Secret")
+		})
+	}
+}
+
+func TestGenerate_KubeconfigContents(t *testing.T) {
+	client := fake.NewSimpleClientset(tokenSecret("cluster-east", testNamespace, map[string][]byte{
+		tokenSecretTokenKey: []byte(testToken),
+		tokenSecretCAKey:    []byte(testCA),
+	}))
+
+	out, err := Generate(context.Background(), client, testServerURL, Options{
+		MemberClusterName:        "cluster-east",
+		MemberClusterNamespace:   testNamespace,
+		OperatorNamespace:        "mongodb-operator",
+		MemberClusterLogicalName: "cluster-east",
+	})
+	require.NoError(t, err)
+
+	secret := findByKind(parseResources(t, out), "Secret")
+	require.NotNil(t, secret)
+	stringData, _, err := unstructured.NestedStringMap(secret.Object, "stringData")
+	require.NoError(t, err)
+	rawKubeconfig, ok := stringData[credentialSecretKey]
+	require.True(t, ok, "credential Secret must have a %q key", credentialSecretKey)
+
+	cfg, err := clientcmd.Load([]byte(rawKubeconfig))
+	require.NoError(t, err)
+
+	// Single-context kubeconfig with the extracted server, CA and bearer token.
+	require.Len(t, cfg.Clusters, 1)
+	require.Len(t, cfg.Contexts, 1)
+	require.Len(t, cfg.AuthInfos, 1)
+	require.NotEmpty(t, cfg.CurrentContext)
+
+	currentCtx := cfg.Contexts[cfg.CurrentContext]
+	require.NotNil(t, currentCtx)
+	cluster := cfg.Clusters[currentCtx.Cluster]
+	require.NotNil(t, cluster)
+	assert.Equal(t, testServerURL, cluster.Server)
+	assert.Equal(t, []byte(testCA), cluster.CertificateAuthorityData)
+	assert.Equal(t, testNamespace, currentCtx.Namespace)
+
+	authInfo := cfg.AuthInfos[currentCtx.AuthInfo]
+	require.NotNil(t, authInfo)
+	assert.Equal(t, testToken, authInfo.Token)
+}
+
+func TestGenerate_Errors(t *testing.T) {
+	tests := map[string]struct {
+		objects     []*corev1.Secret
+		wantErrText string
+	}{
+		"missing token secret": {
+			objects:     nil,
+			wantErrText: "reading token secret",
+		},
+		"missing token key": {
+			objects: []*corev1.Secret{tokenSecret("cluster-east", testNamespace, map[string][]byte{
+				tokenSecretCAKey: []byte(testCA),
+			})},
+			wantErrText: `has no "token" key`,
+		},
+		"missing ca key": {
+			objects: []*corev1.Secret{tokenSecret("cluster-east", testNamespace, map[string][]byte{
+				tokenSecretTokenKey: []byte(testToken),
+			})},
+			wantErrText: `has no "ca.crt" key`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			for _, o := range tc.objects {
+				_, err := client.CoreV1().Secrets(o.Namespace).Create(context.Background(), o, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			_, err := Generate(context.Background(), client, testServerURL, Options{
+				MemberClusterName:        "cluster-east",
+				MemberClusterNamespace:   testNamespace,
+				OperatorNamespace:        "mongodb-operator",
+				MemberClusterLogicalName: "cluster-east",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrText)
+		})
+	}
+}

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
@@ -59,7 +59,7 @@ func parseOutput(t *testing.T, manifest string) (corev1.Secret, operatorv1.Membe
 // and checked in TestGenerate_KubeconfigContents.
 func wantCredentialSecret(memberClusterName string) corev1.Secret {
 	return corev1.Secret{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Secret"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mck-credential-" + memberClusterName,
 			Namespace: testOperatorNamespace,
@@ -72,7 +72,7 @@ func wantCredentialSecret(memberClusterName string) corev1.Secret {
 // wantMemberCluster is the MemberCluster CR Generate should emit.
 func wantMemberCluster(memberClusterName, logicalName string) operatorv1.MemberCluster {
 	return operatorv1.MemberCluster{
-		TypeMeta: metav1.TypeMeta{APIVersion: "operator.mongodb.com/v1", Kind: "MemberCluster"},
+		TypeMeta: metav1.TypeMeta{APIVersion: operatorv1.GroupVersion.String(), Kind: "MemberCluster"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      memberClusterName,
 			Namespace: testOperatorNamespace,

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
@@ -2,27 +2,28 @@ package memberregistration
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
 )
 
 const (
-	testNamespace = "mongodb"
-	testServerURL = "https://api.cluster-east.example.com:6443"
-	testToken     = "eyJ-test-token"
-	testCA        = "test-ca-data"
+	testNamespace         = "mongodb"
+	testOperatorNamespace = "mongodb-operator"
+	testServerURL         = "https://api.cluster-east.example.com:6443"
+	testToken             = "eyJ-test-token"
+	testCA                = "test-ca-data"
 )
 
 // tokenSecret returns a ServiceAccount token Secret as generate-member-resources would have
@@ -38,38 +39,52 @@ func tokenSecret(clusterName, namespace string, data map[string][]byte) *corev1.
 	}
 }
 
-// parseResources decodes a multi-document YAML manifest into unstructured objects.
-func parseResources(t *testing.T, manifest string) []*unstructured.Unstructured {
+// parseOutput decodes Generate's output into the two typed docs it emits, in order: Secret, then MemberCluster.
+func parseOutput(t *testing.T, manifest string) (corev1.Secret, operatorv1.MemberCluster) {
 	t.Helper()
-	var out []*unstructured.Unstructured
 	dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
-	for {
-		obj := &unstructured.Unstructured{}
-		err := dec.Decode(obj)
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err, "failed to parse rendered manifest")
-		if obj.GetKind() == "" {
-			continue
-		}
-		out = append(out, obj)
-	}
-	return out
+
+	var secret corev1.Secret
+	require.NoError(t, dec.Decode(&secret), "decoding the first document as a Secret")
+	require.Equal(t, "Secret", secret.Kind, "credential Secret must be the first document")
+
+	var memberCluster operatorv1.MemberCluster
+	require.NoError(t, dec.Decode(&memberCluster), "decoding the second document as a MemberCluster")
+
+	require.ErrorIs(t, dec.Decode(new(struct{})), io.EOF, "expected exactly two documents")
+	return secret, memberCluster
 }
 
-func findByKind(rs []*unstructured.Unstructured, kind string) *unstructured.Unstructured {
-	for _, r := range rs {
-		if r.GetKind() == kind {
-			return r
-		}
+// wantCredentialSecret is the Secret Generate should emit. The kubeconfig payload is blanked here
+// and checked in TestGenerate_KubeconfigContents.
+func wantCredentialSecret(memberClusterName string) corev1.Secret {
+	return corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mck-credential-" + memberClusterName,
+			Namespace: testOperatorNamespace,
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{credentialSecretKey: ""},
 	}
-	return nil
+}
+
+// wantMemberCluster is the MemberCluster CR Generate should emit.
+func wantMemberCluster(memberClusterName, logicalName string) operatorv1.MemberCluster {
+	return operatorv1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{APIVersion: "operator.mongodb.com/v1", Kind: "MemberCluster"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      memberClusterName,
+			Namespace: testOperatorNamespace,
+		},
+		Spec: operatorv1.MemberClusterSpec{
+			ClusterName:         logicalName,
+			CredentialSecretRef: corev1.LocalObjectReference{Name: "mck-credential-" + memberClusterName},
+		},
+	}
 }
 
 func TestGenerate(t *testing.T) {
-	const operatorNamespace = "mongodb-operator"
-
 	tests := map[string]struct {
 		memberClusterName string
 		logicalName       string
@@ -96,37 +111,19 @@ func TestGenerate(t *testing.T) {
 			out, err := Generate(context.Background(), client, testServerURL, Options{
 				MemberClusterName:        tc.memberClusterName,
 				MemberClusterNamespace:   testNamespace,
-				OperatorNamespace:        operatorNamespace,
+				OperatorNamespace:        testOperatorNamespace,
 				MemberClusterLogicalName: tc.logicalName,
 			})
 			require.NoError(t, err)
 
-			resources := parseResources(t, out)
+			gotSecret, gotMemberCluster := parseOutput(t, out)
 
-			// Exactly a credential Secret and a MemberCluster CR, in that order.
-			require.Len(t, resources, 2)
-			assert.Equal(t, "Secret", resources[0].GetKind(), "credential Secret must come first")
-			assert.Equal(t, "MemberCluster", resources[1].GetKind())
+			// Contents checked in TestGenerate_KubeconfigContents; here just require it present, then blank for the compare.
+			require.NotEmpty(t, gotSecret.StringData[credentialSecretKey], "credential Secret must carry a kubeconfig")
+			gotSecret.StringData[credentialSecretKey] = ""
 
-			wantCredentialSecretName := "mck-credential-" + tc.memberClusterName
-
-			secret := findByKind(resources, "Secret")
-			require.NotNil(t, secret)
-			assert.Equal(t, wantCredentialSecretName, secret.GetName())
-			assert.Equal(t, operatorNamespace, secret.GetNamespace())
-			assert.Equal(t, "v1", secret.GetAPIVersion())
-			secretType, _, _ := unstructured.NestedString(secret.Object, "type")
-			assert.Equal(t, string(corev1.SecretTypeOpaque), secretType)
-
-			mc := findByKind(resources, "MemberCluster")
-			require.NotNil(t, mc)
-			assert.Equal(t, tc.memberClusterName, mc.GetName(), "metadata.name comes from MemberClusterName")
-			assert.Equal(t, operatorNamespace, mc.GetNamespace())
-			assert.Equal(t, "operator.mongodb.com/v1", mc.GetAPIVersion())
-			clusterName, _, _ := unstructured.NestedString(mc.Object, "spec", "clusterName")
-			assert.Equal(t, tc.logicalName, clusterName, "spec.clusterName comes from MemberClusterLogicalName")
-			credRef, _, _ := unstructured.NestedString(mc.Object, "spec", "credentialSecretRef", "name")
-			assert.Equal(t, wantCredentialSecretName, credRef, "MemberCluster must reference the credential Secret")
+			assert.Equal(t, wantCredentialSecret(tc.memberClusterName), gotSecret)
+			assert.Equal(t, wantMemberCluster(tc.memberClusterName, tc.logicalName), gotMemberCluster)
 		})
 	}
 }
@@ -140,22 +137,19 @@ func TestGenerate_KubeconfigContents(t *testing.T) {
 	out, err := Generate(context.Background(), client, testServerURL, Options{
 		MemberClusterName:        "cluster-east",
 		MemberClusterNamespace:   testNamespace,
-		OperatorNamespace:        "mongodb-operator",
+		OperatorNamespace:        testOperatorNamespace,
 		MemberClusterLogicalName: "cluster-east",
 	})
 	require.NoError(t, err)
 
-	secret := findByKind(parseResources(t, out), "Secret")
-	require.NotNil(t, secret)
-	stringData, _, err := unstructured.NestedStringMap(secret.Object, "stringData")
-	require.NoError(t, err)
-	rawKubeconfig, ok := stringData[credentialSecretKey]
+	secret, _ := parseOutput(t, out)
+	rawKubeconfig, ok := secret.StringData[credentialSecretKey]
 	require.True(t, ok, "credential Secret must have a %q key", credentialSecretKey)
 
 	cfg, err := clientcmd.Load([]byte(rawKubeconfig))
 	require.NoError(t, err)
 
-	// Single-context kubeconfig with the extracted server, CA and bearer token.
+	// Single-context kubeconfig.
 	require.Len(t, cfg.Clusters, 1)
 	require.Len(t, cfg.Contexts, 1)
 	require.Len(t, cfg.AuthInfos, 1)
@@ -208,7 +202,7 @@ func TestGenerate_Errors(t *testing.T) {
 			_, err := Generate(context.Background(), client, testServerURL, Options{
 				MemberClusterName:        "cluster-east",
 				MemberClusterNamespace:   testNamespace,
-				OperatorNamespace:        "mongodb-operator",
+				OperatorNamespace:        testOperatorNamespace,
 				MemberClusterLogicalName: "cluster-east",
 			})
 			require.Error(t, err)

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
@@ -89,8 +89,8 @@ func TestGenerate(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tokenSecret(tc.memberClusterName, testNamespace, map[string][]byte{
-				tokenSecretTokenKey: []byte(testToken),
-				tokenSecretCAKey:    []byte(testCA),
+				corev1.ServiceAccountTokenKey:  []byte(testToken),
+				corev1.ServiceAccountRootCAKey: []byte(testCA),
 			}))
 
 			out, err := Generate(context.Background(), client, testServerURL, Options{
@@ -133,8 +133,8 @@ func TestGenerate(t *testing.T) {
 
 func TestGenerate_KubeconfigContents(t *testing.T) {
 	client := fake.NewSimpleClientset(tokenSecret("cluster-east", testNamespace, map[string][]byte{
-		tokenSecretTokenKey: []byte(testToken),
-		tokenSecretCAKey:    []byte(testCA),
+		corev1.ServiceAccountTokenKey:  []byte(testToken),
+		corev1.ServiceAccountRootCAKey: []byte(testCA),
 	}))
 
 	out, err := Generate(context.Background(), client, testServerURL, Options{
@@ -185,13 +185,13 @@ func TestGenerate_Errors(t *testing.T) {
 		},
 		"missing token key": {
 			objects: []*corev1.Secret{tokenSecret("cluster-east", testNamespace, map[string][]byte{
-				tokenSecretCAKey: []byte(testCA),
+				corev1.ServiceAccountRootCAKey: []byte(testCA),
 			})},
 			wantErrText: `has no "token" key`,
 		},
 		"missing ca key": {
 			objects: []*corev1.Secret{tokenSecret("cluster-east", testNamespace, map[string][]byte{
-				tokenSecretTokenKey: []byte(testToken),
+				corev1.ServiceAccountTokenKey: []byte(testToken),
 			})},
 			wantErrText: `has no "ca.crt" key`,
 		},

--- a/pkg/kubectl-mongodb/memberresources/memberresources.go
+++ b/pkg/kubectl-mongodb/memberresources/memberresources.go
@@ -15,6 +15,7 @@ import (
 	"helm.sh/helm/v3/pkg/engine"
 
 	helmchart "github.com/mongodb/mongodb-kubernetes/helm_chart"
+	"github.com/mongodb/mongodb-kubernetes/pkg/resourcenames"
 )
 
 // memberTemplates are the chart templates rendered into the output, in order. Everything a
@@ -61,7 +62,7 @@ func Render(clusterName, namespace string, watchedNamespaces []string, imagePull
 	}
 
 	renderValues, err := chartutil.ToRenderValues(chrt, values, chartutil.ReleaseOptions{
-		Name:      "mck-member-" + clusterName,
+		Name:      resourcenames.MemberClusterResourceName(clusterName),
 		Namespace: namespace,
 	}, chartutil.DefaultCapabilities)
 	if err != nil {

--- a/pkg/resourcenames/central_cluster.go
+++ b/pkg/resourcenames/central_cluster.go
@@ -1,0 +1,14 @@
+package resourcenames
+
+// Names in this file are for resources that live on the central (operator) cluster.
+
+const (
+	// memberClusterCredentialSecretPrefix prefixes the per-cluster credential Secret name.
+	memberClusterCredentialSecretPrefix = "mck-credential-" //nolint:gosec // It is a credential name prefix, not a secret value.
+)
+
+// MemberClusterCredentialSecretName returns the name of the per-cluster credential Secret placed on the
+// central (operator) cluster.
+func MemberClusterCredentialSecretName(memberClusterName string) string {
+	return memberClusterCredentialSecretPrefix + memberClusterName
+}

--- a/pkg/resourcenames/member_cluster.go
+++ b/pkg/resourcenames/member_cluster.go
@@ -1,0 +1,24 @@
+// Package resourcenames centralises the names of resources used for MCK multi-cluster
+// configuration. These names form a contract shared by the kubectl plugin and the operator.
+//
+// The <member-cluster> segment used by the functions in this package is the RFC 1123 name
+// (MemberCluster CR metadata.name), not the logical spec.clusterName.
+package resourcenames
+
+const (
+	// memberClusterResourceNamePrefix prefixes every member-cluster RBAC resource name.
+	memberClusterResourceNamePrefix = "mck-member-"
+)
+
+// MemberClusterResourceName returns the base name (mck-member-<member-cluster>) shared by the
+// member-cluster RBAC resources on the member cluster; individual resources append a suffix
+// (-sa, -token, -role, -role-binding).
+func MemberClusterResourceName(memberClusterName string) string {
+	return memberClusterResourceNamePrefix + memberClusterName
+}
+
+// MemberClusterTokenSecretName returns the name of the long-lived ServiceAccount token Secret on the
+// member cluster for that cluster's operator ServiceAccount (mck-member-<member-cluster>-sa).
+func MemberClusterTokenSecretName(memberClusterName string) string {
+	return MemberClusterResourceName(memberClusterName) + "-token"
+}


### PR DESCRIPTION
# Summary

Adds the `kubectl mongodb multicluster generate-member-registration` command: it connects to one member cluster (via a kubeconfig context), reads the ServiceAccount token that `generate-member-resources` created on it, and emits a **credential Secret** (a single-context kubeconfig) and a **`MemberCluster` CR** referencing it to stdout — for `kubectl apply` or GitOps. Purely additive; the operator stays inert to `MemberCluster` CRs until a later slice.

Also folds in the RBAC-unification-slice note (previously #1388, now closed).

Stacked on #1381.

## Proof of Work

`go test ./pkg/kubectl-mongodb/... ./pkg/resourcenames/...` passes and `make precommit-full` is clean. `kubectl mongodb multicluster generate-member-registration --help` renders the flags/usage.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title? (CLOUDP-423293)
- [x] Have you checked whether your jira ticket required DOCSP changes? (none needed)
- [x] Have you added changelog file? (`changelog/20260716_feature_generate_member_registration.md`)

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
