### PR TITLE
KUBE-181: Validate MongoDBSearch GA operator upgrades

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -1485,6 +1485,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_search_mc_sharded_om_lifecycle
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_search_replicaset_external_mongodb_multi_mongot_managed_lb
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -991,10 +991,7 @@ task_groups:
     <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_operator_upgrade_replica_set
-      # TODO(KUBE-102): re-enable post-GA. Disabled because the MongoDBSearch CRD is
-      # intentionally broken on upgrade by the GA API refactor (sizing moved into clusters[]),
-      # so the upgrade test's pre-upgrade old-format search CR no longer applies.
-      # - e2e_operator_upgrade_search
+      - e2e_operator_upgrade_search
       - e2e_sharded_cluster_operator_upgrade_v1_27_to_mck
       - e2e_operator_proxy
       - e2e_operator_partial_crd
@@ -1018,10 +1015,7 @@ task_groups:
     <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_operator_upgrade_replica_set
-      # TODO(KUBE-102): re-enable post-GA. Disabled because the MongoDBSearch CRD is
-      # intentionally broken on upgrade by the GA API refactor (sizing moved into clusters[]),
-      # so the upgrade test's pre-upgrade old-format search CR no longer applies.
-      # - e2e_operator_upgrade_search
+      - e2e_operator_upgrade_search
       - e2e_sharded_cluster_operator_upgrade_v1_27_to_mck
       - e2e_operator_proxy
       - e2e_operator_partial_crd

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1008,10 +1008,7 @@ task_groups:
     <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_operator_upgrade_replica_set
-      # TODO(KUBE-102): re-enable post-GA. Disabled because the MongoDBSearch CRD is
-      # intentionally broken on upgrade by the GA API refactor (sizing moved into clusters[]),
-      # so the upgrade test's pre-upgrade old-format search CR no longer applies.
-      # - e2e_operator_upgrade_search
+      - e2e_operator_upgrade_search
       - e2e_sharded_cluster_operator_upgrade_v1_27_to_mck
       - e2e_operator_proxy
       - e2e_operator_partial_crd
@@ -1035,10 +1032,7 @@ task_groups:
     <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_operator_upgrade_replica_set
-      # TODO(KUBE-102): re-enable post-GA. Disabled because the MongoDBSearch CRD is
-      # intentionally broken on upgrade by the GA API refactor (sizing moved into clusters[]),
-      # so the upgrade test's pre-upgrade old-format search CR no longer applies.
-      # - e2e_operator_upgrade_search
+      - e2e_operator_upgrade_search
       - e2e_sharded_cluster_operator_upgrade_v1_27_to_mck
       - e2e_operator_proxy
       - e2e_operator_partial_crd

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1231,6 +1231,15 @@ task_groups:
       - e2e_om_feature_controls
       - e2e_multi_cluster_sharded_disaster_recovery
 
+  # Multi-cluster MongoDBSearch tests that need a self-hosted Ops Manager:
+  # the metrics forwarder requires OM >= 8.0.25, so these cannot run on the
+  # cloud-qa multi-cluster variants.
+  - name: e2e_multi_cluster_om80_search_task_group
+    max_hosts: -1
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
+    tasks:
+      - e2e_search_mc_sharded_om_lifecycle
+
   # Dedicated task group for deploying OM Multi-Cluster when the operator is in the central cluster
   # that is not in the mesh
   - name: e2e_multi_cluster_om_operator_not_in_mesh_task_group
@@ -1837,6 +1846,15 @@ buildvariants:
     <<: *base_om7_dependency
     tasks:
       - name: e2e_static_multi_cluster_om_appdb_task_group
+
+  - name: e2e_multi_cluster_om80_search
+    display_name: e2e_multi_cluster_om80_search
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
+    <<: [*production_code_paths, *base_om8_dependency]
+    run_on:
+      - ubuntu2404-large
+    tasks:
+      - name: e2e_multi_cluster_om80_search_task_group
 
   - name: e2e_multi_cluster_om_operator_not_in_mesh
     display_name: e2e_multi_cluster_om_operator_not_in_mesh

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1214,6 +1214,15 @@ task_groups:
       - e2e_om_feature_controls
       - e2e_multi_cluster_sharded_disaster_recovery
 
+  # Multi-cluster MongoDBSearch tests that need a self-hosted Ops Manager:
+  # the metrics forwarder requires OM >= 8.0.25, so these cannot run on the
+  # cloud-qa multi-cluster variants.
+  - name: e2e_multi_cluster_om80_search_task_group
+    max_hosts: -1
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
+    tasks:
+      - e2e_search_mc_sharded_om_lifecycle
+
   # Dedicated task group for deploying OM Multi-Cluster when the operator is in the central cluster
   # that is not in the mesh
   - name: e2e_multi_cluster_om_operator_not_in_mesh_task_group
@@ -1820,6 +1829,15 @@ buildvariants:
     <<: *base_om7_dependency
     tasks:
       - name: e2e_static_multi_cluster_om_appdb_task_group
+
+  - name: e2e_multi_cluster_om80_search
+    display_name: e2e_multi_cluster_om80_search
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
+    <<: [*production_code_paths, *base_om8_dependency]
+    run_on:
+      - ubuntu2404-large
+    tasks:
+      - name: e2e_multi_cluster_om80_search_task_group
 
   - name: e2e_multi_cluster_om_operator_not_in_mesh
     display_name: e2e_multi_cluster_om_operator_not_in_mesh

--- a/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/common/search/mc_search_helper.py
@@ -481,6 +481,33 @@ def patch_mongot_host_via_ac(
     om_tester.wait_agents_ready(timeout=timeout)
 
 
+def remove_mongot_host_via_ac(mdb, log=logger, timeout: int = 900) -> None:
+    """Pop mongotHost+searchIndexManagementHostAndPort from every AC process, then block
+    until every agent applies the new goal version.
+
+    The unwire counterpart of ``patch_mongot_host_via_ac``: on an external source these
+    keys are customer-owned AC state the operator never drains, so Search deletion ends
+    with the customer removing them.
+    """
+    om_tester = mdb.get_om_tester()
+    ac_path = f"/groups/{om_tester.context.project_id}/automationConfig"
+    ac = om_tester.om_request("get", ac_path).json()
+    unwired: List[str] = []
+    for process in ac.get("processes", []):
+        sp = process.get("args2_6", {}).get("setParameter", {})
+        removed = [key for key in ("mongotHost", "searchIndexManagementHostAndPort") if sp.pop(key, None) is not None]
+        if removed:
+            unwired.append(f"{process.get('name', '')}: {removed}")
+    assert (
+        unwired
+    ), f"no AC process carried mongot routing keys; AC contained {[p.get('name') for p in ac.get('processes', [])]}"
+    log.info(f"unwired {len(unwired)} processes: {unwired}")
+    ac["version"] = ac.get("version", 0) + 1
+    _put_automation_config_past_lock(om_tester, ac_path, ac)
+    log.info(f"PUT automation config v{ac['version']} without mongot routing keys")
+    om_tester.wait_agents_ready(timeout=timeout)
+
+
 def _put_automation_config_past_lock(om_tester, ac_path: str, ac: dict, attempts: int = 3) -> None:
     """clear_feature_controls + PUT, retried on 401 — the operator can re-assert
     EXTERNALLY_MANAGED_LOCK between the clear and the PUT."""
@@ -649,22 +676,27 @@ def patch_per_cluster_sharded_mongot_host_via_om(
     cluster_indexes: List[int],
     envoy_proxy_port: int,
     multi_cluster: bool,
+    proxy_cluster_index: Optional[Callable[[int], int]] = None,
 ) -> None:
     """PUT the OM automation config so each sharded process targets its cluster-local proxy.
 
     Per (cluster, shard): shard mongod → ``shard_proxy_service_host`` (cluster-local per-shard
     proxy); per cluster: mongos → ``mc_proxy_svc_fqdn`` (cluster-level proxy). Cluster-generic:
     ``cluster_indexes=[0]`` + ``multi_cluster=False`` is the single-cluster sharded invocation.
+    ``proxy_cluster_index`` maps a process's cluster index to the cluster whose proxies it
+    targets (default: its own) — e.g. to repoint a removed cluster's still-running source
+    processes at a survivor's proxies.
     """
+    target = proxy_cluster_index or (lambda cluster_index: cluster_index)
     shard_proxy_host = {
         (cluster_index, shard_index): search_resource_names.shard_proxy_service_host(
-            mdbs_resource_name, f"{mdb.name}-{shard_index}", namespace, envoy_proxy_port, cluster_index
+            mdbs_resource_name, f"{mdb.name}-{shard_index}", namespace, envoy_proxy_port, target(cluster_index)
         )
         for cluster_index in cluster_indexes
         for shard_index in range(shard_count)
     }
     mongos_proxy_host = {
-        cluster_index: f"{search_resource_names.mc_proxy_svc_fqdn(mdbs_resource_name, namespace, cluster_index)}:{envoy_proxy_port}"
+        cluster_index: f"{search_resource_names.mc_proxy_svc_fqdn(mdbs_resource_name, namespace, target(cluster_index))}:{envoy_proxy_port}"
         for cluster_index in cluster_indexes
     }
     logger.info(f"sharded shard-proxy map: {shard_proxy_host}")
@@ -698,21 +730,24 @@ def assert_sharded_mongot_host_observed(
     envoy_proxy_port: int,
     multi_cluster: bool,
     member_api_client_by_cluster: Optional[Mapping[int, kubernetes.client.ApiClient]] = None,
+    proxy_cluster_index: Optional[Callable[[int], int]] = None,
     timeout: int = 300,
 ) -> None:
     """Poll each shard's first mongod on disk and confirm its cluster-local proxy host landed.
 
     Reads ``/data/automation-mongod.conf`` so we verify the agent applied the AC patch,
     not just that OM accepted it. ``member_api_client_by_cluster`` targets the cluster
-    hosting each pod (MC); SC leaves it None (default client).
+    hosting each pod (MC); SC leaves it None (default client). ``proxy_cluster_index``
+    mirrors ``patch_per_cluster_sharded_mongot_host_via_om``'s parameter of the same name.
     """
+    target = proxy_cluster_index or (lambda cluster_index: cluster_index)
     expected: Dict[str, str] = {}
     pod_to_cluster: Dict[str, int] = {}
     for cluster_index in cluster_indexes:
         for shard_index in range(shard_count):
             pod_name = f"{mdb.name}-{shard_index}-{cluster_index}-0" if multi_cluster else f"{mdb.name}-{shard_index}-0"
             expected[pod_name] = search_resource_names.shard_proxy_service_host(
-                mdbs_resource_name, f"{mdb.name}-{shard_index}", namespace, envoy_proxy_port, cluster_index
+                mdbs_resource_name, f"{mdb.name}-{shard_index}", namespace, envoy_proxy_port, target(cluster_index)
             )
             pod_to_cluster[pod_name] = cluster_index
 

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
@@ -26,7 +26,7 @@ the customer unwires them — spec keys via the operator, routing keys via the A
 
 import json
 from copy import deepcopy
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 
 import kubernetes
 import pymongo.errors
@@ -288,9 +288,7 @@ def _shard_sts_names(cluster_index: int, shard_names: List[str]) -> List[str]:
     ]
 
 
-def _shard_artifact_readers(
-    mcc: MultiClusterClient, namespace: str, shard_name: str
-) -> Dict[str, Callable[[], object]]:
+def _shard_artifact_readers(mcc: MultiClusterClient, namespace: str, shard_name: str) -> Dict[str, Callable[[], Any]]:
     ci = _idx(mcc)
     core = mcc.core_v1_api()
     sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
@@ -309,13 +307,13 @@ def _shard_artifact_readers(
 
 def _local_artifact_readers(
     mcc: MultiClusterClient, namespace: str, shard_names: List[str]
-) -> Dict[str, Callable[[], object]]:
+) -> Dict[str, Callable[[], Any]]:
     """Direct readers for the concrete (kind, name) identities of one cluster's Search
     artifact set: per-(cluster, shard) mongot resources plus the cluster-level proxy
     Service and Envoy Deployment/ConfigMap."""
     ci = _idx(mcc)
     apps = mcc.apps_v1_api()
-    readers: Dict[str, Callable[[], object]] = {}
+    readers: Dict[str, Callable[[], Any]] = {}
     for shard_name in shard_names:
         readers.update(_shard_artifact_readers(mcc, namespace, shard_name))
     cluster_proxy = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, ci)
@@ -327,7 +325,7 @@ def _local_artifact_readers(
     return readers
 
 
-def _reader_uids(readers: Dict[str, Callable[[], object]]) -> Dict[str, str]:
+def _reader_uids(readers: Dict[str, Callable[[], Any]]) -> Dict[str, str]:
     """UIDs of every captured artifact; reading them doubles as a presence guard."""
     return {what: read().metadata.uid for what, read in readers.items()}
 
@@ -359,7 +357,7 @@ def _customer_input_uids(mcc: MultiClusterClient, namespace: str, cluster_index:
 
 
 def _wait_for_cluster_artifacts_swept(
-    mcc: MultiClusterClient, namespace: str, readers: Dict[str, Callable[[], object]], shard_names: List[str]
+    mcc: MultiClusterClient, namespace: str, readers: Dict[str, Callable[[], Any]], shard_names: List[str]
 ) -> None:
     """Identity 404-polls for every captured artifact, then PVC reap, then the
     label-scoped emptiness backstop for labeled orphans outside the inventory."""
@@ -997,7 +995,7 @@ def test_remove_shard_lifecycle(
     removed_shard = _shard_names(INITIAL_SHARD_COUNT)[-1]
 
     live_uids: Dict[str, Dict[str, str]] = {}
-    removed_readers: Dict[str, Dict[str, Callable[[], object]]] = {}
+    removed_readers: Dict[str, Dict[str, Callable[[], Any]]] = {}
     for mcc in member_cluster_clients:
         live_uids[mcc.cluster_name] = _reader_uids(_local_artifact_readers(mcc, namespace, live_shards))
         readers = _shard_artifact_readers(mcc, namespace, removed_shard)

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
@@ -244,7 +244,7 @@ def _assert_lb_cert_proxy_sans(
         )
         missing = expected_sans - sans
         assert not missing, f"LB server cert {secret_name} missing proxy SANs: {sorted(missing)}"
-        logger.info(f"LB server cert {secret_name} covers all {len(expected_sans)} proxy SANs")
+        logger.info(f"LB server cert for cluster {ci} covers all {len(expected_sans)} proxy SANs")
 
 
 def _source_router_hosts(namespace: str) -> List[str]:

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
@@ -1,0 +1,1261 @@
+"""Full MongoDBSearch lifecycle on a 3-cluster hub-and-spoke sharded source with self-hosted Ops Manager.
+
+Hub topology: central MC operator on cluster-1 managing clusters 1-3, self-hosted
+Ops Manager 8.0.25 with a multi-cluster AppDB (the metrics forwarder requires
+OM >= 8.0.25, so this cannot run on cloud-qa), a 3-shard TLS+SCRAM MultiCluster
+sharded MongoDB source, and a MongoDBSearch with three named cluster entries,
+managed LB, and the metrics forwarder pointed at the source's OM project.
+
+Routing is per-cluster: each cluster's shard mongods target their own cluster's
+per-shard proxy Services and each cluster's mongos its own cluster's router proxy.
+Spec setParameter is per-shard and uniform across clusters, so the two routing keys
+are wired per process directly in the OM automation config (customer-owned,
+external-source semantics); only the four uniform base keys ride the spec.
+
+Lifecycle under test, in order: baseline per-(cluster, shard) fan-out with exact
+OM MONGOT host registration and the per-cluster routing observed on every pod,
+the $search data plane through every cluster's mongos, trailing-shard removal
+(search shard list first, then the source; survivors keep cluster-local routing),
+cluster-entry removal (cluster-3 fully swept, its still-running source processes
+rewired to a survivor's proxies, while both survivors stay byte-identical and
+serving), and the CR-delete tail (OM host deregistration, forwarder teardown,
+finalizer release, label sweeps on all three clusters, and the search
+setParameters draining out of the still-Running source's automation config once
+the customer unwires them — spec keys via the operator, routing keys via the AC).
+"""
+
+import json
+from copy import deepcopy
+from typing import Callable, Dict, List
+
+import kubernetes
+import pymongo.errors
+import yaml
+from cryptography import x509
+from kubernetes.client import CoreV1Api
+from kubetester import create_or_update_secret, read_secret, try_load
+from kubetester.certs import create_tls_certs
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import run_periodically
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.multicluster_client import MultiClusterClient
+from kubetester.operator import Operator
+from kubetester.opsmanager import MongoDBOpsManager
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests import test_logger
+from tests.common.multicluster.multicluster_utils import (
+    assert_deployment_ready_in_cluster,
+    assert_workload_ready_in_cluster,
+)
+from tests.common.search import search_resource_names
+from tests.common.search.connectivity import (
+    CLUSTER_LOCATION_TAG_KEY,
+    mongot_data_pvc_names,
+    protected_search_input_uids,
+    wait_for_metrics_forwarder_phase,
+    wait_for_mongot_pvcs_deleted,
+    wait_for_resource_deleted,
+    wait_for_search_deleted,
+    wait_for_search_owned_resources_deleted,
+)
+from tests.common.search.mc_search_helper import (
+    assert_sharded_mongot_host_observed,
+    patch_per_cluster_sharded_mongot_host_via_om,
+    remove_mongot_host_via_ac,
+)
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
+from tests.common.search.sharded_search_helper import (
+    create_issuer_ca,
+    create_lb_certificates,
+    create_per_shard_search_tls_certs,
+)
+from tests.conftest import get_issuer_ca_filepath
+from tests.multicluster.conftest import cluster_spec_list
+from tests.multicluster_search.conftest import (
+    ADMIN_USER_NAME,
+    ADMIN_USER_PASSWORD,
+    ENVOY_PROXY_PORT,
+    MDBS_TLS_CERT_PREFIX,
+    MONGOT_USER_NAME,
+    SOURCE_CERT_PREFIX,
+    USER_NAME,
+    USER_PASSWORD,
+    create_search_users,
+    install_central_mc_operator,
+)
+from tests.search.om_deployment import get_ops_manager
+
+logger = test_logger.get_test_logger(__name__)
+
+MDB_RESOURCE_NAME = "mdb-mc-sh-om"
+MDBS_RESOURCE_NAME = "mdb-mc-sh-om-search"
+
+INITIAL_SHARD_COUNT = 3
+REDUCED_SHARD_COUNT = 2
+
+MEMBERS_PER_CLUSTER: List[int | None] = [1, 1, 1]
+MONGOS_PER_CLUSTER: List[int | None] = [1, 1, 1]
+CONFIG_SRV_PER_CLUSTER: List[int | None] = [1, 1, 1]
+
+CLUSTER_COUNT = len(MEMBERS_PER_CLUSTER)
+MONGOT_REPLICAS_PER_CLUSTER = 1
+# The trailing entry is removed; its source processes keep running and get rewired
+# (direct AC) to the REWIRE_TARGET_INDEX survivor's proxies for the same shard.
+REMOVED_CLUSTER_INDEX = 2
+REWIRE_TARGET_INDEX = 0
+
+# 9 mongot JVMs share one kind host with OM's JVM and 15 source mongods; the default
+# mongot request (cpu=2, memory=4Gi => 2Gi heap) does not fit, and a 1Gi heap serves
+# sample_mflix fine.
+MONGOT_RESOURCE_REQUESTS = {"cpu": "500m", "memory": "2Gi"}
+
+CA_CONFIGMAP_NAME = f"{MDB_RESOURCE_NAME}-ca"
+
+# setParameter keys wiring the source to mongot. On an external source the operator
+# never writes them: the four base keys are customer-set spec (additionalMongodConfig,
+# uniform across shards and clusters) and the two routing keys are set per process
+# directly in the OM automation config, the only layer that can express per-cluster
+# endpoints. The customer unwires both halves on Search delete (see the delete test).
+SEARCH_SET_PARAMETER_KEYS = (
+    "mongotHost",
+    "searchIndexManagementHostAndPort",
+    "skipAuthenticationToSearchIndexManagementServer",
+    "skipAuthenticationToMongot",
+    "searchTLSMode",
+    "useGrpcForSearch",
+)
+
+BASE_SEARCH_SET_PARAMETER = {
+    "skipAuthenticationToSearchIndexManagementServer": False,
+    "skipAuthenticationToMongot": False,
+    "searchTLSMode": "requireTLS",
+    "useGrpcForSearch": True,
+}
+
+SEARCH_INDEX_READY_TIMEOUT = 300
+SEARCH_QUERY_RETRY_TIMEOUT = 60
+
+
+def _idx(mcc: MultiClusterClient) -> int:
+    assert mcc.cluster_index is not None, f"cluster_index unset on {mcc.cluster_name!r}"
+    return mcc.cluster_index
+
+
+def _shard_names(shard_count: int) -> List[str]:
+    return [f"{MDB_RESOURCE_NAME}-{shard_idx}" for shard_idx in range(shard_count)]
+
+
+def _wire_routing_via_ac(
+    mdb: MongoDB,
+    namespace: str,
+    cluster_indexes: List[int],
+    shard_count: int,
+    proxy_cluster_index: Callable[[int], int] | None = None,
+) -> None:
+    """Direct-AC wiring of the two routing keys: shard mongods -> their cluster's per-shard
+    proxy, mongos -> their cluster's router proxy (or ``proxy_cluster_index``'s target).
+    Recomputed from the live AC on every call, and blocks until agents reach goal state."""
+    patch_per_cluster_sharded_mongot_host_via_om(
+        mdb=mdb,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        namespace=namespace,
+        shard_count=shard_count,
+        cluster_indexes=cluster_indexes,
+        envoy_proxy_port=ENVOY_PROXY_PORT,
+        multi_cluster=True,
+        proxy_cluster_index=proxy_cluster_index,
+    )
+
+
+def _assert_mongos_mongot_host(namespace: str, cluster_index: int, proxy_index: int, timeout: int = 300) -> None:
+    """Poll one cluster's mongos via getParameter until it reports the proxy_index cluster's
+    router proxy as its effective mongot routing (mongos restarts to apply setParameter)."""
+    expected = (
+        f"{search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, proxy_index)}:{ENVOY_PROXY_PORT}"
+    )
+    tester = _per_cluster_mongos_search_tester(namespace, cluster_index, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+
+    def check() -> tuple:
+        try:
+            params = tester.client.admin.command(
+                {"getParameter": 1, "mongotHost": 1, "searchIndexManagementHostAndPort": 1}
+            )
+        except pymongo.errors.PyMongoError as exc:
+            return False, f"cluster {cluster_index}: mongos getParameter error: {exc}"
+        got = (params.get("mongotHost"), params.get("searchIndexManagementHostAndPort"))
+        return got == (expected, expected), f"cluster {cluster_index}: mongos routing {got}, want {expected!r}"
+
+    run_periodically(check, timeout=timeout, sleep_time=5, msg=f"cluster {cluster_index}: mongos mongot routing")
+
+
+def _assert_routing_observed(
+    namespace: str,
+    mdb: MongoDB,
+    member_cluster_clients: List[MultiClusterClient],
+    shard_count: int,
+    proxy_cluster_index: Callable[[int], int] | None = None,
+) -> None:
+    """Effective routing on every pod of the given clusters: each (cluster, shard) mongod's
+    on-disk automation config and each cluster's mongos getParameter must report the
+    target cluster's proxy endpoints (default target: the pod's own cluster)."""
+    target = proxy_cluster_index or (lambda cluster_index: cluster_index)
+    assert_sharded_mongot_host_observed(
+        mdb=mdb,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        namespace=namespace,
+        shard_count=shard_count,
+        cluster_indexes=[_idx(mcc) for mcc in member_cluster_clients],
+        envoy_proxy_port=ENVOY_PROXY_PORT,
+        multi_cluster=True,
+        member_api_client_by_cluster={_idx(mcc): mcc.api_client for mcc in member_cluster_clients},
+        proxy_cluster_index=proxy_cluster_index,
+    )
+    for mcc in member_cluster_clients:
+        ci = _idx(mcc)
+        _assert_mongos_mongot_host(namespace, ci, target(ci))
+
+
+def _assert_lb_cert_proxy_sans(
+    namespace: str, central_cluster_client: kubernetes.client.ApiClient, cluster_indexes: List[int]
+) -> None:
+    """Every cluster's Envoy server cert must SAN every cluster's per-shard proxy and
+    router proxy FQDNs: with per-cluster routing each cluster's mongods/mongos dial their
+    own cluster's proxies over requireTLS, and the cluster-removal rewire additionally
+    sends the removed cluster's processes to a survivor's proxies."""
+    expected_sans = {
+        search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, ci) for ci in cluster_indexes
+    } | {
+        f"{search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, ci)}"
+        f".{namespace}.svc.cluster.local"
+        for ci in cluster_indexes
+        for shard_name in _shard_names(INITIAL_SHARD_COUNT)
+    }
+    for ci in cluster_indexes:
+        secret_name = search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, ci)
+        pem = read_secret(namespace, secret_name, api_client=central_cluster_client)["tls.crt"]
+        sans = set(
+            x509.load_pem_x509_certificate(pem.encode())
+            .extensions.get_extension_for_class(x509.SubjectAlternativeName)
+            .value.get_values_for_type(x509.DNSName)
+        )
+        missing = expected_sans - sans
+        assert not missing, f"LB server cert {secret_name} missing proxy SANs: {sorted(missing)}"
+        logger.info(f"LB server cert {secret_name} covers all {len(expected_sans)} proxy SANs")
+
+
+def _source_router_hosts(namespace: str) -> List[str]:
+    # Per-pod headless Services (`<sts>-<clusterIdx>-<podIdx>-svc`) are reachable
+    # cross-cluster via Istio; the per-cluster `<sts>-<clusterIdx>-svc` is not.
+    return [
+        f"{MDB_RESOURCE_NAME}-mongos-{cluster_idx}-{pod_idx}-svc.{namespace}.svc.cluster.local:27017"
+        for cluster_idx, n_mongos in enumerate(MONGOS_PER_CLUSTER)
+        if n_mongos
+        for pod_idx in range(n_mongos)
+    ]
+
+
+def _source_shard_list(namespace: str, shard_count: int) -> List[dict]:
+    return [
+        {
+            "shardName": shard_name,
+            "hosts": [
+                f"{shard_name}-{cluster_idx}-0-svc.{namespace}.svc.cluster.local:27017"
+                for cluster_idx in range(len(MEMBERS_PER_CLUSTER))
+                if MEMBERS_PER_CLUSTER[cluster_idx] is not None
+            ],
+        }
+        for shard_name in _shard_names(shard_count)
+    ]
+
+
+def _expected_mongot_hosts(mdbs: MongoDBSearch, shard_count: int, cluster_indexes: List[int]) -> set:
+    shard_names = _shard_names(shard_count)
+    hosts: set = set()
+    for cluster_index in cluster_indexes:
+        hosts |= mdbs.shard_mongot_pod_hostnames(shard_names, cluster_index)
+    return hosts
+
+
+def _shard_sts_names(cluster_index: int, shard_names: List[str]) -> List[str]:
+    return [
+        search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, cluster_index)
+        for shard_name in shard_names
+    ]
+
+
+def _shard_artifact_readers(
+    mcc: MultiClusterClient, namespace: str, shard_name: str
+) -> Dict[str, Callable[[], object]]:
+    ci = _idx(mcc)
+    core = mcc.core_v1_api()
+    sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
+    svc = search_resource_names.shard_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+    proxy = search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+    cm = search_resource_names.shard_configmap_name(MDBS_RESOURCE_NAME, shard_name, ci)
+    secret = search_resource_names.shard_operator_managed_tls_secret_name(MDBS_RESOURCE_NAME, shard_name, ci)
+    return {
+        f"StatefulSet/{sts}": lambda n=sts: mcc.read_namespaced_stateful_set(n, namespace),
+        f"Service/{svc}": lambda n=svc: mcc.read_namespaced_service(n, namespace),
+        f"Service/{proxy}": lambda n=proxy: mcc.read_namespaced_service(n, namespace),
+        f"ConfigMap/{cm}": lambda n=cm: mcc.read_namespaced_config_map(n, namespace),
+        f"Secret/{secret}": lambda n=secret: core.read_namespaced_secret(n, namespace),
+    }
+
+
+def _local_artifact_readers(
+    mcc: MultiClusterClient, namespace: str, shard_names: List[str]
+) -> Dict[str, Callable[[], object]]:
+    """Direct readers for the concrete (kind, name) identities of one cluster's Search
+    artifact set: per-(cluster, shard) mongot resources plus the cluster-level proxy
+    Service and Envoy Deployment/ConfigMap."""
+    ci = _idx(mcc)
+    apps = mcc.apps_v1_api()
+    readers: Dict[str, Callable[[], object]] = {}
+    for shard_name in shard_names:
+        readers.update(_shard_artifact_readers(mcc, namespace, shard_name))
+    cluster_proxy = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, ci)
+    envoy_dep = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, ci)
+    envoy_cm = search_resource_names.lb_configmap_name(MDBS_RESOURCE_NAME, ci)
+    readers[f"Service/{cluster_proxy}"] = lambda: mcc.read_namespaced_service(cluster_proxy, namespace)
+    readers[f"Deployment/{envoy_dep}"] = lambda: apps.read_namespaced_deployment(envoy_dep, namespace)
+    readers[f"ConfigMap/{envoy_cm}"] = lambda: mcc.read_namespaced_config_map(envoy_cm, namespace)
+    return readers
+
+
+def _reader_uids(readers: Dict[str, Callable[[], object]]) -> Dict[str, str]:
+    """UIDs of every captured artifact; reading them doubles as a presence guard."""
+    return {what: read().metadata.uid for what, read in readers.items()}
+
+
+def _customer_input_uids(mcc: MultiClusterClient, namespace: str, cluster_index: int) -> Dict[str, str]:
+    """UIDs of the customer-replicated Search inputs on one cluster (must survive cleanup).
+
+    Includes all INITIAL_SHARD_COUNT per-shard certs: they are customer Secrets, so even
+    the removed shard's cert must stay untouched by every sweep."""
+
+    def shard_cert(shard_name: str) -> str:
+        return search_resource_names.shard_tls_cert_name(
+            MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index
+        )
+
+    all_shards = _shard_names(INITIAL_SHARD_COUNT)
+    return protected_search_input_uids(
+        mcc.core_v1_api(),
+        namespace,
+        shard_cert(all_shards[0]),
+        f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+        CA_CONFIGMAP_NAME,
+        additional_secret_names=(
+            search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+            search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, cluster_index),
+            *(shard_cert(shard_name) for shard_name in all_shards[1:]),
+        ),
+    )
+
+
+def _wait_for_cluster_artifacts_swept(
+    mcc: MultiClusterClient, namespace: str, readers: Dict[str, Callable[[], object]], shard_names: List[str]
+) -> None:
+    """Identity 404-polls for every captured artifact, then PVC reap, then the
+    label-scoped emptiness backstop for labeled orphans outside the inventory."""
+    for what, read in readers.items():
+        wait_for_resource_deleted(read, f"{what} in {mcc.cluster_name}")
+    for sts_name in _shard_sts_names(_idx(mcc), shard_names):
+        wait_for_mongot_pvcs_deleted(namespace, sts_name, api_client=mcc.api_client)
+    wait_for_search_owned_resources_deleted(
+        mcc.apps_v1_api(),
+        mcc.core_v1_api(),
+        namespace,
+        MDBS_RESOURCE_NAME,
+        where=mcc.cluster_name,
+    )
+
+
+def _forwarder_names(cluster_index: int) -> Dict[str, str]:
+    return {
+        "deployment": search_resource_names.metrics_forwarder_deployment_name(MDBS_RESOURCE_NAME, cluster_index),
+        "config": search_resource_names.metrics_forwarder_configmap_name(MDBS_RESOURCE_NAME, cluster_index),
+        "agent_key": search_resource_names.metrics_forwarder_agent_key_secret_name(MDBS_RESOURCE_NAME, cluster_index),
+        "ca_cert": search_resource_names.metrics_forwarder_ca_configmap_name(MDBS_RESOURCE_NAME, cluster_index),
+    }
+
+
+def _forwarder_artifact_uids(mcc: MultiClusterClient, namespace: str, cluster_index: int) -> Dict[str, str]:
+    """UIDs of the cluster's forwarder artifacts; reading them doubles as a presence guard.
+
+    The CA ConfigMap is excluded: it is only replicated when the project ConfigMap
+    carries sslMMSCAConfigMap, and this suite talks to OM over plain HTTP.
+    """
+    names = _forwarder_names(cluster_index)
+    apps = mcc.apps_v1_api()
+    core = mcc.core_v1_api()
+    return {
+        names["deployment"]: apps.read_namespaced_deployment(names["deployment"], namespace).metadata.uid,
+        names["config"]: core.read_namespaced_config_map(names["config"], namespace).metadata.uid,
+        names["agent_key"]: core.read_namespaced_secret(names["agent_key"], namespace).metadata.uid,
+    }
+
+
+def _wait_for_forwarder_artifacts_deleted(mcc: MultiClusterClient, namespace: str, cluster_index: int) -> None:
+    names = _forwarder_names(cluster_index)
+    apps = mcc.apps_v1_api()
+    core = mcc.core_v1_api()
+    for read_fn, what in (
+        (lambda: apps.read_namespaced_deployment(names["deployment"], namespace), f"Deployment {names['deployment']}"),
+        (lambda: core.read_namespaced_config_map(names["config"], namespace), f"ConfigMap {names['config']}"),
+        (lambda: core.read_namespaced_secret(names["agent_key"], namespace), f"Secret {names['agent_key']}"),
+        (lambda: core.read_namespaced_config_map(names["ca_cert"], namespace), f"ConfigMap {names['ca_cert']}"),
+    ):
+        wait_for_resource_deleted(read_fn, f"[{mcc.cluster_name}] metrics forwarder {what}")
+
+
+def _state_cm_clusters(central_core: CoreV1Api, namespace: str) -> Dict[str, dict]:
+    cm = central_core.read_namespaced_config_map(
+        search_resource_names.metrics_forwarder_state_configmap_name(MDBS_RESOURCE_NAME), namespace
+    )
+    return json.loads(cm.data["state"]).get("clusters", {})
+
+
+def _wait_for_state_cm_converged(
+    central_core: CoreV1Api, namespace: str, expected_indexes: Dict[str, int], live_shards: List[str]
+) -> None:
+    """Poll the forwarder topology-state CM to the converged shape: exactly the expected
+    clusters, each pinned to its index with shardReplicas covering exactly the live shards
+    and no host deletion still in flight (one-shot equality is wrong mid-deferral).
+    Sharded entries populate shardReplicas and leave replicas at 0."""
+    want_shard_replicas = {shard_name: MONGOT_REPLICAS_PER_CLUSTER for shard_name in live_shards}
+
+    def converged() -> tuple:
+        clusters = _state_cm_clusters(central_core, namespace)
+        if set(clusters) != set(expected_indexes):
+            return False, f"state CM clusters {sorted(clusters)} != {sorted(expected_indexes)}"
+        for name, entry in clusters.items():
+            if entry.get("clusterIndex") != expected_indexes[name]:
+                return False, f"{name}: clusterIndex={entry.get('clusterIndex')}, want {expected_indexes[name]}"
+            if entry.get("shardReplicas") != want_shard_replicas:
+                return False, f"{name}: shardReplicas={entry.get('shardReplicas')}, want {want_shard_replicas}"
+            if entry.get("pendingHostDeletions") or entry.get("hostDeletionReadyAfter"):
+                return False, f"{name}: host deletions still in flight: {entry}"
+        return True, f"state CM converged for {sorted(expected_indexes)}"
+
+    run_periodically(converged, timeout=300, sleep_time=5, msg="metrics forwarder state CM convergence")
+
+
+def _routing_ready_groups(central_core: CoreV1Api, namespace: str) -> List[str]:
+    cm = central_core.read_namespaced_config_map(
+        search_resource_names.search_state_configmap_name(MDBS_RESOURCE_NAME), namespace
+    )
+    return json.loads(cm.data["state"]).get("routingReadyMongotGroups", [])
+
+
+def _per_cluster_mongos_search_tester(
+    namespace: str,
+    cluster_index: int,
+    username: str,
+    password: str,
+) -> SearchTester:
+    """SearchTester pinned to a specific cluster's mongos via its per-pod headless Service.
+
+    `directConnection=true` keeps the driver from discovering the other clusters' mongos.
+    """
+    mongos_host = f"{MDB_RESOURCE_NAME}-mongos-{cluster_index}-0-svc.{namespace}.svc.cluster.local:27017"
+    conn_str = f"mongodb://{username}:{password}@{mongos_host}/?directConnection=true&authSource=admin"
+    return SearchTester(conn_str, use_ssl=True, ca_path=get_issuer_ca_filepath())
+
+
+def _wait_for_search_results(namespace: str, cluster_index: int, timeout: int = SEARCH_QUERY_RETRY_TIMEOUT) -> None:
+    tester = _per_cluster_mongos_search_tester(namespace, cluster_index, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+
+    def execute_search() -> tuple:
+        try:
+            results = movies.text_search_movies("Star Wars")
+            return bool(results), f"cluster {cluster_index}: $search returned {len(results)} results"
+        except pymongo.errors.PyMongoError as exc:
+            return False, f"cluster {cluster_index}: $search error: {exc}"
+
+    run_periodically(
+        execute_search,
+        timeout=timeout,
+        sleep_time=5,
+        msg=f"cluster {cluster_index}: $search via mongos",
+    )
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@fixture(scope="module")
+def ca_configmap(
+    issuer_ca_filepath: str,
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+) -> str:
+    # Central cluster first (the operator reads from here), then each member cluster
+    # so mongot pods can verify the source MongoDB TLS cert.
+    name = create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME)
+    for mcc in member_cluster_clients:
+        create_issuer_ca(issuer_ca_filepath, namespace, CA_CONFIGMAP_NAME, api_client=mcc.api_client)
+    return name
+
+
+@fixture(scope="module")
+def central_mc_operator(
+    namespace: str,
+    central_cluster_name: str,
+    multi_cluster_operator_installation_config: dict,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    member_cluster_names: List[str],
+) -> Operator:
+    return install_central_mc_operator(
+        namespace,
+        central_cluster_name,
+        multi_cluster_operator_installation_config,
+        central_cluster_client,
+        member_cluster_clients,
+        member_cluster_names,
+        watch_search=True,
+    )
+
+
+@fixture(scope="module")
+def om(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_names: List[str],
+) -> MongoDBOpsManager:
+    ops_manager = get_ops_manager(namespace)
+    assert ops_manager is not None
+    # get_ops_manager spreads OM over the member clusters; a single OM pod is enough
+    # here and preserves the host's pod budget for the 9 mongot JVMs.
+    ops_manager["spec"]["clusterSpecList"] = cluster_spec_list(member_cluster_names[:1], [1])
+    ops_manager["spec"]["applicationDatabase"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, [1, 1, 1])
+    ops_manager.create_admin_secret(api_client=central_cluster_client)
+    return ops_manager
+
+
+@fixture(scope="module")
+def mdb(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_names: List[str],
+    ca_configmap: str,
+    om: MongoDBOpsManager,
+) -> MongoDB:
+    """3-shard MC sharded MongoDB source with TLS+SCRAM, distributed across 3 member clusters."""
+    resource = MongoDB.from_yaml(
+        yaml_fixture("search-q3-mc-sharded.yaml"),
+        name=MDB_RESOURCE_NAME,
+        namespace=namespace,
+    )
+    # Point at the in-cluster OM instead of the fixture's cloud-qa my-project/my-credentials.
+    resource.configure(om, MDB_RESOURCE_NAME, api_client=central_cluster_client)
+
+    # Tag each shard member nodeLocation=<clusterName> so every cluster's mongot matchTagSets
+    # selects its cluster-local shard members (tagSets constrain reads per shard via the router).
+    shard_member_configs = [
+        [{"tags": {CLUSTER_LOCATION_TAG_KEY: name}} for _ in range(count or 0)]
+        for name, count in zip(member_cluster_names, MEMBERS_PER_CLUSTER)
+    ]
+    resource["spec"]["shard"]["clusterSpecList"] = cluster_spec_list(
+        member_cluster_names, MEMBERS_PER_CLUSTER, member_configs=shard_member_configs
+    )
+    resource["spec"]["configSrv"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, CONFIG_SRV_PER_CLUSTER)
+    resource["spec"]["mongos"]["clusterSpecList"] = cluster_spec_list(member_cluster_names, MONGOS_PER_CLUSTER)
+
+    resource["spec"]["shardCount"] = INITIAL_SHARD_COUNT
+    # Only the uniform base search params ride the spec (their operator drain on delete is
+    # under test); the per-cluster routing keys are wired directly in the OM automation
+    # config once the search CR is up (test_create_search_resource).
+    resource["spec"]["shard"]["additionalMongodConfig"] = {"setParameter": dict(BASE_SEARCH_SET_PARAMETER)}
+    resource["spec"]["mongos"]["additionalMongodConfig"] = {"setParameter": dict(BASE_SEARCH_SET_PARAMETER)}
+
+    resource["spec"]["security"] = {
+        "certsSecretPrefix": SOURCE_CERT_PREFIX,
+        "tls": {"ca": ca_configmap},
+        "authentication": {"enabled": True, "modes": ["SCRAM"]},
+    }
+
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="module")
+def mdbs(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+    mdb: MongoDB,
+    ca_configmap: str,
+) -> MongoDBSearch:
+    """MongoDBSearch over the external sharded source, one named entry per member cluster.
+
+    externalHostname starts with {shardName}. so the operator can derive the
+    cluster-level proxy-svc FQDN for mongos by stripping that prefix.
+    """
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-q2-mc-rs-search.yaml"),
+        name=MDBS_RESOURCE_NAME,
+        namespace=namespace,
+    )
+
+    resource["spec"]["source"] = {
+        "username": MONGOT_USER_NAME,
+        "passwordSecretRef": {
+            "name": f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+            "key": "password",
+        },
+        "external": {
+            "shardedCluster": {
+                "router": {"hosts": _source_router_hosts(namespace)},
+                "shards": _source_shard_list(namespace, INITIAL_SHARD_COUNT),
+            },
+            "tls": {"ca": {"name": ca_configmap}},
+        },
+    }
+
+    resource["spec"]["security"] = {
+        "tls": {"certsSecretPrefix": MDBS_TLS_CERT_PREFIX},
+    }
+
+    clusters = []
+    for mcc in member_cluster_clients:
+        ci = _idx(mcc)
+        clusters.append(
+            {
+                "name": mcc.cluster_name,
+                "index": ci,
+                "replicas": MONGOT_REPLICAS_PER_CLUSTER,
+                "resourceRequirements": {"requests": dict(MONGOT_RESOURCE_REQUESTS)},
+                "loadBalancer": {
+                    "managed": {
+                        "externalHostname": search_resource_names.shard_proxy_svc_hostname_template(
+                            MDBS_RESOURCE_NAME, namespace, ci
+                        ),
+                        # Shard-agnostic cluster-level endpoint for mongos: the per-cluster proxy-svc
+                        # FQDN (matches the LB cert SAN). Distinct per cluster via the cluster index.
+                        "routerHostname": search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, ci),
+                    },
+                },
+                "syncSourceSelector": {"matchTagSets": [{CLUSTER_LOCATION_TAG_KEY: mcc.cluster_name}]},
+            }
+        )
+    resource["spec"]["clusters"] = clusters
+
+    # External sources can't auto-resolve the Ops Manager project, so the forwarder is
+    # given the source's project ConfigMap and agent-credentials Secret explicitly.
+    # Instantiated after the source is Running, so status.projectId is set.
+    mdb.load()
+    resource["spec"]["observability"] = {
+        "prometheus": {"mode": "enabled"},
+        "metricsForwarder": {
+            "opsManager": {
+                "projectConfigMapRef": {"name": mdb.config_map_name},
+                "agentCredentials": {"name": f"{mdb['status']['projectId']}-group-secret"},
+            },
+        },
+    }
+
+    resource.api = kubernetes.client.CustomObjectsApi(central_cluster_client)
+    try_load(resource)
+    return resource
+
+
+# =============================================================================
+# Test steps
+# =============================================================================
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_install_operator(central_mc_operator: Operator):
+    central_mc_operator.wait_for_operator_ready()
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_create_ops_manager(om: MongoDBOpsManager):
+    om.update()
+    om.om_status().assert_reaches_phase(Phase.Running, timeout=1500)
+    om.appdb_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_install_source_tls_certificates(
+    namespace: str,
+    multi_cluster_issuer: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdb: MongoDB,
+):
+    """Source MongoDB per-component TLS certs — written to central; operator copies to members.
+
+    ShardedCluster with certsSecretPrefix expects one secret per component, not a bundle:
+    `{prefix}-{resource}-{N}-cert` per shard, plus `-config-cert` and `-mongos-cert`.
+    Each cert SANs every member-cluster cross-cluster pod FQDN.
+    """
+
+    def _issue(component_resource: str, secret_name: str, distribution: List[int | None]):
+        create_tls_certs(
+            issuer=multi_cluster_issuer,
+            namespace=namespace,
+            resource_name=component_resource,
+            replicas_cluster_distribution=distribution,
+            secret_name=secret_name,
+            api_client=central_cluster_client,
+        )
+
+    for shard_name in _shard_names(INITIAL_SHARD_COUNT):
+        _issue(shard_name, f"{SOURCE_CERT_PREFIX}-{shard_name}-cert", MEMBERS_PER_CLUSTER)
+    _issue(
+        f"{MDB_RESOURCE_NAME}-config",
+        f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-config-cert",
+        CONFIG_SRV_PER_CLUSTER,
+    )
+    _issue(
+        f"{MDB_RESOURCE_NAME}-mongos",
+        f"{SOURCE_CERT_PREFIX}-{MDB_RESOURCE_NAME}-mongos-cert",
+        MONGOS_PER_CLUSTER,
+    )
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_create_mdb_source(mdb: MongoDB):
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=1800)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_create_users(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    admin_user: MongoDBUser,
+    mdb_user: MongoDBUser,
+    mongot_user: MongoDBUser,
+):
+    create_search_users(namespace, central_cluster_client, admin_user, mdb_user, mongot_user)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_create_search_certs(
+    namespace: str,
+    multi_cluster_issuer: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Issue per-(cluster, shard) mongot certs + LB certs on central.
+
+    cert-manager is installed only on the central cluster, so issuing per-cluster
+    Certificate CRs on members would 404. Secrets land on central; the next step
+    replicates them to each member.
+    """
+    for i in range(len(member_cluster_clients)):
+        create_per_shard_search_tls_certs(
+            namespace=namespace,
+            issuer=multi_cluster_issuer,
+            prefix=MDBS_TLS_CERT_PREFIX,
+            shard_count=INITIAL_SHARD_COUNT,
+            mdb_resource_name=MDB_RESOURCE_NAME,
+            mdbs_resource_name=MDBS_RESOURCE_NAME,
+            cluster_index=i,
+            api_client=central_cluster_client,
+        )
+
+    # One Envoy server+client cert per cluster index, each SANing every cluster's
+    # per-shard and router proxy FQDNs (the endpoints mongods/mongos dial over requireTLS).
+    create_lb_certificates(
+        namespace=namespace,
+        issuer=multi_cluster_issuer,
+        shard_count=INITIAL_SHARD_COUNT,
+        mdb_resource_name=MDB_RESOURCE_NAME,
+        mdbs_resource_name=MDBS_RESOURCE_NAME,
+        tls_cert_prefix=MDBS_TLS_CERT_PREFIX,
+        cluster_indexes=list(range(len(member_cluster_clients))),
+        api_client=central_cluster_client,
+    )
+    _assert_lb_cert_proxy_sans(namespace, central_cluster_client, list(range(len(member_cluster_clients))))
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_replicate_secrets_to_members(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Copy centrally-issued Secrets to each member cluster.
+
+    The MongoDBSearch controller does NOT auto-replicate Secrets (intentional design;
+    customer-replicated). The MongoDB sharded controller replicates source certs, but
+    Search's own prefix is not covered. Without this step mongot pods on members can't
+    mount their TLS material and stay PodInitializing.
+    """
+    central_core = CoreV1Api(api_client=central_cluster_client)
+
+    def _copy(secret_name: str, mcc: MultiClusterClient) -> None:
+        secret_type = central_core.read_namespaced_secret(name=secret_name, namespace=namespace).type or "Opaque"
+        data = read_secret(namespace, secret_name, api_client=central_cluster_client)
+        create_or_update_secret(namespace, secret_name, data, type=secret_type, api_client=mcc.api_client)
+
+    # Mongot password — same copy to every member cluster.
+    password_secret = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
+    for mcc in member_cluster_clients:
+        _copy(password_secret, mcc)
+
+    # Per-cluster Secrets — LB certs + per-(cluster, shard) mongot certs go to their owning cluster.
+    for i, mcc in enumerate(member_cluster_clients):
+        _copy(search_resource_names.lb_server_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, i), mcc)
+        _copy(search_resource_names.lb_client_cert_name(MDBS_RESOURCE_NAME, MDBS_TLS_CERT_PREFIX, i), mcc)
+        for shard_name in _shard_names(INITIAL_SHARD_COUNT):
+            _copy(
+                search_resource_names.shard_tls_cert_name(
+                    MDBS_RESOURCE_NAME, shard_name, MDBS_TLS_CERT_PREFIX, cluster_index=i
+                ),
+                mcc,
+            )
+        logger.info(f"Replicated per-cluster Secrets to {mcc.cluster_name} (cluster_index={i})")
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_create_search_resource(
+    namespace: str,
+    mdb: MongoDB,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=1200)
+    # With the proxies up, the customer wires the routing keys per process in the OM AC so
+    # every cluster's mongods and mongos target their own cluster's proxy Services.
+    _wire_routing_via_ac(mdb, namespace, [_idx(mcc) for mcc in member_cluster_clients], INITIAL_SHARD_COUNT)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_baseline_topology(
+    namespace: str,
+    mdb: MongoDB,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Every (cluster, shard) pair must have a mongot StatefulSet, headless Service, proxy
+    Service, and ConfigMap carrying that cluster's matchTagSets as replicationReader.tagSets;
+    every cluster must additionally expose the labelled cluster-level proxy Service (mongos
+    routing) and a ready Envoy Deployment, and every pod must observe its own cluster's
+    proxy endpoints as its effective mongot routing."""
+    assert (
+        len(member_cluster_clients) == CLUSTER_COUNT
+    ), f"expected {CLUSTER_COUNT} member clusters, got {len(member_cluster_clients)}"
+    for mcc in member_cluster_clients:
+        ci = _idx(mcc)
+        for shard_name in _shard_names(INITIAL_SHARD_COUNT):
+            sts_name = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            svc_name = search_resource_names.shard_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            cm_name = search_resource_names.shard_configmap_name(MDBS_RESOURCE_NAME, shard_name, ci)
+            proxy_svc_name = search_resource_names.shard_proxy_service_name(MDBS_RESOURCE_NAME, shard_name, ci)
+
+            mcc.read_namespaced_stateful_set(sts_name, namespace)
+            mcc.read_namespaced_service(svc_name, namespace)
+            mcc.read_namespaced_service(proxy_svc_name, namespace)
+            cm = mcc.read_namespaced_config_map(cm_name, namespace)
+
+            config_yaml = cm.data.get("config.yml") or cm.data.get("mongot.yaml")
+            assert config_yaml, f"mongot CM {cm_name} missing config payload; data keys={list(cm.data or {})}"
+            rr = yaml.safe_load(config_yaml).get("syncSource", {}).get("replicationReader")
+            expected_tag_sets = [[{"name": CLUSTER_LOCATION_TAG_KEY, "value": mcc.cluster_name}]]
+            assert rr is not None, f"mongot CM {cm_name} in {mcc.cluster_name}: syncSource.replicationReader absent"
+            assert rr.get("readPreference") != "primary", (
+                f"mongot CM {cm_name} in {mcc.cluster_name}: readPreference is 'primary' "
+                "(tagSets require a non-primary read preference)"
+            )
+            assert rr.get("tagSets") == expected_tag_sets, (
+                f"mongot CM {cm_name} in {mcc.cluster_name}: replicationReader.tagSets "
+                f"{rr.get('tagSets')!r} != expected {expected_tag_sets!r}"
+            )
+
+        cluster_proxy_name = search_resource_names.mc_proxy_svc_name(MDBS_RESOURCE_NAME, ci)
+        labels = mcc.read_namespaced_service(cluster_proxy_name, namespace).metadata.labels or {}
+        assert labels.get("component") == "search-proxy", (
+            f"[{mcc.cluster_name}] cluster-level proxy Service {cluster_proxy_name} missing "
+            f"component=search-proxy label; got {labels}"
+        )
+
+        envoy_name = search_resource_names.lb_deployment_name(MDBS_RESOURCE_NAME, cluster_index=ci)
+        assert_deployment_ready_in_cluster(mcc.apps_v1_api(), name=envoy_name, namespace=namespace)
+        logger.info(f"[{mcc.cluster_name}] baseline topology verified (cluster_index={ci})")
+
+    _assert_routing_observed(namespace, mdb, member_cluster_clients, INITIAL_SHARD_COUNT)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_metrics_forwarder_baseline(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdb: MongoDB,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Non-vacuous baseline: forwarder Running on all three clusters with every (cluster,
+    shard) mongot pod registered as a MONGOT host in OM and the topology-state CM tracking
+    exactly the 3x3 shardReplicas shape — otherwise the removal tests would pass trivially."""
+    wait_for_metrics_forwarder_phase(mdbs, Phase.Running, timeout=300)
+    mdbs.assert_cluster_statuses(expected_count=CLUSTER_COUNT, expect_managed_lb=True, expect_metrics_forwarder=True)
+
+    shard_names = _shard_names(INITIAL_SHARD_COUNT)
+    for mcc in member_cluster_clients:
+        ci = _idx(mcc)
+        assert_workload_ready_in_cluster(
+            mcc,
+            namespace,
+            {sts_name: MONGOT_REPLICAS_PER_CLUSTER for sts_name in _shard_sts_names(ci, shard_names)},
+            _forwarder_names(ci)["deployment"],
+            timeout=300,
+        )
+
+    mdbs.load()
+    mdb.get_om_tester().assert_mongot_hosts_converged(
+        _expected_mongot_hosts(mdbs, INITIAL_SHARD_COUNT, [_idx(mcc) for mcc in member_cluster_clients]),
+        timeout=600,
+    )
+
+    _wait_for_state_cm_converged(
+        CoreV1Api(api_client=central_cluster_client),
+        namespace,
+        {mcc.cluster_name: _idx(mcc) for mcc in member_cluster_clients},
+        shard_names,
+    )
+
+
+# =============================================================================
+# Data plane: $search via per-cluster mongos
+# =============================================================================
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_restore_sample_database(namespace: str, tools_pod):
+    tester = _per_cluster_mongos_search_tester(namespace, 0, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    tester.mongorestore_from_url(
+        archive_url="https://atlas-education.s3.amazonaws.com/sample_mflix.archive",
+        ns_include="sample_mflix.*",
+        tools_pod=tools_pod,
+    )
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_shard_sample_collection(namespace: str):
+    """Shard sample_mflix.movies across the 3 shards so $search exercises every per-shard mongot."""
+    admin = _per_cluster_mongos_search_tester(namespace, 0, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    admin.shard_and_distribute_collection("sample_mflix", "movies")
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_create_search_index(namespace: str):
+    tester = _per_cluster_mongos_search_tester(namespace, 0, USER_NAME, USER_PASSWORD)
+    movies = SampleMoviesSearchHelper(search_tester=tester)
+    movies.create_search_index()
+    tester.wait_for_search_indexes_ready(movies.db_name, movies.col_name, timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_per_cluster_search_query(
+    namespace: str,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """$search via each cluster's mongos — proves every cluster's Envoy + per-shard mongot
+    path returns results. Each cluster's mongos targets its OWN cluster's router proxy
+    (baseline-asserted on-pod), so a per-cluster non-empty result validates that cluster's
+    local (cluster x shard) data path.
+    """
+    for cluster_index in range(len(member_cluster_clients)):
+        _wait_for_search_results(namespace, cluster_index)
+
+
+# =============================================================================
+# Lifecycle: shard removal, cluster-entry removal, and CR deletion
+# =============================================================================
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_remove_shard_lifecycle(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdb: MongoDB,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Dropping the trailing shard (search shard list FIRST so its mongot is torn down
+    before the data-bearing shard disappears, then the source) must sweep the removed
+    shard's mongot artifacts on every cluster, deregister exactly its OM hosts, prune the
+    routing-ready latch, converge the forwarder state CM, and leave the live shards'
+    artifacts untouched (UID-pinned) with every surviving pod still observing its own
+    cluster's routing (the direct-AC keys sit outside spec, so the source reconcile's
+    merge must preserve them)."""
+    live_shards = _shard_names(REDUCED_SHARD_COUNT)
+    removed_shard = _shard_names(INITIAL_SHARD_COUNT)[-1]
+
+    live_uids: Dict[str, Dict[str, str]] = {}
+    removed_readers: Dict[str, Dict[str, Callable[[], object]]] = {}
+    for mcc in member_cluster_clients:
+        live_uids[mcc.cluster_name] = _reader_uids(_local_artifact_readers(mcc, namespace, live_shards))
+        readers = _shard_artifact_readers(mcc, namespace, removed_shard)
+        # Presence guard: a 404 or missing-PVC failure here fails the capture, so the
+        # deletion polls below can never pass vacuously.
+        for read in readers.values():
+            read()
+        removed_sts = search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, removed_shard, _idx(mcc))
+        assert mongot_data_pvc_names(
+            namespace, removed_sts, api_client=mcc.api_client
+        ), f"[{mcc.cluster_name}] expected mongot data PVCs for {removed_sts}"
+        removed_readers[mcc.cluster_name] = readers
+
+    mdbs.load()
+    mdbs["spec"]["source"]["external"]["shardedCluster"]["shards"] = _source_shard_list(namespace, REDUCED_SHARD_COUNT)
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+
+    mdb.load()
+    mdb["spec"]["shardCount"] = REDUCED_SHARD_COUNT
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=1800)
+
+    _assert_routing_observed(namespace, mdb, member_cluster_clients, REDUCED_SHARD_COUNT)
+
+    for mcc in member_cluster_clients:
+        for what, read in removed_readers[mcc.cluster_name].items():
+            wait_for_resource_deleted(read, f"{what} in {mcc.cluster_name}")
+        wait_for_mongot_pvcs_deleted(
+            namespace,
+            search_resource_names.shard_statefulset_name(MDBS_RESOURCE_NAME, removed_shard, _idx(mcc)),
+            api_client=mcc.api_client,
+        )
+        assert (
+            _reader_uids(_local_artifact_readers(mcc, namespace, live_shards)) == live_uids[mcc.cluster_name]
+        ), f"[{mcc.cluster_name}] live-shard artifact UIDs changed when shard {removed_shard} was removed"
+
+    mdbs.load()
+    mdb.get_om_tester().assert_mongot_hosts_converged(
+        _expected_mongot_hosts(mdbs, REDUCED_SHARD_COUNT, [_idx(mcc) for mcc in member_cluster_clients]),
+        timeout=600,
+    )
+
+    central_core = CoreV1Api(api_client=central_cluster_client)
+    _wait_for_state_cm_converged(
+        central_core,
+        namespace,
+        {mcc.cluster_name: _idx(mcc) for mcc in member_cluster_clients},
+        live_shards,
+    )
+
+    def routing_latch_pruned() -> tuple:
+        groups = _routing_ready_groups(central_core, namespace)
+        return set(groups) == set(live_shards), f"routingReadyMongotGroups={sorted(groups)}, want {sorted(live_shards)}"
+
+    run_periodically(
+        routing_latch_pruned, timeout=300, sleep_time=5, msg="routing-ready latch to prune the removed shard"
+    )
+
+    _wait_for_search_results(namespace, 0, timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_remove_cluster_entry(
+    namespace: str,
+    central_cluster_client: kubernetes.client.ApiClient,
+    mdb: MongoDB,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """Dropping the cluster-3 entry must sweep every mongot/Envoy/forwarder artifact on
+    that cluster (main + Envoy + metrics sweeps), deregister exactly its OM hosts, drop
+    its entry from the topology-state CM, and leave BOTH survivors byte-identical
+    (UID-pinned) and serving $search. The removed cluster's SOURCE processes keep running
+    but point at its now-deleted proxies, so the customer rewires them (direct AC) to a
+    survivor's proxies for the same shard before the data-plane asserts."""
+    assert (
+        len(member_cluster_clients) == CLUSTER_COUNT
+    ), f"expected {CLUSTER_COUNT} member clusters, got {len(member_cluster_clients)}"
+    survivors, removed = member_cluster_clients[:-1], member_cluster_clients[-1]
+    assert (
+        _idx(removed) == REMOVED_CLUSTER_INDEX
+    ), f"expected the trailing entry to be index {REMOVED_CLUSTER_INDEX}, got {_idx(removed)}"
+
+    live_shards = _shard_names(REDUCED_SHARD_COUNT)
+
+    survivor_uids: Dict[str, Dict[str, str]] = {}
+    survivor_forwarder_uids: Dict[str, Dict[str, str]] = {}
+    for mcc in survivors:
+        survivor_uids[mcc.cluster_name] = _reader_uids(_local_artifact_readers(mcc, namespace, live_shards))
+        survivor_forwarder_uids[mcc.cluster_name] = _forwarder_artifact_uids(mcc, namespace, _idx(mcc))
+
+    # Presence guard on the cluster being removed (mongot + Envoy + PVCs + forwarder).
+    removed_readers = _local_artifact_readers(removed, namespace, live_shards)
+    for read in removed_readers.values():
+        read()
+    for sts_name in _shard_sts_names(_idx(removed), live_shards):
+        assert mongot_data_pvc_names(
+            namespace, sts_name, api_client=removed.api_client
+        ), f"[{removed.cluster_name}] expected mongot data PVCs for {sts_name}"
+    _forwarder_artifact_uids(removed, namespace, _idx(removed))
+    removed_protected_uids = _customer_input_uids(removed, namespace, _idx(removed))
+
+    central_core = CoreV1Api(api_client=central_cluster_client)
+    state_before = _state_cm_clusters(central_core, namespace)
+    assert set(state_before) == {
+        mcc.cluster_name for mcc in member_cluster_clients
+    }, f"state CM clusters {sorted(state_before)} do not match the member clusters"
+
+    mdbs.load()
+    surviving_entries = [deepcopy(e) for e in mdbs["spec"]["clusters"] if e["name"] != removed.cluster_name]
+    assert len(surviving_entries) == len(
+        survivors
+    ), f"expected one spec.clusters entry per survivor, got {surviving_entries}"
+    mdbs["spec"]["clusters"] = surviving_entries
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=900)
+    mdbs.assert_cluster_statuses(expected_count=len(survivors), expect_managed_lb=True, expect_metrics_forwarder=True)
+
+    # The removed cluster's source processes now point at dead endpoints — the customer
+    # repoints them at the REWIRE_TARGET_INDEX survivor's proxies (reachable via the mesh).
+    _wire_routing_via_ac(
+        mdb, namespace, [REMOVED_CLUSTER_INDEX], REDUCED_SHARD_COUNT, proxy_cluster_index=lambda _: REWIRE_TARGET_INDEX
+    )
+
+    _wait_for_cluster_artifacts_swept(removed, namespace, removed_readers, live_shards)
+    _wait_for_forwarder_artifacts_deleted(removed, namespace, _idx(removed))
+
+    mdbs.load()
+    mdb.get_om_tester().assert_mongot_hosts_converged(
+        _expected_mongot_hosts(mdbs, REDUCED_SHARD_COUNT, [_idx(mcc) for mcc in survivors]),
+        timeout=600,
+    )
+
+    def state_entry_dropped() -> tuple:
+        clusters = _state_cm_clusters(central_core, namespace)
+        if removed.cluster_name in clusters:
+            return False, f"state CM still tracks {removed.cluster_name}: {sorted(clusters)}"
+        return True, f"state CM clusters: {sorted(clusters)}"
+
+    run_periodically(state_entry_dropped, timeout=300, sleep_time=5, msg="metrics forwarder state entry cleanup")
+
+    state_after = _state_cm_clusters(central_core, namespace)
+    expected_survivor_state = {mcc.cluster_name: state_before[mcc.cluster_name] for mcc in survivors}
+    assert state_after == expected_survivor_state, (
+        f"survivor state CM entries changed when {removed.cluster_name} was removed: "
+        f"before={expected_survivor_state}, after={state_after}"
+    )
+
+    # Effective routing after the removal: survivors keep their own-cluster endpoints;
+    # the removed cluster's processes observe the rewired survivor endpoints.
+    _assert_routing_observed(namespace, mdb, survivors, REDUCED_SHARD_COUNT)
+    _assert_routing_observed(
+        namespace, mdb, [removed], REDUCED_SHARD_COUNT, proxy_cluster_index=lambda _: REWIRE_TARGET_INDEX
+    )
+
+    for mcc in survivors:
+        assert (
+            _reader_uids(_local_artifact_readers(mcc, namespace, live_shards)) == survivor_uids[mcc.cluster_name]
+        ), f"[{mcc.cluster_name}] managed artifact UIDs changed when {removed.cluster_name} was removed"
+        assert (
+            _forwarder_artifact_uids(mcc, namespace, _idx(mcc)) == survivor_forwarder_uids[mcc.cluster_name]
+        ), f"[{mcc.cluster_name}] forwarder artifact UIDs changed when {removed.cluster_name} was removed"
+        assert_workload_ready_in_cluster(
+            mcc,
+            namespace,
+            {sts_name: MONGOT_REPLICAS_PER_CLUSTER for sts_name in _shard_sts_names(_idx(mcc), live_shards)},
+            _forwarder_names(_idx(mcc))["deployment"],
+            timeout=300,
+        )
+        _wait_for_search_results(namespace, _idx(mcc), timeout=SEARCH_INDEX_READY_TIMEOUT)
+
+    assert (
+        _customer_input_uids(removed, namespace, _idx(removed)) == removed_protected_uids
+    ), f"[{removed.cluster_name}] customer-replicated Search inputs changed during the cluster sweep"
+
+
+@mark.e2e_search_mc_sharded_om_lifecycle
+def test_delete_search_resource(
+    namespace: str,
+    mdb: MongoDB,
+    mdbs: MongoDBSearch,
+    member_cluster_clients: List[MultiClusterClient],
+):
+    """CR delete: OM must drop every MONGOT host before the metrics finalizer releases
+    (the CR reading back 404 proves the whole pre-deletion path ran), the label sweeps
+    must empty every member cluster — including already-removed cluster-3 — the
+    customer-replicated inputs must survive untouched, and unwiring the search
+    setParameters from the still-Running source must drain them out of the automation
+    config. Destroys the workload — keep it last."""
+    survivors, removed = member_cluster_clients[:-1], member_cluster_clients[-1]
+    live_shards = _shard_names(REDUCED_SHARD_COUNT)
+
+    per_cluster = []
+    for mcc in survivors:
+        readers = _local_artifact_readers(mcc, namespace, live_shards)
+        for read in readers.values():
+            read()
+        for sts_name in _shard_sts_names(_idx(mcc), live_shards):
+            assert mongot_data_pvc_names(
+                namespace, sts_name, api_client=mcc.api_client
+            ), f"[{mcc.cluster_name}] expected mongot data PVCs for {sts_name}"
+        per_cluster.append((mcc, readers))
+    protected_uids = {
+        mcc.cluster_name: _customer_input_uids(mcc, namespace, _idx(mcc)) for mcc in member_cluster_clients
+    }
+
+    om_tester = mdb.get_om_tester()
+    mdbs.delete()
+
+    # Phase A: the exact-empty MONGOT host set proves deregistration ran before the
+    # finalizer released (the source's own MONGOD/MONGOS hosts are unaffected).
+    om_tester.assert_mongot_hosts_converged(set(), timeout=600)
+    for mcc in survivors:
+        _wait_for_forwarder_artifacts_deleted(mcc, namespace, _idx(mcc))
+    wait_for_search_deleted(mdbs, timeout=600)
+
+    for mcc, readers in per_cluster:
+        _wait_for_cluster_artifacts_swept(mcc, namespace, readers, live_shards)
+    # Cluster-3 was swept on entry removal and must stay empty through the CR delete.
+    wait_for_search_owned_resources_deleted(
+        removed.apps_v1_api(),
+        removed.core_v1_api(),
+        namespace,
+        MDBS_RESOURCE_NAME,
+        where=removed.cluster_name,
+    )
+
+    for mcc in member_cluster_clients:
+        assert (
+            _customer_input_uids(mcc, namespace, _idx(mcc)) == protected_uids[mcc.cluster_name]
+        ), f"[{mcc.cluster_name}] customer-replicated Search inputs changed during CR deletion"
+
+    # The search wiring on an external source is customer-owned, so the operator cannot
+    # drop it on Search delete the way it does for internal sources: the customer removes
+    # the direct-AC routing keys per process, then clears the base keys from the spec so
+    # the operator's key-removal diff drains them. The poll below proves all six keys
+    # leave every process's automation config while the source stays Running.
+    remove_mongot_host_via_ac(mdb)
+    mdb.load()
+    cleared = {key: None for key in BASE_SEARCH_SET_PARAMETER}
+    mdb["spec"]["shard"]["additionalMongodConfig"] = {"setParameter": cleared}
+    mdb["spec"]["mongos"]["additionalMongodConfig"] = {"setParameter": cleared}
+    mdb.update()
+    mdb.assert_reaches_phase(Phase.Running, timeout=900)
+
+    def search_parameters_dropped() -> tuple:
+        ac_tester = om_tester.get_automation_config_tester()
+        leftovers = []
+        for process in ac_tester.get_all_processes():
+            set_parameter = process.get("args2_6", {}).get("setParameter", {})
+            present = [key for key in SEARCH_SET_PARAMETER_KEYS if key in set_parameter]
+            if present:
+                leftovers.append(f"{process['name']}: {present}")
+        return not leftovers, f"search setParameters still in automation config: {leftovers}"
+
+    run_periodically(
+        search_parameters_dropped,
+        timeout=300,
+        sleep_time=10,
+        msg="source automation config to drop the search setParameters",
+    )

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_search/mc_sharded_om_lifecycle.py
@@ -222,10 +222,11 @@ def _assert_routing_observed(
 def _assert_lb_cert_proxy_sans(
     namespace: str, central_cluster_client: kubernetes.client.ApiClient, cluster_indexes: List[int]
 ) -> None:
-    """Every cluster's Envoy server cert must SAN every cluster's per-shard proxy and
-    router proxy FQDNs: with per-cluster routing each cluster's mongods/mongos dial their
-    own cluster's proxies over requireTLS, and the cluster-removal rewire additionally
-    sends the removed cluster's processes to a survivor's proxies."""
+    """Every cluster's Envoy server cert must carry SAN entries for every cluster's
+    per-shard proxy and router proxy FQDNs: with per-cluster routing each cluster's
+    mongods/mongos dial their own cluster's proxies over requireTLS, and the
+    cluster-removal rewire additionally sends the removed cluster's processes to a
+    survivor's proxies."""
     expected_sans = {
         search_resource_names.mc_proxy_svc_fqdn(MDBS_RESOURCE_NAME, namespace, ci) for ci in cluster_indexes
     } | {

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -24,11 +24,7 @@ from tests.common.search.connectivity import (
 )
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
-from tests.common.search.search_resource_names import (
-    lb_deployment_name,
-    mongot_statefulset_name,
-    proxy_service_name,
-)
+from tests.common.search.search_resource_names import lb_deployment_name, mongot_statefulset_name, proxy_service_name
 from tests.common.search.search_tester import SearchTester
 from tests.conftest import get_default_operator, install_official_operator, log_deployments_info
 from tests.constants import MCK_HELM_CHART, OFFICIAL_OPERATOR_IMAGE_NAME, OPERATOR_NAME

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -437,11 +437,13 @@ class TestOperatorUpgrade:
     ):
         operator = Operator(namespace=namespace, helm_args=operator_installation_config)
         expected = operator_installation_config["search.version"]
-        assert expected != upgrade_state.pre_mongot_version, f"upgrade left MDB_SEARCH_VERSION unchanged at {expected}"
         operator_version = get_operator_search_version(operator)
         assert operator_version == expected, f"operator MDB_SEARCH_VERSION {operator_version} != {expected}"
-        wait_for_mongot_rollout(namespace, expected, upgrade_state.mongot_pod_uid)
-        assert get_mongot_image_tag(namespace) != upgrade_state.pre_mongot_version
+        # The target's default Search version can legitimately equal GA's; mongot only
+        # rolls when the version actually changes, so gate the rollout wait on that.
+        if expected != upgrade_state.pre_mongot_version:
+            wait_for_mongot_rollout(namespace, expected, upgrade_state.mongot_pod_uid)
+        assert get_mongot_image_tag(namespace) == expected
 
     def test_search_running_after_upgrade(self, mdbs: MongoDBSearch):
         mdbs.assert_reaches_phase(phase=Phase.Running, timeout=300)
@@ -453,6 +455,7 @@ class TestOperatorUpgrade:
         self,
         namespace: str,
         mdbs: MongoDBSearch,
+        operator_installation_config: dict[str, str],
         upgrade_state: UpgradeState,
     ):
         mdbs.load()
@@ -479,7 +482,10 @@ class TestOperatorUpgrade:
             f"missing={missing}, uid_changed(pre, post)={replaced}, post-upgrade={post_upgrade_uids}"
         )
         assert pvc.metadata.uid == upgrade_state.mongot_pvc_uid
-        assert pod.metadata.uid != upgrade_state.mongot_pod_uid, "mongot pod did not roll to the upgraded image"
+        # The pod only rolls when the Search version changes across the upgrade;
+        # with identical GA/target versions the adopted pod legitimately stays put.
+        if operator_installation_config["search.version"] != upgrade_state.pre_mongot_version:
+            assert pod.metadata.uid != upgrade_state.mongot_pod_uid, "mongot pod did not roll to the upgraded image"
 
     def test_search_query_after_upgrade(self, sample_movies_helper: SampleMoviesSearchHelper):
         sample_movies_helper.assert_search_query(retry_timeout=60)

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -1,4 +1,8 @@
+from dataclasses import dataclass, field
+from typing import Any
+
 from kubernetes import client
+from kubernetes.client.exceptions import ApiException
 from kubetester import get_service, get_statefulset, run_periodically, try_load
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
@@ -10,14 +14,30 @@ from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
 from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search.connectivity import (
+    SEARCH_OWNER_NAME_LABEL,
+    SEARCH_OWNER_NAMESPACE_LABEL,
+    mongot_data_pvc_names,
+    wait_for_mongot_pvcs_deleted,
+    wait_for_search_deleted,
+    wait_for_search_owned_resources_deleted,
+)
 from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
 from tests.common.search.search_deployment_helper import SearchDeploymentHelper
-from tests.common.search.search_resource_names import lb_deployment_name, mongot_statefulset_name, proxy_service_name
+from tests.common.search.search_resource_names import (
+    lb_deployment_name,
+    mongot_statefulset_name,
+    proxy_service_name,
+)
 from tests.common.search.search_tester import SearchTester
-from tests.conftest import get_default_operator, log_deployments_info
+from tests.conftest import get_default_operator, install_official_operator, log_deployments_info
+from tests.constants import MCK_HELM_CHART, OFFICIAL_OPERATOR_IMAGE_NAME, OPERATOR_NAME
 from tests.search.om_deployment import get_ops_manager
 
 logger = test_logger.get_test_logger(__name__)
+
+GA_OPERATOR_VERSION = "1.9.1"
+GA_MONGOT_VERSION = "1.70.1"
 
 MDB_RESOURCE_NAME = "mdb-rs"
 
@@ -30,46 +50,228 @@ MONGOT_USER_PASSWORD = f"{MONGOT_USER_NAME}-password"
 USER_NAME = "mdb-user"
 USER_PASSWORD = f"{USER_NAME}-password"
 
+MONGOT_STATEFULSET_NAME = mongot_statefulset_name(MDB_RESOURCE_NAME)
 
-def get_operator_search_version(namespace: str, operator: Operator) -> str:
-    """Read MDB_SEARCH_VERSION from the operator pod."""
+
+@dataclass
+class UpgradeState:
+    """Pre-upgrade snapshot compared against the post-upgrade cluster state."""
+
+    search_uid: str = ""
+    pre_mongot_version: str = ""
+    artifact_uids: dict[str, str] = field(default_factory=dict)
+    mongot_pod_uid: str = ""
+    mongot_pvc_uid: str = ""
+    customer_input_uids: dict[str, str] = field(default_factory=dict)
+
+
+def expected_current_operator_image(operator_installation_config: dict[str, str]) -> str:
+    registry = operator_installation_config["registry.operator"].rstrip("/")
+    version = operator_installation_config["operator.version"]
+    build = operator_installation_config.get("operator.build", "")
+    return f"{registry}/{OFFICIAL_OPERATOR_IMAGE_NAME}:{version}{build}"
+
+
+def get_ready_operator_container(operator: Operator) -> Any:
+    """The single operator pod's operator container, asserted actually READY —
+    the Deployment template updates before the new pod is serving."""
     pods = operator.list_operator_pods()
-    assert len(pods) > 0, "No operator pods found"
+    assert len(pods) == 1, f"expected one operator pod, got {[pod.metadata.name for pod in pods]}"
     pod = pods[0]
-    env_var = next((e for e in pod.spec.containers[0].env if e.name == "MDB_SEARCH_VERSION"), None)
+    statuses = [s for s in pod.status.container_statuses or [] if s.name == OPERATOR_NAME]
+    assert len(statuses) == 1 and statuses[0].ready, f"operator container in pod {pod.metadata.name} is not ready"
+    containers = [container for container in pod.spec.containers if container.name == OPERATOR_NAME]
+    assert len(containers) == 1, f"expected one {OPERATOR_NAME} container, got {[c.name for c in containers]}"
+    return containers[0]
+
+
+def assert_operator_image(operator: Operator, expected_image: str) -> None:
+    image = get_ready_operator_container(operator).image
+    assert image == expected_image, f"ready operator pod image {image} != {expected_image}"
+
+
+def get_operator_search_version(operator: Operator) -> str:
+    """Read MDB_SEARCH_VERSION from the ready operator pod."""
+    container = get_ready_operator_container(operator)
+    env_var = next((e for e in container.env if e.name == "MDB_SEARCH_VERSION"), None)
     assert env_var is not None, "MDB_SEARCH_VERSION not found in operator pod env"
     return env_var.value
 
 
+def image_tag(image: str) -> str:
+    image_name, separator, tag = image.rpartition(":")
+    assert separator and image_name and tag, f"image {image!r} has no tag"
+    return tag
+
+
 def get_mongot_image_tag(namespace: str) -> str:
-    """Read the image tag from the mongot container in the search StatefulSet.
-
-    Because in this test installs released operator and the name of K8s resources is diff
-    there than what is expected by helpers. That's why we try the new cluster-indexed naming first,
-    then fall back to previous naming for when the released (old) operator created the StatefulSet.
-
-    TODO: Remove fallback after the next operator release ships with new naming.
-    """
-    for name in [mongot_statefulset_name(MDB_RESOURCE_NAME), f"{MDB_RESOURCE_NAME}-search"]:
-        try:
-            sts = get_statefulset(namespace, name)
-            mongot = next((c for c in sts.spec.template.spec.containers if c.name == "mongot"), None)
-            if mongot:
-                return mongot.image.split(":")[-1]
-        except Exception:
-            continue
-    raise AssertionError("mongot StatefulSet not found with either naming convention")
+    sts = get_statefulset(namespace, MONGOT_STATEFULSET_NAME)
+    mongot = next((container for container in sts.spec.template.spec.containers if container.name == "mongot"), None)
+    assert mongot is not None, f"StatefulSet {MONGOT_STATEFULSET_NAME} has no mongot container"
+    return image_tag(mongot.image)
 
 
-def assert_mongot_version_matches_operator(namespace: str, operator: Operator, phase: str):
-    """Assert that the mongot image tag matches the operator's MDB_SEARCH_VERSION."""
-    expected = get_operator_search_version(namespace, operator)
+def assert_mongot_version(namespace: str, operator: Operator, expected: str, phase: str) -> str:
+    operator_version = get_operator_search_version(operator)
     actual = get_mongot_image_tag(namespace)
-    logger.info(f"Mongot version check ({phase}): operator MDB_SEARCH_VERSION={expected}, mongot image tag={actual}")
+    logger.info(
+        f"Mongot version check ({phase}): expected={expected}, "
+        f"operator MDB_SEARCH_VERSION={operator_version}, mongot image tag={actual}"
+    )
+    assert operator_version == expected, f"operator MDB_SEARCH_VERSION {operator_version} != {expected}"
     assert actual == expected, f"mongot image tag {actual} != operator MDB_SEARCH_VERSION {expected}"
+    return actual
+
+
+def wait_for_mongot_rollout(namespace: str, expected_version: str, previous_pod_uid: str) -> None:
+    core = client.CoreV1Api()
+    pod_name = f"{MONGOT_STATEFULSET_NAME}-0"
+
+    def rolled_out() -> tuple[bool, str]:
+        statefulset_version = get_mongot_image_tag(namespace)
+        try:
+            pod = core.read_namespaced_pod(pod_name, namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return False, f"Pod {pod_name} is absent"
+            raise
+
+        mongot = next((container for container in pod.spec.containers if container.name == "mongot"), None)
+        if mongot is None:
+            return False, f"Pod {pod_name} has no mongot container"
+        mongot_status = next((s for s in pod.status.container_statuses or [] if s.name == "mongot"), None)
+        if mongot_status is None:
+            return False, f"Pod {pod_name} has no mongot container status"
+
+        pod_version = image_tag(mongot.image)
+        ready = bool(mongot_status.ready)
+        replaced = pod.metadata.uid != previous_pod_uid
+        complete = statefulset_version == pod_version == expected_version and ready and replaced
+        return complete, (
+            f"StatefulSet version={statefulset_version}, pod version={pod_version}, "
+            f"ready={ready}, replaced={replaced}"
+        )
+
+    run_periodically(rolled_out, timeout=600, sleep_time=5, msg=f"mongot rollout to {expected_version}")
+
+
+def list_search_artifacts(namespace: str) -> dict[str, list[Any]]:
+    selector = f"{SEARCH_OWNER_NAME_LABEL}={MDB_RESOURCE_NAME},{SEARCH_OWNER_NAMESPACE_LABEL}={namespace}"
+    apps = client.AppsV1Api()
+    core = client.CoreV1Api()
+    name_prefix = f"{MDB_RESOURCE_NAME}-search"
+
+    def search_named(resources: list[Any]) -> list[Any]:
+        return [
+            resource
+            for resource in resources
+            if resource.metadata.name == name_prefix or resource.metadata.name.startswith(f"{name_prefix}-")
+        ]
+
+    return {
+        "StatefulSets": search_named(apps.list_namespaced_stateful_set(namespace).items),
+        "Services": search_named(core.list_namespaced_service(namespace).items),
+        "ConfigMaps": search_named(core.list_namespaced_config_map(namespace).items),
+        "Deployments": search_named(apps.list_namespaced_deployment(namespace).items),
+        "Secrets": core.list_namespaced_secret(namespace, label_selector=selector).items,
+    }
+
+
+def search_owned_artifact_uids(namespace: str) -> dict[str, str]:
+    result = {
+        f"{kind}/{resource.metadata.name}": resource.metadata.uid
+        for kind, resources in list_search_artifacts(namespace).items()
+        for resource in resources
+    }
+    assert all(result.values()), f"Search artifacts missing UIDs: {result}"
+    return result
+
+
+def read_mongot_pod_and_pvc(namespace: str) -> tuple[Any, Any]:
+    core = client.CoreV1Api()
+    pod = core.read_namespaced_pod(f"{MONGOT_STATEFULSET_NAME}-0", namespace)
+    pvc_names = mongot_data_pvc_names(namespace, MONGOT_STATEFULSET_NAME)
+    assert len(pvc_names) == 1, f"expected one mongot PVC, got {pvc_names}"
+    return pod, core.read_namespaced_persistent_volume_claim(pvc_names[0], namespace)
+
+
+def assert_search_owner_reference(resource: Any, search_uid: str, expect_controller: bool) -> None:
+    """The GA 1.9.1 operator stamps a single non-controller MongoDBSearch owner
+    reference on Search resources; the upgraded operator stamps a single controller
+    reference (controller=true, blockOwnerDeletion) as the native-GC backstop on the
+    local cluster."""
+    owner_references = resource.metadata.owner_references or []
+    assert len(owner_references) == 1, (
+        f"{resource.kind} {resource.metadata.name} has ownerReferences={owner_references}, "
+        "expected exactly one MongoDBSearch owner"
+    )
+    owner = owner_references[0]
+    assert owner.kind == "MongoDBSearch"
+    assert owner.name == MDB_RESOURCE_NAME
+    assert owner.uid == search_uid
+    if expect_controller:
+        assert owner.controller is True
+    else:
+        assert owner.controller is not True
+
+
+def customer_input_uids(
+    namespace: str,
+    mdb: MongoDB,
+    users: tuple[MongoDBUser, MongoDBUser, MongoDBUser],
+) -> dict[str, str]:
+    uids: dict[str, str] = {}
+    for resource in (mdb, *users):
+        resource.load()
+        uid = resource["metadata"]["uid"]
+        assert uid, f"{resource.name} has no UID"
+        uids[f"custom-resource/{resource.name}"] = uid
+
+    core = client.CoreV1Api()
+    manager_configs = tuple(name for name in ("opsManager", "cloudManager") if name in mdb["spec"])
+    assert len(manager_configs) == 1, f"expected exactly one manager config, found {manager_configs}"
+    project_configmap = core.read_namespaced_config_map(mdb.config_map_name, namespace)
+    assert project_configmap.metadata.uid, f"ConfigMap {mdb.config_map_name} has no UID"
+    uids[f"configmap/{mdb.config_map_name}"] = project_configmap.metadata.uid
+
+    for secret_name in (
+        f"{ADMIN_USER_NAME}-password",
+        f"{USER_NAME}-password",
+        f"{MDB_RESOURCE_NAME}-{MONGOT_USER_NAME}-password",
+    ):
+        secret = core.read_namespaced_secret(secret_name, namespace)
+        assert secret.metadata.uid, f"Secret {secret_name} has no UID"
+        uids[f"secret/{secret_name}"] = secret.metadata.uid
+    return uids
 
 
 # --- Module-scoped fixtures (persist across upgrade) ---
+
+
+@fixture(scope="module")
+def upgrade_state() -> UpgradeState:
+    return UpgradeState()
+
+
+@fixture(scope="module")
+def ga_operator(
+    namespace: str,
+    managed_security_context: str,
+    operator_installation_config: dict[str, str],
+) -> Operator:
+    return install_official_operator(
+        namespace,
+        managed_security_context,
+        operator_installation_config,
+        central_cluster_name=None,
+        central_cluster_client=None,
+        member_cluster_clients=None,
+        member_cluster_names=None,
+        custom_operator_version=GA_OPERATOR_VERSION,
+        helm_chart_path=MCK_HELM_CHART,
+        operator_name=OPERATOR_NAME,
+        operator_image=OFFICIAL_OPERATOR_IMAGE_NAME,
+    )
 
 
 @fixture(scope="module")
@@ -130,8 +332,9 @@ def sample_movies_helper(mdb: MongoDB, namespace: str) -> SampleMoviesSearchHelp
 @mark.e2e_operator_upgrade_search
 class TestDeployOnOfficialOperator:
 
-    def test_install_latest_official_operator(self, namespace: str, official_operator: Operator):
-        official_operator.wait_for_operator_ready()
+    def test_install_ga_operator(self, namespace: str, ga_operator: Operator):
+        ga_operator.wait_for_operator_ready()
+        assert_operator_image(ga_operator, f"quay.io/mongodb/{OFFICIAL_OPERATOR_IMAGE_NAME}:{GA_OPERATOR_VERSION}")
         log_deployments_info(namespace)
 
     @skip_if_cloud_manager
@@ -167,8 +370,10 @@ class TestDeployOnOfficialOperator:
         mdbs.update()
         mdbs.assert_reaches_phase(Phase.Running, timeout=300)
 
-    def test_verify_mongot_version(self, namespace: str, official_operator: Operator):
-        assert_mongot_version_matches_operator(namespace, official_operator, "pre-upgrade")
+    def test_verify_mongot_version(self, namespace: str, ga_operator: Operator, upgrade_state: UpgradeState):
+        upgrade_state.pre_mongot_version = assert_mongot_version(
+            namespace, ga_operator, GA_MONGOT_VERSION, "pre-upgrade"
+        )
 
     def test_wait_for_database_resource_ready(self, mdb: MongoDB):
         mdb.assert_abandons_phase(Phase.Running, timeout=300)
@@ -183,6 +388,33 @@ class TestDeployOnOfficialOperator:
     def test_search_query_before_upgrade(self, sample_movies_helper: SampleMoviesSearchHelper):
         sample_movies_helper.assert_search_query(retry_timeout=60)
 
+    def test_capture_single_cluster_upgrade_state(
+        self,
+        namespace: str,
+        mdbs: MongoDBSearch,
+        mdb: MongoDB,
+        admin_user: MongoDBUser,
+        user: MongoDBUser,
+        mongot_user: MongoDBUser,
+        upgrade_state: UpgradeState,
+    ):
+        mdbs.load()
+        upgrade_state.search_uid = mdbs["metadata"]["uid"]
+        sts = get_statefulset(namespace, MONGOT_STATEFULSET_NAME)
+        assert_search_owner_reference(sts, upgrade_state.search_uid, expect_controller=False)
+        # GA never stamps the component label; its appearance after the upgrade
+        # (together with the controller owner ref) is the adoption marker.
+        labels = sts.metadata.labels or {}
+        assert "component" not in labels, f"GA-created StatefulSet unexpectedly carries a component label: {labels}"
+
+        pod, pvc = read_mongot_pod_and_pvc(namespace)
+        upgrade_state.artifact_uids = search_owned_artifact_uids(namespace)
+        upgrade_state.mongot_pod_uid = pod.metadata.uid
+        upgrade_state.mongot_pvc_uid = pvc.metadata.uid
+        assert upgrade_state.mongot_pod_uid
+        assert upgrade_state.mongot_pvc_uid
+        upgrade_state.customer_input_uids = customer_input_uids(namespace, mdb, (admin_user, user, mongot_user))
+
 
 @mark.e2e_operator_upgrade_search
 class TestOperatorUpgrade:
@@ -192,17 +424,62 @@ class TestOperatorUpgrade:
             namespace, operator_installation_config=operator_installation_config, apply_crds_first=True
         )
         operator.wait_for_operator_ready()
+        target_image = expected_current_operator_image(operator_installation_config)
+        assert target_image != f"quay.io/mongodb/{OFFICIAL_OPERATOR_IMAGE_NAME}:{GA_OPERATOR_VERSION}"
+        assert_operator_image(operator, target_image)
         log_deployments_info(namespace)
+
+    def test_verify_mongot_version_after_upgrade(
+        self,
+        namespace: str,
+        operator_installation_config: dict[str, str],
+        upgrade_state: UpgradeState,
+    ):
+        operator = Operator(namespace=namespace, helm_args=operator_installation_config)
+        expected = operator_installation_config["search.version"]
+        assert expected != upgrade_state.pre_mongot_version, f"upgrade left MDB_SEARCH_VERSION unchanged at {expected}"
+        operator_version = get_operator_search_version(operator)
+        assert operator_version == expected, f"operator MDB_SEARCH_VERSION {operator_version} != {expected}"
+        wait_for_mongot_rollout(namespace, expected, upgrade_state.mongot_pod_uid)
+        assert get_mongot_image_tag(namespace) != upgrade_state.pre_mongot_version
 
     def test_search_running_after_upgrade(self, mdbs: MongoDBSearch):
         mdbs.assert_reaches_phase(phase=Phase.Running, timeout=300)
 
-    def test_verify_mongot_version_after_upgrade(self, namespace: str, operator_installation_config: dict[str, str]):
-        operator = Operator(namespace=namespace, helm_args=operator_installation_config)
-        assert_mongot_version_matches_operator(namespace, operator, "post-upgrade")
-
     def test_database_running_after_upgrade(self, mdb: MongoDB):
         mdb.assert_reaches_phase(phase=Phase.Running, timeout=600)
+
+    def test_adopts_existing_single_cluster_artifacts(
+        self,
+        namespace: str,
+        mdbs: MongoDBSearch,
+        upgrade_state: UpgradeState,
+    ):
+        mdbs.load()
+        assert mdbs["metadata"]["uid"] == upgrade_state.search_uid
+        sts = get_statefulset(namespace, MONGOT_STATEFULSET_NAME)
+        assert_search_owner_reference(sts, upgrade_state.search_uid, expect_controller=True)
+        labels = sts.metadata.labels or {}
+        assert (
+            labels.get("component") == "mongot"
+        ), f"upgraded operator must stamp component=mongot on the adopted StatefulSet: {labels}"
+
+        pod, pvc = read_mongot_pod_and_pvc(namespace)
+        # Every pre-upgrade artifact must survive adoption in place (same kind/name/UID);
+        # artifacts newly introduced by the target operator are allowed.
+        post_upgrade_uids = search_owned_artifact_uids(namespace)
+        missing = {what: uid for what, uid in upgrade_state.artifact_uids.items() if what not in post_upgrade_uids}
+        replaced = {
+            what: (uid, post_upgrade_uids[what])
+            for what, uid in upgrade_state.artifact_uids.items()
+            if what in post_upgrade_uids and post_upgrade_uids[what] != uid
+        }
+        assert not missing and not replaced, (
+            f"pre-upgrade Search artifacts must survive adoption with their UIDs: "
+            f"missing={missing}, uid_changed(pre, post)={replaced}, post-upgrade={post_upgrade_uids}"
+        )
+        assert pvc.metadata.uid == upgrade_state.mongot_pvc_uid
+        assert pod.metadata.uid != upgrade_state.mongot_pod_uid, "mongot pod did not roll to the upgraded image"
 
     def test_search_query_after_upgrade(self, sample_movies_helper: SampleMoviesSearchHelper):
         sample_movies_helper.assert_search_query(retry_timeout=60)
@@ -243,3 +520,62 @@ class TestScaleWithManagedLB:
 
     def test_search_query_after_scale(self, sample_movies_helper: SampleMoviesSearchHelper):
         sample_movies_helper.assert_search_query(retry_timeout=60)
+
+
+@mark.e2e_operator_upgrade_search
+class TestPostUpgradeCleanup:
+
+    def test_search_has_no_finalizers(self, mdbs: MongoDBSearch):
+        mdbs.load()
+        assert not (mdbs["metadata"].get("finalizers") or []), (
+            f"MongoDBSearch has finalizers and cannot prove owner-reference GC with the operator down: "
+            f"{mdbs['metadata'].get('finalizers')}"
+        )
+
+    def test_scale_operator_down(self, namespace: str):
+        apps = client.AppsV1Api()
+        core = client.CoreV1Api()
+        apps.patch_namespaced_deployment_scale(OPERATOR_NAME, namespace, {"spec": {"replicas": 0}})
+
+        def scaled_down() -> tuple[bool, str]:
+            deployment = apps.read_namespaced_deployment(OPERATOR_NAME, namespace)
+            spec_replicas = deployment.spec.replicas or 0
+            current_replicas = deployment.status.replicas or 0
+            ready_replicas = deployment.status.ready_replicas or 0
+            operator_pods = core.list_namespaced_pod(
+                namespace,
+                label_selector=f"app.kubernetes.io/name={OPERATOR_NAME}",
+            ).items
+            done = spec_replicas == current_replicas == ready_replicas == 0 and not operator_pods
+            pod_names = [pod.metadata.name for pod in operator_pods]
+            return done, f"spec={spec_replicas}, current={current_replicas}, ready={ready_replicas}, pods={pod_names}"
+
+        run_periodically(scaled_down, timeout=120, sleep_time=5, msg=f"Operator Deployment {OPERATOR_NAME} scale-down")
+
+    def test_delete_search_resource(self, mdbs: MongoDBSearch):
+        mdbs.delete()
+        wait_for_search_deleted(mdbs, timeout=300)
+
+    def test_owner_reference_gc_removes_search_artifacts(self, namespace: str):
+        wait_for_search_owned_resources_deleted(
+            client.AppsV1Api(),
+            client.CoreV1Api(),
+            namespace,
+            MDB_RESOURCE_NAME,
+            where=f"post-upgrade MongoDBSearch {namespace}/{MDB_RESOURCE_NAME}",
+            timeout=300,
+        )
+        wait_for_mongot_pvcs_deleted(namespace, MONGOT_STATEFULSET_NAME, timeout=300)
+
+    def test_customer_inputs_are_preserved(
+        self,
+        namespace: str,
+        mdb: MongoDB,
+        admin_user: MongoDBUser,
+        user: MongoDBUser,
+        mongot_user: MongoDBUser,
+        upgrade_state: UpgradeState,
+    ):
+        assert customer_input_uids(namespace, mdb, (admin_user, user, mongot_user)) == (
+            upgrade_state.customer_input_uids
+        )

--- a/scripts/dev/contexts/e2e_multi_cluster_om80_search
+++ b/scripts/dev/contexts/e2e_multi_cluster_om80_search
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/root-context"
+source "${script_dir}/variables/om80"
+source "${script_dir}/variables/mongodb_search_dev"
+
+export KUBE_ENVIRONMENT_NAME=multi
+export CLUSTER_NAME="kind-e2e-cluster-1"
+export MEMBER_CLUSTERS="kind-e2e-cluster-1 kind-e2e-cluster-2 kind-e2e-cluster-3"
+export CENTRAL_CLUSTER=kind-e2e-cluster-1
+export TEST_POD_CLUSTER=kind-e2e-cluster-1
+export test_pod_cluster=kind-e2e-cluster-1
+
+# MCK is capable of deploying a webhook (optional).
+# To do so it needs know which pods to select for routing traffic
+# in the Service and operator name currently serves as a selector.
+# This value must be different for multi cluster setup,
+# but we can unify once we are done with unified operator
+# installation for both multicluster and single cluster setups.
+export OPERATOR_NAME="mongodb-kubernetes-operator-multi-cluster"


### PR DESCRIPTION
# Summary

Validates the pre-GA→current operator **upgrade path for MongoDBSearch** — GA-created artifacts are adopted in place (same kind/name/UID) with the controller owner reference and `component` label stamped post-upgrade — plus a **full 3-cluster hub-and-spoke sharded lifecycle e2e on self-hosted OM** (new `e2e_multi_cluster_om80_search` variant). Re-enables `e2e_operator_upgrade_search` in both operator task groups. Stacked on #1383.

- **Upgrade suite** (`tests/upgrades/operator_upgrade_search.py`): pre-upgrade artifact/UID capture from the GA operator (GA stamps no owner labels — their post-upgrade appearance is the adoption marker; hence name-prefix listing pre-upgrade), post-upgrade UID stability, and GC-with-operator-scaled-down proving owner-reference locality.
- **OM lifecycle module** (`tests/multicluster_search/mc_sharded_om_lifecycle.py`): metrics forwarder on self-hosted OM incl. OM host deregistration + finalizer release; live cluster removal; all six mongot `setParameter` keys drained at unwiring, asserted directly in the automation config (routing keys removed via AC edit, base keys via spec). Forwarder teardown asserts the three kinds that exist on plain-HTTP OM (the CA ConfigMap is never created there).

## Proof of Work

- **Head `ce11184a5`** = the 4 commits rebased byte-identical onto #1383's `eb6da7b25` (range-diff all `=`) + one lint-fix commit (`ty` reader-callable typing). **PR patch [`6a887993`](https://spruce.corp.mongodb.com/version/6a887993eaddf70007d699bb) fully green** — incl. the new `e2e_multi_cluster_om80_search` variant and the re-enabled upgrade task; the single red was an unrelated kind SA-token bootstrap flake, green on restart. The static-operator variant isn't tagged `pr_patch_e2e`, so its `e2e_operator_upgrade_search` run was proven via surgical patch [`6a888bbe`](https://spruce.corp.mongodb.com/version/6a888bbe1688c400073a9c1a) — all green.
- Earlier lineage: 69/69 full matrix incl. both upgrade-task wirings ([`6a67d2fb`](https://spruce.corp.mongodb.com/version/6a67d2fb23f20c000767e00e)); the lifecycle module has five consecutive green runs (first full pass [`6a68e413`](https://spruce.corp.mongodb.com/version/6a68e4136d2d540007a68bb4)).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` label retained

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
