### PR TITLE
CLOUDP-407997: Fix mckci promote call by enabling Go

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -653,9 +653,11 @@ tasks:
       - command: shell.exec
         type: test
         params:
+          shell: bash
           working_dir: src/github.com/mongodb/mongodb-kubernetes
           script: |
-            scripts/mckci release promote group --commit "${revision}"
+            source .generated/context.export.env
+            scripts/mckci release promote images --commit "${revision}"
 
   # Notify Slack about build failures
   # On patches: stdout only. On mainline: stdout + Slack

--- a/ci/internal/release/images_promote.go
+++ b/ci/internal/release/images_promote.go
@@ -14,14 +14,29 @@ type ImagesPromoteResult struct {
 	Tags    []string
 }
 
+// shortCommit mirrors the COMMIT_SHA_SHORT computed in
+// scripts/dev/contexts/evg-private-context (via git rev-parse --short=8 HEAD)
+// and used as the staging build tag in scripts/release/atomic_pipeline.py.
+// If commit is longer than 8 characters the first 8 are returned; otherwise
+// commit is returned unchanged (handles both full 40-char SHAs and values
+// already shortened).
+func shortCommit(commit string) string {
+	if len(commit) > 8 {
+		return commit[:8]
+	}
+	return commit
+}
+
 // PromoteImages promotes every image at the given commit, writing
 // promoted-{commit}-{version} and promoted-latest to each image's PRIMARY
 // staging repository only (secondary repositories are intentionally left
-// untouched for now). The source image is the version-tagged image the staging
-// build already pushed, e.g. <staging-repo>:<version>.
+// untouched for now). The source image is the short-commit-tagged image the
+// staging build already pushed, e.g. <staging-repo>:<short-commit> (matching the
+// COMMIT_SHA_SHORT tag produced by scripts/dev/contexts/evg-private-context and
+// scripts/release/atomic_pipeline.py).
 //
 // It hard-fails on the first image that cannot be promoted (e.g. its
-// version-tagged source image is missing), so a broken merge build does not
+// commit-tagged source image is missing), so a broken merge build does not
 // silently promote a partial image set. connect resolves a Registry for an image's
 // host; the CLI passes DefaultRegistryConnector and tests inject a fake.
 func PromoteImages(images []ReleaseImage, commit string, dryRun bool, connect RegistryConnector) ([]ImagesPromoteResult, error) {
@@ -32,10 +47,11 @@ func PromoteImages(images []ReleaseImage, commit string, dryRun bool, connect Re
 		return nil, errors.New("no images to promote")
 	}
 
+	srcTag := shortCommit(commit)
 	results := make([]ImagesPromoteResult, 0, len(images))
 	for _, img := range images {
 		host, path := splitHostRepo(img.StagingRepo)
-		src := fmt.Sprintf("%s:%s", img.StagingRepo, img.Version)
+		src := fmt.Sprintf("%s:%s", img.StagingRepo, srcTag)
 		tags, err := Promote(PromoteInputs{
 			Image:   src,
 			Commit:  commit,

--- a/ci/internal/release/images_promote_test.go
+++ b/ci/internal/release/images_promote_test.go
@@ -44,12 +44,12 @@ func TestPromoteImages(t *testing.T) {
 
 	want := []copyCall{
 		{
-			srcRef:  "quay.io/staging/mongodb-kubernetes:1.9.2",
+			srcRef:  "quay.io/staging/mongodb-kubernetes:abc1234",
 			dstRepo: "staging/mongodb-kubernetes",
 			tags:    []string{PromotedTagFor("abc1234", "1.9.2"), promotedLatestTag()},
 		},
 		{
-			srcRef:  "quay.io/staging/mongodb-kubernetes-readinessprobe:1.0.24",
+			srcRef:  "quay.io/staging/mongodb-kubernetes-readinessprobe:abc1234",
 			dstRepo: "staging/mongodb-kubernetes-readinessprobe",
 			tags:    []string{PromotedTagFor("abc1234", "1.0.24"), promotedLatestTag()},
 		},
@@ -68,7 +68,7 @@ func TestPromoteImages(t *testing.T) {
 func TestPromoteImagesHardFailsOnMissingSource(t *testing.T) {
 	fake := &fakeRegistry{
 		fail: map[string]error{
-			"quay.io/staging/mongodb-kubernetes-readinessprobe:1.0.24": errors.New("source not found"),
+			"quay.io/staging/mongodb-kubernetes-readinessprobe:abc1234": errors.New("source not found"),
 		},
 	}
 	connect := func(url string) Registry { return fake }
@@ -81,6 +81,38 @@ func TestPromoteImagesHardFailsOnMissingSource(t *testing.T) {
 	_, err := PromoteImages(images, "abc1234", false, connect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected hard failure mentioning readiness-probe, got %v", err)
+	}
+}
+
+func TestPromoteImagesUsesShortCommitAsSourceTag(t *testing.T) {
+	fake := &fakeRegistry{}
+	connect := func(url string) Registry { return fake }
+
+	images := []ReleaseImage{
+		{Name: "operator", StagingRepo: "quay.io/staging/mongodb-kubernetes", Version: "2.0.0", IsAnchor: true},
+	}
+	fullCommit := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+	results, err := PromoteImages(images, fullCommit, false, connect)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(results))
+	}
+
+	// Source tag must be the first 8 chars of the full commit.
+	wantSrcRef := "quay.io/staging/mongodb-kubernetes:a1b2c3d4"
+	if len(fake.copies) != 1 {
+		t.Fatalf("copies: got %d, want 1", len(fake.copies))
+	}
+	if fake.copies[0].srcRef != wantSrcRef {
+		t.Errorf("srcRef: got %q, want %q", fake.copies[0].srcRef, wantSrcRef)
+	}
+	// Destination tag must still use the FULL commit.
+	wantDstTag := PromotedTagFor(fullCommit, "2.0.0")
+	if fake.copies[0].tags[0] != wantDstTag {
+		t.Errorf("promoted tag: got %q, want %q", fake.copies[0].tags[0], wantDstTag)
 	}
 }
 


### PR DESCRIPTION
# Summary

Ensure Go is available so it does not fail to run `mckci`:
e.g.
https://spruce.corp.mongodb.com/task/mongodb_kubernetes_mckci_release_promote_mckci_release_promote_b9536bd3d7d7760924e2daeb053286ee03caca03_26_07_21_11_03_09/logs?execution=0

- Fix CLI call to use images, instead of group. 
- Tag the build image, which uses the commit sha prefix, not the version.

## Proof of Work

Tested by allowing to patch on `mckci_release_promote` locally
```shell
% git diff
diff --git a/.evergreen.yml b/.evergreen.yml
index b110a81be..563df6008 100644
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -2284,11 +2284,11 @@ buildvariants:
   # Only on commit builds — see DEVPROD-27436 note on notify_master_build_status below.
   - name: mckci_release_promote
     display_name: mckci_release_promote
-    allowed_requesters: [ "commit" ]
-    depends_on:
-      - name: "*"
-        variant: ".staging"
-        status: "success"
+    allowed_requesters: [ "commit", "patch" ]
+    # depends_on:
+    #   - name: "*"
+    #     variant: ".staging"
+    #     status: "success"
     run_on:
       - ubuntu2404-small
     tasks:
jose.vazquez@M-GCDWYL7D9T ~/mongodb/mongodb-kubernetes (CLOUDP-407997/fix-mckci-promote)
% evergreen patch -p mongodb-kubernetes -v mckci_release_promote -t mckci_release_promote -d "Test mckci_release_promote Go PATH fix" -f -y -u --path .evergreen.yml
Patch successfully created.

         ID : 6a5f7e11365c0b00089e9a8a
    Project : mongodb-kubernetes
    Created : 2026-07-21 14:11:31.824 +0000 UTC
Description : Test mckci_release_promote Go PATH fix
      Build : https://spruce.corp.mongodb.com/version/6a5f7e11365c0b00089e9a8a
     Status : created
 ```
 ✅ [Quick test passed](https://spruce.corp.mongodb.com/version/6a5f7e11365c0b00089e9a8a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
   