### PR TITLE
Example patch using custom MongoDB Agent (108.0.26.9047-1)

### DIFF
--- a/build_info_agent.json
+++ b/build_info_agent.json
@@ -1,7 +1,7 @@
 {
   "platforms": {
     "linux/amd64": {
-      "agent_suffixes": ["linux_x86_64.tar.gz"],
+      "agent_suffixes": ["linux_x86_64.tar.gz", "rhel8_x86_64.tar.gz"],
       "tools_suffixes": ["rhel93-x86_64-{TOOLS_VERSION}.tgz", "rhel90-x86_64-{TOOLS_VERSION}.tgz"]
     },
     "linux/arm64": {

--- a/controllers/operator/agents/upgrade.go
+++ b/controllers/operator/agents/upgrade.go
@@ -48,29 +48,7 @@ type ClientSecret struct {
 // happens and all existing MongoDBs are required to get agents upgraded (otherwise the "You need to upgrade the
 // automation agent before publishing other changes" error happens for automation config pushes from the Operator)
 func UpgradeAllIfNeeded(ctx context.Context, cs ClientSecret, omConnectionFactory om.ConnectionFactory, watchNamespace []string, isMulti bool) {
-	mux.Lock()
-	defer mux.Unlock()
-
-	if !time.Now().After(nextScheduledTime) {
-		return
-	}
-	log := zap.S()
-	log.Info("Performing a regular upgrade of Agents for all the MongoDB resources in the cluster...")
-
-	allMDBs, err := readAllMongoDBs(ctx, cs.Client, watchNamespace, isMulti)
-	if err != nil {
-		log.Errorf("Failed to read MongoDB resources to ensure Agents have the latest version: %s", err)
-		return
-	}
-
-	err = doUpgrade(ctx, cs.Client, cs.SecretClient, omConnectionFactory, allMDBs)
-	if err != nil {
-		log.Errorf("Failed to perform upgrade of Agents: %s", err)
-	}
-
-	log.Info("The upgrade of Agents for all the MongoDB resources in the cluster is finished.")
-
-	nextScheduledTime = nextScheduledTime.Add(pause)
+	// Disabled for custom agent testing — prevents auto-upgrade from overwriting the custom agent
 }
 
 // ScheduleUpgrade allows to reset the timer to Now() which makes sure the next MongoDB reconciliation will ensure

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
@@ -117,7 +117,7 @@ download_agent() {
     script_log "Downloading Agent version: ${AGENT_VERSION}"
     script_log "Downloading a Mongodb Agent from ${base_url:?}"
     curl_opts=(
-        "${base_url}/download/agent/automation/${AGENT_FILE}"
+        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/patches/6a5f74111e6a450007f4f7a5/automation-agent/local/mongodb-mms-automation-agent-108.0.26.9047-1.rhel8_x86_64.tar.gz"
 
         "--location" "--silent" "--retry" "3" "--fail" "-v"
         "--output" "automation-agent.tar.gz"

--- a/release.json
+++ b/release.json
@@ -6,7 +6,7 @@
   "initDatabaseVersion": "1.10.0",
   "initOpsManagerVersion": "1.10.0",
   "databaseImageVersion": "1.10.0",
-  "agentVersion": "108.0.12.8846-1",
+  "agentVersion": "108.0.26.9047-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
   "openshift": {

--- a/scripts/release/agent/validation.py
+++ b/scripts/release/agent/validation.py
@@ -187,7 +187,7 @@ def get_working_agent_filename(agent_version: str, platform: str) -> str:
         The working filename, or the first filename if none work
     """
     agent_base_url = (
-        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/automation-agent/prod"
+        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/patches/6a5f74111e6a450007f4f7a5/automation-agent/local"
     )
 
     return _find_working_filename(agent_version, platform, agent_base_url, _build_agent_filenames, "agent")

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -343,7 +343,7 @@ def build_agent_pipeline(
     )
 
     agent_base_url = (
-        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/automation-agent/prod"
+        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/patches/6a5f74111e6a450007f4f7a5/automation-agent/local"
     )
     tools_base_url = "https://fastdl.mongodb.org/tools/db"
 


### PR DESCRIPTION
## Summary

Example patch for testing a custom MongoDB Agent build against the MCK e2e suite. Not intended to be merged — reusable template for testing custom agent builds from Evergreen patches.

**Agent**: version `108.0.26.9047-1` from Evergreen patch `6a5f74111e6a450007f4f7a5` (amd64, `rhel8_x86_64.tar.gz`).

## Changes

**Common (all architectures):**
- `controllers/operator/agents/upgrade.go` — disable `UpgradeAllIfNeeded` to prevent auto-upgrade from overwriting the custom agent

**Non-static (CloudQA, Community, OM non-static):**
- `docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh` — replace the download URL with the custom S3 URL (one line)

**Static + AppDB (Static CloudQA, Static OM/AppDB):**
- `scripts/release/atomic_pipeline.py` — replace the agent build S3 URL with the custom patch URL
- `scripts/release/agent/validation.py` — replace `get_working_agent_filename`'s validation URL with the custom patch URL (validation and download must use the same URL)
- `release.json` — bump `agentVersion` to `108.0.26.9047-1` so `generate_agent_build_args` constructs the correct filename
- `build_info_agent.json` — add `rhel8_x86_64.tar.gz` as a fallback suffix for amd64 (only file that exists at the custom S3 URL)

## How to use

Submit an Evergreen patch with the desired e2e variant:

```
evergreen patch -p mongodb-kubernetes -v e2e_mdb_kind_ubi_cloudqa -t e2e_mdb_kind_cloudqa_task_group -y -f --browse --param evergreen_retry=false -u -d "test custom agent"
```

## Proof of Work

- e2e: pending — this is an example patch; the Evergreen patch above is the test
- unit: `go build ./controllers/operator/agents/` passes
