### PR TITLE
test: extend Search operator-upgrade convergence timeout

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -202,7 +202,7 @@ class TestOperatorUpgrade:
         assert_mongot_version_matches_operator(namespace, operator, "post-upgrade")
 
     def test_database_running_after_upgrade(self, mdb: MongoDB):
-        mdb.assert_reaches_phase(phase=Phase.Running, timeout=300)
+        mdb.assert_reaches_phase(phase=Phase.Running, timeout=600)
 
     def test_search_query_after_upgrade(self, sample_movies_helper: SampleMoviesSearchHelper):
         sample_movies_helper.assert_search_query(retry_timeout=60)


### PR DESCRIPTION
# Summary

The Search operator-upgrade test can require slightly more than 300 seconds for the MongoDB resource to return to `Running` while its agents converge on the new automation goal. Increase that wait to 600 seconds, matching the Search convergence bound used throughout the search test suite. The test still fails if convergence does not complete and continues to verify the post-upgrade Search query.

## Proof of Work

- Evergreen [`6a60f58d675e8600077b878a`](https://spruce.corp.mongodb.com/version/6a60f58d675e8600077b878a): `e2e_operator_upgrade_search` passed at execution 0. The database wait reproduced the lagging-agent state and completed naturally after 306.328 seconds without restarting pods.
- Evergreen full canonical matrix for the earlier 800-second revision: [`6a612606020d9600076bba80`](https://spruce.corp.mongodb.com/version/6a612606020d9600076bba80) — all 69 tasks green across 12 variants, `e2e_operator_upgrade_search` passing at execution 0 (the timeout bump alone suffices; observed convergence ~306s, comfortably inside 600). The 600-second head is validated by the full canonical matrix [`6a616736e38dd4000798ea58`](https://spruce.corp.mongodb.com/version/6a616736e38dd4000798ea58) — all 69 tasks green, `e2e_operator_upgrade_search` passing at execution 0 with the 600s bound. One unrelated task (`e2e_search_external_metrics_forwarder_sharded` on om80) failed its initial database-provisioning step and passed on Evergreen's automatic restart. One unrelated task (`e2e_search_enterprise_metrics_forwarder_sharded` on om80) failed its initial database-provisioning step (`test_create_database_resource`, a file this PR does not touch) and passed on a manual restart.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog` label applies because this is a test-only timeout adjustment.

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
