### PR TITLE
CLOUDP-407997: Fix container copying

### DIFF
--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // ErrTagNotFound is returned by Registry.Digest when the reference does not
@@ -57,13 +59,34 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 	if err != nil {
 		return fmt.Errorf("get %s: %w", srcRef, err)
 	}
+
+	var img v1.Image
+	var idx v1.ImageIndex
+	if desc.MediaType.IsIndex() {
+		idx, err = desc.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("get index %s: %w", srcRef, err)
+		}
+	} else {
+		img, err = desc.Image()
+		if err != nil {
+			return fmt.Errorf("get image %s: %w", srcRef, err)
+		}
+	}
+
 	for _, tag := range tags {
 		dst, err := name.NewTag(fmt.Sprintf("%s/%s:%s", t.host, dstRepo, tag), t.nameOpts()...)
 		if err != nil {
 			return fmt.Errorf("parse target tag %s: %w", tag, err)
 		}
-		if err := remote.Tag(dst, desc, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-			return fmt.Errorf("tag %s: %w", tag, err)
+		if idx != nil {
+			if err := remote.WriteIndex(dst, idx, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+				return fmt.Errorf("write index %s: %w", tag, err)
+			}
+		} else {
+			if err := remote.Write(dst, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+				return fmt.Errorf("write image %s: %w", tag, err)
+			}
 		}
 	}
 	return nil

--- a/ci/internal/release/registry_test.go
+++ b/ci/internal/release/registry_test.go
@@ -1,0 +1,52 @@
+package release
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRegistry_CopyWithTags(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err, "failed to parse test server url")
+	host := u.Host // e.g., 127.0.0.1:54321
+
+	fakeImg, err := random.Image(1024, 2)
+	require.NoError(t, err, "failed to create random fake image")
+
+	wantDigest, err := fakeImg.Digest()
+	require.NoError(t, err, "failed to get src digest")
+
+	srcRefStr := host + "/source-repo:v1"
+	srcRef, err := name.ParseReference(srcRefStr, name.Insecure)
+	require.NoError(t, err, "failed to parse src ref")
+	require.NoError(t, remote.Write(srcRef, fakeImg), "failed to write source image")
+
+	// 4. Exercise cRegistry.CopyWithTags (Insecure mode since HTTP)
+	reg := &cRegistry{host: host, insecure: true}
+	tags := []string{"latest", "v1.0.0"}
+
+	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", tags),
+		"CopyWithTags failed")
+
+	for _, tag := range tags {
+		dstRef, err := name.ParseReference(host+"/target-repo:"+tag, name.Insecure)
+		require.NoError(t, err, "failed to parse dst ref")
+
+		dstDesc, err := remote.Get(dstRef)
+		require.NoError(t, err, "failed to get target image %s", tag)
+
+		// Verify SHA digest preservation!
+		assert.Equal(t, dstDesc.Digest, wantDigest, "digest mismatch for tag %s", tag)
+	}
+}


### PR DESCRIPTION
# Summary

Not just tag at destination, but ensure to copy any underlying indexed images recursively.

This already behaves like `skopeo copy --preserve-digest` as it clones raw images and indexes, without any re-parsing or re-formatting involved. 

## Proof of Work

CI tests pass, including a new added unit test.

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
