### PR TITLE
Fix EVG issues - recent evergreen doesn't allow multiple << 

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -646,7 +646,6 @@ functions:
           FLAGS: ${flags}
           AGENT_VERSION_OVERRIDE: ${agent_version}
           AGENT_TOOLS_VERSION: ${agent_tools_version}
-          MDB_CUSTOM_AGENT_URL: ${mdb_custom_agent_url}
 
   teardown_cloud_qa_all:
     - command: shell.exec

--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -646,6 +646,7 @@ functions:
           FLAGS: ${flags}
           AGENT_VERSION_OVERRIDE: ${agent_version}
           AGENT_TOOLS_VERSION: ${agent_tools_version}
+          MDB_CUSTOM_AGENT_URL: ${mdb_custom_agent_url}
 
   teardown_cloud_qa_all:
     - command: shell.exec

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -222,10 +222,6 @@ parameters:
     value: "0"
     description: set this to 1 if you want shell scripts to enable set -x
 
-  - key: mdb_custom_agent_url
-    value: ""
-    description: "Full URL to a custom agent tarball. When set (via Evergreen expansion from mms-automation downstream_expansions.set), agent and init-database image builds use this URL instead of the production S3 path. Both manual (release.json customAgent) and automatic (MDB_CUSTOM_AGENT_URL) modes share the same code path."
-
 # Triggered manually or by PCT.
 patch_aliases:
   - alias: "periodic_teardowns"
@@ -273,10 +269,6 @@ patch_aliases:
   - alias: "race"
     description: "Run race detector variants"
     variant_tags: [ "race" ]
-    task: ".*"
-  - alias: "agent_integration"
-    description: "Run static and non-static E2E pairs with a custom agent from upstream (triggered by mms-automation Patch Trigger Alias)"
-    variant_tags: [ "agent_integration" ]
     task: ".*"
 
 # Triggered whenever the GitHub PR is created
@@ -1613,7 +1605,7 @@ buildvariants:
 
   - name: e2e_om70_kind_ubi
     display_name: e2e_om70_kind_ubi
-    tags: [ "staging", "e2e_test_suite", "patch", "om7", "agent_integration" ]
+    tags: [ "staging", "e2e_test_suite", "patch", "om7" ]
     run_on:
       - ubuntu2204-medium-high-memory
     <<: *base_om7_dependency
@@ -1625,7 +1617,7 @@ buildvariants:
 
   - name: e2e_static_om70_kind_ubi
     display_name: e2e_static_om70_kind_ubi
-    tags: [ "staging", "e2e_test_suite", "static", "om7", "agent_integration" ]
+    tags: [ "staging", "e2e_test_suite", "static", "om7" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
@@ -1636,7 +1628,7 @@ buildvariants:
 
   - name: e2e_om80_kind_ubi
     display_name: e2e_om80_kind_ubi
-    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "agent_integration" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
     <<: [*production_code_paths, *base_om8_dependency]
     run_on:
       - ubuntu2204-medium-high-memory
@@ -1650,7 +1642,7 @@ buildvariants:
 
   - name: e2e_static_om80_kind_ubi
     display_name: e2e_static_om80_kind_ubi
-    tags: [ "staging", "e2e_test_suite", "static", "agent_integration" ]
+    tags: [ "staging", "e2e_test_suite", "static" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om8_dependency

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -222,6 +222,10 @@ parameters:
     value: "0"
     description: set this to 1 if you want shell scripts to enable set -x
 
+  - key: mdb_custom_agent_url
+    value: ""
+    description: "Full URL to a custom agent tarball. When set (via Evergreen expansion from mms-automation downstream_expansions.set), agent and init-database image builds use this URL instead of the production S3 path. Both manual (release.json customAgent) and automatic (MDB_CUSTOM_AGENT_URL) modes share the same code path."
+
 # Triggered manually or by PCT.
 patch_aliases:
   - alias: "periodic_teardowns"
@@ -269,6 +273,10 @@ patch_aliases:
   - alias: "race"
     description: "Run race detector variants"
     variant_tags: [ "race" ]
+    task: ".*"
+  - alias: "agent_integration"
+    description: "Run static and non-static E2E pairs with a custom agent from upstream (triggered by mms-automation Patch Trigger Alias)"
+    variant_tags: [ "agent_integration" ]
     task: ".*"
 
 # Triggered whenever the GitHub PR is created
@@ -1605,7 +1613,7 @@ buildvariants:
 
   - name: e2e_om70_kind_ubi
     display_name: e2e_om70_kind_ubi
-    tags: [ "staging", "e2e_test_suite", "patch", "om7" ]
+    tags: [ "staging", "e2e_test_suite", "patch", "om7", "agent_integration" ]
     run_on:
       - ubuntu2204-medium-high-memory
     <<: *base_om7_dependency
@@ -1617,7 +1625,7 @@ buildvariants:
 
   - name: e2e_static_om70_kind_ubi
     display_name: e2e_static_om70_kind_ubi
-    tags: [ "staging", "e2e_test_suite", "static", "om7" ]
+    tags: [ "staging", "e2e_test_suite", "static", "om7", "agent_integration" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
@@ -1628,7 +1636,7 @@ buildvariants:
 
   - name: e2e_om80_kind_ubi
     display_name: e2e_om80_kind_ubi
-    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
+    tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "agent_integration" ]
     <<: [*production_code_paths, *base_om8_dependency]
     run_on:
       - ubuntu2204-medium-high-memory
@@ -1642,7 +1650,7 @@ buildvariants:
 
   - name: e2e_static_om80_kind_ubi
     display_name: e2e_static_om80_kind_ubi
-    tags: [ "staging", "e2e_test_suite", "static" ]
+    tags: [ "staging", "e2e_test_suite", "static", "agent_integration" ]
     run_on:
       - ubuntu2404-large
     <<: *base_om8_dependency

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -716,16 +716,14 @@ task_groups:
   # Task group for deploying mongodbcommunity resources and testing the (former) MCO
   - name: e2e_mdb_community_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task]
     tasks:
       - e2e_community_replicaset_scale
 
   # This is the task group that contains all the tests run in the e2e_mdb_kind_ubi_cloudqa build variant
   - name: e2e_mdb_kind_cloudqa_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       # e2e_kube_only_task_group
       - e2e_crd_validation
@@ -852,14 +850,12 @@ task_groups:
       - e2e_replica_set_oidc_workforce
       - e2e_sharded_cluster_oidc_m2m_group
       - e2e_sharded_cluster_oidc_m2m_user
-    <<: *teardown_group
 
   # All MongoDBSearch tests that fit on large instances (mongot requires 2 CPU).
   # Added to cloudqa-large variants.
   - name: e2e_mdb_kind_search_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks: &single_cluster_search_tasks
       - e2e_search_community_basic
       - e2e_search_community_auto_embedding
@@ -880,14 +876,12 @@ task_groups:
       - e2e_search_replicaset_external_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_mongot_replicaset_x509_auth
-    <<: *teardown_group
 
   # MongoDBSearch tests that require a large instance (multiple mongots per shard:
   # 2 shards x 2 mongots x 2 CPU = 8 CPU). Added to cloudqa-large variants.
   - name: e2e_mdb_kind_search_large_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_search_sharded_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_sharded_internal_mongodb_multi_mongot_managed_lb
@@ -904,7 +898,6 @@ task_groups:
       - e2e_search_cds_hot_reload
       - e2e_search_envoy_retry_policy
       - e2e_search_auto_embedding_rolling_restart
-    <<: *teardown_group
 
   # Coverage for the multi-cluster block (GA default). The
   # e2e_mdb_kind_ubi_cloudqa_search_block variant leaves MDB_SEARCH_ENABLE_MULTI_CLUSTER
@@ -913,22 +906,19 @@ task_groups:
   # replicaset + sharded sources) proving SC search is unaffected.
   - name: e2e_mdb_kind_search_block_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_search_block_multi_cluster
       - e2e_search_community_basic
       - e2e_search_replicaset_external_mongodb_single_mongot
       - e2e_search_sharded_internal_mongodb_single_mongot
-    <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_task_group but for om80 variants.
   # Uses setup_and_teardown_task (not cloudqa) since ops_manager_version is not 'cloud_qa'.
   # Metrics-forwarder tests require Ops Manager, so they run only on the om variant.
   - name: e2e_om80_kind_search_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_search_community_basic
       - e2e_search_community_auto_embedding
@@ -951,15 +941,13 @@ task_groups:
       - e2e_search_mongot_replicaset_x509_auth
       - e2e_search_enterprise_metrics_forwarder_replicaset
       - e2e_search_external_metrics_forwarder_replicaset
-    <<: *teardown_group
 
   # Same as e2e_mdb_kind_search_large_task_group but for om80 variants.
   # Uses setup_and_teardown_task (not cloudqa) since ops_manager_version is not 'cloud_qa'.
   # Metrics-forwarder tests require Ops Manager, so they run only on the om variant.
   - name: e2e_om80_kind_search_large_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_search_sharded_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_sharded_internal_mongodb_multi_mongot_managed_lb
@@ -978,25 +966,20 @@ task_groups:
       - e2e_search_auto_embedding_rolling_restart
       - e2e_search_enterprise_metrics_forwarder_sharded
       - e2e_search_external_metrics_forwarder_sharded
-    <<: *teardown_group
 
   # this task group contains just a one task, which is smoke testing whether the operator
   # works correctly when we run it without installing webhook cluster roles
   - name: e2e_mdb_kind_no_webhook_roles_cloudqa_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_replica_set_agent_flags_and_readinessProbe
-    <<: *teardown_group
 
   # This task group mostly duplicates tests running in e2e_mdb_kind_ubi_cloudqa
   # This is mostly a smoke test, so we execute only a few essential ones.
   - name: e2e_mdb_openshift_ubi_cloudqa_task_group
     max_hosts: 2
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
-    <<: *teardown_group
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_crd_validation
       - e2e_replica_set_scram_sha_256_user_connectivity
@@ -1006,16 +989,13 @@ task_groups:
 
   - name: e2e_mdb_openshift_search_ubi_cloudqa_task_group
     max_hosts: 1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
-    <<: *teardown_group
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_search_sharded_openshift_external
 
   - name: e2e_custom_domain_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa]
     tasks:
       - e2e_replica_set
 
@@ -1023,8 +1003,7 @@ task_groups:
   # cluster-wide resources so should be run in isolated K8s clusters only (Kind or Minikube).
   - name: e2e_operator_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_operator_upgrade_replica_set
       # TODO(KUBE-102): re-enable post-GA. Disabled because the MongoDBSearch CRD is
@@ -1038,24 +1017,20 @@ task_groups:
       - e2e_operator_multi_namespaces
       - e2e_appdb_tls_operator_upgrade_v1_32_to_mck
       - e2e_meko_mck_upgrade
-    <<: *teardown_group
 
   # e2e_operator_race_with_telemetry_task_group includes the tests for testing the operator with race detector enabled
   # additionally, it sends telemetry to cloud-dev; more here: https://wiki.corp.mongodb.com/display/MMS/Telemetry
   - name: e2e_operator_race_with_telemetry_task_group
     max_hosts: -1
-    <<: *setup_group_multi_cluster
-    <<: *setup_and_teardown_task
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_reconcile_race_with_telemetry
-    <<: *teardown_group
 
   # e2e_operator_task_group includes the tests for the specific Operator configuration/behavior. They may deal with
   # cluster-wide resources so should be run in isolated K8s clusters only (Kind or Minikube).
   - name: e2e_static_operator_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_operator_upgrade_replica_set
       # TODO(KUBE-102): re-enable post-GA. Disabled because the MongoDBSearch CRD is
@@ -1069,12 +1044,10 @@ task_groups:
       - e2e_operator_multi_namespaces
       - e2e_appdb_tls_operator_upgrade_v1_32_to_mck
       - e2e_meko_mck_upgrade
-    <<: *teardown_group
 
   - name: e2e_multi_cluster_kind_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_multi_cluster_replica_set
       - e2e_multi_cluster_replica_set_migration
@@ -1145,12 +1118,10 @@ task_groups:
       - e2e_search_simulated_mc_rs
       - e2e_search_simulated_mc_sharded
 
-    <<: *teardown_group
 
   - name: e2e_multi_cluster_2_clusters_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_multi_cluster_2_clusters_replica_set
       - e2e_multi_cluster_2_clusters_clusterwide
@@ -1160,12 +1131,10 @@ task_groups:
       - e2e_search_connectivity_tool_mc_sharded
       - e2e_search_ext_mc_rs_x509_enc_mtls
       - e2e_search_ext_mc_sharded_scram_enc_mtls
-    <<: *teardown_group
 
   - name: e2e_multi_cluster_om_appdb_task_group
     max_hosts: -1
-    <<: *setup_group_multi_cluster
-    <<: *setup_and_teardown_task
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
     tasks:
       # Dedicated AppDB Multi-Cluster tests
       - e2e_multi_cluster_appdb_validation
@@ -1215,12 +1184,10 @@ task_groups:
     # disabled tests:
     #    - e2e_om_multiple # multi-cluster failures in EVG
     #    - e2e_om_appdb_scale_up_down # test not "reused" for multi-cluster appdb
-    <<: *teardown_group
 
   - name: e2e_static_multi_cluster_om_appdb_task_group
     max_hosts: -1
-    <<: *setup_group_multi_cluster
-    <<: *setup_and_teardown_task
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
     tasks:
       # Dedicated AppDB Multi-Cluster tests
       - e2e_multi_cluster_appdb_validation
@@ -1267,25 +1234,21 @@ task_groups:
       - e2e_om_update_before_reconciliation
       - e2e_om_feature_controls
       - e2e_multi_cluster_sharded_disaster_recovery
-    <<: *teardown_group
 
   # Dedicated task group for deploying OM Multi-Cluster when the operator is in the central cluster
   # that is not in the mesh
   - name: e2e_multi_cluster_om_operator_not_in_mesh_task_group
     max_hosts: -1
-    <<: *setup_group_multi_cluster
-    <<: *setup_and_teardown_task
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_multi_cluster_om_clusterwide_operator_not_in_mesh_networking
-    <<: *teardown_group
 
 
   # This task group runs on Kind clusters and includes ALL Ops Manager tests
   # including the cluster-wide resources changing and operator upgrade tests.
   - name: e2e_ops_manager_kind_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_appdb_external_connectivity
       - e2e_om_appdb_flags_and_config
@@ -1325,12 +1288,10 @@ task_groups:
       - e2e_vault_setup_om
       - e2e_vault_setup_om_backup
       - e2e_operator_upgrade_ops_manager
-    <<: *teardown_group
 
   - name: e2e_static_ops_manager_kind_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_appdb_external_connectivity
       - e2e_om_appdb_flags_and_config
@@ -1369,94 +1330,74 @@ task_groups:
     #    - e2e_om_ops_manager_https_enabled_internet_mode
     #    - e2e_om_ops_manager_https_enabled
     #    - e2e_om_ops_manager_https_enabled_prefix
-    <<: *teardown_group
 
   - name: e2e_smoke_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_ops_manager_backup
-    <<: *teardown_group
 
   - name: e2e_smoke_arm_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_replica_set
-    <<: *teardown_group
 
   - name: e2e_smoke_ibm_task_group
     max_hosts: -1
-    <<: *setup_group_ibm
-    <<: *setup_and_teardown_task_cloudqa
+    <<: [*setup_group_ibm, *setup_and_teardown_task_cloudqa, *teardown_group]
     tasks:
       - e2e_replica_set
-    <<: *teardown_group
 
   - name: e2e_ops_manager_kind_5_0_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_remotemode
       - e2e_om_ops_manager_backup_restore
       - e2e_om_ops_manager_queryable_backup
       - e2e_om_ops_manager_backup
-    <<: *teardown_group
 
   # TODO (CLOUDP-346008): Remove this task group once the issue with queryable backup task is resolved in OM8
   - name: e2e_ops_manager_kind_5_0_only_task_group_without_queryable_backup
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_remotemode
       - e2e_om_ops_manager_backup_restore
       - e2e_om_ops_manager_backup
-    <<: *teardown_group
 
   # Tests features only supported on OM60
   - name: e2e_ops_manager_kind_6_0_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_ops_manager_prometheus
-    <<: *teardown_group
 
   # Tests features only supported on OM80
   - name: e2e_ops_manager_kind_8_0_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_ops_manager_backup_object_lock
-    <<: *teardown_group
 
   # Tests features only supported on OM70 and OM80, its only upgrade test as we test upgrading from 6 to 7 or 7 to 8
   - name: e2e_ops_manager_upgrade_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_ops_manager_upgrade
-    <<: *teardown_group
 
   # Tests features only supported on OM60
   - name: e2e_static_ops_manager_kind_6_0_only_task_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_ops_manager_prometheus
-    <<: *teardown_group
 
   - name: e2e_kind_olm_group
     max_hosts: -1
-    <<: *setup_group
-    <<: *setup_and_teardown_task
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     setup_task_can_fail_task: true
     setup_task:
       # Even if the two first tasks are already part of setup_and_teardown_task,
@@ -1470,7 +1411,6 @@ task_groups:
       - e2e_olm_operator_upgrade
       - e2e_olm_operator_upgrade_with_resources
       - e2e_olm_meko_operator_upgrade_with_resources
-    <<: *teardown_group
 
 buildvariants:
   ## OCP version drift check — opens a PR if the cluster version has changed
@@ -1507,10 +1447,9 @@ buildvariants:
   - name: e2e_mdb_community
     display_name: e2e_mdb_community
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *community_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *community_dependency
     tasks:
       - name: e2e_mdb_community_task_group
 
@@ -1518,30 +1457,27 @@ buildvariants:
   - name: e2e_mdb_kind_ubi_cloudqa
     display_name: e2e_mdb_kind_ubi_cloudqa
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-medium
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_mdb_kind_cloudqa_task_group
 
   - name: e2e_custom_domain_mdb_kind_ubi_cloudqa
     display_name: e2e_custom_domain_mdb_kind_ubi_cloudqa
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_custom_domain_task_group
 
   - name: e2e_static_mdb_kind_ubi_cloudqa
     display_name: e2e_static_mdb_kind_ubi_cloudqa
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-medium
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_mdb_kind_cloudqa_task_group
 
@@ -1568,10 +1504,9 @@ buildvariants:
   - name: e2e_mdb_kind_ubi_cloudqa_large
     display_name: e2e_mdb_kind_ubi_cloudqa_large
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_mdb_kind_search_task_group
       - name: e2e_mdb_kind_search_large_task_group
@@ -1592,10 +1527,9 @@ buildvariants:
   - name: e2e_mdb_kind_ubi_cloudqa_search_block
     display_name: e2e_mdb_kind_ubi_cloudqa_search_block
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_mdb_kind_search_block_task_group
 
@@ -1695,10 +1629,9 @@ buildvariants:
   - name: e2e_om80_kind_ubi
     display_name: e2e_om80_kind_ubi
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_om8_dependency]
     run_on:
       - ubuntu2204-medium-high-memory
-    <<: *base_om8_dependency
     tasks:
       - name: e2e_ops_manager_kind_only_task_group
       # TODO (CLOUDP-346008): Replace this task group with e2e_ops_manager_kind_5_0_only_task_group once the issue with queryable backup task is resolved in OM8
@@ -1721,10 +1654,9 @@ buildvariants:
   - name: e2e_om80_kind_ubi_large
     display_name: e2e_om80_kind_ubi_large
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_om8_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_om8_dependency
     tasks:
       - name: e2e_om80_kind_search_task_group
       - name: e2e_om80_kind_search_large_task_group
@@ -1871,10 +1803,9 @@ buildvariants:
   - name: e2e_multi_cluster_kind
     display_name: e2e_multi_cluster_kind
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_om7_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_om7_dependency
     tasks:
       - name: e2e_multi_cluster_kind_task_group
 
@@ -1890,10 +1821,9 @@ buildvariants:
   - name: e2e_multi_cluster_2_clusters
     display_name: e2e_multi_cluster_2_clusters
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_om7_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_om7_dependency
     tasks:
       - name: e2e_multi_cluster_2_clusters_task_group
 
@@ -1909,10 +1839,9 @@ buildvariants:
   - name: e2e_multi_cluster_om_appdb
     display_name: e2e_multi_cluster_om_appdb
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_om7_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_om7_dependency
     tasks:
       - name: e2e_multi_cluster_om_appdb_task_group
 
@@ -1928,10 +1857,9 @@ buildvariants:
   - name: e2e_multi_cluster_om_operator_not_in_mesh
     display_name: e2e_multi_cluster_om_operator_not_in_mesh
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_om7_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_om7_dependency
     tasks:
       - name: e2e_multi_cluster_om_operator_not_in_mesh_task_group
 
@@ -1940,10 +1868,9 @@ buildvariants:
   - name: e2e_operator_kind_ubi_cloudqa
     display_name: e2e_operator_kind_ubi_cloudqa
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_operator_task_group
 
@@ -1959,10 +1886,9 @@ buildvariants:
   - name: e2e_operator_no_webhook_roles_cloudqa
     display_name: e2e_operator_no_webhook_roles_cloudqa
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
-    <<: *production_code_paths
+    <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-large
-    <<: *base_no_om_image_dependency
     tasks:
       - name: e2e_mdb_kind_no_webhook_roles_cloudqa_task_group
 
@@ -2011,8 +1937,7 @@ buildvariants:
   - name: e2e_mco_tests
     display_name: "e2e_mco_tests"
     tags: [ "pr_patch_e2e", "staging", "e2e_mco_test_suite" ]
-    <<: *production_code_paths
-    <<: *community_dependency
+    <<: [*production_code_paths, *community_dependency]
     run_on:
       - ubuntu2404-large
 


### PR DESCRIPTION
# Summary

This pull request refactors the `.evergreen.yml` configuration to standardize and simplify the use of YAML anchors and merges for task groups and build variants. The main changes consolidate multiple `<<:` merge keys into single array merges, ensure teardown steps are consistently included, and clean up redundancy in build variant definitions.

**Task group configuration improvements:**

* Replaced multiple individual `<<:` YAML merge keys with a single array merge for task groups, improving readability and maintainability in `.evergreen.yml`.

## Proof of Work

- ci starts and runs 

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
