### PR TITLE
Avoid golvulncheck in precommit (lean on GH wf only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,15 +141,6 @@ repos:
         stages: [pre-commit]
         priority: 6
 
-      - id: govulncheck
-        name: govulncheck
-        entry: env GOTELEMETRY=off go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
-        language: system
-        pass_filenames: false
-        files: (\.go$|^go\.(mod|sum)$)
-        stages: [pre-commit]
-        priority: 6
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
# Summary

Avoid running `golvulncheck` on pre-commit directly, as introduces unnecessary noise on feature branches. Rely on the GitHub workflow alone instead, which runs when merging on master.

## Proof of Work

CI pass

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
