### PR TITLE
KUBE-179: harden metrics-forwarder and Envoy cleanup error paths

### DIFF
--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -1046,6 +1046,10 @@ func (s *MongoDBSearch) IsWireprotoEnabled() bool {
 	return ok && val == "true"
 }
 
+func (s *MongoDBSearch) IsReconciliationDisabled() bool {
+	return s.Annotations[DisableReconciliationAnnotation] == "true"
+}
+
 func (s *MongoDBSearch) GetEffectiveMongotPort() int32 {
 	if s.IsWireprotoEnabled() {
 		return s.GetMongotWireprotoPort()

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -861,7 +861,7 @@ func (s *MongoDBSearch) GetOwnerReferences() []metav1.OwnerReference {
 	ownerReference := *metav1.NewControllerRef(s, schema.GroupVersionKind{
 		Group:   v1.SchemeGroupVersion.Group,
 		Version: v1.SchemeGroupVersion.Version,
-		Kind:    s.Kind,
+		Kind:    s.GetKind(),
 	})
 	return []metav1.OwnerReference{ownerReference}
 }

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -31,6 +31,26 @@ func TestReplicasOrDefault(t *testing.T) {
 	})
 }
 
+func TestIsReconciliationDisabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "nil annotations"},
+		{name: "missing annotation", annotations: map[string]string{"other": "true"}},
+		{name: "false", annotations: map[string]string{DisableReconciliationAnnotation: "false"}},
+		{name: "true", annotations: map[string]string{DisableReconciliationAnnotation: "true"}, want: true},
+		{name: "case sensitive", annotations: map[string]string{DisableReconciliationAnnotation: "True"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			search := &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations}}
+			assert.Equal(t, tc.want, search.IsReconciliationDisabled())
+		})
+	}
+}
+
 func TestHasMultipleReplicas(t *testing.T) {
 	mk := func(cs ...ClusterSpec) *MongoDBSearch {
 		return &MongoDBSearch{Spec: MongoDBSearchSpec{Clusters: cs}}

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -152,7 +152,7 @@ func NewAppDBReplicaSetReconciler(ctx context.Context, imageUrls images.ImageUrl
 func (r *ReconcileAppDbReplicaSet) initializeStateStore(ctx context.Context, appDBSpec omv1.AppDBSpec, omAnnotations map[string]string, log *zap.SugaredLogger) error {
 	r.deploymentState = NewAppDBDeploymentState()
 
-	r.stateStore = NewStateStore[AppDBDeploymentState](&appDBSpec, r.ownerReferences, r.centralClient)
+	r.stateStore = NewStateStore[AppDBDeploymentState](&appDBSpec, r.ownerReferences, r.centralClient, "")
 	if state, err := r.stateStore.ReadState(ctx); err != nil {
 		if apiErrors.IsNotFound(err) {
 			// If the deployment state config map is missing, then it might be either:

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -201,7 +201,7 @@ func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *Op
 func (r *OpsManagerReconcilerHelper) initializeStateStore(ctx context.Context, reconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger, clusterNamesFromClusterSpecList []string) error {
 	r.deploymentState = NewOMDeploymentState()
 
-	r.stateStore = NewStateStore[OMDeploymentState](opsManager, kube.BaseOwnerReference(opsManager), reconciler.client)
+	r.stateStore = NewStateStore[OMDeploymentState](opsManager, kube.BaseOwnerReference(opsManager), reconciler.client, "")
 	if err := r.stateStore.read(ctx); err != nil {
 		if apiErrors.IsNotFound(err) {
 			// If the deployment state config map is missing, then it might be either:

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -95,6 +95,7 @@ type MongoDBSearchReconciler struct {
 
 	memberClusterClientsMap map[string]kubernetesClient.Client // per-cluster Kubernetes client; empty in single-cluster installs
 	memberClusterReadersMap map[string]client.Reader
+	localNamedClusters      bool
 	operatorClusterName     string
 
 	prepareSearch prepareSearchFunc
@@ -130,6 +131,7 @@ func newMongoDBSearchReconciler(
 		operatorSearchConfig:    operatorSearchConfig,
 		memberClusterClientsMap: clientsMap,
 		memberClusterReadersMap: memberClusterReadersMap,
+		localNamedClusters:      operatorClusterName != "" || (len(memberClustersMap) == 0 && !env.ReadBoolOrDefault(util.SearchEnableMultiClusterEnv, false)), // nolint:forbidigo
 		operatorClusterName:     operatorClusterName,
 		prepareSearch:           newPrepareSearch(operatorClusterName),
 	}
@@ -191,6 +193,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		}
 	}
 
+	// Adopt state written by GA releases even when its data needs no change.
 	state, err := searchcontroller.MutateSearchState(ctx, r.kubeClient, mdbSearch, func(*searchcontroller.SearchDeploymentState) bool {
 		return false
 	})
@@ -198,7 +201,18 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("failed to read search state: %w", err)), log)
 	}
 
-	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(r.kubeClient, mdbSearch, searchSource, r.operatorSearchConfig, r.memberClusterClientsMap, state)
+	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(
+		r.kubeClient,
+		mdbSearch,
+		searchSource,
+		r.operatorSearchConfig,
+		r.memberClusterClientsMap,
+		state,
+		r.localNamedClusters,
+	).WithCleanupReaders(
+		r.uncachedReader,
+		r.memberClusterReadersMap,
+	)
 
 	result, err := reconcileHelper.Reconcile(ctx, log).ReconcileResult()
 	if err != nil {

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.uber.org/zap"
@@ -13,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -87,30 +89,48 @@ func newPrepareSearch(operatorClusterName string) prepareSearchFunc {
 
 type MongoDBSearchReconciler struct {
 	kubeClient           kubernetesClient.Client
+	uncachedReader       client.Reader
 	watch                *watch.ResourceWatcher
 	operatorSearchConfig searchcontroller.OperatorSearchConfig
 
 	memberClusterClientsMap map[string]kubernetesClient.Client // per-cluster Kubernetes client; empty in single-cluster installs
+	memberClusterReadersMap map[string]client.Reader
+	operatorClusterName     string
 
 	prepareSearch prepareSearchFunc
 }
 
 func newMongoDBSearchReconciler(
 	kubeClient client.Client,
+	apiReader client.Reader,
 	operatorSearchConfig searchcontroller.OperatorSearchConfig,
 	memberClustersMap map[string]client.Client,
+	memberClusterReadersMap map[string]client.Reader,
 	operatorClusterName string,
 ) *MongoDBSearchReconciler {
 	clientsMap := make(map[string]kubernetesClient.Client, len(memberClustersMap))
 	for k, v := range memberClustersMap {
 		clientsMap[k] = kubernetesClient.NewClient(v)
 	}
+	if memberClusterReadersMap == nil {
+		memberClusterReadersMap = make(map[string]client.Reader, len(memberClustersMap))
+		for clusterName, memberClient := range memberClustersMap {
+			memberClusterReadersMap[clusterName] = memberClient
+		}
+	}
+
+	if apiReader == nil {
+		apiReader = kubeClient
+	}
 
 	return &MongoDBSearchReconciler{
 		kubeClient:              kubernetesClient.NewClient(kubeClient),
+		uncachedReader:          apiReader,
 		watch:                   watch.NewResourceWatcher(),
 		operatorSearchConfig:    operatorSearchConfig,
 		memberClusterClientsMap: clientsMap,
+		memberClusterReadersMap: memberClusterReadersMap,
+		operatorClusterName:     operatorClusterName,
 		prepareSearch:           newPrepareSearch(operatorClusterName),
 	}
 }
@@ -129,7 +149,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	// pause reconciliation on a single CR so owned objects can be mutated
 	// without the operator reverting them.
 	// Useful for tests when the operator is running locally and not in the pod.
-	if mdbSearch.GetAnnotations()[searchv1.DisableReconciliationAnnotation] == "true" {
+	if mdbSearch.IsReconciliationDisabled() {
 		log.Infof("MongoDBSearch %s/%s reconciliation disabled by %s annotation; skipping",
 			mdbSearch.GetNamespace(), mdbSearch.GetName(), searchv1.DisableReconciliationAnnotation)
 		return reconcile.Result{}, nil
@@ -153,24 +173,7 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		r.watch.AddWatchedResourceIfNotAdded(searchSource.KeyfileSecretName(), mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
 	}
 
-	// Watch for changes in database source CA certificate secrets or configmaps
-	tlsSourceConfig := searchSource.TLSConfig()
-	if tlsSourceConfig != nil {
-		for wType, resources := range tlsSourceConfig.ResourcesToWatch {
-			for _, resource := range resources {
-				r.watch.AddWatchedResourceIfNotAdded(resource.Name, resource.Namespace, wType, mdbSearch.NamespacedName())
-			}
-		}
-	}
-
-	// Watch our own TLS certificate secret for changes (non-sharded only; sharded watches are per-member-cluster)
-	if mdbSearch.Spec.Security.TLS != nil {
-		if _, ok := searchSource.(searchcontroller.SearchSourceShardedDeployment); !ok {
-			// Non-sharded: watch the single source secret
-			sourceSecretNsName := mdbSearch.TLSSecretNamespacedName()
-			r.watch.AddWatchedResourceIfNotAdded(sourceSecretNsName.Name, sourceSecretNsName.Namespace, watch.Secret, mdbSearch.NamespacedName())
-		}
-	}
+	r.registerTLSResourceWatches(mdbSearch, searchSource)
 
 	if mdbSearch.Spec.AutoEmbedding != nil {
 		r.watch.AddWatchedResourceIfNotAdded(mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name, mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
@@ -236,13 +239,76 @@ func (r *MongoDBSearchReconciler) surfaceMissingSecrets(
 	}
 }
 
-func (r *MongoDBSearchReconciler) getSourceMongoDBForSearch(ctx context.Context, kubeClient client.Client, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
+func (r *MongoDBSearchReconciler) getSourceMongoDBForSearch(ctx context.Context, kubeClient client.Reader, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
 	return getSearchSource(ctx, kubeClient, r.watch, search, log)
 }
 
+type mongoDBSearchResourceWatch struct {
+	obj        client.Object
+	handler    handler.EventHandler
+	predicates []predicate.Predicate
+}
+
+func centralMongoDBSearchResourceWatches(r *MongoDBSearchReconciler) []mongoDBSearchResourceWatch {
+	searchOwnerHandler := handler.EnqueueRequestsFromMapFunc(khandler.EnqueueMemberClusterObjectToSearch)
+	searchOwnerPredicates := []predicate.Predicate{watch.PredicatesForMultiClusterSearchResource()}
+	return []mongoDBSearchResourceWatch{
+		{obj: &searchv1.MongoDBSearch{}, handler: &handler.EnqueueRequestForObject{}},
+		{obj: &mdbv1.MongoDB{}, handler: &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}},
+		{obj: &mdbcv1.MongoDBCommunity{}, handler: &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch}},
+		{obj: &appsv1.Deployment{}, handler: searchOwnerHandler, predicates: searchOwnerPredicates},
+		{obj: &appsv1.StatefulSet{}, handler: searchOwnerHandler, predicates: searchOwnerPredicates},
+		{obj: &corev1.Service{}, handler: searchOwnerHandler, predicates: searchOwnerPredicates},
+		{obj: &corev1.Secret{}, handler: &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch, MapFunc: khandler.EnqueueMemberClusterObjectToSearch}},
+		{obj: &corev1.ConfigMap{}, handler: &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch, MapFunc: khandler.EnqueueMemberClusterObjectToSearch}},
+	}
+}
+
+func memberMongoDBSearchResourceWatches(r *MongoDBSearchReconciler) []mongoDBSearchResourceWatch {
+	searchOwnerHandler := handler.EnqueueRequestsFromMapFunc(khandler.EnqueueMemberClusterObjectToSearch)
+	searchOwnerPredicates := []predicate.Predicate{watch.PredicatesForMultiClusterSearchResource()}
+	return []mongoDBSearchResourceWatch{
+		{obj: &appsv1.Deployment{}, handler: searchOwnerHandler, predicates: searchOwnerPredicates},
+		{obj: &appsv1.StatefulSet{}, handler: searchOwnerHandler, predicates: searchOwnerPredicates},
+		{obj: &corev1.Service{}, handler: searchOwnerHandler, predicates: searchOwnerPredicates},
+		{obj: &corev1.ConfigMap{}, handler: &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch, MapFunc: khandler.EnqueueMemberClusterObjectToSearch}},
+		{obj: &corev1.Secret{}, handler: &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch, MapFunc: khandler.EnqueueMemberClusterObjectToSearch}},
+	}
+}
+
+func (r *MongoDBSearchReconciler) registerTLSResourceWatches(mdbSearch *searchv1.MongoDBSearch, searchSource searchcontroller.SearchSourceDBResource) {
+	if tlsSourceConfig := searchSource.TLSConfig(); tlsSourceConfig != nil {
+		for wType, resources := range tlsSourceConfig.ResourcesToWatch {
+			for _, resource := range resources {
+				r.watch.AddWatchedResourceIfNotAdded(resource.Name, resource.Namespace, wType, mdbSearch.NamespacedName())
+			}
+		}
+	}
+	if mdbSearch.Spec.Security.TLS == nil {
+		return
+	}
+	if shardedSource, ok := searchSource.(searchcontroller.SearchSourceShardedDeployment); ok {
+		for _, cluster := range mdbSearch.Spec.Clusters {
+			for _, shardName := range shardedSource.GetShardNames() {
+				sourceSecretNsName := mdbSearch.TLSSecretForClusterShard(cluster.ResolveIndex(), shardName)
+				r.watch.AddWatchedResourceIfNotAdded(sourceSecretNsName.Name, sourceSecretNsName.Namespace, watch.Secret, mdbSearch.NamespacedName())
+			}
+		}
+		return
+	}
+	for _, secret := range []types.NamespacedName{
+		mdbSearch.TLSSecretNamespacedName(),
+		mdbSearch.TLSOperatorSecretNamespacedName(),
+	} {
+		r.watch.AddWatchedResourceIfNotAdded(secret.Name, secret.Namespace, watch.Secret, mdbSearch.NamespacedName())
+	}
+}
+
+var errSearchSourceNotFound = errors.New("MongoDBSearch source not found")
+
 // getSearchSource resolves the source database for a MongoDBSearch resource.
 // Shared by both the main search controller and the Envoy controller.
-func getSearchSource(ctx context.Context, kubeClient client.Client, watcher *watch.ResourceWatcher, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
+func getSearchSource(ctx context.Context, kubeClient client.Reader, watcher *watch.ResourceWatcher, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
 	if search.IsExternalMongoDBSource() {
 		externalSpec := search.Spec.Source.ExternalMongoDBSource
 		if search.IsExternalSourceSharded() {
@@ -265,7 +331,9 @@ func getSearchSource(ctx context.Context, kubeClient client.Client, watcher *wat
 			return nil, xerrors.Errorf("error getting MongoDB %s: %w", sourceName, err)
 		}
 	} else {
-		watcher.AddWatchedResourceIfNotAdded(sourceMongoDBResourceRef.Name, sourceMongoDBResourceRef.Namespace, watch.MongoDB, search.NamespacedName())
+		if watcher != nil {
+			watcher.AddWatchedResourceIfNotAdded(sourceMongoDBResourceRef.Name, sourceMongoDBResourceRef.Namespace, watch.MongoDB, search.NamespacedName())
+		}
 		if mdb.GetResourceType() == mdbv1.ShardedCluster {
 			return searchcontroller.NewShardedInternalSearchSource(mdb, search), nil
 		}
@@ -278,11 +346,13 @@ func getSearchSource(ctx context.Context, kubeClient client.Client, watcher *wat
 			return nil, xerrors.Errorf("error getting MongoDBCommunity %s: %w", sourceName, err)
 		}
 	} else {
-		watcher.AddWatchedResourceIfNotAdded(sourceMongoDBResourceRef.Name, sourceMongoDBResourceRef.Namespace, "MongoDBCommunity", search.NamespacedName())
+		if watcher != nil {
+			watcher.AddWatchedResourceIfNotAdded(sourceMongoDBResourceRef.Name, sourceMongoDBResourceRef.Namespace, "MongoDBCommunity", search.NamespacedName())
+		}
 		return searchcontroller.NewCommunityResourceSearchSource(mdbc), nil
 	}
 
-	return nil, xerrors.Errorf("No database resource named %s found", sourceName)
+	return nil, xerrors.Errorf("%w: no database resource named %s", errSearchSourceNotFound, sourceName)
 }
 
 func mdbcSearchIndexBuilder(rawObj client.Object) []string {
@@ -306,10 +376,16 @@ func AddMongoDBSearchController(
 		return err
 	}
 
+	memberClusterReadersMap := make(map[string]client.Reader, len(memberClusterObjectsMap))
+	for clusterName, memberCluster := range memberClusterObjectsMap {
+		memberClusterReadersMap[clusterName] = memberCluster.GetAPIReader()
+	}
 	r := newMongoDBSearchReconciler(
 		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		operatorSearchConfig,
 		multicluster.ClustersMapToClientMap(memberClusterObjectsMap),
+		memberClusterReadersMap,
 		operatorClusterName,
 	)
 
@@ -321,27 +397,8 @@ func AddMongoDBSearchController(
 		return err
 	}
 
-	ownerHandler := handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &searchv1.MongoDBSearch{}, handler.OnlyControllerOwner())
-	// status.Clusters for Search/LB/MetricsForwarder is updated via search controller, adding deployment in watch list would make sure that
-	// search reconcile is triggered when deployment change that would make sure we have up to date status of these components in status.Clusters.
-	// deploymentOwnerHandler is different from ownerHandler in the sense that it's for normal owner references and not controller owner references.
-	deploymentOwnerHandler := handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &searchv1.MongoDBSearch{})
-	centralWatches := []struct {
-		obj     client.Object
-		handler handler.EventHandler
-	}{
-		{&searchv1.MongoDBSearch{}, &handler.EnqueueRequestForObject{}},
-		{&mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}},
-		{&mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch}},
-		{&corev1.Secret{}, &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch}},
-		{&corev1.ConfigMap{}, &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch}},
-		{&appsv1.StatefulSet{}, ownerHandler},
-		{&corev1.Service{}, ownerHandler},
-		{&corev1.Secret{}, ownerHandler},
-		{&appsv1.Deployment{}, deploymentOwnerHandler},
-	}
-	for _, w := range centralWatches {
-		if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), w.obj, w.handler)); err != nil {
+	for _, w := range centralMongoDBSearchResourceWatches(r) {
+		if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), w.obj, w.handler, w.predicates...)); err != nil {
 			return xerrors.Errorf("failed to set MongoDBSearch central watch for %T: %w", w.obj, err)
 		}
 	}
@@ -364,19 +421,10 @@ func AddMongoDBSearchController(
 
 		// Per-member-cluster watches map events back to the parent MongoDBSearch
 		// via the search-owner labels (cross-cluster owner refs do not GC).
-		searchOwnerHandler := handler.EnqueueRequestsFromMapFunc(khandler.EnqueueMemberClusterObjectToSearch)
-		searchOwnerPredicate := watch.PredicatesForMultiClusterSearchResource()
-		watchedTypes := []client.Object{
-			&appsv1.StatefulSet{},
-			&corev1.Service{},
-			&appsv1.Deployment{},
-			&corev1.ConfigMap{},
-			&corev1.Secret{},
-		}
 		for k, v := range memberClusterObjectsMap {
-			for _, gvk := range watchedTypes {
-				if err := c.Watch(source.Kind[client.Object](v.GetCache(), gvk, searchOwnerHandler, searchOwnerPredicate)); err != nil {
-					return xerrors.Errorf("failed to set MongoDBSearch member-cluster watch on %s for %T: %w", k, gvk, err)
+			for _, w := range memberMongoDBSearchResourceWatches(r) {
+				if err := c.Watch(source.Kind[client.Object](v.GetCache(), w.obj, w.handler, w.predicates...)); err != nil {
+					return xerrors.Errorf("failed to set MongoDBSearch member-cluster watch on %s for %T: %w", k, w.obj, err)
 				}
 			}
 		}

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -7,7 +7,10 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -143,8 +146,32 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	log.Info("-> MongoDBSearch.Reconcile")
 
 	mdbSearch := &searchv1.MongoDBSearch{}
-	if result, err := commoncontroller.GetResource(ctx, r.kubeClient, request, mdbSearch, log); err != nil {
-		return result, err
+	if err := r.kubeClient.Get(ctx, request.NamespacedName, mdbSearch); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Errorf("Failed to query object %s: %s", request.NamespacedName, err)
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, err
+		}
+
+		absent, confirmErr := r.confirmSearchAbsentWithAPIReader(ctx, request.NamespacedName)
+		if confirmErr != nil {
+			return reconcile.Result{}, confirmErr
+		}
+		if !absent {
+			log.Infof("MongoDBSearch %s still exists in uncached reader; skipping NotFound sweep", request.NamespacedName)
+			return reconcile.Result{}, nil
+		}
+
+		r.watch.RemoveDependentWatchedResources(request.NamespacedName)
+
+		if sweepErr := r.sweepOwnedResourcesOnSearchNotFound(ctx, request.NamespacedName, log); sweepErr != nil {
+			return reconcile.Result{}, sweepErr
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !mdbSearch.DeletionTimestamp.IsZero() {
+		log.Infof("MongoDBSearch %s/%s is deleting; skipping main-controller reconcile", mdbSearch.Namespace, mdbSearch.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// Short-circuit: the disable-reconciliation annotation allows to
@@ -255,6 +282,135 @@ func (r *MongoDBSearchReconciler) surfaceMissingSecrets(
 
 func (r *MongoDBSearchReconciler) getSourceMongoDBForSearch(ctx context.Context, kubeClient client.Reader, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
 	return getSearchSource(ctx, kubeClient, r.watch, search, log)
+}
+
+func (r *MongoDBSearchReconciler) confirmSearchAbsentWithAPIReader(ctx context.Context, nsName types.NamespacedName) (bool, error) {
+	search := &searchv1.MongoDBSearch{}
+	if err := r.uncachedReader.Get(ctx, nsName, search); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, xerrors.Errorf("failed to confirm MongoDBSearch absence for %s via uncached reader: %w", nsName, err)
+	}
+	return false, nil
+}
+
+func (r *MongoDBSearchReconciler) sweepOwnedResourcesOnSearchNotFound(ctx context.Context, nsName types.NamespacedName, log *zap.SugaredLogger) error {
+	searchSelector := client.MatchingLabels{
+		khandler.MongoDBSearchOwnerNameLabel:      nsName.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: nsName.Namespace,
+	}
+
+	clusters := []searchSweepCluster{
+		{name: "central", listReader: r.uncachedReader, parentReader: r.uncachedReader, deleteClient: r.kubeClient},
+	}
+	for clusterName, memberClient := range r.memberClusterClientsMap {
+		clusters = append(clusters, searchSweepCluster{
+			name:         clusterName,
+			listReader:   memberClient,
+			parentReader: r.memberClusterReadersMap[clusterName],
+			deleteClient: memberClient,
+		})
+	}
+
+	orderedKinds := []struct {
+		kind    string
+		newList func() client.ObjectList
+	}{
+		{kind: "Deployment", newList: func() client.ObjectList { return &appsv1.DeploymentList{} }},
+		{kind: "StatefulSet", newList: func() client.ObjectList { return &appsv1.StatefulSetList{} }},
+		{kind: "Service", newList: func() client.ObjectList { return &corev1.ServiceList{} }},
+		{kind: "ConfigMap", newList: func() client.ObjectList { return &corev1.ConfigMapList{} }},
+		{kind: "Secret", newList: func() client.ObjectList { return &corev1.SecretList{} }},
+	}
+
+	var errs error
+	for _, k := range orderedKinds {
+		for _, cluster := range clusters {
+			if err := r.sweepOwnedResourceKind(ctx, nsName, cluster.listReader, cluster.parentReader, cluster.deleteClient, cluster.name, k.kind, k.newList(), searchSelector, log); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+type searchSweepCluster struct {
+	name         string
+	listReader   client.Reader
+	parentReader client.Reader
+	deleteClient kubernetesClient.Client
+}
+
+func (r *MongoDBSearchReconciler) sweepOwnedResourceKind(
+	ctx context.Context,
+	search types.NamespacedName,
+	listReader client.Reader,
+	parentReader client.Reader,
+	deleteClient kubernetesClient.Client,
+	clusterName string,
+	kind string,
+	list client.ObjectList,
+	selector client.MatchingLabels,
+	log *zap.SugaredLogger,
+) error {
+	if err := listReader.List(ctx, list, client.InNamespace(search.Namespace), selector); err != nil {
+		return xerrors.Errorf("failed listing %ss for deleted MongoDBSearch %s on cluster %q: %w", kind, search, clusterName, err)
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return xerrors.Errorf("failed extracting %s list for deleted MongoDBSearch %s on cluster %q: %w", kind, search, clusterName, err)
+	}
+
+	var errs error
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok {
+			continue
+		}
+		eligible, err := searchCleanupCandidateEligible(ctx, search, parentReader, clusterName, kind, obj)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+		if !eligible {
+			continue
+		}
+		log.Infof("Deleting %s %s for deleted MongoDBSearch %s on cluster %q", kind, obj.GetName(), search, clusterName)
+		if err := deleteClient.Delete(ctx, obj, client.Preconditions{
+			UID:             ptr.To(obj.GetUID()),
+			ResourceVersion: ptr.To(obj.GetResourceVersion()),
+		}); err != nil && !apierrors.IsNotFound(err) {
+			errs = errors.Join(errs, xerrors.Errorf("failed deleting %s %s for deleted MongoDBSearch %s on cluster %q: %w", kind, obj.GetName(), search, clusterName, err))
+		}
+	}
+	return errs
+}
+
+func searchCleanupCandidateEligible(
+	ctx context.Context,
+	search types.NamespacedName,
+	parentReader client.Reader,
+	clusterName string,
+	kind string,
+	obj client.Object,
+) (bool, error) {
+	ownerUID := obj.GetLabels()[khandler.MongoDBSearchOwnerUIDLabel]
+	if ownerUID == "" {
+		return false, nil
+	}
+	if parentReader == nil {
+		return false, xerrors.Errorf("no live reader available to verify MongoDBSearch %s on cluster %q before deleting %s %s", search, clusterName, kind, obj.GetName())
+	}
+
+	localSearch := &searchv1.MongoDBSearch{}
+	if err := parentReader.Get(ctx, search, localSearch); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err) {
+			return true, nil
+		}
+		return false, xerrors.Errorf("failed reading MongoDBSearch %s on cluster %q before deleting %s %s: %w", search, clusterName, kind, obj.GetName(), err)
+	}
+	return ownerUID != string(localSearch.UID), nil
 }
 
 type mongoDBSearchResourceWatch struct {

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -44,13 +44,29 @@ import (
 // reports any per-cluster customer-replicated secret missing. Reconcile returns
 // (Result{RequeueAfter: secretsCheckRequeueAfter}, nil) so we don't trigger
 // exponential backoff while the customer is fixing the gap.
-const secretsCheckRequeueAfter = 30 * time.Second
+const (
+	secretsCheckRequeueAfter = 30 * time.Second
+	searchMongotComponent    = "mongot"
+	searchProxyComponent     = "search-proxy"
+)
 
 // prepareSearchFunc is the shared pre-reconcile gate for both search reconcilers;
 // writeStatus routes validation failures to the caller's own status surface. Returns
 // skip=true when the caller must stop reconciling (validation failed, or this
 // operator does not own the CR).
 type prepareSearchFunc func(search *searchv1.MongoDBSearch, log *zap.SugaredLogger, writeStatus func(workflow.Status) (reconcile.Result, error)) (skip bool, res reconcile.Result, err error)
+
+func isRemovedSearchOperatorCluster(search *searchv1.MongoDBSearch, operatorClusterName string) bool {
+	if operatorClusterName == "" || len(search.Spec.Clusters) == 0 {
+		return false
+	}
+	for _, cluster := range search.Spec.Clusters {
+		if cluster.Name == operatorClusterName {
+			return false
+		}
+	}
+	return true
+}
 
 // newPrepareSearch picks the gate once at construction so Reconcile never branches
 // on the operator mode. ValidateSpec runs on the UN-NARROWED spec first: per-cluster
@@ -181,6 +197,43 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 	if mdbSearch.IsReconciliationDisabled() {
 		log.Infof("MongoDBSearch %s/%s reconciliation disabled by %s annotation; skipping",
 			mdbSearch.GetNamespace(), mdbSearch.GetName(), searchv1.DisableReconciliationAnnotation)
+		return reconcile.Result{}, nil
+	}
+
+	topologyCurrent, err := cleanupRemovedMemberSearchResources(
+		ctx,
+		r.uncachedReader,
+		mdbSearch,
+		r.memberClusterReadersMap,
+		r.memberClusterClientsMap,
+		mainSearchResourceCleanups(mdbSearch),
+		log,
+	)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !topologyCurrent {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	if isRemovedSearchOperatorCluster(mdbSearch, r.operatorClusterName) {
+		r.watch.RemoveDependentWatchedResources(mdbSearch.NamespacedName())
+		topologyCurrent, err := cleanupRemovedLocalSearchResources(
+			ctx,
+			r.uncachedReader,
+			r.uncachedReader,
+			r.kubeClient,
+			mdbSearch,
+			r.operatorClusterName,
+			mainSearchResourceCleanups(mdbSearch),
+			log,
+		)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if !topologyCurrent {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		return reconcile.Result{}, nil
 	}
 
@@ -340,6 +393,172 @@ type searchSweepCluster struct {
 	listReader   client.Reader
 	parentReader client.Reader
 	deleteClient kubernetesClient.Client
+}
+
+type searchResourceCleanup struct {
+	kind        string
+	name        string
+	component   string
+	omitCluster bool
+	newList     func() client.ObjectList
+}
+
+func mainSearchResourceCleanups(search *searchv1.MongoDBSearch) []searchResourceCleanup {
+	return []searchResourceCleanup{
+		{kind: "StatefulSet", component: searchMongotComponent, newList: func() client.ObjectList { return &appsv1.StatefulSetList{} }},
+		{kind: "headless Service", component: searchMongotComponent, newList: func() client.ObjectList { return &corev1.ServiceList{} }},
+		{kind: "proxy Service", component: searchProxyComponent, newList: func() client.ObjectList { return &corev1.ServiceList{} }},
+		{kind: "ConfigMap", component: searchMongotComponent, newList: func() client.ObjectList { return &corev1.ConfigMapList{} }},
+		{kind: "state ConfigMap", name: searchcontroller.SearchStateCMName(search), omitCluster: true, newList: func() client.ObjectList { return &corev1.ConfigMapList{} }},
+		{kind: "x509 client auth Secret", name: search.X509OperatorManagedSecret().Name, newList: func() client.ObjectList { return &corev1.SecretList{} }},
+		{kind: "SCRAM client auth Secret", name: search.ScramClientCertOperatorManagedSecret().Name, newList: func() client.ObjectList { return &corev1.SecretList{} }},
+		{kind: "Secret", component: searchMongotComponent, newList: func() client.ObjectList { return &corev1.SecretList{} }},
+	}
+}
+
+func envoySearchResourceCleanups() []searchResourceCleanup {
+	return []searchResourceCleanup{
+		{kind: "Deployment", component: searchProxyComponent, newList: func() client.ObjectList { return &appsv1.DeploymentList{} }},
+		{kind: "ConfigMap", component: searchProxyComponent, newList: func() client.ObjectList { return &corev1.ConfigMapList{} }},
+	}
+}
+
+func cleanupRemovedMemberSearchResources(
+	ctx context.Context,
+	parentReader client.Reader,
+	search *searchv1.MongoDBSearch,
+	memberReaders map[string]client.Reader,
+	memberClients map[string]kubernetesClient.Client,
+	cleanups []searchResourceCleanup,
+	log *zap.SugaredLogger,
+) (bool, error) {
+	desired := make(map[string]struct{}, len(search.Spec.Clusters))
+	for _, cluster := range search.Spec.Clusters {
+		desired[cluster.Name] = struct{}{}
+	}
+	var errs error
+	topologyCurrent := true
+	for clusterName, memberClient := range memberClients {
+		if _, ok := desired[clusterName]; ok {
+			continue
+		}
+		memberReader := memberReaders[clusterName]
+		if memberReader == nil {
+			errs = errors.Join(errs, xerrors.Errorf("cannot clean removed cluster %q MongoDBSearch resources without an API reader", clusterName))
+			continue
+		}
+		clusterCurrent, err := cleanupRemovedLocalSearchResources(
+			ctx,
+			parentReader,
+			memberReader,
+			memberClient,
+			search,
+			clusterName,
+			cleanups,
+			log,
+		)
+		topologyCurrent = topologyCurrent && clusterCurrent
+		errs = errors.Join(errs, err)
+	}
+	return topologyCurrent, errs
+}
+
+func cleanupRemovedLocalSearchResources(
+	ctx context.Context,
+	parentReader client.Reader,
+	listReader client.Reader,
+	deleteClient kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName string,
+	cleanups []searchResourceCleanup,
+	log *zap.SugaredLogger,
+) (bool, error) {
+	if search.UID == "" {
+		return false, xerrors.Errorf("cannot clean removed cluster %q resources for MongoDBSearch %s without a UID", clusterName, search.NamespacedName())
+	}
+	// One up-front uncached confirmation that the cluster really is removed from the
+	// live CR; the label + UID + precondition gates below make each delete safe.
+	removed, err := confirmSearchClusterRemoved(ctx, parentReader, search, clusterName)
+	if err != nil {
+		return false, err
+	}
+	if !removed {
+		return false, nil
+	}
+	var errs error
+	for _, cleanup := range cleanups {
+		selector := client.MatchingLabels{
+			khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+			khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			khandler.MongoDBSearchOwnerUIDLabel:       string(search.UID),
+		}
+		if !cleanup.omitCluster {
+			selector[khandler.MongoDBSearchClusterNameLabel] = clusterName
+		}
+		if cleanup.component != "" {
+			selector[khandler.MongoDBSearchComponentLabel] = cleanup.component
+		}
+		list := cleanup.newList()
+		if err := listReader.List(ctx, list, client.InNamespace(search.Namespace), selector); err != nil {
+			errs = errors.Join(errs, xerrors.Errorf("failed listing removed cluster %q MongoDBSearch %ss: %w", clusterName, cleanup.kind, err))
+			continue
+		}
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			errs = errors.Join(errs, xerrors.Errorf("failed extracting removed cluster %q MongoDBSearch %s list: %w", clusterName, cleanup.kind, err))
+			continue
+		}
+		for _, item := range items {
+			obj, ok := item.(client.Object)
+			if !ok {
+				continue
+			}
+			current, ok := obj.DeepCopyObject().(client.Object)
+			if !ok {
+				continue
+			}
+			if err := listReader.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				errs = errors.Join(errs, xerrors.Errorf("failed confirming removed cluster %q MongoDBSearch %s %s: %w", clusterName, cleanup.kind, obj.GetName(), err))
+				continue
+			}
+			if cleanup.name != "" && current.GetName() != cleanup.name {
+				continue
+			}
+			if current.GetUID() != obj.GetUID() ||
+				current.GetLabels()[khandler.MongoDBSearchOwnerUIDLabel] != string(search.UID) {
+				continue
+			}
+			if !cleanup.omitCluster && current.GetLabels()[khandler.MongoDBSearchClusterNameLabel] != clusterName {
+				continue
+			}
+			if cleanup.component != "" && current.GetLabels()[khandler.MongoDBSearchComponentLabel] != cleanup.component {
+				continue
+			}
+			if err := deleteClient.Delete(ctx, current, client.Preconditions{
+				UID:             ptr.To(current.GetUID()),
+				ResourceVersion: ptr.To(current.GetResourceVersion()),
+			}); err != nil && !apierrors.IsNotFound(err) {
+				errs = errors.Join(errs, xerrors.Errorf("failed deleting removed cluster %q MongoDBSearch %s %s: %w", clusterName, cleanup.kind, obj.GetName(), err))
+				continue
+			}
+			log.Infof("Deleted removed cluster %q MongoDBSearch %s %s", clusterName, cleanup.kind, obj.GetName())
+		}
+	}
+	return true, errs
+}
+
+func confirmSearchClusterRemoved(ctx context.Context, reader client.Reader, expected *searchv1.MongoDBSearch, clusterName string) (bool, error) {
+	current := &searchv1.MongoDBSearch{}
+	if err := reader.Get(ctx, expected.NamespacedName(), current); err != nil {
+		return false, xerrors.Errorf("failed confirming cluster %q removal from MongoDBSearch %s: %w", clusterName, expected.NamespacedName(), err)
+	}
+	if current.UID != expected.UID {
+		return false, nil
+	}
+	return isRemovedSearchOperatorCluster(current, clusterName), nil
 }
 
 func (r *MongoDBSearchReconciler) sweepOwnedResourceKind(

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -188,7 +188,9 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		}
 	}
 
-	state, err := searchcontroller.ReadSearchState(ctx, r.kubeClient, mdbSearch)
+	state, err := searchcontroller.MutateSearchState(ctx, r.kubeClient, mdbSearch, func(*searchcontroller.SearchDeploymentState) bool {
+		return false
+	})
 	if err != nil {
 		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("failed to read search state: %w", err)), log)
 	}

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"testing"
@@ -38,6 +39,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1" //nolint:depguard
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/mongot"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
@@ -233,6 +235,161 @@ func searchCleanupLabels(searchKey types.NamespacedName, searchUID types.UID) ma
 		khandler.MongoDBSearchOwnerNameLabel:      searchKey.Name,
 		khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
 		khandler.MongoDBSearchOwnerUIDLabel:       string(searchUID),
+	}
+}
+
+type staleRemovedClusterListReader struct {
+	client.Reader
+	stale corev1.ConfigMap
+}
+
+type searchReadErrorReader struct {
+	client.Reader
+	err error
+}
+
+func (r searchReadErrorReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*searchv1.MongoDBSearch); ok {
+		return r.err
+	}
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+func (r staleRemovedClusterListReader) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	configMaps, ok := list.(*corev1.ConfigMapList)
+	if !ok {
+		return nil
+	}
+	configMaps.Items = []corev1.ConfigMap{r.stale}
+	return nil
+}
+
+func TestCleanupRemovedLocalSearchResourcesFailsClosedOnRecreation(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		liveClusters     []searchv1.ClusterSpec
+		listedResourceID types.UID
+		parentReadErr    error
+		wantCurrent      bool
+	}{
+		{name: "child recreated", liveClusters: []searchv1.ClusterSpec{{Name: "cluster-b"}}, listedResourceID: "stale-uid", wantCurrent: true},
+		{name: "cluster re-added", liveClusters: []searchv1.ClusterSpec{{Name: "cluster-a"}}, listedResourceID: "replacement-uid"},
+		{name: "parent live read fails", liveClusters: []searchv1.ClusterSpec{{Name: "cluster-b"}}, listedResourceID: "replacement-uid", parentReadErr: fmt.Errorf("injected parent read error")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{
+				Name: "search", Namespace: mock.TestNamespace, UID: "search-uid",
+			}, Spec: searchv1.MongoDBSearchSpec{Clusters: []searchv1.ClusterSpec{{Name: "cluster-b"}}}}
+			liveSearch := search.DeepCopy()
+			liveSearch.Spec.Clusters = tc.liveClusters
+			labels := khandler.MongoDBSearchManagedLabels(search, "", searchMongotComponent, "cluster-a")
+			replacement := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: "config", Namespace: search.Namespace, UID: "replacement-uid", Labels: labels,
+			}}
+			stale := replacement.DeepCopy()
+			stale.UID = tc.listedResourceID
+			backing := mock.NewEmptyFakeClientBuilder().WithObjects(liveSearch, replacement).Build()
+			reader := staleRemovedClusterListReader{Reader: backing, stale: *stale}
+			var parentReader client.Reader = reader
+			if tc.parentReadErr != nil {
+				parentReader = searchReadErrorReader{Reader: reader, err: tc.parentReadErr}
+			}
+
+			topologyCurrent, err := cleanupRemovedLocalSearchResources(
+				ctx,
+				parentReader,
+				reader,
+				kubernetesClient.NewClient(backing),
+				search,
+				"cluster-a",
+				[]searchResourceCleanup{{
+					kind: "ConfigMap", component: searchMongotComponent, newList: func() client.ObjectList { return &corev1.ConfigMapList{} },
+				}},
+				zap.S(),
+			)
+
+			if tc.parentReadErr != nil {
+				require.ErrorIs(t, err, tc.parentReadErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantCurrent, topologyCurrent)
+			require.NoError(t, backing.Get(ctx, client.ObjectKeyFromObject(replacement), &corev1.ConfigMap{}))
+		})
+	}
+}
+
+func TestCleanupRemovedMemberSearchResourcesSkipsReaddedTargetAndContinuesOthers(t *testing.T) {
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: mock.TestNamespace, UID: "search-uid"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}},
+		},
+	}
+	liveSearch := search.DeepCopy()
+	liveSearch.Spec.Clusters = append(liveSearch.Spec.Clusters, searchv1.ClusterSpec{Name: "cluster-b", Index: ptr.To(int32(1))})
+	parentReader := mock.NewEmptyFakeClientBuilder().WithObjects(liveSearch).Build()
+	objectsFor := func(clusterName string, index int) []client.Object {
+		labels := func(component string) map[string]string {
+			return khandler.MongoDBSearchManagedLabels(search, "", component, clusterName)
+		}
+		return []client.Object{
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("proxy-%s", clusterName), Namespace: search.Namespace, UID: types.UID(clusterName + "-deployment"), Labels: labels(searchProxyComponent)}},
+			&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: search.StatefulSetNamespacedNameForCluster(index).Name, Namespace: search.Namespace, UID: types.UID(clusterName + "-statefulset"), Labels: labels(searchMongotComponent)}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: search.SearchServiceNamespacedNameForCluster(index).Name, Namespace: search.Namespace, UID: types.UID(clusterName + "-headless"), Labels: labels(searchMongotComponent)}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: search.ProxyServiceNamespacedNameForCluster(index).Name, Namespace: search.Namespace, UID: types.UID(clusterName + "-proxy"), Labels: labels(searchProxyComponent)}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.MongotConfigConfigMapNameForCluster(index).Name, Namespace: search.Namespace, UID: types.UID(clusterName + "-config"), Labels: labels(searchMongotComponent)}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: searchcontroller.SearchStateCMName(search), Namespace: search.Namespace, UID: types.UID(clusterName + "-state"), Labels: labels("")}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.X509OperatorManagedSecret().Name, Namespace: search.Namespace, UID: types.UID(clusterName + "-legacy-x509"), Labels: labels("")}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.ScramClientCertOperatorManagedSecret().Name, Namespace: search.Namespace, UID: types.UID(clusterName + "-legacy-scram"), Labels: labels("")}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("generated-%s", clusterName), Namespace: search.Namespace, UID: types.UID(clusterName + "-secret"), Labels: labels(searchMongotComponent)}},
+		}
+	}
+	clusterBObjects := objectsFor("cluster-b", 1)
+	clusterCObjects := objectsFor("cluster-c", 2)
+	clusterB := mock.NewEmptyFakeClientBuilder().WithObjects(clusterBObjects...).Build()
+	clusterC := mock.NewEmptyFakeClientBuilder().WithObjects(clusterCObjects...).Build()
+
+	topologyCurrent, err := cleanupRemovedMemberSearchResources(
+		t.Context(),
+		parentReader,
+		search,
+		map[string]client.Reader{"cluster-b": clusterB, "cluster-c": clusterC},
+		map[string]kubernetesClient.Client{
+			"cluster-b": kubernetesClient.NewClient(clusterB),
+			"cluster-c": kubernetesClient.NewClient(clusterC),
+		},
+		append(mainSearchResourceCleanups(search), envoySearchResourceCleanups()...),
+		zap.S(),
+	)
+
+	require.NoError(t, err)
+	assert.False(t, topologyCurrent)
+	for _, obj := range clusterBObjects {
+		require.NoError(t, clusterB.Get(t.Context(), client.ObjectKeyFromObject(obj), obj.DeepCopyObject().(client.Object)))
+	}
+	for _, obj := range clusterCObjects {
+		assert.True(t, apiErrors.IsNotFound(clusterC.Get(t.Context(), client.ObjectKeyFromObject(obj), obj.DeepCopyObject().(client.Object))))
+	}
+}
+
+func TestIsRemovedSearchOperatorCluster(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		operatorClusterName string
+		clusters            []searchv1.ClusterSpec
+		want                bool
+	}{
+		{name: "central operator", clusters: nil, want: false},
+		{name: "projected cluster retained", operatorClusterName: "cluster-a", clusters: []searchv1.ClusterSpec{{Name: "cluster-a"}}, want: false},
+		{name: "projected cluster removed with another retained", operatorClusterName: "cluster-a", clusters: []searchv1.ClusterSpec{{Name: "cluster-b"}}, want: true},
+		{name: "empty topology remains a validation error", operatorClusterName: "cluster-a", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			search := &searchv1.MongoDBSearch{Spec: searchv1.MongoDBSearchSpec{Clusters: tc.clusters}}
+			assert.Equal(t, tc.want, isRemovedSearchOperatorCluster(search, tc.operatorClusterName))
+		})
 	}
 }
 
@@ -1619,6 +1776,7 @@ func TestNewMongoDBSearchReconciler_SingleCluster(t *testing.T) {
 
 	assert.NotNil(t, r.kubeClient, "central kubeClient must be set")
 	assert.Empty(t, r.memberClusterClientsMap, "members map must be empty in single-cluster mode")
+	assert.True(t, r.localNamedClusters)
 }
 
 func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
@@ -1635,6 +1793,9 @@ func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
 	assert.Len(t, r.memberClusterClientsMap, 2)
 	assert.NotNil(t, r.memberClusterClientsMap["us-east-k8s"])
 	assert.NotNil(t, r.memberClusterClientsMap["eu-west-k8s"])
+	assert.Same(t, east, r.memberClusterReadersMap["us-east-k8s"])
+	assert.Same(t, west, r.memberClusterReadersMap["eu-west-k8s"])
+	assert.False(t, r.localNamedClusters)
 }
 
 func TestNewMongoDBSearchReconciler_EmptyHubMapStaysRemote(t *testing.T) {
@@ -1774,7 +1935,7 @@ func TestMongoDBSearchReconcile_Success_MultiCluster(t *testing.T) {
 
 			// Owner labels stamp cross-cluster identity — owner refs do not
 			// carry between clusters, so labels are the link back to the CR.
-			assertSearchOwnerLabels(t, search, tc.clusterName, sts, headlessSvc, proxySvc, cm)
+			assertSearchOwnerLabels(t, search, tc.clusterName, false, sts, headlessSvc, proxySvc, cm)
 		})
 	}
 }
@@ -1844,13 +2005,19 @@ func driveSearchReconcileToRunning(
 // (EnqueueMemberClusterObjectToSearch) and label-based GC depend on these, so a
 // path that creates resources without them passes existence checks but breaks
 // re-enqueue in e2e only.
-func assertSearchOwnerLabels(t *testing.T, search *searchv1.MongoDBSearch, clusterName string, objs ...client.Object) {
+func assertSearchOwnerLabels(t *testing.T, search *searchv1.MongoDBSearch, clusterName string, sameCluster bool, objs ...client.Object) {
 	t.Helper()
 	for _, obj := range objs {
 		labels := obj.GetLabels()
 		assert.Equal(t, search.Name, labels[khandler.MongoDBSearchOwnerNameLabel], "owner-name label on %T %s", obj, obj.GetName())
 		assert.Equal(t, search.Namespace, labels[khandler.MongoDBSearchOwnerNamespaceLabel], "owner-namespace label on %T %s", obj, obj.GetName())
 		assert.Equal(t, clusterName, labels[khandler.MongoDBSearchClusterNameLabel], "cluster-name label on %T %s", obj, obj.GetName())
+		if sameCluster {
+			require.Len(t, obj.GetOwnerReferences(), 1, "same-cluster resource %T %s must retain the GC backstop", obj, obj.GetName())
+			assert.Equal(t, search.UID, obj.GetOwnerReferences()[0].UID)
+		} else {
+			assert.Empty(t, obj.GetOwnerReferences(), "cross-cluster resource %T %s must remain label-only", obj, obj.GetName())
+		}
 	}
 }
 
@@ -1866,7 +2033,7 @@ func newOperatorPerClusterMongoDBSearch(name, namespace string) *searchv1.MongoD
 		},
 	}
 	return &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},
 		Spec: searchv1.MongoDBSearchSpec{
 			Version: "1.70.1",
 			Source: &searchv1.MongoDBSource{
@@ -1920,7 +2087,7 @@ func TestReconcile_OperatorPerCluster_ProjectedReconcilesLocalOnly(t *testing.T)
 			require.NoError(t, c.Get(ctx, search.SearchServiceNamespacedNameForCluster(tc.wantIdx), headless),
 				"headless search Service at pinned index %d must exist", tc.wantIdx)
 
-			assertSearchOwnerLabels(t, search, tc.opCluster, sts, cm, proxy, headless)
+			assertSearchOwnerLabels(t, search, tc.opCluster, true, sts, cm, proxy, headless)
 
 			// The other cluster's index MUST be untouched — this operator never wrote it.
 			err := c.Get(ctx, search.StatefulSetNamespacedNameForCluster(tc.wrongIdx), &appsv1.StatefulSet{})
@@ -1936,6 +2103,134 @@ func TestReconcile_OperatorPerCluster_ProjectedReconcilesLocalOnly(t *testing.T)
 				"projected reconcile must reach Running; got %q (msg=%q)", got.Status.Phase, got.Status.Message)
 		})
 	}
+}
+
+func TestReconcile_OperatorPerCluster_RemovedClusterCleansLocalResources(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
+
+	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
+	legacyAuthLabels := khandler.MongoDBSearchManagedLabels(search, "", "", "cluster-c")
+	managed := []client.Object{
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "removed-mongot", Namespace: search.Namespace, UID: "removed-sts", Labels: khandler.MongoDBSearchManagedLabels(search, "", searchMongotComponent, "cluster-c")}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "removed-headless", Namespace: search.Namespace, UID: "removed-headless", Labels: khandler.MongoDBSearchManagedLabels(search, "", searchMongotComponent, "cluster-c")}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "removed-proxy", Namespace: search.Namespace, UID: "removed-proxy", Labels: khandler.MongoDBSearchManagedLabels(search, "", searchProxyComponent, "cluster-c")}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "removed-config", Namespace: search.Namespace, UID: "removed-config", Labels: khandler.MongoDBSearchManagedLabels(search, "", searchMongotComponent, "cluster-c")}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: searchcontroller.SearchStateCMName(search), Namespace: search.Namespace, UID: "removed-state", Labels: khandler.MongoDBSearchManagedLabels(search, "", "", "")}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.X509OperatorManagedSecret().Name, Namespace: search.Namespace, UID: "legacy-x509", Labels: maps.Clone(legacyAuthLabels)}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.ScramClientCertOperatorManagedSecret().Name, Namespace: search.Namespace, UID: "legacy-scram", Labels: maps.Clone(legacyAuthLabels)}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "removed-secret", Namespace: search.Namespace, UID: "removed-secret", Labels: khandler.MongoDBSearchManagedLabels(search, "", searchMongotComponent, "cluster-c")}},
+	}
+	for _, obj := range managed {
+		require.NoError(t, c.Create(ctx, obj))
+	}
+	metricsConfig := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      "metrics-owned",
+		Namespace: search.Namespace,
+		UID:       "metrics-owned",
+		Labels:    khandler.MongoDBSearchManagedLabels(search, "", metricsForwarderLabelName, "cluster-c"),
+	}}
+	require.NoError(t, c.Create(ctx, metricsConfig))
+	customerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "customer-source-secret", Namespace: search.Namespace, UID: "customer-source", Labels: maps.Clone(legacyAuthLabels),
+		},
+		Data: map[string][]byte{"value": []byte("customer")},
+	}
+	require.NoError(t, c.Create(ctx, customerSecret))
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
+	res, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	for _, obj := range managed {
+		err = c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		assert.True(t, apiErrors.IsNotFound(err), "%T %s must be deleted", obj, obj.GetName())
+	}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(metricsConfig), &corev1.ConfigMap{}),
+		"main cleanup must leave metrics resources to the metrics controller")
+	preservedCustomer := &corev1.Secret{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(customerSecret), preservedCustomer))
+	assert.Equal(t, customerSecret.UID, preservedCustomer.UID)
+	assert.Equal(t, customerSecret.Data, preservedCustomer.Data)
+
+	// State ConfigMap must not be created.
+	stateCM := &corev1.ConfigMap{}
+	assert.True(t, apiErrors.IsNotFound(
+		c.Get(ctx, types.NamespacedName{Name: search.Name + "-search-state", Namespace: search.Namespace}, stateCM)),
+		"state ConfigMap must not be created in no-match path")
+
+	// Status must NOT have been mutated — Phase remains the zero value.
+	updated := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, req.NamespacedName, updated))
+	assert.Equal(t, status.Phase(""), updated.Status.Phase, "no-match reconcile must not touch status")
+}
+
+func TestMongoDBSearchReconcile_HubRemovedClusterCleansManagedMemberResources(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
+	search.Spec.Clusters = search.Spec.Clusters[:1]
+	memberA := mock.NewEmptyFakeClientBuilder().Build()
+	memberB := mock.NewEmptyFakeClientBuilder().Build()
+	labels := khandler.MongoDBSearchManagedLabels(search, "", searchMongotComponent, "cluster-b")
+
+	managed := []client.Object{
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: search.StatefulSetNamespacedNameForCluster(1).Name, Namespace: search.Namespace, UID: "removed-sts", Labels: labels}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.StatefulSetNamespacedNameForCluster(1).Name + "-tls", Namespace: search.Namespace, UID: "removed-secret", Labels: labels}},
+	}
+	for _, obj := range managed {
+		require.NoError(t, memberB.Create(ctx, obj))
+	}
+
+	reconciler, _ := newSearchReconcilerWithMembers(t, nil, map[string]client.Client{
+		"cluster-a": memberA,
+		"cluster-b": memberB,
+	}, "", search)
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+	for _, obj := range managed {
+		assert.True(t, apiErrors.IsNotFound(memberB.Get(ctx, client.ObjectKeyFromObject(obj), obj)), "%T %s must be deleted", obj, obj.GetName())
+	}
+}
+
+func TestMongoDBSearchReconcile_ReaddedMemberAbortsCachedTopologySweep(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	staleSearch := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
+	clusterB := staleSearch.Spec.Clusters[1]
+	staleSearch.Spec.Clusters = staleSearch.Spec.Clusters[:1]
+	liveSearch := staleSearch.DeepCopy()
+	liveSearch.Spec.Clusters = append(liveSearch.Spec.Clusters, clusterB)
+
+	memberA := mock.NewEmptyFakeClientBuilder().Build()
+	memberB := mock.NewEmptyFakeClientBuilder().Build()
+	managed := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+		Name:      staleSearch.StatefulSetNamespacedNameForCluster(1).Name,
+		Namespace: staleSearch.Namespace,
+		UID:       "readded-sts",
+		Labels:    khandler.MongoDBSearchManagedLabels(staleSearch, "", searchMongotComponent, "cluster-b"),
+	}}
+	require.NoError(t, memberB.Create(ctx, managed))
+
+	cachedCentral := mock.NewEmptyFakeClientBuilder().WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(staleSearch).Build()
+	liveReader := mock.NewEmptyFakeClientBuilder().WithObjects(liveSearch).Build()
+	reconciler := newMongoDBSearchReconciler(
+		cachedCentral,
+		liveReader,
+		searchcontroller.OperatorSearchConfig{},
+		map[string]client.Client{"cluster-a": memberA, "cluster-b": memberB},
+		map[string]client.Reader{"cluster-a": memberA, "cluster-b": memberB},
+		"",
+	)
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: staleSearch.NamespacedName()})
+	require.NoError(t, err)
+	assert.True(t, result.Requeue)
+	require.NoError(t, memberB.Get(ctx, client.ObjectKeyFromObject(managed), &appsv1.StatefulSet{}))
 }
 
 // Customer pin is authoritative: re-pinning renders at the new index. The
@@ -2099,13 +2394,13 @@ func TestReconcile_OperatorPerCluster_ShardedSource_ProjectedReconcilesLocalOnly
 				require.NoError(t, c.Get(ctx, search.MongotServiceForClusterShard(tc.wantIdx, shard), svc),
 					"headless Service for shard %s must exist", shard)
 
-				assertSearchOwnerLabels(t, search, tc.opCluster, sts, cm, svc)
+				assertSearchOwnerLabels(t, search, tc.opCluster, true, sts, cm, svc)
 			}
 
 			clusterLevelProxy := &corev1.Service{}
 			require.NoError(t, c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.wantIdx), clusterLevelProxy),
 				"cluster-level proxy Service at pinned index %d must exist", tc.wantIdx)
-			assertSearchOwnerLabels(t, search, tc.opCluster, clusterLevelProxy)
+			assertSearchOwnerLabels(t, search, tc.opCluster, true, clusterLevelProxy)
 
 			// The other operator's index MUST be untouched.
 			for _, shard := range []string{"sh-0", "sh-1"} {
@@ -2393,39 +2688,4 @@ func markAllDeploymentsAvailable(ctx context.Context, namespace string, clients 
 		}
 	}
 	return nil
-}
-
-func TestReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
-	enableSearchMCReconcile(t)
-	ctx := context.Background()
-	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
-
-	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
-	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
-
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
-	res, err := reconciler.Reconcile(ctx, req)
-	require.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
-
-	// No per-cluster resources created at any index.
-	for _, idx := range []int{0, 1, 2} {
-		sts := &appsv1.StatefulSet{}
-		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, search.StatefulSetNamespacedNameForCluster(idx), sts)),
-			"STS at index %d must not exist", idx)
-		cm := &corev1.ConfigMap{}
-		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, search.MongotConfigConfigMapNameForCluster(idx), cm)),
-			"mongot ConfigMap at index %d must not exist", idx)
-	}
-
-	// State ConfigMap must not be created.
-	stateCM := &corev1.ConfigMap{}
-	assert.True(t, apiErrors.IsNotFound(
-		c.Get(ctx, types.NamespacedName{Name: search.Name + "-search-state", Namespace: search.Namespace}, stateCM)),
-		"state ConfigMap must not be created in no-match path")
-
-	// Status must NOT have been mutated — Phase remains the zero value.
-	updated := &searchv1.MongoDBSearch{}
-	require.NoError(t, c.Get(ctx, req.NamespacedName, updated))
-	assert.Equal(t, status.Phase(""), updated.Status.Phase, "no-match reconcile must not touch status")
 }

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -11,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -26,6 +29,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/mock"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1" //nolint:depguard
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
@@ -92,7 +96,7 @@ func newSearchReconcilerWithOperatorConfig(
 
 	fakeClient := builder.Build()
 
-	return newMongoDBSearchReconciler(fakeClient, operatorConfig, map[string]client.Client{}, ""), fakeClient
+	return newMongoDBSearchReconciler(fakeClient, fakeClient, operatorConfig, map[string]client.Client{}, nil, ""), fakeClient
 }
 
 func newSearchReconciler(
@@ -188,6 +192,201 @@ func TestMongoDBSearchReconcile_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, apiErrors.IsNotFound(err))
 	assert.Equal(t, reconcile.Result{}, res)
+}
+
+func TestMongoDBSearchDeploymentWatchesRouteLifecycleEvents(t *testing.T) {
+	reconciler, _ := newSearchReconciler(nil)
+	topologies := []struct {
+		name    string
+		watches []mongoDBSearchResourceWatch
+	}{
+		{name: "central", watches: centralMongoDBSearchResourceWatches(reconciler)},
+		{name: "member", watches: memberMongoDBSearchResourceWatches(reconciler)},
+	}
+	searchKey := types.NamespacedName{Name: "search", Namespace: mock.TestNamespace}
+	labeled := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      "owned",
+		Namespace: searchKey.Namespace,
+		Labels: map[string]string{
+			khandler.MongoDBSearchOwnerNameLabel:      searchKey.Name,
+			khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
+		},
+	}}
+	plain := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: labeled.Name, Namespace: labeled.Namespace}}
+
+	for _, topology := range topologies {
+		t.Run(topology.name, func(t *testing.T) {
+			var deploymentWatch *mongoDBSearchResourceWatch
+			for i := range topology.watches {
+				if _, ok := topology.watches[i].obj.(*appsv1.Deployment); ok {
+					deploymentWatch = &topology.watches[i]
+					break
+				}
+			}
+			require.NotNil(t, deploymentWatch)
+			require.Len(t, deploymentWatch.predicates, 1)
+			p := deploymentWatch.predicates[0]
+
+			tests := []struct {
+				name string
+				send func(workqueue.TypedRateLimitingInterface[reconcile.Request])
+			}{
+				{
+					name: "create",
+					send: func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+						e := event.TypedCreateEvent[client.Object]{Object: labeled}
+						require.True(t, p.Create(event.CreateEvent{Object: labeled}))
+						deploymentWatch.handler.Create(t.Context(), e, q)
+					},
+				},
+				{
+					name: "update",
+					send: func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+						e := event.TypedUpdateEvent[client.Object]{ObjectOld: labeled, ObjectNew: labeled.DeepCopy()}
+						require.True(t, p.Update(e))
+						deploymentWatch.handler.Update(t.Context(), e, q)
+					},
+				},
+				{
+					name: "update label removal",
+					send: func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+						e := event.TypedUpdateEvent[client.Object]{ObjectOld: labeled, ObjectNew: plain}
+						require.True(t, p.Update(e))
+						deploymentWatch.handler.Update(t.Context(), e, q)
+					},
+				},
+				{
+					name: "delete",
+					send: func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+						e := event.TypedDeleteEvent[client.Object]{Object: labeled}
+						require.True(t, p.Delete(event.DeleteEvent{Object: labeled}))
+						deploymentWatch.handler.Delete(t.Context(), e, q)
+					},
+				},
+			}
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+					defer q.ShutDown()
+					tc.send(q)
+					require.Equal(t, 1, q.Len())
+					req, shutdown := q.Get()
+					require.False(t, shutdown)
+					assert.Equal(t, searchKey, req.NamespacedName)
+					q.Done(req)
+				})
+			}
+		})
+	}
+}
+
+func TestMemberMongoDBSearchConfigWatchesRouteUnlabeledDependencies(t *testing.T) {
+	reconciler, _ := newSearchReconciler(nil)
+	searchKey := types.NamespacedName{Name: "search", Namespace: mock.TestNamespace}
+	tests := []struct {
+		name         string
+		resourceType watch.Type
+		newObject    func(data string) client.Object
+	}{
+		{
+			name:         "ConfigMap",
+			resourceType: watch.ConfigMap,
+			newObject: func(data string) client.Object {
+				return &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "source-ca", Namespace: searchKey.Namespace},
+					Data:       map[string]string{"value": data},
+				}
+			},
+		},
+		{
+			name:         "Secret",
+			resourceType: watch.Secret,
+			newObject: func(data string) client.Object {
+				return &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "source-tls", Namespace: searchKey.Namespace},
+					Data:       map[string][]byte{"value": []byte(data)},
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldObject := tc.newObject("old")
+			newObject := tc.newObject("new")
+			reconciler.watch.AddWatchedResourceIfNotAdded(oldObject.GetName(), oldObject.GetNamespace(), tc.resourceType, searchKey)
+			var resourceWatch *mongoDBSearchResourceWatch
+			watches := memberMongoDBSearchResourceWatches(reconciler)
+			for i := range watches {
+				candidate := &watches[i]
+				if reflect.TypeOf(candidate.obj) == reflect.TypeOf(oldObject) {
+					resourceWatch = candidate
+					break
+				}
+			}
+			require.NotNil(t, resourceWatch)
+			assert.Empty(t, resourceWatch.predicates)
+
+			for _, send := range []func(workqueue.TypedRateLimitingInterface[reconcile.Request]){
+				func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+					resourceWatch.handler.Create(t.Context(), event.TypedCreateEvent[client.Object]{Object: oldObject}, q)
+				},
+				func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+					resourceWatch.handler.Update(t.Context(), event.TypedUpdateEvent[client.Object]{ObjectOld: oldObject, ObjectNew: newObject}, q)
+				},
+				func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+					resourceWatch.handler.Delete(t.Context(), event.TypedDeleteEvent[client.Object]{Object: oldObject}, q)
+				},
+			} {
+				q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+				send(q)
+				require.Equal(t, 1, q.Len())
+				request, shutdown := q.Get()
+				require.False(t, shutdown)
+				assert.Equal(t, searchKey, request.NamespacedName)
+				q.Done(request)
+				q.ShutDown()
+			}
+		})
+	}
+}
+
+func TestRegisterTLSResourceWatchesIncludesShardedMemberDependencies(t *testing.T) {
+	reconciler, _ := newSearchReconciler(nil)
+	search := newMongoDBSearch("search", mock.TestNamespace, "")
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(3))},
+	}
+	search.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "source-certs"}
+	externalSource := &searchv1.ExternalMongoDBSource{
+		ShardedCluster: &searchv1.ExternalShardedClusterConfig{
+			Router: searchv1.ExternalRouterConfig{Hosts: []string{"mongos:27017"}},
+			Shards: []searchv1.ExternalShardConfig{
+				{ShardName: "shard-a", Hosts: []string{"shard-a:27017"}},
+				{ShardName: "shard-b", Hosts: []string{"shard-b:27017"}},
+			},
+		},
+		TLS: &searchv1.ExternalMongodTLS{CA: &corev1.LocalObjectReference{Name: "source-ca"}},
+	}
+
+	reconciler.registerTLSResourceWatches(search, searchcontroller.NewShardedExternalSearchSource(search.Namespace, externalSource))
+
+	watched := reconciler.watch.GetWatchedResources()
+	expected := []watch.Object{{
+		ResourceType: watch.ConfigMap,
+		Resource:     types.NamespacedName{Name: "source-ca", Namespace: search.Namespace},
+	}}
+	for _, cluster := range search.Spec.Clusters {
+		for _, shardName := range []string{"shard-a", "shard-b"} {
+			expected = append(expected, watch.Object{
+				ResourceType: watch.Secret,
+				Resource:     search.TLSSecretForClusterShard(cluster.ResolveIndex(), shardName),
+			})
+		}
+	}
+	for _, resource := range expected {
+		assert.Contains(t, watched[resource], search.NamespacedName(), "missing dependency watch for %s", resource)
+	}
 }
 
 func TestMongoDBSearchReconcile_MissingSource(t *testing.T) {
@@ -520,7 +719,7 @@ func TestNewMongoDBSearchReconciler_SingleCluster(t *testing.T) {
 	central := newFakeClientForTest(t)
 	members := map[string]client.Client{} // empty -> single-cluster install
 
-	r := newMongoDBSearchReconciler(central, searchcontroller.OperatorSearchConfig{}, members, "")
+	r := newMongoDBSearchReconciler(central, central, searchcontroller.OperatorSearchConfig{}, members, nil, "")
 
 	assert.NotNil(t, r.kubeClient, "central kubeClient must be set")
 	assert.Empty(t, r.memberClusterClientsMap, "members map must be empty in single-cluster mode")
@@ -535,7 +734,7 @@ func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
 		"eu-west-k8s": west,
 	}
 
-	r := newMongoDBSearchReconciler(central, searchcontroller.OperatorSearchConfig{}, members, "")
+	r := newMongoDBSearchReconciler(central, central, searchcontroller.OperatorSearchConfig{}, members, nil, "")
 
 	assert.Len(t, r.memberClusterClientsMap, 2)
 	assert.NotNil(t, r.memberClusterClientsMap["us-east-k8s"])
@@ -556,6 +755,32 @@ func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
 
 	require.NoError(t, err, "missing secret must surface as RequeueAfter, not an error")
 	require.True(t, res.RequeueAfter > 0, "must requeue when a customer-replicated secret is missing")
+}
+
+func TestMongoDBSearchReconcile_RegistersOperatorTLSSecretWatch(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
+	search.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "certs"}}
+	mdbc := newMongoDBCommunity("mdb", mock.TestNamespace)
+	reconciler, c := newSearchReconciler(mdbc, search)
+
+	sourceTLS := search.TLSSecretNamespacedName()
+	require.NoError(t, c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: sourceTLS.Name, Namespace: sourceTLS.Namespace},
+		Data: map[string][]byte{
+			"tls.crt": []byte("dummy"),
+			"tls.key": []byte("dummy"),
+		},
+	}))
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace},
+	})
+	require.NoError(t, err)
+
+	operatorTLS := search.TLSOperatorSecretNamespacedName()
+	watched := reconciler.watch.GetWatchedResources()
+	assert.Contains(t, watched[watch.Object{ResourceType: watch.Secret, Resource: operatorTLS}], search.NamespacedName())
 }
 
 // pinnedCluster builds a spec.clusters[] entry with an explicit clusterIndex
@@ -670,7 +895,7 @@ func newSearchReconcilerWithMembers(
 		}
 	}
 	centralClient := builder.Build()
-	return newMongoDBSearchReconciler(centralClient, searchcontroller.OperatorSearchConfig{}, memberClients, operatorClusterName), centralClient
+	return newMongoDBSearchReconciler(centralClient, centralClient, searchcontroller.OperatorSearchConfig{}, memberClients, nil, operatorClusterName), centralClient
 }
 
 // driveSearchReconcileToRunning loops Reconcile up to maxPasses, seeding LoadBalancer
@@ -805,41 +1030,6 @@ func TestReconcile_OperatorPerCluster_ProjectedReconcilesLocalOnly(t *testing.T)
 				"projected reconcile must reach Running; got %q (msg=%q)", got.Status.Phase, got.Status.Message)
 		})
 	}
-}
-
-func TestReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
-	enableSearchMCReconcile(t)
-	ctx := context.Background()
-	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
-
-	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
-	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
-
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
-	res, err := reconciler.Reconcile(ctx, req)
-	require.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
-
-	// No per-cluster resources created at any index.
-	for _, idx := range []int{0, 1, 2} {
-		sts := &appsv1.StatefulSet{}
-		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, search.StatefulSetNamespacedNameForCluster(idx), sts)),
-			"STS at index %d must not exist", idx)
-		cm := &corev1.ConfigMap{}
-		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, search.MongotConfigConfigMapNameForCluster(idx), cm)),
-			"mongot ConfigMap at index %d must not exist", idx)
-	}
-
-	// State ConfigMap must not be created.
-	stateCM := &corev1.ConfigMap{}
-	assert.True(t, apiErrors.IsNotFound(
-		c.Get(ctx, types.NamespacedName{Name: search.Name + "-search-state", Namespace: search.Namespace}, stateCM)),
-		"state ConfigMap must not be created in no-match path")
-
-	// Status must NOT have been mutated — Phase remains the zero value.
-	updated := &searchv1.MongoDBSearch{}
-	require.NoError(t, c.Get(ctx, req.NamespacedName, updated))
-	assert.Equal(t, status.Phase(""), updated.Status.Phase, "no-match reconcile must not touch status")
 }
 
 // Customer pin is authoritative: re-pinning renders at the new index. The
@@ -1239,4 +1429,39 @@ func markAllDeploymentsAvailable(ctx context.Context, namespace string, clients 
 		}
 	}
 	return nil
+}
+
+func TestReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	search := newOperatorPerClusterMongoDBSearch("mdb-search", mock.TestNamespace)
+
+	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
+	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}}
+	res, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
+
+	// No per-cluster resources created at any index.
+	for _, idx := range []int{0, 1, 2} {
+		sts := &appsv1.StatefulSet{}
+		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, search.StatefulSetNamespacedNameForCluster(idx), sts)),
+			"STS at index %d must not exist", idx)
+		cm := &corev1.ConfigMap{}
+		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, search.MongotConfigConfigMapNameForCluster(idx), cm)),
+			"mongot ConfigMap at index %d must not exist", idx)
+	}
+
+	// State ConfigMap must not be created.
+	stateCM := &corev1.ConfigMap{}
+	assert.True(t, apiErrors.IsNotFound(
+		c.Get(ctx, types.NamespacedName{Name: search.Name + "-search-state", Namespace: search.Namespace}, stateCM)),
+		"state ConfigMap must not be created in no-match path")
+
+	// Status must NOT have been mutated — Phase remains the zero value.
+	updated := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, req.NamespacedName, updated))
+	assert.Equal(t, status.Phase(""), updated.Status.Phase, "no-match reconcile must not touch status")
 }

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -741,6 +741,16 @@ func TestNewMongoDBSearchReconciler_MultiCluster(t *testing.T) {
 	assert.NotNil(t, r.memberClusterClientsMap["eu-west-k8s"])
 }
 
+func TestNewMongoDBSearchReconciler_EmptyHubMapStaysRemote(t *testing.T) {
+	t.Setenv(util.SearchEnableMultiClusterEnv, "true")
+	central := newFakeClientForTest(t)
+
+	r := newMongoDBSearchReconciler(central, central, searchcontroller.OperatorSearchConfig{}, nil, nil, "")
+
+	assert.Empty(t, r.memberClusterClientsMap)
+	assert.False(t, r.localNamedClusters)
+}
+
 func TestMongoDBSearchReconcile_MissingSecret_Requeues(t *testing.T) {
 	ctx := context.Background()
 	search := newMongoDBSearch("search", mock.TestNamespace, "mdb")
@@ -1072,7 +1082,7 @@ func newOperatorPerClusterShardedMongoDBSearch(name, namespace string) *searchv1
 		},
 	}
 	return &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},
 		Spec: searchv1.MongoDBSearchSpec{
 			Version: "1.70.1",
 			Source: &searchv1.MongoDBSource{
@@ -1103,6 +1113,64 @@ func operatorPerClusterShardedTLSSecrets(search *searchv1.MongoDBSearch, cluster
 		})
 	}
 	return out
+}
+
+func TestMongoDBSearchReconcile_ShardReductionSweepsStaleResourcesAndTLSSecret(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := t.Context()
+	search := newOperatorPerClusterShardedMongoDBSearch("mdb-search", mock.TestNamespace)
+	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-a", search)
+	sourceSecrets := operatorPerClusterShardedTLSSecrets(search, 0)
+	for i, obj := range sourceSecrets {
+		secret := obj.(*corev1.Secret)
+		secret.UID = types.UID(fmt.Sprintf("source-secret-%d-uid", i))
+		require.NoError(t, c.Create(ctx, secret))
+	}
+
+	got := driveSearchReconcileToRunning(ctx, t, reconciler, c, search, 5)
+	require.Equal(t, status.PhaseRunning, got.Status.Phase, got.Status.Message)
+	for _, shardName := range []string{"sh-0", "sh-1"} {
+		require.NoError(t, c.Get(ctx, search.MongotStatefulSetForClusterShard(0, shardName), &appsv1.StatefulSet{}))
+		require.NoError(t, c.Get(ctx, search.MongotServiceForClusterShard(0, shardName), &corev1.Service{}))
+		require.NoError(t, c.Get(ctx, search.MongotConfigMapForClusterShard(0, shardName), &corev1.ConfigMap{}))
+		require.NoError(t, c.Get(ctx, search.TLSOperatorSecretForClusterShard(0, shardName), &corev1.Secret{}))
+	}
+
+	liveSearch := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, search.NamespacedName(), liveSearch))
+	liveSearch.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards =
+		liveSearch.Spec.Source.ExternalMongoDBSource.ShardedCluster.Shards[:1]
+	require.NoError(t, c.Update(ctx, liveSearch))
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: search.NamespacedName()})
+
+	require.NoError(t, err)
+	assert.Positive(t, result.RequeueAfter)
+	updatedSearch := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, search.NamespacedName(), updatedSearch))
+	assert.Equal(t, status.PhaseRunning, updatedSearch.Status.Phase, updatedSearch.Status.Message)
+	for _, stale := range []struct {
+		key types.NamespacedName
+		obj client.Object
+	}{
+		{key: search.MongotStatefulSetForClusterShard(0, "sh-1"), obj: &appsv1.StatefulSet{}},
+		{key: search.MongotServiceForClusterShard(0, "sh-1"), obj: &corev1.Service{}},
+		{key: search.MongotConfigMapForClusterShard(0, "sh-1"), obj: &corev1.ConfigMap{}},
+		{key: search.TLSOperatorSecretForClusterShard(0, "sh-1"), obj: &corev1.Secret{}},
+	} {
+		assert.True(t, apiErrors.IsNotFound(c.Get(ctx, stale.key, stale.obj)), "%T %s", stale.obj, stale.key)
+	}
+	require.NoError(t, c.Get(ctx, search.MongotStatefulSetForClusterShard(0, "sh-0"), &appsv1.StatefulSet{}))
+	require.NoError(t, c.Get(ctx, search.MongotServiceForClusterShard(0, "sh-0"), &corev1.Service{}))
+	require.NoError(t, c.Get(ctx, search.MongotConfigMapForClusterShard(0, "sh-0"), &corev1.ConfigMap{}))
+	require.NoError(t, c.Get(ctx, search.TLSOperatorSecretForClusterShard(0, "sh-0"), &corev1.Secret{}))
+	for _, obj := range sourceSecrets {
+		want := obj.(*corev1.Secret)
+		actual := &corev1.Secret{}
+		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(want), actual))
+		assert.Equal(t, want.UID, actual.UID)
+		assert.Equal(t, want.Data, actual.Data)
+	}
 }
 
 func TestReconcile_OperatorPerCluster_ShardedSource_ProjectedReconcilesLocalOnly(t *testing.T) {

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -10,12 +10,17 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -37,6 +42,15 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 )
+
+func observeControllerLogs(t *testing.T) *observer.ObservedLogs {
+	t.Helper()
+	core, logs := observer.New(zap.InfoLevel)
+	previous := zap.L()
+	zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(func() { zap.ReplaceGlobals(previous) })
+	return logs
+}
 
 func newMongoDBCommunity(name, namespace string) *mdbcv1.MongoDBCommunity {
 	return &mdbcv1.MongoDBCommunity{
@@ -189,9 +203,616 @@ func TestMongoDBSearchReconcile_NotFound(t *testing.T) {
 		reconcile.Request{NamespacedName: types.NamespacedName{Name: "missing", Namespace: "test"}},
 	)
 
-	assert.Error(t, err)
-	assert.True(t, apiErrors.IsNotFound(err))
+	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, res)
+}
+
+func TestMongoDBSearchReconcile_NotFoundRemovesDependentWatches(t *testing.T) {
+	ctx := context.Background()
+	searchKey := types.NamespacedName{Name: "missing-watch-cleanup", Namespace: mock.TestNamespace}
+	otherSearchKey := types.NamespacedName{Name: "other-search", Namespace: mock.TestNamespace}
+	reconciler, _ := newSearchReconciler(nil, nil)
+
+	sharedSecret := types.NamespacedName{Name: "shared-secret", Namespace: mock.TestNamespace}
+	reconciler.watch.AddWatchedResourceIfNotAdded(sharedSecret.Name, sharedSecret.Namespace, watch.Secret, searchKey)
+	reconciler.watch.AddWatchedResourceIfNotAdded(sharedSecret.Name, sharedSecret.Namespace, watch.Secret, otherSearchKey)
+	reconciler.watch.AddWatchedResourceIfNotAdded("owned-config", mock.TestNamespace, watch.ConfigMap, searchKey)
+
+	res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	for watchedObj, dependents := range reconciler.watch.GetWatchedResources() {
+		assert.NotContains(t, dependents, searchKey, "deleted search must be removed from watcher key %s", watchedObj)
+	}
+	assert.Contains(t, reconciler.watch.GetWatchedResources()[watch.Object{ResourceType: watch.Secret, Resource: sharedSecret}], otherSearchKey)
+}
+
+func searchCleanupLabels(searchKey types.NamespacedName, searchUID types.UID) map[string]string {
+	return map[string]string{
+		khandler.MongoDBSearchOwnerNameLabel:      searchKey.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
+		khandler.MongoDBSearchOwnerUIDLabel:       string(searchUID),
+	}
+}
+
+type staleCentralListClient struct {
+	client.Client
+	sweepListCalls int
+}
+
+func (c *staleCentralListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if isSweepOwnedResourceList(list) {
+		c.sweepListCalls++
+		return nil
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+type trackingListReader struct {
+	client.Reader
+	sweepListCalls int
+}
+
+type staleSearchCacheClient struct {
+	client.Client
+}
+
+type adoptingDeleteClient struct {
+	client.Client
+	adopted bool
+}
+
+func (c *adoptingDeleteClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if _, ok := obj.(*appsv1.Deployment); ok && !c.adopted {
+		c.adopted = true
+		live := &appsv1.Deployment{}
+		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), live); err != nil {
+			return err
+		}
+		live.Labels[khandler.MongoDBSearchOwnerUIDLabel] = "recreated-search-uid"
+		if err := c.Client.Update(ctx, live); err != nil {
+			return err
+		}
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func (c *staleSearchCacheClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*searchv1.MongoDBSearch); ok {
+		return apiErrors.NewNotFound(schema.GroupResource{Group: "mongodb.com", Resource: "mongodbsearches"}, key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (r *trackingListReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if isSweepOwnedResourceList(list) {
+		r.sweepListCalls++
+	}
+	return r.Reader.List(ctx, list, opts...)
+}
+
+func isSweepOwnedResourceList(list client.ObjectList) bool {
+	switch list.(type) {
+	case *appsv1.DeploymentList, *appsv1.StatefulSetList, *corev1.ServiceList, *corev1.ConfigMapList, *corev1.SecretList:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepUsesUncachedReaderForCentralList(t *testing.T) {
+	ctx := context.Background()
+	searchKey := types.NamespacedName{Name: "missing-central-list", Namespace: mock.TestNamespace}
+	searchUID := types.UID("deleted-search-uid")
+	ownedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owned-central-deployment",
+			Namespace: searchKey.Namespace,
+			Labels:    searchCleanupLabels(searchKey, searchUID),
+		},
+	}
+
+	centralBackingClient := mock.NewEmptyFakeClientBuilder().WithObjects(ownedDeployment).Build()
+	staleCentralClient := &staleCentralListClient{Client: centralBackingClient}
+	uncachedReader := &trackingListReader{Reader: centralBackingClient}
+
+	reconciler := newMongoDBSearchReconciler(
+		staleCentralClient,
+		uncachedReader,
+		searchcontroller.OperatorSearchConfig{},
+		map[string]client.Client{},
+		nil,
+		"",
+	)
+	res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	assert.True(t, apiErrors.IsNotFound(centralBackingClient.Get(ctx, client.ObjectKeyFromObject(ownedDeployment), &appsv1.Deployment{})))
+	assert.Greater(t, uncachedReader.sweepListCalls, 0, "central sweep must list via uncached reader")
+	assert.Equal(t, 0, staleCentralClient.sweepListCalls, "central sweep must not list via cached central client")
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepChecksTargetClusterParentUID(t *testing.T) {
+	searchKey := types.NamespacedName{Name: "target-local-search", Namespace: mock.TestNamespace}
+	localUID := types.UID("target-local-search-uid")
+
+	tests := []struct {
+		name          string
+		localParent   bool
+		childUID      types.UID
+		parentReadErr error
+		wantDeleted   bool
+		wantErr       string
+	}{
+		{name: "matching local parent UID is preserved", localParent: true, childUID: localUID},
+		{name: "different explicit UID remains eligible", localParent: true, childUID: "deleted-central-search-uid", wantDeleted: true},
+		{name: "UID-less child is preserved with local parent", localParent: true},
+		{name: "UID-less child is preserved without local parent"},
+		{name: "explicit UID is swept without local parent", childUID: "deleted-central-search-uid", wantDeleted: true},
+		{
+			name:     "NoMatch means target cluster has no local parent",
+			childUID: "deleted-central-search-uid",
+			parentReadErr: &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: v1.SchemeGroupVersion.Group, Kind: "MongoDBSearch"},
+				SearchedVersions: []string{v1.SchemeGroupVersion.Version},
+			},
+			wantDeleted: true,
+		},
+		{
+			name:     "unregistered kind means target cluster has no local parent",
+			childUID: "deleted-central-search-uid",
+			parentReadErr: runtime.NewNotRegisteredErrForKind(
+				"member-cluster",
+				v1.SchemeGroupVersion.WithKind("MongoDBSearch"),
+			),
+			wantDeleted: true,
+		},
+		{
+			name:          "ordinary target read error fails closed",
+			childUID:      "deleted-central-search-uid",
+			parentReadErr: fmt.Errorf("injected target-cluster live read error"),
+			wantErr:       "injected target-cluster live read error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := map[string]string{
+				khandler.MongoDBSearchOwnerNameLabel:      searchKey.Name,
+				khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
+			}
+			if tc.childUID != "" {
+				labels[khandler.MongoDBSearchOwnerUIDLabel] = string(tc.childUID)
+			}
+			memberStatefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+				Name:      "member-mongot",
+				Namespace: searchKey.Namespace,
+				Labels:    labels,
+			}}
+			memberObjects := []client.Object{memberStatefulSet}
+			if tc.localParent {
+				memberObjects = append(memberObjects, &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{
+					Name: searchKey.Name, Namespace: searchKey.Namespace, UID: localUID,
+				}})
+			}
+
+			centralClient := mock.NewEmptyFakeClientBuilder().Build()
+			memberBuilder := mock.NewEmptyFakeClientBuilder()
+			for _, obj := range memberObjects {
+				memberBuilder.WithObjects(obj)
+			}
+			memberClient := memberBuilder.Build()
+			var memberReader client.Reader = memberClient
+			if tc.parentReadErr != nil {
+				memberReader = interceptor.NewClient(memberClient, interceptor.Funcs{
+					Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+						return tc.parentReadErr
+					},
+				})
+			}
+			reconciler := newMongoDBSearchReconciler(
+				centralClient,
+				centralClient,
+				searchcontroller.OperatorSearchConfig{},
+				map[string]client.Client{"member-a": memberClient},
+				map[string]client.Reader{"member-a": memberReader},
+				"",
+			)
+
+			result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: searchKey})
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, reconcile.Result{}, result)
+			err = memberClient.Get(t.Context(), client.ObjectKeyFromObject(memberStatefulSet), &appsv1.StatefulSet{})
+			if tc.wantDeleted {
+				assert.True(t, apiErrors.IsNotFound(err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepPreservesResourcesWhenSearchIsRecreated(t *testing.T) {
+	ctx := context.Background()
+	searchKey := types.NamespacedName{Name: "recreated-search", Namespace: mock.TestNamespace}
+	newSearch := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: searchKey.Name, Namespace: searchKey.Namespace, UID: "new-uid"},
+	}
+	ownedObjects := []client.Object{
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: "old-search-sts", Namespace: searchKey.Namespace,
+			Labels: searchCleanupLabels(searchKey, "old-uid"),
+		}},
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: "new-search-sts", Namespace: searchKey.Namespace,
+			Labels: searchCleanupLabels(searchKey, newSearch.UID),
+		}},
+	}
+	cachedBacking := mock.NewEmptyFakeClientBuilder().WithObjects(ownedObjects...).Build()
+	reconciler := newMongoDBSearchReconciler(
+		&staleSearchCacheClient{Client: cachedBacking},
+		mock.NewEmptyFakeClientBuilder().WithObjects(newSearch).Build(),
+		searchcontroller.OperatorSearchConfig{},
+		nil,
+		nil,
+		"",
+	)
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+	for _, obj := range ownedObjects {
+		require.NoError(t, cachedBacking.Get(ctx, client.ObjectKeyFromObject(obj), obj.DeepCopyObject().(client.Object)))
+	}
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepPreservesAdoptedChild(t *testing.T) {
+	ctx := context.Background()
+	searchKey := types.NamespacedName{Name: "recreated-before-delete", Namespace: mock.TestNamespace}
+	deletedSearchUID := types.UID("deleted-search-uid")
+	ownedDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: "adopted-search-deployment", Namespace: searchKey.Namespace, UID: "child-uid",
+		Labels: searchCleanupLabels(searchKey, deletedSearchUID),
+	}}
+	backingClient := mock.NewEmptyFakeClientBuilder().WithObjects(ownedDeployment).Build()
+	deleteClient := &adoptingDeleteClient{Client: backingClient}
+	reconciler := newMongoDBSearchReconciler(
+		deleteClient,
+		backingClient,
+		searchcontroller.OperatorSearchConfig{},
+		nil,
+		nil,
+		"",
+	)
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+
+	require.Error(t, err)
+	live := &appsv1.Deployment{}
+	require.NoError(t, backingClient.Get(ctx, client.ObjectKeyFromObject(ownedDeployment), live))
+	assert.Equal(t, "recreated-search-uid", live.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepAggregatesFailuresAndContinues(t *testing.T) {
+	ctx := context.Background()
+	searchKey := types.NamespacedName{Name: "failed-sweep", Namespace: mock.TestNamespace}
+	searchUID := types.UID("deleted-search-uid")
+	ownerLabels := searchCleanupLabels(searchKey, searchUID)
+	failedConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "failed-configmap-delete", Namespace: searchKey.Namespace, Labels: ownerLabels}}
+	failedSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "failed-secret-delete", Namespace: searchKey.Namespace, Labels: ownerLabels}}
+	deletedService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "successful-service-delete", Namespace: searchKey.Namespace, Labels: ownerLabels}}
+	deleteAttempts := map[string]int{}
+	listErr := fmt.Errorf("injected Deployment list failure")
+	configMapDeleteErr := fmt.Errorf("injected ConfigMap delete failure")
+	secretDeleteErr := fmt.Errorf("injected Secret delete failure")
+	kubeClient := mock.NewEmptyFakeClientBuilder().
+		WithObjects(failedConfigMap, failedSecret, deletedService).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*appsv1.DeploymentList); ok {
+					return listErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteAttempts[obj.GetName()]++
+				switch obj.GetName() {
+				case failedConfigMap.Name:
+					return configMapDeleteErr
+				case failedSecret.Name:
+					return secretDeleteErr
+				default:
+					return c.Delete(ctx, obj, opts...)
+				}
+			},
+		}).
+		Build()
+	reconciler := newMongoDBSearchReconciler(kubeClient, kubeClient, searchcontroller.OperatorSearchConfig{}, nil, nil, "")
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, listErr.Error())
+	assert.ErrorContains(t, err, configMapDeleteErr.Error())
+	assert.ErrorContains(t, err, secretDeleteErr.Error())
+	assert.Equal(t, 1, deleteAttempts[failedConfigMap.Name])
+	assert.Equal(t, 1, deleteAttempts[failedSecret.Name])
+	assert.True(t, apiErrors.IsNotFound(kubeClient.Get(ctx, client.ObjectKeyFromObject(deletedService), &corev1.Service{})))
+	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(failedConfigMap), &corev1.ConfigMap{}))
+	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(failedSecret), &corev1.Secret{}))
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepRetriesPartialCleanup(t *testing.T) {
+	ctx := t.Context()
+	searchKey := types.NamespacedName{Name: "retry-cleanup", Namespace: mock.TestNamespace}
+	searchUID := types.UID("deleted-search-uid")
+	deletedService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "service-deleted-before-retry",
+		Namespace: searchKey.Namespace,
+		Labels:    searchCleanupLabels(searchKey, searchUID),
+	}}
+	retriedSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      "secret-retried",
+		Namespace: searchKey.Namespace,
+		Labels:    searchCleanupLabels(searchKey, searchUID),
+	}}
+	retryErr := fmt.Errorf("injected transient delete error")
+	failedOnce := false
+	kubeClient := mock.NewEmptyFakeClientBuilder().
+		WithObjects(deletedService, retriedSecret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if obj.GetName() == retriedSecret.Name && !failedOnce {
+					failedOnce = true
+					return retryErr
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	reconciler := newMongoDBSearchReconciler(kubeClient, kubeClient, searchcontroller.OperatorSearchConfig{}, nil, nil, "")
+	request := reconcile.Request{NamespacedName: searchKey}
+
+	_, err := reconciler.Reconcile(ctx, request)
+	require.ErrorContains(t, err, retryErr.Error())
+	assert.True(t, apiErrors.IsNotFound(kubeClient.Get(ctx, client.ObjectKeyFromObject(deletedService), &corev1.Service{})))
+	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(retriedSecret), &corev1.Secret{}))
+
+	result, err := reconciler.Reconcile(ctx, request)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+	assert.True(t, apiErrors.IsNotFound(kubeClient.Get(ctx, client.ObjectKeyFromObject(retriedSecret), &corev1.Secret{})))
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepUsesUIDDeletePrecondition(t *testing.T) {
+	ctx := t.Context()
+	searchKey := types.NamespacedName{Name: "deleted-search", Namespace: mock.TestNamespace}
+	searchUID := types.UID("deleted-search-uid")
+	oldUID := types.UID("listed-resource-uid")
+	newUID := types.UID("replacement-resource-uid")
+	ownedDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      "owned-deployment",
+		Namespace: searchKey.Namespace,
+		UID:       oldUID,
+		Labels:    searchCleanupLabels(searchKey, searchUID),
+	}}
+
+	kubeClient := mock.NewEmptyFakeClientBuilder().
+		WithObjects(ownedDeployment).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteOptions := (&client.DeleteOptions{}).ApplyOptions(opts)
+				require.NotNil(t, deleteOptions.Preconditions)
+				require.NotNil(t, deleteOptions.Preconditions.UID)
+				assert.Equal(t, oldUID, *deleteOptions.Preconditions.UID)
+
+				require.NoError(t, c.Delete(ctx, obj))
+				replacement := ownedDeployment.DeepCopy()
+				replacement.UID = newUID
+				replacement.ResourceVersion = ""
+				require.NoError(t, c.Create(ctx, replacement))
+				return apiErrors.NewConflict(
+					schema.GroupResource{Group: appsv1.GroupName, Resource: "deployments"},
+					obj.GetName(),
+					fmt.Errorf("UID precondition failed"),
+				)
+			},
+		}).
+		Build()
+	reconciler := newMongoDBSearchReconciler(kubeClient, kubeClient, searchcontroller.OperatorSearchConfig{}, nil, nil, "")
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "UID precondition failed")
+	current := &appsv1.Deployment{}
+	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(ownedDeployment), current))
+	assert.Equal(t, newUID, current.UID)
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepsOwnedResourcesAcrossClusters(t *testing.T) {
+	ctx := context.Background()
+	searchKey := types.NamespacedName{Name: "missing-search", Namespace: mock.TestNamespace}
+	searchUID := types.UID("deleted-search-uid")
+	ownerLabels := searchCleanupLabels(searchKey, searchUID)
+	uidlessOwnerLabels := map[string]string{
+		khandler.MongoDBSearchOwnerNameLabel:      searchKey.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
+	}
+
+	otherSearchLabels := map[string]string{
+		khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+		khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
+	}
+	missingNameLabels := map[string]string{
+		khandler.MongoDBSearchOwnerNamespaceLabel: searchKey.Namespace,
+	}
+	missingNamespaceLabels := map[string]string{
+		khandler.MongoDBSearchOwnerNameLabel: searchKey.Name,
+	}
+
+	type trackedObject struct {
+		object       client.Object
+		shouldDelete bool
+		reason       string
+	}
+	kindBuilders := []struct {
+		kind      string
+		newObject func(name string, labels map[string]string) client.Object
+	}{
+		{
+			kind: "deployment",
+			newObject: func(name string, labels map[string]string) client.Object {
+				return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: searchKey.Namespace, Labels: labels}}
+			},
+		},
+		{
+			kind: "statefulset",
+			newObject: func(name string, labels map[string]string) client.Object {
+				return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: searchKey.Namespace, Labels: labels}}
+			},
+		},
+		{
+			kind: "service",
+			newObject: func(name string, labels map[string]string) client.Object {
+				return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: searchKey.Namespace, Labels: labels}}
+			},
+		},
+		{
+			kind: "configmap",
+			newObject: func(name string, labels map[string]string) client.Object {
+				return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: searchKey.Namespace, Labels: labels}}
+			},
+		},
+		{
+			kind: "secret",
+			newObject: func(name string, labels map[string]string) client.Object {
+				return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: searchKey.Namespace, Labels: labels}}
+			},
+		},
+	}
+	buildObjects := func(prefix string) []trackedObject {
+		var objects []trackedObject
+		for _, kind := range kindBuilders {
+			objects = append(objects,
+				trackedObject{
+					object:       kind.newObject(fmt.Sprintf("%s-%s-owned", prefix, kind.kind), ownerLabels),
+					shouldDelete: true,
+					reason:       "explicit owner UID without a target-local parent must be swept",
+				},
+				trackedObject{
+					object:       kind.newObject(fmt.Sprintf("%s-%s-uidless", prefix, kind.kind), uidlessOwnerLabels),
+					shouldDelete: false,
+					reason:       "UID-less owner object must be preserved fail-closed",
+				},
+				trackedObject{
+					object:       kind.newObject(fmt.Sprintf("%s-%s-other-search", prefix, kind.kind), otherSearchLabels),
+					shouldDelete: false,
+					reason:       "different owner-name label must not be swept",
+				},
+				trackedObject{
+					object:       kind.newObject(fmt.Sprintf("%s-%s-missing-name", prefix, kind.kind), missingNameLabels),
+					shouldDelete: false,
+					reason:       "missing owner-name label must not be swept",
+				},
+				trackedObject{
+					object:       kind.newObject(fmt.Sprintf("%s-%s-missing-namespace", prefix, kind.kind), missingNamespaceLabels),
+					shouldDelete: false,
+					reason:       "missing owner-namespace label must not be swept",
+				},
+				trackedObject{
+					object:       kind.newObject(fmt.Sprintf("%s-%s-unlabeled", prefix, kind.kind), nil),
+					shouldDelete: false,
+					reason:       "unlabeled resource must not be swept",
+				},
+			)
+		}
+		objects = append(objects,
+			trackedObject{
+				object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:      prefix + "-owned-pod",
+					Namespace: searchKey.Namespace,
+					Labels:    ownerLabels,
+				}},
+				shouldDelete: false,
+				reason:       "Pods must remain outside the explicit top-level sweep allowlist",
+			},
+			trackedObject{
+				object: &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+					Name:      prefix + "-owned-pvc",
+					Namespace: searchKey.Namespace,
+					Labels:    ownerLabels,
+				}},
+				shouldDelete: false,
+				reason:       "PVCs must remain outside the explicit top-level sweep allowlist",
+			},
+		)
+		return objects
+	}
+
+	centralObjects := buildObjects("central")
+	centralBuilder := mock.NewEmptyFakeClientBuilder()
+	for _, tracked := range centralObjects {
+		centralBuilder.WithObjects(tracked.object)
+	}
+	centralClient := centralBuilder.Build()
+
+	memberObjects := buildObjects("member")
+	memberBuilder := mock.NewEmptyFakeClientBuilder()
+	for _, tracked := range memberObjects {
+		memberBuilder.WithObjects(tracked.object)
+	}
+	memberClient := memberBuilder.Build()
+
+	reconciler := newMongoDBSearchReconciler(
+		centralClient,
+		centralClient,
+		searchcontroller.OperatorSearchConfig{},
+		map[string]client.Client{"member-a": memberClient},
+		nil,
+		"",
+	)
+	clusterCases := []struct {
+		name    string
+		client  client.Client
+		objects []trackedObject
+	}{
+		{name: "central", client: centralClient, objects: centralObjects},
+		{name: "member-a", client: memberClient, objects: memberObjects},
+	}
+
+	for _, cluster := range clusterCases {
+		for _, tracked := range cluster.objects {
+			key := client.ObjectKeyFromObject(tracked.object)
+			require.NoError(t, cluster.client.Get(ctx, key, tracked.object.DeepCopyObject().(client.Object)))
+		}
+	}
+
+	res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: searchKey})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	for _, cluster := range clusterCases {
+		for _, tracked := range cluster.objects {
+			key := client.ObjectKeyFromObject(tracked.object)
+			err := cluster.client.Get(ctx, key, tracked.object.DeepCopyObject().(client.Object))
+			if tracked.shouldDelete {
+				assert.True(t, apiErrors.IsNotFound(err),
+					"[%s] %s (%s) should be deleted; err=%v", cluster.name, key.Name, tracked.reason, err)
+				continue
+			}
+			require.NoError(t, err,
+				"[%s] %s (%s) should be preserved", cluster.name, key.Name, tracked.reason)
+		}
+	}
 }
 
 func TestMongoDBSearchDeploymentWatchesRouteLifecycleEvents(t *testing.T) {
@@ -387,6 +1008,281 @@ func TestRegisterTLSResourceWatchesIncludesShardedMemberDependencies(t *testing.
 	for _, resource := range expected {
 		assert.Contains(t, watched[resource], search.NamespacedName(), "missing dependency watch for %s", resource)
 	}
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepLifecycle_SingleCluster(t *testing.T) {
+	ctx := context.Background()
+	search := newMongoDBSearch("search-lifecycle-sc", mock.TestNamespace, "source")
+	search.UID = "search-lifecycle-sc-uid"
+	search.Spec.Version = "1.70.1"
+	mdbc := newMongoDBCommunity("source", mock.TestNamespace)
+	reconciler, central := newSearchReconciler(mdbc, search)
+
+	got := driveSearchReconcileToRunning(ctx, t, reconciler, central, search, 5)
+	require.Equal(t, status.PhaseRunning, got.Status.Phase, "single-cluster reconcile must create resources before NotFound sweep")
+
+	stsName := search.StatefulSetNamespacedNameForCluster(0)
+	headlessName := search.SearchServiceNamespacedNameForCluster(0)
+	proxyName := search.ProxyServiceNamespacedNameForCluster(0)
+	cmName := search.MongotConfigConfigMapNameForCluster(0)
+	searchStateCMName := types.NamespacedName{Name: searchcontroller.SearchStateCMName(search), Namespace: search.Namespace}
+	metricsStateCMName := types.NamespacedName{Name: fmt.Sprintf("%s-metrics-forwarder-state", search.Name), Namespace: search.Namespace}
+	operatorTLSSecretName := search.TLSOperatorSecretNamespacedName()
+
+	require.NoError(t, central.Get(ctx, stsName, &appsv1.StatefulSet{}))
+	require.NoError(t, central.Get(ctx, headlessName, &corev1.Service{}))
+	require.NoError(t, central.Get(ctx, proxyName, &corev1.Service{}))
+	require.NoError(t, central.Get(ctx, cmName, &corev1.ConfigMap{}))
+
+	ownerLabels := searchCleanupLabels(search.NamespacedName(), search.UID)
+	ownedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-owned-deployment", Namespace: search.Namespace, Labels: ownerLabels},
+	}
+	ownedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-owned-secret", Namespace: search.Namespace, Labels: ownerLabels},
+	}
+	ownedSearchStateCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: searchStateCMName.Name, Namespace: searchStateCMName.Namespace, Labels: ownerLabels},
+	}
+	ownedMetricsStateCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: metricsStateCMName.Name, Namespace: metricsStateCMName.Namespace, Labels: ownerLabels},
+	}
+	ownedOperatorTLSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: operatorTLSSecretName.Name, Namespace: operatorTLSSecretName.Namespace, Labels: ownerLabels},
+	}
+	unlabeledDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-foreign-unlabeled", Namespace: search.Namespace},
+	}
+	unlabeledTLSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-foreign-unlabeled-tls", Namespace: search.Namespace},
+	}
+	otherSearchStateCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.Name + "-other-search-state",
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	otherSearchSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.Name + "-other-search-secret",
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	for _, obj := range []client.Object{
+		ownedDeployment,
+		ownedSecret,
+		ownedSearchStateCM,
+		ownedMetricsStateCM,
+		ownedOperatorTLSSecret,
+		unlabeledDeployment,
+		unlabeledTLSSecret,
+		otherSearchStateCM,
+		otherSearchSecret,
+	} {
+		require.NoError(t, central.Create(ctx, obj))
+	}
+
+	require.NoError(t, central.Delete(ctx, search))
+	res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, stsName, &appsv1.StatefulSet{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, headlessName, &corev1.Service{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, proxyName, &corev1.Service{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, cmName, &corev1.ConfigMap{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(ownedDeployment), &appsv1.Deployment{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(ownedSecret), &corev1.Secret{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, searchStateCMName, &corev1.ConfigMap{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, metricsStateCMName, &corev1.ConfigMap{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, operatorTLSSecretName, &corev1.Secret{})))
+
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unlabeledDeployment), &appsv1.Deployment{}))
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unlabeledTLSSecret), &corev1.Secret{}))
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(otherSearchStateCM), &corev1.ConfigMap{}))
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(otherSearchSecret), &corev1.Secret{}))
+}
+
+func TestMongoDBSearchReconcile_NotFoundSweepLifecycle_MultiCluster(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "search-lifecycle-mc", Namespace: mock.TestNamespace, UID: "search-lifecycle-mc-uid"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Version: "1.70.1",
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+					HostAndPorts: []string{"mdb-0.mdb.svc:27017", "mdb-1.mdb.svc:27017"},
+				},
+			},
+			Clusters: []searchv1.ClusterSpec{
+				{
+					Name: "us-east", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-east.example.com"}},
+				},
+				{
+					Name: "us-west", Index: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
+					LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-us-west.example.com"}},
+				},
+			},
+		},
+	}
+
+	eastClient := mock.NewEmptyFakeClientBuilder().Build()
+	westClient := mock.NewEmptyFakeClientBuilder().Build()
+	reconciler, central := newSearchReconcilerWithMembers(t, nil, map[string]client.Client{
+		"us-east": eastClient,
+		"us-west": westClient,
+	}, "", search)
+
+	got := driveSearchReconcileToRunning(ctx, t, reconciler, central, search, 5, eastClient, westClient)
+	require.Equal(t, status.PhaseRunning, got.Status.Phase, "multi-cluster reconcile must create resources before NotFound sweep")
+
+	centralOwnerLabels := searchCleanupLabels(search.NamespacedName(), search.UID)
+	centralOwnedStateCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      searchcontroller.SearchStateCMName(search),
+			Namespace: search.Namespace,
+			Labels:    centralOwnerLabels,
+		},
+	}
+	centralOwnedMetricsStateCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-metrics-forwarder-state", search.Name),
+			Namespace: search.Namespace,
+			Labels:    centralOwnerLabels,
+		},
+	}
+	centralOwnedTLSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.TLSOperatorSecretNamespacedName().Name,
+			Namespace: search.Namespace,
+			Labels:    centralOwnerLabels,
+		},
+	}
+	centralKeepOtherStateCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.Name + "-central-keep-other-state",
+			Namespace: search.Namespace,
+			Labels: map[string]string{
+				khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			},
+		},
+	}
+	centralKeepNoLabelTLSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-central-keep-unlabeled-tls", Namespace: search.Namespace},
+	}
+	for _, obj := range []client.Object{
+		centralOwnedStateCM,
+		centralOwnedMetricsStateCM,
+		centralOwnedTLSSecret,
+		centralKeepOtherStateCM,
+		centralKeepNoLabelTLSSecret,
+	} {
+		require.NoError(t, central.Create(ctx, obj))
+	}
+
+	type clusterCase struct {
+		name        string
+		idx         int
+		client      client.Client
+		ownedDep    string
+		ownedSec    string
+		keepOther   string
+		keepNoLabel string
+	}
+	cases := []clusterCase{
+		{name: "us-east", idx: 0, client: eastClient},
+		{name: "us-west", idx: 1, client: westClient},
+	}
+
+	for i := range cases {
+		tc := &cases[i]
+		require.NoError(t, tc.client.Get(ctx, search.StatefulSetNamespacedNameForCluster(tc.idx), &appsv1.StatefulSet{}))
+		require.NoError(t, tc.client.Get(ctx, search.SearchServiceNamespacedNameForCluster(tc.idx), &corev1.Service{}))
+		require.NoError(t, tc.client.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.idx), &corev1.Service{}))
+		require.NoError(t, tc.client.Get(ctx, search.MongotConfigConfigMapNameForCluster(tc.idx), &corev1.ConfigMap{}))
+
+		ownerLabels := searchCleanupLabels(search.NamespacedName(), search.UID)
+		ownerLabels[khandler.MongoDBSearchClusterNameLabel] = tc.name
+		tc.ownedDep = fmt.Sprintf("%s-%s-owned-deployment", search.Name, tc.name)
+		tc.ownedSec = fmt.Sprintf("%s-%s-owned-secret", search.Name, tc.name)
+		tc.keepOther = fmt.Sprintf("%s-%s-keep-other", search.Name, tc.name)
+		tc.keepNoLabel = fmt.Sprintf("%s-%s-keep-unlabeled", search.Name, tc.name)
+		require.NoError(t, tc.client.Create(ctx, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: tc.ownedDep, Namespace: search.Namespace, Labels: ownerLabels},
+		}))
+		require.NoError(t, tc.client.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: tc.ownedSec, Namespace: search.Namespace, Labels: ownerLabels},
+		}))
+		require.NoError(t, tc.client.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tc.keepOther,
+				Namespace: search.Namespace,
+				Labels: map[string]string{
+					khandler.MongoDBSearchOwnerNameLabel:      "other-search",
+					khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+				},
+			},
+		}))
+		require.NoError(t, tc.client.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: tc.keepNoLabel, Namespace: search.Namespace},
+		}))
+	}
+
+	require.NoError(t, central.Delete(ctx, search))
+	res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(centralOwnedStateCM), &corev1.ConfigMap{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(centralOwnedMetricsStateCM), &corev1.ConfigMap{})))
+	assert.True(t, apiErrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(centralOwnedTLSSecret), &corev1.Secret{})))
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(centralKeepOtherStateCM), &corev1.ConfigMap{}))
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(centralKeepNoLabelTLSSecret), &corev1.Secret{}))
+
+	for _, tc := range cases {
+		assert.True(t, apiErrors.IsNotFound(tc.client.Get(ctx, search.StatefulSetNamespacedNameForCluster(tc.idx), &appsv1.StatefulSet{})))
+		assert.True(t, apiErrors.IsNotFound(tc.client.Get(ctx, search.SearchServiceNamespacedNameForCluster(tc.idx), &corev1.Service{})))
+		assert.True(t, apiErrors.IsNotFound(tc.client.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.idx), &corev1.Service{})))
+		assert.True(t, apiErrors.IsNotFound(tc.client.Get(ctx, search.MongotConfigConfigMapNameForCluster(tc.idx), &corev1.ConfigMap{})))
+		assert.True(t, apiErrors.IsNotFound(tc.client.Get(ctx, types.NamespacedName{Name: tc.ownedDep, Namespace: search.Namespace}, &appsv1.Deployment{})))
+		assert.True(t, apiErrors.IsNotFound(tc.client.Get(ctx, types.NamespacedName{Name: tc.ownedSec, Namespace: search.Namespace}, &corev1.Secret{})))
+
+		require.NoError(t, tc.client.Get(ctx, types.NamespacedName{Name: tc.keepOther, Namespace: search.Namespace}, &corev1.ConfigMap{}))
+		require.NoError(t, tc.client.Get(ctx, types.NamespacedName{Name: tc.keepNoLabel, Namespace: search.Namespace}, &corev1.ConfigMap{}))
+	}
+}
+
+func TestMongoDBSearchReconcile_DeletionTimestampTakesPriorityOverDisableAnnotation(t *testing.T) {
+	ctx := context.Background()
+	logs := observeControllerLogs(t)
+	now := metav1.Now()
+	search := newMongoDBSearch("search", mock.TestNamespace, "missing-source")
+	search.DeletionTimestamp = &now
+	search.Finalizers = []string{"kubernetes"}
+	search.Annotations = map[string]string{searchv1.DisableReconciliationAnnotation: "true"}
+
+	reconciler, c := newSearchReconciler(nil, search)
+	res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	updated := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: search.Name, Namespace: search.Namespace}, updated))
+	assert.Empty(t, updated.Status.Phase)
+	assert.Equal(t, 1, logs.FilterMessageSnippet("is deleting; skipping main-controller reconcile").Len())
+	assert.Zero(t, logs.FilterMessageSnippet("reconciliation disabled").Len())
 }
 
 func TestMongoDBSearchReconcile_MissingSource(t *testing.T) {

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha1" //nolint //Used to derive a stable host identifier, not for security.
 	"crypto/sha256"
@@ -357,10 +358,25 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		}
 	}
 
-	var firstFailure error
+	initialTopologyState, err := json.Marshal(topologyState)
+	if err != nil {
+		return workflow.Failed(fmt.Errorf("failed to marshal topology state: %w", err))
+	}
+
+	var reconcileErrs error
 	var worstPhase status.Phase
 	pendingPodTerminations := false
+	preparedWork := make([]clusterWorkItem, 0, len(workList))
+	recordStatus := func(w clusterWorkItem, st workflow.Status) {
+		worstPhase = searchv1.WorstOfPhase(worstPhase, st.Phase())
+		if !st.IsOK() {
+			reconcileErrs = errors.Join(reconcileErrs, fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st)))
+		}
+	}
 
+	// Phase 1: bring every cluster's topology entry up to date in memory. Hosts whose
+	// deferral window elapsed are deregistered from Ops Manager here, before any
+	// forwarder resource is written.
 	for _, w := range workList {
 		var st workflow.Status
 		switch w.Client {
@@ -368,32 +384,37 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 			st = workflow.Pending("Member cluster %q not registered with the operator", w.ClusterName)
 		default:
 			var pending bool
-			pending, st = r.reconcileForCluster(ctx, mdbSearch, shardNames, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, w, log)
+			pending, st = r.prepareCluster(ctx, mdbSearch, shardNames, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, topologyState, w, log)
 			if pending {
 				pendingPodTerminations = true
 			}
+			if st.IsOK() {
+				preparedWork = append(preparedWork, w)
+			}
 		}
-		worstPhase = searchv1.WorstOfPhase(worstPhase, st.Phase())
-		if !st.IsOK() && firstFailure == nil {
-			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st))
-		}
+		recordStatus(w, st)
 	}
 
-	removedPending, removedErr := r.cleanupRemovedClusters(ctx, mdbSearch, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, workList, log)
+	removedPending, removedErr := r.cleanupRemovedClusters(ctx, mdbSearch, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, workList, topologyState, log)
 	pendingPodTerminations = pendingPodTerminations || removedPending
 	if removedErr != nil {
 		worstPhase = searchv1.WorstOfPhase(worstPhase, status.PhaseFailed)
-		if firstFailure == nil {
-			firstFailure = removedErr
+		reconcileErrs = errors.Join(reconcileErrs, removedErr)
+	}
+
+	// Single state write for the whole reconcile, skipped when nothing changed.
+	updatedTopologyState, err := json.Marshal(topologyState)
+	if err != nil {
+		return workflow.Failed(fmt.Errorf("failed to marshal topology state: %w", err))
+	}
+	if !bytes.Equal(initialTopologyState, updatedTopologyState) {
+		if err := r.openTopologyStateStore(mdbSearch).WriteState(ctx, topologyState, log); err != nil {
+			return workflow.Failed(fmt.Errorf("failed to write topology state: %w", err))
 		}
 	}
 
 	if cleaningRemovedOperator && removedErr == nil && !removedPending && controllerutil.ContainsFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
-		currentState, err := r.loadTopologyState(ctx, mdbSearch)
-		if err != nil {
-			return workflow.Failed(err)
-		}
-		if _, stateExists := currentState.Clusters[r.operatorClusterName]; !stateExists {
+		if _, stateExists := topologyState.Clusters[r.operatorClusterName]; !stateExists {
 			controllerutil.RemoveFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer)
 			if err := r.kubeClient.Update(ctx, mdbSearch); err != nil {
 				return workflow.Failed(fmt.Errorf("failed to remove finalizer after cleaning removed cluster %q: %w", r.operatorClusterName, err))
@@ -401,11 +422,16 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		}
 	}
 
-	if firstFailure != nil {
+	// Phase 2: ensure forwarder resources only for clusters whose topology state is durable.
+	for _, w := range preparedWork {
+		recordStatus(w, r.reconcileForCluster(ctx, mdbSearch, shardNames, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, w, log))
+	}
+
+	if reconcileErrs != nil {
 		if worstPhase == status.PhaseFailed {
-			return workflow.Failed(firstFailure)
+			return workflow.Failed(reconcileErrs)
 		}
-		return workflow.Pending("%s", firstFailure)
+		return workflow.Pending("%s", reconcileErrs)
 	}
 
 	log.Info("MongoDBSearchMetricsForwarder reconciliation complete")
@@ -522,9 +548,9 @@ func validatePersistedClusterIndexes(workList []clusterWorkItem, topologyState *
 }
 
 // cleanupRemovedClusters reaps metrics forwarder resources, Ops Manager hosts, and the
-// persisted state entry for clusters present in the topology state but no longer in
+// topology state entry for clusters present in the topology state but no longer in
 // spec.clusters (including the legacy ""-keyed entry after a move to named clusters).
-// It loads the state itself so it observes the entries the per-cluster loop just wrote.
+// It mutates topologyState in place; the caller persists the state afterwards.
 // Returns pending=true while a removed cluster's forwarder Deployment is still going away.
 //
 // Host deregistration uses the CR's CURRENT Ops Manager project: if the project (or its
@@ -537,15 +563,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedClusters(
 	projectConfig mdbv1.ProjectConfig,
 	agentSecretName string,
 	currentWork []clusterWorkItem,
+	topologyState *searchTopologyState,
 	log *zap.SugaredLogger,
 ) (bool, error) {
-	topologyState, err := r.loadAndMigrateTopologyState(ctx, search, log)
-	if err != nil {
-		return false, err
-	}
 	removedWork := r.persistedOnlyClusterWork(search, currentWork, topologyState)
 	pending := false
-	stateChanged := false
 	var cleanupErr error
 	for _, w := range removedWork {
 		if w.Client == nil {
@@ -590,19 +612,35 @@ func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedClusters(
 			continue
 		}
 		delete(topologyState.Clusters, w.ClusterName)
-		stateChanged = true
-	}
-	if stateChanged {
-		if err := r.openTopologyStateStore(search).WriteState(ctx, topologyState, log); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to write topology state after removed-cluster cleanup: %w", err))
-		}
 	}
 	return pending, cleanupErr
 }
 
-// reconcileForCluster runs the per-cluster reconcile: replicate dependencies, reconcile topology
-// state, render the OTel config, and ensure the ConfigMap and Deployment. Returns whether any
-// host deletions are still pending (triggering a requeue) and the workflow status.
+// prepareCluster runs phase 1 for one cluster: it updates the cluster's entry in the shared
+// in-memory topology state and deregisters Ops Manager hosts whose deferral window elapsed.
+// Returns whether any host deletions are still pending (triggering a requeue) and the
+// workflow status.
+func (r *MongoDBSearchMetricsForwarderReconciler) prepareCluster(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	shardNames []string,
+	groupID string,
+	projectConfig mdbv1.ProjectConfig,
+	agentSecretName string,
+	topologyState *searchTopologyState,
+	w clusterWorkItem,
+	log *zap.SugaredLogger,
+) (pendingTerminations bool, st workflow.Status) {
+	pending, err := r.reconcileTopologyState(ctx, search, shardNames, groupID, projectConfig, agentSecretName, topologyState, w, log)
+	if err != nil {
+		return false, workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+	}
+	return pending, workflow.OK()
+}
+
+// reconcileForCluster runs phase 2 for one cluster: replicate dependencies, render the OTel
+// config, and ensure the ConfigMap and Deployment. It runs only after the topology state has
+// been persisted, so a forwarder never starts pushing metrics for hosts the state does not track.
 func (r *MongoDBSearchMetricsForwarderReconciler) reconcileForCluster(
 	ctx context.Context,
 	search *searchv1.MongoDBSearch,
@@ -612,14 +650,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileForCluster(
 	agentSecretName string,
 	w clusterWorkItem,
 	log *zap.SugaredLogger,
-) (pendingTerminations bool, st workflow.Status) {
+) workflow.Status {
 	if err := r.replicateForwarderDependencies(ctx, search, agentSecretName, projectConfig.SSLMMSCAConfigMap, w, log); err != nil {
-		return false, workflow.Failed(fmt.Errorf("cluster=%q: failed to replicate dependencies: %w", w.ClusterName, err))
-	}
-
-	pending, err := r.reconcileTopologyState(ctx, search, shardNames, groupID, projectConfig, agentSecretName, w, log)
-	if err != nil {
-		return false, workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+		return workflow.Failed(fmt.Errorf("cluster=%q: failed to replicate dependencies: %w", w.ClusterName, err))
 	}
 
 	agentKeySecretName := search.MetricsForwarderAgentKeySecretNameForCluster(w.ClusterIndex)
@@ -642,18 +675,18 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileForCluster(
 		ScrapeInterval:                    prometheusDefaultScrapeInterval,
 	})
 	if err != nil {
-		return false, workflow.Failed(fmt.Errorf("cluster=%q: failed to generate metrics forwarder config: %w", w.ClusterName, err))
+		return workflow.Failed(fmt.Errorf("cluster=%q: failed to generate metrics forwarder config: %w", w.ClusterName, err))
 	}
 
 	if err := r.ensureMetricsForwarderConfigMap(ctx, search, configYAML, w, log); err != nil {
-		return false, workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+		return workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
 	}
 
 	if err := r.ensureMetricsForwarderDeployment(ctx, search, configYAML, groupID, agentKeySecretName, caConfigMapName, w, log); err != nil {
-		return false, workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+		return workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
 	}
 
-	return pending, workflow.OK()
+	return workflow.OK()
 }
 
 // replicateForwarderDependencies copies the agent-key Secret and (when present) the OM CA ConfigMap
@@ -987,8 +1020,9 @@ func desiredClusterTopology(search *searchv1.MongoDBSearch, shardNames []string,
 
 // reconcileTopologyState reconciles the topology state for one cluster work item: it detects
 // removed mongot pods, advances each through the deletion state machine, deregisters hosts in Ops
-// Manager at the right moment, and persists the updated state. Returns true while any deletion is
-// still in flight, which causes the caller to requeue.
+// Manager at the right moment, and updates the cluster's entry in the shared in-memory state
+// (the caller persists it once for all clusters). Returns true while any deletion is still in
+// flight, which causes the caller to requeue.
 //
 // # Why a state machine
 //
@@ -1030,15 +1064,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileTopologyState(
 	groupID string,
 	projectConfig mdbv1.ProjectConfig,
 	agentSecretName string,
+	fullState *searchTopologyState,
 	w clusterWorkItem,
 	log *zap.SugaredLogger,
 ) (bool, error) {
 	current, err := desiredClusterTopology(search, shardNames, w)
-	if err != nil {
-		return false, err
-	}
-
-	fullState, err := r.loadTopologyState(ctx, search)
 	if err != nil {
 		return false, err
 	}
@@ -1098,10 +1128,6 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileTopologyState(
 		current.HostDeletionReadyAfter = hostDeletionReadyAfter
 	}
 	fullState.Clusters[w.ClusterName] = current
-
-	if err := r.openTopologyStateStore(search).WriteState(ctx, fullState, log); err != nil {
-		return false, fmt.Errorf("failed to write topology state: %w", err)
-	}
 
 	pending := len(stillTerminating) > 0 || len(hostDeletionReadyAfter) > 0
 	return pending, nil

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -182,6 +182,14 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 		return r.updateMetricsForwarderStatus(ctx, mdbSearch, st, log)
 	}
 
+	// The pause annotation must silence every controller that mutates owned objects,
+	// so manual edits to the forwarder Deployment/ConfigMap survive while reconciliation is disabled.
+	if mdbSearch.IsReconciliationDisabled() {
+		log.Infof("MongoDBSearch %s/%s reconciliation disabled by %s annotation; skipping metrics forwarder reconcile",
+			mdbSearch.GetNamespace(), mdbSearch.GetName(), searchv1.DisableReconciliationAnnotation)
+		return reconcile.Result{}, nil
+	}
+
 	mode := mdbSearch.Spec.Observability.MetricsForwarder.Mode
 	switch mode {
 	case searchv1.MetricsForwarderModeAuto, "":

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -683,7 +683,7 @@ func (o metricsForwarderStateOwner) GetOwnerLabels() map[string]string {
 }
 
 func (r *MongoDBSearchMetricsForwarderReconciler) openTopologyStateStore(search *searchv1.MongoDBSearch) *StateStore[searchTopologyState] {
-	return NewStateStore[searchTopologyState](metricsForwarderStateOwner{MongoDBSearch: search}, search.GetOwnerReferences(), r.kubeClient)
+	return NewStateStore[searchTopologyState](metricsForwarderStateOwner{MongoDBSearch: search}, search.GetOwnerReferences(), r.kubeClient, string(search.UID))
 }
 
 // reconcileTopologyState reconciles the topology state for one cluster work item: it detects

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -181,6 +181,10 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 		return reconcile.Result{}, nil
 	}
 
+	if isRemovedSearchOperatorCluster(mdbSearch, r.operatorClusterName) {
+		return r.reconcileCore(ctx, mdbSearch, log).ReconcileResult()
+	}
+
 	if skip, result, err := r.prepareSearch(mdbSearch, log,
 		func(st workflow.Status) (reconcile.Result, error) {
 			if !mdbSearch.IsMetricsForwarderEnabled() {
@@ -253,7 +257,8 @@ func (r *MongoDBSearchMetricsForwarderReconciler) loadAndMigrateTopologyState(
 
 func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Context, mdbSearch *searchv1.MongoDBSearch, log *zap.SugaredLogger) workflow.Status {
 	deleting := !mdbSearch.DeletionTimestamp.IsZero()
-	if !deleting {
+	cleaningRemovedOperator := isRemovedSearchOperatorCluster(mdbSearch, r.operatorClusterName)
+	if !deleting && !cleaningRemovedOperator {
 		if r.defaultImage == "" {
 			return workflow.Invalid("%s environment variable must be set on the operator to use metrics forwarder", util.MetricsForwarderImageEnv)
 		}
@@ -339,15 +344,17 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		r.watch.AddWatchedResourceIfNotAdded(projectConfig.SSLMMSCAConfigMap, mdbSearch.Namespace, watch.ConfigMap, mdbSearch.NamespacedName())
 	}
 
-	if supported, st := r.checkOMVersionForMetricsEndpoint(mdbSearch, projectConfig, log); !supported {
-		if err := r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log); err != nil {
-			return workflow.Failed(err)
+	if !cleaningRemovedOperator {
+		if supported, st := r.checkOMVersionForMetricsEndpoint(mdbSearch, projectConfig, log); !supported {
+			if err := r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log); err != nil {
+				return workflow.Failed(err)
+			}
+			return st
 		}
-		return st
-	}
 
-	if err := r.ensureFinalizer(ctx, mdbSearch, log); err != nil {
-		return workflow.Failed(fmt.Errorf("failed to add finalizer: %w", err))
+		if err := r.ensureFinalizer(ctx, mdbSearch, log); err != nil {
+			return workflow.Failed(fmt.Errorf("failed to add finalizer: %w", err))
+		}
 	}
 
 	var firstFailure error
@@ -369,6 +376,28 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		worstPhase = searchv1.WorstOfPhase(worstPhase, st.Phase())
 		if !st.IsOK() && firstFailure == nil {
 			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st))
+		}
+	}
+
+	removedPending, removedErr := r.cleanupRemovedClusters(ctx, mdbSearch, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, workList, log)
+	pendingPodTerminations = pendingPodTerminations || removedPending
+	if removedErr != nil {
+		worstPhase = searchv1.WorstOfPhase(worstPhase, status.PhaseFailed)
+		if firstFailure == nil {
+			firstFailure = removedErr
+		}
+	}
+
+	if cleaningRemovedOperator && removedErr == nil && !removedPending && controllerutil.ContainsFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
+		currentState, err := r.loadTopologyState(ctx, mdbSearch)
+		if err != nil {
+			return workflow.Failed(err)
+		}
+		if _, stateExists := currentState.Clusters[r.operatorClusterName]; !stateExists {
+			controllerutil.RemoveFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer)
+			if err := r.kubeClient.Update(ctx, mdbSearch); err != nil {
+				return workflow.Failed(fmt.Errorf("failed to remove finalizer after cleaning removed cluster %q: %w", r.operatorClusterName, err))
+			}
 		}
 	}
 
@@ -490,6 +519,85 @@ func validatePersistedClusterIndexes(workList []clusterWorkItem, topologyState *
 		return fmt.Errorf("cluster %q index is immutable: persisted index %d, requested index %d", w.ClusterName, *persisted.ClusterIndex, w.ClusterIndex)
 	}
 	return nil
+}
+
+// cleanupRemovedClusters reaps metrics forwarder resources, Ops Manager hosts, and the
+// persisted state entry for clusters present in the topology state but no longer in
+// spec.clusters (including the legacy ""-keyed entry after a move to named clusters).
+// It loads the state itself so it observes the entries the per-cluster loop just wrote.
+// Returns pending=true while a removed cluster's forwarder Deployment is still going away.
+//
+// Host deregistration uses the CR's CURRENT Ops Manager project: if the project (or its
+// credentials) changes concurrently with a cluster removal, hosts registered under the
+// previous project may stay monitored in Ops Manager until cleaned up manually.
+func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedClusters(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	groupID string,
+	projectConfig mdbv1.ProjectConfig,
+	agentSecretName string,
+	currentWork []clusterWorkItem,
+	log *zap.SugaredLogger,
+) (bool, error) {
+	topologyState, err := r.loadAndMigrateTopologyState(ctx, search, log)
+	if err != nil {
+		return false, err
+	}
+	removedWork := r.persistedOnlyClusterWork(search, currentWork, topologyState)
+	pending := false
+	stateChanged := false
+	var cleanupErr error
+	for _, w := range removedWork {
+		if w.Client == nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cluster=%q: no Kubernetes client registered", w.ClusterName))
+			continue
+		}
+		// Deployment first: a still-running collector would push metrics for the
+		// deregistered hosts and Ops Manager would implicitly re-add them.
+		depName := search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex)
+		found, err := r.deleteMetricsForwarderObject(
+			ctx,
+			search,
+			w,
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: search.Namespace}},
+			"Deployment",
+			client.PropagationPolicy(metav1.DeletePropagationForeground),
+		)
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+		if found {
+			pending = true
+			continue
+		}
+
+		clusterState := topologyState.Clusters[w.ClusterName]
+		mongotHostsToDelete := mongotPodsForFullCleanup(search, w.ClusterIndex, clusterState)
+		deregistered, err := r.cleanupRemovedMongotPodsWithGuard(ctx, search, mongotHostsToDelete, groupID, projectConfig, agentSecretName, w.ClusterName, log)
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+			continue
+		}
+		if !deregistered {
+			// Removal could not be confirmed on the live CR (deleted, replaced, or the
+			// cluster was re-added): keep the persisted entry and its resources.
+			log.Infof("Skipping metrics cleanup for cluster %q: its removal could not be confirmed on the live MongoDBSearch", w.ClusterName)
+			continue
+		}
+		if err := r.deleteMetricsForwarderResources(ctx, search, []clusterWorkItem{w}, log); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+		delete(topologyState.Clusters, w.ClusterName)
+		stateChanged = true
+	}
+	if stateChanged {
+		if err := r.openTopologyStateStore(search).WriteState(ctx, topologyState, log); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to write topology state after removed-cluster cleanup: %w", err))
+		}
+	}
+	return pending, cleanupErr
 }
 
 // reconcileForCluster runs the per-cluster reconcile: replicate dependencies, reconcile topology
@@ -1117,6 +1225,51 @@ func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedMongotPods(ctx c
 
 	log.Infof("Cleaned up %d removed mongot host(s) from Ops Manager", len(hostIDs))
 	return nil
+}
+
+// cleanupRemovedMongotPodsWithGuard re-reads the MongoDBSearch with the uncached state
+// reader immediately before deregistering hosts: the removed-cluster work list is derived
+// from a possibly stale cache, and a host deregistration cannot be undone by the next
+// reconcile. It reports whether deregistration ran; false with a nil error means the
+// cluster's removal could not be confirmed on the live CR (CR deleted, replaced by a new
+// CR with the same name, or the cluster re-added) and the caller must keep the cluster's
+// persisted state. An empty podNames list needs no deregistration and reports true.
+func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedMongotPodsWithGuard(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	podNames []string,
+	groupID string,
+	projectConfig mdbv1.ProjectConfig,
+	agentSecretName string,
+	removedClusterName string,
+	log *zap.SugaredLogger,
+) (bool, error) {
+	if len(podNames) == 0 {
+		return true, nil
+	}
+	live := &searchv1.MongoDBSearch{}
+	if err := r.stateReader.Get(ctx, search.NamespacedName(), live); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("MongoDBSearch %s is gone; leaving host deregistration to the deletion cleanup path", search.NamespacedName())
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to confirm MongoDBSearch %s before deregistering hosts: %w", search.NamespacedName(), err)
+	}
+	if live.UID != search.UID {
+		return false, nil
+	}
+	removed := isRemovedSearchOperatorCluster(live, removedClusterName)
+	if removedClusterName == "" {
+		// The legacy ""-keyed entry counts as removed once the CR runs named clusters.
+		removed = len(live.Spec.Clusters) > 0
+	}
+	if !removed {
+		return false, nil
+	}
+	if err := r.cleanupRemovedMongotPods(ctx, search, podNames, groupID, projectConfig, agentSecretName, log); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // mongotHostID returns the stable Ops Manager host id for a mongot pod. It matches the

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -1008,6 +1008,7 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployme
 			dep.Labels = merge.StringToStringMap(dep.Labels, deploymentOverride.MetadataWrapper.Labels)
 			dep.Annotations = merge.StringToStringMap(dep.Annotations, deploymentOverride.MetadataWrapper.Annotations)
 		}
+		dep.Labels = khandler.ReapplyProtectedSearchLabels(dep.Labels, labels)
 
 		if clusterName == "" {
 			return controllerutil.SetOwnerReference(search, dep, c.Scheme())
@@ -1123,16 +1124,7 @@ func metricsForwarderResourceRequirements(search *searchv1.MongoDBSearch) corev1
 // metricsForwarderLabelsForCluster returns resource labels including cross-cluster enqueue labels.
 // clusterName=="" (single-cluster/central): cluster-name label is omitted.
 func metricsForwarderLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
-	labels := map[string]string{
-		"app":                                search.MetricsForwarderDeploymentNameForCluster(clusterIndex),
-		"component":                          metricsForwarderLabelName,
-		khandler.MongoDBSearchOwnerNameLabel: search.Name,
-		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
-	}
-	if clusterName != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
-	}
-	return labels
+	return khandler.MongoDBSearchManagedLabels(search, search.MetricsForwarderDeploymentNameForCluster(clusterIndex), metricsForwarderLabelName, clusterName)
 }
 
 func metricsForwarderPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterIndex int) map[string]string {

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -21,11 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeCluster "sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -93,17 +96,21 @@ const (
 // MongoDBSearchMetricsForwarderReconciler reconciles the metrics forwarder Deployment
 // that forwards mongot Prometheus metrics to Ops Manager.
 type MongoDBSearchMetricsForwarderReconciler struct {
-	kubeClient         kubernetesClient.Client
-	secretClient       secrets.SecretClient
-	watch              *watch.ResourceWatcher
-	defaultImage       string
-	omRequester        omAgentRequester
-	otelConfigTemplate searchcontroller.MetricsForwarderOTelConfigTemplate
+	kubeClient          kubernetesClient.Client
+	secretClient        secrets.SecretClient
+	watch               *watch.ResourceWatcher
+	defaultImage        string
+	omRequester         omAgentRequester
+	otelConfigTemplate  searchcontroller.MetricsForwarderOTelConfigTemplate
+	operatorClusterName string
+	stateReader         client.Reader
 
 	prepareSearch prepareSearchFunc
 	// clientForCluster resolves the client for one cluster name; nil = cluster not
 	// registered with the operator (hub-and-spoke only).
 	clientForCluster func(clusterName string) kubernetesClient.Client
+	readerForCluster func(clusterName string) client.Reader
+	isLocalCluster   func(clusterName string) bool
 }
 
 func newMongoDBSearchMetricsForwarderReconciler(c client.Client, defaultImage string, memberClusterMap map[string]client.Client, operatorClusterName string) *MongoDBSearchMetricsForwarderReconciler {
@@ -113,27 +120,30 @@ func newMongoDBSearchMetricsForwarderReconciler(c client.Client, defaultImage st
 	}
 
 	r := &MongoDBSearchMetricsForwarderReconciler{
-		kubeClient:         kubernetesClient.NewClient(c),
-		secretClient:       secrets.SecretClient{KubeClient: kubernetesClient.NewClient(c)},
-		watch:              watch.NewResourceWatcher(),
-		defaultImage:       defaultImage,
-		omRequester:        omHTTPAgentRequester{},
-		otelConfigTemplate: searchcontroller.NewMetricsForwarderOTelConfigTemplate(),
-		prepareSearch:      newPrepareSearch(operatorClusterName),
+		kubeClient:          kubernetesClient.NewClient(c),
+		secretClient:        secrets.SecretClient{KubeClient: kubernetesClient.NewClient(c)},
+		watch:               watch.NewResourceWatcher(),
+		defaultImage:        defaultImage,
+		omRequester:         omHTTPAgentRequester{},
+		otelConfigTemplate:  searchcontroller.NewMetricsForwarderOTelConfigTemplate(),
+		operatorClusterName: operatorClusterName,
+		stateReader:         c,
+		prepareSearch:       newPrepareSearch(operatorClusterName),
 	}
-	if len(clientsMap) == 0 {
-		// Single-cluster and per-cluster-operator installs render everything locally.
-		r.clientForCluster = func(string) kubernetesClient.Client { return r.kubeClient }
-	} else {
-		// Empty clusterName is the central/local cluster (single-cluster sharded
-		// search in a hub-and-spoke install); only named entries are member clusters.
-		r.clientForCluster = func(clusterName string) kubernetesClient.Client {
-			if clusterName == "" {
-				return r.kubeClient
-			}
-			return clientsMap[clusterName]
+	localNamedClusters := operatorClusterName != "" || (len(memberClusterMap) == 0 && !env.ReadBoolOrDefault(util.SearchEnableMultiClusterEnv, false)) // nolint:forbidigo
+	r.clientForCluster = func(clusterName string) kubernetesClient.Client {
+		if clusterName == "" || localNamedClusters {
+			return r.kubeClient
 		}
+		return clientsMap[clusterName]
 	}
+	r.readerForCluster = func(clusterName string) client.Reader {
+		if clusterName == "" || localNamedClusters {
+			return r.kubeClient
+		}
+		return clientsMap[clusterName]
+	}
+	r.isLocalCluster = func(clusterName string) bool { return clusterName == "" || localNamedClusters }
 	return r
 }
 
@@ -152,31 +162,12 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 		return result, err
 	}
 
-	if skip, result, err := r.prepareSearch(mdbSearch, log,
-		func(st workflow.Status) (reconcile.Result, error) {
-			if !mdbSearch.IsMetricsForwarderEnabled() {
-				return st.ReconcileResult()
-			}
-			return r.updateMetricsForwarderStatus(ctx, mdbSearch, st, log)
-		}); skip {
-		return result, err
-	}
-
-	// A resource being deleted must always run cleanup, regardless of the configured forwarder mode.
-	// The finalizer is only added while the forwarder is enabled, so its presence means hosts may be
-	// registered in Ops Manager. Without handling deletion here, disabling the forwarder (which takes
-	// the mode out of the auto/enabled branch that owns deletion handling) before deleting the
-	// MongoDBSearch would leak monitored hosts in Ops Manager and leave the finalizer in place,
-	// blocking deletion. reconcileCore performs the DeletionTimestamp/finalizer cleanup once the Ops
-	// Manager connection context is resolved.
 	if !mdbSearch.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
 			return reconcile.Result{}, nil
 		}
 		st := r.reconcileCore(ctx, mdbSearch, log)
 		if st.IsOK() {
-			// Cleanup succeeded and the finalizer was removed, so the resource is now gone; there is
-			// no status left to update.
 			return reconcile.Result{}, nil
 		}
 		return r.updateMetricsForwarderStatus(ctx, mdbSearch, st, log)
@@ -190,11 +181,23 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 		return reconcile.Result{}, nil
 	}
 
+	if skip, result, err := r.prepareSearch(mdbSearch, log,
+		func(st workflow.Status) (reconcile.Result, error) {
+			if !mdbSearch.IsMetricsForwarderEnabled() {
+				return st.ReconcileResult()
+			}
+			return r.updateMetricsForwarderStatus(ctx, mdbSearch, st, log)
+		}); skip {
+		return result, err
+	}
+
 	mode := mdbSearch.Spec.Observability.MetricsForwarder.Mode
 	switch mode {
 	case searchv1.MetricsForwarderModeAuto, "":
 		if !mdbSearch.IsMetricsForwarderEnabled() {
-			r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log)
+			if err := r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log); err != nil {
+				return r.updateMetricsForwarderStatus(ctx, mdbSearch, workflow.Failed(err), log)
+			}
 			return r.clearMetricsForwarderStatus(ctx, mdbSearch, log)
 		}
 
@@ -205,37 +208,92 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 		}
 		return r.updateMetricsForwarderStatus(ctx, mdbSearch, r.reconcileCore(ctx, mdbSearch, log), log)
 	case searchv1.MetricsForwarderModeDisabled:
-		r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log)
+		if err := r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log); err != nil {
+			return r.updateMetricsForwarderStatus(ctx, mdbSearch, workflow.Failed(err), log)
+		}
 		return r.updateMetricsForwarderStatus(ctx, mdbSearch, workflow.Disabled(), log)
 	default:
 		return r.updateMetricsForwarderStatus(ctx, mdbSearch, workflow.Invalid("unknown metrics forwarder mode %q", mode), log)
 	}
 }
 
-// deleteMetricsForwarderResourcesFromState builds the cluster work list from spec.clusters and
-// deletes all metrics forwarder resources.
-func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResourcesFromState(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) {
-	workList := r.buildClusterWorkList(search)
-	r.deleteMetricsForwarderResources(ctx, search, workList, log)
+func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResourcesFromState(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) error {
+	topologyState, err := r.loadAndMigrateTopologyState(ctx, search, log)
+	if err != nil {
+		return err
+	}
+	currentWork := r.buildClusterWorkList(search)
+	if err := validatePersistedClusterIndexes(currentWork, topologyState); err != nil {
+		return err
+	}
+	workList := append(currentWork, r.persistedOnlyClusterWork(search, currentWork, topologyState)...)
+	return r.deleteMetricsForwarderResources(ctx, search, workList, log)
+}
+
+func (r *MongoDBSearchMetricsForwarderReconciler) loadAndMigrateTopologyState(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) (*searchTopologyState, error) {
+	topologyState, err := r.loadTopologyState(ctx, search)
+	if err != nil {
+		return nil, err
+	}
+	needsMigration, err := r.topologyStateNeedsMigration(ctx, search)
+	if err != nil {
+		return nil, err
+	}
+	if needsMigration {
+		if err := r.openTopologyStateStore(search).WriteState(ctx, topologyState, log); err != nil {
+			return nil, fmt.Errorf("failed to migrate topology state before cleanup: %w", err)
+		}
+	}
+	return topologyState, nil
 }
 
 func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Context, mdbSearch *searchv1.MongoDBSearch, log *zap.SugaredLogger) workflow.Status {
-	if r.defaultImage == "" {
-		return workflow.Invalid("%s environment variable must be set on the operator to use metrics forwarder", util.MetricsForwarderImageEnv)
-	}
+	deleting := !mdbSearch.DeletionTimestamp.IsZero()
+	if !deleting {
+		if r.defaultImage == "" {
+			return workflow.Invalid("%s environment variable must be set on the operator to use metrics forwarder", util.MetricsForwarderImageEnv)
+		}
 
-	if mdbSearch.Status.Version == "" {
-		return workflow.Pending("Waiting for MongoDBSearch version to be reconciled")
+		if mdbSearch.Status.Version == "" {
+			return workflow.Pending("Waiting for MongoDBSearch version to be reconciled")
+		}
 	}
 
 	searchSource, err := getSearchSource(ctx, r.kubeClient, r.watch, mdbSearch, log)
 	if err != nil {
 		return workflow.Pending("Waiting for search source: %s", err)
 	}
+	topologyState, err := r.loadAndMigrateTopologyState(ctx, mdbSearch, log)
+	if err != nil {
+		return workflow.Failed(err)
+	}
 
 	fwdCtx, groupId, fwdStatus, supported := r.resolveForwarderContext(mdbSearch, searchSource)
 	if !supported {
-		r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log)
+		if err := r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log); err != nil {
+			return workflow.Failed(err)
+		}
+		if deleting {
+			for clusterName, clusterState := range topologyState.Clusters {
+				hasPersistedHosts := clusterState.Replicas > 0 || len(clusterState.PendingHostDeletions) > 0 || len(clusterState.HostDeletionReadyAfter) > 0
+				for _, replicas := range clusterState.ShardReplicas {
+					hasPersistedHosts = hasPersistedHosts || replicas > 0
+				}
+				if hasPersistedHosts {
+					return workflow.Failed(fmt.Errorf("cluster=%q: cannot remove metrics finalizer for unsupported source while persisted Ops Manager hosts require cleanup", clusterName))
+				}
+			}
+			if controllerutil.RemoveFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
+				if err := r.kubeClient.Update(ctx, mdbSearch); err != nil {
+					return workflow.Failed(fmt.Errorf("failed to remove finalizer for unsupported metrics forwarder source: %w", err))
+				}
+				return workflow.OK()
+			}
+		}
 		if mdbSearch.Spec.Observability.MetricsForwarder.Mode == searchv1.MetricsForwarderModeAuto {
 			mdbSearch.Status.MetricsForwarder = nil
 			return workflow.OK()
@@ -259,29 +317,37 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 	}
 
 	workList := r.buildClusterWorkList(mdbSearch)
+	if err := validatePersistedClusterIndexes(workList, topologyState); err != nil {
+		return workflow.Invalid("%s", err)
+	}
+	var shardNames []string
+	if shardedSource, ok := searchSource.(searchcontroller.SearchSourceShardedDeployment); ok {
+		shardNames = shardedSource.GetShardNames()
+	}
 
-	if !mdbSearch.DeletionTimestamp.IsZero() {
+	if deleting {
 		log.Info("MongoDBSearch is being deleted")
 		if controllerutil.ContainsFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
-			return r.preDeletionCleanup(ctx, mdbSearch, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, workList, log)
+			return r.preDeletionCleanup(ctx, mdbSearch, shardNames, groupId, projectConfig, fwdCtx.agentApiKeySecret.Name, workList, log)
 		}
 		return workflow.OK()
 	}
 
 	r.watch.AddWatchedResourceIfNotAdded(fwdCtx.projectConfigMapRef.Name, mdbSearch.Namespace, watch.ConfigMap, mdbSearch.NamespacedName())
+	r.watch.AddWatchedResourceIfNotAdded(fwdCtx.agentApiKeySecret.Name, mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
+	if projectConfig.SSLMMSCAConfigMap != "" {
+		r.watch.AddWatchedResourceIfNotAdded(projectConfig.SSLMMSCAConfigMap, mdbSearch.Namespace, watch.ConfigMap, mdbSearch.NamespacedName())
+	}
 
 	if supported, st := r.checkOMVersionForMetricsEndpoint(mdbSearch, projectConfig, log); !supported {
-		r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log)
+		if err := r.deleteMetricsForwarderResourcesFromState(ctx, mdbSearch, log); err != nil {
+			return workflow.Failed(err)
+		}
 		return st
 	}
 
 	if err := r.ensureFinalizer(ctx, mdbSearch, log); err != nil {
 		return workflow.Failed(fmt.Errorf("failed to add finalizer: %w", err))
-	}
-
-	var shardNames []string
-	if shardedSource, ok := searchSource.(searchcontroller.SearchSourceShardedDeployment); ok {
-		shardNames = shardedSource.GetShardNames()
 	}
 
 	var firstFailure error
@@ -325,14 +391,105 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 // ClusterIndex=0. spec.clusters is validated non-empty, so the empty-clusters branch is a
 // defensive backstop only.
 func (r *MongoDBSearchMetricsForwarderReconciler) buildClusterWorkList(search *searchv1.MongoDBSearch) []clusterWorkItem {
+	if r.operatorClusterName != "" {
+		if len(search.Spec.Clusters) == 0 {
+			return []clusterWorkItem{r.clusterWorkItem(search, "", 0)}
+		}
+		for _, c := range search.Spec.Clusters {
+			if c.Name == r.operatorClusterName {
+				return []clusterWorkItem{r.clusterWorkItem(search, c.Name, c.ResolveIndex())}
+			}
+		}
+		return nil
+	}
 	if len(search.Spec.Clusters) == 0 {
-		return []clusterWorkItem{{ClusterName: "", ClusterIndex: 0, Client: r.kubeClient}}
+		return []clusterWorkItem{r.clusterWorkItem(search, "", 0)}
 	}
 	work := make([]clusterWorkItem, 0, len(search.Spec.Clusters))
 	for _, c := range search.Spec.Clusters {
-		work = append(work, clusterWorkItem{ClusterName: c.Name, ClusterIndex: c.ResolveIndex(), Client: r.clientForCluster(c.Name)})
+		work = append(work, r.clusterWorkItem(search, c.Name, c.ResolveIndex()))
 	}
 	return work
+}
+
+func (r *MongoDBSearchMetricsForwarderReconciler) clusterWorkItem(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) clusterWorkItem {
+	work := clusterWorkItem{
+		ClusterName:  clusterName,
+		ClusterIndex: clusterIndex,
+		Client:       r.clientForCluster(clusterName),
+	}
+	if r.isLocalCluster(clusterName) {
+		work.OwnerReferences = search.GetOwnerReferences()
+	}
+	return work
+}
+
+func (r *MongoDBSearchMetricsForwarderReconciler) loadTopologyState(ctx context.Context, search *searchv1.MongoDBSearch) (*searchTopologyState, error) {
+	topologyState, err := r.openTopologyStateStore(search).ReadStateWithReader(ctx, r.stateReader)
+	if apierrors.IsNotFound(err) {
+		return &searchTopologyState{Clusters: map[string]clusterTopologyState{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read topology state: %w", err)
+	}
+	if topologyState.Clusters == nil {
+		topologyState.Clusters = map[string]clusterTopologyState{}
+	}
+	return topologyState, nil
+}
+
+func (r *MongoDBSearchMetricsForwarderReconciler) topologyStateNeedsMigration(ctx context.Context, search *searchv1.MongoDBSearch) (bool, error) {
+	cm := &corev1.ConfigMap{}
+	stateStore := r.openTopologyStateStore(search)
+	if err := r.stateReader.Get(ctx, kube.ObjectKey(search.Namespace, stateStore.getStateConfigMapName()), cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to inspect topology state metadata: %w", err)
+	}
+	desiredOwnerReferences := search.GetOwnerReferences()
+	return cm.Data[stateOwnerUIDKey] != string(search.UID) ||
+		!apiequality.Semantic.DeepEqual(cm.OwnerReferences, desiredOwnerReferences), nil
+}
+
+// persistedOnlyClusterWork returns work items for clusters that exist in the persisted
+// topology state but not in the current work list: clusters removed from spec.clusters,
+// and the legacy ""-keyed entry once the CR has moved to named clusters. In per-cluster
+// operator mode the list is narrowed to this operator's own cluster. A nil persisted
+// index falls back to 0; the label gate in deleteMetricsForwarderObject makes a
+// wrong-index delete a safe no-op.
+func (r *MongoDBSearchMetricsForwarderReconciler) persistedOnlyClusterWork(search *searchv1.MongoDBSearch, currentWork []clusterWorkItem, topologyState *searchTopologyState) []clusterWorkItem {
+	currentNames := make(map[string]struct{}, len(currentWork))
+	for _, w := range currentWork {
+		currentNames[w.ClusterName] = struct{}{}
+	}
+	var work []clusterWorkItem
+	for clusterName, clusterState := range topologyState.Clusters {
+		if _, ok := currentNames[clusterName]; ok {
+			continue
+		}
+		if r.operatorClusterName != "" && clusterName != "" && clusterName != r.operatorClusterName {
+			continue
+		}
+		clusterIndex := 0
+		if clusterState.ClusterIndex != nil {
+			clusterIndex = *clusterState.ClusterIndex
+		}
+		work = append(work, r.clusterWorkItem(search, clusterName, clusterIndex))
+	}
+	sort.Slice(work, func(i, j int) bool { return work[i].ClusterName < work[j].ClusterName })
+	return work
+}
+
+func validatePersistedClusterIndexes(workList []clusterWorkItem, topologyState *searchTopologyState) error {
+	for _, w := range workList {
+		persisted, ok := topologyState.Clusters[w.ClusterName]
+		if !ok || persisted.ClusterIndex == nil || *persisted.ClusterIndex == w.ClusterIndex {
+			continue
+		}
+		return fmt.Errorf("cluster %q index is immutable: persisted index %d, requested index %d", w.ClusterName, *persisted.ClusterIndex, w.ClusterIndex)
+	}
+	return nil
 }
 
 // reconcileForCluster runs the per-cluster reconcile: replicate dependencies, reconcile topology
@@ -380,11 +537,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileForCluster(
 		return false, workflow.Failed(fmt.Errorf("cluster=%q: failed to generate metrics forwarder config: %w", w.ClusterName, err))
 	}
 
-	if err := r.ensureMetricsForwarderConfigMap(ctx, search, configYAML, w.ClusterName, w.ClusterIndex, w.Client, log); err != nil {
+	if err := r.ensureMetricsForwarderConfigMap(ctx, search, configYAML, w, log); err != nil {
 		return false, workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
 	}
 
-	if err := r.ensureMetricsForwarderDeployment(ctx, search, configYAML, groupID, agentKeySecretName, caConfigMapName, w.ClusterName, w.ClusterIndex, w.Client, log); err != nil {
+	if err := r.ensureMetricsForwarderDeployment(ctx, search, configYAML, groupID, agentKeySecretName, caConfigMapName, w, log); err != nil {
 		return false, workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
 	}
 
@@ -414,6 +571,7 @@ func (r *MongoDBSearchMetricsForwarderReconciler) replicateForwarderDependencies
 		SetByteData(srcSecret.Data).
 		SetDataType(srcSecret.Type).
 		SetLabels(labels).
+		SetOwnerReferences(w.OwnerReferences).
 		Build()
 	if err := kubeSecret.CreateOrUpdate(ctx, w.Client, destSecret); err != nil {
 		return fmt.Errorf("failed to replicate agent-key Secret to cluster %q: %w", w.ClusterName, err)
@@ -431,9 +589,10 @@ func (r *MongoDBSearchMetricsForwarderReconciler) replicateForwarderDependencies
 	}
 	destCM := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.MetricsForwarderCACertConfigMapNameForCluster(w.ClusterIndex),
-			Namespace: ns,
-			Labels:    labels,
+			Name:            search.MetricsForwarderCACertConfigMapNameForCluster(w.ClusterIndex),
+			Namespace:       ns,
+			Labels:          labels,
+			OwnerReferences: w.OwnerReferences,
 		},
 		Data: caData,
 	}
@@ -650,6 +809,8 @@ func newOMHTTPClient(projectConfig mdbv1.ProjectConfig) *omapi.Client {
 
 // clusterTopologyState captures the MongoDBSearch topology for one member cluster persisted between reconciles.
 type clusterTopologyState struct {
+	// ClusterIndex is the stable suffix used by this cluster's generated resource names.
+	ClusterIndex         *int           `json:"clusterIndex,omitempty"`
 	Replicas             int            `json:"replicas"`
 	ShardReplicas        map[string]int `json:"shardReplicas,omitempty"`
 	PendingHostDeletions []string       `json:"pendingHostDeletions,omitempty"`
@@ -694,6 +855,28 @@ func (r *MongoDBSearchMetricsForwarderReconciler) openTopologyStateStore(search 
 	return NewStateStore[searchTopologyState](metricsForwarderStateOwner{MongoDBSearch: search}, search.GetOwnerReferences(), r.kubeClient, string(search.UID))
 }
 
+func desiredClusterTopology(search *searchv1.MongoDBSearch, shardNames []string, w clusterWorkItem) (clusterTopologyState, error) {
+	current := clusterTopologyState{ClusterIndex: ptr.To(w.ClusterIndex)}
+	if len(shardNames) > 0 {
+		current.ShardReplicas = make(map[string]int, len(shardNames))
+		for _, shardName := range shardNames {
+			c, err := search.ResolveSizingForClusterShard(w.ClusterName, shardName)
+			if err != nil {
+				return clusterTopologyState{}, fmt.Errorf("failed to resolve sizing for cluster %q shard %q: %w", w.ClusterName, shardName, err)
+			}
+			current.ShardReplicas[shardName] = c.ReplicasOrDefault()
+		}
+		return current, nil
+	}
+
+	c, err := search.ResolveSizingForClusterShard(w.ClusterName, "")
+	if err != nil {
+		return clusterTopologyState{}, fmt.Errorf("failed to resolve sizing for cluster %q: %w", w.ClusterName, err)
+	}
+	current.Replicas = c.ReplicasOrDefault()
+	return current, nil
+}
+
 // reconcileTopologyState reconciles the topology state for one cluster work item: it detects
 // removed mongot pods, advances each through the deletion state machine, deregisters hosts in Ops
 // Manager at the right moment, and persists the updated state. Returns true while any deletion is
@@ -725,8 +908,8 @@ func (r *MongoDBSearchMetricsForwarderReconciler) openTopologyStateStore(search 
 // # State persistence
 //
 // The full state for all clusters under a MongoDBSearch CR is stored in a single ConfigMap keyed
-// by metricsForwarderStateOwner. Each reconcile reads that map, updates the entry for w.ClusterName,
-// and writes it back. Two fields carry pods across reconcile boundaries:
+// by metricsForwarderStateOwner. Each reconcile reads that map once, updates all cluster entries,
+// and writes it once. Two fields carry pods across reconcile boundaries:
 //   - PendingHostDeletions: pods with an active DeletionTimestamp (terminating).
 //   - HostDeletionReadyAfter: pods confirmed gone, mapped to their earliest-safe-deregister timestamp.
 //
@@ -742,37 +925,14 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileTopologyState(
 	w clusterWorkItem,
 	log *zap.SugaredLogger,
 ) (bool, error) {
-	current := clusterTopologyState{}
-	if len(shardNames) > 0 {
-		current.ShardReplicas = make(map[string]int, len(shardNames))
-		for _, shardName := range shardNames {
-			c, err := search.ResolveSizingForClusterShard(w.ClusterName, shardName)
-			if err != nil {
-				return false, fmt.Errorf("failed to resolve sizing for cluster %q shard %q: %w", w.ClusterName, shardName, err)
-			}
-			current.ShardReplicas[shardName] = c.ReplicasOrDefault()
-		}
-	} else {
-		c, err := search.ResolveSizingForClusterShard(w.ClusterName, "")
-		if err != nil {
-			return false, fmt.Errorf("failed to resolve sizing for cluster %q: %w", w.ClusterName, err)
-		}
-		current.Replicas = c.ReplicasOrDefault()
-	}
-
-	stateStore := r.openTopologyStateStore(search)
-
-	var fullState searchTopologyState
-	prevFull, err := stateStore.ReadState(ctx)
+	current, err := desiredClusterTopology(search, shardNames, w)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("failed to read topology state: %w", err)
-		}
-	} else {
-		fullState = *prevFull
+		return false, err
 	}
-	if fullState.Clusters == nil {
-		fullState.Clusters = make(map[string]clusterTopologyState)
+
+	fullState, err := r.loadTopologyState(ctx, search)
+	if err != nil {
+		return false, err
 	}
 
 	previous := fullState.Clusters[w.ClusterName]
@@ -831,7 +991,7 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileTopologyState(
 	}
 	fullState.Clusters[w.ClusterName] = current
 
-	if err := stateStore.WriteState(ctx, &fullState, log); err != nil {
+	if err := r.openTopologyStateStore(search).WriteState(ctx, fullState, log); err != nil {
 		return false, fmt.Errorf("failed to write topology state: %w", err)
 	}
 
@@ -871,6 +1031,25 @@ func computeDeletedMongotPods(search *searchv1.MongoDBSearch, clusterIndex int, 
 	}
 
 	return deletedPods
+}
+
+func mongotPodsForFullCleanup(search *searchv1.MongoDBSearch, clusterIndex int, state clusterTopologyState) []string {
+	pods := make(map[string]struct{})
+	for _, podName := range computeDeletedMongotPods(search, clusterIndex, state, clusterTopologyState{}) {
+		pods[podName] = struct{}{}
+	}
+	for _, podName := range state.PendingHostDeletions {
+		pods[podName] = struct{}{}
+	}
+	for podName := range state.HostDeletionReadyAfter {
+		pods[podName] = struct{}{}
+	}
+	result := make([]string, 0, len(pods))
+	for podName := range pods {
+		result = append(result, podName)
+	}
+	sort.Strings(result)
+	return result
 }
 
 type deleteHostsRequest struct {
@@ -950,48 +1129,44 @@ func mongotHostID(groupID, namespace, podName string) string {
 }
 
 // ensureMetricsForwarderConfigMap creates or updates the metrics forwarder ConfigMap for one cluster.
-// OwnerReference is set only for the central cluster (clusterName == ""); member-cluster objects
-// use labels for cross-cluster GC.
-func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, configYAML []byte, clusterName string, clusterIndex int, c kubernetesClient.Client, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, configYAML []byte, w clusterWorkItem, log *zap.SugaredLogger) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.MetricsForwarderConfigMapNameForCluster(clusterIndex),
+			Name:      search.MetricsForwarderConfigMapNameForCluster(w.ClusterIndex),
 			Namespace: search.Namespace,
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
-		cm.Labels = metricsForwarderLabelsForCluster(search, clusterName, clusterIndex)
+	_, err := controllerutil.CreateOrUpdate(ctx, w.Client, cm, func() error {
+		cm.OwnerReferences = w.OwnerReferences
+		cm.Labels = metricsForwarderLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
 		cm.Data = map[string]string{metricsForwarderConfigFileName: string(configYAML)}
-		if clusterName == "" {
-			return controllerutil.SetOwnerReference(search, cm, c.Scheme())
-		}
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to ensure metrics forwarder ConfigMap: %w", err)
 	}
-	log.Infof("metrics forwarder ConfigMap created/updated (cluster=%q)", clusterName)
+	log.Infof("metrics forwarder ConfigMap created/updated (cluster=%q)", w.ClusterName)
 	return nil
 }
 
 // ensureMetricsForwarderDeployment creates or updates the metrics forwarder Deployment for one cluster.
-// OwnerReference is set only for the central cluster (clusterName == "").
-func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployment(ctx context.Context, search *searchv1.MongoDBSearch, configYAML []byte, groupID, agentKeySecretName, caConfigMapName, clusterName string, clusterIndex int, c kubernetesClient.Client, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployment(ctx context.Context, search *searchv1.MongoDBSearch, configYAML []byte, groupID, agentKeySecretName, caConfigMapName string, w clusterWorkItem, log *zap.SugaredLogger) error {
 	configHash := fmt.Sprintf("%x", sha256.Sum256(configYAML))
-	labels := metricsForwarderLabelsForCluster(search, clusterName, clusterIndex)
-	podLabels := metricsForwarderPodLabelsForCluster(search, clusterIndex)
+	labels := metricsForwarderLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
+	podLabels := metricsForwarderPodLabelsForCluster(search, w.ClusterIndex)
 	resources := metricsForwarderResourceRequirements(search)
 	managedSecurityContext := env.ReadBoolOrDefault(podtemplatespec.ManagedSecurityContextEnv, false) // nolint:forbidigo
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.MetricsForwarderDeploymentNameForCluster(clusterIndex),
+			Name:      search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex),
 			Namespace: search.Namespace,
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, dep, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, w.Client, dep, func() error {
+		dep.OwnerReferences = w.OwnerReferences
 		dep.Labels = labels
 
 		dep.Spec = appsv1.DeploymentSpec{
@@ -1006,7 +1181,7 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployme
 						metricsForwarderConfigHashAnnotation: configHash,
 					},
 				},
-				Spec: buildMetricsForwarderPodSpec(search, agentKeySecretName, caConfigMapName, clusterIndex, r.defaultImage, resources, managedSecurityContext),
+				Spec: buildMetricsForwarderPodSpec(search, agentKeySecretName, caConfigMapName, w.ClusterIndex, r.defaultImage, resources, managedSecurityContext),
 			},
 		}
 
@@ -1017,16 +1192,12 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployme
 			dep.Annotations = merge.StringToStringMap(dep.Annotations, deploymentOverride.MetadataWrapper.Annotations)
 		}
 		dep.Labels = khandler.ReapplyProtectedSearchLabels(dep.Labels, labels)
-
-		if clusterName == "" {
-			return controllerutil.SetOwnerReference(search, dep, c.Scheme())
-		}
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to ensure metrics forwarder Deployment: %w", err)
 	}
-	log.Infof("metrics forwarder Deployment created/updated (cluster=%q)", clusterName)
+	log.Infof("metrics forwarder Deployment created/updated (cluster=%q)", w.ClusterName)
 	return nil
 }
 
@@ -1172,17 +1343,16 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureFinalizer(ctx context.Co
 	return nil
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context.Context, search *searchv1.MongoDBSearch, groupID string, projectConfig mdbv1.ProjectConfig, agentSecretName string, workList []clusterWorkItem, log *zap.SugaredLogger) workflow.Status {
+func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context.Context, search *searchv1.MongoDBSearch, shardNames []string, groupID string, projectConfig mdbv1.ProjectConfig, agentSecretName string, workList []clusterWorkItem, log *zap.SugaredLogger) workflow.Status {
 	log.Info("Performing pre deletion cleanup before deleting MongoDBSearch metrics forwarder")
 
-	stateStore := r.openTopologyStateStore(search)
-	topologyState, err := stateStore.ReadState(ctx)
+	topologyState, err := r.loadTopologyState(ctx, search)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return workflow.Failed(fmt.Errorf("failed to read the topology state: %w", err))
-		}
-		topologyState = &searchTopologyState{}
+		return workflow.Failed(err)
 	}
+	// Persisted-only clusters (already removed from spec, or this operator's own cluster
+	// when it was removed) still hold resources and Ops Manager hosts to clean up.
+	workList = append(workList, r.persistedOnlyClusterWork(search, workList, topologyState)...)
 
 	// Check for running Deployments. If any exist, delete them and requeue. We must
 	// not deregister OM hosts while any forwarder pod is still running — a live collector would
@@ -1200,15 +1370,20 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 			continue
 		}
 		depName := search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex)
-		dep := &appsv1.Deployment{}
-		if err := w.Client.Get(ctx, kube.ObjectKey(ns, depName), dep); err == nil {
+		found, err := r.deleteMetricsForwarderObject(
+			ctx,
+			search,
+			w,
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: ns}},
+			"Deployment",
+			client.PropagationPolicy(metav1.DeletePropagationForeground),
+		)
+		if err != nil {
+			return workflow.Failed(err)
+		}
+		if found {
 			anyDepFound = true
 			log.Infof("Deleting metrics forwarder Deployment %s (cluster=%q) before deregistering Ops Manager hosts", depName, w.ClusterName)
-			if delErr := w.Client.Delete(ctx, dep); delErr != nil && !apierrors.IsNotFound(delErr) {
-				log.Warnf("Failed to delete metrics forwarder Deployment %s (cluster=%q): %s", depName, w.ClusterName, delErr)
-			}
-		} else if !apierrors.IsNotFound(err) {
-			return workflow.Failed(fmt.Errorf("failed to check metrics forwarder Deployment %s: %w", depName, err))
 		}
 	}
 	if anyDepFound {
@@ -1221,13 +1396,15 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 			continue
 		}
 		clusterState := topologyState.Clusters[w.ClusterName]
-		mongotHostsToDelete := computeDeletedMongotPods(search, w.ClusterIndex, clusterState, clusterTopologyState{})
+		mongotHostsToDelete := mongotPodsForFullCleanup(search, w.ClusterIndex, clusterState)
 		if err := r.cleanupRemovedMongotPods(ctx, search, mongotHostsToDelete, groupID, projectConfig, agentSecretName, log); err != nil {
-			return workflow.Failed(err)
+			return workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
 		}
 	}
 
-	r.deleteMetricsForwarderResources(ctx, search, workList, log)
+	if err := r.deleteMetricsForwarderResources(ctx, search, workList, log); err != nil {
+		return workflow.Failed(err)
+	}
 
 	if finalizerRemoved := controllerutil.RemoveFinalizer(search, util.SearchMetricsForwarderFinalizer); !finalizerRemoved {
 		return workflow.Failed(fmt.Errorf("failed to remove finalizer"))
@@ -1242,8 +1419,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 
 // deleteMetricsForwarderResources removes per-cluster metrics forwarder resources.
 // Clusters not registered with the operator (Client==nil) are skipped.
-func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) {
+func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) error {
 	ns := search.Namespace
+	var deleteErr error
 	for _, w := range workList {
 		if w.Client == nil {
 			continue
@@ -1251,41 +1429,116 @@ func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResource
 		depName := search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex)
 		cmName := search.MetricsForwarderConfigMapNameForCluster(w.ClusterIndex)
 		secretName := search.MetricsForwarderAgentKeySecretNameForCluster(w.ClusterIndex)
-
-		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: ns}}
-		if err := w.Client.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnf("Failed to delete metrics forwarder Deployment %s (cluster=%q): %s", depName, w.ClusterName, err)
-		} else if err == nil {
-			log.Infof("Deleted metrics forwarder Deployment %s (cluster=%q)", depName, w.ClusterName)
-		}
-
-		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns}}
-		if err := w.Client.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnf("Failed to delete metrics forwarder ConfigMap %s (cluster=%q): %s", cmName, w.ClusterName, err)
-		} else if err == nil {
-			log.Infof("Deleted metrics forwarder ConfigMap %s (cluster=%q)", cmName, w.ClusterName)
-		}
-
-		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns}}
-		if err := w.Client.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnf("Failed to delete metrics forwarder agent-key Secret %s (cluster=%q): %s", secretName, w.ClusterName, err)
-		} else if err == nil {
-			log.Infof("Deleted metrics forwarder agent-key Secret %s (cluster=%q)", secretName, w.ClusterName)
-		}
-
 		caName := search.MetricsForwarderCACertConfigMapNameForCluster(w.ClusterIndex)
-		caCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: caName, Namespace: ns}}
-		if err := w.Client.Delete(ctx, caCM); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnf("Failed to delete metrics forwarder CA ConfigMap %s (cluster=%q): %s", caName, w.ClusterName, err)
-		} else if err == nil {
-			log.Infof("Deleted metrics forwarder CA ConfigMap %s (cluster=%q)", caName, w.ClusterName)
+		resources := []struct {
+			kind string
+			obj  client.Object
+			opts []client.DeleteOption
+		}{
+			{kind: "Deployment", obj: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: ns}}, opts: []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationForeground)}},
+			{kind: "ConfigMap", obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns}}},
+			{kind: "agent-key Secret", obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns}}},
+			{kind: "CA ConfigMap", obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: caName, Namespace: ns}}},
 		}
+		for _, resource := range resources {
+			found, err := r.deleteMetricsForwarderObject(ctx, search, w, resource.obj, resource.kind, resource.opts...)
+			if err != nil {
+				deleteErr = errors.Join(deleteErr, err)
+				continue
+			}
+			if found {
+				log.Infof("Deleted metrics forwarder %s %s (cluster=%q)", resource.kind, resource.obj.GetName(), w.ClusterName)
+			}
+		}
+	}
+	return deleteErr
+}
+
+// deleteMetricsForwarderObject deletes one forwarder-owned object if it exists and still
+// carries this Search identity's forwarder labels (customer objects and other identities
+// are never touched), using UID+ResourceVersion delete preconditions against the version
+// just read. Returns whether the object was found eligible for deletion.
+func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderObject(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	w clusterWorkItem,
+	obj client.Object,
+	kind string,
+	opts ...client.DeleteOption,
+) (bool, error) {
+	reader := r.readerForCluster(w.ClusterName)
+	if reader == nil {
+		return false, fmt.Errorf("cluster=%q: no API reader registered", w.ClusterName)
+	}
+	if err := reader.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cluster=%q: failed to check metrics forwarder %s %s: %w", w.ClusterName, kind, obj.GetName(), err)
+	}
+	desiredLabels := metricsForwarderLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
+	for _, key := range []string{
+		khandler.MongoDBSearchOwnerNameLabel,
+		khandler.MongoDBSearchOwnerNamespaceLabel,
+		khandler.MongoDBSearchOwnerUIDLabel,
+		khandler.MongoDBSearchClusterNameLabel,
+		khandler.MongoDBSearchComponentLabel,
+	} {
+		if obj.GetLabels()[key] != desiredLabels[key] {
+			return false, nil
+		}
+	}
+	opts = append(opts, client.Preconditions{
+		UID:             ptr.To(obj.GetUID()),
+		ResourceVersion: ptr.To(obj.GetResourceVersion()),
+	})
+	if err := w.Client.Delete(ctx, obj, opts...); err != nil && !apierrors.IsNotFound(err) {
+		return true, fmt.Errorf("cluster=%q: failed to delete metrics forwarder %s %s: %w", w.ClusterName, kind, obj.GetName(), err)
+	}
+	return true, nil
+}
+
+func centralMongoDBSearchMetricsForwarderResourceWatches(r *MongoDBSearchMetricsForwarderReconciler) []mongoDBSearchResourceWatch {
+	mapperFunc := khandler.EnqueueMemberClusterObjectToSearch
+	mapper := handler.EnqueueRequestsFromMapFunc(mapperFunc)
+	searchOwnerPredicate := []predicate.Predicate{watch.PredicatesForMultiClusterSearchResource()}
+	return []mongoDBSearchResourceWatch{
+		{obj: &mdbv1.MongoDB{}, handler: &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch}},
+		{obj: &appsv1.Deployment{}, handler: mapper, predicates: searchOwnerPredicate},
+		{obj: &corev1.ConfigMap{}, handler: &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch, MapFunc: mapperFunc}},
+		{obj: &corev1.Secret{}, handler: &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch, MapFunc: mapperFunc}},
+	}
+}
+
+func memberMongoDBSearchMetricsForwarderResourceWatches(r *MongoDBSearchMetricsForwarderReconciler) []mongoDBSearchResourceWatch {
+	mapperFunc := khandler.EnqueueMemberClusterObjectToSearch
+	mapper := handler.EnqueueRequestsFromMapFunc(mapperFunc)
+	searchOwnerPredicate := []predicate.Predicate{watch.PredicatesForMultiClusterSearchResource()}
+	return []mongoDBSearchResourceWatch{
+		{obj: &appsv1.Deployment{}, handler: mapper, predicates: searchOwnerPredicate},
+		{obj: &corev1.ConfigMap{}, handler: &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch, MapFunc: mapperFunc}},
+		{obj: &corev1.Secret{}, handler: &watch.ResourcesHandler{ResourceType: watch.Secret, ResourceWatcher: r.watch, MapFunc: mapperFunc}},
 	}
 }
 
 // AddMongoDBSearchMetricsForwarderController registers the metrics forwarder controller with the manager.
 func AddMongoDBSearchMetricsForwarderController(ctx context.Context, mgr manager.Manager, defaultImage string, memberClusterObjectsMap map[string]runtimeCluster.Cluster, operatorClusterName string) error {
-	r := newMongoDBSearchMetricsForwarderReconciler(mgr.GetClient(), defaultImage, multicluster.ClustersMapToClientMap(memberClusterObjectsMap), operatorClusterName)
+	r := newMongoDBSearchMetricsForwarderReconciler(
+		mgr.GetClient(),
+		defaultImage,
+		multicluster.ClustersMapToClientMap(memberClusterObjectsMap),
+		operatorClusterName,
+	)
+	r.stateReader = mgr.GetAPIReader()
+	r.readerForCluster = func(clusterName string) client.Reader {
+		if r.isLocalCluster(clusterName) {
+			return mgr.GetAPIReader()
+		}
+		if memberCluster, ok := memberClusterObjectsMap[clusterName]; ok {
+			return memberCluster.GetAPIReader()
+		}
+		return nil
+	}
 
 	c, err := controller.New("mongodbsearchmetricsforwarder", mgr, controller.Options{
 		Reconciler:              r,
@@ -1298,30 +1551,18 @@ func AddMongoDBSearchMetricsForwarderController(ctx context.Context, mgr manager
 	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &searchv1.MongoDBSearch{}, &handler.EnqueueRequestForObject{})); err != nil {
 		return err
 	}
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &mdbv1.MongoDB{}, &watch.ResourcesHandler{ResourceType: watch.MongoDB, ResourceWatcher: r.watch})); err != nil {
-		return err
-	}
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.ConfigMap{}, &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch})); err != nil {
-		return err
-	}
-
-	// Central-cluster owned resources (single-cluster path).
-	ownerHandler := handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &searchv1.MongoDBSearch{}, handler.OnlyControllerOwner())
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &appsv1.Deployment{}, ownerHandler)); err != nil {
-		return err
-	}
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.ConfigMap{}, ownerHandler)); err != nil {
-		return err
+	for _, w := range centralMongoDBSearchMetricsForwarderResourceWatches(r) {
+		if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), w.obj, w.handler, w.predicates...)); err != nil {
+			return err
+		}
 	}
 
 	// Per-member-cluster resource watches: label-based mapper, since cross-cluster owner refs don't GC.
-	mapper := handler.EnqueueRequestsFromMapFunc(khandler.EnqueueMemberClusterObjectToSearch)
 	for k, v := range memberClusterObjectsMap {
-		if err := c.Watch(source.Kind[client.Object](v.GetCache(), &appsv1.Deployment{}, mapper)); err != nil {
-			return fmt.Errorf("failed to set metrics forwarder Deployment watch on member cluster %s: %w", k, err)
-		}
-		if err := c.Watch(source.Kind[client.Object](v.GetCache(), &corev1.ConfigMap{}, mapper)); err != nil {
-			return fmt.Errorf("failed to set metrics forwarder ConfigMap watch on member cluster %s: %w", k, err)
+		for _, w := range memberMongoDBSearchMetricsForwarderResourceWatches(r) {
+			if err := c.Watch(source.Kind[client.Object](v.GetCache(), w.obj, w.handler, w.predicates...)); err != nil {
+				return fmt.Errorf("failed to set metrics forwarder member-cluster watch on %s for %T: %w", k, w.obj, err)
+			}
 		}
 	}
 

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -1542,10 +1542,19 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 	//
 	// Checking before deleting ensures the requeue happens: if we deleted first and then checked,
 	// the check could find the object already gone (e.g. fake client in tests) and skip the wait.
+	//
+	// Each cluster progresses independently: a cluster whose Deployment is still terminating,
+	// whose client is missing, or that hit an error is blocked for this pass, while the other
+	// clusters continue through host deregistration and resource deletion. Errors are
+	// aggregated across clusters and the finalizer stays until every cluster is fully clean.
 	ns := search.Namespace
 	anyDepFound := false
+	blocked := map[string]struct{}{}
+	var cleanupErr error
 	for _, w := range workList {
 		if w.Client == nil {
+			blocked[w.ClusterName] = struct{}{}
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cluster=%q: no Kubernetes client registered", w.ClusterName))
 			continue
 		}
 		depName := search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex)
@@ -1558,31 +1567,38 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 			client.PropagationPolicy(metav1.DeletePropagationForeground),
 		)
 		if err != nil {
-			return workflow.Failed(err)
+			blocked[w.ClusterName] = struct{}{}
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
 		}
 		if found {
+			blocked[w.ClusterName] = struct{}{}
 			anyDepFound = true
 			log.Infof("Deleting metrics forwarder Deployment %s (cluster=%q) before deregistering Ops Manager hosts", depName, w.ClusterName)
 		}
 	}
-	if anyDepFound {
-		return workflow.Pending("Waiting for metrics forwarder Deployment to be fully deleted before deregistering Ops Manager hosts")
-	}
 
-	// All Deployments are gone: deregister hosts, clean up remaining resources, and remove finalizer.
+	// Deployments confirmed gone: deregister the cluster's hosts, then its remaining resources.
 	for _, w := range workList {
-		if w.Client == nil {
+		if _, skip := blocked[w.ClusterName]; skip {
 			continue
 		}
 		clusterState := topologyState.Clusters[w.ClusterName]
 		mongotHostsToDelete := mongotPodsForFullCleanup(search, w.ClusterIndex, clusterState)
 		if err := r.cleanupRemovedMongotPods(ctx, search, mongotHostsToDelete, groupID, projectConfig, agentSecretName, log); err != nil {
-			return workflow.Failed(fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cluster=%q: %w", w.ClusterName, err))
+			continue
+		}
+		if err := r.deleteMetricsForwarderResources(ctx, search, []clusterWorkItem{w}, log); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
 		}
 	}
 
-	if err := r.deleteMetricsForwarderResources(ctx, search, workList, log); err != nil {
-		return workflow.Failed(err)
+	if cleanupErr != nil {
+		return workflow.Failed(cleanupErr)
+	}
+	if anyDepFound {
+		return workflow.Pending("Waiting for metrics forwarder Deployment to be fully deleted before deregistering Ops Manager hosts")
 	}
 
 	if finalizerRemoved := controllerutil.RemoveFinalizer(search, util.SearchMetricsForwarderFinalizer); !finalizerRemoved {

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -12,9 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,6 +43,16 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/versionutil"
+)
+
+const (
+	testNamespace     = "test-ns"
+	testSearchName    = "my-search"
+	testMDBName       = "my-mongodb"
+	testProjectCMName = "my-project-cm"
+	testGroupID       = "test-group-id-123"
+	testDefaultImage  = "quay.io/mongodb/metrics-forwarder:latest"
+	testOMBaseURL     = "http://ops-manager.example.com:8080"
 )
 
 // newTestMongoDB creates a MongoDB resource with opsManager connection spec and a status with a project ID.
@@ -104,6 +120,7 @@ func newMetricsForwarderReconciler(defaultImage string, objects ...client.Object
 
 	r := &MongoDBSearchMetricsForwarderReconciler{
 		kubeClient:         kc,
+		stateReader:        fakeClient,
 		secretClient:       secrets.SecretClient{KubeClient: kc},
 		watch:              watch.NewResourceWatcher(),
 		defaultImage:       defaultImage,
@@ -111,6 +128,8 @@ func newMetricsForwarderReconciler(defaultImage string, objects ...client.Object
 		otelConfigTemplate: searchcontroller.NewMetricsForwarderOTelConfigTemplate(),
 		prepareSearch:      newPrepareSearch(""),
 		clientForCluster:   func(string) kubernetesClient.Client { return kc },
+		readerForCluster:   func(string) client.Reader { return kc },
+		isLocalCluster:     func(string) bool { return true },
 	}
 	return r, fakeClient
 }
@@ -205,9 +224,26 @@ func recordingDeleteHostsRequester(dst *[]string) stubOMAgentRequester {
 	}
 }
 
+type changingSearchReader struct {
+	client.Reader
+	searches []*searchv1.MongoDBSearch
+	gets     int
+}
+
+func (r *changingSearchReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	search, ok := obj.(*searchv1.MongoDBSearch)
+	if !ok {
+		return r.Reader.Get(ctx, key, obj, opts...)
+	}
+	index := min(r.gets, len(r.searches)-1)
+	r.searches[index].DeepCopyInto(search)
+	r.gets++
+	return nil
+}
+
 // getTopologyState reads and decodes the metrics-forwarder topology state ConfigMap,
 // returning the single-cluster (clusterName=="") entry.
-func getTopologyState(t *testing.T, c client.Client, search *searchv1.MongoDBSearch) clusterTopologyState {
+func getFullTopologyState(t *testing.T, c client.Client, search *searchv1.MongoDBSearch) searchTopologyState {
 	t.Helper()
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{
@@ -216,6 +252,12 @@ func getTopologyState(t *testing.T, c client.Client, search *searchv1.MongoDBSea
 	}, cm))
 	var state searchTopologyState
 	require.NoError(t, json.Unmarshal([]byte(cm.Data[stateKey]), &state))
+	return state
+}
+
+func getTopologyState(t *testing.T, c client.Client, search *searchv1.MongoDBSearch) clusterTopologyState {
+	t.Helper()
+	state := getFullTopologyState(t, c, search)
 	return state.Clusters[""]
 }
 
@@ -399,6 +441,301 @@ func TestStateStoreEmptyOwnerUIDPreservesExistingSemantics(t *testing.T) {
 	assert.Equal(t, 3, state.Clusters[""].Replicas)
 }
 
+func TestReconcile_MarkerlessForeignStateDoesNotReplayPendingHosts(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "new-search-uid"
+	search.Spec.Observability.MetricsForwarder.Mode = searchv1.MetricsForwarderModeEnabled
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentSecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{
+		ClusterIndex:           ptr.To(0),
+		HostDeletionReadyAfter: map[string]int64{"old-search-pod-0": 0},
+	})
+	delete(stateCM.Data, stateOwnerUIDKey)
+	stateCM.OwnerReferences = search.GetOwnerReferences()
+	stateCM.OwnerReferences[0].UID = "old-search-uid"
+	r, c := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentSecret, stateCM)
+	var deletedHostIDs []string
+	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+
+	reconcileMetricsForwarder(t, r, search.Namespace, search.Name)
+
+	assert.Empty(t, deletedHostIDs)
+	currentState := getFullTopologyState(t, c, search)
+	assert.Empty(t, currentState.Clusters[""].PendingHostDeletions)
+	assert.Empty(t, currentState.Clusters[""].HostDeletionReadyAfter)
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(stateCM), cm))
+	assert.Equal(t, string(search.UID), cm.Data[stateOwnerUIDKey])
+	require.Len(t, cm.OwnerReferences, 1)
+	assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+}
+
+func TestReconcile_MarkerlessCurrentOwnerMigratesBeforeHostCleanup(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Observability.MetricsForwarder.Mode = searchv1.MetricsForwarderModeEnabled
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentSecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{
+		ClusterIndex:           ptr.To(0),
+		PendingHostDeletions:   []string{"removed-pod-0"},
+		HostDeletionReadyAfter: map[string]int64{"removed-pod-0": 0},
+	})
+	delete(stateCM.Data, stateOwnerUIDKey)
+	stateCM.OwnerReferences = search.GetOwnerReferences()
+	stateCM.OwnerReferences[0].Kind = ""
+	stateCM.OwnerReferences[0].APIVersion = ""
+	r, c := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentSecret, stateCM)
+	withWatch, ok := c.(client.WithWatch)
+	require.True(t, ok)
+	var events []string
+	r.kubeClient = kubernetesClient.NewClient(interceptor.NewClient(withWatch, interceptor.Funcs{
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == stateCM.Name {
+				events = append(events, "state-write")
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+	}))
+	r.omRequester = stubOMAgentRequester{fn: func(_ mdbv1.ProjectConfig, method, path, _ string, _ any) ([]byte, error) {
+		if method == "POST" && strings.HasSuffix(path, "/v1/delete") {
+			cm := &corev1.ConfigMap{}
+			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(stateCM), cm))
+			assert.Equal(t, string(search.UID), cm.Data[stateOwnerUIDKey])
+			assert.Equal(t, search.GetOwnerReferences(), cm.OwnerReferences)
+			events = append(events, "host-delete")
+			return []byte(`{"results":[]}`), nil
+		}
+		return nil, fmt.Errorf("unexpected OM agent request: %s %s", method, path)
+	}}
+
+	reconcileMetricsForwarder(t, r, search.Namespace, search.Name)
+
+	require.Contains(t, events, "host-delete")
+	assert.Less(t, slices.Index(events, "state-write"), slices.Index(events, "host-delete"))
+}
+
+func TestDeleteMetricsForwarderResourcesFromState_MigratesMarkerlessStateBeforeDelete(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Observability.MetricsForwarder.Mode = searchv1.MetricsForwarderModeDisabled
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0)})
+	delete(stateCM.Data, stateOwnerUIDKey)
+	stateCM.OwnerReferences = search.GetOwnerReferences()
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+		UID:       "forwarder-uid",
+		Labels:    metricsForwarderLabelsForCluster(search, "", 0),
+	}}
+	r, c := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, stateCM, deployment)
+	withWatch, ok := c.(client.WithWatch)
+	require.True(t, ok)
+	var events []string
+	r.kubeClient = kubernetesClient.NewClient(interceptor.NewClient(withWatch, interceptor.Funcs{
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == stateCM.Name {
+				events = append(events, "state-write")
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok {
+				cm := &corev1.ConfigMap{}
+				require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(stateCM), cm))
+				assert.Equal(t, string(search.UID), cm.Data[stateOwnerUIDKey])
+				require.Len(t, cm.OwnerReferences, 1)
+				assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+				events = append(events, "resource-delete")
+			}
+			return cl.Delete(ctx, obj, opts...)
+		},
+	}))
+	r.clientForCluster = func(string) kubernetesClient.Client { return r.kubeClient }
+
+	require.NoError(t, r.deleteMetricsForwarderResourcesFromState(t.Context(), search, zap.S()))
+
+	require.Contains(t, events, "state-write")
+	require.Contains(t, events, "resource-delete")
+	assert.Less(t, slices.Index(events, "state-write"), slices.Index(events, "resource-delete"))
+}
+
+func TestReconcileCoreRegistersMetricsCredentialAndCAWatches(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	projectCM.Data[util.SSLMMSCAConfigMap] = "ops-manager-ca"
+	caConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "ops-manager-ca", Namespace: testNamespace},
+		Data:       map[string]string{"mms-ca.crt": "certificate"},
+	}
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, caConfigMap, agentKeySecret)
+	currentSearch := getMongoDBSearch(t, fakeClient, search.Namespace, search.Name)
+
+	st := r.reconcileCore(t.Context(), currentSearch, zap.S())
+
+	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	watched := r.watch.GetWatchedResources()
+	for _, resource := range []watch.Object{
+		{ResourceType: watch.ConfigMap, Resource: client.ObjectKeyFromObject(projectCM)},
+		{ResourceType: watch.ConfigMap, Resource: client.ObjectKeyFromObject(caConfigMap)},
+		{ResourceType: watch.Secret, Resource: client.ObjectKeyFromObject(agentKeySecret)},
+	} {
+		assert.Contains(t, watched[resource], search.NamespacedName(), "missing dependency watch for %s", resource)
+	}
+}
+
+func TestMongoDBSearchMetricsDependencyWatchesRouteRotations(t *testing.T) {
+	searchKey := types.NamespacedName{Name: testSearchName, Namespace: testNamespace}
+	for _, topology := range []struct {
+		name    string
+		watches func(*MongoDBSearchMetricsForwarderReconciler) []mongoDBSearchResourceWatch
+	}{
+		{name: "central", watches: centralMongoDBSearchMetricsForwarderResourceWatches},
+		{name: "member", watches: memberMongoDBSearchMetricsForwarderResourceWatches},
+	} {
+		t.Run(topology.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name         string
+				resourceType watch.Type
+				newObject    func(data string) client.Object
+			}{
+				{
+					name:         "ConfigMap",
+					resourceType: watch.ConfigMap,
+					newObject: func(data string) client.Object {
+						return &corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{Name: "ops-manager-ca", Namespace: searchKey.Namespace},
+							Data:       map[string]string{"value": data},
+						}
+					},
+				},
+				{
+					name:         "Secret",
+					resourceType: watch.Secret,
+					newObject: func(data string) client.Object {
+						return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "agent-key", Namespace: searchKey.Namespace},
+							Data:       map[string][]byte{"value": []byte(data)},
+						}
+					},
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					r, _ := newMetricsForwarderReconciler(testDefaultImage)
+					oldObject := tc.newObject("old")
+					newObject := tc.newObject("new")
+					r.watch.AddWatchedResourceIfNotAdded(oldObject.GetName(), oldObject.GetNamespace(), tc.resourceType, searchKey)
+					var resourceWatch *mongoDBSearchResourceWatch
+					watches := topology.watches(r)
+					for i := range watches {
+						if reflect.TypeOf(watches[i].obj) == reflect.TypeOf(oldObject) {
+							resourceWatch = &watches[i]
+							break
+						}
+					}
+					require.NotNil(t, resourceWatch)
+					assert.Empty(t, resourceWatch.predicates)
+
+					for _, send := range []func(workqueue.TypedRateLimitingInterface[reconcile.Request]){
+						func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+							resourceWatch.handler.Create(t.Context(), event.TypedCreateEvent[client.Object]{Object: oldObject}, q)
+						},
+						func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+							resourceWatch.handler.Update(t.Context(), event.TypedUpdateEvent[client.Object]{ObjectOld: oldObject, ObjectNew: newObject}, q)
+						},
+						func(q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+							resourceWatch.handler.Delete(t.Context(), event.TypedDeleteEvent[client.Object]{Object: oldObject}, q)
+						},
+					} {
+						q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+						send(q)
+						require.Equal(t, 1, q.Len())
+						request, shutdown := q.Get()
+						require.False(t, shutdown)
+						assert.Equal(t, searchKey, request.NamespacedName)
+						q.Done(request)
+						q.ShutDown()
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestReconcileCore_RejectsChangedPersistedClusterIndex(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(7))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-a": {ClusterIndex: ptr.To(0), Replicas: 1},
+		"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	oldDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+		Labels:    metricsForwarderLabelsForCluster(search, "cluster-a", 0),
+	}}
+	validDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:        search.MetricsForwarderDeploymentNameForCluster(1),
+		Namespace:   search.Namespace,
+		UID:         "cluster-b-deployment",
+		Annotations: map[string]string{"sentinel": "unchanged"},
+		Labels:      metricsForwarderLabelsForCluster(search, "cluster-b", 1),
+	}}
+	validConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        search.MetricsForwarderConfigMapNameForCluster(1),
+			Namespace:   search.Namespace,
+			UID:         "cluster-b-config",
+			Annotations: map[string]string{"sentinel": "unchanged"},
+			Labels:      metricsForwarderLabelsForCluster(search, "cluster-b", 1),
+		},
+		Data: map[string]string{"sentinel": "unchanged"},
+	}
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM, oldDeployment, validDeployment, validConfigMap,
+	)
+	currentSearch := getMongoDBSearch(t, fakeClient, search.Namespace, search.Name)
+
+	st := r.reconcileCore(t.Context(), currentSearch, zap.S())
+
+	require.False(t, st.IsOK())
+	assert.Contains(t, searchcontroller.MessageFromStatus(st), `cluster "cluster-a" index is immutable: persisted index 0, requested index 7`)
+	topologyState := getFullTopologyState(t, fakeClient, search)
+	require.NotNil(t, topologyState.Clusters["cluster-a"].ClusterIndex)
+	assert.Equal(t, 0, *topologyState.Clusters["cluster-a"].ClusterIndex)
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(oldDeployment), &appsv1.Deployment{}))
+	actualValidDeployment := &appsv1.Deployment{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(validDeployment), actualValidDeployment))
+	assert.Equal(t, validDeployment.UID, actualValidDeployment.UID)
+	assert.Equal(t, validDeployment.Annotations, actualValidDeployment.Annotations)
+	actualValidConfigMap := &corev1.ConfigMap{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(validConfigMap), actualValidConfigMap))
+	assert.Equal(t, validConfigMap.UID, actualValidConfigMap.UID)
+	assert.Equal(t, validConfigMap.Annotations, actualValidConfigMap.Annotations)
+	assert.Equal(t, validConfigMap.Data, actualValidConfigMap.Data)
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name: search.MetricsForwarderDeploymentNameForCluster(7), Namespace: search.Namespace,
+	}, &appsv1.Deployment{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
 func reconcileMetricsForwarder(t *testing.T, r *MongoDBSearchMetricsForwarderReconciler, namespace, name string) reconcile.Result {
 	t.Helper()
 	result, err := r.Reconcile(context.Background(), reconcile.Request{
@@ -414,6 +751,193 @@ func getMongoDBSearch(t *testing.T, c client.Client, namespace, name string) *se
 	err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, search)
 	require.NoError(t, err)
 	return search
+}
+
+func TestEnsureMetricsForwarderResources_SingleCluster_AdoptsOwnerRef(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage)
+	legacyOwnerReferences := []metav1.OwnerReference{{
+		APIVersion: "mongodb.com/v1",
+		Kind:       "MongoDBSearch",
+		Name:       search.Name,
+		UID:        "old-search-uid",
+	}}
+	require.NoError(t, fakeClient.Create(t.Context(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:            search.MetricsForwarderConfigMapNameForCluster(0),
+		Namespace:       search.Namespace,
+		OwnerReferences: legacyOwnerReferences,
+	}}))
+	require.NoError(t, fakeClient.Create(t.Context(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:            search.MetricsForwarderDeploymentNameForCluster(0),
+		Namespace:       search.Namespace,
+		OwnerReferences: legacyOwnerReferences,
+	}}))
+
+	require.NoError(t, r.ensureMetricsForwarderConfigMap(
+		context.Background(),
+		search,
+		[]byte("receivers: {}"),
+		r.clusterWorkItem(search, "", 0),
+		zap.S(),
+	))
+	require.NoError(t, r.ensureMetricsForwarderDeployment(
+		context.Background(),
+		search,
+		[]byte("receivers: {}"),
+		testGroupID,
+		"agent-key-secret",
+		"",
+		r.clusterWorkItem(search, "", 0),
+		zap.S(),
+	))
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      search.MetricsForwarderConfigMapNameForCluster(0),
+		Namespace: search.Namespace,
+	}, cm))
+	require.Len(t, cm.OwnerReferences, 1)
+	assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+	assert.Equal(t, search.Name, cm.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, cm.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+
+	dep := &appsv1.Deployment{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+	}, dep))
+	require.Len(t, dep.OwnerReferences, 1)
+	assert.Equal(t, search.UID, dep.OwnerReferences[0].UID)
+	assert.Equal(t, search.Name, dep.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, dep.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+}
+
+func TestEnsureMetricsForwarderResources_MultiCluster_NoOwnerRef(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	memberClient := mock.NewEmptyFakeClientBuilder().Build()
+	r := newMongoDBSearchMetricsForwarderReconciler(
+		mock.NewEmptyFakeClientBuilder().Build(),
+		testDefaultImage,
+		map[string]client.Client{"member-a": memberClient},
+		"",
+	)
+	work := r.clusterWorkItem(search, "member-a", 0)
+
+	require.NoError(t, r.ensureMetricsForwarderConfigMap(t.Context(), search, []byte("receivers: {}"), work, zap.S()))
+	require.NoError(t, r.ensureMetricsForwarderDeployment(t.Context(), search, []byte("receivers: {}"), testGroupID, "agent-key-secret", "", work, zap.S()))
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, memberClient.Get(t.Context(), types.NamespacedName{
+		Name: search.MetricsForwarderConfigMapNameForCluster(0), Namespace: search.Namespace,
+	}, cm))
+	assert.Empty(t, cm.OwnerReferences)
+	dep := &appsv1.Deployment{}
+	require.NoError(t, memberClient.Get(t.Context(), types.NamespacedName{
+		Name: search.MetricsForwarderDeploymentNameForCluster(0), Namespace: search.Namespace,
+	}, dep))
+	assert.Empty(t, dep.OwnerReferences)
+}
+
+func TestReplicateForwarderDependencies_OwnerReferencesFollowLocality(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent-key", Namespace: search.Namespace},
+		Data:       map[string][]byte{"key": []byte("value")},
+	}
+	sourceCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "om-ca", Namespace: search.Namespace},
+		Data:       map[string]string{"ca-pem": "certificate"},
+	}
+	tests := []struct {
+		name         string
+		clusterName  string
+		crossCluster bool
+	}{
+		{name: "same cluster"},
+		{name: "cross cluster", clusterName: "member-a", crossCluster: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			central := mock.NewEmptyFakeClientBuilder().WithObjects(sourceSecret.DeepCopy(), sourceCA.DeepCopy()).Build()
+			target := central
+			var members map[string]client.Client
+			if tc.crossCluster {
+				target = mock.NewEmptyFakeClientBuilder().Build()
+				members = map[string]client.Client{tc.clusterName: target}
+			}
+			r := newMongoDBSearchMetricsForwarderReconciler(central, testDefaultImage, members, "")
+			work := r.clusterWorkItem(search, tc.clusterName, 0)
+
+			require.NoError(t, r.replicateForwarderDependencies(t.Context(), search, sourceSecret.Name, sourceCA.Name, work, zap.S()))
+
+			generatedSecret := &corev1.Secret{}
+			require.NoError(t, target.Get(t.Context(), types.NamespacedName{
+				Name: search.MetricsForwarderAgentKeySecretNameForCluster(0), Namespace: search.Namespace,
+			}, generatedSecret))
+			generatedCA := &corev1.ConfigMap{}
+			require.NoError(t, target.Get(t.Context(), types.NamespacedName{
+				Name: search.MetricsForwarderCACertConfigMapNameForCluster(0), Namespace: search.Namespace,
+			}, generatedCA))
+			if tc.crossCluster {
+				assert.Empty(t, generatedSecret.OwnerReferences)
+				assert.Empty(t, generatedCA.OwnerReferences)
+			} else {
+				require.Len(t, generatedSecret.OwnerReferences, 1)
+				require.Len(t, generatedCA.OwnerReferences, 1)
+				assert.Equal(t, search.UID, generatedSecret.OwnerReferences[0].UID)
+				assert.Equal(t, search.UID, generatedCA.OwnerReferences[0].UID)
+			}
+		})
+	}
+}
+
+func TestBuildClusterWorkList_TopologyCoverage(t *testing.T) {
+	t.Run("named single-cluster uses index 0 and central client", func(t *testing.T) {
+		central := mock.NewEmptyFakeClientBuilder().Build()
+		r := newMongoDBSearchMetricsForwarderReconciler(central, testDefaultImage, nil, "")
+		search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+		search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "kind-e2e-cluster-1"}}
+
+		wl := r.buildClusterWorkList(search)
+		require.Len(t, wl, 1)
+		assert.Equal(t, "kind-e2e-cluster-1", wl[0].ClusterName)
+		assert.Equal(t, 0, wl[0].ClusterIndex)
+		assert.Equal(t, r.kubeClient, wl[0].Client)
+	})
+
+	t.Run("projected operator-per-cluster entry keeps pinned index", func(t *testing.T) {
+		central := mock.NewEmptyFakeClientBuilder().Build()
+		r := newMongoDBSearchMetricsForwarderReconciler(central, testDefaultImage, nil, "cluster-b")
+		search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+		search.Spec.Clusters = []searchv1.ClusterSpec{{
+			Name:  "cluster-b",
+			Index: ptr.To(int32(7)),
+		}}
+
+		wl := r.buildClusterWorkList(search)
+		require.Len(t, wl, 1)
+		assert.Equal(t, "cluster-b", wl[0].ClusterName)
+		assert.Equal(t, 7, wl[0].ClusterIndex)
+		assert.Equal(t, r.kubeClient, wl[0].Client)
+		require.Len(t, wl[0].OwnerReferences, 1)
+		assert.Equal(t, search.UID, wl[0].OwnerReferences[0].UID)
+	})
+
+	t.Run("hub with every member client missing stays remote", func(t *testing.T) {
+		t.Setenv(util.SearchEnableMultiClusterEnv, "true")
+		central := mock.NewEmptyFakeClientBuilder().Build()
+		r := newMongoDBSearchMetricsForwarderReconciler(central, testDefaultImage, nil, "")
+		search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+		search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+
+		wl := r.buildClusterWorkList(search)
+
+		require.Len(t, wl, 1)
+		assert.Nil(t, wl[0].Client)
+		assert.Empty(t, wl[0].OwnerReferences)
+		assert.Nil(t, r.readerForCluster("cluster-a"))
+		assert.False(t, r.isLocalCluster("cluster-a"))
+	})
 }
 
 // envMap indexes a container's environment variables by name for easy assertion.
@@ -684,7 +1208,7 @@ func TestEnsureMetricsForwarderDeployment_OverridePreservesProtectedSearchLabels
 	}
 	r, kubeClient := newMetricsForwarderReconciler(testDefaultImage)
 
-	require.NoError(t, r.ensureMetricsForwarderDeployment(t.Context(), search, []byte("config"), "group", "agent-key", "", "member-a", 2, r.kubeClient, zap.S()))
+	require.NoError(t, r.ensureMetricsForwarderDeployment(t.Context(), search, []byte("config"), "group", "agent-key", "", r.clusterWorkItem(search, "member-a", 2), zap.S()))
 
 	dep := &appsv1.Deployment{}
 	require.NoError(t, kubeClient.Get(t.Context(), types.NamespacedName{Name: search.MetricsForwarderDeploymentNameForCluster(2), Namespace: search.Namespace}, dep))
@@ -819,23 +1343,81 @@ func TestReconcile_DisabledMode_DeletesResources(t *testing.T) {
 			Mode: searchv1.MetricsForwarderModeDisabled,
 		},
 	}
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-a": {ClusterIndex: ptr.To(0)},
+		"cluster-b": {ClusterIndex: ptr.To(1)},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	existingDep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(1),
+		Namespace: testNamespace,
+		UID:       "metrics-deployment-uid",
+		Labels:    metricsForwarderLabelsForCluster(search, "cluster-b", 1),
+	}}
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace), stateCM, existingDep)
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	var propagationPolicy *metav1.DeletionPropagation
+	var preconditions *metav1.Preconditions
+	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok {
+				deleteOptions := &client.DeleteOptions{}
+				for _, opt := range opts {
+					opt.ApplyToDelete(deleteOptions)
+				}
+				propagationPolicy = deleteOptions.PropagationPolicy
+				preconditions = deleteOptions.Preconditions
+			}
+			return cl.Delete(ctx, obj, opts...)
+		},
+	}))
+	r.kubeClient = interceptedClient
+	r.clientForCluster = func(string) kubernetesClient.Client { return interceptedClient }
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
-	// Verify Deployment was NOT created
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{
+	err = fakeClient.Get(context.Background(), types.NamespacedName{
 		Namespace: testNamespace,
-		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+		Name:      search.MetricsForwarderDeploymentNameForCluster(1),
 	}, dep)
 	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "expected deployment to not exist")
+	require.NotNil(t, propagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationForeground, *propagationPolicy)
+	require.NotNil(t, preconditions)
+	assert.Equal(t, existingDep.UID, *preconditions.UID)
+	assert.NotEmpty(t, *preconditions.ResourceVersion)
 
 	// Verify status shows disabled
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
 	assert.Equal(t, status.PhaseDisabled, updatedSearch.Status.MetricsForwarder.Phase)
+}
+
+func TestDeleteMetricsForwarderResourcesPreservesForeignReplacement(t *testing.T) {
+	ctx := context.Background()
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = types.UID("search-uid")
+	foreign := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+			Namespace: search.Namespace,
+			Labels:    map[string]string{"app": "foreign"},
+		},
+	}
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, search, foreign)
+
+	err := r.deleteMetricsForwarderResources(ctx, search, []clusterWorkItem{{
+		ClusterIndex: 0,
+		Client:       r.kubeClient,
+	}}, zap.S())
+	require.NoError(t, err)
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(foreign), &appsv1.Deployment{}))
 }
 
 // newTestMongoDBCommunity creates a minimal MongoDBCommunity source resource.
@@ -863,6 +1445,34 @@ func TestReconcile_CommunitySource_AddsNoFinalizer(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "no deployment should be created for a community source")
 }
 
+func TestReconcile_DeletionWithCommunitySourceRemovesExistingFinalizer(t *testing.T) {
+	mdbc := newTestMongoDBCommunity(testMDBName, testNamespace)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdbc, search)
+	require.NoError(t, fakeClient.Delete(context.Background(), search))
+
+	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+	err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(search), &searchv1.MongoDBSearch{})
+	assert.True(t, apierrors.IsNotFound(err), "unsupported sources must not retain the metrics finalizer during deletion")
+}
+
+func TestReconcile_DeletionWithCommunitySourceRetainsFinalizerForPersistedHosts(t *testing.T) {
+	mdbc := newTestMongoDBCommunity(testMDBName, testNamespace)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0), Replicas: 1})
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdbc, search, stateCM)
+	require.NoError(t, fakeClient.Delete(context.Background(), search))
+
+	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+	remainingSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+	assert.Contains(t, remainingSearch.Finalizers, util.SearchMetricsForwarderFinalizer)
+	assert.Equal(t, 1, getTopologyState(t, fakeClient, search).Replicas)
+}
+
 func TestReconcile_PrometheusDisabled_MetricsForwarderEnabled_Invalid(t *testing.T) {
 	// When prometheus is explicitly disabled but the metrics forwarder is enabled (mode=enabled or
 	// auto with internal source), the reconciler must report Invalid status because the forwarder
@@ -887,6 +1497,138 @@ func TestReconcile_PrometheusDisabled_MetricsForwarderEnabled_Invalid(t *testing
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Prometheus")
 }
 
+func TestReconcile_DeletionTakesPriorityOverDisableAnnotationAndDisabledMode(t *testing.T) {
+	// Regression test: deleting a MongoDBSearch whose metrics forwarder was disabled must still
+	// deregister its Ops Manager hosts and remove the finalizer. The disabled-mode reconcile path does
+	// not own deletion handling, so without the top-level deletion check in Reconcile the finalizer
+	// would leak (blocking deletion) and the monitored hosts would stay registered in Ops Manager.
+	//
+	// Because the forwarder was disabled, no Deployment was ever created. The two-phase deletion in
+	// preDeletionCleanup completes in a single reconcile: phase 1 finds no Deployment to delete,
+	// phase 2 sees no Deployment present, and the finalizer is removed immediately.
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Observability = searchv1.ObservabilityConfig{
+		MetricsForwarder: searchv1.MetricsForwarderConfig{
+			Mode: searchv1.MetricsForwarderModeDisabled,
+		},
+	}
+	search.Annotations = map[string]string{searchv1.DisableReconciliationAnnotation: "true"}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	// Internal enterprise sources resolve the agent key secret from the project id; see agents.ApiKeySecretName.
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	// Seed the topology state an enabled forwarder would have written: two mongot replicas.
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 2})
+
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+
+	// Capture the host ids passed to the Ops Manager delete-hosts API.
+	var deletedHostIDs []string
+	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+
+	// Trigger deletion: with the finalizer present the fake client sets a DeletionTimestamp instead of
+	// removing the object outright.
+	require.NoError(t, fakeClient.Delete(context.Background(), search))
+
+	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+	// Both mongot hosts from the persisted topology are deregistered from Ops Manager.
+	stsName := search.StatefulSetNamespacedNameForCluster(0).Name
+	assert.ElementsMatch(t, []string{
+		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", stsName)),
+		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-1", stsName)),
+	}, deletedHostIDs)
+
+	// The finalizer is removed, so the resource is fully deleted.
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, &searchv1.MongoDBSearch{})
+	assert.True(t, apierrors.IsNotFound(err), "expected MongoDBSearch to be deleted after finalizer removal, got err=%v", err)
+}
+
+func TestReconcile_DeletionBypassesNormalValidationAndImageGates(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a"}, {Name: "cluster-b"}}
+	search.Status.Version = ""
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+
+	r, fakeClient := newMetricsForwarderReconciler("", mdb, search, projectCM, agentKeySecret)
+	require.NoError(t, fakeClient.Delete(context.Background(), search))
+
+	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, &searchv1.MongoDBSearch{})
+	assert.True(t, apierrors.IsNotFound(err), "deletion cleanup must not be blocked by normal validation, image, or version gates")
+}
+
+func TestReconcile_MissingClusterClientSurfacesPending(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
+	r.clientForCluster = func(string) kubernetesClient.Client { return nil }
+
+	st := r.reconcileCore(context.Background(), getMongoDBSearch(t, fakeClient, testNamespace, testSearchName), zap.S())
+
+	require.Equal(t, status.PhasePending, st.Phase())
+	assert.Contains(t, searchcontroller.MessageFromStatus(st), `cluster "cluster-a"`)
+}
+
+func TestPreDeletionCleanup_HostCleanupFailureRetainsFinalizer(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-a": {ClusterIndex: ptr.To(0), Replicas: 1},
+		"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	agentSecretName := "agent-key-secret"
+	agentKeySecret := newTestAgentKeySecret(agentSecretName, testNamespace)
+	r, _ := newMetricsForwarderReconciler(testDefaultImage, search, stateCM, agentKeySecret)
+	clusterAHostID := mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", search.StatefulSetNamespacedNameForCluster(0).Name))
+
+	var requestedHostIDs []string
+	r.omRequester = stubOMAgentRequester{fn: func(_ mdbv1.ProjectConfig, method, path, _ string, body any) ([]byte, error) {
+		require.Equal(t, "POST", method)
+		require.True(t, strings.HasSuffix(path, "/v1/delete"))
+		hostIDs := body.(deleteHostsRequest).HostIds
+		requestedHostIDs = append(requestedHostIDs, hostIDs...)
+		if hostIDs[0] == clusterAHostID {
+			return nil, fmt.Errorf("injected cluster-a host cleanup failure")
+		}
+		return []byte(`{"results":[]}`), nil
+	}}
+
+	st := r.preDeletionCleanup(
+		context.Background(),
+		search,
+		nil,
+		testGroupID,
+		mdbv1.ProjectConfig{BaseURL: testOMBaseURL},
+		agentSecretName,
+		r.buildClusterWorkList(search),
+		zap.NewNop().Sugar(),
+	)
+
+	require.False(t, st.IsOK())
+	assert.Contains(t, searchcontroller.MessageFromStatus(st), "injected cluster-a host cleanup failure")
+	assert.Contains(t, search.Finalizers, util.SearchMetricsForwarderFinalizer,
+		"finalizer must stay until host cleanup succeeds")
+}
+
 func TestReconcile_DeletionWhileEnabled_WaitsForDeploymentThenDeregistersHosts(t *testing.T) {
 	// When a MongoDBSearch is deleted while the forwarder is enabled, preDeletionCleanup must not
 	// deregister OM hosts until the forwarder Deployment has been fully deleted. A live collector
@@ -900,13 +1642,14 @@ func TestReconcile_DeletionWhileEnabled_WaitsForDeploymentThenDeregistersHosts(t
 	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
-	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 1})
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0), Replicas: 1})
 
 	// Pre-create a Deployment to simulate the forwarder having been running.
 	existingDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      search.MetricsForwarderDeploymentNameForCluster(0),
 			Namespace: testNamespace,
+			Labels:    metricsForwarderLabelsForCluster(search, "", 0),
 		},
 	}
 
@@ -916,15 +1659,42 @@ func TestReconcile_DeletionWhileEnabled_WaitsForDeploymentThenDeregistersHosts(t
 	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
 
 	require.NoError(t, fakeClient.Delete(context.Background(), search))
+	var propagationPolicy *metav1.DeletionPropagation
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, key.Name)
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deleteOptions := &client.DeleteOptions{}
+			for _, opt := range opts {
+				opt.ApplyToDelete(deleteOptions)
+			}
+			propagationPolicy = deleteOptions.PropagationPolicy
+			return cl.Delete(ctx, obj, opts...)
+		},
+	}))
+	r.kubeClient = interceptedClient
+	r.clientForCluster = func(string) kubernetesClient.Client { return interceptedClient }
 
 	// First reconcile: Deployment still exists → preDeletionCleanup deletes it and returns Pending.
 	result1 := reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 	assert.True(t, result1.RequeueAfter > 0 || result1.Requeue, "expected requeue on first deletion reconcile")
 	assert.Empty(t, deletedHostIDs, "expected no host deregistration while Deployment still exists")
+	require.NotNil(t, propagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationForeground, *propagationPolicy)
 
 	// The Deployment should now be gone (deleted by phase 1).
 	depErr := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: existingDep.Name}, &appsv1.Deployment{})
 	assert.True(t, apierrors.IsNotFound(depErr), "expected Deployment to be deleted after first reconcile")
+	midDeleteSearch := &searchv1.MongoDBSearch{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, midDeleteSearch))
+	require.NotNil(t, midDeleteSearch.DeletionTimestamp)
+	assert.Contains(t, midDeleteSearch.Finalizers, util.SearchMetricsForwarderFinalizer, "finalizer must remain until host cleanup finishes")
 
 	// Second reconcile: Deployment is gone → hosts deregistered and finalizer removed.
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
@@ -1846,6 +2616,140 @@ func TestMetricsForwarder_OMVersionSemverParseError_ExplicitConnection_Failed(t 
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created when OM version cannot be parsed")
 }
 
+func TestReconcileCore_MultiClusterTopologyStateWrittenOnce(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
+
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	stateCMName := fmt.Sprintf("%s-metrics-forwarder-state", search.Name)
+	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.ConfigMap); ok && key.Name == stateCMName {
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+	}))
+	r.kubeClient = interceptedClient
+	currentSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+
+	st := r.reconcileCore(context.Background(), currentSearch, zap.NewNop().Sugar())
+
+	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	stateCM := &corev1.ConfigMap{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: stateCMName}, stateCM))
+	var topologyState searchTopologyState
+	require.NoError(t, json.Unmarshal([]byte(stateCM.Data[stateKey]), &topologyState))
+	require.Len(t, topologyState.Clusters, 2)
+	require.NotNil(t, topologyState.Clusters["cluster-a"].ClusterIndex)
+	require.NotNil(t, topologyState.Clusters["cluster-b"].ClusterIndex)
+	assert.Equal(t, 0, *topologyState.Clusters["cluster-a"].ClusterIndex)
+	assert.Equal(t, 1, *topologyState.Clusters["cluster-b"].ClusterIndex)
+}
+
+func TestReconcileCore_StateWriteFailurePreventsDeploymentCreation(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
+
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	stateCMName := fmt.Sprintf("%s-metrics-forwarder-state", search.Name)
+	injectedErr := fmt.Errorf("injected topology state write failure")
+	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == stateCMName {
+				return injectedErr
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+	}))
+	r.kubeClient = interceptedClient
+	r.clientForCluster = func(string) kubernetesClient.Client { return interceptedClient }
+	currentSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+
+	st := r.reconcileCore(context.Background(), currentSearch, zap.NewNop().Sugar())
+
+	require.False(t, st.IsOK())
+	assert.Contains(t, searchcontroller.MessageFromStatus(st), injectedErr.Error())
+	dep := &appsv1.Deployment{}
+	err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+	}, dep)
+	assert.True(t, apierrors.IsNotFound(err), "forwarder Deployment must not start before topology state is durable")
+}
+
+func TestReconcileCore_UncachedMissingTopologyIsRewrittenBeforeDeployment(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0), Replicas: 1})
+	stateCM.OwnerReferences = search.GetOwnerReferences()
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+	r.stateReader = mock.NewEmptyFakeClientBuilder().Build()
+
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	var writes []string
+	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok {
+				writes = append(writes, "deployment")
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == stateCM.Name {
+				writes = append(writes, "state")
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+	}))
+	r.kubeClient = interceptedClient
+	r.clientForCluster = func(string) kubernetesClient.Client { return interceptedClient }
+	currentSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+
+	st := r.reconcileCore(context.Background(), currentSearch, zap.NewNop().Sugar())
+
+	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	assert.Equal(t, []string{"state", "deployment"}, writes)
+}
+
+func TestReconcileCore_LegacyTopologyStateOwnerReferenceIsAdopted(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 1})
+	stateCM.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "mongodb.com/v1",
+		Kind:       "MongoDBSearch",
+		Name:       search.Name,
+	}}
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+	currentSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+
+	st := r.reconcileCore(context.Background(), currentSearch, zap.NewNop().Sugar())
+
+	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	updatedStateCM := &corev1.ConfigMap{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: stateCM.Name}, updatedStateCM))
+	require.Len(t, updatedStateCM.OwnerReferences, 1)
+	assert.Equal(t, search.UID, updatedStateCM.OwnerReferences[0].UID)
+}
+
 // callReconcileTopologyState invokes reconcileTopologyState directly against the
 // single-cluster (clusterName=="", clusterIndex=0) work item, bypassing the full
 // Reconcile path so each test targets one state-machine transition.
@@ -2091,61 +2995,4 @@ func TestReconcileTopologyState_Sharded_RemovedShardAndScaleDown(t *testing.T) {
 		assert.Contains(t, state.HostDeletionReadyAfter, podName,
 			"pod %s expected in HostDeletionReadyAfter", podName)
 	}
-}
-
-const (
-	testNamespace     = "test-ns"
-	testSearchName    = "my-search"
-	testMDBName       = "my-mongodb"
-	testProjectCMName = "my-project-cm"
-	testGroupID       = "test-group-id-123"
-	testDefaultImage  = "quay.io/mongodb/metrics-forwarder:latest"
-	testOMBaseURL     = "http://ops-manager.example.com:8080"
-)
-
-func TestReconcile_DeletionWhileDisabled_DeregistersHostsAndRemovesFinalizer(t *testing.T) {
-	// Regression test: deleting a MongoDBSearch whose metrics forwarder was disabled must still
-	// deregister its Ops Manager hosts and remove the finalizer. The disabled-mode reconcile path does
-	// not own deletion handling, so without the top-level deletion check in Reconcile the finalizer
-	// would leak (blocking deletion) and the monitored hosts would stay registered in Ops Manager.
-	//
-	// Because the forwarder was disabled, no Deployment was ever created. The two-phase deletion in
-	// preDeletionCleanup completes in a single reconcile: phase 1 finds no Deployment to delete,
-	// phase 2 sees no Deployment present, and the finalizer is removed immediately.
-	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
-	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
-	search.Spec.Observability = searchv1.ObservabilityConfig{
-		MetricsForwarder: searchv1.MetricsForwarderConfig{
-			Mode: searchv1.MetricsForwarderModeDisabled,
-		},
-	}
-	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
-	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
-	// Internal enterprise sources resolve the agent key secret from the project id; see agents.ApiKeySecretName.
-	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
-	// Seed the topology state an enabled forwarder would have written: two mongot replicas.
-	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 2})
-
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
-
-	// Capture the host ids passed to the Ops Manager delete-hosts API.
-	var deletedHostIDs []string
-	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
-
-	// Trigger deletion: with the finalizer present the fake client sets a DeletionTimestamp instead of
-	// removing the object outright.
-	require.NoError(t, fakeClient.Delete(context.Background(), search))
-
-	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
-
-	// Both mongot hosts from the persisted topology are deregistered from Ops Manager.
-	stsName := search.StatefulSetNamespacedNameForCluster(0).Name
-	assert.ElementsMatch(t, []string{
-		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", stsName)),
-		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-1", stsName)),
-	}, deletedHostIDs)
-
-	// The finalizer is removed, so the resource is fully deleted.
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, &searchv1.MongoDBSearch{})
-	assert.True(t, apierrors.IsNotFound(err), "expected MongoDBSearch to be deleted after finalizer removal, got err=%v", err)
 }

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -187,12 +187,17 @@ func newTestTopologyStateConfigMap(t *testing.T, search *searchv1.MongoDBSearch,
 	state := searchTopologyState{Clusters: map[string]clusterTopologyState{"": clusterState}}
 	stateJSON, err := json.Marshal(state)
 	require.NoError(t, err)
+	data := map[string]string{stateKey: string(stateJSON)}
+	if search.UID != "" {
+		data[stateOwnerUIDKey] = string(search.UID)
+	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-metrics-forwarder-state", search.Name),
 			Namespace: search.Namespace,
+			Labels:    metricsForwarderLabels(search),
 		},
-		Data: map[string]string{stateKey: string(stateJSON)},
+		Data: data,
 	}
 }
 
@@ -222,6 +227,186 @@ func getTopologyState(t *testing.T, c client.Client, search *searchv1.MongoDBSea
 	var state searchTopologyState
 	require.NoError(t, json.Unmarshal([]byte(cm.Data[stateKey]), &state))
 	return state.Clusters[""]
+}
+
+func TestOpenTopologyStateStore_UIDSemantics(t *testing.T) {
+	tests := []struct {
+		name          string
+		recordedUID   *string
+		wantNotFound  bool
+		writeReplicas int
+	}{
+		{name: "missing marker adopts legacy state", writeReplicas: 4},
+		{name: "matching marker preserves state", recordedUID: ptr.To("search-uid"), writeReplicas: 4},
+		{name: "mismatched marker resets state", recordedUID: ptr.To("old-search-uid"), wantNotFound: true, writeReplicas: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+			search.UID = "search-uid"
+			storedState := searchTopologyState{Clusters: map[string]clusterTopologyState{"": {Replicas: 3}}}
+			stateJSON, err := json.Marshal(storedState)
+			require.NoError(t, err)
+			data := map[string]string{stateKey: string(stateJSON)}
+			if tc.recordedUID != nil {
+				data[stateOwnerUIDKey] = *tc.recordedUID
+			}
+			stateOwnerUID := search.UID
+			if tc.wantNotFound {
+				stateOwnerUID = "old-search-uid"
+			}
+			stateCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-metrics-forwarder-state", search.Name),
+					Namespace: search.Namespace,
+					Labels:    metricsForwarderLabels(search),
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "mongodb.com/v1",
+						Kind:               "MongoDBSearch",
+						Name:               search.Name,
+						UID:                stateOwnerUID,
+						Controller:         ptr.To(true),
+						BlockOwnerDeletion: ptr.To(true),
+					}},
+				},
+				Data: data,
+			}
+
+			r, c := newMetricsForwarderReconciler(testDefaultImage, search, stateCM)
+			store := r.openTopologyStateStore(search)
+			state, err := store.ReadState(ctx)
+			if tc.wantNotFound {
+				require.Error(t, err)
+				assert.True(t, apierrors.IsNotFound(err))
+				state = &searchTopologyState{Clusters: map[string]clusterTopologyState{}}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, 3, state.Clusters[""].Replicas)
+			}
+
+			state.Clusters[""] = clusterTopologyState{Replicas: tc.writeReplicas}
+			require.NoError(t, store.WriteState(ctx, state, zap.S()))
+
+			cm := &corev1.ConfigMap{}
+			require.NoError(t, c.Get(ctx, types.NamespacedName{
+				Namespace: search.Namespace,
+				Name:      fmt.Sprintf("%s-metrics-forwarder-state", search.Name),
+			}, cm))
+			assert.Equal(t, string(search.UID), cm.Data[stateOwnerUIDKey])
+			assert.Equal(t, tc.writeReplicas, getTopologyState(t, c, search).Replicas)
+			assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+			require.Len(t, cm.OwnerReferences, 1)
+			assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+		})
+	}
+}
+
+func TestOpenTopologyStateStore_RejectsMarkerlessForeignOwner(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "new-search-uid"
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{
+		PendingHostDeletions: []string{"old-search-pod-0"},
+	})
+	delete(stateCM.Data, stateOwnerUIDKey)
+	stateCM.OwnerReferences = search.GetOwnerReferences()
+	stateCM.OwnerReferences[0].UID = "old-search-uid"
+
+	r, _ := newMetricsForwarderReconciler(testDefaultImage, search, stateCM)
+	_, err := r.openTopologyStateStore(search).ReadState(t.Context())
+
+	require.True(t, apierrors.IsNotFound(err), err)
+}
+
+func TestOpenTopologyStateStore_MarkerlessOwnerIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutateOwner func(*metav1.OwnerReference)
+		wantAdopt   bool
+	}{
+		{name: "exact owner", wantAdopt: true},
+		{name: "legacy empty kind and API version", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.Kind = ""
+			owner.APIVersion = ""
+		}, wantAdopt: true},
+		{name: "legacy empty kind", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.Kind = ""
+		}, wantAdopt: true},
+		{name: "legacy empty API version", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.APIVersion = ""
+		}, wantAdopt: true},
+		{name: "wrong non-empty kind", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.Kind = "MongoDB"
+		}},
+		{name: "wrong non-empty API version", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.APIVersion = "mongodb.com/v2"
+		}},
+		{name: "wrong name", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.Name = "other-search"
+		}},
+		{name: "wrong UID", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.UID = "old-search-uid"
+		}},
+		{name: "non-controller owner", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.Controller = ptr.To(false)
+		}},
+		{name: "owner without controller marker", mutateOwner: func(owner *metav1.OwnerReference) {
+			owner.Controller = nil
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+			search.UID = "search-uid"
+			stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{
+				PendingHostDeletions:   []string{"removed-pod-0"},
+				HostDeletionReadyAfter: map[string]int64{"removed-pod-0": 0},
+			})
+			delete(stateCM.Data, stateOwnerUIDKey)
+			stateCM.OwnerReferences = search.GetOwnerReferences()
+			if tc.mutateOwner != nil {
+				tc.mutateOwner(&stateCM.OwnerReferences[0])
+			}
+			r, _ := newMetricsForwarderReconciler(testDefaultImage, search, stateCM)
+
+			state, err := r.openTopologyStateStore(search).ReadState(t.Context())
+
+			if !tc.wantAdopt {
+				require.True(t, apierrors.IsNotFound(err), err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, []string{"removed-pod-0"}, state.Clusters[""].PendingHostDeletions)
+			assert.Equal(t, map[string]int64{"removed-pod-0": 0}, state.Clusters[""].HostDeletionReadyAfter)
+		})
+	}
+}
+
+func TestStateStoreEmptyOwnerUIDPreservesExistingSemantics(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 3})
+	delete(stateCM.Data, stateOwnerUIDKey)
+	stateCM.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "mongodb.com/v2",
+		Kind:       "MongoDB",
+		Name:       "other-owner",
+		UID:        "other-uid",
+		Controller: ptr.To(false),
+	}}
+	_, c := newMetricsForwarderReconciler(testDefaultImage, search, stateCM)
+	store := NewStateStore[searchTopologyState](
+		metricsForwarderStateOwner{MongoDBSearch: search},
+		search.GetOwnerReferences(),
+		kubernetesClient.NewClient(c),
+		"",
+	)
+
+	state, err := store.ReadState(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, state.Clusters[""].Replicas)
 }
 
 func reconcileMetricsForwarder(t *testing.T, r *MongoDBSearchMetricsForwarderReconciler, namespace, name string) reconcile.Result {

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -565,6 +565,32 @@ func TestDeleteMetricsForwarderResourcesFromState_MigratesMarkerlessStateBeforeD
 	assert.Less(t, slices.Index(events, "state-write"), slices.Index(events, "resource-delete"))
 }
 
+func TestReconcileCore_LegacyTopologyStateEntryCleanedAfterMoveToNamedClusters(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{
+		ClusterIndex: ptr.To(0),
+	})
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+	currentSearch := getMongoDBSearch(t, fakeClient, search.Namespace, search.Name)
+
+	st := r.reconcileCore(t.Context(), currentSearch, zap.S())
+
+	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	topologyState := getFullTopologyState(t, fakeClient, search)
+	assert.NotContains(t, topologyState.Clusters, "")
+	require.Contains(t, topologyState.Clusters, "cluster-a")
+	require.NotNil(t, topologyState.Clusters["cluster-a"].ClusterIndex)
+	assert.Equal(t, 0, *topologyState.Clusters["cluster-a"].ClusterIndex)
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{
+		Name: search.MetricsForwarderDeploymentNameForCluster(0), Namespace: search.Namespace,
+	}, &appsv1.Deployment{}))
+}
+
 func TestReconcileCoreRegistersMetricsCredentialAndCAWatches(t *testing.T) {
 	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
@@ -734,6 +760,59 @@ func TestReconcileCore_RejectsChangedPersistedClusterIndex(t *testing.T) {
 		Name: search.MetricsForwarderDeploymentNameForCluster(7), Namespace: search.Namespace,
 	}, &appsv1.Deployment{})
 	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestCleanupRemovedClusters_LegacyStateCleansCentralResourcesAndStateEntry(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0)})
+	legacyDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+		Labels:    metricsForwarderLabelsForCluster(search, "", 0),
+	}}
+	r, centralClient := newMetricsForwarderReconciler(testDefaultImage, search, stateCM, legacyDeployment)
+	memberDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+		Labels:    metricsForwarderLabelsForCluster(search, "cluster-a", 0),
+	}}
+	memberClient := mock.NewEmptyFakeClientBuilder().WithObjects(memberDeployment).Build()
+	memberKubeClient := kubernetesClient.NewClient(memberClient)
+	r.isLocalCluster = func(clusterName string) bool { return clusterName == "" }
+	r.clientForCluster = func(clusterName string) kubernetesClient.Client {
+		if clusterName == "" {
+			return kubernetesClient.NewClient(centralClient)
+		}
+		return memberKubeClient
+	}
+	r.readerForCluster = func(clusterName string) client.Reader {
+		if clusterName == "" {
+			return centralClient
+		}
+		return memberClient
+	}
+	currentWork := []clusterWorkItem{{
+		ClusterName: "cluster-a", ClusterIndex: 0, Client: memberKubeClient,
+	}}
+
+	pending, err := r.cleanupRemovedClusters(
+		t.Context(), search, testGroupID, mdbv1.ProjectConfig{}, "agent-key", currentWork, zap.S(),
+	)
+	require.NoError(t, err)
+	assert.True(t, pending)
+	assert.True(t, apierrors.IsNotFound(centralClient.Get(t.Context(), client.ObjectKeyFromObject(legacyDeployment), &appsv1.Deployment{})))
+	require.NoError(t, memberClient.Get(t.Context(), client.ObjectKeyFromObject(memberDeployment), &appsv1.Deployment{}))
+	assert.Contains(t, getFullTopologyState(t, centralClient, search).Clusters, "")
+
+	pending, err = r.cleanupRemovedClusters(
+		t.Context(), search, testGroupID, mdbv1.ProjectConfig{}, "agent-key", currentWork, zap.S(),
+	)
+	require.NoError(t, err)
+	assert.False(t, pending)
+	assert.NotContains(t, getFullTopologyState(t, centralClient, search).Clusters, "")
+	require.NoError(t, memberClient.Get(t.Context(), client.ObjectKeyFromObject(memberDeployment), &appsv1.Deployment{}))
 }
 
 func reconcileMetricsForwarder(t *testing.T, r *MongoDBSearchMetricsForwarderReconciler, namespace, name string) reconcile.Result {
@@ -1627,6 +1706,287 @@ func TestPreDeletionCleanup_HostCleanupFailureRetainsFinalizer(t *testing.T) {
 	assert.Contains(t, searchcontroller.MessageFromStatus(st), "injected cluster-a host cleanup failure")
 	assert.Contains(t, search.Finalizers, util.SearchMetricsForwarderFinalizer,
 		"finalizer must stay until host cleanup succeeds")
+}
+
+func TestReconcile_RemovedPerClusterOperatorCleansPersistedTopology(t *testing.T) {
+	pendingPodName := "pending-removed-cluster-mongot"
+	deferredPodName := "deferred-removed-cluster-mongot"
+	for _, tc := range []struct {
+		name           string
+		deleteSearch   bool
+		topology       map[string]clusterTopologyState
+		extraHostIDs   []string
+		wantSearchGone bool
+	}{
+		{
+			name:         "during Search deletion",
+			deleteSearch: true,
+			topology: map[string]clusterTopologyState{
+				"cluster-a": {ClusterIndex: ptr.To(0)},
+				"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+			},
+			wantSearchGone: true,
+		},
+		{
+			name: "after cluster removal",
+			topology: map[string]clusterTopologyState{
+				"cluster-b": {
+					ClusterIndex:           ptr.To(1),
+					Replicas:               1,
+					PendingHostDeletions:   []string{pendingPodName},
+					HostDeletionReadyAfter: map[string]int64{deferredPodName: time.Now().Add(time.Hour).UnixNano()},
+				},
+			},
+			extraHostIDs: []string{
+				mongotHostID(testGroupID, testNamespace, pendingPodName),
+				mongotHostID(testGroupID, testNamespace, deferredPodName),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+			search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+			search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+			search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+			projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+			agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+			stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+			stateJSON, err := json.Marshal(searchTopologyState{Clusters: tc.topology})
+			require.NoError(t, err)
+			stateCM.Data[stateKey] = string(stateJSON)
+			removedClusterDep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      search.MetricsForwarderDeploymentNameForCluster(1),
+				Namespace: testNamespace,
+				Labels:    metricsForwarderLabelsForCluster(search, "cluster-b", 1),
+			}}
+			r, fakeClient := newMetricsForwarderReconciler(
+				testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM, removedClusterDep,
+			)
+			r.operatorClusterName = "cluster-b"
+			var deletedHostIDs []string
+			r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+			if tc.deleteSearch {
+				require.NoError(t, fakeClient.Delete(t.Context(), search))
+			}
+
+			result := reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+			assert.True(t, result.RequeueAfter > 0 || result.Requeue)
+			assert.Empty(t, deletedHostIDs)
+			reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+			assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(removedClusterDep), &appsv1.Deployment{})))
+			stsName := search.StatefulSetNamespacedNameForCluster(1).Name
+			wantHostIDs := append([]string{
+				mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", stsName)),
+			}, tc.extraHostIDs...)
+			assert.ElementsMatch(t, wantHostIDs, deletedHostIDs)
+			err = fakeClient.Get(t.Context(), client.ObjectKeyFromObject(search), &searchv1.MongoDBSearch{})
+			if tc.wantSearchGone {
+				assert.True(t, apierrors.IsNotFound(err), "expected persisted cleanup before finalizer removal")
+				return
+			}
+			require.NoError(t, err)
+			assert.NotContains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
+
+			result = reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+			assert.False(t, result.Requeue)
+			assert.Equal(t, util.TWENTY_FOUR_HOURS, result.RequeueAfter)
+		})
+	}
+}
+
+func TestReconcile_RemovedPerClusterOperatorPreservesReaddedCluster(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	liveSearch := search.DeepCopy()
+	liveSearch.Spec.Clusters = append(liveSearch.Spec.Clusters, searchv1.ClusterSpec{Name: "cluster-b", Index: ptr.To(int32(1))})
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentSecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(1),
+		Namespace: search.Namespace,
+		UID:       "cluster-b-forwarder",
+		Labels:    metricsForwarderLabelsForCluster(search, "cluster-b", 1),
+	}}
+
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentSecret, stateCM, deployment)
+	r.operatorClusterName = "cluster-b"
+	r.stateReader = mock.NewEmptyFakeClientBuilder().WithObjects(liveSearch, stateCM.DeepCopy()).Build()
+	var deletedHostIDs []string
+	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+
+	result := reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+	assert.True(t, result.Requeue || result.RequeueAfter > 0)
+	// The forwarder Deployment delete is recoverable (recreated once the operator's cache
+	// catches up with the re-added cluster); the irreversible pieces are guarded: no Ops
+	// Manager host deregistration and the persisted state entry stays.
+	assert.Empty(t, deletedHostIDs)
+	assert.Contains(t, getFullTopologyState(t, fakeClient, search).Clusters, "cluster-b")
+	assert.Contains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
+}
+
+func TestCleanupRemovedClusters_UncachedGuardBlocksHostDeregistration(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		liveSearch func(search *searchv1.MongoDBSearch) *searchv1.MongoDBSearch
+	}{
+		{
+			name: "removed cluster re-added on the live CR",
+			liveSearch: func(search *searchv1.MongoDBSearch) *searchv1.MongoDBSearch {
+				live := search.DeepCopy()
+				live.Spec.Clusters = append(live.Spec.Clusters, searchv1.ClusterSpec{Name: "cluster-b", Index: ptr.To(int32(1))})
+				return live
+			},
+		},
+		{
+			name: "same-name replacement CR with a different UID",
+			liveSearch: func(search *searchv1.MongoDBSearch) *searchv1.MongoDBSearch {
+				live := search.DeepCopy()
+				live.UID = "replacement-search-uid"
+				return live
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+			search.UID = "search-uid"
+			search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+			stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+			stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+				"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+			}})
+			require.NoError(t, err)
+			stateCM.Data[stateKey] = string(stateJSON)
+			agentKeySecret := newTestAgentKeySecret("agent-key-secret", search.Namespace)
+			r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, search, agentKeySecret, stateCM)
+			r.operatorClusterName = "cluster-b"
+			reader := &changingSearchReader{
+				Reader:   fakeClient,
+				searches: []*searchv1.MongoDBSearch{tc.liveSearch(search)},
+			}
+			r.stateReader = reader
+			var deletedHostIDs []string
+			r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+
+			pending, err := r.cleanupRemovedClusters(
+				t.Context(),
+				search,
+				testGroupID,
+				mdbv1.ProjectConfig{},
+				"agent-key-secret",
+				nil,
+				zap.S(),
+			)
+			require.NoError(t, err)
+			assert.False(t, pending)
+			assert.Empty(t, deletedHostIDs, "hosts must not be deregistered when the live CR does not confirm the removal")
+			assert.Contains(t, getFullTopologyState(t, fakeClient, search).Clusters, "cluster-b",
+				"the persisted state entry must be retained for the next reconcile")
+		})
+	}
+}
+
+func TestCleanupRemovedClustersSkipsReaddedTargetWithoutSuppressingOtherCleanup(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.UID = "search-uid"
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+	liveSearch := search.DeepCopy()
+	liveSearch.Spec.Clusters = append(liveSearch.Spec.Clusters, searchv1.ClusterSpec{Name: "cluster-b", Index: ptr.To(int32(1))})
+	clusterBDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MetricsForwarderDeploymentNameForCluster(1),
+		Namespace: search.Namespace,
+		UID:       "cluster-b-forwarder",
+		Labels:    metricsForwarderLabelsForCluster(search, "cluster-b", 1),
+	}}
+	clusterB := mock.NewEmptyFakeClientBuilder().WithObjects(clusterBDeployment).Build()
+	clusterC := mock.NewEmptyFakeClientBuilder().Build()
+	agentKeySecret := newTestAgentKeySecret("agent-key-secret", search.Namespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+		"cluster-c": {ClusterIndex: ptr.To(2), Replicas: 1},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	central := mock.NewEmptyFakeClientBuilder().WithObjects(search, agentKeySecret, stateCM).Build()
+	r := newMongoDBSearchMetricsForwarderReconciler(
+		central,
+		testDefaultImage,
+		map[string]client.Client{"cluster-b": clusterB, "cluster-c": clusterC},
+		"",
+	)
+	r.stateReader = mock.NewEmptyFakeClientBuilder().WithObjects(liveSearch, stateCM.DeepCopy()).Build()
+	var deletedHostIDs []string
+	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+
+	pending, err := r.cleanupRemovedClusters(
+		t.Context(),
+		search,
+		testGroupID,
+		mdbv1.ProjectConfig{},
+		"agent-key-secret",
+		nil,
+		zap.S(),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, pending, "the re-added cluster's Deployment delete must requeue")
+	topologyState := getFullTopologyState(t, central, search)
+	assert.Contains(t, topologyState.Clusters, "cluster-b", "re-added cluster's state entry must be retained")
+	assert.NotContains(t, topologyState.Clusters, "cluster-c")
+	assert.Equal(t, []string{
+		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", search.StatefulSetNamespacedNameForCluster(2).Name)),
+	}, deletedHostIDs, "only the truly removed cluster's hosts are deregistered")
+}
+
+func TestReconcile_RemovedPerClusterOperatorRetriesFailedFinalizerRemoval(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-b": {ClusterIndex: ptr.To(1)},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+	r.operatorClusterName = "cluster-b"
+
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	failFinalizerUpdate := true
+	r.kubeClient = kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*searchv1.MongoDBSearch); ok && failFinalizerUpdate {
+				failFinalizerUpdate = false
+				return fmt.Errorf("injected finalizer update failure")
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+	}))
+
+	firstResult := reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+	assert.True(t, firstResult.RequeueAfter > 0 || firstResult.Requeue)
+	assert.Contains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer,
+		"finalizer must survive a failed removal update and be retried")
+
+	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+	finalState := getFullTopologyState(t, fakeClient, search)
+	assert.NotContains(t, finalState.Clusters, "cluster-b")
+	assert.NotContains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
 }
 
 func TestReconcile_DeletionWhileEnabled_WaitsForDeploymentThenDeregistersHosts(t *testing.T) {

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	mdbcv1 "github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/api/v1" //nolint:depguard
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
@@ -362,16 +363,27 @@ func TestBuildMetricsForwarderPodSpec_ContainerArgs(t *testing.T) {
 
 func TestMetricsForwarderLabels(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-search", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-search", Namespace: "ns", UID: "search-uid"},
 	}
 
 	labels := metricsForwarderLabels(search)
 	assert.Equal(t, "my-search-search-metrics-forwarder-0", labels["app"])
-	assert.Equal(t, metricsForwarderLabelName, labels["component"])
+	assert.Equal(t, metricsForwarderLabelName, labels[khandler.MongoDBSearchComponentLabel])
+	assert.Equal(t, "my-search", labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, "ns", labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), labels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.NotContains(t, labels, khandler.MongoDBSearchClusterNameLabel)
+
+	memberLabels := metricsForwarderLabelsForCluster(search, "us-east", 3)
+	assert.Equal(t, search.MetricsForwarderDeploymentNameForCluster(3), memberLabels["app"])
+	assert.Equal(t, "my-search", memberLabels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, "ns", memberLabels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), memberLabels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, "us-east", memberLabels[khandler.MongoDBSearchClusterNameLabel])
 
 	podLabels := metricsForwarderPodLabels(search)
 	assert.Equal(t, "my-search-search-metrics-forwarder-0", podLabels["app"])
-	assert.NotContains(t, podLabels, "component")
+	assert.NotContains(t, podLabels, khandler.MongoDBSearchComponentLabel)
 }
 
 func TestMetricsForwarderResourceRequirements_Defaults(t *testing.T) {
@@ -471,6 +483,42 @@ func TestDeploymentConfigurationOverride_MetricsForwarder(t *testing.T) {
 	// Container preserved
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, testDefaultImage, dep.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestEnsureMetricsForwarderDeployment_OverridePreservesProtectedSearchLabels(t *testing.T) {
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns", UID: "search-uid"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Observability: searchv1.ObservabilityConfig{
+				MetricsForwarder: searchv1.MetricsForwarderConfig{
+					Deployment: &v1.DeploymentConfiguration{
+						MetadataWrapper: v1.DeploymentMetadataWrapper{
+							Labels: map[string]string{
+								"custom-label":                            "custom-value",
+								khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
+								khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
+								khandler.MongoDBSearchOwnerUIDLabel:       "wrong-uid",
+								khandler.MongoDBSearchClusterNameLabel:    "wrong-cluster",
+								khandler.MongoDBSearchComponentLabel:      "wrong-component",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	r, kubeClient := newMetricsForwarderReconciler(testDefaultImage)
+
+	require.NoError(t, r.ensureMetricsForwarderDeployment(t.Context(), search, []byte("config"), "group", "agent-key", "", "member-a", 2, r.kubeClient, zap.S()))
+
+	dep := &appsv1.Deployment{}
+	require.NoError(t, kubeClient.Get(t.Context(), types.NamespacedName{Name: search.MetricsForwarderDeploymentNameForCluster(2), Namespace: search.Namespace}, dep))
+	assert.Equal(t, "custom-value", dep.Labels["custom-label"])
+	assert.Equal(t, search.Name, dep.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, dep.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), dep.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, "member-a", dep.Labels[khandler.MongoDBSearchClusterNameLabel])
+	assert.Equal(t, metricsForwarderLabelName, dep.Labels[khandler.MongoDBSearchComponentLabel])
 }
 
 func TestDeploymentConfigurationOverride_MetricsForwarder_EnvVars(t *testing.T) {

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -762,6 +762,17 @@ func TestReconcileCore_RejectsChangedPersistedClusterIndex(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
+// callCleanupRemovedClusters loads the topology state, runs cleanupRemovedClusters against
+// it, and persists the mutated state, as reconcileCore does.
+func callCleanupRemovedClusters(t *testing.T, r *MongoDBSearchMetricsForwarderReconciler, search *searchv1.MongoDBSearch, agentSecretName string, currentWork []clusterWorkItem) (bool, error) {
+	t.Helper()
+	topologyState, err := r.loadTopologyState(t.Context(), search)
+	require.NoError(t, err)
+	pending, cleanupErr := r.cleanupRemovedClusters(t.Context(), search, testGroupID, mdbv1.ProjectConfig{}, agentSecretName, currentWork, topologyState, zap.S())
+	require.NoError(t, r.openTopologyStateStore(search).WriteState(t.Context(), topologyState, zap.S()))
+	return pending, cleanupErr
+}
+
 func TestCleanupRemovedClusters_LegacyStateCleansCentralResourcesAndStateEntry(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	search.UID = "search-uid"
@@ -797,18 +808,14 @@ func TestCleanupRemovedClusters_LegacyStateCleansCentralResourcesAndStateEntry(t
 		ClusterName: "cluster-a", ClusterIndex: 0, Client: memberKubeClient,
 	}}
 
-	pending, err := r.cleanupRemovedClusters(
-		t.Context(), search, testGroupID, mdbv1.ProjectConfig{}, "agent-key", currentWork, zap.S(),
-	)
+	pending, err := callCleanupRemovedClusters(t, r, search, "agent-key", currentWork)
 	require.NoError(t, err)
 	assert.True(t, pending)
 	assert.True(t, apierrors.IsNotFound(centralClient.Get(t.Context(), client.ObjectKeyFromObject(legacyDeployment), &appsv1.Deployment{})))
 	require.NoError(t, memberClient.Get(t.Context(), client.ObjectKeyFromObject(memberDeployment), &appsv1.Deployment{}))
 	assert.Contains(t, getFullTopologyState(t, centralClient, search).Clusters, "")
 
-	pending, err = r.cleanupRemovedClusters(
-		t.Context(), search, testGroupID, mdbv1.ProjectConfig{}, "agent-key", currentWork, zap.S(),
-	)
+	pending, err = callCleanupRemovedClusters(t, r, search, "agent-key", currentWork)
 	require.NoError(t, err)
 	assert.False(t, pending)
 	assert.NotContains(t, getFullTopologyState(t, centralClient, search).Clusters, "")
@@ -1877,15 +1884,7 @@ func TestCleanupRemovedClusters_UncachedGuardBlocksHostDeregistration(t *testing
 			var deletedHostIDs []string
 			r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
 
-			pending, err := r.cleanupRemovedClusters(
-				t.Context(),
-				search,
-				testGroupID,
-				mdbv1.ProjectConfig{},
-				"agent-key-secret",
-				nil,
-				zap.S(),
-			)
+			pending, err := callCleanupRemovedClusters(t, r, search, "agent-key-secret", nil)
 			require.NoError(t, err)
 			assert.False(t, pending)
 			assert.Empty(t, deletedHostIDs, "hosts must not be deregistered when the live CR does not confirm the removal")
@@ -1928,15 +1927,7 @@ func TestCleanupRemovedClustersSkipsReaddedTargetWithoutSuppressingOtherCleanup(
 	var deletedHostIDs []string
 	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
 
-	pending, err := r.cleanupRemovedClusters(
-		t.Context(),
-		search,
-		testGroupID,
-		mdbv1.ProjectConfig{},
-		"agent-key-secret",
-		nil,
-		zap.S(),
-	)
+	pending, err := callCleanupRemovedClusters(t, r, search, "agent-key-secret", nil)
 
 	require.NoError(t, err)
 	assert.True(t, pending, "the re-added cluster's Deployment delete must requeue")
@@ -2990,12 +2981,19 @@ func TestReconcileCore_MultiClusterTopologyStateWrittenOnce(t *testing.T) {
 	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
 	require.True(t, ok)
 	stateCMName := fmt.Sprintf("%s-metrics-forwarder-state", search.Name)
+	stateWrites := 0
 	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
 		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, ok := obj.(*corev1.ConfigMap); ok && key.Name == stateCMName {
 				return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
 			}
 			return cl.Get(ctx, key, obj, opts...)
+		},
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == stateCMName {
+				stateWrites++
+			}
+			return cl.Create(ctx, obj, opts...)
 		},
 	}))
 	r.kubeClient = interceptedClient
@@ -3004,6 +3002,7 @@ func TestReconcileCore_MultiClusterTopologyStateWrittenOnce(t *testing.T) {
 	st := r.reconcileCore(context.Background(), currentSearch, zap.NewNop().Sugar())
 
 	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	assert.Equal(t, 1, stateWrites, "both clusters' topology must land in one state write")
 	stateCM := &corev1.ConfigMap{}
 	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: stateCMName}, stateCM))
 	var topologyState searchTopologyState
@@ -3048,6 +3047,12 @@ func TestReconcileCore_StateWriteFailurePreventsDeploymentCreation(t *testing.T)
 		Name:      search.MetricsForwarderDeploymentNameForCluster(0),
 	}, dep)
 	assert.True(t, apierrors.IsNotFound(err), "forwarder Deployment must not start before topology state is durable")
+	generatedAgentKeySecret := &corev1.Secret{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      search.MetricsForwarderAgentKeySecretNameForCluster(0),
+	}, generatedAgentKeySecret)
+	assert.True(t, apierrors.IsNotFound(err), "forwarder dependencies must not be replicated before topology state is durable")
 }
 
 func TestReconcileCore_UncachedMissingTopologyIsRewrittenBeforeDeployment(t *testing.T) {
@@ -3087,6 +3092,55 @@ func TestReconcileCore_UncachedMissingTopologyIsRewrittenBeforeDeployment(t *tes
 	assert.Equal(t, []string{"state", "deployment"}, writes)
 }
 
+func TestReconcileCore_StableTopologyStateIsNotWritten(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0), Replicas: 1})
+	stateCM.OwnerReferences = search.GetOwnerReferences()
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+
+	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
+	require.True(t, ok)
+	stateWrites := 0
+	interceptedClient := kubernetesClient.NewClient(interceptor.NewClient(fakeClientWithWatch, interceptor.Funcs{
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == stateCM.Name {
+				stateWrites++
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+	}))
+	r.kubeClient = interceptedClient
+	currentSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+
+	st := r.reconcileCore(context.Background(), currentSearch, zap.NewNop().Sugar())
+
+	require.True(t, st.IsOK(), searchcontroller.MessageFromStatus(st))
+	assert.Zero(t, stateWrites)
+}
+
+func TestReconcile_AggregatesAllMissingClusterClients(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
+	r.clientForCluster = func(string) kubernetesClient.Client { return nil }
+
+	st := r.reconcileCore(context.Background(), getMongoDBSearch(t, fakeClient, testNamespace, testSearchName), zap.S())
+
+	require.Equal(t, status.PhasePending, st.Phase())
+	message := searchcontroller.MessageFromStatus(st)
+	assert.Contains(t, message, `cluster "cluster-a"`)
+	assert.Contains(t, message, `cluster "cluster-b"`)
+}
+
 func TestReconcileCore_LegacyTopologyStateOwnerReferenceIsAdopted(t *testing.T) {
 	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
@@ -3112,12 +3166,21 @@ func TestReconcileCore_LegacyTopologyStateOwnerReferenceIsAdopted(t *testing.T) 
 
 // callReconcileTopologyState invokes reconcileTopologyState directly against the
 // single-cluster (clusterName=="", clusterIndex=0) work item, bypassing the full
-// Reconcile path so each test targets one state-machine transition.
+// Reconcile path so each test targets one state-machine transition. It loads and
+// persists the topology state around the call, as reconcileCore does.
 func callReconcileTopologyState(t *testing.T, r *MongoDBSearchMetricsForwarderReconciler, search *searchv1.MongoDBSearch, shardNames []string, agentSecretName string) (bool, error) {
 	t.Helper()
 	projectConfig := mdbv1.ProjectConfig{BaseURL: testOMBaseURL}
 	w := clusterWorkItem{ClusterName: "", ClusterIndex: 0, Client: r.kubeClient}
-	return r.reconcileTopologyState(context.Background(), search, shardNames, testGroupID, projectConfig, agentSecretName, w, zap.NewNop().Sugar())
+	topologyState, err := r.loadTopologyState(context.Background(), search)
+	if err != nil {
+		return false, err
+	}
+	pending, err := r.reconcileTopologyState(context.Background(), search, shardNames, testGroupID, projectConfig, agentSecretName, topologyState, w, zap.NewNop().Sugar())
+	if err != nil {
+		return false, err
+	}
+	return pending, r.openTopologyStateStore(search).WriteState(context.Background(), topologyState, zap.NewNop().Sugar())
 }
 
 // newTestMongoDBSearchWithReplicas creates a MongoDBSearch with an explicit replica count on the

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -1715,6 +1715,81 @@ func TestPreDeletionCleanup_HostCleanupFailureRetainsFinalizer(t *testing.T) {
 		"finalizer must stay until host cleanup succeeds")
 }
 
+func TestPreDeletionCleanup_AggregatesHostCleanupAcrossClusters(t *testing.T) {
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{})
+	stateJSON, err := json.Marshal(searchTopologyState{Clusters: map[string]clusterTopologyState{
+		"cluster-a": {ClusterIndex: ptr.To(0), Replicas: 1},
+		"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
+	}})
+	require.NoError(t, err)
+	stateCM.Data[stateKey] = string(stateJSON)
+	agentSecretName := "agent-key-secret"
+	agentKeySecret := newTestAgentKeySecret(agentSecretName, testNamespace)
+	r, _ := newMetricsForwarderReconciler(testDefaultImage, search, stateCM, agentKeySecret)
+
+	var requestedHostIDs []string
+	r.omRequester = stubOMAgentRequester{fn: func(_ mdbv1.ProjectConfig, method, path, _ string, body any) ([]byte, error) {
+		require.Equal(t, "POST", method)
+		require.True(t, strings.HasSuffix(path, "/v1/delete"))
+		requestedHostIDs = append(requestedHostIDs, body.(deleteHostsRequest).HostIds...)
+		return nil, fmt.Errorf("injected host cleanup failure for request %d", len(requestedHostIDs))
+	}}
+
+	st := r.preDeletionCleanup(
+		context.Background(),
+		search,
+		nil,
+		testGroupID,
+		mdbv1.ProjectConfig{BaseURL: testOMBaseURL},
+		agentSecretName,
+		r.buildClusterWorkList(search),
+		zap.NewNop().Sugar(),
+	)
+
+	require.False(t, st.IsOK())
+	message := searchcontroller.MessageFromStatus(st)
+	assert.Contains(t, message, "injected host cleanup failure for request 1")
+	assert.Contains(t, message, "injected host cleanup failure for request 2")
+	assert.Len(t, requestedHostIDs, 2, "host cleanup must continue to cluster-b after cluster-a fails")
+	assert.Contains(t, search.Finalizers, util.SearchMetricsForwarderFinalizer)
+}
+
+func TestReconcile_DeletionFailsClosedWhenClusterClientIsMissing(t *testing.T) {
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Clusters = []searchv1.ClusterSpec{
+		{Name: "cluster-a", Index: ptr.To(int32(0))},
+		{Name: "cluster-b", Index: ptr.To(int32(1))},
+	}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
+	r.clientForCluster = func(clusterName string) kubernetesClient.Client {
+		if clusterName == "cluster-b" {
+			return nil
+		}
+		return r.kubeClient
+	}
+	require.NoError(t, fakeClient.Delete(context.Background(), search))
+	deletingSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+
+	st := r.reconcileCore(context.Background(), deletingSearch, zap.S())
+
+	require.False(t, st.IsOK())
+	assert.Contains(t, searchcontroller.MessageFromStatus(st), `cluster="cluster-b": no Kubernetes client registered`)
+	remainingSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
+	assert.Contains(t, remainingSearch.Finalizers, util.SearchMetricsForwarderFinalizer,
+		"finalizer must stay while an unreachable cluster may still hold forwarder resources")
+}
+
 func TestReconcile_RemovedPerClusterOperatorCleansPersistedTopology(t *testing.T) {
 	pendingPodName := "pending-removed-cluster-mongot"
 	deferredPodName := "deferred-removed-cluster-mongot"

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -39,16 +39,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/versionutil"
 )
 
-const (
-	testNamespace     = "test-ns"
-	testSearchName    = "my-search"
-	testMDBName       = "my-mongodb"
-	testProjectCMName = "my-project-cm"
-	testGroupID       = "test-group-id-123"
-	testDefaultImage  = "quay.io/mongodb/metrics-forwarder:latest"
-	testOMBaseURL     = "http://ops-manager.example.com:8080"
-)
-
 // newTestMongoDB creates a MongoDB resource with opsManager connection spec and a status with a project ID.
 func newTestMongoDB(name, namespace, projectCMName, groupID string) *mdbv1.MongoDB {
 	mdb := &mdbv1.MongoDB{
@@ -801,6 +791,24 @@ func TestReconcile_EnterpriseSource_CreatesDeploymentAndConfigMap(t *testing.T) 
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
 	assert.Equal(t, status.PhaseRunning, updatedSearch.Status.MetricsForwarder.Phase)
+
+	t.Run("reconciliation disabled: manual ConfigMap edits survive", func(t *testing.T) {
+		cmKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      search.MetricsForwarderConfigMapNameForCluster(0),
+		}
+		cm.Data["config.yaml"] = "manually-patched"
+		require.NoError(t, fakeClient.Update(context.Background(), cm))
+
+		updatedSearch.Annotations = map[string]string{searchv1.DisableReconciliationAnnotation: "true"}
+		require.NoError(t, fakeClient.Update(context.Background(), updatedSearch))
+
+		reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+		require.NoError(t, fakeClient.Get(context.Background(), cmKey, cm))
+		assert.Equal(t, "manually-patched", cm.Data["config.yaml"],
+			"a paused CR's forwarder ConfigMap must not be rewritten by the reconciler")
+	})
 }
 
 func TestReconcile_DisabledMode_DeletesResources(t *testing.T) {
@@ -877,53 +885,6 @@ func TestReconcile_PrometheusDisabled_MetricsForwarderEnabled_Invalid(t *testing
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
 	assert.Equal(t, status.PhaseFailed, updatedSearch.Status.MetricsForwarder.Phase)
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Prometheus")
-}
-
-func TestReconcile_DeletionWhileDisabled_DeregistersHostsAndRemovesFinalizer(t *testing.T) {
-	// Regression test: deleting a MongoDBSearch whose metrics forwarder was disabled must still
-	// deregister its Ops Manager hosts and remove the finalizer. The disabled-mode reconcile path does
-	// not own deletion handling, so without the top-level deletion check in Reconcile the finalizer
-	// would leak (blocking deletion) and the monitored hosts would stay registered in Ops Manager.
-	//
-	// Because the forwarder was disabled, no Deployment was ever created. The two-phase deletion in
-	// preDeletionCleanup completes in a single reconcile: phase 1 finds no Deployment to delete,
-	// phase 2 sees no Deployment present, and the finalizer is removed immediately.
-	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
-	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
-	search.Spec.Observability = searchv1.ObservabilityConfig{
-		MetricsForwarder: searchv1.MetricsForwarderConfig{
-			Mode: searchv1.MetricsForwarderModeDisabled,
-		},
-	}
-	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
-	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
-	// Internal enterprise sources resolve the agent key secret from the project id; see agents.ApiKeySecretName.
-	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
-	// Seed the topology state an enabled forwarder would have written: two mongot replicas.
-	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 2})
-
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
-
-	// Capture the host ids passed to the Ops Manager delete-hosts API.
-	var deletedHostIDs []string
-	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
-
-	// Trigger deletion: with the finalizer present the fake client sets a DeletionTimestamp instead of
-	// removing the object outright.
-	require.NoError(t, fakeClient.Delete(context.Background(), search))
-
-	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
-
-	// Both mongot hosts from the persisted topology are deregistered from Ops Manager.
-	stsName := search.StatefulSetNamespacedNameForCluster(0).Name
-	assert.ElementsMatch(t, []string{
-		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", stsName)),
-		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-1", stsName)),
-	}, deletedHostIDs)
-
-	// The finalizer is removed, so the resource is fully deleted.
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, &searchv1.MongoDBSearch{})
-	assert.True(t, apierrors.IsNotFound(err), "expected MongoDBSearch to be deleted after finalizer removal, got err=%v", err)
 }
 
 func TestReconcile_DeletionWhileEnabled_WaitsForDeploymentThenDeregistersHosts(t *testing.T) {
@@ -2130,4 +2091,61 @@ func TestReconcileTopologyState_Sharded_RemovedShardAndScaleDown(t *testing.T) {
 		assert.Contains(t, state.HostDeletionReadyAfter, podName,
 			"pod %s expected in HostDeletionReadyAfter", podName)
 	}
+}
+
+const (
+	testNamespace     = "test-ns"
+	testSearchName    = "my-search"
+	testMDBName       = "my-mongodb"
+	testProjectCMName = "my-project-cm"
+	testGroupID       = "test-group-id-123"
+	testDefaultImage  = "quay.io/mongodb/metrics-forwarder:latest"
+	testOMBaseURL     = "http://ops-manager.example.com:8080"
+)
+
+func TestReconcile_DeletionWhileDisabled_DeregistersHostsAndRemovesFinalizer(t *testing.T) {
+	// Regression test: deleting a MongoDBSearch whose metrics forwarder was disabled must still
+	// deregister its Ops Manager hosts and remove the finalizer. The disabled-mode reconcile path does
+	// not own deletion handling, so without the top-level deletion check in Reconcile the finalizer
+	// would leak (blocking deletion) and the monitored hosts would stay registered in Ops Manager.
+	//
+	// Because the forwarder was disabled, no Deployment was ever created. The two-phase deletion in
+	// preDeletionCleanup completes in a single reconcile: phase 1 finds no Deployment to delete,
+	// phase 2 sees no Deployment present, and the finalizer is removed immediately.
+	mdb := newTestMongoDB(testMDBName, testNamespace, testProjectCMName, testGroupID)
+	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
+	search.Spec.Observability = searchv1.ObservabilityConfig{
+		MetricsForwarder: searchv1.MetricsForwarderConfig{
+			Mode: searchv1.MetricsForwarderModeDisabled,
+		},
+	}
+	search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
+	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
+	// Internal enterprise sources resolve the agent key secret from the project id; see agents.ApiKeySecretName.
+	agentKeySecret := newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace)
+	// Seed the topology state an enabled forwarder would have written: two mongot replicas.
+	stateCM := newTestTopologyStateConfigMap(t, search, clusterTopologyState{Replicas: 2})
+
+	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret, stateCM)
+
+	// Capture the host ids passed to the Ops Manager delete-hosts API.
+	var deletedHostIDs []string
+	r.omRequester = recordingDeleteHostsRequester(&deletedHostIDs)
+
+	// Trigger deletion: with the finalizer present the fake client sets a DeletionTimestamp instead of
+	// removing the object outright.
+	require.NoError(t, fakeClient.Delete(context.Background(), search))
+
+	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
+
+	// Both mongot hosts from the persisted topology are deregistered from Ops Manager.
+	stsName := search.StatefulSetNamespacedNameForCluster(0).Name
+	assert.ElementsMatch(t, []string{
+		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-0", stsName)),
+		mongotHostID(testGroupID, testNamespace, fmt.Sprintf("%s-1", stsName)),
+	}, deletedHostIDs)
+
+	// The finalizer is removed, so the resource is fully deleted.
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, &searchv1.MongoDBSearch{})
+	assert.True(t, apierrors.IsNotFound(err), "expected MongoDBSearch to be deleted after finalizer removal, got err=%v", err)
 }

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -81,9 +81,13 @@ type envoyRoute struct {
 }
 
 type MongoDBSearchEnvoyReconciler struct {
-	kubeClient        kubernetesClient.Client
-	watch             *watch.ResourceWatcher
-	defaultEnvoyImage string
+	kubeClient          kubernetesClient.Client
+	apiReader           client.Reader
+	watch               *watch.ResourceWatcher
+	defaultEnvoyImage   string
+	operatorClusterName string
+	memberClients       map[string]kubernetesClient.Client
+	memberReaders       map[string]client.Reader
 
 	prepareSearch prepareSearchFunc
 	// clientForCluster resolves the client for one cluster name; nil = cluster not
@@ -92,16 +96,30 @@ type MongoDBSearchEnvoyReconciler struct {
 }
 
 func newMongoDBSearchEnvoyReconciler(c client.Client, defaultEnvoyImage string, memberClustersMap map[string]client.Client, operatorClusterName string) *MongoDBSearchEnvoyReconciler {
+	return newMongoDBSearchEnvoyReconcilerWithReaders(c, c, defaultEnvoyImage, memberClustersMap, nil, operatorClusterName)
+}
+
+func newMongoDBSearchEnvoyReconcilerWithReaders(c client.Client, apiReader client.Reader, defaultEnvoyImage string, memberClustersMap map[string]client.Client, memberReaders map[string]client.Reader, operatorClusterName string) *MongoDBSearchEnvoyReconciler {
 	clientsMap := make(map[string]kubernetesClient.Client, len(memberClustersMap))
 	for k, v := range memberClustersMap {
 		clientsMap[k] = kubernetesClient.NewClient(v)
 	}
+	if memberReaders == nil {
+		memberReaders = make(map[string]client.Reader, len(memberClustersMap))
+		for clusterName, memberClient := range memberClustersMap {
+			memberReaders[clusterName] = memberClient
+		}
+	}
 
 	r := &MongoDBSearchEnvoyReconciler{
-		kubeClient:        kubernetesClient.NewClient(c),
-		watch:             watch.NewResourceWatcher(),
-		defaultEnvoyImage: defaultEnvoyImage,
-		prepareSearch:     newPrepareSearch(operatorClusterName),
+		kubeClient:          kubernetesClient.NewClient(c),
+		apiReader:           apiReader,
+		watch:               watch.NewResourceWatcher(),
+		defaultEnvoyImage:   defaultEnvoyImage,
+		operatorClusterName: operatorClusterName,
+		memberClients:       clientsMap,
+		memberReaders:       memberReaders,
+		prepareSearch:       newPrepareSearch(operatorClusterName),
 	}
 	if len(clientsMap) == 0 {
 		// Single-cluster and per-cluster-operator installs render everything locally.
@@ -129,6 +147,14 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	mdbSearch := &searchv1.MongoDBSearch{}
 	if result, err := commoncontroller.GetResource(ctx, r.kubeClient, request, mdbSearch, log); err != nil {
 		return result, err
+	}
+
+	// The pause annotation must silence every controller that mutates owned objects,
+	// so manual edits (e.g. to the LB ConfigMap) survive while reconciliation is disabled.
+	if mdbSearch.IsReconciliationDisabled() {
+		log.Infof("MongoDBSearch %s/%s reconciliation disabled by %s annotation; skipping envoy reconcile",
+			mdbSearch.GetNamespace(), mdbSearch.GetName(), searchv1.DisableReconciliationAnnotation)
+		return reconcile.Result{}, nil
 	}
 
 	// Envoy validation failures surface on /status/loadBalancer so the Envoy sub-status
@@ -167,6 +193,12 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	if err != nil {
 		return r.updateLBStatus(ctx, mdbSearch, workflow.Pending("Waiting for search source: %s", err), log)
 	}
+	r.watch.AddWatchedResourceIfNotAdded(
+		searchcontroller.SearchStateCMName(mdbSearch),
+		mdbSearch.Namespace,
+		watch.ConfigMap,
+		mdbSearch.NamespacedName(),
+	)
 
 	// Load the per-CR state for the routing-readiness switch.
 	state, err := searchcontroller.ReadSearchState(ctx, r.kubeClient, mdbSearch)
@@ -814,7 +846,18 @@ func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, d
 	// NOTE: The field index for MongoDBSearchIndexFieldName is already registered
 	// by AddMongoDBSearchController. Do not register it again here.
 
-	r := newMongoDBSearchEnvoyReconciler(mgr.GetClient(), defaultEnvoyImage, multicluster.ClustersMapToClientMap(memberClusterObjectsMap), operatorClusterName)
+	memberReaders := make(map[string]client.Reader, len(memberClusterObjectsMap))
+	for clusterName, memberCluster := range memberClusterObjectsMap {
+		memberReaders[clusterName] = memberCluster.GetAPIReader()
+	}
+	r := newMongoDBSearchEnvoyReconcilerWithReaders(
+		mgr.GetClient(),
+		mgr.GetAPIReader(),
+		defaultEnvoyImage,
+		multicluster.ClustersMapToClientMap(memberClusterObjectsMap),
+		memberReaders,
+		operatorClusterName,
+	)
 
 	c, err := controller.New("mongodbsearchenvoy", mgr, controller.Options{
 		Reconciler:              r,
@@ -833,13 +876,13 @@ func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, d
 	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &mdbcv1.MongoDBCommunity{}, &watch.ResourcesHandler{ResourceType: "MongoDBCommunity", ResourceWatcher: r.watch})); err != nil {
 		return err
 	}
-
-	// Central-cluster owned Envoy resources (single-cluster path).
-	ownerHandler := handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &searchv1.MongoDBSearch{}, handler.OnlyControllerOwner())
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &appsv1.Deployment{}, ownerHandler)); err != nil {
+	mapperFunc := khandler.EnqueueMemberClusterObjectToSearch
+	mapper := handler.EnqueueRequestsFromMapFunc(mapperFunc)
+	searchOwnerPredicate := watch.PredicatesForMultiClusterSearchResource()
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &appsv1.Deployment{}, mapper, searchOwnerPredicate)); err != nil {
 		return err
 	}
-	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.ConfigMap{}, ownerHandler)); err != nil {
+	if err := c.Watch(source.Kind[client.Object](mgr.GetCache(), &corev1.ConfigMap{}, &watch.ResourcesHandler{ResourceType: watch.ConfigMap, ResourceWatcher: r.watch, MapFunc: mapperFunc})); err != nil {
 		return err
 	}
 
@@ -847,12 +890,11 @@ func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, d
 	// cross-cluster owner refs don't GC. Same pattern as the AppDB MC and
 	// sharded MC controllers (see appdbreplicaset_controller.go and
 	// mongodbshardedcluster_controller.go).
-	mapper := handler.EnqueueRequestsFromMapFunc(khandler.EnqueueMemberClusterObjectToSearch)
 	for k, v := range memberClusterObjectsMap {
-		if err := c.Watch(source.Kind[client.Object](v.GetCache(), &appsv1.Deployment{}, mapper)); err != nil {
+		if err := c.Watch(source.Kind[client.Object](v.GetCache(), &appsv1.Deployment{}, mapper, searchOwnerPredicate)); err != nil {
 			return fmt.Errorf("failed to set Envoy Deployment watch on member cluster %s: %w", k, err)
 		}
-		if err := c.Watch(source.Kind[client.Object](v.GetCache(), &corev1.ConfigMap{}, mapper)); err != nil {
+		if err := c.Watch(source.Kind[client.Object](v.GetCache(), &corev1.ConfigMap{}, mapper, searchOwnerPredicate)); err != nil {
 			return fmt.Errorf("failed to set Envoy ConfigMap watch on member cluster %s: %w", k, err)
 		}
 	}

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -555,6 +555,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 			dep.Labels = merge.StringToStringMap(dep.Labels, managedLB.Deployment.MetadataWrapper.Labels)
 			dep.Annotations = merge.StringToStringMap(dep.Annotations, managedLB.Deployment.MetadataWrapper.Annotations)
 		}
+		dep.Labels = khandler.ReapplyProtectedSearchLabels(dep.Labels, labels)
 
 		if clusterName == "" {
 			return controllerutil.SetOwnerReference(search, dep, c.Scheme())
@@ -780,17 +781,7 @@ func defaultEnvoyResourceRequirements() corev1.ResourceRequirements {
 // clusterIndex is used for the "app" label (resource name); clusterName is used
 // for the cluster-name label so label selectors remain name-keyed.
 func envoyLabelsForCluster(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) map[string]string {
-	labels := map[string]string{
-		"app":                                search.LoadBalancerDeploymentNameForCluster(clusterIndex),
-		"component":                          labelName,
-		khandler.MongoDBSearchOwnerNameLabel: search.Name,
-		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
-	}
-	// In single-cluster legacy mode (clusterName==""), omit the per-cluster label so existing watchers continue to match.
-	if clusterName != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
-	}
-	return labels
+	return khandler.MongoDBSearchManagedLabels(search, search.LoadBalancerDeploymentNameForCluster(clusterIndex), labelName, clusterName)
 }
 
 // envoyReplicas returns the cluster's desired Envoy replica count.

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -65,6 +65,14 @@ const (
 	labelName = "search-proxy"
 )
 
+var (
+	// errEnvoyCleanupStale reports that the live MongoDBSearch no longer matches the snapshot
+	// this cleanup was computed from (newer generation, LB re-managed, or CR replaced).
+	errEnvoyCleanupStale             = errors.New("MongoDBSearch changed during Envoy cleanup")
+	errEnvoyCleanupParentCheck       = errors.New("failed to confirm MongoDBSearch before Envoy cleanup")
+	errEnvoyCleanupOwnershipMismatch = errors.New("refusing to delete Envoy resource with non-canonical ownership")
+)
+
 // envoyRoute defines routing information for one Envoy entrypoint.
 // Per-shard routes carry exactly one UpstreamHosts entry (the shard's mongot Service FQDN).
 // The cluster-level route carries N entries — one per shard mongot Service in that cluster —
@@ -215,9 +223,22 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	if !mdbSearch.IsLBModeManaged() {
 		if mdbSearch.Status.LoadBalancer != nil {
 			if err := r.deleteEnvoyResources(ctx, mdbSearch, r.buildClusterWorkList(mdbSearch), log); err != nil {
-				return reconcile.Result{}, err
+				if errors.Is(err, errEnvoyCleanupStale) {
+					return reconcile.Result{Requeue: true}, nil
+				}
+				if errors.Is(err, errEnvoyCleanupParentCheck) {
+					return reconcile.Result{}, err
+				}
+				current, confirmErr := r.confirmEnvoyCleanupRequired(ctx, mdbSearch)
+				if confirmErr != nil {
+					if errors.Is(confirmErr, errEnvoyCleanupStale) {
+						return reconcile.Result{Requeue: true}, nil
+					}
+					return reconcile.Result{}, confirmErr
+				}
+				return r.updateLBStatusAfterCleanupFailure(ctx, current, workflow.Failed(err), log)
 			}
-			r.clearLBStatus(ctx, mdbSearch, log)
+			return r.clearLBStatus(ctx, mdbSearch, log)
 		}
 		return reconcile.Result{}, nil
 	}
@@ -374,19 +395,22 @@ func (r *MongoDBSearchEnvoyReconciler) updateLBStatus(ctx context.Context, searc
 
 // clearLBStatus removes the loadBalancer substatus when LB is no longer configured.
 // An explicit null patch is required: the status helper would translate workflow.OK
-// into a Running substatus instead of removing it.
-func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) {
-	search.Status.LoadBalancer = nil
-	payload, err := json.Marshal([]map[string]any{
-		{"op": "replace", "path": "/status/loadBalancer", "value": nil},
-	})
+// into a Running substatus instead of removing it. The live CR is re-confirmed first
+// so a Search that was re-managed or replaced mid-cleanup keeps its status.
+func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (reconcile.Result, error) {
+	current, err := r.confirmEnvoyCleanupRequired(ctx, search)
 	if err != nil {
-		log.Warnf("Failed to clear loadBalancer status: %s", err)
-		return
+		if errors.Is(err, errEnvoyCleanupStale) {
+			return reconcile.Result{Requeue: true}, nil
+		}
+		return reconcile.Result{}, err
 	}
-	if err := r.kubeClient.Status().Patch(ctx, search, client.RawPatch(types.JSONPatchType, payload)); err != nil {
-		log.Warnf("Failed to clear loadBalancer status: %s", err)
+	if err := r.patchLBStatusForCleanup(ctx, current, nil); err != nil {
+		log.Errorf("Failed to clear loadBalancer status: %s", err)
+		return reconcile.Result{}, err
 	}
+	search.Status.LoadBalancer = nil
+	return reconcile.Result{}, nil
 }
 
 // deleteEnvoyResources removes per-cluster Envoy resources on managed→unmanaged LB transition.
@@ -429,8 +453,11 @@ func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(ctx context.Context,
 			}
 			desiredLabels := envoyLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
 			if !hasCanonicalEnvoyOwnership(resource.obj, desiredLabels) {
-				errs = errors.Join(errs, fmt.Errorf("refusing to delete Envoy %s %s with non-canonical ownership in cluster %q", resource.kind, client.ObjectKeyFromObject(resource.obj), w.ClusterName))
+				errs = errors.Join(errs, fmt.Errorf("%w: %s %s in cluster %q", errEnvoyCleanupOwnershipMismatch, resource.kind, client.ObjectKeyFromObject(resource.obj), w.ClusterName))
 				continue
+			}
+			if _, err := r.confirmEnvoyCleanupRequired(ctx, search); err != nil {
+				return errors.Join(errs, err)
 			}
 			if err := w.Client.Delete(ctx, resource.obj, client.Preconditions{
 				UID:             ptr.To(resource.obj.GetUID()),
@@ -460,6 +487,48 @@ func hasCanonicalEnvoyOwnership(obj metav1.Object, desiredLabels map[string]stri
 	actualCluster, hasActualCluster := actualLabels[khandler.MongoDBSearchClusterNameLabel]
 	desiredCluster, hasDesiredCluster := desiredLabels[khandler.MongoDBSearchClusterNameLabel]
 	return hasActualCluster == hasDesiredCluster && (!hasDesiredCluster || actualCluster == desiredCluster)
+}
+
+// confirmEnvoyCleanupRequired re-reads the MongoDBSearch with the uncached reader and checks
+// that the cleanup decision still holds: same CR (UID), same spec revision (generation), and
+// the LB still unmanaged. Cleanup runs off a possibly stale cache; deleting Deployments or
+// wiping /status/loadBalancer for a CR that was re-managed or replaced would fight the next
+// reconcile. Returns errEnvoyCleanupStale when the cleanup must be re-evaluated.
+func (r *MongoDBSearchEnvoyReconciler) confirmEnvoyCleanupRequired(ctx context.Context, expected *searchv1.MongoDBSearch) (*searchv1.MongoDBSearch, error) {
+	current := &searchv1.MongoDBSearch{}
+	if err := r.apiReader.Get(ctx, expected.NamespacedName(), current); err != nil {
+		return nil, fmt.Errorf("%w: %w", errEnvoyCleanupParentCheck, err)
+	}
+	if current.UID != expected.UID || current.Generation != expected.Generation || current.IsLBModeManaged() {
+		return nil, fmt.Errorf("%w: Envoy cleanup is stale for MongoDBSearch %s", errEnvoyCleanupStale, expected.NamespacedName())
+	}
+	return current, nil
+}
+
+// updateLBStatusAfterCleanupFailure records a cleanup failure on /status/loadBalancer using
+// the generation-guarded cleanup patch, so a concurrently updated CR is never overwritten.
+func (r *MongoDBSearchEnvoyReconciler) updateLBStatusAfterCleanupFailure(ctx context.Context, search *searchv1.MongoDBSearch, st workflow.Status, log *zap.SugaredLogger) (reconcile.Result, error) {
+	partOption := searchv1.NewSearchPartOption(searchv1.SearchPartLoadBalancer)
+	search.UpdateStatus(st.Phase(), append([]status.Option{partOption}, st.StatusOptions()...)...)
+	if err := r.patchLBStatusForCleanup(ctx, search, search.Status.LoadBalancer); err != nil {
+		log.Errorf("Failed to update loadBalancer cleanup status: %s", err)
+		return reconcile.Result{}, err
+	}
+	return st.ReconcileResult()
+}
+
+// patchLBStatusForCleanup patches /status/loadBalancer with JSON-patch test preconditions on
+// uid and generation: the patch is rejected server-side if the CR changed since it was confirmed.
+func (r *MongoDBSearchEnvoyReconciler) patchLBStatusForCleanup(ctx context.Context, search *searchv1.MongoDBSearch, value any) error {
+	payload, err := json.Marshal([]map[string]any{
+		{"op": "test", "path": "/metadata/uid", "value": string(search.UID)},
+		{"op": "test", "path": "/metadata/generation", "value": search.Generation},
+		{"op": "replace", "path": "/status/loadBalancer", "value": value},
+	})
+	if err != nil {
+		return err
+	}
+	return r.kubeClient.Status().Patch(ctx, search, client.RawPatch(types.JSONPatchType, payload))
 }
 
 func (r *MongoDBSearchEnvoyReconciler) readerForCluster(clusterName string) client.Reader {

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -145,6 +146,10 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	if result, err := commoncontroller.GetResource(ctx, r.kubeClient, request, mdbSearch, log); err != nil {
 		return result, err
 	}
+	if !mdbSearch.DeletionTimestamp.IsZero() {
+		log.Infof("MongoDBSearch %s/%s is deleting; skipping envoy reconcile", mdbSearch.Namespace, mdbSearch.Name)
+		return reconcile.Result{}, nil
+	}
 
 	// The pause annotation must silence every controller that mutates owned objects,
 	// so manual edits (e.g. to the LB ConfigMap) survive while reconciliation is disabled.
@@ -174,7 +179,9 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	// If LB was previously active (status exists), clean up Envoy resources first.
 	if !mdbSearch.IsLBModeManaged() {
 		if mdbSearch.Status.LoadBalancer != nil {
-			r.deleteEnvoyResources(ctx, mdbSearch, r.buildClusterWorkList(mdbSearch), log)
+			if err := r.deleteEnvoyResources(ctx, mdbSearch, r.buildClusterWorkList(mdbSearch), log); err != nil {
+				return reconcile.Result{}, err
+			}
 			r.clearLBStatus(ctx, mdbSearch, log)
 		}
 		return reconcile.Result{}, nil
@@ -331,43 +338,100 @@ func (r *MongoDBSearchEnvoyReconciler) updateLBStatus(ctx context.Context, searc
 }
 
 // clearLBStatus removes the loadBalancer substatus when LB is no longer configured.
-// This works because UpdateStatus uses a JSON Patch targeting only /status/loadBalancer,
-// so it won't conflict with the main controller patching /status.
+// An explicit null patch is required: the status helper would translate workflow.OK
+// into a Running substatus instead of removing it.
 func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) {
 	search.Status.LoadBalancer = nil
-	partOption := searchv1.NewSearchPartOption(searchv1.SearchPartLoadBalancer)
-	// GetStatus with LB part will return nil, which patches null into /status/loadBalancer
-	if _, err := commoncontroller.UpdateStatus(ctx, r.kubeClient, search, workflow.OK(), log, partOption); err != nil {
+	payload, err := json.Marshal([]map[string]any{
+		{"op": "replace", "path": "/status/loadBalancer", "value": nil},
+	})
+	if err != nil {
+		log.Warnf("Failed to clear loadBalancer status: %s", err)
+		return
+	}
+	if err := r.kubeClient.Status().Patch(ctx, search, client.RawPatch(types.JSONPatchType, payload)); err != nil {
 		log.Warnf("Failed to clear loadBalancer status: %s", err)
 	}
 }
 
 // deleteEnvoyResources removes per-cluster Envoy resources on managed→unmanaged LB transition.
-// Client == nil (cluster not registered) work items are skipped: the reconciler could not
-// have created anything for those clusters.
-func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) {
+func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) error {
 	ns := search.Namespace
+	var errs error
 	for _, w := range workList {
 		if w.Client == nil {
+			errs = errors.Join(errs, fmt.Errorf("cluster %q: no Kubernetes client registered for Envoy cleanup", w.ClusterName))
 			continue
 		}
-		depName := search.LoadBalancerDeploymentNameForCluster(w.ClusterIndex)
-		cmName := search.LoadBalancerConfigMapNameForCluster(w.ClusterIndex)
-
-		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: ns}}
-		if err := w.Client.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnf("Failed to delete Envoy Deployment %s (cluster=%q): %s", depName, w.ClusterName, err)
-		} else if err == nil {
-			log.Infof("Deleted Envoy Deployment %s (cluster=%q)", depName, w.ClusterName)
+		reader := r.readerForCluster(w.ClusterName)
+		if reader == nil {
+			errs = errors.Join(errs, fmt.Errorf("cluster %q: no API reader registered for Envoy cleanup", w.ClusterName))
+			continue
 		}
-
-		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns}}
-		if err := w.Client.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnf("Failed to delete Envoy ConfigMap %s (cluster=%q): %s", cmName, w.ClusterName, err)
-		} else if err == nil {
-			log.Infof("Deleted Envoy ConfigMap %s (cluster=%q)", cmName, w.ClusterName)
+		resources := []struct {
+			kind string
+			obj  client.Object
+		}{
+			{
+				kind: "Deployment",
+				obj: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name: search.LoadBalancerDeploymentNameForCluster(w.ClusterIndex), Namespace: ns,
+				}},
+			},
+			{
+				kind: "ConfigMap",
+				obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+					Name: search.LoadBalancerConfigMapNameForCluster(w.ClusterIndex), Namespace: ns,
+				}},
+			},
+		}
+		for _, resource := range resources {
+			if err := reader.Get(ctx, client.ObjectKeyFromObject(resource.obj), resource.obj); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errs = errors.Join(errs, fmt.Errorf("cluster %q: failed to get Envoy %s %s: %w", w.ClusterName, resource.kind, resource.obj.GetName(), err))
+				}
+				continue
+			}
+			desiredLabels := envoyLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
+			if !hasCanonicalEnvoyOwnership(resource.obj, desiredLabels) {
+				errs = errors.Join(errs, fmt.Errorf("refusing to delete Envoy %s %s with non-canonical ownership in cluster %q", resource.kind, client.ObjectKeyFromObject(resource.obj), w.ClusterName))
+				continue
+			}
+			if err := w.Client.Delete(ctx, resource.obj, client.Preconditions{
+				UID:             ptr.To(resource.obj.GetUID()),
+				ResourceVersion: ptr.To(resource.obj.GetResourceVersion()),
+			}); err != nil && !apierrors.IsNotFound(err) {
+				errs = errors.Join(errs, fmt.Errorf("cluster %q: failed to delete Envoy %s %s: %w", w.ClusterName, resource.kind, resource.obj.GetName(), err))
+				continue
+			}
+			log.Infof("Deleted Envoy %s %s (cluster=%q)", resource.kind, resource.obj.GetName(), w.ClusterName)
 		}
 	}
+	return errs
+}
+
+func hasCanonicalEnvoyOwnership(obj metav1.Object, desiredLabels map[string]string) bool {
+	actualLabels := obj.GetLabels()
+	for _, key := range []string{
+		khandler.MongoDBSearchOwnerNameLabel,
+		khandler.MongoDBSearchOwnerNamespaceLabel,
+		khandler.MongoDBSearchOwnerUIDLabel,
+		khandler.MongoDBSearchComponentLabel,
+	} {
+		if actualLabels[key] != desiredLabels[key] {
+			return false
+		}
+	}
+	actualCluster, hasActualCluster := actualLabels[khandler.MongoDBSearchClusterNameLabel]
+	desiredCluster, hasDesiredCluster := desiredLabels[khandler.MongoDBSearchClusterNameLabel]
+	return hasActualCluster == hasDesiredCluster && (!hasDesiredCluster || actualCluster == desiredCluster)
+}
+
+func (r *MongoDBSearchEnvoyReconciler) readerForCluster(clusterName string) client.Reader {
+	if r.isLocalCluster(clusterName) {
+		return r.apiReader
+	}
+	return r.memberReaders[clusterName]
 }
 
 // caKeyNameFromTLSConfig returns the CA key filename for Envoy config file paths.

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -159,6 +159,41 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 		return reconcile.Result{}, nil
 	}
 
+	topologyCurrent, err := cleanupRemovedMemberSearchResources(
+		ctx,
+		r.apiReader,
+		mdbSearch,
+		r.memberReaders,
+		r.memberClients,
+		envoySearchResourceCleanups(),
+		log,
+	)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !topologyCurrent {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if isRemovedSearchOperatorCluster(mdbSearch, r.operatorClusterName) {
+		topologyCurrent, err := cleanupRemovedLocalSearchResources(
+			ctx,
+			r.apiReader,
+			r.apiReader,
+			r.kubeClient,
+			mdbSearch,
+			r.operatorClusterName,
+			envoySearchResourceCleanups(),
+			log,
+		)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if !topologyCurrent {
+			return reconcile.Result{Requeue: true}, nil
+		}
+		return reconcile.Result{}, nil
+	}
+
 	// Envoy validation failures surface on /status/loadBalancer so the Envoy sub-status
 	// stays authoritative for LB shape errors.
 	if skip, result, err := r.prepareSearch(mdbSearch, log,

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -93,6 +94,7 @@ type MongoDBSearchEnvoyReconciler struct {
 	// clientForCluster resolves the client for one cluster name; nil = cluster not
 	// registered with the operator (hub-and-spoke only).
 	clientForCluster func(clusterName string) kubernetesClient.Client
+	isLocalCluster   func(clusterName string) bool
 }
 
 func newMongoDBSearchEnvoyReconciler(c client.Client, defaultEnvoyImage string, memberClustersMap map[string]client.Client, operatorClusterName string) *MongoDBSearchEnvoyReconciler {
@@ -121,19 +123,14 @@ func newMongoDBSearchEnvoyReconcilerWithReaders(c client.Client, apiReader clien
 		memberReaders:       memberReaders,
 		prepareSearch:       newPrepareSearch(operatorClusterName),
 	}
-	if len(clientsMap) == 0 {
-		// Single-cluster and per-cluster-operator installs render everything locally.
-		r.clientForCluster = func(string) kubernetesClient.Client { return r.kubeClient }
-	} else {
-		// Empty clusterName is the central/local cluster (single-cluster sharded
-		// search in a hub-and-spoke install); only named entries are member clusters.
-		r.clientForCluster = func(clusterName string) kubernetesClient.Client {
-			if clusterName == "" {
-				return r.kubeClient
-			}
-			return clientsMap[clusterName]
+	localNamedClusters := operatorClusterName != "" || (len(memberClustersMap) == 0 && !env.ReadBoolOrDefault(util.SearchEnableMultiClusterEnv, false)) // nolint:forbidigo
+	r.clientForCluster = func(clusterName string) kubernetesClient.Client {
+		if clusterName == "" || localNamedClusters {
+			return r.kubeClient
 		}
+		return clientsMap[clusterName]
 	}
+	r.isLocalCluster = func(clusterName string) bool { return clusterName == "" || localNamedClusters }
 	return r
 }
 
@@ -210,7 +207,7 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	tlsEnabled := mdbSearch.IsTLSConfigured()
 
 	workList := r.buildClusterWorkList(mdbSearch)
-	var firstFailure error
+	var reconcileErrs error
 	var worstPhase status.Phase
 
 	for _, w := range workList {
@@ -222,41 +219,54 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 			st = r.reconcileForCluster(ctx, mdbSearch, searchSource, tlsEnabled, tlsCfg, w, state.RoutingReadyMongotGroups, log)
 		}
 		worstPhase = searchv1.WorstOfPhase(worstPhase, st.Phase())
-		if !st.IsOK() && firstFailure == nil {
-			firstFailure = fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st))
+		if !st.IsOK() {
+			reconcileErrs = errors.Join(reconcileErrs, fmt.Errorf("cluster %q: %s", w.ClusterName, searchcontroller.MessageFromStatus(st)))
 		}
 	}
 
-	if firstFailure != nil {
+	if reconcileErrs != nil {
 		// Worst-of phase: preserve the most severe phase seen across clusters.
 		// Without this branch the JSON patch would downgrade Failed → Pending.
 		if worstPhase == status.PhaseFailed {
-			return r.updateLBStatus(ctx, mdbSearch, workflow.Failed(firstFailure), log)
+			return r.updateLBStatus(ctx, mdbSearch, workflow.Failed(reconcileErrs), log)
 		}
-		return r.updateLBStatus(ctx, mdbSearch, workflow.Pending("%s", firstFailure), log)
+		return r.updateLBStatus(ctx, mdbSearch, workflow.Pending("%s", reconcileErrs), log)
 	}
 
 	log.Info("MongoDBSearchEnvoy reconciliation complete")
 	return r.updateLBStatus(ctx, mdbSearch, workflow.OK(), log)
 }
 
-// clusterWorkItem is one per-cluster unit. Single-cluster: ClusterName="", ClusterIndex=0.
-// Client == nil sentinel = cluster not registered with the operator (hub-and-spoke only).
+// clusterWorkItem is one per-cluster unit. OwnerReferences carries the local
+// Search GC backstop and is nil for cross-cluster member resources.
 type clusterWorkItem struct {
-	ClusterName  string
-	ClusterIndex int
-	Client       kubernetesClient.Client
+	ClusterName     string
+	ClusterIndex    int
+	Client          kubernetesClient.Client
+	OwnerReferences []metav1.OwnerReference
 }
 
 // spec.clusters is validated non-empty, so the empty-clusters branch is a
 // defensive backstop only.
 func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.MongoDBSearch) []clusterWorkItem {
 	if len(search.Spec.Clusters) == 0 {
-		return []clusterWorkItem{{ClusterName: "", ClusterIndex: 0, Client: r.kubeClient}}
+		return []clusterWorkItem{r.clusterWorkItem(search, "", 0)}
 	}
 	work := make([]clusterWorkItem, 0, len(search.Spec.Clusters))
 	for _, c := range search.Spec.Clusters {
-		work = append(work, clusterWorkItem{ClusterName: c.Name, ClusterIndex: c.ResolveIndex(), Client: r.clientForCluster(c.Name)})
+		work = append(work, r.clusterWorkItem(search, c.Name, c.ResolveIndex()))
+	}
+	return work
+}
+
+func (r *MongoDBSearchEnvoyReconciler) clusterWorkItem(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int) clusterWorkItem {
+	work := clusterWorkItem{
+		ClusterName:  clusterName,
+		ClusterIndex: clusterIndex,
+		Client:       r.clientForCluster(clusterName),
+	}
+	if r.isLocalCluster(clusterName) {
+		work.OwnerReferences = search.GetOwnerReferences()
 	}
 	return work
 }
@@ -277,8 +287,7 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 	routingReadyMongotGroups []string,
 	log *zap.SugaredLogger,
 ) workflow.Status {
-	clusterName, clusterIndex, c := w.ClusterName, w.ClusterIndex, w.Client
-
+	clusterName, clusterIndex := w.ClusterName, w.ClusterIndex
 	routes := buildRoutesForCluster(search, source, clusterIndex, clusterName, routingReadyMongotGroups)
 	if len(routes) == 0 {
 		return workflow.Pending("No routes to configure for load balancer (cluster=%q)", clusterName)
@@ -304,11 +313,11 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 
-	if err := r.ensureConfigMap(ctx, search, bootstrapJSON, cdsJSON, ldsJSON, clusterName, clusterIndex, c, log); err != nil {
+	if err := r.ensureConfigMap(ctx, search, bootstrapJSON, cdsJSON, ldsJSON, w, log); err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 	// Ensure Deployment (hash only bootstrap — CDS/LDS are hot-reloaded by Envoy via filesystem xDS)
-	if err := r.ensureDeployment(ctx, search, bootstrapJSON, clusterName, clusterIndex, managedLB, c, tlsCfg, log); err != nil {
+	if err := r.ensureDeployment(ctx, search, bootstrapJSON, w, managedLB, tlsCfg, log); err != nil {
 		return workflow.Failed(fmt.Errorf("cluster=%q: %w", clusterName, err))
 	}
 	return workflow.OK()
@@ -488,28 +497,21 @@ func buildReplicaSetRouteForCluster(search *searchv1.MongoDBSearch, clusterIndex
 // ensureConfigMap creates or updates the Envoy ConfigMap with three files:
 // bootstrap.json (static), cds.json (dynamic clusters), and lds.json (dynamic listener).
 // Kubernetes ConfigMap updates are atomic (symlink swap), so all files update together.
-//
-// Cross-cluster ownership note: Kubernetes garbage collection does not span
-// clusters, so we only set an OwnerReference when writing into the central
-// cluster (clusterName == ""). Cleanup of member-cluster objects is handled
-// explicitly in deleteEnvoyResources.
-func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, cdsJSON, ldsJSON, clusterName string, clusterIndex int, c kubernetesClient.Client, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, cdsJSON, ldsJSON string, w clusterWorkItem, log *zap.SugaredLogger) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.LoadBalancerConfigMapNameForCluster(clusterIndex),
+			Name:      search.LoadBalancerConfigMapNameForCluster(w.ClusterIndex),
 			Namespace: search.Namespace,
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
-		cm.Labels = envoyLabelsForCluster(search, clusterName, clusterIndex)
+	_, err := controllerutil.CreateOrUpdate(ctx, w.Client, cm, func() error {
+		cm.OwnerReferences = w.OwnerReferences
+		cm.Labels = envoyLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
 		cm.Data = map[string]string{
 			"bootstrap.json": bootstrapJSON,
 			"cds.json":       cdsJSON,
 			"lds.json":       ldsJSON,
-		}
-		if clusterName == "" {
-			return controllerutil.SetOwnerReference(search, cm, c.Scheme())
 		}
 		return nil
 	})
@@ -517,7 +519,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, sear
 		return fmt.Errorf("failed to ensure Envoy ConfigMap: %w", err)
 	}
 
-	log.Infof("Envoy ConfigMap created/updated (cluster=%q)", clusterName)
+	log.Infof("Envoy ConfigMap created/updated (cluster=%q)", w.ClusterName)
 	return nil
 }
 
@@ -535,16 +537,14 @@ func envoyConfigHash(configJSON string) (string, error) {
 // ensureDeployment creates or updates the Envoy Deployment.
 // The config hash is computed from bootstrapJSON only — CDS/LDS changes are
 // hot-reloaded by Envoy via filesystem xDS and do not require a pod restart.
-//
-// Cross-cluster ownership note: see ensureConfigMap.
-func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, clusterName string, clusterIndex int, managedLB *searchv1.ManagedLBConfig, c kubernetesClient.Client, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON string, w clusterWorkItem, managedLB *searchv1.ManagedLBConfig, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
 	configHash, err := envoyConfigHash(bootstrapJSON)
 	if err != nil {
 		return err
 	}
 	replicas := envoyReplicas(managedLB)
-	labels := envoyLabelsForCluster(search, clusterName, clusterIndex)
-	podLabels := envoyPodLabelsForCluster(search, clusterIndex)
+	labels := envoyLabelsForCluster(search, w.ClusterName, w.ClusterIndex)
+	podLabels := envoyPodLabelsForCluster(search, w.ClusterIndex)
 	tlsEnabled := search.IsTLSConfigured()
 	image, err := r.envoyContainerImage()
 	if err != nil {
@@ -555,12 +555,13 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      search.LoadBalancerDeploymentNameForCluster(clusterIndex),
+			Name:      search.LoadBalancerDeploymentNameForCluster(w.ClusterIndex),
 			Namespace: search.Namespace,
 		},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, c, dep, func() error {
+	_, err = controllerutil.CreateOrUpdate(ctx, w.Client, dep, func() error {
+		dep.OwnerReferences = w.OwnerReferences
 		dep.Labels = labels
 
 		podAnnotations := merge.StringToStringMap(dep.Spec.Template.Annotations, map[string]string{
@@ -577,7 +578,7 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 					Labels:      podLabels,
 					Annotations: podAnnotations,
 				},
-				Spec: buildEnvoyPodSpec(search, clusterIndex, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
+				Spec: buildEnvoyPodSpec(search, w.ClusterIndex, tlsCfg, tlsEnabled, image, resources, managedSecurityContext),
 			},
 		}
 
@@ -588,17 +589,13 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 			dep.Annotations = merge.StringToStringMap(dep.Annotations, managedLB.Deployment.MetadataWrapper.Annotations)
 		}
 		dep.Labels = khandler.ReapplyProtectedSearchLabels(dep.Labels, labels)
-
-		if clusterName == "" {
-			return controllerutil.SetOwnerReference(search, dep, c.Scheme())
-		}
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to ensure Envoy Deployment: %w", err)
 	}
 
-	log.Infof("Envoy Deployment created/updated (cluster=%q)", clusterName)
+	log.Infof("Envoy Deployment created/updated (cluster=%q)", w.ClusterName)
 	return nil
 }
 

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -1992,7 +1992,7 @@ func TestDeleteEnvoyResources_PreservesNonCanonicalOwnership(t *testing.T) {
 			err := r.deleteEnvoyResources(ctx, search, []clusterWorkItem{{
 				ClusterName: tc.clusterName, ClusterIndex: 0, Client: r.clientForCluster(tc.clusterName),
 			}}, zap.S())
-			require.ErrorContains(t, err, "non-canonical ownership")
+			require.ErrorIs(t, err, errEnvoyCleanupOwnershipMismatch)
 			actual := &appsv1.Deployment{}
 			require.NoError(t, target.Get(ctx, client.ObjectKeyFromObject(deployment), actual))
 			assert.Equal(t, deployment.UID, actual.UID)
@@ -2024,10 +2024,10 @@ func TestDeleteEnvoyResources_PreservesReplacementBetweenCachedObservationAndLiv
 	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(search.DeepCopy(), liveDeployment, liveConfigMap).Build()
 	r := newMongoDBSearchEnvoyReconcilerWithReaders(central, apiReader, "envoy:latest", nil, nil, "")
 
-	require.ErrorContains(t, r.deleteEnvoyResources(ctx, search, []clusterWorkItem{{
+	require.ErrorIs(t, r.deleteEnvoyResources(ctx, search, []clusterWorkItem{{
 		ClusterIndex: 0,
 		Client:       r.clientForCluster(""),
-	}}, zap.S()), "non-canonical ownership")
+	}}, zap.S()), errEnvoyCleanupOwnershipMismatch)
 	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(cachedDeployment), &appsv1.Deployment{}))
 	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(cachedConfigMap), &corev1.ConfigMap{}))
 }
@@ -2037,6 +2037,17 @@ func TestDeleteEnvoyResources_PreservesReplacementBetweenCachedObservationAndLiv
 type failingWriteClient struct {
 	client.Client
 	message string
+}
+
+type failingDeploymentDeleteClient struct {
+	client.Client
+}
+
+func (c failingDeploymentDeleteClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if _, ok := obj.(*appsv1.Deployment); ok {
+		return fmt.Errorf("injected Envoy Deployment delete failure")
+	}
+	return c.Client.Delete(ctx, obj, opts...)
 }
 
 func (f failingWriteClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
@@ -2328,6 +2339,190 @@ func TestEnvoyReconcile_LBCleanup_DeletesAtPinnedIndex(t *testing.T) {
 	patched := &searchv1.MongoDBSearch{}
 	require.NoError(t, central.Get(ctx, search.NamespacedName(), patched))
 	assert.Nil(t, patched.Status.LoadBalancer)
+}
+
+func TestEnvoyReconcile_StaleCleanupPreservesManagedResourcesAndStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutateLive func(*searchv1.MongoDBSearch)
+	}{
+		{
+			name: "load balancer re-enabled",
+			mutateLive: func(search *searchv1.MongoDBSearch) {
+				search.Generation++
+				search.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
+			},
+		},
+		{
+			name: "same UID with newer unmanaged generation",
+			mutateLive: func(search *searchv1.MongoDBSearch) {
+				search.Generation++
+			},
+		},
+		{
+			name: "Search recreated",
+			mutateLive: func(search *searchv1.MongoDBSearch) {
+				search.UID = "recreated-search-uid"
+				search.Generation = 1
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enableSearchMCReconcile(t)
+			ctx := t.Context()
+			scheme := envoyTestScheme(t)
+			search := &searchv1.MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid", Generation: 3},
+				Spec: searchv1.MongoDBSearchSpec{
+					Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
+					Clusters: []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(3))}},
+				},
+				Status: searchv1.MongoDBSearchStatus{LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}},
+			}
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerDeploymentNameForCluster(3), Namespace: search.Namespace, Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+			}}
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerConfigMapNameForCluster(3), Namespace: search.Namespace, Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+			}}
+			cachedClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&searchv1.MongoDBSearch{}).
+				WithObjects(search, deployment, configMap).
+				Build()
+			liveSearch := search.DeepCopy()
+			tc.mutateLive(liveSearch)
+			apiReader := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(liveSearch, deployment.DeepCopy(), configMap.DeepCopy()).
+				Build()
+			r := newMongoDBSearchEnvoyReconcilerWithReaders(cachedClient, apiReader, "envoy:latest", nil, nil, "cluster-a")
+
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: search.NamespacedName()})
+
+			require.NoError(t, err)
+			assert.True(t, result.Requeue)
+			require.NoError(t, cachedClient.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{}))
+			require.NoError(t, cachedClient.Get(ctx, client.ObjectKeyFromObject(configMap), &corev1.ConfigMap{}))
+			patched := &searchv1.MongoDBSearch{}
+			require.NoError(t, cachedClient.Get(ctx, search.NamespacedName(), patched))
+			require.NotNil(t, patched.Status.LoadBalancer)
+			assert.Equal(t, status.PhaseRunning, patched.Status.LoadBalancer.Phase)
+		})
+	}
+}
+
+func TestEnvoyReconcile_ParentChangesAfterResourceDeletesBeforeStatusPatch(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := t.Context()
+	scheme := envoyTestScheme(t)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid", Generation: 3},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
+			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(3))}},
+		},
+		Status: searchv1.MongoDBSearchStatus{LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}},
+	}
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: search.LoadBalancerDeploymentNameForCluster(3), Namespace: search.Namespace, Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+	}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: search.LoadBalancerConfigMapNameForCluster(3), Namespace: search.Namespace, Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+	}}
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&searchv1.MongoDBSearch{}).
+		WithObjects(search, deployment, configMap).
+		Build()
+	liveReader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(search.DeepCopy(), deployment.DeepCopy(), configMap.DeepCopy()).
+		Build()
+	newerSearch := search.DeepCopy()
+	newerSearch.Generation++
+	apiReader := &changingSearchReader{
+		Reader:   liveReader,
+		searches: []*searchv1.MongoDBSearch{search, search, newerSearch},
+	}
+	r := newMongoDBSearchEnvoyReconcilerWithReaders(cachedClient, apiReader, "envoy:latest", nil, nil, "cluster-a")
+
+	result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: search.NamespacedName()})
+
+	require.NoError(t, err)
+	assert.True(t, result.Requeue)
+	assert.Equal(t, 3, apiReader.gets)
+	assert.True(t, apierrors.IsNotFound(cachedClient.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})))
+	assert.True(t, apierrors.IsNotFound(cachedClient.Get(ctx, client.ObjectKeyFromObject(configMap), &corev1.ConfigMap{})))
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, cachedClient.Get(ctx, search.NamespacedName(), patched))
+	require.NotNil(t, patched.Status.LoadBalancer)
+	assert.Equal(t, status.PhaseRunning, patched.Status.LoadBalancer.Phase)
+}
+
+func TestPatchLBStatusForCleanupRejectsNewerGeneration(t *testing.T) {
+	scheme := envoyTestScheme(t)
+	liveSearch := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid", Generation: 4},
+		Status:     searchv1.MongoDBSearchStatus{LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}},
+	}
+	staleSearch := liveSearch.DeepCopy()
+	staleSearch.Generation--
+	central := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&searchv1.MongoDBSearch{}).
+		WithObjects(liveSearch).
+		Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+
+	require.Error(t, r.patchLBStatusForCleanup(t.Context(), staleSearch, nil))
+	current := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(t.Context(), liveSearch.NamespacedName(), current))
+	require.NotNil(t, current.Status.LoadBalancer)
+	assert.Equal(t, status.PhaseRunning, current.Status.LoadBalancer.Phase)
+}
+
+func TestEnvoyReconcile_LBCleanupFailureRetainsStatusForRetry(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid", Generation: 1},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
+			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(3))}},
+		},
+		Status: searchv1.MongoDBSearchStatus{LoadBalancer: &searchv1.LoadBalancerStatus{Phase: status.PhaseRunning}},
+	}
+	deploymentKey := types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(3), Namespace: search.Namespace}
+	configMapKey := types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(3), Namespace: search.Namespace}
+	central := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&searchv1.MongoDBSearch{}).
+		WithObjects(
+			search,
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name: deploymentKey.Name, Namespace: deploymentKey.Namespace, Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+			}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: configMapKey.Name, Namespace: configMapKey.Namespace, Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+			}},
+		).
+		Build()
+	failingClient := failingDeploymentDeleteClient{Client: central}
+	r := newMongoDBSearchEnvoyReconciler(failingClient, "envoy:latest", nil, "cluster-a")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: search.NamespacedName()})
+
+	require.NoError(t, err)
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, search.NamespacedName(), patched))
+	require.NotNil(t, patched.Status.LoadBalancer)
+	assert.Equal(t, status.PhaseFailed, patched.Status.LoadBalancer.Phase)
+	assert.Contains(t, patched.Status.LoadBalancer.Message, "injected Envoy Deployment delete failure")
+	require.NoError(t, central.Get(ctx, deploymentKey, &appsv1.Deployment{}))
+	assert.True(t, apierrors.IsNotFound(central.Get(ctx, configMapKey, &corev1.ConfigMap{})))
 }
 
 func TestEnvoyReconcile_MultiCluster_FailedFirstThenOK_AggregatesFailed(t *testing.T) {

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -916,12 +916,14 @@ func TestLoadBalancerNamesForCluster_IndexBased(t *testing.T) {
 }
 
 func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
-	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
+	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"}}
 
 	// Single-cluster: cluster-name label must be absent; app label uses index 0.
 	single := envoyLabelsForCluster(search, "", 0)
 	assert.Equal(t, "mdb-search", single[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", single[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), single[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, labelName, single[khandler.MongoDBSearchComponentLabel])
 	_, hasCluster := single[khandler.MongoDBSearchClusterNameLabel]
 	assert.False(t, hasCluster)
 	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(0), single["app"])
@@ -930,8 +932,44 @@ func TestEnvoyLabels_StampsCrossClusterEnqueueLabels(t *testing.T) {
 	mc := envoyLabelsForCluster(search, "us-east-k8s", 3)
 	assert.Equal(t, "mdb-search", mc[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, "ns", mc[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), mc[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, labelName, mc[khandler.MongoDBSearchComponentLabel])
 	assert.Equal(t, "us-east-k8s", mc[khandler.MongoDBSearchClusterNameLabel])
 	assert.Equal(t, search.LoadBalancerDeploymentNameForCluster(3), mc["app"])
+}
+
+func TestEnsureDeployment_OverridePreservesProtectedSearchLabels(t *testing.T) {
+	scheme := envoyTestScheme(t)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newMongoDBSearchEnvoyReconciler(kubeClient, "envoy:latest", nil, "")
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
+	}
+	managedLB := &searchv1.ManagedLBConfig{
+		Deployment: &v1.DeploymentConfiguration{
+			MetadataWrapper: v1.DeploymentMetadataWrapper{
+				Labels: map[string]string{
+					"custom-label":                            "custom-value",
+					khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
+					khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
+					khandler.MongoDBSearchOwnerUIDLabel:       "wrong-uid",
+					khandler.MongoDBSearchClusterNameLabel:    "wrong-cluster",
+					khandler.MongoDBSearchComponentLabel:      "wrong-component",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, r.ensureDeployment(t.Context(), search, `{"x":1}`, "member-a", 2, managedLB, r.kubeClient, nil, zap.S()))
+
+	dep := &appsv1.Deployment{}
+	require.NoError(t, kubeClient.Get(t.Context(), types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(2), Namespace: search.Namespace}, dep))
+	assert.Equal(t, "custom-value", dep.Labels["custom-label"])
+	assert.Equal(t, search.Name, dep.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, dep.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), dep.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, "member-a", dep.Labels[khandler.MongoDBSearchClusterNameLabel])
+	assert.Equal(t, labelName, dep.Labels[khandler.MongoDBSearchComponentLabel])
 }
 
 // --- envoy replicas defaulting ------------------------------------------

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
 )
 
@@ -47,6 +48,9 @@ import (
 // behaviour seed this CM before constructing the reconciler.
 func seedSearchStateCM(t *testing.T, ctx context.Context, c client.Client, searchName, ns string, routingReady []string) {
 	t.Helper()
+	search := &searchv1.MongoDBSearch{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: searchName, Namespace: ns}, search))
+
 	state := searchcontroller.SearchDeploymentState{
 		RoutingReadyMongotGroups: routingReady,
 	}
@@ -56,10 +60,16 @@ func seedSearchStateCM(t *testing.T, ctx context.Context, c client.Client, searc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      searchName + "-search-state",
 			Namespace: ns,
+			Labels: map[string]string{
+				khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+				khandler.MongoDBSearchOwnerUIDLabel:       string(search.UID),
+			},
 		},
 		Data: map[string]string{stateKey: string(raw)},
 	}
-	require.NoError(t, c.Create(ctx, cm))
+	err = c.Create(ctx, cm)
+	require.NoError(t, err)
 }
 
 func TestBuildReplicaSetRoute(t *testing.T) {
@@ -460,6 +470,8 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	assert.Equal(t, resource.MustParse("500m"), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
 }
 
+// --- per-cluster route renderer tests -----------------------------------------
+
 func TestBuildRoutesForCluster_RS_PerClusterHostname(t *testing.T) {
 	one := int32(1)
 	search := &searchv1.MongoDBSearch{
@@ -561,26 +573,18 @@ type mockShardedSourceForEnvoy struct {
 	shardNames []string
 }
 
-func (m *mockShardedSourceForEnvoy) GetShardCount() int { return len(m.shardNames) }
-
+func (m *mockShardedSourceForEnvoy) GetShardCount() int      { return len(m.shardNames) }
 func (m *mockShardedSourceForEnvoy) GetShardNames() []string { return m.shardNames }
-
 func (m *mockShardedSourceForEnvoy) GetUnmanagedLBEndpointForShard(_ string) string {
 	return ""
 }
-
 func (m *mockShardedSourceForEnvoy) MongosHostsAndPorts() []string { return nil }
-
-func (m *mockShardedSourceForEnvoy) KeyfileSecretName() string { return "" }
-
+func (m *mockShardedSourceForEnvoy) KeyfileSecretName() string     { return "" }
 func (m *mockShardedSourceForEnvoy) TLSConfig() *searchcontroller.TLSSourceConfig {
 	return nil
 }
-
 func (m *mockShardedSourceForEnvoy) HostSeeds(_ string) ([]string, error) { return nil, nil }
-
-func (m *mockShardedSourceForEnvoy) Validate() error { return nil }
-
+func (m *mockShardedSourceForEnvoy) Validate() error                      { return nil }
 func (m *mockShardedSourceForEnvoy) ResourceType() mdbv1.ResourceType {
 	return mdbv1.ShardedCluster
 }
@@ -851,6 +855,8 @@ func TestEnvoyFilterChain_PerClusterSNI(t *testing.T) {
 		"per-cluster SNIs must all be distinct; collisions break per-cluster TLS routing")
 }
 
+// --- reconciler constructor with member-cluster client maps ------------------
+
 func TestNewMongoDBSearchEnvoyReconciler_AcceptsMemberClusters(t *testing.T) {
 	central := fake.NewClientBuilder().Build()
 	memberA := fake.NewClientBuilder().Build()
@@ -869,10 +875,23 @@ func TestNewMongoDBSearchEnvoyReconciler_AcceptsMemberClusters(t *testing.T) {
 
 func TestNewMongoDBSearchEnvoyReconciler_NilMembersMap(t *testing.T) {
 	central := fake.NewClientBuilder().Build()
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
-	require.NotNil(t, r)
-	assert.Equal(t, r.kubeClient, r.clientForCluster("any-cluster"), "nil members map must fall back to the central client")
+	t.Run("legacy local", func(t *testing.T) {
+		r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+		require.NotNil(t, r)
+		assert.Equal(t, r.kubeClient, r.clientForCluster("any-cluster"))
+		assert.True(t, r.isLocalCluster("any-cluster"))
+	})
+	t.Run("hub with missing clients", func(t *testing.T) {
+		t.Setenv(util.SearchEnableMultiClusterEnv, "true")
+		r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+		require.NotNil(t, r)
+		assert.Nil(t, r.clientForCluster("any-cluster"))
+		assert.False(t, r.isLocalCluster("any-cluster"))
+		assert.Equal(t, r.kubeClient, r.clientForCluster(""))
+	})
 }
+
+// --- clusterWorkItem.Client population ----------------------------------------
 
 func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 	centralRaw := fake.NewClientBuilder().Build()
@@ -900,6 +919,8 @@ func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 	assert.Equal(t, r.clientForCluster("a"), wl[0].Client, "known member must use member client")
 	assert.Nil(t, wl[1].Client, "unregistered member must carry the nil-Client sentinel, not the central client")
 }
+
+// --- per-cluster name helpers + cross-cluster enqueue labels ------------------
 
 func TestLoadBalancerNamesForCluster_IndexBased(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
@@ -973,6 +994,8 @@ func TestEnsureDeployment_OverridePreservesProtectedSearchLabels(t *testing.T) {
 	assert.Equal(t, "member-a", dep.Labels[khandler.MongoDBSearchClusterNameLabel])
 	assert.Equal(t, labelName, dep.Labels[khandler.MongoDBSearchComponentLabel])
 }
+
+// --- envoy replicas defaulting ------------------------------------------
 
 func TestEnvoyReplicas_DefaultsTo1(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
@@ -1080,6 +1103,8 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 	assert.Empty(t, cm.OwnerReferences)
 }
 
+// --- reconcile loop + per-cluster status --------------------------------------
+
 func TestBuildClusterWorkList_SingleClusterDegenerate(t *testing.T) {
 	r := newMongoDBSearchEnvoyReconciler(fake.NewClientBuilder().Build(), "envoy:latest", nil, "")
 	search := &searchv1.MongoDBSearch{}
@@ -1144,7 +1169,7 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source: &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
 			Clusters: []searchv1.ClusterSpec{{
@@ -1391,6 +1416,8 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 	}
 }
 
+// --- end-to-end Reconcile + status aggregation -------------------------------
+
 // TestReconcile_WorstOfPhase_Aggregated exercises the full Reconcile path:
 // two clusters in spec.clusters[]; one is a member registered with the operator
 // (succeeds), the other isn't (Pending). The top-level Phase must be the
@@ -1459,31 +1486,20 @@ func TestReconcile_WorstOfPhase_Aggregated(t *testing.T) {
 // phase patched onto status.loadBalancer is Failed (not Pending). Without
 // this guard, all errors would be downgraded to Pending in the final write.
 func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
+	enableSearchMCReconcile(t)
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
 
-	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
-		Spec: searchv1.MongoDBSearchSpec{
-			Source: &searchv1.MongoDBSource{
-				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
-					HostAndPorts: []string{"mongo-0:27017"},
-				},
-			},
-			Clusters: []searchv1.ClusterSpec{{
-				Name: "a",
-				LoadBalancer: &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-a.example.com"},
-				},
-			}},
-		},
-	}
+	search := newMCEnvoySearch("mdb-search", "ns", "",
+		pinnedCluster("a", 0),
+		pinnedCluster("b", 1),
+	)
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 
-	// Member client is a fake that fails every write — drives Failed.
-	memberA := failingWriteClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	memberA := failingWriteClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build(), message: "injected cluster-a failure"}
+	memberB := failingWriteClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build(), message: "injected cluster-b failure"}
 
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA}, "")
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA, "b": memberB}, "")
 
 	_, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"},
@@ -1496,7 +1512,11 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 	require.NotNil(t, patched.Status.LoadBalancer)
 	assert.Equal(t, status.PhaseFailed, patched.Status.LoadBalancer.Phase,
 		"all-Failed clusters must aggregate to top-level Failed, not Pending")
+	assert.Contains(t, patched.Status.LoadBalancer.Message, "injected cluster-a failure")
+	assert.Contains(t, patched.Status.LoadBalancer.Message, "injected cluster-b failure")
 }
+
+// --- index-based naming reconcile loop tests ----------------------------------
 
 // TestReconcile_NoStateCM_RendersFromPins asserts that the Envoy controller
 // resolves per-cluster indices from spec.clusters[].clusterIndex alone: with no
@@ -1761,6 +1781,30 @@ func TestDeleteEnvoyResources_MCFanOut(t *testing.T) {
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: "ns"}, &corev1.ConfigMap{})))
 }
 
+func TestEnvoyReconcile_HubRemovedClusterCleansManagedMemberResources(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	search := newMCEnvoySearch("mdb-search", "ns", "search-uid", pinnedCluster("cluster-a", 0))
+	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
+	memberB := fake.NewClientBuilder().WithScheme(scheme).Build()
+	labels := khandler.MongoDBSearchManagedLabels(search, "", searchProxyComponent, "cluster-b")
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: search.Namespace, UID: "removed-deployment", Labels: labels}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: search.Namespace, UID: "removed-config", Labels: labels}}
+	require.NoError(t, memberB.Create(ctx, deployment))
+	require.NoError(t, memberB.Create(ctx, configMap))
+
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{
+		"cluster-a": memberA,
+		"cluster-b": memberB,
+	}, "")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(search)})
+	require.NoError(t, err)
+	assert.True(t, apierrors.IsNotFound(memberB.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})))
+	assert.True(t, apierrors.IsNotFound(memberB.Get(ctx, client.ObjectKeyFromObject(configMap), &corev1.ConfigMap{})))
+}
+
 func TestDeleteEnvoyResources_MissingClientDoesNotBlockHealthyCluster(t *testing.T) {
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
@@ -1992,18 +2036,26 @@ func TestDeleteEnvoyResources_PreservesReplacementBetweenCachedObservationAndLiv
 // simulate a per-cluster Failed status without needing a real envtest.
 type failingWriteClient struct {
 	client.Client
+	message string
 }
 
 func (f failingWriteClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
-	return fmt.Errorf("simulated write failure")
+	return fmt.Errorf("%s", f.failureMessage())
 }
 
 func (f failingWriteClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-	return fmt.Errorf("simulated write failure")
+	return fmt.Errorf("%s", f.failureMessage())
 }
 
 func (f failingWriteClient) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
-	return fmt.Errorf("simulated write failure")
+	return fmt.Errorf("%s", f.failureMessage())
+}
+
+func (f failingWriteClient) failureMessage() string {
+	if f.message == "" {
+		return "simulated write failure"
+	}
+	return f.message
 }
 
 func TestEnvoyConfigHash_WhitespaceInvariant(t *testing.T) {
@@ -2105,7 +2157,7 @@ func newOperatorPerClusterEnvoySearch(name, namespace string, clusterBIndex int3
 	clusterB := pinnedCluster("cluster-b", clusterBIndex)
 	clusterB.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"}}
 	return &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source: &searchv1.MongoDBSource{
 				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
@@ -2119,8 +2171,7 @@ func TestBuildClusterWorkList_OperatorPerCluster_UsesProjectedIndex(t *testing.T
 	// Operator-per-cluster with unified CR: members map empty; LocalizeToCluster already narrowed
 	// spec.Clusters to one entry whose projected clusterIndex must be honoured.
 	central := fake.NewClientBuilder().Build()
-	// operatorClusterName is "" — this test exercises buildClusterWorkList directly, not Reconcile.
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "kind-e2e-cluster-2")
 	search := &searchv1.MongoDBSearch{
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{
@@ -2331,7 +2382,7 @@ func TestEnvoyReconcile_OperatorPerCluster_Match_RendersAtPinnedIndex(t *testing
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(7), Namespace: "ns"}, cm),
 		"Envoy ConfigMap must render at pinned index 7")
 
-	assertSearchOwnerLabels(t, search, "cluster-b", dep, cm)
+	assertSearchOwnerLabels(t, search, "cluster-b", true, dep, cm)
 
 	// Nothing at index 0 — the array-position index must not leak through.
 	assert.True(t, apierrors.IsNotFound(central.Get(ctx,
@@ -2366,6 +2417,53 @@ func TestEnvoyReconcile_OperatorPerCluster_MissingClusterIndex_Invalid(t *testin
 	assert.Contains(t, patched.Status.LoadBalancer.Message,
 		"one operator per cluster requires index on every spec.clusters[] entry (missing on",
 		"message must come from ValidateOperatorPerClusterIndices")
+}
+
+func TestEnvoyReconcile_OperatorPerCluster_RemovedClusterCleansLocalResources(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+
+	// Both entries pinned so the no-op is attributable to LocalizeToCluster, not validation.
+	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 1)
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      "removed-envoy",
+		Namespace: search.Namespace,
+		UID:       "removed-envoy",
+		Labels:    khandler.MongoDBSearchManagedLabels(search, "", searchProxyComponent, "cluster-c"),
+	}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      "removed-envoy-config",
+		Namespace: search.Namespace,
+		UID:       "removed-envoy-config",
+		Labels:    khandler.MongoDBSearchManagedLabels(search, "", searchProxyComponent, "cluster-c"),
+	}}
+	require.NoError(t, central.Create(ctx, deployment))
+	require.NoError(t, central.Create(ctx, configMap))
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-c")
+
+	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+	assert.True(t, apierrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})))
+	assert.True(t, apierrors.IsNotFound(central.Get(ctx, client.ObjectKeyFromObject(configMap), &corev1.ConfigMap{})))
+
+	// No Envoy Deployment / ConfigMap at any index on the central client.
+	for _, i := range []int{0, 1, 2} {
+		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(i), Namespace: "ns"}, &appsv1.Deployment{})),
+			"Envoy Deployment at index %d must not exist", i)
+		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+			types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(i), Namespace: "ns"}, &corev1.ConfigMap{})),
+			"Envoy ConfigMap at index %d must not exist", i)
+	}
+
+	// LB status untouched: the no-op returns before any status patch.
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	assert.Nil(t, patched.Status.LoadBalancer, "no-match reconcile must not write loadBalancer status")
 }
 
 func TestEnvoyReconcile_UnregisteredCluster_PendingAndNoCentralWrites(t *testing.T) {
@@ -2586,36 +2684,4 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 		"restartedAt must survive re-apply so the rollout is not reverted")
 	assert.Equal(t, originalHash, dep.Spec.Template.Annotations[envoyConfigHashAnnotation],
 		"operator-owned config-hash annotation must remain present and authoritative")
-}
-
-func TestEnvoyReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
-	enableSearchMCReconcile(t)
-	ctx := context.Background()
-	scheme := envoyTestScheme(t)
-
-	// Both entries pinned so the no-op is attributable to LocalizeToCluster, not validation.
-	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 1)
-	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
-
-	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-c")
-
-	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
-	require.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
-
-	// No Envoy Deployment / ConfigMap at any index on the central client.
-	for _, i := range []int{0, 1, 2} {
-		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
-			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(i), Namespace: "ns"}, &appsv1.Deployment{})),
-			"Envoy Deployment at index %d must not exist", i)
-		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
-			types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(i), Namespace: "ns"}, &corev1.ConfigMap{})),
-			"Envoy ConfigMap at index %d must not exist", i)
-	}
-
-	// LB status untouched: the no-op returns before any status patch.
-	patched := &searchv1.MongoDBSearch{}
-	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
-	assert.Nil(t, patched.Status.LoadBalancer, "no-match reconcile must not write loadBalancer status")
 }

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 
@@ -1168,6 +1169,39 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 	assert.Contains(t, patched.Status.LoadBalancer.Message, "missing-cluster")
 }
 
+func TestReconcile_DeletionTimestampTakesPriorityOverDisableAnnotation(t *testing.T) {
+	ctx := context.Background()
+	logs := observeControllerLogs(t)
+	now := metav1.Now()
+	scheme := envoyTestScheme(t)
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "mdb-search",
+			Namespace:         "ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+			Annotations: map[string]string{
+				searchv1.DisableReconciliationAnnotation: "true",
+			},
+		},
+		Spec: searchv1.MongoDBSearchSpec{Clusters: []searchv1.ClusterSpec{{}}},
+	}
+
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+
+	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	updated := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, updated))
+	assert.Nil(t, updated.Status.LoadBalancer)
+	assert.Equal(t, 1, logs.FilterMessageSnippet("is deleting; skipping envoy reconcile").Len())
+	assert.Zero(t, logs.FilterMessageSnippet("reconciliation disabled").Len())
+}
+
 func TestReconcile_RegistersSearchStateConfigMapWatch(t *testing.T) {
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
@@ -1697,15 +1731,14 @@ func TestReconcile_StableIndexAcrossClusterRemovals(t *testing.T) {
 func TestDeleteEnvoyResources_MCFanOut(t *testing.T) {
 	ctx := context.Background()
 	scheme := envoyTestScheme(t)
-	central := fake.NewClientBuilder().WithScheme(scheme).Build()
-
 	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
 	}
-	depA := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}}
-	cmA := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}}
-	depB := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}}
-	cmB := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: "ns"}}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithObjects(search).Build()
+	depA := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns", Labels: envoyLabelsForCluster(search, "a", 0)}}
+	cmA := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns", Labels: envoyLabelsForCluster(search, "a", 0)}}
+	depB := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns", Labels: envoyLabelsForCluster(search, "b", 1)}}
+	cmB := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: "ns", Labels: envoyLabelsForCluster(search, "b", 1)}}
 	memberA := fake.NewClientBuilder().WithScheme(scheme).WithObjects(depA, cmA).Build()
 	memberB := fake.NewClientBuilder().WithScheme(scheme).WithObjects(depB, cmB).Build()
 
@@ -1715,7 +1748,7 @@ func TestDeleteEnvoyResources_MCFanOut(t *testing.T) {
 		{ClusterName: "a", ClusterIndex: 0, Client: r.clientForCluster("a")},
 		{ClusterName: "b", ClusterIndex: 1, Client: r.clientForCluster("b")},
 	}
-	r.deleteEnvoyResources(ctx, search, workList, zap.S())
+	require.NoError(t, r.deleteEnvoyResources(ctx, search, workList, zap.S()))
 
 	// Both member clusters: Deployment + ConfigMap gone at their respective indices.
 	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx,
@@ -1726,6 +1759,233 @@ func TestDeleteEnvoyResources_MCFanOut(t *testing.T) {
 		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}, &appsv1.Deployment{})))
 	assert.True(t, apierrors.IsNotFound(memberB.Get(ctx,
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: "ns"}, &corev1.ConfigMap{})))
+}
+
+func TestDeleteEnvoyResources_MissingClientDoesNotBlockHealthyCluster(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"}}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithObjects(search).Build()
+	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA}, "")
+
+	lbObjects := func(clusterName string, idx int) (*appsv1.Deployment, *corev1.ConfigMap) {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerDeploymentNameForCluster(idx), Namespace: "ns", Labels: envoyLabelsForCluster(search, clusterName, idx),
+			}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerConfigMapNameForCluster(idx), Namespace: "ns", Labels: envoyLabelsForCluster(search, clusterName, idx),
+			}}
+	}
+
+	// Pre-seed LB resources for the unregistered (nil-Client) cluster on the CENTRAL
+	// client at the same index the work item carries, plus resources for a registered
+	// cluster on its member client.
+	unregDep, unregCM := lbObjects("unregistered", 0)
+	require.NoError(t, central.Create(ctx, unregDep))
+	require.NoError(t, central.Create(ctx, unregCM))
+	regDep, regCM := lbObjects("a", 1)
+	require.NoError(t, memberA.Create(ctx, regDep))
+	require.NoError(t, memberA.Create(ctx, regCM))
+
+	err := r.deleteEnvoyResources(ctx, search, []clusterWorkItem{
+		{ClusterName: "unregistered", ClusterIndex: 0, Client: nil},
+		{ClusterName: "a", ClusterIndex: 1, Client: r.clientForCluster("a")},
+	}, zap.S())
+	require.ErrorContains(t, err, `cluster "unregistered": no Kubernetes client registered for Envoy cleanup`)
+
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregDep), &appsv1.Deployment{}),
+		"nil-Client item must not delete the central Deployment")
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregCM), &corev1.ConfigMap{}),
+		"nil-Client item must not delete the central ConfigMap")
+
+	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regDep), &appsv1.Deployment{})))
+	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regCM), &corev1.ConfigMap{})))
+}
+
+func TestDeleteEnvoyResources_CanonicalOwnershipByTopology(t *testing.T) {
+	tests := []struct {
+		name                string
+		clusterName         string
+		operatorClusterName string
+		hubMember           bool
+	}{
+		{name: "legacy central"},
+		{name: "projected local", clusterName: "cluster-a", operatorClusterName: "cluster-a"},
+		{name: "hub member", clusterName: "cluster-a", hubMember: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := envoyTestScheme(t)
+			search := &searchv1.MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
+			}
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: search.Namespace,
+				UID: "deployment-uid", ResourceVersion: "1", Labels: envoyLabelsForCluster(search, tc.clusterName, 0),
+			}}
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: search.Namespace,
+				UID: "config-uid", ResourceVersion: "1", Labels: envoyLabelsForCluster(search, tc.clusterName, 0),
+			}}
+			centralObjects := []client.Object{search}
+			if !tc.hubMember {
+				centralObjects = append(centralObjects, deployment, configMap)
+			}
+			central := fake.NewClientBuilder().WithScheme(scheme).WithObjects(centralObjects...).Build()
+			var member client.Client
+			memberClients := map[string]client.Client(nil)
+			memberReaders := map[string]client.Reader(nil)
+			target := client.Client(central)
+			if tc.hubMember {
+				member = fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, configMap).Build()
+				memberClients = map[string]client.Client{tc.clusterName: member}
+				memberReaders = map[string]client.Reader{tc.clusterName: member}
+				target = member
+			}
+			r := newMongoDBSearchEnvoyReconcilerWithReaders(
+				central, central, "envoy:latest", memberClients, memberReaders, tc.operatorClusterName,
+			)
+
+			require.NoError(t, r.deleteEnvoyResources(ctx, search, []clusterWorkItem{{
+				ClusterName: tc.clusterName, ClusterIndex: 0, Client: r.clientForCluster(tc.clusterName),
+			}}, zap.S()))
+			assert.True(t, apierrors.IsNotFound(target.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})))
+			assert.True(t, apierrors.IsNotFound(target.Get(ctx, client.ObjectKeyFromObject(configMap), &corev1.ConfigMap{})))
+		})
+	}
+}
+
+func TestDeleteEnvoyResources_PreservesNonCanonicalOwnership(t *testing.T) {
+	tests := []struct {
+		name                string
+		clusterName         string
+		operatorClusterName string
+		hubMember           bool
+		mutateLabels        func(map[string]string)
+	}{
+		{
+			name: "wrong Search UID",
+			mutateLabels: func(labels map[string]string) {
+				labels[khandler.MongoDBSearchOwnerUIDLabel] = "replacement-uid"
+			},
+		},
+		{
+			name:        "wrong component on projected local",
+			clusterName: "cluster-a", operatorClusterName: "cluster-a",
+			mutateLabels: func(labels map[string]string) {
+				labels[khandler.MongoDBSearchComponentLabel] = "other-component"
+			},
+		},
+		{
+			name:        "wrong cluster on hub member",
+			clusterName: "cluster-a", hubMember: true,
+			mutateLabels: func(labels map[string]string) {
+				labels[khandler.MongoDBSearchClusterNameLabel] = "cluster-b"
+			},
+		},
+		{
+			name: "cluster label present on legacy",
+			mutateLabels: func(labels map[string]string) {
+				labels[khandler.MongoDBSearchClusterNameLabel] = ""
+			},
+		},
+		{
+			name:        "cluster label absent on projected local",
+			clusterName: "cluster-a", operatorClusterName: "cluster-a",
+			mutateLabels: func(labels map[string]string) {
+				delete(labels, khandler.MongoDBSearchClusterNameLabel)
+			},
+		},
+		{
+			name:        "wrong Search name on hub member",
+			clusterName: "cluster-a", hubMember: true,
+			mutateLabels: func(labels map[string]string) {
+				labels[khandler.MongoDBSearchOwnerNameLabel] = "replacement-search"
+			},
+		},
+		{
+			name:        "wrong Search namespace on hub member",
+			clusterName: "cluster-a", hubMember: true,
+			mutateLabels: func(labels map[string]string) {
+				labels[khandler.MongoDBSearchOwnerNamespaceLabel] = "replacement-namespace"
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := envoyTestScheme(t)
+			search := &searchv1.MongoDBSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
+			}
+			labels := maps.Clone(envoyLabelsForCluster(search, tc.clusterName, 0))
+			tc.mutateLabels(labels)
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: search.Namespace,
+				UID: "deployment-uid", ResourceVersion: "1", Labels: labels,
+			}}
+			centralObjects := []client.Object{search}
+			if !tc.hubMember {
+				centralObjects = append(centralObjects, deployment)
+			}
+			central := fake.NewClientBuilder().WithScheme(scheme).WithObjects(centralObjects...).Build()
+			var member client.Client
+			memberClients := map[string]client.Client(nil)
+			memberReaders := map[string]client.Reader(nil)
+			target := client.Client(central)
+			if tc.hubMember {
+				member = fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+				memberClients = map[string]client.Client{tc.clusterName: member}
+				memberReaders = map[string]client.Reader{tc.clusterName: member}
+				target = member
+			}
+			r := newMongoDBSearchEnvoyReconcilerWithReaders(
+				central, central, "envoy:latest", memberClients, memberReaders, tc.operatorClusterName,
+			)
+
+			err := r.deleteEnvoyResources(ctx, search, []clusterWorkItem{{
+				ClusterName: tc.clusterName, ClusterIndex: 0, Client: r.clientForCluster(tc.clusterName),
+			}}, zap.S())
+			require.ErrorContains(t, err, "non-canonical ownership")
+			actual := &appsv1.Deployment{}
+			require.NoError(t, target.Get(ctx, client.ObjectKeyFromObject(deployment), actual))
+			assert.Equal(t, deployment.UID, actual.UID)
+		})
+	}
+}
+
+func TestDeleteEnvoyResources_PreservesReplacementBetweenCachedObservationAndLiveGet(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
+	}
+	deploymentLabels := envoyLabelsForCluster(search, "", 0)
+	deploymentLabels[khandler.MongoDBSearchOwnerUIDLabel] = "replacement-uid"
+	liveDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: search.Namespace, Labels: deploymentLabels,
+	}}
+	liveConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: search.Namespace,
+	}}
+	cachedDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: liveDeployment.Name, Namespace: search.Namespace, Labels: envoyLabelsForCluster(search, "", 0),
+	}}
+	cachedConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: liveConfigMap.Name, Namespace: search.Namespace, Labels: envoyLabelsForCluster(search, "", 0),
+	}}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithObjects(search, cachedDeployment, cachedConfigMap).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(search.DeepCopy(), liveDeployment, liveConfigMap).Build()
+	r := newMongoDBSearchEnvoyReconcilerWithReaders(central, apiReader, "envoy:latest", nil, nil, "")
+
+	require.ErrorContains(t, r.deleteEnvoyResources(ctx, search, []clusterWorkItem{{
+		ClusterIndex: 0,
+		Client:       r.clientForCluster(""),
+	}}, zap.S()), "non-canonical ownership")
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(cachedDeployment), &appsv1.Deployment{}))
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(cachedConfigMap), &corev1.ConfigMap{}))
 }
 
 // failingWriteClient wraps a client.Client and rejects every write so we can
@@ -2014,6 +2274,9 @@ func TestEnvoyReconcile_LBCleanup_DeletesAtPinnedIndex(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(central.Get(ctx,
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(3), Namespace: "ns"}, &corev1.ConfigMap{})),
 		"Envoy ConfigMap at the pinned index 3 must be deleted")
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, search.NamespacedName(), patched))
+	assert.Nil(t, patched.Status.LoadBalancer)
 }
 
 func TestEnvoyReconcile_MultiCluster_FailedFirstThenOK_AggregatesFailed(t *testing.T) {
@@ -2323,52 +2586,6 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 		"restartedAt must survive re-apply so the rollout is not reverted")
 	assert.Equal(t, originalHash, dep.Spec.Template.Annotations[envoyConfigHashAnnotation],
 		"operator-owned config-hash annotation must remain present and authoritative")
-}
-
-func TestDeleteEnvoyResources_SkipsUnregisteredCluster(t *testing.T) {
-	ctx := context.Background()
-	scheme := envoyTestScheme(t)
-	central := fake.NewClientBuilder().WithScheme(scheme).Build()
-	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA}, "")
-	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-
-	lbObjects := func(idx int) (*appsv1.Deployment, *corev1.ConfigMap) {
-		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-				Name: search.LoadBalancerDeploymentNameForCluster(idx), Namespace: "ns",
-			}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
-				Name: search.LoadBalancerConfigMapNameForCluster(idx), Namespace: "ns",
-			}}
-	}
-
-	// Pre-seed LB resources for the unregistered (nil-Client) cluster on the CENTRAL
-	// client at the same index the work item carries, plus resources for a registered
-	// cluster on its member client.
-	unregDep, unregCM := lbObjects(0)
-	require.NoError(t, central.Create(ctx, unregDep))
-	require.NoError(t, central.Create(ctx, unregCM))
-	regDep, regCM := lbObjects(1)
-	require.NoError(t, memberA.Create(ctx, regDep))
-	require.NoError(t, memberA.Create(ctx, regCM))
-
-	r.deleteEnvoyResources(ctx, search, []clusterWorkItem{
-		// nil Client (cluster not registered): must be skipped, central resources untouched.
-		{ClusterName: "unregistered", ClusterIndex: 0, Client: nil},
-		// registered cluster: its resources must be deleted, proving the loop still runs.
-		{ClusterName: "a", ClusterIndex: 1, Client: r.clientForCluster("a")},
-	}, zap.S())
-
-	// The nil-Client item must not delete anything from the central client.
-	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregDep), &appsv1.Deployment{}),
-		"nil-Client item must not delete the central Deployment")
-	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregCM), &corev1.ConfigMap{}),
-		"nil-Client item must not delete the central ConfigMap")
-
-	// The registered item's resources are gone.
-	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regDep), &appsv1.Deployment{})))
-	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regCM), &corev1.ConfigMap{})))
 }
 
 func TestEnvoyReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -28,6 +28,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/watch"
 	"github.com/mongodb/mongodb-kubernetes/controllers/searchcontroller"
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
@@ -458,8 +459,6 @@ func TestDeploymentConfigurationOverride_ResourceRequirementsComposition(t *test
 	assert.Equal(t, resource.MustParse("500m"), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
 }
 
-// --- per-cluster route renderer tests -----------------------------------------
-
 func TestBuildRoutesForCluster_RS_PerClusterHostname(t *testing.T) {
 	one := int32(1)
 	search := &searchv1.MongoDBSearch{
@@ -561,18 +560,26 @@ type mockShardedSourceForEnvoy struct {
 	shardNames []string
 }
 
-func (m *mockShardedSourceForEnvoy) GetShardCount() int      { return len(m.shardNames) }
+func (m *mockShardedSourceForEnvoy) GetShardCount() int { return len(m.shardNames) }
+
 func (m *mockShardedSourceForEnvoy) GetShardNames() []string { return m.shardNames }
+
 func (m *mockShardedSourceForEnvoy) GetUnmanagedLBEndpointForShard(_ string) string {
 	return ""
 }
+
 func (m *mockShardedSourceForEnvoy) MongosHostsAndPorts() []string { return nil }
-func (m *mockShardedSourceForEnvoy) KeyfileSecretName() string     { return "" }
+
+func (m *mockShardedSourceForEnvoy) KeyfileSecretName() string { return "" }
+
 func (m *mockShardedSourceForEnvoy) TLSConfig() *searchcontroller.TLSSourceConfig {
 	return nil
 }
+
 func (m *mockShardedSourceForEnvoy) HostSeeds(_ string) ([]string, error) { return nil, nil }
-func (m *mockShardedSourceForEnvoy) Validate() error                      { return nil }
+
+func (m *mockShardedSourceForEnvoy) Validate() error { return nil }
+
 func (m *mockShardedSourceForEnvoy) ResourceType() mdbv1.ResourceType {
 	return mdbv1.ShardedCluster
 }
@@ -843,8 +850,6 @@ func TestEnvoyFilterChain_PerClusterSNI(t *testing.T) {
 		"per-cluster SNIs must all be distinct; collisions break per-cluster TLS routing")
 }
 
-// --- reconciler constructor with member-cluster client maps ------------------
-
 func TestNewMongoDBSearchEnvoyReconciler_AcceptsMemberClusters(t *testing.T) {
 	central := fake.NewClientBuilder().Build()
 	memberA := fake.NewClientBuilder().Build()
@@ -867,8 +872,6 @@ func TestNewMongoDBSearchEnvoyReconciler_NilMembersMap(t *testing.T) {
 	require.NotNil(t, r)
 	assert.Equal(t, r.kubeClient, r.clientForCluster("any-cluster"), "nil members map must fall back to the central client")
 }
-
-// --- clusterWorkItem.Client population ----------------------------------------
 
 func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 	centralRaw := fake.NewClientBuilder().Build()
@@ -896,8 +899,6 @@ func TestBuildClusterWorkList_ClientPopulation(t *testing.T) {
 	assert.Equal(t, r.clientForCluster("a"), wl[0].Client, "known member must use member client")
 	assert.Nil(t, wl[1].Client, "unregistered member must carry the nil-Client sentinel, not the central client")
 }
-
-// --- per-cluster name helpers + cross-cluster enqueue labels ------------------
 
 func TestLoadBalancerNamesForCluster_IndexBased(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
@@ -972,8 +973,6 @@ func TestEnsureDeployment_OverridePreservesProtectedSearchLabels(t *testing.T) {
 	assert.Equal(t, labelName, dep.Labels[khandler.MongoDBSearchComponentLabel])
 }
 
-// --- envoy replicas defaulting ------------------------------------------
-
 func TestEnvoyReplicas_DefaultsTo1(t *testing.T) {
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
 	assert.Equal(t, int32(1), envoyReplicas(search.GetManagedLBForCluster("")))
@@ -1029,27 +1028,6 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
-func TestEnsureConfigMap_SingleCluster_WritesToCentralWithOwnerRef(t *testing.T) {
-	scheme := envoyTestScheme(t)
-	central := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
-
-	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
-	}
-	// Single-cluster uses index 0.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "", 0, r.kubeClient, zap.S()))
-
-	cm := &corev1.ConfigMap{}
-	require.NoError(t, central.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
-
-	// Owner ref present in single-cluster path (central cluster).
-	require.Len(t, cm.OwnerReferences, 1)
-	assert.Equal(t, "mdb-search", cm.OwnerReferences[0].Name)
-}
-
 func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 	scheme := envoyTestScheme(t)
 	central := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1070,8 +1048,6 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 	// Cross-cluster: no owner ref (k8s GC does not span clusters).
 	assert.Empty(t, cm.OwnerReferences)
 }
-
-// --- reconcile loop + per-cluster status --------------------------------------
 
 func TestBuildClusterWorkList_SingleClusterDegenerate(t *testing.T) {
 	r := newMongoDBSearchEnvoyReconciler(fake.NewClientBuilder().Build(), "envoy:latest", nil, "")
@@ -1162,6 +1138,40 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 	assert.Contains(t, patched.Status.LoadBalancer.Message, "missing-cluster")
 }
 
+func TestReconcile_RegistersSearchStateConfigMapWatch(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+					HostAndPorts: []string{"mongo-0:27017"},
+				},
+			},
+			Clusters: []searchv1.ClusterSpec{{
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "lb.example.com"},
+				},
+			}},
+		},
+	}
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	stateCMKey := watch.Object{
+		ResourceType: watch.ConfigMap,
+		Resource: types.NamespacedName{
+			Name:      searchcontroller.SearchStateCMName(search),
+			Namespace: search.Namespace,
+		},
+	}
+	assert.Contains(t, r.watch.GetWatchedResources()[stateCMKey], search.NamespacedName())
+}
+
 func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 	scheme := envoyTestScheme(t)
 	central := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1246,8 +1256,6 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 		}})
 	}
 }
-
-// --- end-to-end Reconcile + status aggregation -------------------------------
 
 // TestReconcile_WorstOfPhase_Aggregated exercises the full Reconcile path:
 // two clusters in spec.clusters[]; one is a member registered with the operator
@@ -1356,8 +1364,6 @@ func TestReconcile_AllClustersFailed_TopLevelPhaseIsFailed(t *testing.T) {
 		"all-Failed clusters must aggregate to top-level Failed, not Pending")
 }
 
-// --- index-based naming reconcile loop tests ----------------------------------
-
 // TestReconcile_NoStateCM_RendersFromPins asserts that the Envoy controller
 // resolves per-cluster indices from spec.clusters[].clusterIndex alone: with no
 // <name>-search-state ConfigMap present, a fully-registered MC spec still renders
@@ -1409,6 +1415,28 @@ func TestReconcile_NoStateCM_RendersFromPins(t *testing.T) {
 	require.NoError(t, memberB.Get(ctx,
 		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}, &appsv1.Deployment{}),
 		"cluster-b Deployment must render at pinned index 1 without a state CM")
+
+	t.Run("reconciliation disabled: manual LB ConfigMap edits survive", func(t *testing.T) {
+		cmKey := types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, memberA.Get(ctx, cmKey, cm))
+		cm.Data["cds.json"] = "manually-patched"
+		require.NoError(t, memberA.Update(ctx, cm))
+
+		paused := &searchv1.MongoDBSearch{}
+		require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, paused))
+		paused.Annotations = map[string]string{searchv1.DisableReconciliationAnnotation: "true"}
+		require.NoError(t, central.Update(ctx, paused))
+
+		_, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, memberA.Get(ctx, cmKey, cm))
+		assert.Equal(t, "manually-patched", cm.Data["cds.json"],
+			"a paused CR's LB ConfigMap must not be rewritten by the reconciler")
+	})
 }
 
 // TestReconcile_UsesPinnedIndices asserts that Envoy resources are named with
@@ -1598,52 +1626,6 @@ func TestDeleteEnvoyResources_MCFanOut(t *testing.T) {
 		types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: "ns"}, &appsv1.Deployment{})))
 	assert.True(t, apierrors.IsNotFound(memberB.Get(ctx,
 		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: "ns"}, &corev1.ConfigMap{})))
-}
-
-func TestDeleteEnvoyResources_SkipsUnregisteredCluster(t *testing.T) {
-	ctx := context.Background()
-	scheme := envoyTestScheme(t)
-	central := fake.NewClientBuilder().WithScheme(scheme).Build()
-	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA}, "")
-	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
-
-	lbObjects := func(idx int) (*appsv1.Deployment, *corev1.ConfigMap) {
-		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-				Name: search.LoadBalancerDeploymentNameForCluster(idx), Namespace: "ns",
-			}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
-				Name: search.LoadBalancerConfigMapNameForCluster(idx), Namespace: "ns",
-			}}
-	}
-
-	// Pre-seed LB resources for the unregistered (nil-Client) cluster on the CENTRAL
-	// client at the same index the work item carries, plus resources for a registered
-	// cluster on its member client.
-	unregDep, unregCM := lbObjects(0)
-	require.NoError(t, central.Create(ctx, unregDep))
-	require.NoError(t, central.Create(ctx, unregCM))
-	regDep, regCM := lbObjects(1)
-	require.NoError(t, memberA.Create(ctx, regDep))
-	require.NoError(t, memberA.Create(ctx, regCM))
-
-	r.deleteEnvoyResources(ctx, search, []clusterWorkItem{
-		// nil Client (cluster not registered): must be skipped, central resources untouched.
-		{ClusterName: "unregistered", ClusterIndex: 0, Client: nil},
-		// registered cluster: its resources must be deleted, proving the loop still runs.
-		{ClusterName: "a", ClusterIndex: 1, Client: r.clientForCluster("a")},
-	}, zap.S())
-
-	// The nil-Client item must not delete anything from the central client.
-	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregDep), &appsv1.Deployment{}),
-		"nil-Client item must not delete the central Deployment")
-	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregCM), &corev1.ConfigMap{}),
-		"nil-Client item must not delete the central ConfigMap")
-
-	// The registered item's resources are gone.
-	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regDep), &appsv1.Deployment{})))
-	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regCM), &corev1.ConfigMap{})))
 }
 
 // failingWriteClient wraps a client.Client and rejects every write so we can
@@ -2018,38 +2000,6 @@ func TestEnvoyReconcile_OperatorPerCluster_MissingClusterIndex_Invalid(t *testin
 		"message must come from ValidateOperatorPerClusterIndices")
 }
 
-func TestEnvoyReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
-	enableSearchMCReconcile(t)
-	ctx := context.Background()
-	scheme := envoyTestScheme(t)
-
-	// Both entries pinned so the no-op is attributable to LocalizeToCluster, not validation.
-	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 1)
-	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
-
-	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-c")
-
-	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
-	require.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
-
-	// No Envoy Deployment / ConfigMap at any index on the central client.
-	for _, i := range []int{0, 1, 2} {
-		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
-			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(i), Namespace: "ns"}, &appsv1.Deployment{})),
-			"Envoy Deployment at index %d must not exist", i)
-		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
-			types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(i), Namespace: "ns"}, &corev1.ConfigMap{})),
-			"Envoy ConfigMap at index %d must not exist", i)
-	}
-
-	// LB status untouched: the no-op returns before any status patch.
-	patched := &searchv1.MongoDBSearch{}
-	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
-	assert.Nil(t, patched.Status.LoadBalancer, "no-match reconcile must not write loadBalancer status")
-}
-
 func TestEnvoyReconcile_UnregisteredCluster_PendingAndNoCentralWrites(t *testing.T) {
 	enableSearchMCReconcile(t)
 	ctx := context.Background()
@@ -2268,4 +2218,103 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 		"restartedAt must survive re-apply so the rollout is not reverted")
 	assert.Equal(t, originalHash, dep.Spec.Template.Annotations[envoyConfigHashAnnotation],
 		"operator-owned config-hash annotation must remain present and authoritative")
+}
+
+func TestEnsureConfigMap_SingleCluster_WritesToCentralWithOwnerRef(t *testing.T) {
+	scheme := envoyTestScheme(t)
+	central := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+	}
+	// Single-cluster uses index 0.
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "", 0, r.kubeClient, zap.S()))
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, central.Get(context.Background(),
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
+
+	// Owner ref present in single-cluster path (central cluster).
+	require.Len(t, cm.OwnerReferences, 1)
+	assert.Equal(t, "mdb-search", cm.OwnerReferences[0].Name)
+}
+
+func TestDeleteEnvoyResources_SkipsUnregisteredCluster(t *testing.T) {
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+	central := fake.NewClientBuilder().WithScheme(scheme).Build()
+	memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{"a": memberA}, "")
+	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
+
+	lbObjects := func(idx int) (*appsv1.Deployment, *corev1.ConfigMap) {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerDeploymentNameForCluster(idx), Namespace: "ns",
+			}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: search.LoadBalancerConfigMapNameForCluster(idx), Namespace: "ns",
+			}}
+	}
+
+	// Pre-seed LB resources for the unregistered (nil-Client) cluster on the CENTRAL
+	// client at the same index the work item carries, plus resources for a registered
+	// cluster on its member client.
+	unregDep, unregCM := lbObjects(0)
+	require.NoError(t, central.Create(ctx, unregDep))
+	require.NoError(t, central.Create(ctx, unregCM))
+	regDep, regCM := lbObjects(1)
+	require.NoError(t, memberA.Create(ctx, regDep))
+	require.NoError(t, memberA.Create(ctx, regCM))
+
+	r.deleteEnvoyResources(ctx, search, []clusterWorkItem{
+		// nil Client (cluster not registered): must be skipped, central resources untouched.
+		{ClusterName: "unregistered", ClusterIndex: 0, Client: nil},
+		// registered cluster: its resources must be deleted, proving the loop still runs.
+		{ClusterName: "a", ClusterIndex: 1, Client: r.clientForCluster("a")},
+	}, zap.S())
+
+	// The nil-Client item must not delete anything from the central client.
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregDep), &appsv1.Deployment{}),
+		"nil-Client item must not delete the central Deployment")
+	require.NoError(t, central.Get(ctx, client.ObjectKeyFromObject(unregCM), &corev1.ConfigMap{}),
+		"nil-Client item must not delete the central ConfigMap")
+
+	// The registered item's resources are gone.
+	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regDep), &appsv1.Deployment{})))
+	assert.True(t, apierrors.IsNotFound(memberA.Get(ctx, client.ObjectKeyFromObject(regCM), &corev1.ConfigMap{})))
+}
+
+func TestEnvoyReconcile_OperatorPerCluster_NoMatchSilentNoOp(t *testing.T) {
+	enableSearchMCReconcile(t)
+	ctx := context.Background()
+	scheme := envoyTestScheme(t)
+
+	// Both entries pinned so the no-op is attributable to LocalizeToCluster, not validation.
+	search := newOperatorPerClusterEnvoySearch("mdb-search", "ns", 1)
+	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+
+	// operatorClusterName="cluster-c" — NOT in spec.clusters[].
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-c")
+
+	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res, "no-match reconcile must return zero Result with no error")
+
+	// No Envoy Deployment / ConfigMap at any index on the central client.
+	for _, i := range []int{0, 1, 2} {
+		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(i), Namespace: "ns"}, &appsv1.Deployment{})),
+			"Envoy Deployment at index %d must not exist", i)
+		assert.True(t, apierrors.IsNotFound(central.Get(ctx,
+			types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(i), Namespace: "ns"}, &corev1.ConfigMap{})),
+			"Envoy ConfigMap at index %d must not exist", i)
+	}
+
+	// LB status untouched: the no-op returns before any status patch.
+	patched := &searchv1.MongoDBSearch{}
+	require.NoError(t, central.Get(ctx, types.NamespacedName{Name: "mdb-search", Namespace: "ns"}, patched))
+	assert.Nil(t, patched.Status.LoadBalancer, "no-match reconcile must not write loadBalancer status")
 }

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -961,7 +961,7 @@ func TestEnsureDeployment_OverridePreservesProtectedSearchLabels(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, r.ensureDeployment(t.Context(), search, `{"x":1}`, "member-a", 2, managedLB, r.kubeClient, nil, zap.S()))
+	require.NoError(t, r.ensureDeployment(t.Context(), search, `{"x":1}`, r.clusterWorkItem(search, "member-a", 2), managedLB, nil, zap.S()))
 
 	dep := &appsv1.Deployment{}
 	require.NoError(t, kubeClient.Get(t.Context(), types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(2), Namespace: search.Namespace}, dep))
@@ -1005,7 +1005,7 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
 	// cluster "a" is at index 0 in the mapping.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "a", 0, r.clientForCluster("a"), zap.S()))
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, r.clusterWorkItem(search, "a", 0), zap.S()))
 
 	// Member A has the ConfigMap named with index 0.
 	cmA := &corev1.ConfigMap{}
@@ -1028,6 +1028,36 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
+func TestEnsureConfigMap_SingleCluster_AdoptsOwnerRef(t *testing.T) {
+	scheme := envoyTestScheme(t)
+	central := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+	}
+	require.NoError(t, central.Create(t.Context(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.LoadBalancerConfigMapNameForCluster(0),
+		Namespace: search.Namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: "mongodb.com/v1",
+			Kind:       "MongoDBSearch",
+			Name:       search.Name,
+			UID:        "old-search-uid",
+		}},
+	}}))
+	// Single-cluster uses index 0.
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, r.clusterWorkItem(search, "", 0), zap.S()))
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, central.Get(context.Background(),
+		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
+
+	require.Len(t, cm.OwnerReferences, 1)
+	assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+}
+
 func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 	scheme := envoyTestScheme(t)
 	central := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1039,7 +1069,7 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
 	}
 	// cluster "a" is at index 0.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "a", 0, r.clientForCluster("a"), zap.S()))
+	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, r.clusterWorkItem(search, "a", 0), zap.S()))
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),
@@ -1207,6 +1237,75 @@ func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
+func TestReconcileForCluster_SingleCluster_ResourcesRouteToSearch(t *testing.T) {
+	scheme := envoyTestScheme(t)
+	central := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
+		},
+	}
+
+	st := r.reconcileForCluster(
+		context.Background(),
+		search,
+		nil,
+		false,
+		nil,
+		clusterWorkItem{ClusterName: "", ClusterIndex: 0, Client: r.kubeClient},
+		nil,
+		zap.S(),
+	)
+	require.True(t, st.IsOK())
+
+	objects := []client.Object{
+		&appsv1.Deployment{},
+		&corev1.ConfigMap{},
+	}
+	keys := []types.NamespacedName{
+		{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: search.Namespace},
+		{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: search.Namespace},
+	}
+	for i := range objects {
+		require.NoError(t, central.Get(context.Background(), keys[i], objects[i]))
+		assert.Equal(t, reconcile.Request{NamespacedName: search.NamespacedName()}, khandler.MapMemberClusterObjectToSearch(objects[i]))
+	}
+}
+
+func TestEnsureDeployment_SingleCluster_AdoptsOwnerRef(t *testing.T) {
+	scheme := envoyTestScheme(t)
+	central := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+	search := &searchv1.MongoDBSearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
+		Spec: searchv1.MongoDBSearchSpec{
+			Clusters: []searchv1.ClusterSpec{{LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}}},
+		},
+	}
+	require.NoError(t, central.Create(t.Context(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.LoadBalancerDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: "mongodb.com/v1",
+			Kind:       "MongoDBSearch",
+			Name:       search.Name,
+			UID:        "old-search-uid",
+		}},
+	}}))
+
+	require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, r.clusterWorkItem(search, "", 0), search.GetManagedLBForCluster(""), nil, zap.S()))
+
+	dep := &appsv1.Deployment{}
+	require.NoError(t, central.Get(context.Background(), types.NamespacedName{
+		Name:      search.LoadBalancerDeploymentNameForCluster(0),
+		Namespace: search.Namespace,
+	}, dep))
+	require.Len(t, dep.OwnerReferences, 1)
+	assert.Equal(t, search.UID, dep.OwnerReferences[0].UID)
+}
+
 func TestEnsureDeployment_Replicas(t *testing.T) {
 	scheme := envoyTestScheme(t)
 	central := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1242,13 +1341,14 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 	} {
 		search.Spec.Clusters[0].LoadBalancer.Managed.Replicas = tc.lbReplicas
 		// cluster "a" is at index 0.
-		require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, "a", 0, search.GetManagedLBForCluster("a"), r.clientForCluster("a"), nil, zap.S()))
+		require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, r.clusterWorkItem(search, "a", 0), search.GetManagedLBForCluster("a"), nil, zap.S()))
 
 		dep := &appsv1.Deployment{}
 		require.NoError(t, memberA.Get(context.Background(),
 			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, dep))
 		require.NotNil(t, dep.Spec.Replicas)
 		assert.Equal(t, tc.expectedDeplReplicas, *dep.Spec.Replicas, "envoy replicas must be set to the same value configured in search resource")
+		assert.Empty(t, dep.OwnerReferences)
 
 		memberA.Delete(context.Background(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 			Name:      dep.Name,
@@ -1685,6 +1785,7 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 			},
 			Clusters: []searchv1.ClusterSpec{{
 				Name:         "cluster-a",
+				Index:        ptr.To(int32(0)),
 				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com", RouterHostname: "mongot-router.example.com"}},
 			}},
 		},
@@ -1694,7 +1795,7 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 	// sh-0 switched routing-ready; sh-1 never ready → fallback.
 	seedSearchStateCM(t, ctx, central, "mdb-search", "ns", []string{"sh-0"})
 
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-a")
 	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
 	require.NoError(t, err)
 
@@ -1885,7 +1986,7 @@ func TestEnvoyReconcile_LBCleanup_DeletesAtPinnedIndex(t *testing.T) {
 	scheme := envoyTestScheme(t)
 
 	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid", Generation: 1},
 		Spec: searchv1.MongoDBSearchSpec{
 			Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
 			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(3))}},
@@ -1895,10 +1996,14 @@ func TestEnvoyReconcile_LBCleanup_DeletesAtPinnedIndex(t *testing.T) {
 	}
 	central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 	// Pre-seed the Envoy resources at the pinned index 3.
-	require.NoError(t, central.Create(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(3), Namespace: "ns"}}))
-	require.NoError(t, central.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(3), Namespace: "ns"}}))
+	require.NoError(t, central.Create(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: search.LoadBalancerDeploymentNameForCluster(3), Namespace: "ns", Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+	}}))
+	require.NoError(t, central.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: search.LoadBalancerConfigMapNameForCluster(3), Namespace: "ns", Labels: envoyLabelsForCluster(search, "cluster-a", 3),
+	}}))
 
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
+	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "cluster-a")
 
 	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "mdb-search", Namespace: "ns"}})
 	require.NoError(t, err)
@@ -2199,7 +2304,7 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 	depName := types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}
 
 	// First apply: operator creates the Deployment with its config-hash annotation.
-	require.NoError(t, r.ensureDeployment(ctx, search, `{"bootstrap":1}`, "", 0, managedLB, r.clientForCluster(""), nil, zap.S()))
+	require.NoError(t, r.ensureDeployment(ctx, search, `{"bootstrap":1}`, r.clusterWorkItem(search, "", 0), managedLB, nil, zap.S()))
 
 	dep := &appsv1.Deployment{}
 	require.NoError(t, central.Get(ctx, depName, dep))
@@ -2211,34 +2316,13 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 	require.NoError(t, central.Update(ctx, dep))
 
 	// Re-apply (as any reconcile triggered during the rollout would).
-	require.NoError(t, r.ensureDeployment(ctx, search, `{"bootstrap":1}`, "", 0, managedLB, r.clientForCluster(""), nil, zap.S()))
+	require.NoError(t, r.ensureDeployment(ctx, search, `{"bootstrap":1}`, r.clusterWorkItem(search, "", 0), managedLB, nil, zap.S()))
 
 	require.NoError(t, central.Get(ctx, depName, dep))
 	assert.Equal(t, "2026-07-14T13:53:28Z", dep.Spec.Template.Annotations[restartedAtKey],
 		"restartedAt must survive re-apply so the rollout is not reverted")
 	assert.Equal(t, originalHash, dep.Spec.Template.Annotations[envoyConfigHashAnnotation],
 		"operator-owned config-hash annotation must remain present and authoritative")
-}
-
-func TestEnsureConfigMap_SingleCluster_WritesToCentralWithOwnerRef(t *testing.T) {
-	scheme := envoyTestScheme(t)
-	central := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", nil, "")
-
-	search := &searchv1.MongoDBSearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
-	}
-	// Single-cluster uses index 0.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, "", 0, r.kubeClient, zap.S()))
-
-	cm := &corev1.ConfigMap{}
-	require.NoError(t, central.Get(context.Background(),
-		types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(0), Namespace: "ns"}, cm))
-
-	// Owner ref present in single-cluster path (central cluster).
-	require.Len(t, cm.OwnerReferences, 1)
-	assert.Equal(t, "mdb-search", cm.OwnerReferences[0].Name)
 }
 
 func TestDeleteEnvoyResources_SkipsUnregisteredCluster(t *testing.T) {

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -778,7 +778,7 @@ func blockScalingBothWays(desiredReplicasScalers []interfaces.MultiClusterReplic
 func (r *ShardedClusterReconcileHelper) initializeStateStore(ctx context.Context, reconciler *ReconcileCommonController, sc *mdbv1.MongoDB, log *zap.SugaredLogger) error {
 	r.deploymentState = NewShardedClusterDeploymentState()
 
-	r.stateStore = NewStateStore[ShardedClusterDeploymentState](sc, kube.BaseOwnerReference(sc), reconciler.client)
+	r.stateStore = NewStateStore[ShardedClusterDeploymentState](sc, kube.BaseOwnerReference(sc), reconciler.client, "")
 	if state, err := r.stateStore.ReadState(ctx); err != nil {
 		if errors.IsNotFound(err) {
 			// If the deployment state config map is missing, then it might be either:

--- a/controllers/operator/state_store.go
+++ b/controllers/operator/state_store.go
@@ -19,7 +19,10 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/configmap"
 )
 
-const stateKey = "state"
+const (
+	stateKey         = "state"
+	stateOwnerUIDKey = "ownerUID"
+)
 
 // StateStore is a wrapper for a custom, per-resource deployment state required for the operator to reconciler the resource correctly.
 // It handles serialization/deserialization of any deployment state structure of type S.
@@ -29,9 +32,11 @@ type StateStore[S any] struct {
 	resourceName    string
 	ownerLabels     map[string]string
 	ownerReferences []metav1.OwnerReference
+	ownerUID        string
 	client          kubernetesClient.Client
 
-	data map[string]string
+	data                map[string]string
+	readOwnerReferences []metav1.OwnerReference
 }
 
 // NewStateStore constructs a new instance of the StateStore.
@@ -39,12 +44,13 @@ type StateStore[S any] struct {
 // designed to be thread safe.
 // - owner provides the namespace, name, and labels for the config map
 // - ownerReferences are set on the config map to enable garbage collection when the owner is deleted
-func NewStateStore[S any](owner v1.ResourceOwner, ownerReferences []metav1.OwnerReference, client kubernetesClient.Client) *StateStore[S] {
+func NewStateStore[S any](owner v1.ResourceOwner, ownerReferences []metav1.OwnerReference, client kubernetesClient.Client, ownerUID string) *StateStore[S] {
 	return &StateStore[S]{
 		namespace:       owner.GetNamespace(),
 		resourceName:    owner.GetName(),
 		ownerLabels:     owner.GetOwnerLabels(),
 		ownerReferences: ownerReferences,
+		ownerUID:        ownerUID,
 		client:          client,
 		data:            map[string]string{},
 	}
@@ -57,10 +63,18 @@ func (s *StateStore[S]) read(ctx context.Context) error {
 	}
 
 	s.data = cm.Data
+	s.readOwnerReferences = append([]metav1.OwnerReference(nil), cm.OwnerReferences...)
 	return nil
 }
 
 func (s *StateStore[S]) write(ctx context.Context, log *zap.SugaredLogger) error {
+	if s.data == nil {
+		s.data = map[string]string{}
+	}
+	if s.ownerUID != "" {
+		s.data[stateOwnerUIDKey] = s.ownerUID
+	}
+
 	dataCM := configmap.Builder().
 		SetName(s.getStateConfigMapName()).
 		SetLabels(s.ownerLabels).
@@ -91,6 +105,9 @@ func (s *StateStore[S]) ReadState(ctx context.Context) (*S, error) {
 	if err := s.read(ctx); err != nil {
 		return nil, err
 	}
+	if s.isStaleOwnerUID() {
+		return nil, errors.NewNotFound(schema.GroupResource{}, s.getStateConfigMapName())
+	}
 
 	// Deserialize the state
 	if ok, err := s.getDataValue(stateKey, state); err != nil {
@@ -101,6 +118,32 @@ func (s *StateStore[S]) ReadState(ctx context.Context) (*S, error) {
 	} else {
 		return state, nil
 	}
+}
+
+func (s *StateStore[S]) isStaleOwnerUID() bool {
+	if s.ownerUID == "" {
+		return false
+	}
+	recordedUID, ok := s.data[stateOwnerUIDKey]
+	if ok {
+		return recordedUID != s.ownerUID
+	}
+	for _, expected := range s.ownerReferences {
+		if expected.Controller == nil || !*expected.Controller || string(expected.UID) != s.ownerUID {
+			continue
+		}
+		for _, actual := range s.readOwnerReferences {
+			// Released 1.9.x state can have blank GVK fields after typed reads; any populated field must still match.
+			if actual.Controller != nil && *actual.Controller &&
+				(actual.APIVersion == "" || actual.APIVersion == expected.APIVersion) &&
+				(actual.Kind == "" || actual.Kind == expected.Kind) &&
+				actual.Name == expected.Name &&
+				actual.UID == expected.UID {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (s *StateStore[S]) getDataValue(key string, obj any) (bool, error) {

--- a/controllers/operator/state_store.go
+++ b/controllers/operator/state_store.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,8 +58,12 @@ func NewStateStore[S any](owner v1.ResourceOwner, ownerReferences []metav1.Owner
 }
 
 func (s *StateStore[S]) read(ctx context.Context) error {
+	return s.readWithReader(ctx, s.client)
+}
+
+func (s *StateStore[S]) readWithReader(ctx context.Context, reader client.Reader) error {
 	cm := corev1.ConfigMap{}
-	if err := s.client.Get(ctx, kube.ObjectKey(s.namespace, s.getStateConfigMapName()), &cm); err != nil {
+	if err := reader.Get(ctx, kube.ObjectKey(s.namespace, s.getStateConfigMapName()), &cm); err != nil {
 		return err
 	}
 
@@ -99,10 +104,14 @@ func (s *StateStore[S]) WriteState(ctx context.Context, state *S, log *zap.Sugar
 }
 
 func (s *StateStore[S]) ReadState(ctx context.Context) (*S, error) {
+	return s.ReadStateWithReader(ctx, s.client)
+}
+
+func (s *StateStore[S]) ReadStateWithReader(ctx context.Context, reader client.Reader) (*S, error) {
 	state := new(S)
 
 	// If we don't find the state ConfigMap, return an error
-	if err := s.read(ctx); err != nil {
+	if err := s.readWithReader(ctx, reader); err != nil {
 		return nil, err
 	}
 	if s.isStaleOwnerUID() {

--- a/controllers/operator/watch/config_change_handler.go
+++ b/controllers/operator/watch/config_change_handler.go
@@ -44,19 +44,22 @@ func (w Object) String() string {
 type ResourcesHandler struct {
 	ResourceType    Type
 	ResourceWatcher *ResourceWatcher
+	MapFunc         func(context.Context, client.Object) []reconcile.Request
 }
 
 // Note that we implement Create in addition to Update to be able to handle cases when config map or secret is deleted
 // and then created again.
 func (c *ResourcesHandler) Create(ctx context.Context, e event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	c.doHandle(e.Object.GetNamespace(), e.Object.GetName(), q)
+	c.doMap(ctx, e.Object, q)
 }
 
 func (c *ResourcesHandler) Update(ctx context.Context, e event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if !shouldHandleUpdate(e) {
-		return
+	if shouldHandleUpdate(e) {
+		c.doHandle(e.ObjectOld.GetNamespace(), e.ObjectOld.GetName(), q)
 	}
-	c.doHandle(e.ObjectOld.GetNamespace(), e.ObjectOld.GetName(), q)
+	c.doMap(ctx, e.ObjectOld, q)
+	c.doMap(ctx, e.ObjectNew, q)
 }
 
 // shouldHandleUpdate return true if the update event must be handled. This shouldn't happen if data for watched
@@ -83,16 +86,26 @@ func (c *ResourcesHandler) doHandle(namespace, name string, q workqueue.TypedRat
 	}
 }
 
-// Seems we don't need to react on config map/secret removal..
-func (c *ResourcesHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	switch e.Object.(type) {
-	case *corev1.ConfigMap:
-		return
-	case *corev1.Secret:
+func (c *ResourcesHandler) doMap(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	if c.MapFunc == nil {
 		return
 	}
+	for _, request := range c.MapFunc(ctx, obj) {
+		q.Add(request)
+	}
+}
 
+func (c *ResourcesHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	switch e.Object.(type) {
+	case *corev1.ConfigMap, *corev1.Secret:
+		// MapFunc is the Search-only opt-in for ConfigMap/Secret delete routing;
+		// legacy handlers must not set it only to map create/update events.
+		if c.MapFunc == nil {
+			return
+		}
+	}
 	c.doHandle(e.Object.GetNamespace(), e.Object.GetName(), q)
+	c.doMap(ctx, e.Object, q)
 }
 
 func (c *ResourcesHandler) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/controllers/operator/watch/config_change_handler_test.go
+++ b/controllers/operator/watch/config_change_handler_test.go
@@ -1,13 +1,21 @@
 package watch
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 )
 
 func TestShouldHandleUpdate(t *testing.T) {
@@ -65,4 +73,108 @@ func TestShouldHandleUpdate(t *testing.T) {
 
 		assert.True(t, shouldHandleUpdate(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj}))
 	})
+}
+
+func TestResourcesHandlerDelete(t *testing.T) {
+	search := types.NamespacedName{Name: "search", Namespace: "ns"}
+	labeled := map[string]string{
+		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+	}
+	tests := []struct {
+		name      string
+		obj       client.Object
+		resource  Type
+		tracked   bool
+		mapFunc   func(context.Context, client.Object) []reconcile.Request
+		wantQueue int
+	}{
+		{
+			name:      "legacy ConfigMap handler ignores delete",
+			obj:       &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "state-cm", Namespace: "ns"}},
+			resource:  ConfigMap,
+			tracked:   true,
+			wantQueue: 0,
+		},
+		{
+			name:      "legacy Secret handler ignores delete",
+			obj:       &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-op", Namespace: "ns"}},
+			resource:  Secret,
+			tracked:   true,
+			wantQueue: 0,
+		},
+		{
+			name:      "tracked MongoDB delete routes without map function",
+			obj:       &mdbv1.MongoDB{ObjectMeta: metav1.ObjectMeta{Name: "mdb", Namespace: "ns"}},
+			resource:  MongoDB,
+			tracked:   true,
+			wantQueue: 1,
+		},
+		{
+			name:      "Search handler routes tracked ConfigMap delete",
+			obj:       &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "state-cm", Namespace: "ns"}},
+			resource:  ConfigMap,
+			tracked:   true,
+			mapFunc:   khandler.EnqueueMemberClusterObjectToSearch,
+			wantQueue: 1,
+		},
+		{
+			name: "Search handler maps labeled Secret delete",
+			obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "tls-op", Namespace: "ns", Labels: labeled,
+			}},
+			resource:  Secret,
+			mapFunc:   khandler.EnqueueMemberClusterObjectToSearch,
+			wantQueue: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			watcher := NewResourceWatcher()
+			if tc.tracked {
+				watcher.AddWatchedResourceIfNotAdded(tc.obj.GetName(), tc.obj.GetNamespace(), tc.resource, search)
+			}
+			h := &ResourcesHandler{ResourceType: tc.resource, ResourceWatcher: watcher, MapFunc: tc.mapFunc}
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			defer q.ShutDown()
+
+			h.Delete(t.Context(), event.TypedDeleteEvent[client.Object]{Object: tc.obj}, q)
+
+			assert.Equal(t, tc.wantQueue, q.Len())
+			if tc.wantQueue > 0 {
+				req, shutdown := q.Get()
+				assert.False(t, shutdown)
+				assert.Equal(t, search, req.NamespacedName)
+				q.Done(req)
+			}
+		})
+	}
+}
+
+func TestResourcesHandlerUpdateRoutesRemovedLabels(t *testing.T) {
+	search := types.NamespacedName{Name: "search", Namespace: "ns"}
+	labeled := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      "owned",
+		Namespace: "ns",
+		Labels: map[string]string{
+			khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+			khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+		},
+	}}
+	plain := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owned", Namespace: "ns"}}
+	q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer q.ShutDown()
+	h := &ResourcesHandler{
+		ResourceType:    ConfigMap,
+		ResourceWatcher: NewResourceWatcher(),
+		MapFunc:         khandler.EnqueueMemberClusterObjectToSearch,
+	}
+
+	h.Update(t.Context(), event.TypedUpdateEvent[client.Object]{ObjectOld: labeled, ObjectNew: plain}, q)
+
+	assert.Equal(t, 1, q.Len())
+	req, shutdown := q.Get()
+	assert.False(t, shutdown)
+	assert.Equal(t, search, req.NamespacedName)
+	q.Done(req)
 }

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -126,14 +126,7 @@ func NewMongoDBSearchReconcileHelper(
 // don't cross cluster boundaries; labels are the only path back from a member
 // resource to its central CR (for watch routing and label-based GC).
 func searchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) map[string]string {
-	labels := map[string]string{
-		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
-		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
-	}
-	if clusterName != "" {
-		labels[khandler.MongoDBSearchClusterNameLabel] = clusterName
-	}
-	return labels
+	return khandler.MongoDBSearchManagedLabels(search, "", "", clusterName)
 }
 
 // withSearchOwnerLabels merges the search-owner labels into the STS ObjectMeta
@@ -141,12 +134,9 @@ func searchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) map[s
 // existing STS); the pod-routing labels stay in the unit's podLabels.
 func withSearchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) statefulset.Modification {
 	return func(set *appsv1.StatefulSet) {
-		if set.Labels == nil {
-			set.Labels = map[string]string{}
-		}
-		for k, v := range searchOwnerLabels(search, clusterName) {
-			set.Labels[k] = v
-		}
+		protected := searchOwnerLabels(search, clusterName)
+		protected[khandler.MongoDBSearchComponentLabel] = mongotComponent
+		set.Labels = khandler.ReapplyProtectedSearchLabels(set.Labels, protected)
 	}
 }
 
@@ -668,22 +658,26 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		}
 	}
 
+	tlsSecretLabels := searchOwnerLabels(r.mdbSearch, unit.clusterName)
+	ingressTLSSecretLabels := maps.Clone(tlsSecretLabels)
+	ingressTLSSecretLabels[componentLabelKey] = mongotComponent
+
 	// Per-unit ingress TLS: each shard may have its own secret, so this cannot
 	// be hoisted out of the loop.
-	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource)
+	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource, ingressTLSSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit egress TLS (SCRAM CA + optional client cert): uses unitClient so the
 	// operator-managed secret is created on the cluster where mongot pods run.
-	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient)
+	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient, tlsSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit x509 client cert: uses unitClient for the same reason as egress TLS.
-	x509MongotModification, x509StsModification, err := r.ensureX509ClientCertConfig(ctx, unitClient)
+	x509MongotModification, x509StsModification, err := r.ensureX509ClientCertConfig(ctx, unitClient, tlsSecretLabels)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -730,7 +724,6 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		unitClient,
 		unit.stsName,
 		stsFunc,
-		withSearchOwnerLabels(r.mdbSearch, unit.clusterName),
 		mods.passwordAuthSts,
 		configHashModification,
 		mods.keyfileSts,
@@ -738,7 +731,8 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		egressTlsStsModification,
 		x509StsModification,
 		mods.embeddingConfigSts,
-		stsOverride, // must be last: see StatefulSetOverrideModification
+		stsOverride,
+		withSearchOwnerLabels(r.mdbSearch, unit.clusterName),
 	)
 	if err != nil {
 		return nil, nil, err
@@ -1029,7 +1023,10 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 		expected map[string]bool
 		kind     string
 	}{
-		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels(searchOwnerLabels(r.mdbSearch, "")), expectedSTS, "StatefulSet"},
+		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels{
+			khandler.MongoDBSearchOwnerNameLabel:      r.mdbSearch.Name,
+			khandler.MongoDBSearchOwnerNamespaceLabel: r.mdbSearch.Namespace,
+		}, expectedSTS, "StatefulSet"},
 		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: proxyServiceComponent}, expectedProxy, "proxy Service"},
 		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedHeadless, "headless Service"},
 		{func() client.ObjectList { return &corev1.ConfigMapList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedConfig, "ConfigMap"},
@@ -1383,7 +1380,7 @@ func mongotServicePorts(search *searchv1.MongoDBSearch) []corev1.ServicePort {
 const (
 	appLabelKey           = "app"
 	shardLabelKey         = "shard"
-	componentLabelKey     = "component"
+	componentLabelKey     = khandler.MongoDBSearchComponentLabel
 	proxyServiceComponent = "search-proxy"
 	// mongotComponent is the component-label value on the per-shard mongot headless
 	// Service and ConfigMap (the StatefulSet is swept by owner label instead).
@@ -1696,12 +1693,12 @@ func setupMongotContainerArgsForAPIKeys() container.Modification {
 // ensureIngressTlsConfig processes TLS configuration for any mongot deployment.
 // For non-sharded deployments, pass r.mdbSearch as the tlsResource.
 // For sharded deployments, pass a perShardTLSResource adapter.
-func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
 	if r.mdbSearch.Spec.Security.TLS == nil {
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
 
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource)
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource, labels, tlsResource.GetOwnerReferences())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1775,7 +1772,7 @@ func (x *x509AuthResource) TLSOperatorSecretNamespacedName() types.NamespacedNam
 
 // ensureX509ClientCertConfig processes x509 client certificate configuration for the sync source in case of mongot to mongod communication.
 // When x509 is configured, it replaces username/password auth with x509 certificate auth.
-func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
 	if !r.mdbSearch.IsX509Auth() {
 		return mongot.NOOP(), statefulset.NOOP(), nil
 	}
@@ -1788,7 +1785,7 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 	}
 
 	x509Resource := &x509AuthResource{MongoDBSearch: r.mdbSearch}
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource)
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource, labels, x509Resource.GetOwnerReferences())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1884,7 +1881,7 @@ func (p *perShardTLSResource) TLSOperatorSecretNamespacedName() types.Namespaced
 	return p.TLSOperatorSecretForClusterShard(p.clusterIndex, p.shardName)
 }
 
-func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
 	tlsSourceConfig := r.db.TLSConfig()
 	if tlsSourceConfig == nil {
 		return mongot.NOOP(), statefulset.NOOP(), nil
@@ -1896,7 +1893,7 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 	scramKeyPasswordSecret := r.mdbSearch.ScramKeyFilePasswordSecret()
 	if r.mdbSearch.HasScramClientCert() {
 		scramCertResource := &scramClientCertResource{MongoDBSearch: r.mdbSearch}
-		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource)
+		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource, labels, scramCertResource.GetOwnerReferences())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -92,10 +93,23 @@ type MongoDBSearchReconcileHelper struct {
 	// memberClusterClients holds per-member-cluster Kubernetes clients keyed by
 	// spec.clusters[i].name. Empty in single-cluster installs.
 	memberClusterClients map[string]kubernetesClient.Client
+	localNamedClusters   bool
+	centralReader        client.Reader
+	memberClusterReaders map[string]client.Reader
 
 	// state is the per-CR persisted state from the search state ConfigMap: the
 	// routing-ready switch. Refreshed after every successful switch write.
 	state *SearchDeploymentState
+}
+
+// WithCleanupReaders configures the direct (uncached) readers used by destructive cleanup.
+func (r *MongoDBSearchReconcileHelper) WithCleanupReaders(
+	centralReader client.Reader,
+	memberClusterReaders map[string]client.Reader,
+) *MongoDBSearchReconcileHelper {
+	r.centralReader = centralReader
+	r.memberClusterReaders = memberClusterReaders
+	return r
 }
 
 // NewMongoDBSearchReconcileHelper constructs a reconcile helper. Pass nil for
@@ -107,6 +121,7 @@ func NewMongoDBSearchReconcileHelper(
 	operatorSearchConfig OperatorSearchConfig,
 	memberClusterClients map[string]kubernetesClient.Client,
 	state *SearchDeploymentState,
+	localNamedClusters bool,
 ) *MongoDBSearchReconcileHelper {
 	if state == nil {
 		state = NewSearchDeploymentState()
@@ -117,6 +132,7 @@ func NewMongoDBSearchReconcileHelper(
 		mdbSearch:            mdbSearch,
 		db:                   db,
 		memberClusterClients: memberClusterClients,
+		localNamedClusters:   localNamedClusters,
 		state:                state,
 	}
 }
@@ -127,6 +143,20 @@ func NewMongoDBSearchReconcileHelper(
 // resource to its central CR (for watch routing and label-based GC).
 func searchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) map[string]string {
 	return khandler.MongoDBSearchManagedLabels(search, "", "", clusterName)
+}
+
+func (r *MongoDBSearchReconcileHelper) ownerReferencesForCluster(clusterName string) []metav1.OwnerReference {
+	if clusterName == "" || r.localNamedClusters {
+		return r.mdbSearch.GetOwnerReferences()
+	}
+	return nil
+}
+
+func (r *MongoDBSearchReconcileHelper) physicalClusterName(clusterName string) string {
+	if clusterName == "" || r.localNamedClusters {
+		return ""
+	}
+	return clusterName
 }
 
 // withSearchOwnerLabels merges the search-owner labels into the STS ObjectMeta
@@ -141,10 +171,10 @@ func withSearchOwnerLabels(search *searchv1.MongoDBSearch, clusterName string) s
 }
 
 // clientForCluster returns the Kubernetes client for a unit's member cluster.
-// Empty clusterName / empty memberClusterClients map fall back to the central
-// client (single-cluster install). Unknown clusterName is an error.
+// Empty clusterName and explicitly local named clusters use the central client.
+// Unknown hub member names are errors.
 func (r *MongoDBSearchReconcileHelper) clientForCluster(clusterName string) (kubernetesClient.Client, error) {
-	if clusterName == "" || len(r.memberClusterClients) == 0 {
+	if clusterName == "" || r.localNamedClusters {
 		return r.client, nil
 	}
 	c, ok := r.memberClusterClients[clusterName]
@@ -170,7 +200,9 @@ type reconcileUnit struct {
 	tlsResource         tls.TLSConfigurableResource
 	mongotConfigFn      mongot.Modification
 	clusterName         string // "" routes to the central client (single-cluster)
+	physicalClusterName string
 	clusterIndex        int
+	ownerReferences     []metav1.OwnerReference
 	shardName           string               // shard name for sharded topologies; "" for RS
 	sizing              searchv1.ClusterSpec // resolved per-(cluster, shard) sizing, see ResolveSizingForClusterShard
 }
@@ -191,6 +223,7 @@ type clusterLevelResource struct {
 	clusterIndex     int
 	svcName          types.NamespacedName
 	fallbackPodLabel string
+	ownerReferences  []metav1.OwnerReference
 }
 
 // reconcilePlan is the full per-reconcile work description: a list of units plus the
@@ -201,7 +234,7 @@ type reconcilePlan struct {
 	clusterLevelResources []clusterLevelResource
 	manageProxySvc        bool                                                      // topology-wide: true when the operator owns the proxy Service lifecycle (i.e. the LB is not user-managed)
 	preflight             func(context.Context, *zap.SugaredLogger) workflow.Status // runs before the loop; must return workflow.OK() to proceed
-	cleanup               func(context.Context, *zap.SugaredLogger)                 // runs after the loop; best-effort, errors logged
+	cleanup               func(context.Context, *zap.SugaredLogger) error           // runs after the loop; nil = no cleanup
 }
 
 // buildReconcilePlan returns the full reconcile plan for the current topology.
@@ -246,17 +279,19 @@ func (r *MongoDBSearchReconcileHelper) buildReplicaSetPlan(rsSource SearchSource
 			featureFlagsMongotMod(r.mdbSearch),
 			replicationReaderTagSetsMod(w.SyncSourceSelector))
 		units = append(units, reconcileUnit{
-			stsName:            stsName,
-			headlessSvc:        headlessSvc,
-			proxySvc:           proxySvc,
-			configMapName:      configMapName,
-			podLabels:          map[string]string{appLabelKey: headlessSvc.Name},
-			extraHeadlessPorts: extraPorts,
-			tlsResource:        r.mdbSearch,
-			mongotConfigFn:     mongotConfigFn,
-			clusterName:        w.ClusterName,
-			clusterIndex:       w.ClusterIndex,
-			sizing:             sizing,
+			stsName:             stsName,
+			headlessSvc:         headlessSvc,
+			proxySvc:            proxySvc,
+			configMapName:       configMapName,
+			podLabels:           map[string]string{appLabelKey: headlessSvc.Name},
+			extraHeadlessPorts:  extraPorts,
+			tlsResource:         r.mdbSearch,
+			mongotConfigFn:      mongotConfigFn,
+			clusterName:         w.ClusterName,
+			physicalClusterName: r.physicalClusterName(w.ClusterName),
+			clusterIndex:        w.ClusterIndex,
+			ownerReferences:     r.ownerReferencesForCluster(w.ClusterName),
+			sizing:              sizing,
 		})
 	}
 
@@ -264,7 +299,6 @@ func (r *MongoDBSearchReconcileHelper) buildReplicaSetPlan(rsSource SearchSource
 		units:          units,
 		manageProxySvc: !r.mdbSearch.IsReplicaSetUnmanagedLB(),
 		preflight:      func(context.Context, *zap.SugaredLogger) workflow.Status { return workflow.OK() },
-		cleanup:        func(context.Context, *zap.SugaredLogger) {},
 	}, nil
 }
 
@@ -386,7 +420,9 @@ func (r *MongoDBSearchReconcileHelper) buildShardedPlan(shardedSource SearchSour
 			tlsResource:         &perShardTLSResource{MongoDBSearch: r.mdbSearch, clusterIndex: w.ClusterIndex, shardName: w.ShardName},
 			mongotConfigFn:      mongotConfigFn,
 			clusterName:         w.ClusterName,
+			physicalClusterName: r.physicalClusterName(w.ClusterName),
 			clusterIndex:        w.ClusterIndex,
+			ownerReferences:     r.ownerReferencesForCluster(w.ClusterName),
 			shardName:           w.ShardName,
 			sizing:              sizing,
 		})
@@ -398,6 +434,7 @@ func (r *MongoDBSearchReconcileHelper) buildShardedPlan(shardedSource SearchSour
 				clusterIndex:     w.ClusterIndex,
 				svcName:          r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex),
 				fallbackPodLabel: r.mdbSearch.MongotStatefulSetForClusterShard(w.ClusterIndex, shardNames[0]).Name,
+				ownerReferences:  r.ownerReferencesForCluster(w.ClusterName),
 			})
 		}
 	}
@@ -409,15 +446,17 @@ func (r *MongoDBSearchReconcileHelper) buildShardedPlan(shardedSource SearchSour
 		preflight: func(ctx context.Context, log *zap.SugaredLogger) workflow.Status {
 			return r.validatePerShardTLSSecrets(ctx, log, shardNames)
 		},
-		cleanup: func(ctx context.Context, log *zap.SugaredLogger) {
-			if err := r.cleanupStaleShardResources(ctx, log, shardNames); err != nil {
-				log.Warnf("Failed to cleanup stale shard resources: %s", err)
+		cleanup: func(ctx context.Context, log *zap.SugaredLogger) error {
+			var cleanupErr error
+			if err := r.cleanupStaleShardResources(ctx, log, units); err != nil {
+				cleanupErr = multierror.Append(cleanupErr, fmt.Errorf("failed to cleanup stale shard resources: %w", err))
 			}
 			if r.mdbSearch.IsLBModeManaged() {
 				if err := r.pruneRoutingReady(ctx, shardNames); err != nil {
-					log.Warnf("Failed to prune routing-ready switch entries: %s", err)
+					cleanupErr = multierror.Append(cleanupErr, fmt.Errorf("failed to prune routing-ready switch entries: %w", err))
 				}
 			}
+			return cleanupErr
 		},
 	}
 	if manageProxySvc {
@@ -486,13 +525,22 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 		return workflow.Failed(err)
 	}
 
-	if status := plan.preflight(ctx, log); !status.IsOK() {
-		return status
+	finishWithCleanup := func(reconcileStatus workflow.Status) workflow.Status {
+		if plan.cleanup == nil {
+			return reconcileStatus
+		}
+		if cleanupErr := plan.cleanup(ctx, log); cleanupErr != nil {
+			return workflow.Failed(fmt.Errorf("%s; cleanup failed: %w", MessageFromStatus(reconcileStatus), cleanupErr))
+		}
+		return reconcileStatus
+	}
+	if preflightStatus := plan.preflight(ctx, log); !preflightStatus.IsOK() {
+		return finishWithCleanup(preflightStatus)
 	}
 
 	keyfileStsModification, st, ok := r.ensureKeyfileModification(ctx, log)
 	if !ok {
-		return st
+		return finishWithCleanup(st)
 	}
 
 	// Topology-agnostic modifications (computed once, applied to every unit).
@@ -507,7 +555,7 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 
 	embeddingConfigMongotModification, embeddingConfigStsModification, err := r.ensureEmbeddingConfig(ctx, log)
 	if err != nil {
-		return workflow.Failed(err)
+		return finishWithCleanup(workflow.Failed(err))
 	}
 
 	usePerPodConfig := r.mdbSearch.HasAutoEmbedding()
@@ -557,7 +605,8 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 		}
 		clusterClient, err := r.clientForCluster(res.clusterName)
 		if err != nil {
-			return workflow.Failed(err)
+			reconcileErrs = multierror.Append(reconcileErrs, err)
+			continue
 		}
 		if err := r.ensureSearchService(ctx, log, clusterClient, res.svcName, buildClusterLevelProxyService(r.mdbSearch, res)); err != nil {
 			log.Warnf("Failed to ensure cluster-level proxy service on cluster %q: %s", res.clusterName, err)
@@ -566,7 +615,11 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 		}
 	}
 
-	plan.cleanup(ctx, log)
+	if plan.cleanup != nil {
+		if err := plan.cleanup(ctx, log); err != nil {
+			reconcileErrs = multierror.Append(reconcileErrs, err)
+		}
+	}
 
 	// Mark routing-ready shards across ALL units before the worst-of readiness
 	// return, so one not-ready unit does not block the routing switch for the others.
@@ -659,25 +712,25 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 	}
 
 	tlsSecretLabels := searchOwnerLabels(r.mdbSearch, unit.clusterName)
+	tlsSecretLabels[componentLabelKey] = mongotComponent
 	ingressTLSSecretLabels := maps.Clone(tlsSecretLabels)
-	ingressTLSSecretLabels[componentLabelKey] = mongotComponent
 
 	// Per-unit ingress TLS: each shard may have its own secret, so this cannot
 	// be hoisted out of the loop.
-	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource, ingressTLSSecretLabels)
+	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource, ingressTLSSecretLabels, unit.ownerReferences)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit egress TLS (SCRAM CA + optional client cert): uses unitClient so the
 	// operator-managed secret is created on the cluster where mongot pods run.
-	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient, tlsSecretLabels)
+	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient, tlsSecretLabels, unit.ownerReferences)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit x509 client cert: uses unitClient for the same reason as egress TLS.
-	x509MongotModification, x509StsModification, err := r.ensureX509ClientCertConfig(ctx, unitClient, tlsSecretLabels)
+	x509MongotModification, x509StsModification, err := r.ensureX509ClientCertConfig(ctx, unitClient, tlsSecretLabels, unit.ownerReferences)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -688,6 +741,7 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		unit.configMapName,
 		unit.stsName.Name,
 		unit.clusterName,
+		unit.ownerReferences,
 		unit.sizing.ReplicasOrDefault(),
 		unit.mongotConfigFn,
 		ingressTlsMongotModification,
@@ -723,6 +777,7 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		log,
 		unitClient,
 		unit.stsName,
+		unit.ownerReferences,
 		stsFunc,
 		mods.passwordAuthSts,
 		configHashModification,
@@ -984,58 +1039,113 @@ func (r *MongoDBSearchReconcileHelper) pruneRoutingReady(ctx context.Context, li
 //
 // It fans out over the central client and every member client; per-kind/per-cluster
 // failures are best-effort — aggregated and retried next reconcile.
-func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Context, log *zap.SugaredLogger, currentShardNames []string) error {
-	if r.mdbSearch.IsShardedUnmanagedLB() {
-		return nil
-	}
-
+func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Context, log *zap.SugaredLogger, units []reconcileUnit) error {
 	// Per-kind expected-name sets. They are kept separate (rather than merged) because
 	// shard names can be customer-provided: a stale shard named e.g. "x-svc" would yield
 	// a StatefulSet name that collides with a live shard "x"'s headless Service name, and
 	// a shared set would then wrongly preserve the stale StatefulSet.
-	expectedProxy := map[string]bool{}
-	expectedHeadless := map[string]bool{}
-	expectedSTS := map[string]bool{}
-	expectedConfig := map[string]bool{}
-	seenClusters := map[int]bool{}
-	for _, w := range r.buildShardedWorkList(currentShardNames) {
-		expectedProxy[r.mdbSearch.ProxyServiceNameForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
-		expectedHeadless[r.mdbSearch.MongotServiceForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
-		expectedSTS[r.mdbSearch.MongotStatefulSetForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
-		expectedConfig[r.mdbSearch.MongotConfigMapForClusterShard(w.ClusterIndex, w.ShardName).Name] = true
-		if !seenClusters[w.ClusterIndex] {
-			seenClusters[w.ClusterIndex] = true
-			expectedProxy[r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex).Name] = true
+	manageProxyServices := !r.mdbSearch.IsShardedUnmanagedLB()
+	type resourceExpectations struct {
+		proxy    map[string]bool
+		headless map[string]bool
+		sts      map[string]bool
+		config   map[string]bool
+		secrets  map[string]bool
+	}
+	// Operator-generated auth Secrets are singletons: expected (preserved) only while
+	// their auth mode is on, swept once the mode is turned off.
+	newExpectations := func() resourceExpectations {
+		secrets := map[string]bool{}
+		if r.mdbSearch.IsX509Auth() {
+			secrets[r.mdbSearch.X509OperatorManagedSecret().Name] = true
+		}
+		if r.mdbSearch.HasScramClientCert() {
+			secrets[r.mdbSearch.ScramClientCertOperatorManagedSecret().Name] = true
+		}
+		return resourceExpectations{
+			proxy:    map[string]bool{},
+			headless: map[string]bool{},
+			sts:      map[string]bool{},
+			config:   map[string]bool{},
+			secrets:  secrets,
 		}
 	}
-
-	clients := map[string]kubernetesClient.Client{"": r.client}
-	for name, c := range r.memberClusterClients {
-		clients[name] = c
+	expectedByCluster := map[string]resourceExpectations{}
+	for _, cluster := range r.mdbSearch.Spec.Clusters {
+		expectedByCluster[r.physicalClusterName(cluster.Name)] = newExpectations()
 	}
+	for _, unit := range units {
+		expected := expectedByCluster[unit.physicalClusterName]
+		if expected.sts == nil {
+			expected = newExpectations()
+		}
+		if manageProxyServices {
+			expected.proxy[unit.proxySvc.Name] = true
+			expected.proxy[r.mdbSearch.ProxyServiceNamespacedNameForCluster(unit.clusterIndex).Name] = true
+		}
+		expected.headless[unit.headlessSvc.Name] = true
+		expected.sts[unit.stsName.Name] = true
+		expected.config[unit.configMapName.Name] = true
+		// Live units' ingress Secret names are always expected, even with TLS disabled:
+		// disabling TLS never reaps generated Secrets while the CR lives (CR delete does).
+		expected.secrets[unit.tlsResource.TLSOperatorSecretNamespacedName().Name] = true
+		expectedByCluster[unit.physicalClusterName] = expected
+	}
+	// Every sweep is scoped to this exact Search identity. Component labels further
+	// distinguish proxy and headless Services; mongot ConfigMaps and per-shard
+	// operator TLS Secrets carry the mongot component.
+	ownerSelector := client.MatchingLabels{
+		khandler.MongoDBSearchOwnerNameLabel:      r.mdbSearch.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: r.mdbSearch.Namespace,
+		khandler.MongoDBSearchOwnerUIDLabel:       string(r.mdbSearch.UID),
+	}
+	mongotSelector := maps.Clone(ownerSelector)
+	mongotSelector[componentLabelKey] = mongotComponent
+	proxySelector := maps.Clone(ownerSelector)
+	proxySelector[componentLabelKey] = proxyServiceComponent
 
-	// The mongot StatefulSet is the only StatefulSet we own, so it's scoped by owner
-	// label; proxy and headless Services share a kind but carry distinct component
-	// labels; the mongot ConfigMap carries the mongot component label.
-	sweeps := []struct {
+	type sweep struct {
 		newList  func() client.ObjectList
 		selector client.MatchingLabels
 		expected map[string]bool
 		kind     string
-	}{
-		{func() client.ObjectList { return &appsv1.StatefulSetList{} }, client.MatchingLabels{
-			khandler.MongoDBSearchOwnerNameLabel:      r.mdbSearch.Name,
-			khandler.MongoDBSearchOwnerNamespaceLabel: r.mdbSearch.Namespace,
-		}, expectedSTS, "StatefulSet"},
-		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: proxyServiceComponent}, expectedProxy, "proxy Service"},
-		{func() client.ObjectList { return &corev1.ServiceList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedHeadless, "headless Service"},
-		{func() client.ObjectList { return &corev1.ConfigMapList{} }, client.MatchingLabels{componentLabelKey: mongotComponent}, expectedConfig, "ConfigMap"},
+		eligible func(context.Context, client.Object) (bool, error)
 	}
-
+	// Secrets: sweep only operator-generated name shapes (per-shard ingress TLS and
+	// operator-managed auth Secrets). Customer-provided Secrets — even ones carrying
+	// copied owner labels — never match and are never touched.
+	operatorSecretName := func(_ context.Context, obj client.Object) (bool, error) {
+		return isIngressTLSOperatorSecretName(r.mdbSearch, obj.GetName()) ||
+			isAuthTLSOperatorSecretName(r.mdbSearch, obj.GetName()), nil
+	}
 	var errs error
-	for clusterName, c := range clients {
+	for clusterName, expected := range expectedByCluster {
+		c := r.clientForPhysicalCluster(clusterName)
+		if c == nil {
+			errs = multierror.Append(errs, fmt.Errorf("no Kubernetes client registered for cleanup on cluster %q", clusterName))
+			continue
+		}
+		reader := r.readerForPhysicalCluster(clusterName)
+		if reader == nil {
+			errs = multierror.Append(errs, fmt.Errorf("no Kubernetes API reader registered for cleanup on cluster %q", clusterName))
+			continue
+		}
+		sweeps := []sweep{
+			{newList: func() client.ObjectList { return &appsv1.StatefulSetList{} }, selector: ownerSelector, expected: expected.sts, kind: "StatefulSet"},
+			{newList: func() client.ObjectList { return &corev1.ServiceList{} }, selector: mongotSelector, expected: expected.headless, kind: "headless Service"},
+			{newList: func() client.ObjectList { return &corev1.ConfigMapList{} }, selector: mongotSelector, expected: expected.config, kind: "ConfigMap"},
+			{newList: func() client.ObjectList { return &corev1.SecretList{} }, selector: mongotSelector, expected: expected.secrets, kind: "Secret", eligible: operatorSecretName},
+		}
+		if manageProxyServices {
+			sweeps = append(sweeps, sweep{
+				newList:  func() client.ObjectList { return &corev1.ServiceList{} },
+				selector: proxySelector,
+				expected: expected.proxy,
+				kind:     "proxy Service",
+			})
+		}
 		for _, s := range sweeps {
-			if err := r.sweepStaleShardResources(ctx, log, c, clusterName, s.newList(), s.selector, s.expected, s.kind); err != nil {
+			if err := r.sweepStaleShardResources(ctx, log, c, reader, clusterName, s.newList(), s.selector, s.expected, s.kind, s.eligible); err != nil {
 				errs = multierror.Append(errs, err)
 			}
 		}
@@ -1043,10 +1153,50 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 	return errs
 }
 
+func isIngressTLSOperatorSecretName(search *searchv1.MongoDBSearch, name string) bool {
+	if name == search.TLSOperatorSecretNamespacedName().Name {
+		return true
+	}
+	prefix := search.Name + "-search-"
+	const suffix = "-certificate-key"
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	clusterIndex, shardName, found := strings.Cut(strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix), "-")
+	index, err := strconv.Atoi(clusterIndex)
+	return found && err == nil && index >= 0 && shardName != "" &&
+		name == search.TLSOperatorSecretForClusterShard(index, shardName).Name
+}
+
+func isAuthTLSOperatorSecretName(search *searchv1.MongoDBSearch, name string) bool {
+	return name == search.X509OperatorManagedSecret().Name ||
+		name == search.ScramClientCertOperatorManagedSecret().Name
+}
+
+func (r *MongoDBSearchReconcileHelper) clientForPhysicalCluster(clusterName string) kubernetesClient.Client {
+	if clusterName == "" {
+		return r.client
+	}
+	return r.memberClusterClients[clusterName]
+}
+
+func (r *MongoDBSearchReconcileHelper) readerForPhysicalCluster(clusterName string) client.Reader {
+	if clusterName == "" {
+		if r.centralReader != nil {
+			return r.centralReader
+		}
+		return r.client
+	}
+	if reader := r.memberClusterReaders[clusterName]; reader != nil {
+		return reader
+	}
+	return r.memberClusterClients[clusterName]
+}
+
 // sweepStaleShardResources lists one resource kind on a cluster (scoped by selector)
-// and deletes every object this search owns whose name isn't in expected.
-func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Context, log *zap.SugaredLogger, c kubernetesClient.Client, clusterName string, list client.ObjectList, selector client.MatchingLabels, expected map[string]bool, kind string) error {
-	if err := c.List(ctx, list, client.InNamespace(r.mdbSearch.Namespace), selector); err != nil {
+// and deletes every eligible object this search owns whose name isn't in expected.
+func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Context, log *zap.SugaredLogger, c kubernetesClient.Client, reader client.Reader, clusterName string, list client.ObjectList, selector client.MatchingLabels, expected map[string]bool, kind string, eligible func(context.Context, client.Object) (bool, error)) error {
+	if err := reader.List(ctx, list, client.InNamespace(r.mdbSearch.Namespace), selector); err != nil {
 		return xerrors.Errorf("failed to list %ss on cluster %q: %w", kind, clusterName, err)
 	}
 	items, err := meta.ExtractList(list)
@@ -1060,21 +1210,52 @@ func (r *MongoDBSearchReconcileHelper) sweepStaleShardResources(ctx context.Cont
 		if !ok || expected[obj.GetName()] || !r.ownsForSweep(obj) {
 			continue
 		}
-		log.Infof("Deleting stale %s %s on cluster %q", kind, obj.GetName(), clusterName)
-		if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-			errs = multierror.Append(errs, xerrors.Errorf("failed to delete stale %s %s on cluster %q: %w", kind, obj.GetName(), clusterName, err))
+		live, ok := obj.DeepCopyObject().(client.Object)
+		if !ok {
+			return fmt.Errorf("failed to copy stale %s %s on cluster %q", kind, obj.GetName(), clusterName)
+		}
+		if err := reader.Get(ctx, client.ObjectKeyFromObject(obj), live); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to confirm stale %s %s on cluster %q: %w", kind, obj.GetName(), clusterName, err)
+		}
+		if live.GetUID() != obj.GetUID() || live.GetResourceVersion() != obj.GetResourceVersion() {
+			return fmt.Errorf("stale %s %s changed during cleanup on cluster %q", kind, obj.GetName(), clusterName)
+		}
+		if expected[live.GetName()] || !r.ownsForSweep(live) {
+			continue
+		}
+		if eligible != nil {
+			ok, err := eligible(ctx, live)
+			if err != nil {
+				return fmt.Errorf("failed to confirm stale %s %s eligibility on cluster %q: %w", kind, live.GetName(), clusterName, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+		log.Infof("Deleting stale %s %s on cluster %q", kind, live.GetName(), clusterName)
+		if err := c.Delete(ctx, live, client.Preconditions{
+			UID:             ptr.To(live.GetUID()),
+			ResourceVersion: ptr.To(live.GetResourceVersion()),
+		}); err != nil && !apierrors.IsNotFound(err) {
+			errs = multierror.Append(errs, xerrors.Errorf("failed to delete stale %s %s on cluster %q: %w", kind, live.GetName(), clusterName, err))
 		}
 	}
 	return errs
 }
 
-// ownsForSweep reports whether obj belongs to this search by its owner-name +
-// owner-namespace labels. Owner refs don't cross clusters, so labels are the
-// uniform ownership signal on central and member clusters alike.
+// ownsForSweep reports whether obj belongs to this exact search identity.
+// Owner refs don't cross clusters, so labels are the uniform ownership signal
+// on central and member clusters alike.
 func (r *MongoDBSearchReconcileHelper) ownsForSweep(obj client.Object) bool {
 	labels := obj.GetLabels()
-	return labels[khandler.MongoDBSearchOwnerNameLabel] == r.mdbSearch.Name &&
-		labels[khandler.MongoDBSearchOwnerNamespaceLabel] == r.mdbSearch.Namespace
+	searchUID := string(r.mdbSearch.UID)
+	return searchUID != "" &&
+		labels[khandler.MongoDBSearchOwnerNameLabel] == r.mdbSearch.Name &&
+		labels[khandler.MongoDBSearchOwnerNamespaceLabel] == r.mdbSearch.Namespace &&
+		labels[khandler.MongoDBSearchOwnerUIDLabel] == searchUID
 }
 
 // ensureKeyfileModification returns the keyfile StatefulSet modification if wireproto is enabled.
@@ -1125,22 +1306,43 @@ func (r *MongoDBSearchReconcileHelper) validatePerShardTLSSecrets(ctx context.Co
 		return workflow.Failed(xerrors.New("spec.security.tls.certificateKeySecretRef is not supported for sharded clusters, use spec.security.tls.certsSecretPrefix instead"))
 	}
 
+	var validationErrs error
+	var worstPhase status.Phase
 	for _, w := range r.buildShardedWorkList(shardNames) {
+		var validationStatus workflow.Status
 		clusterClient, err := r.clientForCluster(w.ClusterName)
 		if err != nil {
-			return workflow.Failed(xerrors.Errorf("no client for cluster %q: %w", w.ClusterName, err))
+			validationStatus = workflow.Failed(xerrors.Errorf("no client for cluster %q: %w", w.ClusterName, err))
+		} else {
+			secretNsName := r.mdbSearch.TLSSecretForClusterShard(w.ClusterIndex, w.ShardName)
+			tlsSecret := &corev1.Secret{}
+			err = clusterClient.Get(ctx, secretNsName, tlsSecret)
+			if apierrors.IsNotFound(err) {
+				log.Infof("Waiting for per-shard TLS secret %s to be created", secretNsName)
+				validationStatus = workflow.Pending("Waiting for TLS secret %s for shard %s to be created", secretNsName.Name, w.ShardName)
+			} else if err != nil {
+				validationStatus = workflow.Failed(xerrors.Errorf("failed to get TLS secret %s for shard %s: %w", secretNsName.Name, w.ShardName, err))
+			} else {
+				validationStatus = workflow.OK()
+			}
 		}
-		secretNsName := r.mdbSearch.TLSSecretForClusterShard(w.ClusterIndex, w.ShardName)
-		tlsSecret := &corev1.Secret{}
-		err = clusterClient.Get(ctx, secretNsName, tlsSecret)
-		if apierrors.IsNotFound(err) {
-			log.Infof("Waiting for per-shard TLS secret %s to be created", secretNsName)
-			return workflow.Pending("Waiting for TLS secret %s for shard %s to be created", secretNsName.Name, w.ShardName)
-		} else if err != nil {
-			return workflow.Failed(xerrors.Errorf("failed to get TLS secret %s for shard %s: %w", secretNsName.Name, w.ShardName, err))
+		worstPhase = searchv1.WorstOfPhase(worstPhase, validationStatus.Phase())
+		if !validationStatus.IsOK() {
+			validationErrs = multierror.Append(validationErrs, fmt.Errorf(
+				"cluster %q shard %q: %s",
+				w.ClusterName,
+				w.ShardName,
+				MessageFromStatus(validationStatus),
+			))
 		}
 	}
 
+	if validationErrs != nil {
+		if worstPhase == status.PhaseFailed {
+			return workflow.Failed(validationErrs)
+		}
+		return workflow.Pending("%s", validationErrs)
+	}
 	return workflow.OK()
 }
 
@@ -1152,11 +1354,12 @@ func (r *MongoDBSearchReconcileHelper) searchImageAndVersion() (string, string) 
 	return fmt.Sprintf("%s/%s", r.operatorSearchConfig.SearchRepo, r.operatorSearchConfig.SearchName), imageVersion
 }
 
-func (r *MongoDBSearchReconcileHelper) createOrUpdateStatefulSet(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, stsName types.NamespacedName, modifications ...statefulset.Modification) (*appsv1.StatefulSet, error) {
+func (r *MongoDBSearchReconcileHelper) createOrUpdateStatefulSet(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, stsName types.NamespacedName, ownerReferences []metav1.OwnerReference, modifications ...statefulset.Modification) (*appsv1.StatefulSet, error) {
 	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: stsName.Name, Namespace: stsName.Namespace}}
 	op, err := controllerutil.CreateOrUpdate(ctx, kubeClient, sts, func() error {
 		statefulset.Apply(modifications...)(sts)
-		return controllerutil.SetOwnerReference(r.mdbSearch, sts, kubeClient.Scheme())
+		sts.OwnerReferences = ownerReferences
+		return nil
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("error creating/updating search statefulset %v: %w", stsName, err)
@@ -1180,7 +1383,7 @@ func (r *MongoDBSearchReconcileHelper) ensureSearchService(ctx context.Context, 
 		if desired.Spec.ClusterIP == "" && existingClusterIP != "" {
 			svc.Spec.ClusterIP = existingClusterIP
 		}
-		return controllerutil.SetOwnerReference(r.mdbSearch, svc, kubeClient.Scheme())
+		return nil
 	})
 	if err != nil {
 		return xerrors.Errorf("error creating/updating search service %v: %w", svcName, err)
@@ -1194,7 +1397,7 @@ func (r *MongoDBSearchReconcileHelper) ensureSearchService(ctx context.Context, 
 // ensureMongotConfig creates or updates the mongot ConfigMap. When
 // auto-embedding is configured, generates leader/follower config files plus
 // pod-name role keys.
-func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, cmName types.NamespacedName, stsName, clusterName string, replicas int, modifications ...mongot.Modification) (string, error) {
+func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, cmName types.NamespacedName, stsName, clusterName string, ownerReferences []metav1.OwnerReference, replicas int, modifications ...mongot.Modification) (string, error) {
 	usePerPodConfig := r.mdbSearch.HasAutoEmbedding()
 
 	mongotConfig := mongot.Config{}
@@ -1229,7 +1432,8 @@ func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, l
 			cm.Labels[k] = v
 		}
 		cm.ResourceVersion = resourceVersion
-		return controllerutil.SetOwnerReference(r.mdbSearch, cm, kubeClient.Scheme())
+		cm.OwnerReferences = ownerReferences
+		return nil
 	})
 	if err != nil {
 		return "", err
@@ -1413,7 +1617,7 @@ func buildHeadlessService(search *searchv1.MongoDBSearch, unit reconcileUnit) co
 		SetSelector(map[string]string{appLabelKey: unit.podLabels[appLabelKey]}).
 		SetClusterIP("None").
 		SetServiceType(corev1.ServiceTypeClusterIP).
-		SetOwnerReferences(search.GetOwnerReferences())
+		SetOwnerReferences(unit.ownerReferences)
 
 	for i := range unit.extraHeadlessPorts {
 		serviceBuilder.AddPort(&unit.extraHeadlessPorts[i])
@@ -1458,7 +1662,7 @@ func buildProxyService(search *searchv1.MongoDBSearch, unit reconcileUnit) corev
 		SetLabels(labels).
 		SetSelector(selector).
 		SetServiceType(corev1.ServiceTypeClusterIP).
-		SetOwnerReferences(search.GetOwnerReferences())
+		SetOwnerReferences(unit.ownerReferences)
 
 	serviceBuilder.AddPort(&corev1.ServicePort{
 		// Named "mongot-grpc" (not "grpc") so Istio classifies the port as opaque
@@ -1501,7 +1705,7 @@ func buildClusterLevelProxyService(search *searchv1.MongoDBSearch, res clusterLe
 		SetLabels(labels).
 		SetSelector(selector).
 		SetServiceType(corev1.ServiceTypeClusterIP).
-		SetOwnerReferences(search.GetOwnerReferences())
+		SetOwnerReferences(res.ownerReferences)
 
 	svcBuilder.AddPort(&corev1.ServicePort{
 		// "mongot-grpc" keeps Istio from L7-classifying this port (see buildProxyService).
@@ -1693,12 +1897,17 @@ func setupMongotContainerArgsForAPIKeys() container.Modification {
 // ensureIngressTlsConfig processes TLS configuration for any mongot deployment.
 // For non-sharded deployments, pass r.mdbSearch as the tlsResource.
 // For sharded deployments, pass a perShardTLSResource adapter.
-func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource, labels map[string]string, ownerReferences []metav1.OwnerReference) (mongot.Modification, statefulset.Modification, error) {
 	if r.mdbSearch.Spec.Security.TLS == nil {
-		return mongot.NOOP(), statefulset.NOOP(), nil
+		return mongot.NOOP(), statefulset.WithPodSpecTemplate(podtemplatespec.Apply(
+			podtemplatespec.RemoveVolume("tls"),
+			podtemplatespec.RemoveVolume("grpc-key-password"),
+			podtemplatespec.RemoveVolumeMount(MongotContainerName, "tls"),
+			podtemplatespec.RemoveVolumeMount(MongotContainerName, "grpc-key-password"),
+		)), nil
 	}
 
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource, labels, tlsResource.GetOwnerReferences())
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, tlsResource, labels, ownerReferences)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1772,9 +1981,10 @@ func (x *x509AuthResource) TLSOperatorSecretNamespacedName() types.NamespacedNam
 
 // ensureX509ClientCertConfig processes x509 client certificate configuration for the sync source in case of mongot to mongod communication.
 // When x509 is configured, it replaces username/password auth with x509 certificate auth.
-func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string, ownerReferences []metav1.OwnerReference) (mongot.Modification, statefulset.Modification, error) {
+	removeX509Volumes := removeMongotVolumesAndMounts("x509-client-cert", "x509-key-password")
 	if !r.mdbSearch.IsX509Auth() {
-		return mongot.NOOP(), statefulset.NOOP(), nil
+		return mongot.NOOP(), removeX509Volumes, nil
 	}
 
 	tlsSourceConfig := r.db.TLSConfig()
@@ -1785,7 +1995,7 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 	}
 
 	x509Resource := &x509AuthResource{MongoDBSearch: r.mdbSearch}
-	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource, labels, x509Resource.GetOwnerReferences())
+	certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, x509Resource, labels, ownerReferences)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1860,7 +2070,7 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 		)))...,
 	))
 
-	return mongotModification, stsModification, nil
+	return mongotModification, statefulset.Apply(removeX509Volumes, stsModification), nil
 }
 
 // perShardTLSResource wraps MongoDBSearch to provide per-(cluster, shard) TLS secret names.
@@ -1881,10 +2091,11 @@ func (p *perShardTLSResource) TLSOperatorSecretNamespacedName() types.Namespaced
 	return p.TLSOperatorSecretForClusterShard(p.clusterIndex, p.shardName)
 }
 
-func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string, ownerReferences []metav1.OwnerReference) (mongot.Modification, statefulset.Modification, error) {
+	removeScramClientVolumes := removeMongotVolumesAndMounts("scram-client-cert", "scram-key-password")
 	tlsSourceConfig := r.db.TLSConfig()
 	if tlsSourceConfig == nil {
-		return mongot.NOOP(), statefulset.NOOP(), nil
+		return mongot.NOOP(), removeScramClientVolumes, nil
 	}
 
 	// Process optional SCRAM client certificate for mTLS
@@ -1893,7 +2104,7 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 	scramKeyPasswordSecret := r.mdbSearch.ScramKeyFilePasswordSecret()
 	if r.mdbSearch.HasScramClientCert() {
 		scramCertResource := &scramClientCertResource{MongoDBSearch: r.mdbSearch}
-		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource, labels, scramCertResource.GetOwnerReferences())
+		certFileName, err := tls.EnsureTLSSecret(ctx, kubeClient, scramCertResource, labels, ownerReferences)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1979,7 +2190,19 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 		)))...,
 	))
 
-	return mongotModification, statefulsetModification, nil
+	return mongotModification, statefulset.Apply(removeScramClientVolumes, statefulsetModification), nil
+}
+
+func removeMongotVolumesAndMounts(names ...string) statefulset.Modification {
+	modifications := make([]podtemplatespec.Modification, 0, len(names)*2)
+	for _, name := range names {
+		modifications = append(
+			modifications,
+			podtemplatespec.RemoveVolume(name),
+			podtemplatespec.RemoveVolumeMount(MongotContainerName, name),
+		)
+	}
+	return statefulset.WithPodSpecTemplate(podtemplatespec.Apply(modifications...))
 }
 
 // scramClientCertResource adapts MongoDBSearch to provide SCRAM client cert secret names.

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -3,7 +3,9 @@ package searchcontroller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -21,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
@@ -114,6 +117,7 @@ func reconcileMongoDBSearch(ctx context.Context, fakeClient kubernetesClient.Cli
 		NewCommunityResourceSearchSource(mdbc),
 		operatorConfig,
 		nil, nil,
+		false,
 	)
 
 	return helper.Reconcile(ctx, zap.S())
@@ -186,7 +190,7 @@ func TestMongoDBSearchReconcileHelper_ValidateSingleMongoDBSearchForSearchSource
 				clientBuilder.WithObjects(v)
 			}
 
-			helper := NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(clientBuilder.Build()), mdbSearch, NewCommunityResourceSearchSource(mdbc), OperatorSearchConfig{}, nil, nil)
+			helper := NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(clientBuilder.Build()), mdbSearch, NewCommunityResourceSearchSource(mdbc), OperatorSearchConfig{}, nil, nil, false)
 			err := helper.ValidateSingleMongoDBSearchForSearchSource(t.Context())
 			if c.expectedError == "" {
 				assert.NoError(t, err)
@@ -383,11 +387,12 @@ func TestGetMongodConfigParameters_PinnedClusterIndex(t *testing.T) {
 func newTestRSUnit(search *searchv1.MongoDBSearch) reconcileUnit {
 	svcName := search.SearchServiceNamespacedName().Name
 	return reconcileUnit{
-		stsName:       search.StatefulSetNamespacedName(),
-		headlessSvc:   search.SearchServiceNamespacedName(),
-		proxySvc:      search.ProxyServiceNamespacedName(),
-		configMapName: search.MongotConfigConfigMapNamespacedName(),
-		podLabels:     map[string]string{appLabelKey: svcName},
+		stsName:         search.StatefulSetNamespacedName(),
+		headlessSvc:     search.SearchServiceNamespacedName(),
+		proxySvc:        search.ProxyServiceNamespacedName(),
+		configMapName:   search.MongotConfigConfigMapNamespacedName(),
+		podLabels:       map[string]string{appLabelKey: svcName},
+		ownerReferences: search.GetOwnerReferences(),
 	}
 }
 
@@ -401,7 +406,26 @@ func newTestShardUnit(search *searchv1.MongoDBSearch, shardName string) reconcil
 		configMapName:       search.MongotConfigMapForClusterShard(0, shardName),
 		podLabels:           map[string]string{appLabelKey: stsName.Name, shardLabelKey: shardName},
 		additionalSvcLabels: map[string]string{shardLabelKey: shardName},
+		ownerReferences:     search.GetOwnerReferences(),
 	}
+}
+
+func newTestShardCleanupUnit(search *searchv1.MongoDBSearch, clusterIndex int, physicalClusterName, shardName string) reconcileUnit {
+	return reconcileUnit{
+		stsName:             search.MongotStatefulSetForClusterShard(clusterIndex, shardName),
+		headlessSvc:         search.MongotServiceForClusterShard(clusterIndex, shardName),
+		proxySvc:            search.ProxyServiceNameForClusterShard(clusterIndex, shardName),
+		configMapName:       search.MongotConfigMapForClusterShard(clusterIndex, shardName),
+		tlsResource:         &perShardTLSResource{MongoDBSearch: search, clusterIndex: clusterIndex, shardName: shardName},
+		physicalClusterName: physicalClusterName,
+		clusterIndex:        clusterIndex,
+	}
+}
+
+func assertOwnedBySearch(t *testing.T, search *searchv1.MongoDBSearch, object metav1.Object) {
+	t.Helper()
+	require.Len(t, object.GetOwnerReferences(), 1)
+	assert.Equal(t, search.UID, object.GetOwnerReferences()[0].UID)
 }
 
 func TestBuildProxyService_NoLB(t *testing.T) {
@@ -412,6 +436,7 @@ func TestBuildProxyService_NoLB(t *testing.T) {
 	svc := buildProxyService(search, unit)
 
 	assert.Equal(t, "test-search-0-proxy-svc", svc.Name)
+	assertOwnedBySearch(t, search, &svc)
 	assert.Equal(t, map[string]string{"app": "test-search-svc"}, svc.Spec.Selector)
 	assert.Equal(t, int32(27028), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(27028), svc.Spec.Ports[0].TargetPort.IntVal)
@@ -664,8 +689,7 @@ func TestStatefulSetOverridePreservesProtectedSearchLabels(t *testing.T) {
 				assert.Equal(t, tc.wantCluster, sts.Labels[khandler.MongoDBSearchClusterNameLabel])
 			}
 			assert.Equal(t, mongotComponent, sts.Labels[khandler.MongoDBSearchComponentLabel])
-			require.Len(t, sts.OwnerReferences, 1)
-			assert.Equal(t, search.UID, sts.OwnerReferences[0].UID)
+			assert.Empty(t, sts.OwnerReferences)
 		})
 	}
 }
@@ -762,7 +786,7 @@ func TestEnsureEmbeddingConfig_APIKeySecretAndProviderEndpont(t *testing.T) {
 	fakeClient := newTestFakeClient(search, apiKeySecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 		SearchVersion: "0.60.0",
-	}, nil, nil)
+	}, nil, nil, false)
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	assert.Nil(t, err)
 
@@ -795,7 +819,7 @@ func TestEnsureEmbeddingConfig_InternalVoyageAI_NoSecretRequired(t *testing.T) {
 	})
 	// The Service backing the endpoint is an operator-managed VoyageAI service.
 	fakeClient := newTestFakeClient(search, voyageAIService("voyage-embedding-svc", "mongodb"))
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{SearchVersion: "0.60.0"}, nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{SearchVersion: "0.60.0"}, nil, nil, false)
 
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	require.NoError(t, err)
@@ -854,7 +878,7 @@ func TestEnsureEmbeddingConfig_SecretRequiredForNonInternal(t *testing.T) {
 				s.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{ProviderEndpoint: tc.endpoint}
 			})
 			fakeClient := newTestFakeClient(append([]client.Object{search}, tc.objects...)...)
-			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{SearchVersion: "0.60.0"}, nil, nil)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{SearchVersion: "0.60.0"}, nil, nil, false)
 
 			_, _, err := helper.ensureEmbeddingConfig(context.TODO(), nil)
 			require.Error(t, err)
@@ -882,7 +906,7 @@ syncSource:
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 		SearchVersion: "0.58.0",
-	}, nil, nil)
+	}, nil, nil, false)
 	ctx := context.TODO()
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	assert.Nil(t, err)
@@ -931,7 +955,7 @@ func TestEnsureEmbeddingConfig_JustAPIKeys(t *testing.T) {
 	fakeClient := newTestFakeClient(search, apiKeySecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 		SearchVersion: "0.60.0",
-	}, nil, nil)
+	}, nil, nil, false)
 	ctx := context.TODO()
 	mongotModif, stsModif, err := helper.ensureEmbeddingConfig(ctx, nil)
 	assert.Nil(t, err)
@@ -1041,7 +1065,7 @@ func TestValidateSearchResource(t *testing.T) {
 		fakeClient := newTestFakeClient(search, tc.apiKeySecret)
 		helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, OperatorSearchConfig{
 			SearchVersion: tc.searchVersion,
-		}, nil, nil)
+		}, nil, nil, false)
 		_, _, err := helper.ensureEmbeddingConfig(ctx, nil)
 		tc.errAssertion(t, err)
 		if tc.errMsg != "" {
@@ -1052,7 +1076,7 @@ func TestValidateSearchResource(t *testing.T) {
 
 func TestValidateSearchImageVersion(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "mongodb")
-	helper := NewMongoDBSearchReconcileHelper(newTestFakeClient(search), search, nil, OperatorSearchConfig{}, nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(newTestFakeClient(search), search, nil, OperatorSearchConfig{}, nil, nil, false)
 
 	for _, tc := range []struct {
 		name         string
@@ -1139,14 +1163,14 @@ func TestEnsureMongotConfig_PerPodModes(t *testing.T) {
 				search.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{}
 			}
 			fakeClient := newTestFakeClient(search)
-			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
 			cmName := search.MongotConfigConfigMapNamespacedName()
 			stsName := search.StatefulSetNamespacedName().Name
 
 			embeddingMod := func(c *mongot.Config) {
 				c.Embedding = &mongot.EmbeddingConfig{IsAutoEmbeddingViewWriter: ptr.To(true)}
 			}
-			_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", int(tc.replicas), embeddingMod)
+			_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", search.GetOwnerReferences(), int(tc.replicas), embeddingMod)
 			require.NoError(t, err)
 
 			cm, err := fakeClient.GetConfigMap(t.Context(), cmName)
@@ -1174,7 +1198,7 @@ func TestEnsureMongotConfig_TransitionBetweenModes(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
 	search.Spec.Clusters = []searchv1.ClusterSpec{{Replicas: ptr.To(int32(1))}}
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
 	cmName := search.MongotConfigConfigMapNamespacedName()
 	stsName := search.StatefulSetNamespacedName().Name
 
@@ -1183,12 +1207,12 @@ func TestEnsureMongotConfig_TransitionBetweenModes(t *testing.T) {
 	}
 
 	// Create ConfigMap in single config mode
-	_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", 1, embeddingMod)
+	_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", search.GetOwnerReferences(), 1, embeddingMod)
 	require.NoError(t, err)
 
 	// Transition to per-pod config mode - verify old key is cleaned up
 	search.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{}
-	_, err = helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", 1, embeddingMod)
+	_, err = helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", search.GetOwnerReferences(), 1, embeddingMod)
 	require.NoError(t, err)
 
 	cm, err := fakeClient.GetConfigMap(t.Context(), cmName)
@@ -1197,7 +1221,7 @@ func TestEnsureMongotConfig_TransitionBetweenModes(t *testing.T) {
 
 	// Transition back to single config mode - verify per-pod keys are cleaned up
 	search.Spec.AutoEmbedding = nil
-	_, err = helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", 1, embeddingMod)
+	_, err = helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", search.GetOwnerReferences(), 1, embeddingMod)
 	require.NoError(t, err)
 
 	cm, err = fakeClient.GetConfigMap(t.Context(), cmName)
@@ -1210,11 +1234,11 @@ func TestEnsureMongotConfig_TransitionBetweenModes(t *testing.T) {
 
 func renderMongotConfig(t *testing.T, search *searchv1.MongoDBSearch, mods ...mongot.Modification) map[string]string {
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
 	cmName := search.MongotConfigConfigMapNamespacedName()
 	stsName := search.StatefulSetNamespacedName().Name
 
-	_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", 1, mods...)
+	_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", search.GetOwnerReferences(), 1, mods...)
 	require.NoError(t, err)
 
 	cm, err := fakeClient.GetConfigMap(t.Context(), cmName)
@@ -1254,12 +1278,12 @@ func TestEnsureMongotConfig_AdvancedMongotConfigsPerCluster(t *testing.T) {
 	withClusterAdvancedMongotConfigs(t, search, 1, `{"querying":{"lucene":{"maxClauseLimit":2048}}}`)
 
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
 	stsName := search.StatefulSetNamespacedName().Name
 
 	renderCluster := func(clusterName string, clusterIdx int) map[string]interface{} {
 		cmName := search.MongotConfigConfigMapNameForCluster(clusterIdx)
-		_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, clusterName, 1)
+		_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, clusterName, search.GetOwnerReferences(), 1)
 		require.NoError(t, err)
 		cm, err := fakeClient.GetConfigMap(t.Context(), cmName)
 		require.NoError(t, err)
@@ -1300,6 +1324,7 @@ func TestReconcileReplicaSet_AdvancedMongotConfigs(t *testing.T) {
 		NewCommunityResourceSearchSource(mdbc),
 		newTestOperatorSearchConfig(),
 		nil, nil,
+		false,
 	)
 
 	result := helper.reconcile(t.Context(), zap.S())
@@ -1555,9 +1580,10 @@ func TestShardedMongotConfigWithoutTLS(t *testing.T) {
 
 // mockShardedSource is a mock implementation of ShardedSearchSourceDBResource for testing
 type mockShardedSource struct {
-	shardNames []string
-	hostSeeds  map[string][]string
-	tlsConfig  *TLSSourceConfig
+	shardNames        []string
+	hostSeeds         map[string][]string
+	tlsConfig         *TLSSourceConfig
+	keyfileSecretName string
 }
 
 func (m *mockShardedSource) GetShardCount() int {
@@ -1586,7 +1612,7 @@ func (m *mockShardedSource) Validate() error {
 }
 
 func (m *mockShardedSource) KeyfileSecretName() string {
-	return ""
+	return m.keyfileSecretName
 }
 
 func (m *mockShardedSource) TLSConfig() *TLSSourceConfig {
@@ -1605,6 +1631,7 @@ func TestBuildShardSearchHeadlessService(t *testing.T) {
 	svc := buildHeadlessService(search, unit)
 
 	assert.Equal(t, "test-search-search-0-my-cluster-0-svc", svc.Name)
+	assertOwnedBySearch(t, search, &svc)
 	assert.Equal(t, "test", svc.Namespace)
 	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 	assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
@@ -1696,6 +1723,7 @@ func TestValidateManagedLBShardedTLS(t *testing.T) {
 				tc.source,
 				OperatorSearchConfig{},
 				nil, nil,
+				false,
 			)
 
 			err := helper.ValidateManagedLBShardedTLS()
@@ -1776,6 +1804,7 @@ func TestValidateMultipleReplicasUnmanagedLBTopology(t *testing.T) {
 				tc.source,
 				OperatorSearchConfig{},
 				nil, nil,
+				false,
 			)
 
 			err := helper.ValidateMultipleReplicasUnmanagedLBTopology()
@@ -2465,6 +2494,7 @@ func TestReconcileSharded_CertificateKeySecretRefRejected(t *testing.T) {
 		shardedSource,
 		newTestOperatorSearchConfig(),
 		nil, nil,
+		false,
 	)
 
 	result := helper.reconcile(t.Context(), zap.S())
@@ -2586,6 +2616,7 @@ func TestValidatePerShardTLSSecrets(t *testing.T) {
 				shardedSource,
 				newTestOperatorSearchConfig(),
 				nil, nil,
+				false,
 			)
 
 			status := helper.validatePerShardTLSSecrets(t.Context(), zap.S(), tc.shardNames)
@@ -2641,10 +2672,218 @@ func TestValidatePerShardTLSSecretsAllExist(t *testing.T) {
 		shardedSource,
 		newTestOperatorSearchConfig(),
 		nil, nil,
+		false,
 	)
 
 	status := helper.validatePerShardTLSSecrets(t.Context(), zap.S(), shardNames)
 	assert.True(t, status.IsOK(), "Expected status to be OK when all secrets exist")
+}
+
+type failingGetKubeClient struct {
+	kubernetesClient.Client
+	err error
+}
+
+func (c failingGetKubeClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return c.err
+}
+
+func TestValidatePerShardTLSSecretsAggregatesAllClusterFailures(t *testing.T) {
+	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+		s.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "my-prefix"}}
+		s.Spec.Clusters = []searchv1.ClusterSpec{
+			{Name: "cluster-a", Index: ptr.To(int32(0))},
+			{Name: "cluster-b", Index: ptr.To(int32(1))},
+		}
+	})
+	clusterA := newTestFakeClient()
+	clusterB := failingGetKubeClient{
+		Client: newTestFakeClient(),
+		err:    errors.New("injected cluster-b read failure"),
+	}
+	helper := NewMongoDBSearchReconcileHelper(
+		newTestFakeClient(search),
+		search,
+		&mockShardedSource{shardNames: []string{"shard-0"}},
+		newTestOperatorSearchConfig(),
+		map[string]kubernetesClient.Client{"cluster-a": clusterA, "cluster-b": clusterB},
+		nil,
+		false,
+	)
+
+	st := helper.validatePerShardTLSSecrets(t.Context(), zap.S(), []string{"shard-0"})
+
+	require.Equal(t, status.PhaseFailed, st.Phase())
+	message := MessageFromStatus(st)
+	assert.Contains(t, message, `cluster "cluster-a" shard "shard-0"`)
+	assert.Contains(t, message, `cluster "cluster-b" shard "shard-0"`)
+	assert.Contains(t, message, "injected cluster-b read failure")
+}
+
+func TestReconcileSharded_PreflightFailureStillCleansStaleResources(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		failClusterALists bool
+		wantPhase         status.Phase
+		wantClusterAStale bool
+	}{
+		{name: "cleanup succeeds and preserves Pending", wantPhase: status.PhasePending},
+		{name: "unreachable target aggregates cleanup error", failClusterALists: true, wantPhase: status.PhaseFailed, wantClusterAStale: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+				s.UID = "search-uid"
+				s.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "certs"}
+				s.Spec.Clusters = []searchv1.ClusterSpec{
+					{Name: "cluster-a", Index: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "search-a.example"}}},
+					{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "search-b.example"}}},
+				}
+				s.Spec.Source = &searchv1.MongoDBSource{
+					ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongos.example:27017"}},
+				}
+			})
+			shardName := "shard-0"
+			managedLabels := func(clusterName string) map[string]string {
+				labels := searchOwnerLabels(search, clusterName)
+				labels[khandler.MongoDBSearchComponentLabel] = mongotComponent
+				return labels
+			}
+			activeSecret := func(clusterIndex int, clusterName string) *corev1.Secret {
+				return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: search.TLSOperatorSecretForClusterShard(clusterIndex, shardName).Name, Namespace: search.Namespace, Labels: managedLabels(clusterName),
+				}}
+			}
+			staleSecret := func(clusterIndex int, clusterName string) *corev1.Secret {
+				return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: search.TLSOperatorSecretForClusterShard(clusterIndex, "stale-shard").Name, Namespace: search.Namespace, Labels: managedLabels(clusterName),
+				}}
+			}
+			staleConfigMap := func(clusterIndex int, clusterName string) *corev1.ConfigMap {
+				return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+					Name: search.MongotConfigMapForClusterShard(clusterIndex, "stale-shard").Name, Namespace: search.Namespace, Labels: managedLabels(clusterName),
+				}}
+			}
+			clusterAActive := activeSecret(0, "cluster-a")
+			clusterAStale := staleSecret(0, "cluster-a")
+			clusterAStaleCM := staleConfigMap(0, "cluster-a")
+			clusterBActive := activeSecret(1, "cluster-b")
+			clusterBStale := staleSecret(1, "cluster-b")
+			clusterBStaleCM := staleConfigMap(1, "cluster-b")
+			clusterABase := mock.NewEmptyFakeClientBuilder().WithObjects(clusterAActive, clusterAStale, clusterAStaleCM).Build()
+			clusterA := kubernetesClient.NewClient(clusterABase)
+			injectedErr := fmt.Errorf("injected cluster-a list failure")
+			if tc.failClusterALists {
+				clusterA = kubernetesClient.NewClient(interceptor.NewClient(clusterABase, interceptor.Funcs{
+					List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+						return injectedErr
+					},
+				}))
+			}
+			clusterB := newTestFakeClient(
+				clusterBActive,
+				clusterBStale,
+				clusterBStaleCM,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: search.TLSSecretForClusterShard(1, shardName).Name, Namespace: search.Namespace,
+					},
+					Data: map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")},
+				},
+			)
+			helper := NewMongoDBSearchReconcileHelper(
+				newTestFakeClient(search),
+				search,
+				&mockShardedSource{
+					shardNames: []string{shardName},
+					hostSeeds:  map[string][]string{shardName: {"shard-0-0.test-ns.svc.cluster.local:27017"}},
+				},
+				newTestOperatorSearchConfig(),
+				map[string]kubernetesClient.Client{"cluster-a": clusterA, "cluster-b": clusterB},
+				nil,
+				false,
+			)
+
+			result := helper.reconcile(t.Context(), zap.S())
+
+			assert.Equal(t, tc.wantPhase, result.Phase())
+			assert.Contains(t, MessageFromStatus(result), search.TLSSecretForClusterShard(0, shardName).Name)
+			if tc.failClusterALists {
+				assert.Contains(t, MessageFromStatus(result), injectedErr.Error())
+			}
+			for _, target := range []struct {
+				client    kubernetesClient.Client
+				active    *corev1.Secret
+				stale     *corev1.Secret
+				staleCM   *corev1.ConfigMap
+				cluster   string
+				keepStale bool
+			}{
+				{client: clusterA, active: clusterAActive, stale: clusterAStale, staleCM: clusterAStaleCM, cluster: "cluster-a", keepStale: tc.wantClusterAStale},
+				{client: clusterB, active: clusterBActive, stale: clusterBStale, staleCM: clusterBStaleCM, cluster: "cluster-b"},
+			} {
+				require.NoError(t, target.client.Get(t.Context(), client.ObjectKeyFromObject(target.active), &corev1.Secret{}), "%s active Secret", target.cluster)
+				staleSecretErr := target.client.Get(t.Context(), client.ObjectKeyFromObject(target.stale), &corev1.Secret{})
+				staleConfigErr := target.client.Get(t.Context(), client.ObjectKeyFromObject(target.staleCM), &corev1.ConfigMap{})
+				if target.keepStale {
+					assert.NoError(t, staleSecretErr, "%s stale Secret remains when target is unreachable", target.cluster)
+					assert.NoError(t, staleConfigErr, "%s stale ConfigMap remains when target is unreachable", target.cluster)
+				} else {
+					assert.True(t, apierrors.IsNotFound(staleSecretErr), "%s stale Secret", target.cluster)
+					assert.True(t, apierrors.IsNotFound(staleConfigErr), "%s stale ConfigMap", target.cluster)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileSharded_PrerequisiteFailureStillCleansStaleResources(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		configure      func(*searchv1.MongoDBSearch, *mockShardedSource)
+		wantStatusText string
+	}{
+		{
+			name: "missing keyfile",
+			configure: func(search *searchv1.MongoDBSearch, source *mockShardedSource) {
+				search.Annotations = map[string]string{searchv1.ForceWireprotoAnnotation: "true"}
+				source.keyfileSecretName = "source-keyfile"
+			},
+			wantStatusText: "Waiting for keyfile secret",
+		},
+		{
+			name: "invalid embedding configuration",
+			configure: func(search *searchv1.MongoDBSearch, _ *mockShardedSource) {
+				search.Spec.AutoEmbedding = &searchv1.EmbeddingConfig{ProviderEndpoint: "https://api.example.com/embeddings"}
+			},
+			wantStatusText: "embeddingModelAPIKeySecret",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+				s.UID = "search-uid"
+			})
+			source := &mockShardedSource{
+				shardNames: []string{"shard-0"},
+				hostSeeds:  map[string][]string{"shard-0": {"shard-0-0.test-ns.svc.cluster.local:27017"}},
+			}
+			tc.configure(search, source)
+			labels := searchOwnerLabels(search, "")
+			labels[khandler.MongoDBSearchComponentLabel] = mongotComponent
+			stale := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      search.MongotConfigMapForClusterShard(0, "stale-shard").Name,
+				Namespace: search.Namespace,
+				Labels:    labels,
+			}}
+			kubeClient := newTestFakeClient(search, stale)
+			helper := NewMongoDBSearchReconcileHelper(kubeClient, search, source, newTestOperatorSearchConfig(), nil, nil, false)
+
+			result := helper.reconcile(t.Context(), zap.S())
+
+			assert.False(t, result.IsOK())
+			assert.Contains(t, MessageFromStatus(result), tc.wantStatusText)
+			assert.True(t, apierrors.IsNotFound(kubeClient.Get(t.Context(), client.ObjectKeyFromObject(stale), &corev1.ConfigMap{})))
+		})
+	}
 }
 
 func TestReconcile_IngressTLSSecretIdentity(t *testing.T) {
@@ -2697,14 +2936,13 @@ func TestReconcile_IngressTLSSecretIdentity(t *testing.T) {
 				objects = append(objects, sourceObject)
 			}
 			fakeClient := newTestFakeClient(objects...)
-			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, nil)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, nil, false)
 
 			helper.reconcile(t.Context(), zap.S())
 
 			operatorSecret, err := fakeClient.GetSecret(t.Context(), operatorSecretName)
 			require.NoError(t, err)
-			require.Len(t, operatorSecret.OwnerReferences, 1)
-			assert.Equal(t, search.UID, operatorSecret.OwnerReferences[0].UID)
+			assertOwnedBySearch(t, search, &operatorSecret)
 			assert.Equal(t, mongotComponent, operatorSecret.Labels[khandler.MongoDBSearchComponentLabel])
 			assert.Equal(t, search.Name, operatorSecret.Labels[khandler.MongoDBSearchOwnerNameLabel])
 			assert.Equal(t, search.Namespace, operatorSecret.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
@@ -2714,13 +2952,65 @@ func TestReconcile_IngressTLSSecretIdentity(t *testing.T) {
 	}
 }
 
+func TestEnsureIngressTLSSecretOwnershipByLocality(t *testing.T) {
+	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+		s.UID = "search-uid"
+		s.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "my-prefix"}
+	})
+	tests := []struct {
+		name               string
+		clusterName        string
+		memberClients      map[string]kubernetesClient.Client
+		localNamedClusters bool
+		wantOwnerRef       bool
+		wantClientError    bool
+		wantPhysical       string
+	}{
+		{name: "legacy single cluster", wantOwnerRef: true},
+		{name: "projected named cluster", clusterName: "member-a", localNamedClusters: true, wantOwnerRef: true},
+		{name: "hub member cluster", clusterName: "member-a", memberClients: map[string]kubernetesClient.Client{"member-a": nil}, wantPhysical: "member-a"},
+		{name: "hub missing every client", clusterName: "member-a", wantClientError: true, wantPhysical: "member-a"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sourceSecretName := search.TLSSecretNamespacedName()
+			sourceSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: sourceSecretName.Name, Namespace: sourceSecretName.Namespace},
+				Data:       map[string][]byte{"tls.crt": []byte("cert-data"), "tls.key": []byte("key-data")},
+			}
+			fakeClient := newTestFakeClient(sourceSecret)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), tc.memberClients, nil, tc.localNamedClusters)
+			_, clientErr := helper.clientForCluster(tc.clusterName)
+			assert.Equal(t, tc.wantClientError, clientErr != nil)
+			assert.Equal(t, tc.wantPhysical, helper.physicalClusterName(tc.clusterName))
+
+			_, _, err := helper.ensureIngressTlsConfig(
+				t.Context(),
+				fakeClient,
+				search,
+				searchOwnerLabels(search, tc.clusterName),
+				helper.ownerReferencesForCluster(tc.clusterName),
+			)
+			require.NoError(t, err)
+
+			operatorSecret, err := fakeClient.GetSecret(t.Context(), search.TLSOperatorSecretNamespacedName())
+			require.NoError(t, err)
+			if tc.wantOwnerRef {
+				assertOwnedBySearch(t, search, &operatorSecret)
+			} else {
+				assert.Empty(t, operatorSecret.OwnerReferences)
+			}
+		})
+	}
+}
+
 func TestEnsureX509ClientCertConfig_NoopWhenNotConfigured(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
 
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""), search.GetOwnerReferences())
 	require.NoError(t, err)
 
 	// Apply modifications and verify no changes
@@ -2759,9 +3049,9 @@ func TestEnsureX509ClientCertConfig_ErrorWhenTLSNotConfigured(t *testing.T) {
 	dbSource := &mockShardedSource{tlsConfig: nil} // No TLS on source
 
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil, false)
 
-	_, _, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
+	_, _, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""), search.GetOwnerReferences())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tls must be enabled")
 }
@@ -2784,16 +3074,18 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	}
 
 	fakeClient := newTestFakeClient(search, x509Secret)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil, false)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
+	labels := searchOwnerLabels(search, "")
+	labels[componentLabelKey] = mongotComponent
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, labels, search.GetOwnerReferences())
 	require.NoError(t, err)
 	operatorSecret, err := fakeClient.GetSecret(t.Context(), search.X509OperatorManagedSecret())
 	require.NoError(t, err)
-	require.Len(t, operatorSecret.OwnerReferences, 1)
-	assert.Equal(t, search.Name, operatorSecret.OwnerReferences[0].Name)
+	assertOwnedBySearch(t, search, &operatorSecret)
 	assert.Equal(t, search.Name, operatorSecret.Labels[khandler.MongoDBSearchOwnerNameLabel])
 	assert.Equal(t, search.Namespace, operatorSecret.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, mongotComponent, operatorSecret.Labels[componentLabelKey])
 
 	// Apply mongot modification to a config with both ReplicaSet and Router (sharded scenario)
 	config := &mongot.Config{
@@ -2863,6 +3155,36 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	}
 }
 
+func TestEnsureEgressTlsConfig_LabelsGeneratedScramClientSecret(t *testing.T) {
+	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+		s.Spec.Source.TLS = &searchv1.SourceTLS{
+			ClientCertificateSecret: corev1.LocalObjectReference{Name: "scram-client-cert"},
+		}
+	})
+	dbSource := &mockShardedSource{tlsConfig: &TLSSourceConfig{
+		CAFileName: "ca-pem",
+		CAVolume:   statefulset.CreateVolumeFromSecret("ca", "ca-secret"),
+	}}
+	clientCert := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "scram-client-cert", Namespace: search.Namespace},
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert-data"),
+			"tls.key": []byte("key-data"),
+		},
+	}
+	fakeClient := newTestFakeClient(search, clientCert)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil, false)
+	labels := searchOwnerLabels(search, "")
+	labels[componentLabelKey] = mongotComponent
+
+	_, _, err := helper.ensureEgressTlsConfig(t.Context(), fakeClient, labels, search.GetOwnerReferences())
+	require.NoError(t, err)
+	operatorSecret, err := fakeClient.GetSecret(t.Context(), search.ScramClientCertOperatorManagedSecret())
+	require.NoError(t, err)
+	assertOwnedBySearch(t, search, &operatorSecret)
+	assert.Equal(t, mongotComponent, operatorSecret.Labels[componentLabelKey])
+}
+
 func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
 		s.Spec.Source.X509 = &searchv1.X509Auth{
@@ -2889,9 +3211,9 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	}
 
 	fakeClient := newTestFakeClient(search, x509Secret, keyPasswordSecret)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil, false)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""), search.GetOwnerReferences())
 	require.NoError(t, err)
 
 	// Verify mongot config has key password path
@@ -2947,7 +3269,7 @@ func TestKeyFilePasswordContentHash(t *testing.T) {
 		objs := append([]client.Object{search}, secrets...)
 		fakeClient := newTestFakeClient(objs...)
 		dbSource := &mockShardedSource{tlsConfig: &TLSSourceConfig{CAFileName: "ca-pem"}}
-		return NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil), fakeClient
+		return NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil, false), fakeClient
 	}
 
 	passwordSecret := func(name, password string) *corev1.Secret {
@@ -3056,6 +3378,7 @@ func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 		shardedSource,
 		newTestOperatorSearchConfig(),
 		nil, nil,
+		false,
 	)
 
 	// Pass 1: applies resources for ALL shards in a single pass, then the
@@ -3115,91 +3438,639 @@ func TestReconcileSharded_CreatesPerShardResources(t *testing.T) {
 }
 
 func TestCleanupStaleShardResources(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		unmanaged  bool
+		tlsEnabled bool
+		authOn     bool
+	}{
+		{name: "managed TLS", tlsEnabled: true},
+		{name: "unmanaged TLS", unmanaged: true, tlsEnabled: true},
+		{name: "managed TLS disabled"},
+		{name: "client-cert auth modes on", tlsEnabled: true, authOn: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+				s.UID = "search-uid"
+				if tc.tlsEnabled {
+					s.Spec.Security.TLS = &searchv1.TLS{CertsSecretPrefix: "certs"}
+				}
+				if tc.authOn {
+					s.Spec.Source.X509 = &searchv1.X509Auth{ClientCertificateSecret: corev1.LocalObjectReference{Name: "x509-source"}}
+					s.Spec.Source.TLS = &searchv1.SourceTLS{ClientCertificateSecret: corev1.LocalObjectReference{Name: "scram-source"}}
+				}
+				if tc.unmanaged {
+					s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{
+						Unmanaged: &searchv1.UnmanagedLBConfig{Endpoint: "{shardName}.example.com:27028"},
+					}
+				} else {
+					s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
+				}
+			})
+			withOwner := func(labels map[string]string, owned bool) map[string]string {
+				if owned {
+					labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
+					labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
+					labels[khandler.MongoDBSearchOwnerUIDLabel] = string(search.UID)
+				}
+				return labels
+			}
+			proxySvc := func(shard string, owned bool) *corev1.Service {
+				return &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: search.ProxyServiceNameForClusterShard(0, shard).Name, Namespace: search.Namespace,
+						Labels: withOwner(map[string]string{"component": proxyServiceComponent}, owned),
+					},
+					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1", Ports: []corev1.ServicePort{{Port: 27028}}},
+				}
+			}
+			mongotSTS := func(shard string, owned bool) *appsv1.StatefulSet {
+				return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+					Name: search.MongotStatefulSetForClusterShard(0, shard).Name, Namespace: search.Namespace, Labels: withOwner(map[string]string{}, owned),
+				}}
+			}
+			mongotHeadless := func(shard string, owned bool) *corev1.Service {
+				return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+					Name: search.MongotServiceForClusterShard(0, shard).Name, Namespace: search.Namespace, Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
+				}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2", Ports: []corev1.ServicePort{{Port: 27027}}}}
+			}
+			mongotCM := func(shard string, owned bool) *corev1.ConfigMap {
+				return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+					Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: search.Namespace, Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
+				}}
+			}
+			mongotTLSSecret := func(shard string, owned bool) *corev1.Secret {
+				return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: search.TLSOperatorSecretForClusterShard(0, shard).Name, Namespace: search.Namespace, Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
+				}}
+			}
+			differentUIDCM := mongotCM("shard-different-uid", true)
+			differentUIDCM.Labels[khandler.MongoDBSearchOwnerUIDLabel] = "different-search-uid"
+			uidlessCM := mongotCM("shard-uidless", true)
+			delete(uidlessCM.Labels, khandler.MongoDBSearchOwnerUIDLabel)
+			differentUIDTLSSecret := mongotTLSSecret("shard-different-uid", true)
+			differentUIDTLSSecret.Labels[khandler.MongoDBSearchOwnerUIDLabel] = "different-search-uid"
+			operatorAuthSecret := func(name types.NamespacedName) *corev1.Secret {
+				return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: name.Name, Namespace: name.Namespace, Labels: withOwner(map[string]string{"component": mongotComponent}, true),
+				}}
+			}
+			// A customer Secret that copied the operator's labels: its non-operator
+			// name shape must keep it out of the sweep.
+			customerSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "customer-provided-cert", Namespace: search.Namespace, Labels: withOwner(map[string]string{"component": mongotComponent}, true),
+			}}
+
+			fakeClient := newTestFakeClient(search,
+				proxySvc("shard-0", true),
+				proxySvc("shard-1", true),
+				proxySvc("shard-2", true),
+				proxySvc("shard-x", false),
+				mongotSTS("shard-1", true), mongotSTS("shard-2", true),
+				mongotHeadless("shard-1", true), mongotHeadless("shard-2", true), mongotHeadless("shard-x", false),
+				mongotCM("shard-1", true), mongotCM("shard-2", true), mongotCM("shard-x", false), differentUIDCM, uidlessCM,
+				mongotTLSSecret("shard-1", true), mongotTLSSecret("shard-2", true), mongotTLSSecret("shard-x", false), differentUIDTLSSecret,
+				operatorAuthSecret(search.X509OperatorManagedSecret()), operatorAuthSecret(search.ScramClientCertOperatorManagedSecret()), customerSecret,
+				mongotHeadless("x", true), mongotSTS("x-svc", true),
+			)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
+			var activeUnits []reconcileUnit
+			for _, shardName := range []string{"shard-0", "shard-1", "x"} {
+				activeUnits = append(activeUnits, newTestShardCleanupUnit(search, 0, "", shardName))
+			}
+
+			require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), activeUnits))
+
+			assertObject := func(nn types.NamespacedName, obj client.Object, wantPresent bool, msg string) {
+				err := fakeClient.Get(t.Context(), nn, obj)
+				if wantPresent {
+					assert.NoError(t, err, msg)
+				} else {
+					assert.True(t, apierrors.IsNotFound(err), msg)
+				}
+			}
+			assertObject(search.ProxyServiceNameForClusterShard(0, "shard-0"), &corev1.Service{}, true, "active proxy Service")
+			assertObject(search.ProxyServiceNameForClusterShard(0, "shard-1"), &corev1.Service{}, true, "active proxy Service")
+			assertObject(search.ProxyServiceNameForClusterShard(0, "shard-2"), &corev1.Service{}, tc.unmanaged, "stale proxy Service")
+			assertObject(search.ProxyServiceNameForClusterShard(0, "shard-x"), &corev1.Service{}, true, "different-owner proxy Service")
+			assertObject(search.MongotStatefulSetForClusterShard(0, "shard-1"), &appsv1.StatefulSet{}, true, "active StatefulSet")
+			assertObject(search.MongotStatefulSetForClusterShard(0, "shard-2"), &appsv1.StatefulSet{}, false, "stale StatefulSet")
+			assertObject(search.MongotServiceForClusterShard(0, "shard-1"), &corev1.Service{}, true, "active headless Service")
+			assertObject(search.MongotServiceForClusterShard(0, "shard-2"), &corev1.Service{}, false, "stale headless Service")
+			assertObject(search.MongotServiceForClusterShard(0, "shard-x"), &corev1.Service{}, true, "different-owner headless Service")
+			assertObject(search.MongotConfigMapForClusterShard(0, "shard-1"), &corev1.ConfigMap{}, true, "active ConfigMap")
+			assertObject(search.MongotConfigMapForClusterShard(0, "shard-2"), &corev1.ConfigMap{}, false, "stale ConfigMap")
+			assertObject(search.MongotConfigMapForClusterShard(0, "shard-x"), &corev1.ConfigMap{}, true, "different-owner ConfigMap")
+			assertObject(client.ObjectKeyFromObject(differentUIDCM), &corev1.ConfigMap{}, true, "different-UID ConfigMap")
+			assertObject(client.ObjectKeyFromObject(uidlessCM), &corev1.ConfigMap{}, true, "UID-less ConfigMap")
+			// Live-shard TLS Secrets survive even with TLS disabled: disabling TLS never
+			// reaps generated Secrets while the CR lives.
+			assertObject(search.TLSOperatorSecretForClusterShard(0, "shard-1"), &corev1.Secret{}, true, "active TLS Secret")
+			assertObject(search.TLSOperatorSecretForClusterShard(0, "shard-2"), &corev1.Secret{}, false, "stale TLS Secret")
+			assertObject(search.TLSOperatorSecretForClusterShard(0, "shard-x"), &corev1.Secret{}, true, "different-owner TLS Secret")
+			assertObject(client.ObjectKeyFromObject(differentUIDTLSSecret), &corev1.Secret{}, true, "different-UID TLS Secret")
+			assertObject(search.X509OperatorManagedSecret(), &corev1.Secret{}, tc.authOn, "x509 operator-managed Secret")
+			assertObject(search.ScramClientCertOperatorManagedSecret(), &corev1.Secret{}, tc.authOn, "SCRAM client-cert operator-managed Secret")
+			assertObject(client.ObjectKeyFromObject(customerSecret), &corev1.Secret{}, true, "customer Secret with copied labels")
+			assertObject(search.MongotServiceForClusterShard(0, "x"), &corev1.Service{}, true, "live shard name-collision Service")
+			assertObject(search.MongotStatefulSetForClusterShard(0, "x-svc"), &appsv1.StatefulSet{}, false, "stale name-collision StatefulSet")
+		})
+	}
+}
+
+func TestCleanupStaleShardResources_UsesDeletePreconditions(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
 		s.UID = "search-uid"
-		s.Spec.Clusters[0].LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}
 	})
-
-	withOwner := func(labels map[string]string, owned bool) map[string]string {
-		if owned {
-			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
-			labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
-		}
-		return labels
+	oldUID := types.UID("listed-resource-uid")
+	newUID := types.UID("replacement-resource-uid")
+	staleLabels := map[string]string{
+		khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+		khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+		khandler.MongoDBSearchOwnerUIDLabel:       string(search.UID),
+		khandler.MongoDBSearchComponentLabel:      mongotComponent,
 	}
-	proxySvc := func(shard string, owned bool) *corev1.Service {
-		return &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: search.ProxyServiceNameForClusterShard(0, shard).Name, Namespace: "test-ns",
-				Labels: withOwner(map[string]string{"component": proxyServiceComponent}, owned),
+	stale := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.MongotConfigMapForClusterShard(0, "stale-shard").Name,
+		Namespace: search.Namespace,
+		UID:       oldUID,
+		Labels:    maps.Clone(staleLabels),
+	}}
+	staleSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      search.TLSOperatorSecretForClusterShard(0, "stale-shard").Name,
+		Namespace: search.Namespace,
+		UID:       types.UID("stale-secret-uid"),
+		Labels:    maps.Clone(staleLabels),
+	}}
+	rawClient := mock.NewEmptyFakeClientBuilder().
+		WithObjects(stale, staleSecret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteOptions := (&client.DeleteOptions{}).ApplyOptions(opts)
+				require.NotNil(t, deleteOptions.Preconditions)
+				require.NotNil(t, deleteOptions.Preconditions.UID)
+				require.NotNil(t, deleteOptions.Preconditions.ResourceVersion)
+				assert.Equal(t, obj.GetUID(), *deleteOptions.Preconditions.UID)
+				assert.Equal(t, obj.GetResourceVersion(), *deleteOptions.Preconditions.ResourceVersion)
+
+				if _, ok := obj.(*corev1.ConfigMap); !ok {
+					return c.Delete(ctx, obj, opts...)
+				}
+				require.NoError(t, c.Delete(ctx, obj))
+				replacement := stale.DeepCopy()
+				replacement.UID = newUID
+				replacement.ResourceVersion = ""
+				replacement.Labels = nil
+				require.NoError(t, c.Create(ctx, replacement))
+				return apierrors.NewConflict(
+					schema.GroupResource{Resource: "configmaps"},
+					obj.GetName(),
+					fmt.Errorf("delete precondition failed"),
+				)
 			},
-			Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1", Ports: []corev1.ServicePort{{Port: 27028}}},
+		}).
+		Build()
+	kubeClient := kubernetesClient.NewClient(rawClient)
+	helper := NewMongoDBSearchReconcileHelper(kubeClient, search, nil, newTestOperatorSearchConfig(), nil, nil, false)
+
+	err := helper.cleanupStaleShardResources(t.Context(), zap.S(), nil)
+
+	require.ErrorContains(t, err, "delete precondition failed")
+	current := &corev1.ConfigMap{}
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(stale), current))
+	assert.Equal(t, newUID, current.UID)
+	assert.True(t, apierrors.IsNotFound(kubeClient.Get(t.Context(), client.ObjectKeyFromObject(staleSecret), &corev1.Secret{})),
+		"stale operator Secret must be swept with delete preconditions")
+}
+
+func TestReconcile_RemovingLegacyClientCertificateSecretsUpdatesStatefulSet(t *testing.T) {
+	authModes := []struct {
+		name                      string
+		volumeNames               []string
+		passwordPreviouslyMounted bool
+	}{
+		{
+			name:        "x509 to SCRAM password",
+			volumeNames: []string{"x509-client-cert", "x509-key-password"},
+		},
+		{
+			name:                      "SCRAM mTLS to SCRAM password",
+			volumeNames:               []string{"scram-client-cert", "scram-key-password"},
+			passwordPreviouslyMounted: true,
+		},
+	}
+	topologies := []struct {
+		name        string
+		clusterName string
+		projected   bool
+		hubMember   bool
+	}{
+		{name: "legacy"},
+		{name: "projected local", clusterName: "cluster-a", projected: true},
+		{name: "hub member", clusterName: "cluster-a", hubMember: true},
+	}
+	for _, authMode := range authModes {
+		for _, topology := range topologies {
+			for _, failUpdate := range []bool{false, true} {
+				name := fmt.Sprintf("%s/%s/success", authMode.name, topology.name)
+				if failUpdate {
+					name = fmt.Sprintf("%s/%s/StatefulSet failure", authMode.name, topology.name)
+				}
+				t.Run(name, func(t *testing.T) {
+					search := newTestMongoDBSearch("test-search", "test-ns", func(search *searchv1.MongoDBSearch) {
+						search.UID = "search-uid"
+						search.Spec.Clusters[0].Name = topology.clusterName
+						search.Spec.Source.PasswordSecretRef = &userv1.SecretKeyRef{Name: "source-user-password", Key: "password"}
+						if topology.clusterName != "" {
+							search.Spec.Clusters[0].Index = ptr.To(int32(0))
+						}
+					})
+					mdbc := newTestMongoDBCommunity("test-mongodb", search.Namespace)
+					labels := searchOwnerLabels(search, topology.clusterName)
+					stsName := search.StatefulSetNamespacedNameForCluster(0)
+					generatedSecrets := []*corev1.Secret{
+						{ObjectMeta: metav1.ObjectMeta{
+							Name: search.X509OperatorManagedSecret().Name, Namespace: search.Namespace,
+							UID: "x509-uid", Labels: maps.Clone(labels),
+						}, Data: map[string][]byte{"value": []byte("x509")}},
+						{ObjectMeta: metav1.ObjectMeta{
+							Name: search.ScramClientCertOperatorManagedSecret().Name, Namespace: search.Namespace,
+							UID: "scram-uid", Labels: maps.Clone(labels),
+						}, Data: map[string][]byte{"value": []byte("scram")}},
+					}
+					secretName := generatedSecrets[0].Name
+					if authMode.volumeNames[0] == "scram-client-cert" {
+						secretName = generatedSecrets[1].Name
+					}
+					volumeMounts := []corev1.VolumeMount{
+						{Name: authMode.volumeNames[0], MountPath: "/operator/cert"},
+						{Name: authMode.volumeNames[1], MountPath: "/operator/password"},
+						{Name: "user-volume", MountPath: "/user"},
+					}
+					volumes := []corev1.Volume{
+						statefulset.CreateVolumeFromSecret(authMode.volumeNames[0], secretName),
+						statefulset.CreateVolumeFromSecret(authMode.volumeNames[1], "auth-key-password"),
+						statefulset.CreateVolumeFromEmptyDir("user-volume"),
+					}
+					if authMode.passwordPreviouslyMounted {
+						volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(
+							"password", MongotSourceUserPasswordPath, statefulset.WithReadOnly(true), statefulset.WithSubPath("password"),
+						))
+						volumes = append(volumes, statefulset.CreateVolumeFromSecret("password", "source-user-password"))
+					}
+					existingSTS := &appsv1.StatefulSet{
+						ObjectMeta: metav1.ObjectMeta{Name: stsName.Name, Namespace: stsName.Namespace, Labels: maps.Clone(labels)},
+						Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:         MongotContainerName,
+								Args:         []string{"-c", "cp stale-password"},
+								VolumeMounts: volumeMounts,
+							}},
+							Volumes: volumes,
+						}}},
+					}
+					sourcePasswordSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+						Name: "source-user-password", Namespace: search.Namespace,
+						UID: "source-password-uid", Labels: maps.Clone(labels),
+					}, Data: map[string][]byte{"password": []byte("source-password")}}
+					authKeyPasswordSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+						Name: "auth-key-password", Namespace: search.Namespace,
+						UID: "auth-key-password-uid", Labels: maps.Clone(labels),
+					}, Data: map[string][]byte{KeyFilePasswordSecretKey: []byte("auth-key-password")}}
+					customerSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+						Name: "customer-source-secret", Namespace: search.Namespace,
+						UID: "customer-uid", Labels: maps.Clone(labels),
+					}, Data: map[string][]byte{"value": []byte("customer")}}
+					targetObjects := []client.Object{
+						existingSTS,
+						generatedSecrets[0],
+						generatedSecrets[1],
+						sourcePasswordSecret,
+						authKeyPasswordSecret,
+						customerSecret,
+					}
+					injectedErr := errors.New("injected StatefulSet update failure")
+					newTargetClient := func(objects ...client.Object) kubernetesClient.Client {
+						base := mock.NewEmptyFakeClientBuilder().WithObjects(objects...).Build()
+						return kubernetesClient.NewClient(interceptor.NewClient(base, interceptor.Funcs{
+							Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+								if _, ok := obj.(*appsv1.StatefulSet); ok && failUpdate {
+									return injectedErr
+								}
+								return c.Update(ctx, obj, opts...)
+							},
+						}))
+					}
+					var centralClient kubernetesClient.Client
+					var targetClient kubernetesClient.Client
+					var memberClients map[string]kubernetesClient.Client
+					if topology.hubMember {
+						centralClient = kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(search, mdbc).Build())
+						targetClient = newTargetClient(targetObjects...)
+						memberClients = map[string]kubernetesClient.Client{topology.clusterName: targetClient}
+					} else {
+						centralObjects := append([]client.Object{search, mdbc}, targetObjects...)
+						centralClient = newTargetClient(centralObjects...)
+						targetClient = centralClient
+					}
+					helper := NewMongoDBSearchReconcileHelper(
+						centralClient,
+						search,
+						NewCommunityResourceSearchSource(mdbc),
+						newTestOperatorSearchConfig(),
+						memberClients,
+						nil,
+						topology.projected,
+					)
+
+					result := helper.reconcile(t.Context(), zap.S())
+					if failUpdate {
+						assert.Contains(t, MessageFromStatus(result), injectedErr.Error())
+					}
+
+					updatedSTS, err := targetClient.GetStatefulSet(t.Context(), stsName)
+					require.NoError(t, err)
+					volumeNames := map[string]bool{}
+					for _, volume := range updatedSTS.Spec.Template.Spec.Volumes {
+						volumeNames[volume.Name] = true
+					}
+					mongotContainer := updatedSTS.Spec.Template.Spec.Containers[0]
+					mountNames := map[string]bool{}
+					for _, mount := range mongotContainer.VolumeMounts {
+						mountNames[mount.Name] = true
+					}
+					for _, volumeName := range authMode.volumeNames {
+						assert.Equal(t, failUpdate, volumeNames[volumeName])
+						assert.Equal(t, failUpdate, mountNames[volumeName])
+					}
+					assert.Equal(t, !failUpdate || authMode.passwordPreviouslyMounted, volumeNames["password"])
+					assert.Equal(t, !failUpdate || authMode.passwordPreviouslyMounted, mountNames["password"])
+					assert.True(t, volumeNames["user-volume"])
+					assert.True(t, mountNames["user-volume"])
+					assert.Equal(t, failUpdate, strings.Contains(mongotContainer.Args[1], "stale-password"))
+					if !failUpdate {
+						passwordVolume := slices.IndexFunc(updatedSTS.Spec.Template.Spec.Volumes, func(volume corev1.Volume) bool {
+							return volume.Name == "password"
+						})
+						require.NotEqual(t, -1, passwordVolume)
+						assert.Equal(t, sourcePasswordSecret.Name, updatedSTS.Spec.Template.Spec.Volumes[passwordVolume].Secret.SecretName)
+						passwordMount := slices.IndexFunc(mongotContainer.VolumeMounts, func(mount corev1.VolumeMount) bool {
+							return mount.Name == "password"
+						})
+						require.NotEqual(t, -1, passwordMount)
+						assert.Equal(t, MongotSourceUserPasswordPath, mongotContainer.VolumeMounts[passwordMount].MountPath)
+						assert.Equal(t, "password", mongotContainer.VolumeMounts[passwordMount].SubPath)
+					}
+
+					// Replica-set topology never reaps generated Secrets mid-life;
+					// switching auth modes only rewires the StatefulSet.
+					preservedSecrets := append([]*corev1.Secret{sourcePasswordSecret, authKeyPasswordSecret, customerSecret}, generatedSecrets...)
+					for _, preserved := range preservedSecrets {
+						actual := &corev1.Secret{}
+						require.NoError(t, targetClient.Get(t.Context(), client.ObjectKeyFromObject(preserved), actual))
+						assert.Equal(t, preserved.UID, actual.UID)
+						assert.Equal(t, preserved.Labels, actual.Labels)
+						assert.Equal(t, preserved.Data, actual.Data)
+					}
+					configMap, err := targetClient.GetConfigMap(t.Context(), search.MongotConfigConfigMapNameForCluster(0))
+					require.NoError(t, err)
+					assert.Contains(t, configMap.Data[MongotConfigFilename], TempSourceUserPasswordPath)
+					assert.NotContains(t, configMap.Data[MongotConfigFilename], X509ClientCertOperatorMountPath)
+					assert.NotContains(t, configMap.Data[MongotConfigFilename], ScramClientCertOperatorMountPath)
+				})
+			}
 		}
 	}
-	mongotSTS := func(shard string, owned bool) *appsv1.StatefulSet {
-		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
-			Name: search.MongotStatefulSetForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{}, owned),
-		}}
-	}
-	mongotHeadless := func(shard string, owned bool) *corev1.Service {
-		return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name: search.MongotServiceForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
-		}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2", Ports: []corev1.ServicePort{{Port: 27027}}}}
-	}
-	mongotCM := func(shard string, owned bool) *corev1.ConfigMap {
-		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
-			Name: search.MongotConfigMapForClusterShard(0, shard).Name, Namespace: "test-ns", Labels: withOwner(map[string]string{"component": mongotComponent}, owned),
-		}}
-	}
+}
 
-	fakeClient := newTestFakeClient(search,
-		proxySvc("shard-0", true),  // active, owned
-		proxySvc("shard-1", true),  // active, owned
-		proxySvc("shard-2", true),  // stale, owned
-		proxySvc("shard-x", false), // different owner
-		mongotSTS("shard-1", true), mongotSTS("shard-2", true),
-		mongotHeadless("shard-1", true), mongotHeadless("shard-2", true), mongotHeadless("shard-x", false),
-		mongotCM("shard-1", true), mongotCM("shard-2", true), mongotCM("shard-x", false),
-		// Name collision: live shard "x"'s headless Svc name == stale "x-svc"'s STS name.
-		// Separate per-kind expected sets keep them apart; a merged set would leak the stale STS.
-		mongotHeadless("x", true), mongotSTS("x-svc", true),
-	)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
-	require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), []string{"shard-0", "shard-1", "x"}))
-
-	_, err := fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-0"))
-	assert.NoError(t, err, "active shard preserved")
-	_, err = fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-1"))
-	assert.NoError(t, err, "active shard preserved")
-	_, err = fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-2"))
-	assert.Error(t, err, "stale shard deleted")
-	_, err = fakeClient.GetService(t.Context(), search.ProxyServiceNameForClusterShard(0, "shard-x"))
-	assert.NoError(t, err, "different owner untouched")
-
-	gone := func(nn types.NamespacedName, obj client.Object, msg string) {
-		assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), nn, obj)), msg)
+func TestReconcileSharded_TLSDisabledRemovesMountsPreservesLiveSecret(t *testing.T) {
+	tests := []struct {
+		name                  string
+		clusterName           string
+		hubMember             bool
+		failStatefulSetUpdate bool
+	}{
+		{name: "successful StatefulSet update removes mounts"},
+		{name: "failed StatefulSet update keeps mounts", failStatefulSetUpdate: true},
+		{name: "failed projected update keeps mounts", clusterName: "cluster-b", failStatefulSetUpdate: true},
+		{name: "failed hub member update keeps mounts", clusterName: "cluster-b", hubMember: true, failStatefulSetUpdate: true},
 	}
-	present := func(nn types.NamespacedName, obj client.Object, msg string) {
-		assert.NoError(t, fakeClient.Get(t.Context(), nn, obj), msg)
-	}
-	present(search.MongotStatefulSetForClusterShard(0, "shard-1"), &appsv1.StatefulSet{}, "active shard STS preserved")
-	gone(search.MongotStatefulSetForClusterShard(0, "shard-2"), &appsv1.StatefulSet{}, "stale shard STS deleted")
-	present(search.MongotServiceForClusterShard(0, "shard-1"), &corev1.Service{}, "active shard headless Service preserved")
-	gone(search.MongotServiceForClusterShard(0, "shard-2"), &corev1.Service{}, "stale shard headless Service deleted")
-	present(search.MongotServiceForClusterShard(0, "shard-x"), &corev1.Service{}, "different-owner headless Service untouched")
-	present(search.MongotConfigMapForClusterShard(0, "shard-1"), &corev1.ConfigMap{}, "active shard ConfigMap preserved")
-	gone(search.MongotConfigMapForClusterShard(0, "shard-2"), &corev1.ConfigMap{}, "stale shard ConfigMap deleted")
-	present(search.MongotConfigMapForClusterShard(0, "shard-x"), &corev1.ConfigMap{}, "different-owner ConfigMap untouched")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+				s.UID = "search-uid"
+				s.Spec.Clusters[0].Name = tc.clusterName
+			})
+			shardName := "shard-0"
+			labels := searchOwnerLabels(search, tc.clusterName)
+			labels[khandler.MongoDBSearchComponentLabel] = mongotComponent
+			stsName := search.MongotStatefulSetForClusterShard(0, shardName)
+			existingSTS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName.Name, Namespace: stsName.Namespace, Labels: maps.Clone(labels)},
+				Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: MongotContainerName,
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "tls", MountPath: "/var/lib/tls"},
+							{Name: "grpc-key-password", MountPath: GrpcKeyPasswordMountPath},
+							{Name: "user-volume", MountPath: "/user"},
+						},
+					}},
+					Volumes: []corev1.Volume{
+						statefulset.CreateVolumeFromSecret("tls", search.TLSOperatorSecretForClusterShard(0, shardName).Name),
+						statefulset.CreateVolumeFromSecret("grpc-key-password", "grpc-key-password"),
+						statefulset.CreateVolumeFromEmptyDir("user-volume"),
+					},
+				}}},
+			}
+			activeSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: search.TLSOperatorSecretForClusterShard(0, shardName).Name, Namespace: search.Namespace, Labels: maps.Clone(labels),
+			}}
+			staleSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: search.TLSOperatorSecretForClusterShard(0, "stale-shard").Name, Namespace: search.Namespace, Labels: maps.Clone(labels),
+			}}
+			injectedErr := fmt.Errorf("injected StatefulSet update failure")
+			targetObjects := []client.Object{existingSTS, activeSecret, staleSecret}
+			if !tc.hubMember {
+				targetObjects = append(targetObjects, search)
+			}
+			targetBase := mock.NewEmptyFakeClientBuilder().WithObjects(targetObjects...).Build()
+			targetClient := kubernetesClient.NewClient(interceptor.NewClient(targetBase, interceptor.Funcs{
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if _, ok := obj.(*appsv1.StatefulSet); ok && tc.failStatefulSetUpdate {
+						return injectedErr
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+			}))
+			centralClient := targetClient
+			var memberClients map[string]kubernetesClient.Client
+			if tc.hubMember {
+				centralClient = newTestFakeClient(search)
+				memberClients = map[string]kubernetesClient.Client{tc.clusterName: targetClient}
+			}
+			helper := NewMongoDBSearchReconcileHelper(
+				centralClient,
+				search,
+				&mockShardedSource{
+					shardNames: []string{shardName},
+					hostSeeds:  map[string][]string{shardName: {"shard-0-0.test-ns.svc.cluster.local:27017"}},
+				},
+				newTestOperatorSearchConfig(),
+				memberClients,
+				nil,
+				tc.clusterName != "" && !tc.hubMember,
+			)
 
-	present(search.MongotServiceForClusterShard(0, "x"), &corev1.Service{}, "live shard x headless Service preserved despite name-collision with stale x-svc STS")
-	gone(search.MongotStatefulSetForClusterShard(0, "x-svc"), &appsv1.StatefulSet{}, "stale x-svc STS reaped despite name-collision with live x headless Service")
+			result := helper.reconcile(t.Context(), zap.S())
+			if tc.failStatefulSetUpdate {
+				assert.Contains(t, MessageFromStatus(result), injectedErr.Error())
+			}
+
+			updatedSTS, err := targetClient.GetStatefulSet(t.Context(), stsName)
+			require.NoError(t, err)
+			volumeNames := map[string]bool{}
+			for _, volume := range updatedSTS.Spec.Template.Spec.Volumes {
+				volumeNames[volume.Name] = true
+			}
+			mountNames := map[string]bool{}
+			for _, mount := range updatedSTS.Spec.Template.Spec.Containers[0].VolumeMounts {
+				mountNames[mount.Name] = true
+			}
+			assert.Equal(t, tc.failStatefulSetUpdate, volumeNames["tls"])
+			assert.Equal(t, tc.failStatefulSetUpdate, volumeNames["grpc-key-password"])
+			assert.Equal(t, tc.failStatefulSetUpdate, mountNames["tls"])
+			assert.Equal(t, tc.failStatefulSetUpdate, mountNames["grpc-key-password"])
+			assert.True(t, volumeNames["user-volume"])
+			assert.True(t, mountNames["user-volume"])
+
+			// Disabling TLS never reaps the live shard's generated Secret; only the
+			// stale shard's Secret is swept.
+			require.NoError(t, targetClient.Get(t.Context(), client.ObjectKeyFromObject(activeSecret), &corev1.Secret{}))
+			assert.True(t, apierrors.IsNotFound(targetClient.Get(
+				t.Context(),
+				client.ObjectKeyFromObject(staleSecret),
+				&corev1.Secret{},
+			)))
+		})
+	}
+}
+
+func TestReconcileReplicaSet_TLSDisabledRemovesMountsPreservesSecrets(t *testing.T) {
+	tests := []struct {
+		name                  string
+		failStatefulSetUpdate bool
+	}{
+		{name: "successful StatefulSet update removes mounts"},
+		{name: "failed StatefulSet update keeps mounts", failStatefulSetUpdate: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+				s.UID = "search-uid"
+			})
+			mdbc := newTestMongoDBCommunity("test-mongodb", "test-ns")
+			labels := searchOwnerLabels(search, "")
+			labels[khandler.MongoDBSearchComponentLabel] = mongotComponent
+			stsName := search.StatefulSetNamespacedNameForCluster(0)
+			existingSTS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName.Name, Namespace: stsName.Namespace, Labels: maps.Clone(labels)},
+				Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: MongotContainerName,
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "tls", MountPath: "/var/lib/tls"},
+							{Name: "grpc-key-password", MountPath: GrpcKeyPasswordMountPath},
+							{Name: "user-volume", MountPath: "/user"},
+						},
+					}},
+					Volumes: []corev1.Volume{
+						statefulset.CreateVolumeFromSecret("tls", search.TLSOperatorSecretNamespacedName().Name),
+						statefulset.CreateVolumeFromSecret("grpc-key-password", "grpc-key-password"),
+						statefulset.CreateVolumeFromEmptyDir("user-volume"),
+					},
+				}}},
+			}
+			activeSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: search.TLSOperatorSecretNamespacedName().Name, Namespace: search.Namespace, Labels: maps.Clone(labels),
+			}}
+			staleSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: search.TLSOperatorSecretForClusterShard(0, "stale-shard").Name, Namespace: search.Namespace, Labels: maps.Clone(labels),
+			}}
+			injectedErr := fmt.Errorf("injected StatefulSet update failure")
+			base := mock.NewEmptyFakeClientBuilder().WithObjects(search, mdbc, existingSTS, activeSecret, staleSecret).Build()
+			fakeClient := kubernetesClient.NewClient(interceptor.NewClient(base, interceptor.Funcs{
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if _, ok := obj.(*appsv1.StatefulSet); ok && tc.failStatefulSetUpdate {
+						return injectedErr
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+			}))
+			helper := NewMongoDBSearchReconcileHelper(
+				fakeClient,
+				search,
+				NewCommunityResourceSearchSource(mdbc),
+				newTestOperatorSearchConfig(),
+				nil,
+				nil,
+				false,
+			)
+
+			result := helper.reconcile(t.Context(), zap.S())
+			if tc.failStatefulSetUpdate {
+				assert.Contains(t, MessageFromStatus(result), injectedErr.Error())
+			}
+
+			updatedSTS, err := fakeClient.GetStatefulSet(t.Context(), stsName)
+			require.NoError(t, err)
+			volumeNames := map[string]bool{}
+			for _, volume := range updatedSTS.Spec.Template.Spec.Volumes {
+				volumeNames[volume.Name] = true
+			}
+			mountNames := map[string]bool{}
+			for _, mount := range updatedSTS.Spec.Template.Spec.Containers[0].VolumeMounts {
+				mountNames[mount.Name] = true
+			}
+			assert.Equal(t, tc.failStatefulSetUpdate, volumeNames["tls"])
+			assert.Equal(t, tc.failStatefulSetUpdate, volumeNames["grpc-key-password"])
+			assert.Equal(t, tc.failStatefulSetUpdate, mountNames["tls"])
+			assert.Equal(t, tc.failStatefulSetUpdate, mountNames["grpc-key-password"])
+			assert.True(t, volumeNames["user-volume"])
+			assert.True(t, mountNames["user-volume"])
+
+			// Replica-set topology has no mid-life Secret sweep at all: generated
+			// Secrets linger until CR delete.
+			for _, preserved := range []*corev1.Secret{activeSecret, staleSecret} {
+				require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(preserved), &corev1.Secret{}))
+			}
+		})
+	}
 }
 
 func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
 	search.UID = "search-uid"
 	mdbc := newTestMongoDBCommunity("test-mongodb", "test-ns")
-	fakeClient := newTestFakeClient(search, mdbc)
+	fakeClient := newTestFakeClient(
+		search,
+		mdbc,
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Name: search.StatefulSetNamespacedNameForCluster(0).Name, Namespace: search.Namespace,
+		}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.SearchServiceNamespacedNameForCluster(0).Name, Namespace: search.Namespace,
+		}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: search.ProxyServiceNamespacedNameForCluster(0).Name, Namespace: search.Namespace,
+		}},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: search.MongotConfigConfigMapNameForCluster(0).Name, Namespace: search.Namespace,
+			},
+			Data: map[string]string{"legacy": "data"},
+		},
+	)
 
 	helper := NewMongoDBSearchReconcileHelper(
 		fakeClient,
@@ -3207,6 +4078,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 		NewCommunityResourceSearchSource(mdbc),
 		newTestOperatorSearchConfig(),
 		nil, nil,
+		false,
 	)
 
 	// Pass 1: creates resources, returns Pending (StatefulSet not ready)
@@ -3235,9 +4107,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, string(search.UID), svc.Labels[khandler.MongoDBSearchOwnerUIDLabel])
 	assert.Equal(t, mongotComponent, svc.Labels[khandler.MongoDBSearchComponentLabel])
 	assert.NotContains(t, svc.Labels, khandler.MongoDBSearchClusterNameLabel)
-	assert.True(t, slices.ContainsFunc(svc.OwnerReferences, func(ref metav1.OwnerReference) bool {
-		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name && ref.UID == search.UID
-	}))
+	assertOwnedBySearch(t, search, &svc)
 
 	portMap := make(map[string]int32)
 	for _, p := range svc.Spec.Ports {
@@ -3260,11 +4130,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, string(search.UID), sts.Labels[khandler.MongoDBSearchOwnerUIDLabel])
 	assert.Equal(t, mongotComponent, sts.Labels[khandler.MongoDBSearchComponentLabel])
 	assert.NotContains(t, sts.Labels, khandler.MongoDBSearchClusterNameLabel)
-
-	// Owner-ref back to the MongoDBSearch CR drives PVC reclaim via GC on CR delete.
-	assert.True(t, slices.ContainsFunc(sts.OwnerReferences, func(ref metav1.OwnerReference) bool {
-		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name
-	}))
+	assertOwnedBySearch(t, search, &sts)
 
 	// Verify ConfigMap
 	cmNsName := search.MongotConfigConfigMapNameForCluster(0)
@@ -3278,9 +4144,7 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
 	assert.Equal(t, mongotComponent, cm.Labels[khandler.MongoDBSearchComponentLabel])
 	assert.NotContains(t, cm.Labels, khandler.MongoDBSearchClusterNameLabel)
-	assert.True(t, slices.ContainsFunc(cm.OwnerReferences, func(ref metav1.OwnerReference) bool {
-		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name && ref.UID == search.UID
-	}))
+	assertOwnedBySearch(t, search, &cm)
 }
 
 type fakeExternalSource struct {
@@ -4307,6 +5171,18 @@ func TestReconcileShardedMC_PerClusterStatusWorstOfShards(t *testing.T) {
 // cluster instead of silently writing to the central client.
 func TestReconcileShardedMC_MissingMemberClusterClient(t *testing.T) {
 	fx := newMCShardedFixture(t)
+	fx.search.UID = "search-uid"
+	stale := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      fx.search.MongotConfigMapForClusterShard(0, "stale-shard").Name,
+		Namespace: fx.search.Namespace,
+		Labels: map[string]string{
+			khandler.MongoDBSearchOwnerNameLabel:      fx.search.Name,
+			khandler.MongoDBSearchOwnerNamespaceLabel: fx.search.Namespace,
+			khandler.MongoDBSearchOwnerUIDLabel:       string(fx.search.UID),
+			khandler.MongoDBSearchComponentLabel:      mongotComponent,
+		},
+	}}
+	require.NoError(t, fx.members["cluster-a"].Create(t.Context(), stale))
 	// Drop cluster-b so the helper has no client for it.
 	delete(fx.members, "cluster-b")
 
@@ -4323,6 +5199,8 @@ func TestReconcileShardedMC_MissingMemberClusterClient(t *testing.T) {
 	for _, sts := range stsList.Items {
 		require.NotContains(t, sts.Name, "search-1-", "cluster-b STS %q must NOT have been created on the central client", sts.Name)
 	}
+	assert.True(t, apierrors.IsNotFound(fx.members["cluster-a"].Get(t.Context(), client.ObjectKeyFromObject(stale), &corev1.ConfigMap{})),
+		"a missing member client must not block stale cleanup on healthy clusters")
 }
 
 // cleanupStaleShardResources must reach into member clusters in MC sharded
@@ -4330,6 +5208,7 @@ func TestReconcileShardedMC_MissingMemberClusterClient(t *testing.T) {
 func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns", func(s *searchv1.MongoDBSearch) {
 		s.UID = "search-uid"
+		s.Spec.Security = searchv1.Security{TLS: &searchv1.TLS{CertsSecretPrefix: "certs"}}
 		s.Spec.Clusters = []searchv1.ClusterSpec{
 			{Name: "cluster-a", Index: ptr.To(int32(0)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
 			{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{}}},
@@ -4343,6 +5222,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		if owned {
 			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
 			labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
+			labels[khandler.MongoDBSearchOwnerUIDLabel] = string(search.UID)
 		}
 		return &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", Labels: labels},
@@ -4355,6 +5235,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		if owned {
 			labels[khandler.MongoDBSearchOwnerNameLabel] = search.Name
 			labels[khandler.MongoDBSearchOwnerNamespaceLabel] = search.Namespace
+			labels[khandler.MongoDBSearchOwnerUIDLabel] = string(search.UID)
 		}
 		return labels
 	}
@@ -4373,6 +5254,11 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 			Name: search.MongotConfigMapForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
 		}}
 	}
+	memberTLSSecret := func(idx int, shard string, owned bool) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: search.TLSOperatorSecretForClusterShard(idx, shard).Name, Namespace: "ns", Labels: withMemberOwner(map[string]string{"component": mongotComponent}, owned),
+		}}
+	}
 
 	// cluster-a (idx 0): keep shard-0 + cluster-level; sh-stale should be deleted.
 	clusterA := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(
@@ -4383,6 +5269,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		memberSTS(0, "sh-0", true), memberSTS(0, "sh-stale", true),
 		memberMongotSvc(0, "sh-0", true), memberMongotSvc(0, "sh-stale", true), memberMongotSvc(0, "sh-foreign", false),
 		memberCM(0, "sh-0", true), memberCM(0, "sh-stale", true),
+		memberTLSSecret(0, "sh-0", true), memberTLSSecret(0, "sh-stale", true), memberTLSSecret(0, "sh-foreign", false),
 	).Build())
 	// cluster-b (idx 1): same pattern, plus an unrelated owned-by-other-CR svc
 	// to guard the label-name check.
@@ -4390,6 +5277,7 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		memberProxySvc("mdb-search-search-1-sh-0-proxy-svc", true),
 		memberProxySvc("mdb-search-search-1-sh-stale-proxy-svc", true),
 		memberProxySvc("mdb-search-search-1-proxy-svc", true),
+		memberSTS(0, "sh-0", true),
 		func() *corev1.Service {
 			svc := memberProxySvc("other-search-search-1-sh-0-proxy-svc", true)
 			svc.Labels[khandler.MongoDBSearchOwnerNameLabel] = "other-search"
@@ -4405,7 +5293,11 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		state:                NewSearchDeploymentState(),
 	}
 
-	require.NoError(t, r.cleanupStaleShardResources(t.Context(), zap.S(), []string{"sh-0"}))
+	activeUnits := []reconcileUnit{
+		newTestShardCleanupUnit(search, 0, "cluster-a", "sh-0"),
+		newTestShardCleanupUnit(search, 1, "cluster-b", "sh-0"),
+	}
+	require.NoError(t, r.cleanupStaleShardResources(t.Context(), zap.S(), activeUnits))
 
 	// Per-cluster expectations: active + cluster-level kept, stale deleted, foreign untouched.
 	for _, tc := range []struct {
@@ -4430,6 +5322,9 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 		err = tc.c.Get(t.Context(), types.NamespacedName{Name: tc.foreign, Namespace: "ns"}, &corev1.Service{})
 		require.NoError(t, err, "%s: foreign Service %q must be untouched", tc.cluster, tc.foreign)
 	}
+	assert.True(t, apierrors.IsNotFound(clusterB.Get(t.Context(),
+		search.MongotStatefulSetForClusterShard(0, "sh-0"), &appsv1.StatefulSet{})),
+		"an active name on another physical cluster must not preserve a stale StatefulSet")
 
 	present := func(name string, obj client.Object, what string) {
 		require.NoError(t, clusterA.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "ns"}, obj), "cluster-a: %s must survive cleanup", what)
@@ -4445,6 +5340,9 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 	present(search.MongotServiceForClusterShard(0, "sh-foreign").Name, &corev1.Service{}, "unowned headless Service")
 	present(search.MongotConfigMapForClusterShard(0, "sh-0").Name, &corev1.ConfigMap{}, "active mongot ConfigMap")
 	gone(search.MongotConfigMapForClusterShard(0, "sh-stale").Name, &corev1.ConfigMap{}, "stale mongot ConfigMap")
+	present(search.TLSOperatorSecretForClusterShard(0, "sh-0").Name, &corev1.Secret{}, "active shard TLS operator Secret")
+	gone(search.TLSOperatorSecretForClusterShard(0, "sh-stale").Name, &corev1.Secret{}, "stale shard TLS operator Secret")
+	present(search.TLSOperatorSecretForClusterShard(0, "sh-foreign").Name, &corev1.Secret{}, "unowned shard TLS operator Secret")
 }
 
 // Empty GetShardNames() yields an empty work list. The reconciler must not fail
@@ -4497,6 +5395,38 @@ func TestReconcileSharded_EmptyShardNames(t *testing.T) {
 	for _, svc := range svcList.Items {
 		require.NotContains(t, svc.Name, "-proxy-svc", "no proxy Services must be created when shardNames is empty, got %q", svc.Name)
 	}
+}
+
+func TestReconcileSharded_StaleCleanupErrorFailsReconcile(t *testing.T) {
+	search := newTestMongoDBSearch("mdb-search", "ns", func(s *searchv1.MongoDBSearch) {
+		s.Spec.Source = &searchv1.MongoDBSource{
+			ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{
+				ShardedCluster: &searchv1.ExternalShardedClusterConfig{
+					Router: searchv1.ExternalRouterConfig{Hosts: []string{"mongos.example:27017"}},
+					Shards: []searchv1.ExternalShardConfig{{ShardName: "ignored", Hosts: []string{"ignored:27017"}}},
+				},
+			},
+		}
+	})
+	injectedErr := fmt.Errorf("injected stale cleanup list failure")
+	base := mock.NewEmptyFakeClientBuilder().WithObjects(search).Build()
+	fakeClient := kubernetesClient.NewClient(interceptor.NewClient(base, interceptor.Funcs{
+		List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+			return injectedErr
+		},
+	}))
+	r := &MongoDBSearchReconcileHelper{
+		mdbSearch:            search,
+		db:                   &mockShardedSource{},
+		client:               fakeClient,
+		operatorSearchConfig: newTestOperatorSearchConfig(),
+		state:                NewSearchDeploymentState(),
+	}
+
+	st := r.reconcile(t.Context(), zap.S())
+
+	require.False(t, st.IsOK())
+	assert.Contains(t, MessageFromStatus(st), injectedErr.Error())
 }
 
 // The Search controller patches /status and the Envoy controller patches
@@ -4597,7 +5527,7 @@ func TestReconcileSharded_RoutingSwitchOneWay(t *testing.T) {
 	// Pre-existing switch entry for a shard that no longer exists — must be pruned.
 	state := NewSearchDeploymentState()
 	state.RoutingReadyMongotGroups = []string{"sh-removed"}
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, state)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, state, false)
 	switchedOn := func(shard string) bool { return slices.Contains(helper.state.RoutingReadyMongotGroups, shard) }
 
 	// Pass 1: STSs created, none routing-ready.
@@ -4699,7 +5629,7 @@ func TestReconcileSharded_SwitchErrorsAggregatedAcrossUnits(t *testing.T) {
 			return cl.Update(ctx, obj, opts...)
 		},
 	}))
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, nil, false)
 	switchedOn := func(shard string) bool { return slices.Contains(helper.state.RoutingReadyMongotGroups, shard) }
 
 	// Both shards meet the threshold; sh-0's switch write fails.
@@ -4741,7 +5671,7 @@ func TestReconcileSharded_StatefulSetTemplateStableAcrossReconciles(t *testing.T
 		},
 	}
 	fakeClient := newTestFakeClient(search)
-	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, shardedSource, newTestOperatorSearchConfig(), nil, nil)
+	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, shardedSource, newTestOperatorSearchConfig(), nil, nil, false)
 
 	helper.reconcile(t.Context(), zap.S())
 	stsNsName := search.MongotStatefulSetForClusterShard(0, "my-cluster-0")

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -33,6 +33,7 @@ import (
 	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/mongot"
+	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 )
 
@@ -613,6 +614,58 @@ func TestMongoDBSearchReconcileHelper_ServiceCreation(t *testing.T) {
 
 			assertServiceBasicProperties(t, svc, mdbSearch)
 			assertServicePorts(t, svc, tc.expectedPorts)
+		})
+	}
+}
+
+func TestStatefulSetOverridePreservesProtectedSearchLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		wantCluster string
+	}{
+		{name: "member cluster restores cluster label", clusterName: "member-a", wantCluster: "member-a"},
+		{name: "legacy single cluster removes injected cluster label"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(search *searchv1.MongoDBSearch) {
+				search.UID = "search-uid"
+				search.Spec.Clusters = []searchv1.ClusterSpec{{
+					Name: tc.clusterName,
+					StatefulSetConfiguration: &v1.StatefulSetConfiguration{
+						MetadataWrapper: v1.StatefulSetMetadataWrapper{
+							Labels: map[string]string{
+								"custom-label":                            "custom-value",
+								khandler.MongoDBSearchOwnerNameLabel:      "wrong-name",
+								khandler.MongoDBSearchOwnerNamespaceLabel: "wrong-namespace",
+								khandler.MongoDBSearchOwnerUIDLabel:       "wrong-uid",
+								khandler.MongoDBSearchClusterNameLabel:    "wrong-cluster",
+								khandler.MongoDBSearchComponentLabel:      "wrong-component",
+							},
+						},
+					},
+				}}
+			})
+			sizing := search.EffectiveClusters()[0]
+			sts := statefulset.New(
+				CreateSearchStatefulSetFunc(search, sizing, "test-search-search-0", search.Namespace, "test-search-search-0-svc", "test-search-search-0-config", map[string]string{"app": "test-search-search-0"}, "mongot:latest", false),
+				StatefulSetOverrideModification(sizing.StatefulSetConfiguration),
+				withSearchOwnerLabels(search, tc.clusterName),
+			)
+
+			assert.Equal(t, "custom-value", sts.Labels["custom-label"])
+			assert.Equal(t, search.Name, sts.Labels[khandler.MongoDBSearchOwnerNameLabel])
+			assert.Equal(t, search.Namespace, sts.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+			assert.Equal(t, string(search.UID), sts.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+			if tc.wantCluster == "" {
+				assert.NotContains(t, sts.Labels, khandler.MongoDBSearchClusterNameLabel)
+			} else {
+				assert.Equal(t, tc.wantCluster, sts.Labels[khandler.MongoDBSearchClusterNameLabel])
+			}
+			assert.Equal(t, mongotComponent, sts.Labels[khandler.MongoDBSearchComponentLabel])
+			require.Len(t, sts.OwnerReferences, 1)
+			assert.Equal(t, search.UID, sts.OwnerReferences[0].UID)
 		})
 	}
 }
@@ -2594,13 +2647,80 @@ func TestValidatePerShardTLSSecretsAllExist(t *testing.T) {
 	assert.True(t, status.IsOK(), "Expected status to be OK when all secrets exist")
 }
 
+func TestReconcile_IngressTLSSecretIdentity(t *testing.T) {
+	shardName := "shard-0"
+	tests := []struct {
+		name  string
+		setup func(*searchv1.MongoDBSearch) (SearchSourceDBResource, client.Object, types.NamespacedName, types.NamespacedName)
+	}{
+		{
+			name: "replica set",
+			setup: func(search *searchv1.MongoDBSearch) (SearchSourceDBResource, client.Object, types.NamespacedName, types.NamespacedName) {
+				mdbc := newTestMongoDBCommunity("test-mongodb", search.Namespace)
+				return NewCommunityResourceSearchSource(mdbc), mdbc, search.TLSSecretNamespacedName(), search.TLSOperatorSecretNamespacedName()
+			},
+		},
+		{
+			name: "sharded",
+			setup: func(search *searchv1.MongoDBSearch) (SearchSourceDBResource, client.Object, types.NamespacedName, types.NamespacedName) {
+				source := &mockShardedSource{
+					shardNames: []string{shardName},
+					hostSeeds: map[string][]string{
+						shardName: {"shard-0-0.shard-0.test-ns.svc.cluster.local:27017"},
+					},
+				}
+				return source, nil, search.TLSSecretForClusterShard(0, shardName), search.TLSOperatorSecretForClusterShard(0, shardName)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			search := newTestMongoDBSearch("test-search", "test-ns", func(s *searchv1.MongoDBSearch) {
+				s.UID = "search-uid"
+				s.Spec.Security = searchv1.Security{
+					TLS: &searchv1.TLS{
+						CertsSecretPrefix: "my-prefix",
+					},
+				}
+			})
+			source, sourceObject, sourceSecretName, operatorSecretName := tc.setup(search)
+			sourceSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: sourceSecretName.Name, Namespace: sourceSecretName.Namespace},
+				Data: map[string][]byte{
+					"tls.crt": []byte("cert-data"),
+					"tls.key": []byte("key-data"),
+				},
+			}
+			objects := []client.Object{search, sourceSecret}
+			if sourceObject != nil {
+				objects = append(objects, sourceObject)
+			}
+			fakeClient := newTestFakeClient(objects...)
+			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, source, newTestOperatorSearchConfig(), nil, nil)
+
+			helper.reconcile(t.Context(), zap.S())
+
+			operatorSecret, err := fakeClient.GetSecret(t.Context(), operatorSecretName)
+			require.NoError(t, err)
+			require.Len(t, operatorSecret.OwnerReferences, 1)
+			assert.Equal(t, search.UID, operatorSecret.OwnerReferences[0].UID)
+			assert.Equal(t, mongotComponent, operatorSecret.Labels[khandler.MongoDBSearchComponentLabel])
+			assert.Equal(t, search.Name, operatorSecret.Labels[khandler.MongoDBSearchOwnerNameLabel])
+			assert.Equal(t, search.Namespace, operatorSecret.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+			assert.Equal(t, string(search.UID), operatorSecret.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+			assert.NotContains(t, operatorSecret.Labels, khandler.MongoDBSearchClusterNameLabel)
+		})
+	}
+}
+
 func TestEnsureX509ClientCertConfig_NoopWhenNotConfigured(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
 
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.NoError(t, err)
 
 	// Apply modifications and verify no changes
@@ -2641,7 +2761,7 @@ func TestEnsureX509ClientCertConfig_ErrorWhenTLSNotConfigured(t *testing.T) {
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
-	_, _, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	_, _, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tls must be enabled")
 }
@@ -2666,8 +2786,14 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	fakeClient := newTestFakeClient(search, x509Secret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.NoError(t, err)
+	operatorSecret, err := fakeClient.GetSecret(t.Context(), search.X509OperatorManagedSecret())
+	require.NoError(t, err)
+	require.Len(t, operatorSecret.OwnerReferences, 1)
+	assert.Equal(t, search.Name, operatorSecret.OwnerReferences[0].Name)
+	assert.Equal(t, search.Name, operatorSecret.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, operatorSecret.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
 
 	// Apply mongot modification to a config with both ReplicaSet and Router (sharded scenario)
 	config := &mongot.Config{
@@ -2765,7 +2891,7 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	fakeClient := newTestFakeClient(search, x509Secret, keyPasswordSecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient)
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search, ""))
 	require.NoError(t, err)
 
 	// Verify mongot config has key password path
@@ -3071,6 +3197,7 @@ func TestCleanupStaleShardResources(t *testing.T) {
 
 func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
+	search.UID = "search-uid"
 	mdbc := newTestMongoDBCommunity("test-mongodb", "test-ns")
 	fakeClient := newTestFakeClient(search, mdbc)
 
@@ -3103,6 +3230,14 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-search-search-0-svc", svc.Spec.Selector["app"])
 	assert.Equal(t, "test-search-search-0-svc", svc.Labels["app"])
 	assert.Empty(t, svc.Labels["shard"])
+	assert.Equal(t, search.Name, svc.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, svc.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), svc.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, mongotComponent, svc.Labels[khandler.MongoDBSearchComponentLabel])
+	assert.NotContains(t, svc.Labels, khandler.MongoDBSearchClusterNameLabel)
+	assert.True(t, slices.ContainsFunc(svc.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name && ref.UID == search.UID
+	}))
 
 	portMap := make(map[string]int32)
 	for _, p := range svc.Spec.Ports {
@@ -3120,6 +3255,11 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 	assert.Equal(t, "test-ns", sts.Namespace)
 	assert.Equal(t, "test-search-search-0-svc", sts.Labels["app"])
 	assert.Empty(t, sts.Labels["shard"])
+	assert.Equal(t, search.Name, sts.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, sts.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), sts.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, mongotComponent, sts.Labels[khandler.MongoDBSearchComponentLabel])
+	assert.NotContains(t, sts.Labels, khandler.MongoDBSearchClusterNameLabel)
 
 	// Owner-ref back to the MongoDBSearch CR drives PVC reclaim via GC on CR delete.
 	assert.True(t, slices.ContainsFunc(sts.OwnerReferences, func(ref metav1.OwnerReference) bool {
@@ -3133,6 +3273,14 @@ func TestReconcileReplicaSet_CreatesResources(t *testing.T) {
 
 	assert.Equal(t, "test-search-search-0-config", cm.Name)
 	assert.Contains(t, cm.Data, MongotConfigFilename)
+	assert.Equal(t, search.Name, cm.Labels[khandler.MongoDBSearchOwnerNameLabel])
+	assert.Equal(t, search.Namespace, cm.Labels[khandler.MongoDBSearchOwnerNamespaceLabel])
+	assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+	assert.Equal(t, mongotComponent, cm.Labels[khandler.MongoDBSearchComponentLabel])
+	assert.NotContains(t, cm.Labels, khandler.MongoDBSearchClusterNameLabel)
+	assert.True(t, slices.ContainsFunc(cm.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.Kind == "MongoDBSearch" && ref.Name == search.Name && ref.UID == search.UID
+	}))
 }
 
 type fakeExternalSource struct {

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -146,7 +146,6 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 		statefulset.WithNamespace(namespace),
 		statefulset.WithServiceName(svcName),
 		statefulset.WithLabels(labels),
-		statefulset.WithOwnerReference(mdbSearch.GetOwnerReferences()),
 		statefulset.WithMatchLabels(labels),
 		statefulset.WithReplicas(sizing.ReplicasOrDefault()),
 		statefulset.WithUpdateStrategyType(appsv1.RollingUpdateStatefulSetStrategyType),
@@ -202,7 +201,7 @@ func nodeAffinityModification(nodeAffinity *corev1.NodeAffinity) podtemplatespec
 // update paths — the first reconcile after STS creation then sees a spurious
 // template diff and rolls every mongot pod. Applying last also makes the user
 // override win over operator-set fields, as the CRD field documents. Protected
-// identity labels may be restored afterward without changing the merged spec.
+// lifecycle labels may be restored afterward without changing the merged spec.
 func StatefulSetOverrideModification(stsConfig *v1.StatefulSetConfiguration) statefulset.Modification {
 	if stsConfig == nil {
 		return statefulset.NOOP()

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -196,12 +196,13 @@ func nodeAffinityModification(nodeAffinity *corev1.NodeAffinity) podtemplatespec
 
 // StatefulSetOverrideModification applies the resolved clusters[].statefulSet, with any
 // shardOverrides[].statefulSet already deep-merged in (see ResolveSizingForClusterShard).
-// It must run LAST in the modification chain, over the fully built StatefulSet: the override
+// It must run after the fully built StatefulSet: the override
 // merge sorts volumes by name, so merging mid-pipeline (before the password/TLS
 // volume modifications append) yields a different volume order on the create and
 // update paths — the first reconcile after STS creation then sees a spurious
 // template diff and rolls every mongot pod. Applying last also makes the user
-// override win over operator-set fields, as the CRD field documents.
+// override win over operator-set fields, as the CRD field documents. Protected
+// identity labels may be restored afterward without changing the merged spec.
 func StatefulSetOverrideModification(stsConfig *v1.StatefulSetConfiguration) statefulset.Modification {
 	if stsConfig == nil {
 		return statefulset.NOOP()

--- a/controllers/searchcontroller/search_state.go
+++ b/controllers/searchcontroller/search_state.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"golang.org/x/xerrors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/configmap"
@@ -50,6 +54,15 @@ func searchStateFromCM(cm *corev1.ConfigMap) (*SearchDeploymentState, error) {
 	return state, nil
 }
 
+func searchStateUIDMatchesOrMissing(cm *corev1.ConfigMap, search *searchv1.MongoDBSearch) bool {
+	recordedUID, ok := cm.Labels[khandler.MongoDBSearchOwnerUIDLabel]
+	if ok {
+		return recordedUID == string(search.UID)
+	}
+	controller := metav1.GetControllerOf(cm)
+	return controller == nil || controller.UID == search.UID
+}
+
 // ReadSearchState reads the per-CR state ConfigMap, treating NotFound as fresh
 // state. Strictly read-only: it never creates or updates the ConfigMap, so it is
 // safe to call from controllers that must not write state (e.g. the Envoy
@@ -66,6 +79,9 @@ func ReadSearchState(
 		}
 		return nil, err
 	}
+	if !searchStateUIDMatchesOrMissing(cm, search) {
+		return NewSearchDeploymentState(), nil
+	}
 	return searchStateFromCM(cm)
 }
 
@@ -73,7 +89,10 @@ func ReadSearchState(
 // search state ConfigMap: a stale base yields 409 Conflict and the reconcile
 // requeues, instead of silently losing a concurrent write (do NOT replace this
 // with configmap.CreateOrUpdate — that is a blind no-RV Update). mutate returns
-// true when the state changed and must be persisted.
+// true when the state changed and must be persisted. If the ConfigMap has an
+// explicit search-uid label that does not match this CR's UID, state is reset
+// before mutate runs. State without that label is adopted unless its controller
+// owner reference explicitly belongs to a previous CR UID.
 func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, mutate func(*SearchDeploymentState) bool) (*SearchDeploymentState, error) {
 	cmName := SearchStateCMName(search)
 	cm := &corev1.ConfigMap{}
@@ -90,7 +109,7 @@ func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *s
 		newCM := configmap.Builder().
 			SetName(cmName).
 			SetNamespace(search.Namespace).
-			SetLabels(search.GetOwnerLabels()).
+			SetLabels(searchOwnerLabels(search, "")).
 			SetOwnerReferences(kube.BaseOwnerReference(search)).
 			SetDataField(searchStateKey, string(data)).
 			Build()
@@ -99,18 +118,48 @@ func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *s
 		return nil, err
 	}
 
-	state, err := searchStateFromCM(cm)
-	if err != nil {
-		return nil, err
+	uidMatches := searchStateUIDMatchesOrMissing(cm, search)
+	state := NewSearchDeploymentState()
+	if uidMatches {
+		state, err = searchStateFromCM(cm)
+		if err != nil {
+			return nil, err
+		}
 	}
-	if !mutate(state) {
+
+	stateChanged := mutate(state)
+	metadataChanged := false
+	// Adopt legacy metadata without replacing an existing controller owner reference.
+	if !slices.ContainsFunc(cm.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.UID == search.UID
+	}) {
+		cm.OwnerReferences = append(cm.OwnerReferences, metav1.OwnerReference{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "MongoDBSearch",
+			Name:       search.Name,
+			UID:        search.UID,
+		})
+		metadataChanged = true
+	}
+	if cm.Labels == nil {
+		cm.Labels = map[string]string{}
+	}
+	for key, value := range searchOwnerLabels(search, "") {
+		if cm.Labels[key] != value {
+			cm.Labels[key] = value
+			metadataChanged = true
+		}
+	}
+
+	if !stateChanged && uidMatches && !metadataChanged {
 		return state, nil
 	}
+
 	data, err := json.Marshal(state)
 	if err != nil {
 		return nil, err
 	}
-	if cm.Data == nil {
+	if cm.Data == nil || !uidMatches {
 		cm.Data = map[string]string{}
 	}
 	cm.Data[searchStateKey] = string(data)

--- a/controllers/searchcontroller/search_state_test.go
+++ b/controllers/searchcontroller/search_state_test.go
@@ -42,7 +42,7 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 	stateCMName := types.NamespacedName{Name: "mysearch-search-state", Namespace: mock.TestNamespace}
 
 	newHelper := func(c client.Client) *MongoDBSearchReconcileHelper {
-		return NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(c), search, nil, OperatorSearchConfig{}, nil, nil)
+		return NewMongoDBSearchReconcileHelper(kubernetesClient.NewClient(c), search, nil, OperatorSearchConfig{}, nil, nil, false)
 	}
 	switchedOn := func(h *MongoDBSearchReconcileHelper, shard string) bool {
 		return slices.Contains(h.state.RoutingReadyMongotGroups, shard)

--- a/controllers/searchcontroller/search_state_test.go
+++ b/controllers/searchcontroller/search_state_test.go
@@ -272,11 +272,14 @@ func TestReadSearchState_UIDGuardBehavior(t *testing.T) {
 	tests := []struct {
 		name           string
 		recordedUID    *string
+		controllerUID  *types.UID
 		expectedGroups []string
 	}{
-		{name: "missing uid marker adopts legacy state", expectedGroups: []string{"stored-shard"}},
-		{name: "uid mismatch returns fresh state", recordedUID: ptr.To("old-search-uid")},
-		{name: "matching uid keeps stored state", recordedUID: ptr.To(string(search.UID)), expectedGroups: []string{"stored-shard"}},
+		{name: "missing uid marker without controller adopts legacy state", expectedGroups: []string{"stored-shard"}},
+		{name: "missing uid marker with current controller adopts legacy state", controllerUID: ptr.To(search.UID), expectedGroups: []string{"stored-shard"}},
+		{name: "missing uid marker with stale controller returns fresh state", controllerUID: ptr.To(types.UID("old-search-uid"))},
+		{name: "matching uid keeps stored state despite stale controller", recordedUID: ptr.To(string(search.UID)), controllerUID: ptr.To(types.UID("old-search-uid")), expectedGroups: []string{"stored-shard"}},
+		{name: "uid mismatch returns fresh state despite current controller", recordedUID: ptr.To("old-search-uid"), controllerUID: ptr.To(search.UID)},
 	}
 
 	for _, tc := range tests {
@@ -288,11 +291,17 @@ func TestReadSearchState_UIDGuardBehavior(t *testing.T) {
 			if tc.recordedUID != nil {
 				labels[khandler.MongoDBSearchOwnerUIDLabel] = *tc.recordedUID
 			}
+			var ownerReferences []metav1.OwnerReference
+			if tc.controllerUID != nil {
+				ownerReferences = kube.BaseOwnerReference(search)
+				ownerReferences[0].UID = *tc.controllerUID
+			}
 			stateCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      SearchStateCMName(search),
-					Namespace: search.Namespace,
-					Labels:    labels,
+					Name:            SearchStateCMName(search),
+					Namespace:       search.Namespace,
+					Labels:          labels,
+					OwnerReferences: ownerReferences,
 				},
 				Data: map[string]string{searchStateKey: string(storedStateRaw)},
 			}
@@ -308,6 +317,76 @@ func TestReadSearchState_UIDGuardBehavior(t *testing.T) {
 			assert.Equal(t, tc.recordedUID != nil, hasUIDLabel, "ReadSearchState must stay read-only")
 			if tc.recordedUID != nil {
 				assert.Equal(t, *tc.recordedUID, recordedUID, "ReadSearchState must stay read-only")
+			}
+			controller := metav1.GetControllerOf(cm)
+			if tc.controllerUID == nil {
+				assert.Nil(t, controller)
+			} else {
+				require.NotNil(t, controller)
+				assert.Equal(t, *tc.controllerUID, controller.UID, "ReadSearchState must stay read-only")
+			}
+		})
+	}
+}
+
+func TestMutateSearchState_UIDGuardBehavior(t *testing.T) {
+	ctx := context.Background()
+	search := newTestMongoDBSearch("mysearch", mock.TestNamespace)
+	search.UID = "new-search-uid"
+
+	storedStateRaw, err := json.Marshal(SearchDeploymentState{RoutingReadyMongotGroups: []string{"stored-shard"}})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		controllerUID  *types.UID
+		expectedGroups []string
+	}{
+		{name: "missing uid marker without controller adopts legacy state", expectedGroups: []string{"stored-shard", "new-shard"}},
+		{name: "missing uid marker with current controller adopts legacy state", controllerUID: ptr.To(search.UID), expectedGroups: []string{"stored-shard", "new-shard"}},
+		{name: "missing uid marker with stale controller resets state", controllerUID: ptr.To(types.UID("old-search-uid")), expectedGroups: []string{"new-shard"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var ownerReferences []metav1.OwnerReference
+			if tc.controllerUID != nil {
+				ownerReferences = kube.BaseOwnerReference(search)
+				ownerReferences[0].UID = *tc.controllerUID
+			}
+			stateCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            SearchStateCMName(search),
+					Namespace:       search.Namespace,
+					Labels:          search.GetOwnerLabels(),
+					OwnerReferences: ownerReferences,
+				},
+				Data: map[string]string{searchStateKey: string(storedStateRaw)},
+			}
+			c := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(stateCM).Build())
+
+			state, err := MutateSearchState(ctx, c, search, func(state *SearchDeploymentState) bool {
+				state.RoutingReadyMongotGroups = append(state.RoutingReadyMongotGroups, "new-shard")
+				return true
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedGroups, state.RoutingReadyMongotGroups)
+
+			cm := &corev1.ConfigMap{}
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: stateCM.Name, Namespace: stateCM.Namespace}, cm))
+			var storedState SearchDeploymentState
+			require.NoError(t, decodeStateJSON(cm, &storedState))
+			assert.Equal(t, tc.expectedGroups, storedState.RoutingReadyMongotGroups)
+			assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+			assert.True(t, slices.ContainsFunc(cm.OwnerReferences, func(ref metav1.OwnerReference) bool {
+				return ref.UID == search.UID
+			}))
+			controller := metav1.GetControllerOf(cm)
+			if tc.controllerUID == nil {
+				assert.Nil(t, controller)
+			} else {
+				require.NotNil(t, controller)
+				assert.Equal(t, *tc.controllerUID, controller.UID, "existing controller reference must be preserved")
 			}
 		})
 	}

--- a/controllers/searchcontroller/search_state_test.go
+++ b/controllers/searchcontroller/search_state_test.go
@@ -10,13 +10,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/mock"
+	khandler "github.com/mongodb/mongodb-kubernetes/pkg/handler"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 )
 
@@ -29,7 +33,7 @@ func decodeStateJSON(cm *corev1.ConfigMap, dst interface{}) error {
 }
 
 // The routing-ready switch persists through RV-checked read-modify-writes on the
-// state ConfigMap: creation with owner metadata, monotonic appends, no-op
+// state ConfigMap: creation with owner identity, monotonic appends, no-op
 // rewrites, pruning, and 409 Conflict on a stale base instead of a silent lost update.
 func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 	ctx := context.Background()
@@ -52,7 +56,7 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 		return st
 	}
 
-	t.Run("first mark creates the state CM with owner metadata", func(t *testing.T) {
+	t.Run("first mark creates the state CM with owner identity", func(t *testing.T) {
 		c := mock.NewEmptyFakeClientBuilder().Build()
 		helper := newHelper(c)
 		require.NoError(t, helper.markRoutingReady(ctx, "sh-0"))
@@ -63,9 +67,10 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 		assert.Equal(t, []string{"sh-0"}, readState(t, c).RoutingReadyMongotGroups)
 		require.Len(t, cm.OwnerReferences, 1)
 		assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
-		for k, v := range search.GetOwnerLabels() {
+		for k, v := range searchOwnerLabels(search, "") {
 			assert.Equal(t, v, cm.Labels[k], "owner label %s", k)
 		}
+		assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
 	})
 
 	t.Run("mark appends to an existing switch", func(t *testing.T) {
@@ -78,6 +83,119 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 
 		require.NoError(t, newHelper(c).markRoutingReady(ctx, "sh-1"))
 		assert.Equal(t, []string{"sh-0", "sh-1"}, readState(t, c).RoutingReadyMongotGroups)
+	})
+
+	t.Run("missing uid marker adopts legacy state and stamps current uid", func(t *testing.T) {
+		c := mock.NewEmptyFakeClientBuilder().Build()
+		legacyState, err := json.Marshal(SearchDeploymentState{RoutingReadyMongotGroups: []string{"legacy-shard"}})
+		require.NoError(t, err)
+		require.NoError(t, c.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      stateCMName.Name,
+				Namespace: stateCMName.Namespace,
+				Labels: map[string]string{
+					khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+					khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+				},
+			},
+			Data: map[string]string{searchStateKey: string(legacyState)},
+		}))
+
+		helper := newHelper(c)
+		require.NoError(t, helper.markRoutingReady(ctx, "sh-0"))
+		assert.Equal(t, []string{"legacy-shard", "sh-0"}, readState(t, c).RoutingReadyMongotGroups)
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, c.Get(ctx, stateCMName, cm))
+		assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+		require.Len(t, cm.OwnerReferences, 1)
+		assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+	})
+
+	t.Run("no-op mutation adopts legacy identity without changing state", func(t *testing.T) {
+		c := mock.NewEmptyFakeClientBuilder().Build()
+		legacyState, err := json.Marshal(SearchDeploymentState{RoutingReadyMongotGroups: []string{"legacy-shard"}})
+		require.NoError(t, err)
+		require.NoError(t, c.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      stateCMName.Name,
+				Namespace: stateCMName.Namespace,
+				Labels: map[string]string{
+					khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+					khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+				},
+				OwnerReferences: kube.BaseOwnerReference(search),
+			},
+			Data: map[string]string{searchStateKey: string(legacyState)},
+		}))
+
+		state, err := MutateSearchState(ctx, kubernetesClient.NewClient(c), search, func(*SearchDeploymentState) bool {
+			return false
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"legacy-shard"}, state.RoutingReadyMongotGroups)
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, c.Get(ctx, stateCMName, cm))
+		require.Len(t, cm.OwnerReferences, 1)
+		assert.Equal(t, search.UID, cm.OwnerReferences[0].UID)
+		assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
+		assert.Equal(t, string(legacyState), cm.Data[searchStateKey])
+	})
+
+	t.Run("no-op mutation does not create missing state", func(t *testing.T) {
+		c := mock.NewEmptyFakeClientBuilder().Build()
+		state, err := MutateSearchState(ctx, kubernetesClient.NewClient(c), search, func(*SearchDeploymentState) bool {
+			return false
+		})
+		require.NoError(t, err)
+		assert.Empty(t, state.RoutingReadyMongotGroups)
+
+		cm := &corev1.ConfigMap{}
+		err = c.Get(ctx, stateCMName, cm)
+		assert.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("uid mismatch resets stale state and preserves owner references", func(t *testing.T) {
+		c := mock.NewEmptyFakeClientBuilder().Build()
+		staleState, err := json.Marshal(SearchDeploymentState{RoutingReadyMongotGroups: []string{"stale-shard"}})
+		require.NoError(t, err)
+		require.NoError(t, c.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      stateCMName.Name,
+				Namespace: stateCMName.Namespace,
+				Labels: map[string]string{
+					khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+					khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+					khandler.MongoDBSearchOwnerUIDLabel:       "old-search-uid",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "mongodb.com/v1",
+					Kind:               "MongoDBSearch",
+					Name:               search.Name,
+					UID:                types.UID("old-search-uid"),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				}},
+			},
+			Data: map[string]string{searchStateKey: string(staleState)},
+		}))
+
+		helper := newHelper(c)
+		require.NoError(t, helper.markRoutingReady(ctx, "sh-0"))
+		assert.Equal(t, []string{"sh-0"}, readState(t, c).RoutingReadyMongotGroups)
+		assert.False(t, switchedOn(helper, "stale-shard"))
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, c.Get(ctx, stateCMName, cm))
+		require.Len(t, cm.OwnerReferences, 2)
+		assert.ElementsMatch(t, []types.UID{"old-search-uid", search.UID}, []types.UID{
+			cm.OwnerReferences[0].UID,
+			cm.OwnerReferences[1].UID,
+		})
+		assert.True(t, *cm.OwnerReferences[0].Controller, "existing controller owner reference must be preserved")
+		assert.Nil(t, cm.OwnerReferences[1].Controller, "current UID adoption reference must not replace the existing controller")
+		assert.Equal(t, string(search.UID), cm.Labels[khandler.MongoDBSearchOwnerUIDLabel])
 	})
 
 	t.Run("already-on switch is a no-op write", func(t *testing.T) {
@@ -141,4 +259,56 @@ func TestRoutingSwitch_StateCMWrites(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, apierrors.IsConflict(err), "stale base must surface 409 Conflict, got: %v", err)
 	})
+}
+
+func TestReadSearchState_UIDGuardBehavior(t *testing.T) {
+	ctx := context.Background()
+	search := newTestMongoDBSearch("mysearch", mock.TestNamespace)
+	search.UID = "new-search-uid"
+
+	storedStateRaw, err := json.Marshal(SearchDeploymentState{RoutingReadyMongotGroups: []string{"stored-shard"}})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		recordedUID    *string
+		expectedGroups []string
+	}{
+		{name: "missing uid marker adopts legacy state", expectedGroups: []string{"stored-shard"}},
+		{name: "uid mismatch returns fresh state", recordedUID: ptr.To("old-search-uid")},
+		{name: "matching uid keeps stored state", recordedUID: ptr.To(string(search.UID)), expectedGroups: []string{"stored-shard"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := map[string]string{
+				khandler.MongoDBSearchOwnerNameLabel:      search.Name,
+				khandler.MongoDBSearchOwnerNamespaceLabel: search.Namespace,
+			}
+			if tc.recordedUID != nil {
+				labels[khandler.MongoDBSearchOwnerUIDLabel] = *tc.recordedUID
+			}
+			stateCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      SearchStateCMName(search),
+					Namespace: search.Namespace,
+					Labels:    labels,
+				},
+				Data: map[string]string{searchStateKey: string(storedStateRaw)},
+			}
+
+			c := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().WithObjects(stateCM).Build())
+			state, err := ReadSearchState(ctx, c, search)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedGroups, state.RoutingReadyMongotGroups)
+
+			cm := &corev1.ConfigMap{}
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Name: stateCM.Name, Namespace: stateCM.Namespace}, cm))
+			recordedUID, hasUIDLabel := cm.Labels[khandler.MongoDBSearchOwnerUIDLabel]
+			assert.Equal(t, tc.recordedUID != nil, hasUIDLabel, "ReadSearchState must stay read-only")
+			if tc.recordedUID != nil {
+				assert.Equal(t, *tc.recordedUID, recordedUID, "ReadSearchState must stay read-only")
+			}
+		})
+	}
 }

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_search.py
@@ -202,7 +202,7 @@ class TestOperatorUpgrade:
         assert_mongot_version_matches_operator(namespace, operator, "post-upgrade")
 
     def test_database_running_after_upgrade(self, mdb: MongoDB):
-        mdb.assert_reaches_phase(phase=Phase.Running, timeout=300)
+        mdb.assert_reaches_phase(phase=Phase.Running, timeout=800)
 
     def test_search_query_after_upgrade(self, sample_movies_helper: SampleMoviesSearchHelper):
         sample_movies_helper.assert_search_query(retry_timeout=60)

--- a/pkg/handler/labels_search.go
+++ b/pkg/handler/labels_search.go
@@ -3,22 +3,64 @@ package handler
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// Cross-cluster enqueue labels for search-owned member-cluster resources.
-// Owner references do not cross cluster boundaries; both the search controller
-// and the Envoy controller stamp these labels on every member-cluster write so
-// mappers / predicates can enqueue the central MongoDBSearch request.
+// Search resource identity labels used for routing and cleanup.
 const (
 	MongoDBSearchOwnerNameLabel      = "mongodb.com/search-name"
 	MongoDBSearchOwnerNamespaceLabel = "mongodb.com/search-namespace"
-	// MongoDBSearchClusterNameLabel records the owning member cluster on
-	// per-cluster member resources (Envoy Deployment + ConfigMap).
+	MongoDBSearchOwnerUIDLabel       = "mongodb.com/search-uid"
+	MongoDBSearchComponentLabel      = "component"
+	// MongoDBSearchClusterNameLabel records the target member cluster.
 	MongoDBSearchClusterNameLabel = "mongodb.com/cluster-name"
 )
+
+// MongoDBSearchManagedLabels returns the protected identity labels shared by
+// Search resource writers, cleanup selectors, and event routing.
+func MongoDBSearchManagedLabels(search metav1.Object, app, component, clusterName string) map[string]string {
+	labels := map[string]string{
+		MongoDBSearchOwnerNameLabel:      search.GetName(),
+		MongoDBSearchOwnerNamespaceLabel: search.GetNamespace(),
+		MongoDBSearchOwnerUIDLabel:       string(search.GetUID()),
+	}
+	if app != "" {
+		labels["app"] = app
+	}
+	if component != "" {
+		labels[MongoDBSearchComponentLabel] = component
+	}
+	if clusterName != "" {
+		labels[MongoDBSearchClusterNameLabel] = clusterName
+	}
+	return labels
+}
+
+// ReapplyProtectedSearchLabels restores labels used for Search event routing
+// and cleanup after user metadata overrides while preserving unrelated labels.
+func ReapplyProtectedSearchLabels(labels, desired map[string]string) map[string]string {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	for _, key := range []string{
+		MongoDBSearchOwnerNameLabel,
+		MongoDBSearchOwnerNamespaceLabel,
+		MongoDBSearchOwnerUIDLabel,
+		MongoDBSearchClusterNameLabel,
+		MongoDBSearchComponentLabel,
+	} {
+		value, ok := desired[key]
+		if !ok {
+			delete(labels, key)
+			continue
+		}
+		labels[key] = value
+	}
+	return labels
+}
 
 // MapMemberClusterObjectToSearch reads the search-owner labels off a watched
 // member-cluster object and returns the reconcile request for the central

--- a/pkg/tls/tls_secret.go
+++ b/pkg/tls/tls_secret.go
@@ -31,7 +31,7 @@ type TLSConfigurableResource interface {
 // ensureTLSSecret will create or update the operator-managed Secret containing
 // the concatenated certificate and key from the user-provided Secret.
 // Returns the file name of the concatenated certificate and key
-func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource) (string, error) {
+func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource, labels map[string]string, ownerReferences []metav1.OwnerReference) (string, error) {
 	certKey, err := getPemOrConcatenatedCrtAndKey(ctx, getUpdateCreator, resource.TLSSecretNamespacedName())
 	if err != nil {
 		return "", err
@@ -43,7 +43,8 @@ func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreat
 		SetName(resource.TLSOperatorSecretNamespacedName().Name).
 		SetNamespace(resource.TLSOperatorSecretNamespacedName().Namespace).
 		SetField(fileName, certKey).
-		SetOwnerReferences(resource.GetOwnerReferences()).
+		SetLabels(labels).
+		SetOwnerReferences(ownerReferences).
 		Build()
 
 	return fileName, secret.CreateOrUpdate(ctx, getUpdateCreator, operatorSecret)


### PR DESCRIPTION
[skip-ci]
# Summary

Error-path and ordering hardening for the MongoDBSearch metrics forwarder and Envoy controllers, split out of the lean lifecycle layer #1382 to keep that PR reviewable. This PR is stacked on #1382 at `d91326aca280e943f116159aaa51e96134e76c89`. Everything here closes pre-existing gaps in error paths and write ordering — none of these are regressions introduced by #1382.

Three commits:

1. **Two-phase metrics reconcile with a single diff-gated state write** (`36348f17a`). The forwarder reconcile now runs in two phases over one in-memory topology state: phase 1 updates every cluster's entry and deregisters Ops Manager hosts whose deferral window elapsed; removed-cluster cleanup mutates the same state. The state is persisted exactly once per reconcile — only when it actually changed — and always before phase 2 ensures ConfigMaps/Deployments, so a forwarder never starts pushing metrics for topology that is not durable. Per-cluster failures are aggregated with `errors.Join` instead of surfacing only the first one. Previously each cluster performed its own read-modify-write (N uncached reads + N blind sequential writes per reconcile) and dependency replication ran before the state write.

2. **Pre-deletion cleanup ordering** (`602446f30`). CR-delete cleanup now tracks blocked clusters instead of failing on the first error: a cluster whose Deployment is still terminating, whose client is missing, or that hit an error is skipped for the pass while the other clusters continue through host deregistration and resource deletion. A missing member-cluster client fails closed (previously it was silently skipped, letting the finalizer drop while an unreachable cluster still held forwarder resources and OM hosts). The finalizer is removed only once every cluster is fully clean.

3. **Envoy LB cleanup confirm/status guards** (`946933632`). The managed→unmanaged cleanup path runs off a possibly stale cache. It now re-confirms the live CR with the uncached reader (same UID, same generation, LB still unmanaged) before every precondition delete and before touching `/status/loadBalancer`; a stale cleanup requeues instead of deleting resources or wiping status for a CR that was re-managed or replaced. Status writes on this path use a JSON patch with uid/generation `test` preconditions, and cleanup failures are recorded on the loadBalancer sub-status instead of being silently dropped. The sentinel errors are scoped to the Envoy controller.

All behaviors of the lean base are preserved: deletion-first Reconcile, the unsupported-source persisted-hosts finalizer guard, the removed-cluster cleanup call, the uncached re-add guard before host deregistration, and the `mongodb.com/disable-reconciliation` pause guards (#1382's) sit untouched upstream of these paths.

Diff: 4 files changed, 549 insertions(+), 105 deletions(-) — all in `controllers/operator/` (metrics forwarder + Envoy controllers and their tests). New unit coverage: single/zero state-write assertions, dependency-replication ordering, cross-cluster error aggregation, fail-closed missing clients, and the restored Envoy stale-cleanup/status-patch test family.

## Proof of Work

Local gates on the branch head (restacked onto #1382's rebased head; content byte-identical to the previously reviewed diff modulo line offsets):

- Per-commit `go build ./...` — clean at each of the 3 commits.
- `go test ./controllers/... ./api/...` — all packages ok, zero failures.
- `make fmt` — no churn; `git diff --check` — clean.
- `go tool gotestsum -- -race -count=1 ./...` — **3097 tests, 3 skipped (env-gated), 0 failures**, no data races.
- #1382's pause subtests and this PR's hardening test families verified passing together in one targeted run.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `skip-changelog`: internal hardening of unreleased controllers, no user-facing behavior change.
