### PR TITLE
CLOUDP-407997: Allow easy manual promotion from evergreen UI

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -2209,11 +2209,12 @@ buildvariants:
   # Only on commit builds — see DEVPROD-27436 note on notify_master_build_status below.
   - name: mckci_release_promote
     display_name: mckci_release_promote
-    allowed_requesters: [ "commit" ]
+    allowed_requesters: [ "commit", "patch" ]
     depends_on:
       - name: "*"
         variant: ".staging"
         status: "success"
+        patch_optional: true
     run_on:
       - ubuntu2404-small
     tasks:


### PR DESCRIPTION
# Summary

The normal new release workflow can only release images from commits that passed all tests at merge time. Currently we have several flaky or broken tests that might prevent us for having a 100% passing merged commit. For cases in which we know the commit/image to be safe, this change allows to easily run the promotion step manually, marking the commits/image as releseable.

## Proof of Work

CI must pass

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed

