### PR TITLE
KUBE-172: Custom agent URL for CI and manual testing

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -646,6 +646,7 @@ functions:
           FLAGS: ${flags}
           AGENT_VERSION_OVERRIDE: ${agent_version}
           AGENT_TOOLS_VERSION: ${agent_tools_version}
+          MDB_CUSTOM_AGENT_URL: ${mdb_custom_agent_url}
 
   teardown_cloud_qa_all:
     - command: shell.exec
@@ -766,6 +767,8 @@ functions:
           - AI_MONGODB_EMBEDDING_QUERY_KEY
         add_to_path:
           - ${workdir}/bin
+        env:
+          MDB_CUSTOM_AGENT_URL: ${mdb_custom_agent_url}
         binary: scripts/evergreen/e2e/e2e.sh
 
   e2e_test_perf:
@@ -793,6 +796,7 @@ functions:
           PERF_TASK_DEPLOYMENTS: ${PERF_TASK_DEPLOYMENTS}
           PERF_TASK_REPLICAS: ${PERF_TASK_REPLICAS}
           TEST_NAME_OVERRIDE: ${TEST_NAME_OVERRIDE}
+          MDB_CUSTOM_AGENT_URL: ${mdb_custom_agent_url}
         binary: scripts/evergreen/e2e/e2e.sh
 
   test_golang_unit:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -79,6 +79,8 @@ variables:
     depends_on:
       - name: build_operator_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
       - name: build_test_image
         variant: init_test_run
       - name: build_readiness_probe_image
@@ -197,6 +199,8 @@ variables:
         variant: init_test_run
       - name: build_init_om_images_ubi
         variant: init_test_run
+      - name: build_agent_images_ubi
+        variant: init_test_run
       - name: publish_helm_chart
         variant: init_test_run
       # Wait for OM images to be published to quay.io on commit builds (staging).
@@ -221,6 +225,10 @@ parameters:
   - key: MDB_BASH_DEBUG
     value: "0"
     description: set this to 1 if you want shell scripts to enable set -x
+
+  - key: mdb_custom_agent_url
+    value: ""
+    description: "Full URL to a custom agent tarball. When set (via Evergreen expansion from mms-automation downstream_expansions.set), agent and init-database image builds use this URL instead of the production S3 path."
 
 # Triggered manually or by PCT.
 patch_aliases:

--- a/EVERGREEN.md
+++ b/EVERGREEN.md
@@ -57,6 +57,15 @@ evergreen patch -p mongodb-kubernetes -a preflight_release_test \
 
 Adjust probe/hook params to match **`release.json`** if your project does not set them by default on patches. **`mongodb-enterprise-server`** preflight still enumerates Quay tags (same as release).
 
+### Custom agent URL
+
+Pass `mdb_custom_agent_url` to override the agent version in all e2e variants (static and non-static). The URL must point to a `.tar.gz` agent tarball; the version is extracted from the filename. No `release.json` changes are needed.
+
+```shell
+evergreen patch -p mongodb-kubernetes -a pr_patch -d "Test custom agent" -f -y -u --path .evergreen.yml \
+  --param mdb_custom_agent_url=https://example.com/mongodb-mms-automation-agent-108.0.26.9047-1.rhel8_x86_64.tar.gz
+```
+
 ## E2E Test Path Filtering on PRs
 
 Evergreen uses two levels of file-based filtering on PRs:

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -592,6 +592,7 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	appdbOpts := construct.AppDBStatefulSetOptions{
 		InitAppDBImage: images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseVersion),
 		MongodbImage:   images.GetOfficialImage(r.imageUrls, opsManager.Spec.AppDB.Version, opsManager.GetAnnotations(), r.defaultArchitecture),
+		CustomAgentURL: r.customAgentURL,
 	}
 	if architectures.IsRunningStaticArchitecture(opsManager.Annotations, r.defaultArchitecture) {
 		if !rs.PodSpec.IsAgentImageOverridden() {
@@ -603,7 +604,6 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 				log.Errorf("Impossible to get agent version, please override the agent image by providing a pod template")
 				return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Failed to get agent version: %w. Please use spec.statefulSet to supply proper Agent version", err)), log)
 			}
-
 			appdbOpts.AgentImage = images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, agentVersion)
 		}
 	} else {

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -64,6 +65,8 @@ type ReconcileCommonController struct {
 	secrets.SecretClient
 
 	resourceWatcher *watch.ResourceWatcher
+
+	customAgentURL string
 }
 
 func NewReconcileCommonController(ctx context.Context, client client.Client) *ReconcileCommonController {
@@ -90,6 +93,8 @@ func NewReconcileCommonController(ctx context.Context, client client.Client) *Re
 			panic(xerrors.Errorf("unable to log in with vault client: %w", err))
 		}
 	}
+	customAgentURL := env.ReadOrDefault(util.EnvVarCustomAgentURL, "") // nolint:forbidigo
+
 	return &ReconcileCommonController{
 		client: newClient,
 		SecretClient: secrets.SecretClient{
@@ -97,6 +102,7 @@ func NewReconcileCommonController(ctx context.Context, client client.Client) *Re
 			KubeClient:  newClient,
 		},
 		resourceWatcher: watch.NewResourceWatcher(),
+		customAgentURL:  customAgentURL,
 	}
 }
 
@@ -760,6 +766,12 @@ func (r *ReconcileCommonController) setupInternalClusterAuthIfItHasChanged(conn 
 // getAgentVersion handles the common logic for error handling and instance initialisation
 // when retrieving the agent version from a controller
 func (r *ReconcileCommonController) getAgentVersion(conn om.Connection, omVersion string, isAppDB bool, log *zap.SugaredLogger) (string, error) {
+	// When a custom agent URL is set, derive the version from the URL filename.
+	// This overrides all other version resolution (Ops Manager API, mapping, Cloud Manager).
+	if r.customAgentURL != "" {
+		return agentVersionFromURL(r.customAgentURL), nil
+	}
+
 	m, err := agentVersionManagement.GetAgentVersionManager()
 	if err != nil || m == nil {
 		return "", xerrors.Errorf("not able to init agentVersionManager: %w", err)
@@ -772,6 +784,18 @@ func (r *ReconcileCommonController) getAgentVersion(conn om.Connection, omVersio
 		log.Debugf("Using agent version %s", agentVersion)
 		return agentVersion, nil
 	}
+}
+
+// agentVersionFromURL extracts the agent version from a custom agent tarball URL.
+// e.g. .../mongodb-mms-automation-agent-108.0.26.9047-1.rhel8_x86_64.tar.gz → 108.0.26.9047-1
+func agentVersionFromURL(url string) string {
+	filename := url[strings.LastIndex(url, "/")+1:]
+	filename = strings.TrimSuffix(filename, ".tar.gz")
+	rest := strings.TrimPrefix(filename, "mongodb-mms-automation-agent-")
+	if idx := strings.LastIndex(rest, "."); idx > 0 {
+		return rest[:idx]
+	}
+	return rest
 }
 
 // deleteClusterResources removes all resources that are associated with the given resource owner in a given cluster.

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -763,8 +763,10 @@ func (r *ReconcileCommonController) setupInternalClusterAuthIfItHasChanged(conn 
 	return err
 }
 
-// getAgentVersion handles the common logic for error handling and instance initialisation
-// when retrieving the agent version from a controller
+// getAgentVersion returns the agent version for static architecture builds.
+// All callers guard with IsRunningStaticArchitecture; in non-static mode the
+// agent is downloaded at runtime via MDB_CUSTOM_AGENT_URL and this function
+// is never called.
 func (r *ReconcileCommonController) getAgentVersion(conn om.Connection, omVersion string, isAppDB bool, log *zap.SugaredLogger) (string, error) {
 	// When a custom agent URL is set, derive the version from the URL filename.
 	// This overrides all other version resolution (Ops Manager API, mapping, Cloud Manager).

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -763,10 +763,9 @@ func (r *ReconcileCommonController) setupInternalClusterAuthIfItHasChanged(conn 
 	return err
 }
 
-// getAgentVersion returns the agent version for static architecture builds.
-// All callers guard with IsRunningStaticArchitecture; in non-static mode the
-// agent is downloaded at runtime via MDB_CUSTOM_AGENT_URL and this function
-// is never called.
+// getAgentVersion resolves the agent version to use. When customAgentURL is set,
+// the version is extracted from the URL filename, overriding the Ops Manager API,
+// mapping file, and Cloud Manager paths.
 func (r *ReconcileCommonController) getAgentVersion(conn om.Connection, omVersion string, isAppDB bool, log *zap.SugaredLogger) (string, error) {
 	// When a custom agent URL is set, derive the version from the URL filename.
 	// This overrides all other version resolution (Ops Manager API, mapping, Cloud Manager).

--- a/controllers/operator/common_controller_test.go
+++ b/controllers/operator/common_controller_test.go
@@ -1085,3 +1085,43 @@ func testFCVsCases(t *testing.T, verifyFCV func(version string, expectedFCV stri
 		})
 	}
 }
+
+func TestAgentVersionFromURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "rhel8 x86_64",
+			url:      "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/patches/6a5f74111e6a450007f4f7a5/automation-agent/local/mongodb-mms-automation-agent-108.0.26.9047-1.rhel8_x86_64.tar.gz",
+			expected: "108.0.26.9047-1",
+		},
+		{
+			name:     "amzn2 aarch64",
+			url:      "https://example.com/mongodb-mms-automation-agent-107.0.23.8833-1.amzn2_aarch64.tar.gz",
+			expected: "107.0.23.8833-1",
+		},
+		{
+			name:     "linux x86_64",
+			url:      "https://example.com/mongodb-mms-automation-agent-11.0.5.6963-1.linux_x86_64.tar.gz",
+			expected: "11.0.5.6963-1",
+		},
+		{
+			name:     "rhel8 ppc64le",
+			url:      "https://example.com/mongodb-mms-automation-agent-13.10.0.8620-1.rhel8_ppc64le.tar.gz",
+			expected: "13.10.0.8620-1",
+		},
+		{
+			name:     "empty string",
+			url:      "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, agentVersionFromURL(tc.url))
+		})
+	}
+}

--- a/controllers/operator/construct/appdb_agent_command.go
+++ b/controllers/operator/construct/appdb_agent_command.go
@@ -21,22 +21,23 @@ const (
 )
 
 // BaseAgentCommand returns the core agent binary invocation flags.
-// Uses ${AGENT_BINARY:-agent/mongodb-agent} so a custom agent downloaded by
+// Uses ${agent_binary:-agent/mongodb-agent} so a custom agent downloaded by
 // downloadCustomAgentIfSet() (non-static mode) takes precedence over the
 // pre-baked binary.
 func BaseAgentCommand() string {
-	return "${AGENT_BINARY:-agent/mongodb-agent} -healthCheckFilePath=" + appdbAgentHealthStatusFilePathValue + " -serveStatusPort=5000"
+	return "${agent_binary:-agent/mongodb-agent} -healthCheckFilePath=" + appdbAgentHealthStatusFilePathValue + " -serveStatusPort=5000"
 }
 
 // downloadCustomAgentIfSet returns a bash snippet that downloads and installs
-// a custom agent from MDB_CUSTOM_AGENT_URL when set, exporting AGENT_BINARY
-// so BaseAgentCommand() picks it up. Only used in non-static mode — in static
-// mode the agent image is already built with the correct binary.
+// a custom agent from MDB_CUSTOM_AGENT_URL when set, setting the local
+// agent_binary variable so BaseAgentCommand() picks it up. Only used in
+// non-static mode — in static mode the agent image is already built with
+// the correct binary.
 func downloadCustomAgentIfSet() string {
 	return `if [[ -n "${MDB_CUSTOM_AGENT_URL:-}" ]]; then
   echo "Using custom agent URL: ${MDB_CUSTOM_AGENT_URL}"
   pushd /tmp >/dev/null || true
-  if ! curl --location --silent --retry 3 --fail --output automation-agent.tar.gz "${MDB_CUSTOM_AGENT_URL}"; then
+  if ! curl --location --silent --retry 3 --fail -v --output automation-agent.tar.gz "${MDB_CUSTOM_AGENT_URL}" 2>&1; then
     echo "Error: failed to download custom agent from ${MDB_CUSTOM_AGENT_URL}"
     exit 1
   fi
@@ -47,7 +48,7 @@ func downloadCustomAgentIfSet() string {
   cp mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /tmp/mongodb-agent
   rm -rf /tmp/automation-agent.tar.gz /tmp/mongodb-mms-automation-agent-*
   chmod +x /tmp/mongodb-agent
-  export AGENT_BINARY=/tmp/mongodb-agent
+  agent_binary=/tmp/mongodb-agent
   popd >/dev/null || true
 fi
 `

--- a/controllers/operator/construct/appdb_agent_command.go
+++ b/controllers/operator/construct/appdb_agent_command.go
@@ -21,8 +21,36 @@ const (
 )
 
 // BaseAgentCommand returns the core agent binary invocation flags.
+// Uses ${AGENT_BINARY:-agent/mongodb-agent} so a custom agent downloaded by
+// downloadCustomAgentIfSet() (non-static mode) takes precedence over the
+// pre-baked binary.
 func BaseAgentCommand() string {
-	return "agent/mongodb-agent -healthCheckFilePath=" + appdbAgentHealthStatusFilePathValue + " -serveStatusPort=5000"
+	return "${AGENT_BINARY:-agent/mongodb-agent} -healthCheckFilePath=" + appdbAgentHealthStatusFilePathValue + " -serveStatusPort=5000"
+}
+
+// downloadCustomAgentIfSet returns a bash snippet that downloads and installs
+// a custom agent from MDB_CUSTOM_AGENT_URL when set, exporting AGENT_BINARY
+// so BaseAgentCommand() picks it up. Only used in non-static mode — in static
+// mode the agent image is already built with the correct binary.
+func downloadCustomAgentIfSet() string {
+	return `if [[ -n "${MDB_CUSTOM_AGENT_URL:-}" ]]; then
+  echo "Using custom agent URL: ${MDB_CUSTOM_AGENT_URL}"
+  pushd /tmp >/dev/null || true
+  if ! curl --location --silent --retry 3 --fail --output automation-agent.tar.gz "${MDB_CUSTOM_AGENT_URL}"; then
+    echo "Error: failed to download custom agent from ${MDB_CUSTOM_AGENT_URL}"
+    exit 1
+  fi
+  if ! tar -xzf automation-agent.tar.gz; then
+    echo "Error: failed to extract custom agent tarball"
+    exit 1
+  fi
+  cp mongodb-mms-automation-agent-*/mongodb-mms-automation-agent /tmp/mongodb-agent
+  rm -rf /tmp/automation-agent.tar.gz /tmp/mongodb-mms-automation-agent-*
+  chmod +x /tmp/mongodb-agent
+  export AGENT_BINARY=/tmp/mongodb-agent
+  popd >/dev/null || true
+fi
+`
 }
 
 // AutomationAgentCommand returns the full command array for the automation agent container.
@@ -41,7 +69,14 @@ func AutomationAgentCommand(withStatic bool, withAgentAPIKeyExport bool, logLeve
 		agentLogOptions += " -logFile " + logFile + " -logLevel " + string(logLevel) + " -maxLogFileDurationHrs " + strconv.Itoa(maxLogFileDurationHours)
 	}
 
-	return []string{"/bin/bash", "-c", GetMongodbUserCommand(withStatic, withAgentAPIKeyExport) + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions}
+	// In non-static mode, download the custom agent if MDB_CUSTOM_AGENT_URL is set.
+	// In static mode, the agent image is already built with the correct binary.
+	downloadSnippet := ""
+	if !withStatic {
+		downloadSnippet = downloadCustomAgentIfSet()
+	}
+
+	return []string{"/bin/bash", "-c", GetMongodbUserCommand(withStatic, withAgentAPIKeyExport) + downloadSnippet + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions}
 }
 
 // GetMongodbUserCommand returns the bash preamble for the automation agent. When

--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -51,6 +51,7 @@ type AppDBStatefulSetOptions struct {
 	AgentImage     string
 
 	PrometheusTLSCertHash string
+	CustomAgentURL        string
 }
 
 // getContainerIndexByName returns the index of a container with the given name in a slice of containers.
@@ -500,7 +501,7 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 				upgradeInitContainer,
 				readinessInitContainer,
 				podtemplatespec.WithContainer(util.AgentContainerName,
-					container.WithEnvs(appdbContainerEnv(*appDb)...),
+					container.WithEnvs(appdbContainerEnv(*appDb, opts.CustomAgentURL)...),
 				),
 				vaultModification(*appDb, podVars, opts),
 				appDbPodSpec(opts.InitAppDBImage, opsManager, defaultArchitecture),
@@ -540,7 +541,7 @@ func IsEnterprise() bool {
 }
 
 // appdbContainerEnv returns the set of env var needed by the AppDB.
-func appdbContainerEnv(appDbSpec om.AppDBSpec) []corev1.EnvVar {
+func appdbContainerEnv(appDbSpec om.AppDBSpec, customAgentURL string) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{
 			Name:      podNamespaceEnv,
@@ -559,6 +560,11 @@ func appdbContainerEnv(appDbSpec om.AppDBSpec) []corev1.EnvVar {
 			Value: appDbSpec.ClusterDomain,
 		},
 	}
+
+	if customAgentURL != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: util.EnvVarCustomAgentURL, Value: customAgentURL})
+	}
+
 	return envVars
 }
 

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -325,6 +325,34 @@ func TestCustomAgentURL(t *testing.T) {
 		t.Fatal("MDB_CUSTOM_AGENT_URL not found in any AppDB container")
 	})
 
+	t.Run("AppDB StatefulSet static has env var but no download snippet", func(t *testing.T) {
+		om := omv1.NewOpsManagerBuilderDefault().Build()
+		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{CustomAgentURL: customURL},
+			scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil),
+			appsv1.OnDeleteStatefulSetStrategyType, architectures.Static, zap.S())
+		assert.NoError(t, err)
+
+		// Env var is still set in static mode.
+		found := false
+		for _, c := range sts.Spec.Template.Spec.Containers {
+			envMap := env.ToMap(c.Env...)
+			if v, ok := envMap[util.EnvVarCustomAgentURL]; ok {
+				assert.Equal(t, customURL, v)
+				found = true
+			}
+		}
+		assert.True(t, found, "MDB_CUSTOM_AGENT_URL should be set in static mode too")
+
+		// Download snippet must not be in the command.
+		for _, c := range sts.Spec.Template.Spec.Containers {
+			if len(c.Command) > 2 {
+				assert.NotContains(t, c.Command[2], "agent_binary=/tmp/mongodb-agent",
+					"static mode should not include download snippet")
+			}
+		}
+	})
+
 	t.Run("AppDB StatefulSet without CustomAgentURL has no env var", func(t *testing.T) {
 		om := omv1.NewOpsManagerBuilderDefault().Build()
 		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
@@ -338,5 +366,29 @@ func TestCustomAgentURL(t *testing.T) {
 			_, ok := envMap[util.EnvVarCustomAgentURL]
 			assert.False(t, ok, "MDB_CUSTOM_AGENT_URL should not be set when CustomAgentURL is empty")
 		}
+	})
+}
+
+func TestAutomationAgentCommandStaticVsNonStatic(t *testing.T) {
+	logLevel := v1.LogLevel("INFO")
+	logFile := "/var/log/mongodb-mms-automation/automation-agent.log"
+	maxLogFileDurationHours := 24
+
+	t.Run("non-static includes download snippet", func(t *testing.T) {
+		cmd := AutomationAgentCommand(false, false, logLevel, logFile, maxLogFileDurationHours)
+		assert.Equal(t, "/bin/bash", cmd[0])
+		assert.Equal(t, "-c", cmd[1])
+		assert.Contains(t, cmd[2], "MDB_CUSTOM_AGENT_URL")
+		assert.Contains(t, cmd[2], "agent_binary=/tmp/mongodb-agent")
+		assert.Contains(t, cmd[2], "${agent_binary:-agent/mongodb-agent}")
+	})
+
+	t.Run("static excludes download snippet", func(t *testing.T) {
+		cmd := AutomationAgentCommand(true, false, logLevel, logFile, maxLogFileDurationHours)
+		assert.Equal(t, "/bin/bash", cmd[0])
+		assert.Equal(t, "-c", cmd[1])
+		assert.NotContains(t, cmd[2], "MDB_CUSTOM_AGENT_URL")
+		assert.NotContains(t, cmd[2], "agent_binary=/tmp/mongodb-agent")
+		assert.Contains(t, cmd[2], "${agent_binary:-agent/mongodb-agent}")
 	})
 }

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -290,3 +290,53 @@ func TestResourceRequirements(t *testing.T) {
 		}
 	}
 }
+
+func TestCustomAgentURL(t *testing.T) {
+	const customURL = "https://example.com/mongodb-mms-automation-agent-108.0.26.9047-1.rhel8_x86_64.tar.gz"
+
+	t.Run("Database StatefulSet has MDB_CUSTOM_AGENT_URL env var", func(t *testing.T) {
+		rs := mdbv1.NewReplicaSetBuilder().Build()
+		optsFunc := ReplicaSetOptions(GetPodEnvOptions())
+		sts := DatabaseStatefulSet(*rs, func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
+			opts := optsFunc(mdb)
+			opts.CustomAgentURL = customURL
+			return opts
+		}, zap.S())
+
+		envMap := env.ToMap(sts.Spec.Template.Spec.Containers[0].Env...)
+		assert.Equal(t, customURL, envMap[util.EnvVarCustomAgentURL])
+	})
+
+	t.Run("AppDB StatefulSet has MDB_CUSTOM_AGENT_URL env var", func(t *testing.T) {
+		om := omv1.NewOpsManagerBuilderDefault().Build()
+		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{CustomAgentURL: customURL},
+			scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil),
+			appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+		assert.NoError(t, err)
+
+		for _, c := range sts.Spec.Template.Spec.Containers {
+			envMap := env.ToMap(c.Env...)
+			if _, ok := envMap[util.EnvVarCustomAgentURL]; ok {
+				assert.Equal(t, customURL, envMap[util.EnvVarCustomAgentURL])
+				return
+			}
+		}
+		t.Fatal("MDB_CUSTOM_AGENT_URL not found in any AppDB container")
+	})
+
+	t.Run("AppDB StatefulSet without CustomAgentURL has no env var", func(t *testing.T) {
+		om := omv1.NewOpsManagerBuilderDefault().Build()
+		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{},
+			scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil),
+			appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+		assert.NoError(t, err)
+
+		for _, c := range sts.Spec.Template.Spec.Containers {
+			envMap := env.ToMap(c.Env...)
+			_, ok := envMap[util.EnvVarCustomAgentURL]
+			assert.False(t, ok, "MDB_CUSTOM_AGENT_URL should not be set when CustomAgentURL is empty")
+		}
+	})
+}

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -2,7 +2,6 @@ package construct
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -106,6 +105,7 @@ type DatabaseStatefulSetOptions struct {
 	DatabaseNonStaticImage string
 	MongodbImage           string
 	AgentImage             string
+	CustomAgentURL         string
 
 	Annotations map[string]string
 	VaultConfig vault.VaultConfiguration
@@ -1029,10 +1029,9 @@ func databaseEnvVars(opts DatabaseStatefulSetOptions) []corev1.EnvVar {
 		)
 	}
 
-	// This is only used for debugging
-	if agentVersion := os.Getenv(util.EnvVarAgentVersion); agentVersion != "" { // nolint:forbidigo
-		zap.S().Debugf("using a custom agent version: %s", agentVersion)
-		vars = append(vars, corev1.EnvVar{Name: util.EnvVarAgentVersion, Value: agentVersion})
+	if opts.CustomAgentURL != "" {
+		zap.S().Debugf("using a custom agent URL: %s", opts.CustomAgentURL)
+		vars = append(vars, corev1.EnvVar{Name: util.EnvVarCustomAgentURL, Value: opts.CustomAgentURL})
 	}
 
 	// append any additional env vars specified.

--- a/controllers/operator/database_statefulset_options.go
+++ b/controllers/operator/database_statefulset_options.go
@@ -136,6 +136,13 @@ func WithAgentImage(image string) func(*construct.DatabaseStatefulSetOptions) {
 	}
 }
 
+// WithCustomAgentURL sets the CustomAgentURL field.
+func WithCustomAgentURL(url string) func(*construct.DatabaseStatefulSetOptions) {
+	return func(opts *construct.DatabaseStatefulSetOptions) {
+		opts.CustomAgentURL = url
+	}
+}
+
 func WithAgentDebug(debug bool) func(options *construct.DatabaseStatefulSetOptions) {
 	return func(options *construct.DatabaseStatefulSetOptions) {
 		options.AgentDebug = debug

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -528,6 +528,8 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(ctx context.Cont
 			WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
 			WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
 			WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, automationAgentVersion)),
+			WithCustomAgentURL(r.customAgentURL),
+
 			WithMongodbImage(images.GetOfficialImage(r.imageUrls, mrs.Spec.Version, mrs.GetAnnotations(), r.defaultArchitecture)),
 			WithAgentDebug(r.agentDebug),
 			WithAgentDebugImage(r.agentDebugImage),

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -618,6 +618,8 @@ func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(ctx context.Context
 		WithInitDatabaseNonStaticImage(images.ContainerImage(reconciler.imageUrls, util.InitDatabaseImageUrlEnv, reconciler.initDatabaseNonStaticImageVersion)),
 		WithDatabaseNonStaticImage(images.ContainerImage(reconciler.imageUrls, util.NonStaticDatabaseEnterpriseImage, reconciler.databaseNonStaticImageVersion)),
 		WithAgentImage(images.ContainerImage(reconciler.imageUrls, util.AgentImageUrlEnv, automationAgentVersion)),
+		WithCustomAgentURL(reconciler.customAgentURL),
+
 		WithMongodbImage(images.GetOfficialImage(reconciler.imageUrls, rs.Spec.Version, rs.GetAnnotations(), reconciler.defaultArchitecture)),
 		WithAgentDebug(reconciler.agentDebug),
 		WithAgentDebugImage(reconciler.agentDebugImage),

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -2446,6 +2446,8 @@ func (r *ShardedClusterReconcileHelper) getConfigServerOptions(ctx context.Conte
 		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
 		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
+		WithCustomAgentURL(r.commonController.customAgentURL),
+
 		WithMongodbImage(images.GetOfficialImage(r.imageUrls, sc.Spec.Version, sc.GetAnnotations(), r.defaultArchitecture)),
 		WithAgentDebug(r.agentDebug),
 		WithAgentDebugImage(r.agentDebugImage),
@@ -2482,6 +2484,8 @@ func (r *ShardedClusterReconcileHelper) getMongosOptions(ctx context.Context, sc
 		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
 		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
+		WithCustomAgentURL(r.commonController.customAgentURL),
+
 		WithMongodbImage(images.GetOfficialImage(r.imageUrls, sc.Spec.Version, sc.GetAnnotations(), r.defaultArchitecture)),
 		WithAgentDebug(r.agentDebug),
 		WithAgentDebugImage(r.agentDebugImage),
@@ -2520,6 +2524,8 @@ func (r *ShardedClusterReconcileHelper) getShardOptions(ctx context.Context, sc 
 		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
 		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
+		WithCustomAgentURL(r.commonController.customAgentURL),
+
 		WithMongodbImage(images.GetOfficialImage(r.imageUrls, sc.Spec.Version, sc.GetAnnotations(), r.defaultArchitecture)),
 		WithAgentDebug(r.agentDebug),
 		WithAgentDebugImage(r.agentDebugImage),

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -265,6 +265,8 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
 		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, automationAgentVersion)),
+		WithCustomAgentURL(r.customAgentURL),
+
 		WithMongodbImage(images.GetOfficialImage(r.imageUrls, s.Spec.Version, s.GetAnnotations(), r.defaultArchitecture)),
 		WithAgentDebug(r.agentDebug),
 		WithAgentDebugImage(r.agentDebugImage),

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher-lib.sh
@@ -114,10 +114,17 @@ download_agent() {
             ;;
     esac
 
-    script_log "Downloading Agent version: ${AGENT_VERSION}"
-    script_log "Downloading a Mongodb Agent from ${base_url:?}"
+    if [[ -n "${MDB_CUSTOM_AGENT_URL:-}" ]]; then
+        script_log "Using custom agent URL: ${MDB_CUSTOM_AGENT_URL}"
+        download_url="${MDB_CUSTOM_AGENT_URL}"
+    else
+        script_log "Downloading Agent version: ${AGENT_VERSION}"
+        script_log "Downloading a Mongodb Agent from ${base_url:?}"
+        download_url="${base_url}/download/agent/automation/${AGENT_FILE}"
+    fi
+
     curl_opts=(
-        "${base_url}/download/agent/automation/${AGENT_FILE}"
+        "${download_url}"
 
         "--location" "--silent" "--retry" "3" "--fail" "-v"
         "--output" "automation-agent.tar.gz"

--- a/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
+++ b/docker/mongodb-kubernetes-init-database/content/agent-launcher.sh
@@ -96,7 +96,8 @@ declare -r base_url
 if [ -z "${MDB_STATIC_CONTAINERS_ARCHITECTURE}" ]; then
   # Download the Automation Agent from Ops Manager
   # Note, that it will be skipped if the agent is supposed to be run in headless mode
-  if [[ -n "${base_url}" ]]; then
+  # unless a custom agent URL is provided, in which case we download it regardless.
+  if [[ -n "${base_url}" ]] || [[ -n "${MDB_CUSTOM_AGENT_URL:-}" ]]; then
       download_agent
   fi
 fi

--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -193,6 +193,10 @@ spec:
               value: "{{ $.Values.registry.agent }}/{{ $.Values.agent.name }}:{{ .Values.agent.version }}"
             - name: {{ $agentImageRepository }}
               value: "{{ $.Values.registry.agent }}/{{ $.Values.agent.name }}"
+            {{- if .Values.agent.customAgentUrl }}
+            - name: MDB_CUSTOM_AGENT_URL
+              value: "{{ .Values.agent.customAgentUrl }}"
+            {{- end }}
             - name: {{ $mongodbImageEnv }}
               value: {{ .Values.mongodb.name }}
             - name: MONGODB_REPO_URL

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -73,6 +73,7 @@ const (
 	EnvVarDebug            = "MDB_AGENT_DEBUG"
 	EnvVarDebugImage       = "MDB_AGENT_DEBUG_IMAGE"
 	EnvVarAgentVersion     = "MDB_AGENT_VERSION"
+	EnvVarCustomAgentURL   = "MDB_CUSTOM_AGENT_URL"
 	EnvVarMultiClusterMode = "MULTI_CLUSTER_MODE"
 
 	// EnvVarSSLRequireValidMMSCertificates bla bla

--- a/scripts/dev/print_operator_env.sh
+++ b/scripts/dev/print_operator_env.sh
@@ -65,6 +65,10 @@ OPERATOR_NAME=\"${OPERATOR_NAME}\"
     echo "MDB_AGENT_VERSION=${MDB_AGENT_VERSION}"
   fi
 
+  if [[ "${MDB_CUSTOM_AGENT_URL:-""}" != "" ]]; then
+    echo "MDB_CUSTOM_AGENT_URL=${MDB_CUSTOM_AGENT_URL}"
+  fi
+
   if [[ "${MDB_AGENT_DEBUG:-""}" != "" ]]; then
     echo "MDB_AGENT_DEBUG=${MDB_AGENT_DEBUG}"
   fi

--- a/scripts/funcs/operator_deployment
+++ b/scripts/funcs/operator_deployment
@@ -26,6 +26,7 @@ get_operator_helm_values() {
     "initDatabase.version=${INIT_DATABASE_VERSION}"
     "database.version=${DATABASE_VERSION}"
     "agent.version=${AGENT_VERSION}"
+    "agent.customAgentUrl=${MDB_CUSTOM_AGENT_URL:-}"
     "readinessProbe.version=${READINESS_PROBE_VERSION}"
     "versionUpgradeHook.version=${VERSION_UPGRADE_HOOK_VERSION}"
     "mongodb.name=mongodb-enterprise-server"

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -2,6 +2,7 @@
 
 """This atomic_pipeline script knows about the details of our Docker images
 and where to fetch and calculate parameters."""
+
 import datetime
 import json
 import os
@@ -64,7 +65,7 @@ def build_image(
     for registry in registries:
         arch_suffix = ""
         if build_configuration.architecture_suffix and len(build_configuration.platforms) == 1:
-            arch_suffix = f"-{build_configuration.platforms[0].split("/")[1]}"
+            arch_suffix = f"-{build_configuration.platforms[0].split('/')[1]}"
 
         tag = f"{registry}:{build_configuration.version}{arch_suffix}"
         if build_configuration.skip_if_exists and builder.check_if_image_exists(tag):
@@ -338,13 +339,25 @@ def build_agent_pipeline(
         f"======== Building agent pipeline for version {agent_version}, build configuration version: {build_configuration.version}"
     )
 
-    platform_build_args = generate_agent_build_args(
-        platforms=build_configuration_copy.platforms, agent_version=agent_version, tools_version=tools_version
-    )
+    custom_agent_url = os.getenv("MDB_CUSTOM_AGENT_URL", "")
+    if custom_agent_url:
+        # Custom agent URLs are single-arch (x86_64); multi-arch not supported.
+        agent_base_url, agent_filename = custom_agent_url.rsplit("/", 1)
+        platform_build_args = {}
+        for platform in build_configuration_copy.platforms:
+            arch = platform.split("/")[-1]
+            platform_build_args[f"mongodb_agent_version_{arch}"] = agent_filename
+        platform_build_args.update(generate_tools_build_args(build_configuration_copy.platforms, tools_version))
+    else:
+        agent_base_url = (
+            "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/automation-agent/prod"
+        )
+        platform_build_args = generate_agent_build_args(
+            platforms=build_configuration_copy.platforms,
+            agent_version=agent_version,
+            tools_version=tools_version,
+        )
 
-    agent_base_url = (
-        "https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/automation-agent/prod"
-    )
     tools_base_url = "https://fastdl.mongodb.org/tools/db"
 
     args = {

--- a/scripts/release/atomic_pipeline.py
+++ b/scripts/release/atomic_pipeline.py
@@ -339,7 +339,7 @@ def build_agent_pipeline(
         f"======== Building agent pipeline for version {agent_version}, build configuration version: {build_configuration.version}"
     )
 
-    custom_agent_url = os.getenv("MDB_CUSTOM_AGENT_URL", "")
+    custom_agent_url = build_configuration_copy.custom_agent_url or ""
     if custom_agent_url:
         # Custom agent URLs are single-arch (x86_64); multi-arch not supported.
         agent_base_url, agent_filename = custom_agent_url.rsplit("/", 1)

--- a/scripts/release/build/image_build_configuration.py
+++ b/scripts/release/build/image_build_configuration.py
@@ -25,6 +25,7 @@ class ImageBuildConfiguration:
     parallel_factor: int = 0
     architecture_suffix: bool = False
     agent_tools_version: Optional[str] = None  # Explicit tools version for agent builds
+    custom_agent_url: Optional[str] = None  # Custom agent URL for testing (overrides prod download)
 
     def is_release_scenario(self) -> bool:
         return self.scenario == BuildScenario.RELEASE

--- a/scripts/release/pipeline.py
+++ b/scripts/release/pipeline.py
@@ -171,6 +171,7 @@ def image_build_config_from_args(args) -> ImageBuildConfiguration:
         parallel_factor=args.parallel_factor,
         architecture_suffix=architecture_suffix,
         agent_tools_version=agent_tools_version,
+        custom_agent_url=args.custom_agent_url,
     )
 
 
@@ -306,6 +307,14 @@ Options: {", ".join(SUPPORTED_SCENARIOS)}. For '{BuildScenario.DEVELOPMENT}' the
         "--architecture-suffix",
         action=argparse.BooleanOptionalAction,
         help="Append architecture suffix to image tags for single platform builds. Can be true or false. This will override the value from build_info.json",
+    )
+    parser.add_argument(
+        "--custom-agent-url",
+        metavar="",
+        action="store",
+        type=str,
+        default="",
+        help="Custom agent URL for testing. Overrides the prod agent download URL.",
     )
 
     args = parser.parse_args()

--- a/scripts/release/pipeline.sh
+++ b/scripts/release/pipeline.sh
@@ -40,6 +40,11 @@ if [[ "${IMAGE_NAME}" == "agent" && "${AGENT_TOOLS_VERSION:-}" != "" ]]; then
     args+=(--agent-tools-version "${AGENT_TOOLS_VERSION}")
 fi
 
+# Pass custom agent URL if set (for testing custom agent builds)
+if [[ "${MDB_CUSTOM_AGENT_URL:-}" != "" ]]; then
+    args+=(--custom-agent-url "${MDB_CUSTOM_AGENT_URL}")
+fi
+
 if [[ "${FLAGS:-}" != "" ]]; then
     IFS=" " read -ra flags <<< "${FLAGS}"
     args+=("${flags[@]}")


### PR DESCRIPTION
# Summary

Adds a custom agent URL mechanism that lets both manual and automatic CI use the same code path to test a custom MongoDB automation agent build against MCK's static and non-static architectures.

The custom agent URL is passed as an Evergreen patch parameter (`mdb_custom_agent_url`), which becomes the `MDB_CUSTOM_AGENT_URL` environment variable. `pipeline.sh` translates it to `--custom-agent-url` for `pipeline.py`, which passes it to `ImageBuildConfiguration`. `atomic_pipeline.py` reads it from the config object (not directly from the env var). No `release.json` changes are needed.

In static mode, `GetAgentVersion()` now checks `MDB_CUSTOM_AGENT_URL` first, extracts the version from the URL, and returns it — short-circuiting the Ops Manager API, mapping file, and Cloud Manager paths that previously returned the wrong (old) agent version.

In non-static mode, the AppDB agent container now downloads the custom agent at runtime via a `downloadCustomAgentIfSet()` bash snippet when `MDB_CUSTOM_AGENT_URL` is set. Previously, the AppDB container directly ran the pre-baked `agent/mongodb-agent` binary and ignored `MDB_CUSTOM_AGENT_URL`. Database containers (OM/CloudQA) already handled this via `agent-launcher.sh` → `download_agent()`.

## How it was verified

Evergreen patch [#8312](https://evergreen.mongodb.com/patch/6a675fea57c72000071bfc97) was submitted with the parameter:

```
mdb_custom_agent_url=https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/patches/6a5f74111e6a450007f4f7a5/automation-agent/local/mongodb-mms-automation-agent-108.0.26.9047-1.rhel8_x86_64.tar.gz
```

All 11 e2e tasks passed. Every agent-deploying variant confirmed `AutomationVersion = 108.0.26.9047` from `agent-verbose.log` artifacts:

| # | Category | Mode | Variant | Task | Agent Version | Evidence |
|---|----------|------|---------|------|--------------|----------|
| 1 | OM6 | non-static | `e2e_om60_kind_ubi` | `e2e_om_appdb_external_connectivity` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_om60_kind_ubi_e2e_om_appdb_external_connectivity_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160078-ziy7e5ditaz_om-appdb-external-db-0-agent-verbose.log&token=4b2d59ab5a1329a779dd5a9674b86404d67ac382e810d42deaccc933ca6e4aab&exp=1785236672) → `AutomationVersion = 108.0.26.9047` |
| 2 | OM6 | static | `e2e_static_om60_kind_ubi` | `e2e_om_appdb_external_connectivity` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_static_om60_kind_ubi_e2e_om_appdb_external_connectivity_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160064-7m1brg9p63z_om-appdb-external-db-0-agent-verbose.log&token=dba649f891bf94cc1dc068c3c8ef01b1143728d24b6b93564954c13dd948b22d&exp=1785236671) → `AutomationVersion = 108.0.26.9047` |
| 3 | OM7 | non-static | `e2e_om70_kind_ubi` | `e2e_om_appdb_external_connectivity` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_om70_kind_ubi_e2e_om_appdb_external_connectivity_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160068-spxcogo1fmz_om-appdb-external-db-0-agent-verbose.log&token=95a630d1630e15759e49d4fb42fa61c7ec6c7a0994deac4903c38a2df5eab121&exp=1785236672) → `AutomationVersion = 108.0.26.9047` |
| 4 | OM7 | static | `e2e_static_om70_kind_ubi` | `e2e_om_appdb_external_connectivity` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_static_om70_kind_ubi_e2e_om_appdb_external_connectivity_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160082-jq7migmquez_om-appdb-external-db-0-agent-verbose.log&token=6c4f171b57b0bebad144083e809add18bddaf1e1b8536d5a0b150bc0cd4302c3&exp=1785236672) → `AutomationVersion = 108.0.26.9047` |
| 5 | OM8 | non-static | `e2e_om80_kind_ubi` | `e2e_om_appdb_external_connectivity` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_om80_kind_ubi_e2e_om_appdb_external_connectivity_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160068-mgp02w3s62z_om-appdb-external-db-0-agent-verbose.log&token=34084df015ce8d69e38870a9c05f7bc878641b0f6b32d2344f5ba8e3984d281d&exp=1785236672) → `AutomationVersion = 108.0.26.9047` |
| 6 | OM8 | static | `e2e_static_om80_kind_ubi` | `e2e_om_appdb_external_connectivity` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_static_om80_kind_ubi_e2e_om_appdb_external_connectivity_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160071-eeu2vrr9m0z_om-appdb-external-db-0-agent-verbose.log&token=8f30655b1166136800786197a88d1bffafeaa3c67e93aa105a3b72adc4640b67&exp=1785236672) → `AutomationVersion = 108.0.26.9047` |
| 7 | AppDB | non-static (upgrade) | `e2e_multi_cluster_om_appdb` | `e2e_appdb_tls_operator_upgrade_v1_32_to_mck` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_multi_cluster_om_appdb_e2e_appdb_tls_operator_upgrade_v1_32_to_mck_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=kind-e2e-cluster-2__a-1785160058-pvw07hgjjcz_om-appdb-upgrade-db-0-0-agent-verbose.log&token=ac807b6e3b62b7f40e036eac9e0585adedb30dbb834bc241419fe5de4a31fcf5&exp=1785236671) → starts `108.0.2.8729`, upgrades to `108.0.26.9047` |
| 8 | AppDB | non-static | `e2e_multi_cluster_om_appdb` | `e2e_multi_cluster_appdb` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_multi_cluster_om_appdb_e2e_multi_cluster_appdb_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=kind-e2e-cluster-2__a-1785160068-t4bbdcxs0sz_om-backup-db-0-0-agent-verbose.log&token=c3ef1f74a7fa8d52caee7debc589ca0d877c6c4c1e14435f08f86f6a081c7b6c&exp=1785236671) → `AutomationVersion = 108.0.26.9047` |
| 9 | AppDB | static | `e2e_static_multi_cluster_om_appdb` | `e2e_multi_cluster_appdb` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_static_multi_cluster_om_appdb_e2e_multi_cluster_appdb_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=kind-e2e-cluster-1__a-1785160054-4cllan0iqjz_om-backup-db-2-0-agent-verbose.log&token=67aa5407756f23c812ad39f8f6c7ee8b6b798d388bca98d8928833eafe42c452&exp=1785236671) → `AutomationVersion = 108.0.26.9047` |
| 10 | CloudQA | non-static | `e2e_mdb_kind_ubi_cloudqa` | `e2e_all_mongodb_resources_parallel` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_mdb_kind_ubi_cloudqa_e2e_all_mongodb_resources_parallel_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160075-i4rda39yvtz_my-replica-set-single-0-agent-verbose.log&token=5a67149946ec5c33d8c40616ff50f5de33c6e3624f89c37aa2ec683d684e51b4&exp=1785236671) → `AutomationVersion = 108.0.26.9047` |
| 11 | CloudQA | static | `e2e_static_mdb_kind_ubi_cloudqa` | `e2e_all_mongodb_resources_parallel` | 108.0.26.9047 ✅ | [agent-verbose.log](https://evergreen.mongodb.com/rest/v2/tasks/mongodb_kubernetes_e2e_static_mdb_kind_ubi_cloudqa_e2e_all_mongodb_resources_parallel_patch_8b203f962785ae71e89f807ac9d7213441e40d00_6a675fea57c72000071bfc97_26_07_27_13_41_00/artifact/sign?execution=0&name=_a-1785160066-hz9u0d6znyz_my-replica-set-single-0-agent-verbose.log&token=9a0a0f8ad211000f7b4917b3ed4abddaa3f9297941ede2c4ecd3a359ae834056&exp=1785236671) → `AutomationVersion = 108.0.26.9047` |

## Unit tests

- `controllers/operator/common_controller_test.go` — `TestAgentVersionFromURL` (5 cases): extracts version string from S3 URL across `rhel8_x86_64`, `amzn2_aarch64`, `linux_x86_64`, `rhel8_ppc64le`, and empty-string fallback
- `controllers/operator/construct/appdb_construction_test.go` — `TestCustomAgentURL` (4 subtests): builds real Database and AppDB StatefulSets, verifies `MDB_CUSTOM_AGENT_URL` env var is present in non-static and static modes, absent when unset; static mode excludes download snippet
- `controllers/operator/construct/appdb_construction_test.go` — `TestAutomationAgentCommandStaticVsNonStatic` (2 subtests): verifies non-static command includes download snippet, static command excludes it

# Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

