### PR TITLE
Remove unused logic member cluster health in search controller

### DIFF
--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -30,7 +29,6 @@ import (
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/commoncontroller"
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
-	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster/memberwatch"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 )
@@ -338,22 +336,9 @@ func AddMongoDBSearchController(
 		}
 	}
 
-	// Health-check goroutine fans out per-cluster reachability changes onto a
-	// GenericEvent channel that the controller watches. Empty memberClusterObjectsMap
-	// (single-cluster install) skips the goroutine entirely — there is nothing to watch.
+	// Per-member-cluster watches. Empty memberClusterObjectsMap (single-cluster
+	// install) skips them entirely — there is nothing to watch.
 	if len(memberClusterObjectsMap) > 0 {
-		eventChannel := make(chan event.GenericEvent)
-		healthChecker := memberwatch.MemberClusterHealthChecker{
-			Cache:                 make(map[string]memberwatch.ClusterHealthChecker),
-			HealthyStreak:         make(map[string]int),
-			RequiredHealthyStreak: env.ReadIntOrDefault(util.RequiredHealthyStreakEnv, util.DefaultRequiredHealthyStreak), // nolint:forbidigo
-		}
-		go healthChecker.WatchMemberClusterHealth(ctx, zap.S(), eventChannel, r.kubeClient, memberClusterObjectsMap)
-
-		if err := c.Watch(source.Channel[client.Object](eventChannel, &handler.EnqueueRequestForObject{})); err != nil {
-			return err
-		}
-
 		// Per-member-cluster watches map events back to the parent MongoDBSearch
 		// via the search-owner labels (cross-cluster owner refs do not GC).
 		searchOwnerHandler := handler.EnqueueRequestsFromMapFunc(khandler.EnqueueMemberClusterObjectToSearch)


### PR DESCRIPTION
# Summary

The member cluster health check that we had in the search controller was actually no-op. `WatchMemberClusterHealth` has comment that says

```
// WatchMemberClusterHealth watches member clusters healthcheck. If a cluster fails healthcheck it re-enqueues the
// MongoDBMultiCluster resources. It is spun up in the mongodb multi reconciler as a go-routine, and is executed every 10 seconds.
```

As we can see it re-queues the `MongoDBMultiCluster` resource and adds it (based on cluster health check) to the `watchChannel` as `GenericEvent`.
The same resource (of type MDBMC) is then used in then enqueued (name/namespace) in the search controller (`EnqueueRequestForObject`), later search reconciler does a get resource for the same enqueued resource. Now the important thing to notice is because `WatchMemberClusterHealth` returned (via channel) MDBMC resource but in search reconciler we are getting MDBS with the same name/namespace, which would just be 404. Which makes this logic no-op.

To make sure that it doesn't have any unwanted side effects we have decided to remove this code block from search controller.

## Proof of Work

Successful CI.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
