### PR TITLE
feat: annotate Slack merge reporter with previous master failures

### DIFF
--- a/scripts/evergreen/notify_master_failures.py
+++ b/scripts/evergreen/notify_master_failures.py
@@ -202,11 +202,48 @@ def get_failed_and_running_tasks(
 MAX_DETAILED_FAILURES = 10
 
 
-def _format_task_name(task: TaskInfo, flaky_map: dict[tuple[str, str], FlakyTask]) -> str:
-    """Format a task display_name, appending flakiness info if known."""
+def get_previous_version_failures(api: EvergreenApi, version_info: VersionInfo) -> set[tuple[str, str]]:
+    """Get the set of (display_name, build_variant) tuples that failed on the previous master version.
+
+    Uses recent_versions_by_project to find the version with the highest order
+    below the current version's order, then reuses get_failed_and_running_tasks
+    to collect its failures.
+
+    Returns an empty set if no previous version is found or if the lookup fails.
+    """
+    current_order = getattr(version_info, "order", None)
+    project_id = getattr(version_info, "project", None)
+    if current_order is None or project_id is None:
+        return set()
+
+    global _api_call_count
+    _api_call_count += 1
+    recent = api.recent_versions_by_project(project_id)
+
+    candidates = [v for v in recent.versions if getattr(v, "order", None) is not None and v.order < current_order]
+    if not candidates:
+        print("No previous master version found", file=sys.stderr)
+        return set()
+
+    prev_version_id = max(candidates, key=lambda v: v.order).version_id
+    print(f"Checking previous master version: {prev_version_id}", file=sys.stderr)
+    prev_failed, _ = get_failed_and_running_tasks(api, prev_version_id, NOTIFICATION_TASKS)
+    return {(t.display_name, t.build_variant) for t in prev_failed}
+
+
+def _format_task_name(
+    task: TaskInfo, flaky_map: dict[tuple[str, str], FlakyTask], prev_failed: set[tuple[str, str]] | None = None
+) -> str:
+    """Format a task display_name, appending flakiness and/or previous-master info if known."""
+    prev_failed = prev_failed or set()
+    annotations = []
     flaky = flaky_map.get((task.display_name, task.build_variant))
     if flaky is not None:
-        return f"{task.display_name} *(flaky: {flaky.flakiness_percent:.0f}% over {flaky.total_runs} runs)*"
+        annotations.append(f"flaky: {flaky.flakiness_percent:.0f}% over {flaky.total_runs} runs")
+    if (task.display_name, task.build_variant) in prev_failed:
+        annotations.append("also on previous master")
+    if annotations:
+        return f"{task.display_name} *({' | '.join(annotations)})*"
     return task.display_name
 
 
@@ -214,6 +251,7 @@ def format_slack_message(
     version_info: VersionInfo,
     failed_tasks: list[TaskInfo] | None = None,
     flaky_map: dict[tuple[str, str], FlakyTask] | None = None,
+    prev_failed: set[tuple[str, str]] | None = None,
 ) -> dict[str, object]:
     """Format a Slack message for build status.
 
@@ -221,8 +259,10 @@ def format_slack_message(
         version_info: Version information
         failed_tasks: List of failed tasks
         flaky_map: Optional {(task_name, variant): FlakyTask} from Honeycomb
+        prev_failed: Optional set of (task_name, variant) that also failed on the previous master
     """
     flaky_map = flaky_map or {}
+    prev_failed = prev_failed or set()
     evergreen_version_url = f"https://spruce.mongodb.com/version/{version_info.version_id}"
     is_failure = bool(failed_tasks)
     num_failures = len(failed_tasks) if failed_tasks else 0
@@ -287,12 +327,26 @@ def format_slack_message(
                 }
             )
 
+    # Previous-master context: how many failed tasks also failed on the previous master build
+    if is_failure and failed_tasks and prev_failed:
+        prev_failed_count = sum(1 for t in failed_tasks if (t.display_name, t.build_variant) in prev_failed)
+        if prev_failed_count > 0:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"_{prev_failed_count} of {num_failures} failed task(s) also failed on the previous master build (likely not caused by this commit)_",
+                    },
+                }
+            )
+
     if is_failure and failed_tasks:
         failures_by_variant: dict[str, list[str]] = {}
         for task in failed_tasks:
             if task.build_variant not in failures_by_variant:
                 failures_by_variant[task.build_variant] = []
-            failures_by_variant[task.build_variant].append(_format_task_name(task, flaky_map))
+            failures_by_variant[task.build_variant].append(_format_task_name(task, flaky_map, prev_failed))
 
         num_variants = len(failures_by_variant)
         blocks.append({"type": "divider"})
@@ -445,16 +499,27 @@ def main() -> None:
         except Exception as e:
             print(f"Warning: flakiness lookup failed: {e}", file=sys.stderr)
 
+    # Look up previous master failures (best-effort, non-fatal).
+    prev_failed: set[tuple[str, str]] = set()
+    if failed_tasks:
+        print("Checking previous master build for same failures...", file=sys.stderr)
+        try:
+            prev_failed = get_previous_version_failures(api, version_info)
+            prev_matches = sum(1 for t in failed_tasks if (t.display_name, t.build_variant) in prev_failed)
+            print(f"  {prev_matches} of {len(failed_tasks)} failed tasks also failed on previous master", file=sys.stderr)
+        except Exception as e:
+            print(f"Warning: previous master lookup failed: {e}", file=sys.stderr)
+
     if failed_tasks or running_tasks:
         print(f"Found {len(failed_tasks)} failed, {len(running_tasks)} running tasks", file=sys.stderr)
 
         if use_slack_dry_run:
-            message = format_slack_message(version_info, failed_tasks, flaky_map)
+            message = format_slack_message(version_info, failed_tasks, flaky_map, prev_failed)
             print(json.dumps(message, indent=2))
         else:
             print_stdout_report(version_info, failed_tasks, running_tasks, flaky_map)
             if use_slack and slack_webhook_url and failed_tasks:
-                message = format_slack_message(version_info, failed_tasks, flaky_map)
+                message = format_slack_message(version_info, failed_tasks, flaky_map, prev_failed)
                 send_slack_notification(slack_webhook_url, message)
     else:
         print("No failed or running tasks found", file=sys.stderr)

--- a/scripts/evergreen/notify_master_failures.py
+++ b/scripts/evergreen/notify_master_failures.py
@@ -205,10 +205,6 @@ MAX_DETAILED_FAILURES = 10
 def get_previous_version_failures(api: EvergreenApi, version_info: VersionInfo) -> set[tuple[str, str]]:
     """Get the set of (display_name, build_variant) tuples that failed on the previous master version.
 
-    Uses recent_versions_by_project to find the version with the highest order
-    below the current version's order, then reuses get_failed_and_running_tasks
-    to collect its failures.
-
     Returns an empty set if no previous version is found or if the lookup fails.
     """
     current_order = getattr(version_info, "order", None)
@@ -218,14 +214,23 @@ def get_previous_version_failures(api: EvergreenApi, version_info: VersionInfo) 
 
     global _api_call_count
     _api_call_count += 1
-    recent = api.recent_versions_by_project(project_id)
+    recent = api.recent_versions_by_project(project_id, params={"limit": "50"})
 
-    candidates = [v for v in recent.versions if getattr(v, "order", None) is not None and v.order < current_order]
+    # Work around evergreen.py bug: RecentVersions.versions passes a list to
+    # Version() instead of individual dicts, so all fields are None.
+    # Access the raw JSON directly.
+    all_versions = [
+        v for wrapper in recent.json.get("versions", [])
+        for v in wrapper.get("versions", [])
+        if v.get("order") is not None
+    ]
+
+    candidates = [v for v in all_versions if v["order"] < current_order]
     if not candidates:
         print("No previous master version found", file=sys.stderr)
         return set()
 
-    prev_version_id = max(candidates, key=lambda v: v.order).version_id
+    prev_version_id = max(candidates, key=lambda v: v["order"])["version_id"]
     print(f"Checking previous master version: {prev_version_id}", file=sys.stderr)
     prev_failed, _ = get_failed_and_running_tasks(api, prev_version_id, NOTIFICATION_TASKS)
     return {(t.display_name, t.build_variant) for t in prev_failed}
@@ -506,7 +511,9 @@ def main() -> None:
         try:
             prev_failed = get_previous_version_failures(api, version_info)
             prev_matches = sum(1 for t in failed_tasks if (t.display_name, t.build_variant) in prev_failed)
-            print(f"  {prev_matches} of {len(failed_tasks)} failed tasks also failed on previous master", file=sys.stderr)
+            print(
+                f"  {prev_matches} of {len(failed_tasks)} failed tasks also failed on previous master", file=sys.stderr
+            )
         except Exception as e:
             print(f"Warning: previous master lookup failed: {e}", file=sys.stderr)
 

--- a/scripts/evergreen/notify_master_failures.py
+++ b/scripts/evergreen/notify_master_failures.py
@@ -220,7 +220,8 @@ def get_previous_version_failures(api: EvergreenApi, version_info: VersionInfo) 
     # Version() instead of individual dicts, so all fields are None.
     # Access the raw JSON directly.
     all_versions = [
-        v for wrapper in recent.json.get("versions", [])
+        v
+        for wrapper in recent.json.get("versions", [])
         for v in wrapper.get("versions", [])
         if v.get("order") is not None
     ]

--- a/scripts/evergreen/tests/test_notify_master_failures.py
+++ b/scripts/evergreen/tests/test_notify_master_failures.py
@@ -11,6 +11,7 @@ from scripts.evergreen.notify_master_failures import (
     VersionInfo,
     format_slack_message,
     get_failed_and_running_tasks,
+    get_previous_version_failures,
     print_stdout_report,
     send_slack_notification,
 )
@@ -154,6 +155,19 @@ class TestFormatSlackMessage:
                 break
         assert "over 18–47 runs" in summary_text
 
+    def test_prev_failed_in_slack(self):
+        """Summary line + per-task annotation when tasks also failed on previous master."""
+        prev_failed = {("e2e_task_1", "variant_a"), ("e2e_task_2", "variant_a")}
+        version_info = make_mock_version(status="failed")
+        message = format_slack_message(version_info, FEW_TASKS, prev_failed=prev_failed)
+        text = " ".join(
+            b["text"]["text"] for b in message["blocks"]
+            if b["type"] == "section" and isinstance(b.get("text"), dict)
+        )
+        assert "2 of 3" in text
+        assert "previous master" in text
+        assert "also on previous master" in text
+
 
 class TestPrintStdoutReport:
     def _report(self, failed_tasks=None, running_tasks=None, **kwargs):
@@ -252,6 +266,37 @@ class TestGetFailedAndRunningTasks:
         assert failed[0].display_name == "e2e_real_fail"
 
 
+class TestGetPreviousVersionFailures:
+    @patch("scripts.evergreen.notify_master_failures.get_failed_and_running_tasks")
+    def test_finds_previous_version(self, mock_failed_tasks):
+        """Should find the version with the highest order below current and return its failures."""
+        mock_v1 = MagicMock()
+        mock_v1.version_id = "v1"
+        mock_v1.order = 95
+
+        mock_v2 = MagicMock()
+        mock_v2.version_id = "v2"
+        mock_v2.order = 99  # closest below current
+
+        mock_v3 = MagicMock()
+        mock_v3.version_id = "v3"
+        mock_v3.order = 101  # above current, should be skipped
+
+        mock_api = MagicMock()
+        mock_api.recent_versions_by_project.return_value.versions = [mock_v1, mock_v2, mock_v3]
+
+        prev_failed_task = make_mock_task("e2e_prev_fail", "variant_a")
+        mock_failed_tasks.return_value = ([prev_failed_task], [])
+
+        version_info = make_mock_version(order=100)
+        version_info.version.project = "my-project"
+
+        result = get_previous_version_failures(mock_api, version_info)
+
+        assert ("e2e_prev_fail", "variant_a") in result
+        assert mock_failed_tasks.call_args[0][1] == "v2"
+
+
 class TestSendSlackNotification:
     @patch("scripts.evergreen.notify_master_failures.requests.post")
     def test_success(self, mock_post):
@@ -273,15 +318,17 @@ class TestMainOutputBehavior:
             patch("scripts.evergreen.notify_master_failures.get_evergreen_api") as api,
             patch("scripts.evergreen.notify_master_failures.wait_for_version_completion") as wait,
             patch("scripts.evergreen.notify_master_failures.get_failed_and_running_tasks") as tasks,
+            patch("scripts.evergreen.notify_master_failures.get_previous_version_failures") as prev_failed,
             patch("scripts.evergreen.notify_master_failures.send_slack_notification") as slack,
             patch("scripts.evergreen.notify_master_failures.print_stdout_report") as stdout,
         ):
             api.return_value = MagicMock()
             slack.return_value = True
+            prev_failed.return_value = set()
             monkeypatch.setenv("version_id", "test")
             monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
             monkeypatch.delenv("NOTIFY_ON_SUCCESS", raising=False)
-            yield {"wait": wait, "tasks": tasks, "slack": slack, "stdout": stdout}
+            yield {"wait": wait, "tasks": tasks, "slack": slack, "stdout": stdout, "prev_failed": prev_failed}
 
     def _run(self, mocks, status, failed=None, running=None, args=None):
         mocks["wait"].return_value = make_mock_version(

--- a/scripts/evergreen/tests/test_notify_master_failures.py
+++ b/scripts/evergreen/tests/test_notify_master_failures.py
@@ -161,8 +161,7 @@ class TestFormatSlackMessage:
         version_info = make_mock_version(status="failed")
         message = format_slack_message(version_info, FEW_TASKS, prev_failed=prev_failed)
         text = " ".join(
-            b["text"]["text"] for b in message["blocks"]
-            if b["type"] == "section" and isinstance(b.get("text"), dict)
+            b["text"]["text"] for b in message["blocks"] if b["type"] == "section" and isinstance(b.get("text"), dict)
         )
         assert "2 of 3" in text
         assert "previous master" in text
@@ -270,20 +269,18 @@ class TestGetPreviousVersionFailures:
     @patch("scripts.evergreen.notify_master_failures.get_failed_and_running_tasks")
     def test_finds_previous_version(self, mock_failed_tasks):
         """Should find the version with the highest order below current and return its failures."""
-        mock_v1 = MagicMock()
-        mock_v1.version_id = "v1"
-        mock_v1.order = 95
-
-        mock_v2 = MagicMock()
-        mock_v2.version_id = "v2"
-        mock_v2.order = 99  # closest below current
-
-        mock_v3 = MagicMock()
-        mock_v3.version_id = "v3"
-        mock_v3.order = 101  # above current, should be skipped
-
+        # Simulate the raw JSON structure from recent_versions_by_project:
+        # {"versions": [{"rolled_up": False, "versions": [{...}, ...]}, ...]}
         mock_api = MagicMock()
-        mock_api.recent_versions_by_project.return_value.versions = [mock_v1, mock_v2, mock_v3]
+        mock_api.recent_versions_by_project.return_value.json = {
+            "versions": [
+                {"rolled_up": False, "versions": [
+                    {"version_id": "v1", "order": 95},
+                    {"version_id": "v2", "order": 99},  # closest below current
+                    {"version_id": "v3", "order": 101},  # above current, should be skipped
+                ]},
+            ]
+        }
 
         prev_failed_task = make_mock_task("e2e_prev_fail", "variant_a")
         mock_failed_tasks.return_value = ([prev_failed_task], [])

--- a/scripts/evergreen/tests/test_notify_master_failures.py
+++ b/scripts/evergreen/tests/test_notify_master_failures.py
@@ -274,11 +274,14 @@ class TestGetPreviousVersionFailures:
         mock_api = MagicMock()
         mock_api.recent_versions_by_project.return_value.json = {
             "versions": [
-                {"rolled_up": False, "versions": [
-                    {"version_id": "v1", "order": 95},
-                    {"version_id": "v2", "order": 99},  # closest below current
-                    {"version_id": "v3", "order": 101},  # above current, should be skipped
-                ]},
+                {
+                    "rolled_up": False,
+                    "versions": [
+                        {"version_id": "v1", "order": 95},
+                        {"version_id": "v2", "order": 99},  # closest below current
+                        {"version_id": "v3", "order": 101},  # above current, should be skipped
+                    ],
+                },
             ]
         }
 


### PR DESCRIPTION
# Summary

The Slack merge reporter currently shows flakiness info for failed tasks but gives no indication of whether a failure was already present on the previous master build. This makes it hard to tell whether a merge introduced a failure or inherited it.

This PR adds a "previous master" check to `notify_master_failures.py`. After collecting failed tasks, the script queries the previous master version via `recent_versions_by_project` and reuses `get_failed_and_running_tasks` to collect its failures. A summary line is added to the Slack message, and each matching task is annotated individually.

## Proof of Work

Verified against real Evergreen data for version 6648 (Jose Vazquez's commit `142e9b74`). Both `private_gke_code_snippets` tasks that failed on 6648 also failed on the previous master version 6647:

```
Current version (6648) failed tasks: 2
  private_gke_code_snippets: test_gke_multi_cluster_no_mesh_snippets.sh
  private_gke_code_snippets: test_gke_multi_cluster_snippets.sh

Previous version (6647) failed tasks: 3
  e2e_multi_cluster_kind: e2e_multi_cluster_replica_set_migration
  private_gke_code_snippets: test_gke_multi_cluster_no_mesh_snippets.sh
  private_gke_code_snippets: test_gke_multi_cluster_snippets.sh

Matches (also on previous master): 2
```

Resulting Slack notification:

```
🔴 Master Build Failures
Run: #6648
Commit: 142e9b74
Author: @jose.vazquez

2 of 2 failed task(s) also failed on the previous master build (likely not caused by this commit)

Failed Tasks (2):
private_gke_code_snippets: test_gke_multi_cluster_no_mesh_snippets.sh *(also on previous master)*, test_gke_multi_cluster_snippets.sh *(also on previous master)*
```


## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->