### PR TITLE
Bump ROSA cluster tracked version for MCK

### DIFF
--- a/kubernetes-versions.json
+++ b/kubernetes-versions.json
@@ -3,7 +3,7 @@
     "min": "1.34.3",
     "max": "1.36.1"
   },
-  "openshift": "4.21",
+  "openshift": "4.22",
   "kind": {
     "images": {
       "min": "268558157000.dkr.ecr.eu-west-1.amazonaws.com/docker-hub-mirrors/kindest/node",


### PR DESCRIPTION
# Summary

Bump out ROSA cluster tracked version to reflect the recent upgrade.

Also includes bump to avoid [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970)

## Proof of Work

```shell
$ $ ./scripts/check-kube-versions.sh
--------------------------------------------------------
Checking Support Policy Compliance
Operator Release Date: 2026-07-27
New Version Buffer: 30 days | EOL Buffer: 30 days
--------------------------------------------------------
Policy Cutoff (New Versions): Releases before 2026-06-27 must be supported.

### Checking Kubernetes Range (1.34 - 1.36)
✓ Max version is correct (1.36)
✓ Min version 1.34 is valid (EOL: 2026-10-27)

### Checking OpenShift Version (4.22)
✓ OpenShift version is correct (4.22)


✓ All version checks passed!
```

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
