### PR TITLE
Fix yaml syntax for variant `private_gke_code_snippets`

### DIFF
--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -252,9 +252,6 @@ buildvariants:
     allowed_requesters: [ "patch", "commit" ]
     run_on:
       - ubuntu2404-small
-    depends_on:
-      - name: build_kubectl_mongodb_plugin
-        variant: init_test_run
     <<: *base_om8_dependency
     tasks:
       - name: gke_code_snippets_task_group


### PR DESCRIPTION
# Summary

This is how the variant looked like 

```
- name: private_gke_code_snippets
    display_name: private_gke_code_snippets
    tags: [ "manual_patch", "staging", "e2e_test_suite" ]
    allowed_requesters: [ "patch", "commit" ]
    run_on:
      - ubuntu2404-small
    depends_on:
      - name: build_kubectl_mongodb_plugin
        variant: init_test_run
    <<: *base_om8_dependency
    tasks:
      - name: gke_code_snippets_task_group
```

Notice that we have `depends_on` and we also use `base_om8_dependency` (which has `depends_on`) as anchor. Now the way yaml anchors work is, because we have `depends_on` already defined, the `depends_on` from `base_om8_dependency` would not be merged properly and because of that even though this variant depends on `base_om8_dependency`, if I run it from CLI 
```
evergreen patch -p mongodb-kubernetes -v private_gke_code_snippets -t test_gke_multi_cluster_no_mesh_snippets.sh -d "private gke code snippets master test" -u -f -y --browse
```
it would not depend (wait for) on the tasks defined in `base_om8_dependency`.

To fix this we remove `depends_on` and because of that `depends_on` from `base_om8_dependency` is used properly.

## Proof of Work

Ran the patch manually to verify.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
