### PR TITLE
CLOUDP-400899: Use a released kubectl plugin for the E2E baseline

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -629,6 +629,18 @@ functions:
         env:
           PLATFORM: ${platform}
 
+  # Fetches a released MCK kubectl plugin from the public GitHub releases.
+  # It provisions the released operator baselines the upgrade tests start from (MEKO and MCK 1.x).
+  download_released_multi_cluster_binary:
+    - command: subprocess.exec
+      params:
+        working_dir: src/github.com/mongodb/mongodb-kubernetes
+        binary: scripts/release/kubectl_mongodb/download_released_kubectl_plugin.sh
+        env:
+          PLATFORM: ${platform}
+          PLUGIN_MAJOR: ${plugin_major|1}
+          GH_TOKEN: ${GH_TOKEN}
+
   pipeline:
     - command: subprocess.exec
       retry_on_failure: true

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -453,6 +453,9 @@ tasks:
       - func: download_multi_cluster_binary
         vars:
           platform: linux/amd64
+      - func: download_released_multi_cluster_binary
+        vars:
+          platform: linux/amd64
       - func: quay_staging_login
       - func: pipeline
         vars:
@@ -463,6 +466,9 @@ tasks:
       - func: clone
       - func: setup_building_host
       - func: download_multi_cluster_binary
+        vars:
+          platform: linux/arm64
+      - func: download_released_multi_cluster_binary
         vars:
           platform: linux/arm64
       - func: quay_staging_login

--- a/docker/mongodb-kubernetes-tests/Dockerfile
+++ b/docker/mongodb-kubernetes-tests/Dockerfile
@@ -91,3 +91,11 @@ COPY public /mongodb-kubernetes/public
 RUN if [ -f "/tests/multi-cluster-kube-config-creator_${TARGETARCH}" ]; then \
     install -m 755 "/tests/multi-cluster-kube-config-creator_${TARGETARCH}" /usr/local/bin/multi-cluster-kube-config-creator; \
     fi
+
+# A released MCK 1.x plugin, used to provision the pre-MemberCluster multi-cluster install flow
+# (kubeconfig Secret + member-list ConfigMap) for the released baselines the upgrade tests start from —
+# both MEKO and MCK 1.x. MCK 2.x no longer ships `multicluster setup`, so the branch-built plugin above
+# cannot do it.
+RUN if [ -f "/tests/multi-cluster-kube-config-creator-mck1x_${TARGETARCH}" ]; then \
+    install -m 755 "/tests/multi-cluster-kube-config-creator-mck1x_${TARGETARCH}" /usr/local/bin/multi-cluster-kube-config-creator-mck1x; \
+    fi

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -697,12 +697,16 @@ def get_multi_cluster_operator(
     member_cluster_names: List[str],
     apply_crds_first: bool = False,
     operator_config_extra_spec: Optional[dict] = None,
+    # TODO(m1kola): slice-7: remove extra_helm_args. It will not longer be needed once we de-duplicate RBAC.
+    extra_helm_args: Optional[dict[str, str]] = None,
 ) -> Operator:
     os.environ["HELM_KUBECONTEXT"] = central_cluster_name
 
     helm_opts = {
         "operator.name": MULTI_CLUSTER_OPERATOR_NAME,
     }
+    if extra_helm_args is not None:
+        helm_opts.update(extra_helm_args)
     return _install_multi_cluster_operator(
         namespace,
         multi_cluster_operator_installation_config,

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -899,14 +899,17 @@ def _install_multi_cluster_operator(
         helm_chart_path or "", custom_operator_version or ""
     )
 
-    prepare_multi_cluster_namespaces(
-        namespace,
-        multi_cluster_operator_installation_config,
-        member_cluster_clients,
-        central_cluster_name,
-        skip_central_cluster=True,
-        helm_chart_path=helm_chart_path,
-    )
+    # Only the released baseline needs this: it renders the chart's database-roles onto the member
+    # clusters, which generate-member-resources already does for the new path.
+    if configure_member_clusters is None:
+        prepare_multi_cluster_namespaces(
+            namespace,
+            multi_cluster_operator_installation_config,
+            member_cluster_clients,
+            central_cluster_name,
+            skip_central_cluster=True,
+            helm_chart_path=helm_chart_path,
+        )
 
     operator = Operator(
         name=operator_name,

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -1145,9 +1145,12 @@ def install_official_operator(
         assert operator_name is not None
         assert central_cluster_name is not None
         os.environ["HELM_KUBECONTEXT"] = central_cluster_name
-        # when running with the local operator, this is executed by scripts/dev/prepare_local_e2e_run.sh
+        # Every baseline we install today is pre-2.x, so the legacy flow is hardcoded. A baseline on a
+        # released 2.x chart would instead need generate-member-resources/-registration from a released
+        # 2.x plugin, so dispatch on the baseline's major once that exists.
+        # Skipped for a local operator: installing a released in-cluster baseline is a CI-only flow.
         if not local_operator():
-            run_kube_config_creation_tool(
+            run_legacy_kube_config_creation_tool(
                 member_cluster_names,
                 namespace,
                 namespace,
@@ -1430,7 +1433,15 @@ def get_api_servers_from_pod_kubeconfig(kubeconfig: str, cluster_clients: Dict[s
     return api_servers
 
 
-def run_kube_config_creation_tool(
+def _mck1x_multi_cluster_plugin_path() -> str:
+    """Path to a released MCK 1.x kubectl-mongodb plugin, installed into the test image."""
+    return os.getenv(
+        "MCK1X_MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH",
+        "multi-cluster-kube-config-creator-mck1x",
+    )
+
+
+def run_legacy_kube_config_creation_tool(
     member_clusters: List[str],
     central_namespace: str,
     member_namespace: str,
@@ -1439,13 +1450,15 @@ def run_kube_config_creation_tool(
     service_account_name: str = "mongodb-kubernetes-operator-multi-cluster",
     operator_name: str = OPERATOR_NAME,
 ):
+    """Provision the pre-`MemberCluster` install flow: kubeconfig Secret + member-list ConfigMap.
+
+    "Legacy" is the flow, not a product — it is the only discovery mechanism MEKO and MCK 1.x
+    understand. Resource names come from the flags, so one released MCK 1.x plugin serves both.
+    """
     central_cluster = _read_multi_cluster_config_value("central_cluster")
     member_clusters_str = ",".join(member_clusters)
     args: list[str] = [
-        os.getenv(
-            "MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH",
-            "multi-cluster-kube-config-creator",
-        ),
+        _mck1x_multi_cluster_plugin_path(),
         "multicluster",
         "setup",
         "--member-clusters",
@@ -1476,9 +1489,9 @@ def run_kube_config_creation_tool(
         args.append("--cluster-scoped")
 
     try:
-        print(f"Running multi-cluster cli setup tool: {' '.join(args)}")
+        print(f"Running legacy multi-cluster cli setup tool: {' '.join(args)}")
         subprocess.check_output(args, stderr=subprocess.STDOUT)
-        print("Finished running multi-cluster cli setup tool")
+        print("Finished running legacy multi-cluster cli setup tool")
     except subprocess.CalledProcessError as exc:
         print(f"Status: FAIL Reason: {exc.output}")
         raise exc

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 import kubernetes.client
 from kubetester import read_configmap
-from kubetester.helm import apply_operator_config_crd
+from kubetester.helm import apply_member_cluster_crd, apply_operator_config_crd
 from kubetester.kubetester import build_operator_config_spec_from_test_env, create_operator_config
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.operator import Operator
@@ -13,6 +13,7 @@ from pytest import fixture, mark
 from tests import test_logger
 from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.conftest import (
+    configure_multi_cluster_members,
     get_central_cluster_name,
     get_custom_appdb_version,
     install_legacy_deployment_state_meko,
@@ -252,6 +253,19 @@ class TestOperatorUpgrade:
         spec = build_operator_config_spec_from_test_env()
         if spec:
             create_operator_config(namespace, spec, api_client=central_cluster_client)
+
+    def test_register_member_clusters(
+        self,
+        namespace: str,
+        central_cluster_name: str,
+        member_cluster_names: List[str],
+        central_cluster_client: kubernetes.client.ApiClient,
+    ):
+        # MCK discovers members from MemberCluster CRs, which MEKO does not create, so register them
+        # before the upgrade. The MEKO kubeconfig Secret + member-list ConfigMap stay in place for the
+        # downgrade leg below.
+        apply_member_cluster_crd(api_client=central_cluster_client)
+        configure_multi_cluster_members(member_cluster_names, namespace, namespace, central_cluster_name)
 
     def test_install_default_operator(self, namespace: str, multi_cluster_operator: Operator):
         logger.info("Installing the operator built from master")

--- a/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py
@@ -135,6 +135,16 @@ scale_on_downgrade = TestCase(
 
 
 @fixture(scope="module")
+def multi_cluster_operator_installation_config(
+    multi_cluster_operator_installation_config: Dict[str, str],
+) -> Dict[str, str]:
+    # TODO(m1kola): slice-7: the fixed-name workload SAs are already applied by the member RBAC
+    # registered below, and Helm refuses to adopt objects it does not own.
+    multi_cluster_operator_installation_config["operator.createResourcesServiceAccountsAndRoles"] = "false"
+    return multi_cluster_operator_installation_config
+
+
+@fixture(scope="module")
 def ops_manager(
     namespace: str,
     custom_version: str,

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
@@ -1,4 +1,5 @@
 from kubetester import get_statefulset
+from kubetester.helm import apply_member_cluster_crd
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.kubetester import skip_if_local
 from kubetester.operator import Operator
@@ -6,7 +7,13 @@ from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests.common.cert.cert_issuer import create_appdb_certs
-from tests.conftest import get_default_operator, get_multi_cluster_operator, install_official_operator, is_multi_cluster
+from tests.conftest import (
+    configure_multi_cluster_members,
+    get_default_operator,
+    get_multi_cluster_operator,
+    install_official_operator,
+    is_multi_cluster,
+)
 from tests.constants import (
     LEGACY_MULTI_CLUSTER_OPERATOR_NAME,
     LEGACY_OPERATOR_CHART,
@@ -139,6 +146,10 @@ def test_upgrade_operator(
     member_cluster_names,
 ):
     if is_multi_cluster():
+        # MCK discovers members from MemberCluster CRs, which the MEKO 1.32 baseline does not create,
+        # so register them before the upgrade or the operator boots as single-cluster.
+        apply_member_cluster_crd(api_client=central_cluster_client)
+        configure_multi_cluster_members(member_cluster_names, namespace, namespace, central_cluster_name)
         operator = get_multi_cluster_operator(
             namespace,
             central_cluster_name,

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py
@@ -158,6 +158,9 @@ def test_upgrade_operator(
             member_cluster_clients,
             member_cluster_names,
             apply_crds_first=True,
+            # TODO(m1kola): slice-7: the workload SAs above are already applied by
+            # configure_multi_cluster_members; Helm can't adopt them without this.
+            extra_helm_args={"operator.createResourcesServiceAccountsAndRoles": "false"},
         )
     else:
         operator = get_default_operator(

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -144,6 +144,9 @@ def test_upgrade_operator(
             central_cluster_client,
             member_cluster_clients,
             member_cluster_names,
+            # TODO(m1kola): slice-7: the workload SAs above are already applied by
+            # configure_multi_cluster_members; Helm can't adopt them without this.
+            extra_helm_args={"operator.createResourcesServiceAccountsAndRoles": "false"},
         )
     else:
         operator = Operator(

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -4,7 +4,7 @@ import kubernetes
 from kubernetes import client
 from kubetester import try_load
 from kubetester.certs import create_mongodb_tls_certs
-from kubetester.helm import apply_operator_config_crd, helm_uninstall
+from kubetester.helm import apply_member_cluster_crd, apply_operator_config_crd, helm_uninstall
 from kubetester.kubetester import build_operator_config_spec_from_test_env, create_operator_config
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
@@ -14,7 +14,12 @@ from kubetester.operator import Operator
 from kubetester.phase import Phase
 from pytest import fixture, mark
 from tests import test_logger
-from tests.conftest import get_multi_cluster_operator, is_multi_cluster, log_deployments_info
+from tests.conftest import (
+    configure_multi_cluster_members,
+    get_multi_cluster_operator,
+    is_multi_cluster,
+    log_deployments_info,
+)
 from tests.constants import (
     LEGACY_MULTI_CLUSTER_OPERATOR_NAME,
     LEGACY_OPERATOR_NAME,
@@ -128,10 +133,10 @@ def test_upgrade_operator(
     if spec:
         create_operator_config(namespace, spec, api_client=central_cluster_client)
     if is_multi_cluster():
-        # TODO(m1kola): slice-6: register the member clusters before upgrading from MEKO. Once the
-        # legacy member-list fallback is gone, an operator that boots without any MemberCluster CRs
-        # defaults to single-cluster and fails to reconcile the existing multi-cluster MongoDB
-        # resources.
+        # MEKO discovers members from the member-list ConfigMap; MCK needs MemberCluster CRs, and one
+        # booting without any falls back to single-cluster. So register them before the upgrade.
+        apply_member_cluster_crd(api_client=central_cluster_client)
+        configure_multi_cluster_members(member_cluster_names, namespace, namespace, central_cluster_name)
         operator = get_multi_cluster_operator(
             namespace,
             central_cluster_name,

--- a/docs/dev/multi-cluster-config-tooling.md
+++ b/docs/dev/multi-cluster-config-tooling.md
@@ -27,17 +27,82 @@ to consume `MemberCluster` CRs (keeping a legacy fallback), then the legacy path
 
 | # | Slice | Jira | Status | Notes |
 |---|-------|------|--------|-------|
-| 1 | `generate-member-resources` command | CLOUDP-423293 | in progress | Embeds the Helm chart (Helm SDK); gated member-cluster RBAC templates; renders to stdout. Front-loads the Helm-SDK dependency risk. |
-| 2 | `generate-member-registration` command | CLOUDP-423293 | in progress | Reads an SA token from a member cluster; emits a credential Secret + `MemberCluster` CR. No Helm SDK. |
-| 3 | Operator `MemberCluster` wiring + watch | CLOUDP-400899 | in progress | Build the per-cluster client map from `MemberCluster` CRs + credential Secrets. **Restart-based watch** chosen for this slice (mirrors the `OperatorConfig` watcher): the watcher restarts the operator on `MemberCluster` add/spec-change/delete. No-restart reactivity deferred to slice 9 (spike found it touches every controller's fan-out; `multicluster-runtime`'s `Provider`+`Engage(ctx)` is a candidate but its reconcile model is inverse to MCK's and it's pre-1.0). Discovery is CRs-if-present-else-legacy; legacy fallback tagged `TODO(m1kola): slice-3`. The member-cluster health checker (`memberwatch`) was made discovery-agnostic — it now sources per-cluster credentials from the in-memory `cluster.GetConfig()` rest.Config instead of the mounted kubeconfig file, so failover/health status works on both paths. |
+| 1 | `generate-member-resources` command | CLOUDP-423293 | done | Embeds the Helm chart (Helm SDK); gated member-cluster RBAC templates; renders to stdout. Front-loads the Helm-SDK dependency risk. |
+| 2 | `generate-member-registration` command | CLOUDP-423293 | done | Reads an SA token from a member cluster; emits a credential Secret + `MemberCluster` CR. No Helm SDK. |
+| 3 | Operator `MemberCluster` wiring + watch | CLOUDP-400899 | done | Build the per-cluster client map from `MemberCluster` CRs + credential Secrets. **Restart-based watch** chosen for this slice (mirrors the `OperatorConfig` watcher): the watcher restarts the operator on `MemberCluster` add/spec-change/delete. No-restart reactivity deferred to slice 9 (spike found it touches every controller's fan-out; `multicluster-runtime`'s `Provider`+`Engage(ctx)` is a candidate but its reconcile model is inverse to MCK's and it's pre-1.0). Discovery is CRs-if-present-else-legacy; legacy fallback tagged `TODO(m1kola): slice-3`. The member-cluster health checker (`memberwatch`) was made discovery-agnostic — it now sources per-cluster credentials from the in-memory `cluster.GetConfig()` rest.Config instead of the mounted kubeconfig file, so failover/health status works on both paths. |
 | 4 | RBAC validation | CLOUDP-400899 | todo (after 5) | `RBACValid` condition validated against the `mongodb.com/rbac-version` annotation emitted by slice 1; startup gate + periodic re-check. **Deferred until after slice 5** — not a blocker for the E2E migration: the slice-3 operator has no runtime RBAC-version awareness, so member clusters set up by the new tooling work without it. |
 | 5 | Migrate MC E2E to new tooling | CLOUDP-400899 | in progress | **Brought forward before slice 4.** Multi-cluster becomes day-2 config: install the operator single-cluster, then apply member RBAC (`generate-member-resources`) + registration (`generate-member-registration` → `MemberCluster` CRs) via new `conftest.py` helpers (`configure_multi_cluster_members`), replacing `run_kube_config_creation_tool` in the fixtures + direct callers. Recovery tests reworked to add/remove `MemberCluster` CRs (no `recover` CLI; `multi_cluster_cli_recover.py` renamed to `multi_cluster_member_add_remove.py`). The AppDB and sharded DR tests, which simulated an unhealthy cluster by editing the legacy member-list ConfigMap, now delete the failed cluster's `MemberCluster` CR + credential Secret instead (the sharded/AppDB controllers have no reachability health-check — a cluster is unhealthy purely by being absent from the operator's member map, which the CR deletion produces under both the current restart-based watch and a future hot reload). Apply the generated RBAC to **every** member cluster including central (do not `skip_central_cluster`) — validates the additive apply. Member configuration is unified in `conftest.py` for both the in-cluster and local operator (the old `prepare_local_e2e_run.sh` / `run_multi_cluster_kube_config_creator` pre-pytest registration is removed) — in both, pytest shares the operator's network vantage so the ambient kubeconfig carries operator-reachable addresses. **Follow-up: slice 9** — a local host-run operator currently exits on a `MemberCluster` CR change (the watcher cancels the manager context) and nothing restarts it, so the operator must be (re)started after the fixtures configure members. Mode "operator in-cluster + tests on host" relies on `kubefwd` and is out of scope. |
-| 6 | Clean break | CLOUDP-400899 | todo | Remove `setup`/`recovery`, the legacy discovery + fallback, and dead `common.go` RBAC/kubeconfig code. Also remove `multiCluster.clusters` and `multiCluster.kubeConfigSecretName` (still set in the `operator-installation-config` ConfigMap for `install_official_operator`'s legacy baseline, and popped for the new path in `_install_multi_cluster_operator`) — plus the `kube-config-volume` mount they gate in `helm_chart/templates/operator.yaml:59-61,263-267`. (Slice 5 already stopped `scripts/funcs/operator_deployment` forcing `operator.createOperatorServiceAccount=false` for multi, so the operator installs its base RBAC via Helm.) |
+| 6 | Clean break | CLOUDP-400899 | in progress | Split into three stacked PRs so no PR is red on its own: **(1)** make the released E2E baseline self-sufficient — see "Released baseline for upgrade tests" below; **(2)** migrate the public doc snippets (`docs/search/1{2,3}-*`, `public/architectures/setup-multi-cluster`) off `multicluster setup` + `--set multiCluster.clusters`, since they run on every PR patch via `private_kind_multi_cluster_code_snippets`; **(3)** the removals. Remove `setup`/`recovery`, the legacy discovery + fallback, and dead `common.go` RBAC/kubeconfig code. Also remove `multiCluster.clusters` and `multiCluster.kubeConfigSecretName` (still set in the `operator-installation-config` ConfigMap for `install_official_operator`'s legacy baseline, and popped for the new path in `_install_multi_cluster_operator`) — plus the `kube-config-volume` mount they gate in `helm_chart/templates/operator.yaml:59-61,263-267`. (Slice 5 already stopped `scripts/funcs/operator_deployment` forcing `operator.createOperatorServiceAccount=false` for multi, so the operator installs its base RBAC via Helm.) |
 | 7 | Member-scoped workload ServiceAccounts | CLOUDP-400899 | todo | End-state so `generate-member-resources` output touches **nothing** from helm/OLM. Un-hardcode the workload pod SA names in the operator (`construct/appdb_construction.go:500`, `construct/opsmanager_construction.go:480`; database SA already per-CR overridable) so pods on member clusters run under member-scoped SAs; emit member-scoped workload RBAC instead of the interim fixed-name `database-roles.yaml`. Single-cluster keeps using the helm-install SAs. |
 | 8 | RBAC de-duplication | CLOUDP-400899 | todo | Single source of truth for the operator's shared workload rules (services/secrets/configmaps/statefulsets/deployments/pods) so extending a permission is one edit, not two. Aim for: base role = shared + central-only (CRDs/operatorconfigs); member role = shared + member extras (serviceaccounts get, nodes, kube-system, /version). Mechanism left open (shared partial, restructured/parameterised template, generating member from the same source, …). Deferred deliberately — see below. |
 | 9 | No-restart `MemberCluster` reactivity (hot reload) | CLOUDP-400899 | todo | Make membership changes reactive **without** restarting the operator — the "later slice" referenced from slice 3, which currently restarts the operator on `MemberCluster` add/spec-change/delete. Candidate mechanism per slice 3: `multicluster-runtime`'s `Provider`+`Engage(ctx)` (reconcile model is inverse to MCK's and it's pre-1.0). This also resolves the **slice-5 local-dev caveat**: a host-run (`make run`) operator currently exits when the watcher cancels the manager context and nothing restarts it, so it must be (re)started after the E2E fixtures configure members day-2. Interim option if hot reload is not ready: wrap the local operator in a restart-loop/supervisor so it behaves like an in-cluster pod. Tagged `TODO(m1kola): slice-9` in `docker/mongodb-kubernetes-tests/tests/conftest.py`. |
 
 **Dependencies:** 3 → {1, 2}; 4 → {1, 3}; 5 → {1, 2}; 6 → 5; 7 → 3 (needs multi-cluster reconcile working; can land any time after); 8 → {5, 7} (runs on the settled, E2E-covered shape); 9 → 3 (makes the slice-3 restart-based watch reactive; resolves the slice-5 local-operator caveat).
+
+## Released baseline for upgrade tests (slice 6, PR 1)
+
+The MC upgrade tests start from a **released** operator chart, which only understands the
+pre-`MemberCluster` discovery pair (monolithic kubeconfig Secret + `<operator-name>-member-list`
+ConfigMap). Slice 6 deletes `multicluster setup` from the branch-built plugin, so the harness can no
+longer produce that baseline with its own tooling. Two changes make the baseline self-sufficient ahead
+of the removal:
+
+**Terminology, because the versions collide.** Two product lines are in play. **MEKO**
+(`mongodb/enterprise-operator`, images `mongodb-enterprise-operator-ubi`) is the pre-MCK enterprise
+operator, reaching 1.33; it is what the repo's `LEGACY_*` constants refer to
+(`LEGACY_OPERATOR_CHART`, `LEGACY_DEPLOYMENT_STATE_VERSION = 1.27.0`). **MCK**
+(`mongodb/mongodb-kubernetes`) merged MEKO and MCO and started its own 1.0–1.9 line. So a bare "1.x" is
+ambiguous, and `legacy` must not be used to mean "MCK 1.x". Naming here is explicit: `mck1x`.
+
+- **A second, released plugin in the test image.** `scripts/release/kubectl_mongodb/download_released_kubectl_plugin.py`
+  resolves the newest published release of a major line (`--major`, default 1 → **MCK 1.x**) from the
+  public GitHub releases (no credentials — unlike the S3-based `download_kubectl_plugin.py`, whose AWS
+  credentials the test pod does not have), verifies it against `checksums.txt`, and drops it next to the
+  branch-built binary. The Dockerfile installs it as `multi-cluster-kube-config-creator-mck1x`;
+  `conftest.run_legacy_kube_config_creation_tool` (the only caller, via `install_official_operator`)
+  invokes it. The version is resolved at image-build time rather than pinned, so the baseline tracks the
+  latest MCK 1.x; `RELEASED_KUBECTL_PLUGIN_VERSION` forces a specific one, and the resolved version is
+  written into the image and logged on use.
+  Evergreen: `download_released_multi_cluster_binary`, called from `build_test_image{,_arm}`.
+
+  **One MCK 1.x plugin serves both MEKO and MCK 1.x baselines.** MCK 1.x inherited `multicluster setup`
+  from MEKO, and the resources it creates are named purely from the flags passed (`--operator-name`,
+  `--service-account`), so it provisions a MEKO baseline just as correctly — no MEKO-repo plugin needed.
+  This is also strictly closer to MEKO's own tooling than the branch build the harness used previously.
+- **Register `MemberCluster` CRs before the upgrade.** An MCK operator that boots with no
+  `MemberCluster` CR falls back to single-cluster and cannot reconcile the pre-existing multi-cluster
+  resources, so registration must precede the helm upgrade rather than follow it (which is what
+  `_install_multi_cluster_operator` does for a fresh install). Each test applies the `MemberCluster` CRD
+  (the legacy chart does not ship it) then calls `configure_multi_cluster_members`; this is idempotent
+  with `_install_multi_cluster_operator`'s own registration step. Done in all three MC
+  upgrade tests, each of which runs on **every PR patch**: `tests/upgrades/meko_mck_upgrade.py`,
+  `tests/upgrades/appdb_tls_operator_upgrade_v1_32_to_mck.py`, and
+  `tests/multicluster_appdb/multicluster_appdb_upgrade_downgrade_v1_27_to_mck.py`.
+
+**Released baseline → released plugin.** The general rule this establishes: whenever the harness
+installs a *released* operator, it provisions that operator's members with a *released* plugin of the
+matching major. The branch-built plugin is only ever used for the branch operator.
+
+So this path is **permanent**, not 2.x-cutover scaffolding, for two independent reasons: MEKO → MCK
+upgrades are supported indefinitely, and the planned **MCK 1.x → 2.x** tests (latest released MCK 1.x →
+branch build, mirroring today's MCK → MCK test) start from a 1.x baseline that also speaks only the
+pre-`MemberCluster` flow. Both keep needing a released MCK 1.x `setup`. Note the 1.x → 2.x test needs no
+new plugin plumbing — it is exactly the baseline this PR already provisions.
+
+The rule has one **latent gap**, which bites only once a **2.x** baseline exists:
+`install_official_operator` hardcodes the pre-`MemberCluster` flow for every multi-cluster baseline.
+That is correct while every baseline is pre-2.x — today they all are, whether pinned to MEKO
+(`LEGACY_OPERATOR_CHART`) or unpinned on `MCK_HELM_CHART` while the latest published MCK release is
+still 1.x. The first MC test to start from a released **2.x** operator (e.g. a 2.x → 2.x upgrade after
+2.x ships) instead needs `generate-member-resources`/`generate-member-registration` from a released 2.x
+plugin, so the flow must be chosen from the baseline chart's major rather than hardcoded. The downloader
+already takes `--major`, so the fetch side is ready; the dispatch is left as a comment at the call site
+rather than built speculatively, since it cannot be exercised until a 2.x release exists.
+
+The released MCK 1.x plugin is deliberately **not** wired into the local dev flow
+(`prepare_local_e2e_run.sh` → `scripts/dev/prepare-multi-cluster/`): `install_official_operator` skips
+legacy provisioning when `local_operator()` is set, so installing a released in-cluster operator as an
+upgrade baseline is a CI-only flow and a local fetch would be dead weight.
 
 ## Interim vs end-state: workload RBAC
 

--- a/scripts/release/kubectl_mongodb/download_released_kubectl_plugin.py
+++ b/scripts/release/kubectl_mongodb/download_released_kubectl_plugin.py
@@ -1,0 +1,151 @@
+"""Download a released `kubectl-mongodb` plugin of a given major line, for the E2E test image.
+
+Upgrade tests start from a released operator, and its member clusters are provisioned with a released
+plugin of the matching major — never the branch build.
+
+Assets come from the public GitHub releases of `mongodb/mongodb-kubernetes`.
+The newest release of the line is resolved at fetch time rather than pinned; set
+`RELEASED_KUBECTL_PLUGIN_VERSION` to force a specific version.
+"""
+
+import argparse
+import hashlib
+import io
+import os
+import tarfile
+
+import requests
+import semver
+from github import Github
+
+from lib.base_logger import logger
+from scripts.release.build.image_build_configuration import SUPPORTED_PLATFORMS
+from scripts.release.kubectl_mongodb.utils import GITHUB_REPO, GITHUB_TOKEN
+
+PLUGIN_VERSION_ENV = "RELEASED_KUBECTL_PLUGIN_VERSION"
+
+CHECKSUMS_ASSET = "checksums.txt"
+# Name of the executable inside the release tarball.
+PLUGIN_BINARY_NAME = "kubectl-mongodb"
+
+
+def local_tests_released_plugin_path(major: int, arch_name: str) -> str:
+    """Where the test image build expects the binary. Suffixed so it sits beside the branch build."""
+    return f"docker/mongodb-kubernetes-tests/multi-cluster-kube-config-creator-mck{major}x_{arch_name}"
+
+
+def resolve_latest_released_version(major: int) -> str:
+    """Highest published (non-draft, non-prerelease) semver release of the given major line."""
+    # Unauthenticated access works; a token only raises the API rate limit.
+    releases = Github(GITHUB_TOKEN or None).get_repo(GITHUB_REPO).get_releases()
+
+    versions = []
+    for release in releases:
+        if release.draft or release.prerelease:
+            continue
+        version = semver.Version.parse(release.tag_name, optional_minor_and_patch=True)
+        # Skip anything that is not a plain release tag, e.g. `1.9.1-test`, `1.0.1-release`.
+        if version.prerelease or version.build:
+            continue
+        if version.major == major:
+            versions.append(version)
+
+    if not versions:
+        raise Exception(f"No published {major}.x release found in {GITHUB_REPO}")
+
+    return str(max(versions))
+
+
+def asset_url(version: str, asset_name: str) -> str:
+    return f"https://github.com/{GITHUB_REPO}/releases/download/{version}/{asset_name}"
+
+
+def download_asset(version: str, asset_name: str) -> bytes:
+    url = asset_url(version, asset_name)
+    logger.info(f"Downloading {url}")
+    response = requests.get(url, timeout=300)
+    response.raise_for_status()
+    return response.content
+
+
+def expected_checksum(checksums: str, asset_name: str) -> str:
+    for line in checksums.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[1] == asset_name:
+            return fields[0]
+    raise Exception(f"No checksum for {asset_name} in {CHECKSUMS_ASSET}")
+
+
+def extract_plugin(tarball: bytes, local_path: str) -> None:
+    with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+        member = tar.extractfile(PLUGIN_BINARY_NAME)
+        if member is None:
+            raise Exception(f"{PLUGIN_BINARY_NAME} not found in release tarball")
+        binary = member.read()
+
+    with open(local_path, "wb") as f:
+        f.write(binary)
+    os.chmod(local_path, 0o755)
+
+
+def download_released_kubectl_plugin(major: int, platform: str, version: str) -> None:
+    os_name, arch_name = platform.split("/")
+    asset_name = f"{PLUGIN_BINARY_NAME}_{version}_{os_name}_{arch_name}.tar.gz"
+
+    tarball = download_asset(version, asset_name)
+    checksums = download_asset(version, CHECKSUMS_ASSET).decode()
+
+    actual = hashlib.sha256(tarball).hexdigest()
+    expected = expected_checksum(checksums, asset_name)
+    if actual != expected:
+        raise Exception(f"Checksum mismatch for {asset_name}: expected {expected}, got {actual}")
+
+    local_path = local_tests_released_plugin_path(major, arch_name)
+    extract_plugin(tarball, local_path)
+    logger.info(f"Installed released kubectl-mongodb plugin {version} ({platform}) at {local_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "-p",
+        "--platform",
+        metavar="",
+        action="store",
+        required=True,
+        type=str,
+        choices=SUPPORTED_PLATFORMS,
+        help=f"Platform of the plugin to download. Options: {", ".join(SUPPORTED_PLATFORMS)}.",
+    )
+    parser.add_argument(
+        "-m",
+        "--major",
+        metavar="",
+        action="store",
+        required=True,
+        type=int,
+        help="Major version line to resolve the newest release from.",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        metavar="",
+        action="store",
+        default=os.environ.get(PLUGIN_VERSION_ENV, ""),
+        type=str,
+        help=f"Exact released version to download. Defaults to ${PLUGIN_VERSION_ENV}, or the newest "
+        f"published release of the --major line.",
+    )
+    args = parser.parse_args()
+
+    version = args.version or resolve_latest_released_version(args.major)
+    logger.info(f"Using released kubectl-mongodb plugin version {version}")
+
+    download_released_kubectl_plugin(args.major, args.platform, version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/kubectl_mongodb/download_released_kubectl_plugin.sh
+++ b/scripts/release/kubectl_mongodb/download_released_kubectl_plugin.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+source scripts/dev/set_env_context.sh
+
+scripts/dev/run_python.sh scripts/release/kubectl_mongodb/download_released_kubectl_plugin.py --platform "${PLATFORM}" --major "${PLUGIN_MAJOR}"


### PR DESCRIPTION
# Summary

The multi-cluster upgrade tests start from a **released** operator, which discovers its member clusters from the kubeconfig Secret + member-list ConfigMap.

We will soon remove `multicluster setup` from the plugin, so the branch build CLI will no longer be able to provision that baseline. A released `kubectl-mongodb` plugin is now fetched into the test image for that purpose.

The upgrade tests also register their `MemberCluster` CRs *before* the operator is upgraded — an MCK operator that boots with none falls back to single-cluster and cannot reconcile the pre-existing multi-cluster resources. Resolves the `TODO(m1kola): slice-6` in `meko_mck_upgrade.py`.

## Proof of Work

Covered by the multi-cluster variants of `e2e_meko_mck_upgrade`, `e2e_appdb_tls_operator_upgrade_v1_32_to_mck` and `e2e_multi_cluster_appdb_upgrade_downgrade_v1_27_to_mck`, all of which run on every PR patch. No operator runtime change.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->