### PR TITLE
Remove dead publish_om* variants and orphaned tasks

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -632,18 +632,6 @@ tasks:
         vars:
           image_name: ops-manager
 
-  - name: publish_ops_manager
-    commands:
-      - func: clone
-      - func: switch_context
-      - func: setup_building_host
-      - func: quay_login
-      - func: setup_docker_sbom
-      - func: pipeline
-        vars:
-          image_name: ops-manager
-          build_scenario: release
-
   - name: prepare_and_upload_openshift_bundles_for_e2e
     commands:
       - func: clone
@@ -2136,36 +2124,6 @@ buildvariants:
       - name: rebuild_specific_agent
 
   ### Build variants for manual patch only
-
-  - name: publish_om70_images
-    display_name: publish_om70_images
-    tags: [ "manual_patch" ]
-    allowed_requesters: [ "patch", "github_pr" ]
-    run_on:
-      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
-    depends_on:
-      - variant: e2e_om70_kind_ubi
-        name: '*'
-      - variant: e2e_static_om70_kind_ubi
-        name: '*'
-    tasks:
-      - name: publish_ops_manager
-      - name: release_agent
-
-  - name: publish_om80_images
-    display_name: publish_om80_images
-    tags: [ "manual_patch" ]
-    allowed_requesters: [ "patch", "github_pr" ]
-    run_on:
-      - release-ubuntu2404-small # This is required for CISA attestation https://jira.mongodb.org/browse/DEVPROD-17780
-    depends_on:
-      - variant: e2e_om80_kind_ubi
-        name: '*'
-      - variant: e2e_static_om80_kind_ubi
-        name: '*'
-    tasks:
-      - name: publish_ops_manager
-      - name: release_agent
 
   - name: migrate_all_agents
     display_name: migrate_all_agents

--- a/changelog/20260729_other_remove_dead_publish_om_variants.md
+++ b/changelog/20260729_other_remove_dead_publish_om_variants.md
@@ -1,0 +1,6 @@
+---
+kind: other
+date: 2026-07-29
+---
+
+* Remove dead `publish_om70_images` and `publish_om80_images` Evergreen build variants and the orphaned `publish_ops_manager` task. These variants were no longer triggered by any automatic or manual path after PCT stopped adding them to bump PR patches in CLOUDP-305848.

--- a/changelog/20260729_other_remove_dead_publish_om_variants.md
+++ b/changelog/20260729_other_remove_dead_publish_om_variants.md
@@ -1,6 +1,0 @@
----
-kind: other
-date: 2026-07-29
----
-
-* Remove dead `publish_om70_images` and `publish_om80_images` Evergreen build variants and the orphaned `publish_ops_manager` task. These variants were no longer triggered by any automatic or manual path after PCT stopped adding them to bump PR patches in CLOUDP-305848.

--- a/scripts/dev/contexts/publish_om60_images
+++ b/scripts/dev/contexts/publish_om60_images
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -Eeou pipefail
-
-script_name=$(readlink -f "${BASH_SOURCE[0]}")
-script_dir=$(dirname "${script_name}")
-
-source "${script_dir}/root-context"
-source "${script_dir}/variables/om60_image"

--- a/scripts/dev/contexts/publish_om70_images
+++ b/scripts/dev/contexts/publish_om70_images
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -Eeou pipefail
-
-script_name=$(readlink -f "${BASH_SOURCE[0]}")
-script_dir=$(dirname "${script_name}")
-
-source "${script_dir}/root-context"
-source "${script_dir}/variables/om70_image"

--- a/scripts/dev/contexts/publish_om80_images
+++ b/scripts/dev/contexts/publish_om80_images
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -Eeou pipefail
-
-script_name=$(readlink -f "${BASH_SOURCE[0]}")
-script_dir=$(dirname "${script_name}")
-
-source "${script_dir}/root-context"
-source "${script_dir}/variables/om80_image"


### PR DESCRIPTION
# Summary

PCT stopped adding `publish_om70_images` / `publish_om80_images` variants to Evergreen patches on OM bump PRs in **CLOUDP-305848** ([10gen/mms#149833](https://github.com/10gen/mms/pull/149833), Dec 2025). The `PublishOMContainerImages` action and `add_variants_to_pull_request_patch` function were removed from PCT at that time, leaving these variants with no automatic or manual trigger path. Additionally, the `release_agent` task referenced by these variants had no task definition anywhere in the Evergreen config — it was a dangling reference that would error if ever scheduled.

Agent and OM images are published to prod (quay.io) by the `release_om_and_agents` task on every commit to master — these removed variants were not part of that flow.

### Removed
- `publish_om70_images` build variant
- `publish_om80_images` build variant
- `publish_ops_manager` task (only consumer was the two variants above)
- `scripts/dev/contexts/publish_om{60,70,80}_images` (orphaned context files)

## Proof of Work

```
$ grep -rn "publish_om70_images\|publish_om80_images\|publish_ops_manager\|release_agent" .evergreen*.yml scripts/dev/contexts/
(no matches)
```

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->