### PR TITLE
CLOUDP-429011 - External AppDB: reconciliation logic and e2e tests

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -815,6 +815,16 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_om_external_appdb_forward
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_om_external_appdb_fresh
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_om_external_connectivity
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1263,6 +1263,8 @@ task_groups:
       - e2e_om_appdb_upgrade
       - e2e_om_appdb_validation
       - e2e_om_appdb_scram
+      - e2e_om_external_appdb_forward
+      - e2e_om_external_appdb_fresh
       - e2e_om_external_connectivity
       - e2e_om_jvm_params
       - e2e_om_migration
@@ -1306,6 +1308,8 @@ task_groups:
       - e2e_om_appdb_upgrade
       - e2e_om_appdb_validation
       - e2e_om_appdb_scram
+      - e2e_om_external_appdb_forward
+      - e2e_om_external_appdb_fresh
       - e2e_om_external_connectivity
       - e2e_om_jvm_params
       - e2e_om_weak_password

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1256,6 +1256,8 @@ task_groups:
       - e2e_om_appdb_upgrade
       - e2e_om_appdb_validation
       - e2e_om_appdb_scram
+      - e2e_om_external_appdb_forward
+      - e2e_om_external_appdb_fresh
       - e2e_om_external_connectivity
       - e2e_om_jvm_params
       - e2e_om_migration
@@ -1299,6 +1301,8 @@ task_groups:
       - e2e_om_appdb_upgrade
       - e2e_om_appdb_validation
       - e2e_om_appdb_scram
+      - e2e_om_external_appdb_forward
+      - e2e_om_external_appdb_fresh
       - e2e_om_external_connectivity
       - e2e_om_jvm_params
       - e2e_om_weak_password

--- a/.idea/mongodb-kubernetes.iml
+++ b/.idea/mongodb-kubernetes.iml
@@ -8,7 +8,6 @@
       <sourceFolder url="file://$MODULE_DIR$/scripts/python" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
-      <excludeFolder url="file://$MODULE_DIR$/docker/mongodb-kubernetes-tests/.venv" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/mongodb-kubernetes.iml
+++ b/.idea/mongodb-kubernetes.iml
@@ -8,6 +8,7 @@
       <sourceFolder url="file://$MODULE_DIR$/scripts/python" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
+      <excludeFolder url="file://$MODULE_DIR$/docker/mongodb-kubernetes-tests/.venv" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/api/mongodb/v1/mdb/mongodb_types.go
+++ b/api/mongodb/v1/mdb/mongodb_types.go
@@ -229,6 +229,10 @@ func (m *MongoDB) GetHostNameOverrideConfigmapName() string {
 	return fmt.Sprintf("%s-hostname-override", m.Name)
 }
 
+func (m *MongoDB) IsRoleAppDB() bool {
+	return m.Spec.Role == RoleAppDB
+}
+
 type AdditionalMongodConfigType int
 
 const (
@@ -1441,7 +1445,7 @@ func (m *MongoDB) InitDefaults() {
 
 	m.Spec.Security = EnsureSecurity(m.Spec.Security)
 
-	if m.Spec.Role == RoleAppDB {
+	if m.IsRoleAppDB() {
 		m.Spec.Security.Authentication = &Authentication{
 			Enabled:            true,
 			Modes:              []AuthMode{util.SCRAM},

--- a/api/mongodb/v1/om/appdb_types.go
+++ b/api/mongodb/v1/om/appdb_types.go
@@ -28,6 +28,21 @@ const (
 	ClusterTopologyMultiCluster = "MultiCluster"
 )
 
+// AppDBUserRoles defines required roles for the AppDB user are outlined in the documentation
+// https://docs.opsmanager.mongodb.com/current/tutorial/prepare-backing-mongodb-instances/#replica-set-security
+var AppDBUserRoles = []authtypes.Role{
+	{Name: "readWriteAnyDatabase", Database: "admin"},
+	{Name: "dbAdminAnyDatabase", Database: "admin"},
+	{Name: "clusterMonitor", Database: "admin"},
+	// Allows user to do db.fsyncLock required by CLOUDP-78890
+	// https://docs.mongodb.com/manual/reference/built-in-roles/#hostManager
+	{Name: "backup", Database: "admin"},
+	{Name: "restore", Database: "admin"},
+	// Allows user to do db.fsyncLock required by CLOUDP-78890
+	// https://docs.mongodb.com/manual/reference/built-in-roles/#hostManager
+	{Name: "hostManager", Database: "admin"},
+}
+
 type AppDBSpec struct {
 	// +kubebuilder:validation:Pattern=^[0-9]+.[0-9]+.[0-9]+(-.+)?$|^$
 	Version string `json:"version"`
@@ -198,8 +213,6 @@ func (m *AppDBSpec) GetAuthOptions() authtypes.Options {
 	}
 }
 
-// GetAuthUsers returns a list of all scram users for this deployment.
-// in this case it is just the Ops Manager user for the AppDB.
 func (m *AppDBSpec) GetAuthUsers() []authtypes.User {
 	passwordSecretName := m.GetOpsManagerUserPasswordSecretName()
 	if m.PasswordSecretKeyRef != nil && m.PasswordSecretKeyRef.Name != "" {
@@ -207,40 +220,9 @@ func (m *AppDBSpec) GetAuthUsers() []authtypes.User {
 	}
 	return []authtypes.User{
 		{
-			Username: util.OpsManagerMongoDBUserName,
-			Database: util.DefaultUserDatabase,
-			// required roles for the AppDB user are outlined in the documentation
-			// https://docs.opsmanager.mongodb.com/current/tutorial/prepare-backing-mongodb-instances/#replica-set-security
-			Roles: []authtypes.Role{
-				{
-					Name:     "readWriteAnyDatabase",
-					Database: "admin",
-				},
-				{
-					Name:     "dbAdminAnyDatabase",
-					Database: "admin",
-				},
-				{
-					Name:     "clusterMonitor",
-					Database: "admin",
-				},
-				// Enables backup and restoration roles
-				// https://docs.mongodb.com/manual/reference/built-in-roles/#backup-and-restoration-roles
-				{
-					Name:     "backup",
-					Database: "admin",
-				},
-				{
-					Name:     "restore",
-					Database: "admin",
-				},
-				// Allows user to do db.fsyncLock required by CLOUDP-78890
-				// https://docs.mongodb.com/manual/reference/built-in-roles/#hostManager
-				{
-					Name:     "hostManager",
-					Database: "admin",
-				},
-			},
+			Username:                   util.OpsManagerMongoDBUserName,
+			Database:                   util.DefaultUserDatabase,
+			Roles:                      AppDBUserRoles,
 			PasswordSecretKey:          m.GetOpsManagerUserPasswordSecretKey(),
 			PasswordSecretName:         passwordSecretName,
 			ScramCredentialsSecretName: m.OpsManagerUserScramCredentialsName(),

--- a/api/mongodb/v1/om/appdb_types.go
+++ b/api/mongodb/v1/om/appdb_types.go
@@ -28,7 +28,7 @@ const (
 	ClusterTopologyMultiCluster = "MultiCluster"
 )
 
-// AppDBUserRoles defines required roles for the AppDB user are outlined in the documentation
+// AppDBUserRoles defines required roles for the AppDB user that are outlined in the documentation
 // https://docs.opsmanager.mongodb.com/current/tutorial/prepare-backing-mongodb-instances/#replica-set-security
 var AppDBUserRoles = []authtypes.Role{
 	{Name: "readWriteAnyDatabase", Database: "admin"},

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -188,6 +188,9 @@ type ExternalAppDBRef struct {
 	// +kubebuilder:validation:Enum=MongoDB
 	// +kubebuilder:validation:Required
 	Kind string `json:"kind"`
+
+	// Transient fields
+	Namespace string `json:"-"`
 }
 
 type Logging struct {
@@ -677,6 +680,8 @@ func (om *MongoDBOpsManager) InitDefaultFields() {
 		om.Spec.AppDB.Namespace = om.Namespace
 		om.Spec.AppDB.ClusterDomain = om.Spec.GetClusterDomain()
 		om.Spec.AppDB.ResourceType = mdbv1.ReplicaSet
+	} else {
+		om.Spec.ExternalApplicationDatabaseRef.Namespace = om.Namespace
 	}
 }
 

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -770,6 +770,12 @@ func (om *MongoDBOpsManager) UpdateStatus(phase status.Phase, statusOptions ...s
 }
 
 func (om *MongoDBOpsManager) updateStatusAppDb(phase status.Phase, statusOptions ...status.Option) {
+	if om.Spec.ExternalApplicationDatabaseRef != nil {
+		om.Status.AppDbStatus = AppDbStatus{}
+		om.Status.AppDbStatus.UpdateCommonFields(phase, om.GetGeneration(), statusOptions...)
+		return
+	}
+
 	om.Status.AppDbStatus.UpdateCommonFields(phase, om.GetGeneration(), statusOptions...)
 
 	if option, exists := status.GetOption(statusOptions, status.ReplicaSetMembersOption{}); exists {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -311,9 +311,14 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 }
 
 func (ms MongoDBOpsManagerSpec) GetAppDbCA() string {
+	if ms.ExternalApplicationDatabaseRef != nil {
+		return ""
+	}
+
 	if ms.AppDB.Security != nil && ms.AppDB.Security.TLSConfig != nil {
 		return ms.AppDB.Security.TLSConfig.CA
 	}
+
 	return ""
 }
 

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -769,6 +769,12 @@ func (om *MongoDBOpsManager) UpdateStatus(phase status.Phase, statusOptions ...s
 }
 
 func (om *MongoDBOpsManager) updateStatusAppDb(phase status.Phase, statusOptions ...status.Option) {
+	if om.Spec.ExternalApplicationDatabaseRef != nil {
+		om.Status.AppDbStatus = AppDbStatus{}
+		om.Status.AppDbStatus.UpdateCommonFields(phase, om.GetGeneration(), statusOptions...)
+		return
+	}
+
 	om.Status.AppDbStatus.UpdateCommonFields(phase, om.GetGeneration(), statusOptions...)
 
 	if option, exists := status.GetOption(statusOptions, status.ReplicaSetMembersOption{}); exists {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -312,7 +312,7 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 }
 
 func (ms MongoDBOpsManagerSpec) GetAppDbCA() string {
-	if ms.ExternalApplicationDatabaseRef != nil {
+	if ms.ExternalAppDBRef != nil {
 		return ""
 	}
 
@@ -686,7 +686,7 @@ func (om *MongoDBOpsManager) InitDefaultFields() {
 		om.Spec.AppDB.ClusterDomain = om.Spec.GetClusterDomain()
 		om.Spec.AppDB.ResourceType = mdbv1.ReplicaSet
 	} else {
-		om.Spec.ExternalApplicationDatabaseRef.Namespace = om.Namespace
+		om.Spec.ExternalAppDBRef.Namespace = om.Namespace
 	}
 }
 
@@ -780,7 +780,7 @@ func (om *MongoDBOpsManager) UpdateStatus(phase status.Phase, statusOptions ...s
 }
 
 func (om *MongoDBOpsManager) updateStatusAppDb(phase status.Phase, statusOptions ...status.Option) {
-	if om.Spec.ExternalApplicationDatabaseRef != nil {
+	if om.Spec.ExternalAppDBRef != nil {
 		om.Status.AppDbStatus = AppDbStatus{}
 		om.Status.AppDbStatus.UpdateCommonFields(phase, om.GetGeneration(), statusOptions...)
 		return

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -187,6 +187,9 @@ type ExternalApplicationDatabaseRef struct {
 	// +kubebuilder:validation:Enum=MongoDB
 	// +kubebuilder:validation:Required
 	Kind string `json:"kind"`
+
+	// Transient fields
+	Namespace string `json:"-"`
 }
 
 type Logging struct {
@@ -676,6 +679,8 @@ func (om *MongoDBOpsManager) InitDefaultFields() {
 		om.Spec.AppDB.Namespace = om.Namespace
 		om.Spec.AppDB.ClusterDomain = om.Spec.GetClusterDomain()
 		om.Spec.AppDB.ResourceType = mdbv1.ReplicaSet
+	} else {
+		om.Spec.ExternalApplicationDatabaseRef.Namespace = om.Namespace
 	}
 }
 

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -702,10 +702,15 @@ func ensureSecurityWithSCRAM(specSecurity *mdbv1.Security) *mdbv1.Security {
 // AppDBName's AppDB branch is nil-safe only via the admission invariant that at least one of
 // applicationDatabase or externalApplicationDatabaseRef is set.
 func (om *MongoDBOpsManager) AppDBName() string {
-	if om.Spec.ExternalAppDBRef != nil {
-		return om.Spec.ExternalAppDBRef.Name
+	if om.IsInternalAppDB() {
+		return om.Spec.AppDB.Name()
 	}
-	return om.Spec.AppDB.Name()
+
+	return om.Spec.ExternalAppDBRef.Name
+}
+
+func (om *MongoDBOpsManager) IsInternalAppDB() bool {
+	return om.Spec.ExternalAppDBRef == nil
 }
 
 func (om *MongoDBOpsManager) SvcName() string {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -312,9 +312,14 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 }
 
 func (ms MongoDBOpsManagerSpec) GetAppDbCA() string {
+	if ms.ExternalApplicationDatabaseRef != nil {
+		return ""
+	}
+
 	if ms.AppDB.Security != nil && ms.AppDB.Security.TLSConfig != nil {
 		return ms.AppDB.Security.TLSConfig.CA
 	}
+
 	return ""
 }
 

--- a/api/mongodb/v1/om/opsmanager_types_test.go
+++ b/api/mongodb/v1/om/opsmanager_types_test.go
@@ -269,11 +269,11 @@ func TestOpsManager_UnmarshalJSON_ExternalRefLeavesAppDBNil(t *testing.T) {
 	assert.Nil(t, om.Spec.AppDB)
 }
 
-func TestUpdateStatusAppDb_ExternalApplicationDatabaseRefResetsStatus(t *testing.T) {
+func TestUpdateStatusAppDb_ExternalAppDBRefResetsStatus(t *testing.T) {
 	t.Run("external ref set + nil AppDB resets AppDbStatus", func(t *testing.T) {
 		resource := &MongoDBOpsManager{
 			Spec: MongoDBOpsManagerSpec{
-				ExternalApplicationDatabaseRef: &ExternalApplicationDatabaseRef{
+				ExternalAppDBRef: &ExternalAppDBRef{
 					Name: "test-om-db",
 					Kind: "MongoDB",
 				},

--- a/api/mongodb/v1/om/opsmanager_types_test.go
+++ b/api/mongodb/v1/om/opsmanager_types_test.go
@@ -268,3 +268,46 @@ func TestOpsManager_UnmarshalJSON_ExternalRefLeavesAppDBNil(t *testing.T) {
 	assert.NotNil(t, om.Spec.ExternalApplicationDatabaseRef)
 	assert.Nil(t, om.Spec.AppDB)
 }
+
+func TestUpdateStatusAppDb_ExternalApplicationDatabaseRefResetsStatus(t *testing.T) {
+	t.Run("external ref set + nil AppDB resets AppDbStatus", func(t *testing.T) {
+		resource := &MongoDBOpsManager{
+			Spec: MongoDBOpsManagerSpec{
+				ExternalApplicationDatabaseRef: &ExternalApplicationDatabaseRef{
+					Name: "test-om-db",
+					Kind: "MongoDB",
+				},
+			},
+		}
+		resource.Status.AppDbStatus.Members = 3
+		resource.Status.AppDbStatus.Version = "4.4.20"
+		resource.Status.AppDbStatus.FeatureCompatibilityVersion = "4.4"
+		resource.Status.AppDbStatus.ClusterStatusList = []status.ClusterStatusItem{{ClusterName: "cluster-1"}}
+		resource.Status.AppDbStatus.Warnings = []status.Warning{"stale warning;"}
+
+		require.NotPanics(t, func() {
+			resource.UpdateStatus(status.PhaseDisabled, status.NewOMPartOption(status.AppDb))
+		})
+
+		assert.Equal(t, status.PhaseDisabled, resource.Status.AppDbStatus.Phase)
+		assert.Empty(t, resource.Status.AppDbStatus.Members)
+		assert.Empty(t, resource.Status.AppDbStatus.Version)
+		assert.Empty(t, resource.Status.AppDbStatus.FeatureCompatibilityVersion)
+		assert.Empty(t, resource.Status.AppDbStatus.ClusterStatusList)
+		assert.Empty(t, resource.Status.AppDbStatus.Warnings)
+	})
+
+	t.Run("internal AppDB does not reset AppDbStatus", func(t *testing.T) {
+		resource := &MongoDBOpsManager{
+			Spec: MongoDBOpsManagerSpec{
+				AppDB: &AppDBSpec{},
+			},
+		}
+		resource.Status.AppDbStatus.Members = 3
+
+		resource.UpdateStatus(status.PhaseRunning, status.NewOMPartOption(status.AppDb))
+
+		assert.Equal(t, status.PhaseRunning, resource.Status.AppDbStatus.Phase)
+		assert.Equal(t, 3, resource.Status.AppDbStatus.Members)
+	})
+}

--- a/api/mongodb/v1/om/opsmanager_types_test.go
+++ b/api/mongodb/v1/om/opsmanager_types_test.go
@@ -268,3 +268,46 @@ func TestOpsManager_UnmarshalJSON_ExternalRefLeavesAppDBNil(t *testing.T) {
 	assert.NotNil(t, om.Spec.ExternalAppDBRef)
 	assert.Nil(t, om.Spec.AppDB)
 }
+
+func TestUpdateStatusAppDb_ExternalApplicationDatabaseRefResetsStatus(t *testing.T) {
+	t.Run("external ref set + nil AppDB resets AppDbStatus", func(t *testing.T) {
+		resource := &MongoDBOpsManager{
+			Spec: MongoDBOpsManagerSpec{
+				ExternalApplicationDatabaseRef: &ExternalApplicationDatabaseRef{
+					Name: "test-om-db",
+					Kind: "MongoDB",
+				},
+			},
+		}
+		resource.Status.AppDbStatus.Members = 3
+		resource.Status.AppDbStatus.Version = "4.4.20"
+		resource.Status.AppDbStatus.FeatureCompatibilityVersion = "4.4"
+		resource.Status.AppDbStatus.ClusterStatusList = []status.ClusterStatusItem{{ClusterName: "cluster-1"}}
+		resource.Status.AppDbStatus.Warnings = []status.Warning{"stale warning;"}
+
+		require.NotPanics(t, func() {
+			resource.UpdateStatus(status.PhaseDisabled, status.NewOMPartOption(status.AppDb))
+		})
+
+		assert.Equal(t, status.PhaseDisabled, resource.Status.AppDbStatus.Phase)
+		assert.Empty(t, resource.Status.AppDbStatus.Members)
+		assert.Empty(t, resource.Status.AppDbStatus.Version)
+		assert.Empty(t, resource.Status.AppDbStatus.FeatureCompatibilityVersion)
+		assert.Empty(t, resource.Status.AppDbStatus.ClusterStatusList)
+		assert.Empty(t, resource.Status.AppDbStatus.Warnings)
+	})
+
+	t.Run("internal AppDB does not reset AppDbStatus", func(t *testing.T) {
+		resource := &MongoDBOpsManager{
+			Spec: MongoDBOpsManagerSpec{
+				AppDB: &AppDBSpec{},
+			},
+		}
+		resource.Status.AppDbStatus.Members = 3
+
+		resource.UpdateStatus(status.PhaseRunning, status.NewOMPartOption(status.AppDb))
+
+		assert.Equal(t, status.PhaseRunning, resource.Status.AppDbStatus.Phase)
+		assert.Equal(t, 3, resource.Status.AppDbStatus.Members)
+	})
+}

--- a/api/mongodb/v1/om/opsmanager_validation_test.go
+++ b/api/mongodb/v1/om/opsmanager_validation_test.go
@@ -410,20 +410,20 @@ func TestOpsManagerValidation_AppDBAndExternalRef(t *testing.T) {
 			testedOm: NewOpsManagerBuilderDefault().
 				SetName("om-test").
 				SetAppDBToNil().
-				SetExternalApplicationDatabaseRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
+				SetExternalAppDBRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
 				Build(),
 		},
 		"applicationDatabase and externalApplicationDatabaseRef both set": {
 			testedOm: NewOpsManagerBuilderDefault().
 				SetName("om-test").
-				SetExternalApplicationDatabaseRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
+				SetExternalAppDBRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
 				Build(),
 		},
 		"externalApplicationDatabaseRef mismatching name": {
 			testedOm: NewOpsManagerBuilderDefault().
 				SetName("om-test").
 				SetAppDBToNil().
-				SetExternalApplicationDatabaseRef(ExternalAppDBRef{Name: "om-test-other", Kind: "MongoDB"}).
+				SetExternalAppDBRef(ExternalAppDBRef{Name: "om-test-other", Kind: "MongoDB"}).
 				Build(),
 			expectedPart:         status.OpsManager,
 			expectedErrorMessage: "spec.externalApplicationDatabaseRef.name must be om-test-db",
@@ -432,7 +432,7 @@ func TestOpsManagerValidation_AppDBAndExternalRef(t *testing.T) {
 			testedOm: NewOpsManagerBuilderDefault().
 				SetName("om-test").
 				SetAppDbVersion("not-a-version").
-				SetExternalApplicationDatabaseRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
+				SetExternalAppDBRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
 				Build(),
 		},
 		"externalApplicationDatabaseRef set, multi-cluster AppDB clusterSpecList ignored": {
@@ -443,14 +443,14 @@ func TestOpsManagerValidation_AppDBAndExternalRef(t *testing.T) {
 					{ClusterName: "dup", Members: 1},
 					{ClusterName: "dup", Members: 1},
 				}).
-				SetExternalApplicationDatabaseRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
+				SetExternalAppDBRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
 				Build(),
 		},
 		"externalApplicationDatabaseRef set and OM-level validators still run": {
 			testedOm: NewOpsManagerBuilderDefault().
 				SetName("om-test").
 				SetVersion("4.4").
-				SetExternalApplicationDatabaseRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
+				SetExternalAppDBRef(ExternalAppDBRef{Name: "om-test-db", Kind: "MongoDB"}).
 				Build(),
 			expectedPart:         status.OpsManager,
 			expectedErrorMessage: "'4.4' is an invalid value for spec.version: Ops Manager Status spec.version 4.4 is invalid",

--- a/api/mongodb/v1/om/opsmanagerbuilder.go
+++ b/api/mongodb/v1/om/opsmanagerbuilder.go
@@ -279,7 +279,7 @@ func (b *OpsManagerBuilder) SetOpsManagerClusterSpecList(clusterSpecItems []Clus
 	return b
 }
 
-func (b *OpsManagerBuilder) SetExternalApplicationDatabaseRef(ref ExternalAppDBRef) *OpsManagerBuilder {
+func (b *OpsManagerBuilder) SetExternalAppDBRef(ref ExternalAppDBRef) *OpsManagerBuilder {
 	b.om.Spec.ExternalAppDBRef = &ref
 	return b
 }

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -686,7 +686,7 @@ func (r *ReconcileAppDbReplicaSet) requestAppDBReverseMigration(ctx context.Cont
 // reclaimAppDBStatefulset transfers the ownership of the AppDB StatefulSet to this OM and clears migration annotations
 func (r *ReconcileAppDbReplicaSet) reclaimAppDBStatefulset(ctx context.Context, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet) error {
 	sts.OwnerReferences = kube.BaseOwnerReference(opsManager)
-	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
+	// stale forward migration annotation cleanup
 	delete(sts.Annotations, util.AppDBMigrationReadyAnnotation)
 	if err := r.client.Update(ctx, &sts); err != nil {
 		return xerrors.Errorf("failed to reclaim StatefulSet %s: %w", sts.GetName(), err)
@@ -870,16 +870,16 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	}
 	appdbOpts.PrometheusTLSCertHash = prometheusCertHash
 
-	allStatefulSetsExist, err := r.allStatefulSetsExist(ctx, opsManager, log)
+	allStatefulSetsExistAndValid, err := r.allStatefulSetsExistsInValidState(ctx, opsManager, log)
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("failed to check the state of all stateful sets: %w", err)), log, appDbStatusOption)
 	}
 
-	publishAutomationConfigFirst := r.publishAutomationConfigFirst(opsManager, allStatefulSetsExist, log)
+	publishAutomationConfigFirst := r.publishAutomationConfigFirst(opsManager, allStatefulSetsExistAndValid, log)
 
 	workflowStatus = workflow.RunInGivenOrder(publishAutomationConfigFirst,
 		func() workflow.Status {
-			return r.deployAutomationConfigAndWaitForAgentsReachGoalState(ctx, log, opsManager, &podVars, allStatefulSetsExist, appdbOpts)
+			return r.deployAutomationConfigAndWaitForAgentsReachGoalState(ctx, log, opsManager, &podVars, allStatefulSetsExistAndValid, appdbOpts)
 		},
 		func() workflow.Status {
 			return r.deployStatefulSet(ctx, opsManager, log, podVars, appdbOpts)
@@ -2373,27 +2373,7 @@ func (r *ReconcileAppDbReplicaSet) getCurrentStatefulsetHostnames(opsManager *om
 	})
 }
 
-// isReAdoptedStatefulSetPendingReshape returns true when a StatefulSet taken back from a
-// MongoDB CR (reverse migration re-adoption) still carries the CR's pod shape and awaits the
-// rewrite to the internal-AppDB pod template. Internal AppDB pods always run a dedicated
-// "mongod" container (static and non-static architecture, vault or secret config backend);
-// MongoDB CR pods never do.
-func isReAdoptedStatefulSetPendingReshape(sts appsv1.StatefulSet) bool {
-	for _, c := range sts.Spec.Template.Spec.Containers {
-		if c.Name == util.MongodbContainerName {
-			return false
-		}
-	}
-	return true
-}
-
-// allStatefulSetsExist reports whether every member cluster's AppDB StatefulSet exists in its
-// internal-AppDB form. A StatefulSet re-adopted from a MongoDB CR that hasn't been reshaped yet
-// counts as not existing: its pods run no headless agent, so waiting for agent goal state before
-// deployStatefulSet rewrites the pod template would deadlock (the wait is skipped while this
-// returns false).
-func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
-	allStsExist := true
+func (r *ReconcileAppDbReplicaSet) allStatefulSetsExistsInValidState(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		stsName := opsManager.Spec.AppDB.NameForCluster(r.helper.getMemberClusterIndex(memberCluster.Name))
 		sts, err := memberCluster.Client.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, stsName))
@@ -2401,17 +2381,19 @@ func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, ops
 			if apiErrors.IsNotFound(err) {
 				// we do not return immediately here to check all clusters and also leave the information on other sts in the debug logs
 				log.Debugf("Statefulset %s/%s does not exist.", memberCluster.Name, stsName)
-				allStsExist = false
-			} else {
-				return false, err
+				return false, nil
 			}
-		} else if isReAdoptedStatefulSetPendingReshape(sts) {
-			log.Debugf("Statefulset %s/%s was re-adopted from a MongoDB CR and still awaits the rewrite to the internal-AppDB pod template.", memberCluster.Name, stsName)
-			allStsExist = false
+
+			return false, err
+		}
+
+		if sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] == trueString {
+			log.Debugf("Statefulset %s/%s has the reverse migration ready annotation set to true.", memberCluster.Name, stsName)
+			return false, nil
 		}
 	}
 
-	return allStsExist, nil
+	return true, nil
 }
 
 // migrateToNewDeploymentState reads old config maps with the deployment state and writes them to the new deploymentState structure.

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -686,7 +686,7 @@ func (r *ReconcileAppDbReplicaSet) requestAppDBReverseMigration(ctx context.Cont
 // reclaimAppDBStatefulset transfers the ownership of the AppDB StatefulSet to this OM and clears migration annotations
 func (r *ReconcileAppDbReplicaSet) reclaimAppDBStatefulset(ctx context.Context, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet) error {
 	sts.OwnerReferences = kube.BaseOwnerReference(opsManager)
-	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
+	// stale forward migration annotation cleanup
 	delete(sts.Annotations, util.AppDBMigrationReadyAnnotation)
 	if err := r.client.Update(ctx, &sts); err != nil {
 		return xerrors.Errorf("failed to reclaim StatefulSet %s: %w", sts.GetName(), err)
@@ -870,16 +870,16 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	}
 	appdbOpts.PrometheusTLSCertHash = prometheusCertHash
 
-	allStatefulSetsExist, err := r.allStatefulSetsExist(ctx, opsManager, log)
+	allStatefulSetsExistAndValid, err := r.allStatefulSetsExistsInValidState(ctx, opsManager, log)
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("failed to check the state of all stateful sets: %w", err)), log, appDbStatusOption)
 	}
 
-	publishAutomationConfigFirst := r.publishAutomationConfigFirst(opsManager, allStatefulSetsExist, log)
+	publishAutomationConfigFirst := r.publishAutomationConfigFirst(opsManager, allStatefulSetsExistAndValid, log)
 
 	workflowStatus = workflow.RunInGivenOrder(publishAutomationConfigFirst,
 		func() workflow.Status {
-			return r.deployAutomationConfigAndWaitForAgentsReachGoalState(ctx, log, opsManager, &podVars, allStatefulSetsExist, appdbOpts)
+			return r.deployAutomationConfigAndWaitForAgentsReachGoalState(ctx, log, opsManager, &podVars, allStatefulSetsExistAndValid, appdbOpts)
 		},
 		func() workflow.Status {
 			return r.deployStatefulSet(ctx, opsManager, log, podVars, appdbOpts)
@@ -2378,27 +2378,7 @@ func (r *ReconcileAppDbReplicaSet) getCurrentStatefulsetHostnames(opsManager *om
 	})
 }
 
-// isReAdoptedStatefulSetPendingReshape returns true when a StatefulSet taken back from a
-// MongoDB CR (reverse migration re-adoption) still carries the CR's pod shape and awaits the
-// rewrite to the internal-AppDB pod template. Internal AppDB pods always run a dedicated
-// "mongod" container (static and non-static architecture, vault or secret config backend);
-// MongoDB CR pods never do.
-func isReAdoptedStatefulSetPendingReshape(sts appsv1.StatefulSet) bool {
-	for _, c := range sts.Spec.Template.Spec.Containers {
-		if c.Name == util.MongodbContainerName {
-			return false
-		}
-	}
-	return true
-}
-
-// allStatefulSetsExist reports whether every member cluster's AppDB StatefulSet exists in its
-// internal-AppDB form. A StatefulSet re-adopted from a MongoDB CR that hasn't been reshaped yet
-// counts as not existing: its pods run no headless agent, so waiting for agent goal state before
-// deployStatefulSet rewrites the pod template would deadlock (the wait is skipped while this
-// returns false).
-func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
-	allStsExist := true
+func (r *ReconcileAppDbReplicaSet) allStatefulSetsExistsInValidState(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		stsName := opsManager.Spec.AppDB.NameForCluster(r.helper.getMemberClusterIndex(memberCluster.Name))
 		sts, err := memberCluster.Client.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, stsName))
@@ -2406,17 +2386,19 @@ func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, ops
 			if apiErrors.IsNotFound(err) {
 				// we do not return immediately here to check all clusters and also leave the information on other sts in the debug logs
 				log.Debugf("Statefulset %s/%s does not exist.", memberCluster.Name, stsName)
-				allStsExist = false
-			} else {
-				return false, err
+				return false, nil
 			}
-		} else if isReAdoptedStatefulSetPendingReshape(sts) {
-			log.Debugf("Statefulset %s/%s was re-adopted from a MongoDB CR and still awaits the rewrite to the internal-AppDB pod template.", memberCluster.Name, stsName)
-			allStsExist = false
+
+			return false, err
+		}
+
+		if sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] == trueString {
+			log.Debugf("Statefulset %s/%s has the reverse migration ready annotation set to true.", memberCluster.Name, stsName)
+			return false, nil
 		}
 	}
 
-	return allStsExist, nil
+	return true, nil
 }
 
 // migrateToNewDeploymentState reads old config maps with the deployment state and writes them to the new deploymentState structure.

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -622,6 +622,115 @@ func (r *ReconcileAppDbReplicaSet) shouldReconcileAppDB(ctx context.Context, ops
 	return true, nil
 }
 
+// ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
+//   - absent: nothing to own - the reconcile continues and creates AppDB Statefulset from scratch
+//   - owned by this OM: proceed
+//   - foreign-owned (a MongoDB CR): request reverse migration via util.AppDBReverseMigrationReadyAnnotation and wait
+//   - ownerless: reclaim - set this OM's OwnerReference, clear both migration annotations and reclaim AppDB secrets
+func (r *ReconcileAppDbReplicaSet) ensureAppDBStatefulSetOwnership(ctx context.Context, opsManager *omv1.MongoDBOpsManager) workflow.Status {
+	stsKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.Name())
+	sts := appsv1.StatefulSet{}
+	if err := r.client.Get(ctx, stsKey, &sts); err != nil {
+		// If appDB statefulset does not exist proceed with reconciliation
+		if apiErrors.IsNotFound(err) {
+			return workflow.OK()
+		}
+
+		return workflow.Failed(xerrors.Errorf("failed to fetch StatefulSet during ownership check: %w", err))
+	}
+
+	// If appDB statefulset is owned by this OM proceed with reconciliation
+	for _, ref := range sts.OwnerReferences {
+		if ref.UID == opsManager.UID {
+			return workflow.OK()
+		}
+	}
+
+	// If appDB statefulset is owned by another resource (external MongoDB CR),
+	// request reverse migration and block until the other controller releases it.
+	if len(sts.OwnerReferences) > 0 {
+		if err := r.requestAppDBReverseMigration(ctx, sts); err != nil {
+			return workflow.Failed(err)
+		}
+
+		return workflow.Pending("waiting for MongoDB controller to release AppDB StatefulSet %s", sts.GetName())
+	}
+
+	if err := r.reclaimAppDBStatefulset(ctx, opsManager, sts); err != nil {
+		return workflow.Failed(err)
+	}
+
+	if err := r.reclaimAppDBSecrets(ctx, opsManager); err != nil {
+		return workflow.Failed(err)
+	}
+
+	return workflow.OK()
+}
+
+func (r *ReconcileAppDbReplicaSet) requestAppDBReverseMigration(ctx context.Context, sts appsv1.StatefulSet) error {
+	if sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] == trueString {
+		return nil
+	}
+
+	if sts.Annotations == nil {
+		sts.Annotations = map[string]string{}
+	}
+	sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] = trueString
+	if err := r.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to request StatefulSet release: %w", err)
+	}
+
+	return nil
+}
+
+// reclaimAppDBStatefulset transfers the ownership of the AppDB StatefulSet to this OM and clears migration annotations
+func (r *ReconcileAppDbReplicaSet) reclaimAppDBStatefulset(ctx context.Context, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet) error {
+	sts.OwnerReferences = kube.BaseOwnerReference(opsManager)
+	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
+	delete(sts.Annotations, util.AppDBMigrationReadyAnnotation)
+	if err := r.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to reclaim StatefulSet %s: %w", sts.GetName(), err)
+	}
+
+	return nil
+}
+
+// reclaimAppDBSecrets transfers the shared handover secrets (password, keyfile) to this OM's
+// ownership at adoption, so the eventual post-handover deletion of the MongoDB CR doesn't
+// garbage-collect secrets the running internal AppDB depends on
+func (r *ReconcileAppDbReplicaSet) reclaimAppDBSecrets(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+	secretNamesToReclaim := []string{
+		omv1.OpsManagerUserPasswordSecretName(opsManager.Spec.AppDB.Name()),
+		opsManager.Spec.AppDB.GetAgentKeyfileSecretNamespacedName().Name,
+	}
+
+	for _, secretName := range secretNamesToReclaim {
+		if err := r.reclaimAppDBSecret(ctx, opsManager, secretName); err != nil {
+			return xerrors.Errorf("failed to reclaim secret %s: %w", secretName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileAppDbReplicaSet) reclaimAppDBSecret(ctx context.Context, opsManager *omv1.MongoDBOpsManager, name string) error {
+	secretToReclaim := corev1.Secret{}
+	if err := r.client.Get(ctx, kube.ObjectKey(opsManager.Namespace, name), &secretToReclaim); err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
+
+		return xerrors.Errorf("failed to fetch secret %s while reclaiming its ownership: %w", name, err)
+	}
+
+	secretToReclaim.OwnerReferences = kube.BaseOwnerReference(opsManager)
+	if err := r.client.Update(ctx, &secretToReclaim); err != nil {
+		return xerrors.Errorf("failed to update secret %s: %w", name, err)
+	}
+
+	return nil
+}
+
 // ReconcileAppDB deploys the "headless" agent, and wait until it reaches the goal state
 func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (res reconcile.Result, e error) {
 	rs := opsManager.Spec.AppDB
@@ -633,6 +742,13 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	log.Info("AppDB ReplicaSet.Reconcile")
 	log.Infow("ReplicaSet.Spec", "spec", rs)
 	log.Infow("ReplicaSet.Status", "status", opsManager.Status.AppDbStatus)
+
+	// Ops Manager must own the AppDB StatefulSet before touching anything: a StatefulSet
+	// still owned by a MongoDB CR (reverse migration) is asked to be released and waited for.
+	appDBStatefulsetOwnershipStatus := r.ensureAppDBStatefulSetOwnership(ctx, opsManager)
+	if !appDBStatefulsetOwnershipStatus.IsOK() {
+		return r.updateStatus(ctx, opsManager, appDBStatefulsetOwnershipStatus, log, appDbStatusOption)
+	}
 
 	if err := r.ensureResourcesForArchitectureChange(ctx, opsManager); err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring resources for upgrade from 1 to 3 container AppDB: %w", err)), log, appDbStatusOption)
@@ -1578,7 +1694,7 @@ func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.Sugared
 				params[k] = v
 			}
 			if requireValidCert {
-				params["sslRequireValidMMSServerCertificates"] = "true"
+				params["sslRequireValidMMSServerCertificates"] = trueString
 			} else {
 				params["sslRequireValidMMSServerCertificates"] = "false"
 			}
@@ -2257,11 +2373,30 @@ func (r *ReconcileAppDbReplicaSet) getCurrentStatefulsetHostnames(opsManager *om
 	})
 }
 
+// isReAdoptedStatefulSetPendingReshape returns true when a StatefulSet taken back from a
+// MongoDB CR (reverse migration re-adoption) still carries the CR's pod shape and awaits the
+// rewrite to the internal-AppDB pod template. Internal AppDB pods always run a dedicated
+// "mongod" container (static and non-static architecture, vault or secret config backend);
+// MongoDB CR pods never do.
+func isReAdoptedStatefulSetPendingReshape(sts appsv1.StatefulSet) bool {
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name == util.MongodbContainerName {
+			return false
+		}
+	}
+	return true
+}
+
+// allStatefulSetsExist reports whether every member cluster's AppDB StatefulSet exists in its
+// internal-AppDB form. A StatefulSet re-adopted from a MongoDB CR that hasn't been reshaped yet
+// counts as not existing: its pods run no headless agent, so waiting for agent goal state before
+// deployStatefulSet rewrites the pod template would deadlock (the wait is skipped while this
+// returns false).
 func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
 	allStsExist := true
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		stsName := opsManager.Spec.AppDB.NameForCluster(r.helper.getMemberClusterIndex(memberCluster.Name))
-		_, err := memberCluster.Client.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, stsName))
+		sts, err := memberCluster.Client.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, stsName))
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
 				// we do not return immediately here to check all clusters and also leave the information on other sts in the debug logs
@@ -2270,6 +2405,9 @@ func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, ops
 			} else {
 				return false, err
 			}
+		} else if isReAdoptedStatefulSetPendingReshape(sts) {
+			log.Debugf("Statefulset %s/%s was re-adopted from a MongoDB CR and still awaits the rewrite to the internal-AppDB pod template.", memberCluster.Name, stsName)
+			allStsExist = false
 		}
 	}
 

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -622,6 +622,115 @@ func (r *ReconcileAppDbReplicaSet) shouldReconcileAppDB(ctx context.Context, ops
 	return true, nil
 }
 
+// ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
+//   - absent: nothing to own - the reconcile continues and creates AppDB Statefulset from scratch
+//   - owned by this OM: proceed
+//   - foreign-owned (a MongoDB CR): request reverse migration via util.AppDBReverseMigrationReadyAnnotation and wait
+//   - ownerless: reclaim - set this OM's OwnerReference, clear both migration annotations and reclaim AppDB secrets
+func (r *ReconcileAppDbReplicaSet) ensureAppDBStatefulSetOwnership(ctx context.Context, opsManager *omv1.MongoDBOpsManager) workflow.Status {
+	stsKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.Name())
+	sts := appsv1.StatefulSet{}
+	if err := r.client.Get(ctx, stsKey, &sts); err != nil {
+		// If appDB statefulset does not exist proceed with reconciliation
+		if apiErrors.IsNotFound(err) {
+			return workflow.OK()
+		}
+
+		return workflow.Failed(xerrors.Errorf("failed to fetch StatefulSet during ownership check: %w", err))
+	}
+
+	// If appDB statefulset is owned by this OM proceed with reconciliation
+	for _, ref := range sts.OwnerReferences {
+		if ref.UID == opsManager.UID {
+			return workflow.OK()
+		}
+	}
+
+	// If appDB statefulset is owned by another resource (external MongoDB CR),
+	// request reverse migration and block until the other controller releases it.
+	if len(sts.OwnerReferences) > 0 {
+		if err := r.requestAppDBReverseMigration(ctx, sts); err != nil {
+			return workflow.Failed(err)
+		}
+
+		return workflow.Pending("waiting for MongoDB controller to release AppDB StatefulSet %s", sts.GetName())
+	}
+
+	if err := r.reclaimAppDBStatefulset(ctx, opsManager, sts); err != nil {
+		return workflow.Failed(err)
+	}
+
+	if err := r.reclaimAppDBSecrets(ctx, opsManager); err != nil {
+		return workflow.Failed(err)
+	}
+
+	return workflow.OK()
+}
+
+func (r *ReconcileAppDbReplicaSet) requestAppDBReverseMigration(ctx context.Context, sts appsv1.StatefulSet) error {
+	if sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] == trueString {
+		return nil
+	}
+
+	if sts.Annotations == nil {
+		sts.Annotations = map[string]string{}
+	}
+	sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] = trueString
+	if err := r.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to request StatefulSet release: %w", err)
+	}
+
+	return nil
+}
+
+// reclaimAppDBStatefulset transfers the ownership of the AppDB StatefulSet to this OM and clears migration annotations
+func (r *ReconcileAppDbReplicaSet) reclaimAppDBStatefulset(ctx context.Context, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet) error {
+	sts.OwnerReferences = kube.BaseOwnerReference(opsManager)
+	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
+	delete(sts.Annotations, util.AppDBMigrationReadyAnnotation)
+	if err := r.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to reclaim StatefulSet %s: %w", sts.GetName(), err)
+	}
+
+	return nil
+}
+
+// reclaimAppDBSecrets transfers the shared handover secrets (password, keyfile) to this OM's
+// ownership at adoption, so the eventual post-handover deletion of the MongoDB CR doesn't
+// garbage-collect secrets the running internal AppDB depends on
+func (r *ReconcileAppDbReplicaSet) reclaimAppDBSecrets(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+	secretNamesToReclaim := []string{
+		omv1.OpsManagerUserPasswordSecretName(opsManager.Spec.AppDB.Name()),
+		opsManager.Spec.AppDB.GetAgentKeyfileSecretNamespacedName().Name,
+	}
+
+	for _, secretName := range secretNamesToReclaim {
+		if err := r.reclaimAppDBSecret(ctx, opsManager, secretName); err != nil {
+			return xerrors.Errorf("failed to reclaim secret %s: %w", secretName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileAppDbReplicaSet) reclaimAppDBSecret(ctx context.Context, opsManager *omv1.MongoDBOpsManager, name string) error {
+	secretToReclaim := corev1.Secret{}
+	if err := r.client.Get(ctx, kube.ObjectKey(opsManager.Namespace, name), &secretToReclaim); err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
+
+		return xerrors.Errorf("failed to fetch secret %s while reclaiming its ownership: %w", name, err)
+	}
+
+	secretToReclaim.OwnerReferences = kube.BaseOwnerReference(opsManager)
+	if err := r.client.Update(ctx, &secretToReclaim); err != nil {
+		return xerrors.Errorf("failed to update secret %s: %w", name, err)
+	}
+
+	return nil
+}
+
 // ReconcileAppDB deploys the "headless" agent, and wait until it reaches the goal state
 func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (res reconcile.Result, e error) {
 	rs := opsManager.Spec.AppDB
@@ -633,6 +742,13 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	log.Info("AppDB ReplicaSet.Reconcile")
 	log.Infow("ReplicaSet.Spec", "spec", rs)
 	log.Infow("ReplicaSet.Status", "status", opsManager.Status.AppDbStatus)
+
+	// Ops Manager must own the AppDB StatefulSet before touching anything: a StatefulSet
+	// still owned by a MongoDB CR (reverse migration) is asked to be released and waited for.
+	appDBStatefulsetOwnershipStatus := r.ensureAppDBStatefulSetOwnership(ctx, opsManager)
+	if !appDBStatefulsetOwnershipStatus.IsOK() {
+		return r.updateStatus(ctx, opsManager, appDBStatefulsetOwnershipStatus, log, appDbStatusOption)
+	}
 
 	if err := r.ensureResourcesForArchitectureChange(ctx, opsManager); err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring resources for upgrade from 1 to 3 container AppDB: %w", err)), log, appDbStatusOption)
@@ -1578,7 +1694,7 @@ func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.Sugared
 				params[k] = v
 			}
 			if requireValidCert {
-				params["sslRequireValidMMSServerCertificates"] = "true"
+				params["sslRequireValidMMSServerCertificates"] = trueString
 			} else {
 				params["sslRequireValidMMSServerCertificates"] = "false"
 			}
@@ -2262,11 +2378,30 @@ func (r *ReconcileAppDbReplicaSet) getCurrentStatefulsetHostnames(opsManager *om
 	})
 }
 
+// isReAdoptedStatefulSetPendingReshape returns true when a StatefulSet taken back from a
+// MongoDB CR (reverse migration re-adoption) still carries the CR's pod shape and awaits the
+// rewrite to the internal-AppDB pod template. Internal AppDB pods always run a dedicated
+// "mongod" container (static and non-static architecture, vault or secret config backend);
+// MongoDB CR pods never do.
+func isReAdoptedStatefulSetPendingReshape(sts appsv1.StatefulSet) bool {
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name == util.MongodbContainerName {
+			return false
+		}
+	}
+	return true
+}
+
+// allStatefulSetsExist reports whether every member cluster's AppDB StatefulSet exists in its
+// internal-AppDB form. A StatefulSet re-adopted from a MongoDB CR that hasn't been reshaped yet
+// counts as not existing: its pods run no headless agent, so waiting for agent goal state before
+// deployStatefulSet rewrites the pod template would deadlock (the wait is skipped while this
+// returns false).
 func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
 	allStsExist := true
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		stsName := opsManager.Spec.AppDB.NameForCluster(r.helper.getMemberClusterIndex(memberCluster.Name))
-		_, err := memberCluster.Client.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, stsName))
+		sts, err := memberCluster.Client.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, stsName))
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
 				// we do not return immediately here to check all clusters and also leave the information on other sts in the debug logs
@@ -2275,6 +2410,9 @@ func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, ops
 			} else {
 				return false, err
 			}
+		} else if isReAdoptedStatefulSetPendingReshape(sts) {
+			log.Debugf("Statefulset %s/%s was re-adopted from a MongoDB CR and still awaits the rewrite to the internal-AppDB pod template.", memberCluster.Name, stsName)
+			allStsExist = false
 		}
 	}
 

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -1119,10 +1119,10 @@ func getPlaceholderReplacer(appdb omv1.AppDBSpec, memberCluster multicluster.Mem
 		mdbv1.ReplicaSet)
 }
 
-func (r *ReconcileAppDbReplicaSet) publishAutomationConfigFirst(opsManager *omv1.MongoDBOpsManager, allStatefulSetsExist bool, log *zap.SugaredLogger) bool {
+func (r *ReconcileAppDbReplicaSet) publishAutomationConfigFirst(opsManager *omv1.MongoDBOpsManager, allStatefulSetsExistAndValid bool, log *zap.SugaredLogger) bool {
 	// The only case when we push the StatefulSet first is when we are ensuring TLS for the already existing AppDB
 	// TODO this feels insufficient. Shouldn't we check if there is actual change in TLS settings requiring to push sts first? Now it will always publish sts first when TLS enabled
-	automationConfigFirst := !allStatefulSetsExist || !opsManager.Spec.AppDB.GetSecurity().IsTLSEnabled()
+	automationConfigFirst := !allStatefulSetsExistAndValid || !opsManager.Spec.AppDB.GetSecurity().IsTLSEnabled()
 
 	if r.isChangingVersion(opsManager) {
 		log.Info("Version change in progress, the StatefulSet must be updated first")

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1855,6 +1856,7 @@ func createRunningAppDB(ctx context.Context, t *testing.T, startingMembers int, 
 		SetServiceName(serviceName).
 		AddVolumeClaimTemplates(appDBStatefulSetVolumeClaimTemplates()).
 		SetReplicas(startingMembers).
+		SetOwnerReference(kube.BaseOwnerReference(opsManager)).
 		Build()
 
 	assert.NoError(t, err)
@@ -2121,4 +2123,226 @@ func monitoringAutomationConfigSecretName(appdb *omv1.AppDBSpec) string {
 
 func monitoringAutomationConfigConfigMapName(appdb *omv1.AppDBSpec) string {
 	return appdb.Name() + "-monitoring-automation-config-version"
+}
+
+func TestReconcileAppDbReplicaSet_BuildAppDBConnectionURL(t *testing.T) {
+	ctx := context.Background()
+	testOm := DefaultOpsManagerBuilder().Build()
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+
+	_, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	appDbReconciler, err := newAppDbReconciler(ctx, kubeClient, testOm, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	require.NoError(t, appDbReconciler.client.CreateSecret(ctx, secret.Builder().
+		SetName(testOm.Spec.AppDB.GetOpsManagerUserPasswordSecretName()).
+		SetNamespace(testOm.Namespace).
+		SetField(util.OpsManagerPasswordKey, "test-password").
+		Build()))
+
+	connString, err := appDbReconciler.BuildAppDBConnectionURL(ctx, testOm, zap.S())
+	require.NoError(t, err)
+	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
+}
+
+func TestIsReAdoptedStatefulSetPendingReshape(t *testing.T) {
+	tests := []struct {
+		name            string
+		containers      []string
+		expectedPending bool
+	}{
+		{
+			name:            "MongoDB-CR shape (non-static) is pending reshape",
+			containers:      []string{util.DatabaseContainerName},
+			expectedPending: true,
+		},
+		{
+			name:            "MongoDB-CR shape (static architecture) is pending reshape",
+			containers:      []string{util.AgentContainerName, util.DatabaseContainerName},
+			expectedPending: true,
+		},
+		{
+			name:            "internal-AppDB shape is not pending reshape",
+			containers:      []string{util.AgentContainerName, util.MongodbContainerName},
+			expectedPending: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := appsv1.StatefulSet{}
+			for _, name := range tt.containers {
+				sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, corev1.Container{Name: name})
+			}
+			assert.Equal(t, tt.expectedPending, isReAdoptedStatefulSetPendingReshape(sts))
+		})
+	}
+}
+
+// TestReconcileAppDB_ReshapesReAdoptedStatefulSet reproduces the reverse-migration state right
+// after re-adoption: the StatefulSet is OM-owned again but still carries the MongoDB CR's pod
+// shape. A single ReconcileAppDB pass must rewrite the pod template to the internal-AppDB shape
+// instead of deadlocking on the agent goal-state wait (which those CR-shaped pods can never
+// satisfy - they run no headless agent).
+func TestReconcileAppDB_ReshapesReAdoptedStatefulSet(t *testing.T) {
+	ctx := context.Background()
+	opsManager := DefaultOpsManagerBuilder().Build()
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
+	require.NoError(t, createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, "pass"))
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	matchLabels, serviceName := appDBStatefulSetLabelsAndServiceName(opsManager.Name)
+	sts, err := statefulset.NewBuilder().
+		SetName(opsManager.Spec.AppDB.Name()).
+		SetNamespace(opsManager.Namespace).
+		SetMatchLabels(matchLabels).
+		SetServiceName(serviceName).
+		AddVolumeClaimTemplates(appDBStatefulSetVolumeClaimTemplates()).
+		SetReplicas(3).
+		SetOwnerReference(kube.BaseOwnerReference(opsManager)).
+		Build()
+	require.NoError(t, err)
+	sts.Spec.Template.Spec.Containers = []corev1.Container{{Name: util.DatabaseContainerName, Image: "busybox"}}
+	require.NoError(t, kubeClient.CreateStatefulSet(ctx, sts))
+
+	res, err := reconciler.ReconcileAppDB(ctx, opsManager)
+	require.NoError(t, err)
+	// first pass after re-adoption ends with a short requeue to configure monitoring;
+	// the point is that it deploys the StatefulSet instead of blocking on the agent goal-state
+	// wait (default Pending, RequeueAfter 10s) which the CR-shaped pods can never satisfy
+	assert.Equal(t, reconcile.Result{RequeueAfter: time.Second}, res, "reconcile must not block on the agent goal-state wait for a CR-shaped StatefulSet")
+
+	result, err := kubeClient.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.Name()))
+	require.NoError(t, err)
+	containerNames := make([]string, 0, len(result.Spec.Template.Spec.Containers))
+	for _, c := range result.Spec.Template.Spec.Containers {
+		containerNames = append(containerNames, c.Name)
+	}
+	assert.Contains(t, containerNames, util.MongodbContainerName, "pod template must be rewritten to the internal-AppDB shape")
+	assert.NotContains(t, containerNames, util.DatabaseContainerName, "the MongoDB-CR container must not survive the reshape")
+}
+
+func TestEnsureAppDBStatefulSetOwnership(t *testing.T) {
+	const crUID = "cr-uid-2222"
+
+	tests := []struct {
+		name string
+		// sts builds the pre-existing AppDB StatefulSet; nil means it doesn't exist
+		sts                       func(testOm *omv1.MongoDBOpsManager) appsv1.StatefulSet
+		omUID                     types.UID
+		expectedOwned             bool
+		expectedOMOwnerRef        bool
+		expectedReverseAnnotation bool
+		expectedForwardAnnotation bool
+	}{
+		{
+			name:          "StatefulSet absent: recreate-from-scratch path proceeds",
+			expectedOwned: true,
+		},
+		{
+			name:  "already OM-owned: proceeds untouched",
+			omUID: "om-uid-1111",
+			sts: func(testOm *omv1.MongoDBOpsManager) appsv1.StatefulSet {
+				return DefaultStatefulSetBuilder().SetName(testOm.Spec.AppDB.Name()).
+					SetOwnerReferences(kube.BaseOwnerReference(testOm)).Build()
+			},
+			expectedOwned:      true,
+			expectedOMOwnerRef: true,
+		},
+		{
+			name:  "CR-owned: requests release and blocks",
+			omUID: "om-uid-1111",
+			sts: func(testOm *omv1.MongoDBOpsManager) appsv1.StatefulSet {
+				return DefaultStatefulSetBuilder().SetName(testOm.Spec.AppDB.Name()).
+					SetOwnerReferences([]metav1.OwnerReference{{APIVersion: "mongodb.com/v1", Kind: "MongoDB", Name: "test-om-db", UID: crUID}}).Build()
+			},
+			expectedOwned:             false,
+			expectedReverseAnnotation: true,
+		},
+		{
+			name:  "ownerless with release request: adopts and clears annotations",
+			omUID: "om-uid-1111",
+			sts: func(testOm *omv1.MongoDBOpsManager) appsv1.StatefulSet {
+				return DefaultStatefulSetBuilder().SetName(testOm.Spec.AppDB.Name()).
+					SetOwnerReferences(nil).
+					SetAnnotations(map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}).Build()
+			},
+			expectedOwned:      true,
+			expectedOMOwnerRef: true,
+		},
+		{
+			name:  "ownerless with stale forward annotation: adopts and clears it",
+			omUID: "om-uid-1111",
+			sts: func(testOm *omv1.MongoDBOpsManager) appsv1.StatefulSet {
+				return DefaultStatefulSetBuilder().SetName(testOm.Spec.AppDB.Name()).
+					SetOwnerReferences(nil).
+					SetAnnotations(map[string]string{util.AppDBMigrationReadyAnnotation: "true"}).Build()
+			},
+			expectedOwned:      true,
+			expectedOMOwnerRef: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			testOm := DefaultOpsManagerBuilder().SetName("test-om").Build()
+			testOm.UID = tt.omUID
+
+			kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(testOm)
+			reconciler, err := newAppDbReconciler(ctx, kubeClient, testOm, omConnectionFactory.GetConnectionFunc, zap.S())
+			require.NoError(t, err)
+			if tt.sts != nil {
+				sts := tt.sts(testOm)
+				require.NoError(t, kubeClient.Create(ctx, &sts))
+			}
+
+			ownershipStatus := reconciler.ensureAppDBStatefulSetOwnership(ctx, testOm)
+			assert.Equal(t, tt.expectedOwned, ownershipStatus.IsOK())
+
+			if tt.sts != nil {
+				result := appsv1.StatefulSet{}
+				require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.Spec.AppDB.Name()), &result))
+				hasOMRef := false
+				for _, ref := range result.OwnerReferences {
+					if ref.UID == testOm.UID {
+						hasOMRef = true
+					}
+				}
+				assert.Equal(t, tt.expectedOMOwnerRef, hasOMRef)
+				assert.Equal(t, tt.expectedReverseAnnotation, result.Annotations[util.AppDBReverseMigrationReadyAnnotation] == "true")
+				assert.Equal(t, tt.expectedForwardAnnotation, result.Annotations[util.AppDBMigrationReadyAnnotation] == "true")
+			}
+		})
+	}
+}
+
+func TestEnsureAppDBStatefulSetOwnership_ClaimsSharedSecretsOnAdoption(t *testing.T) {
+	ctx := context.Background()
+	testOm := DefaultOpsManagerBuilder().SetName("test-om").Build()
+	testOm.UID = types.UID("om-uid-1111")
+
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(testOm)
+	reconciler, err := newAppDbReconciler(ctx, kubeClient, testOm, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	sts := DefaultStatefulSetBuilder().SetName(testOm.Spec.AppDB.Name()).
+		SetOwnerReferences(nil).
+		SetAnnotations(map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}).Build()
+	require.NoError(t, kubeClient.Create(ctx, &sts))
+
+	crOwnerRef := []metav1.OwnerReference{{APIVersion: "mongodb.com/v1", Kind: "MongoDB", Name: "test-om-db", UID: "cr-uid-2222"}}
+	for _, name := range []string{omv1.OpsManagerUserPasswordSecretName("test-om-db"), testOm.Spec.AppDB.GetAgentKeyfileSecretNamespacedName().Name} {
+		s := secret.Builder().SetName(name).SetNamespace(testOm.Namespace).SetField("k", "v").SetOwnerReferences(crOwnerRef).Build()
+		require.NoError(t, kubeClient.CreateSecret(ctx, s))
+	}
+
+	ownershipStatus := reconciler.ensureAppDBStatefulSetOwnership(ctx, testOm)
+	require.True(t, ownershipStatus.IsOK())
+
+	for _, name := range []string{omv1.OpsManagerUserPasswordSecretName("test-om-db"), testOm.Spec.AppDB.GetAgentKeyfileSecretNamespacedName().Name} {
+		s := corev1.Secret{}
+		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, name), &s))
+		require.Len(t, s.OwnerReferences, 1, name)
+		assert.Equal(t, testOm.UID, s.OwnerReferences[0].UID, "secret %s must be claimed by the OM at adoption", name)
+	}
 }

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -2145,44 +2145,11 @@ func TestReconcileAppDbReplicaSet_BuildAppDBConnectionURL(t *testing.T) {
 	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
 }
 
-func TestIsReAdoptedStatefulSetPendingReshape(t *testing.T) {
-	tests := []struct {
-		name            string
-		containers      []string
-		expectedPending bool
-	}{
-		{
-			name:            "MongoDB-CR shape (non-static) is pending reshape",
-			containers:      []string{util.DatabaseContainerName},
-			expectedPending: true,
-		},
-		{
-			name:            "MongoDB-CR shape (static architecture) is pending reshape",
-			containers:      []string{util.AgentContainerName, util.DatabaseContainerName},
-			expectedPending: true,
-		},
-		{
-			name:            "internal-AppDB shape is not pending reshape",
-			containers:      []string{util.AgentContainerName, util.MongodbContainerName},
-			expectedPending: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sts := appsv1.StatefulSet{}
-			for _, name := range tt.containers {
-				sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, corev1.Container{Name: name})
-			}
-			assert.Equal(t, tt.expectedPending, isReAdoptedStatefulSetPendingReshape(sts))
-		})
-	}
-}
-
 // TestReconcileAppDB_ReshapesReAdoptedStatefulSet reproduces the reverse-migration state right
-// after re-adoption: the StatefulSet is OM-owned again but still carries the MongoDB CR's pod
-// shape. A single ReconcileAppDB pass must rewrite the pod template to the internal-AppDB shape
-// instead of deadlocking on the agent goal-state wait (which those CR-shaped pods can never
-// satisfy - they run no headless agent).
+// after re-adoption: the StatefulSet is OM-owned again but still carries the
+// AppDBReverseMigrationReadyAnnotation, signaling that the pod template must be rewritten.
+// A single ReconcileAppDB pass must rewrite the pod template to the internal-AppDB shape
+// instead of deadlocking on the agent goal-state wait.
 func TestReconcileAppDB_ReshapesReAdoptedStatefulSet(t *testing.T) {
 	ctx := context.Background()
 	opsManager := DefaultOpsManagerBuilder().Build()
@@ -2202,6 +2169,7 @@ func TestReconcileAppDB_ReshapesReAdoptedStatefulSet(t *testing.T) {
 		SetOwnerReference(kube.BaseOwnerReference(opsManager)).
 		Build()
 	require.NoError(t, err)
+	sts.Annotations = map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}
 	sts.Spec.Template.Spec.Containers = []corev1.Container{{Name: util.DatabaseContainerName, Image: "busybox"}}
 	require.NoError(t, kubeClient.CreateStatefulSet(ctx, sts))
 
@@ -2209,7 +2177,7 @@ func TestReconcileAppDB_ReshapesReAdoptedStatefulSet(t *testing.T) {
 	require.NoError(t, err)
 	// first pass after re-adoption ends with a short requeue to configure monitoring;
 	// the point is that it deploys the StatefulSet instead of blocking on the agent goal-state
-	// wait (default Pending, RequeueAfter 10s) which the CR-shaped pods can never satisfy
+	// wait which the CR-shaped pods can never satisfy
 	assert.Equal(t, reconcile.Result{RequeueAfter: time.Second}, res, "reconcile must not block on the agent goal-state wait for a CR-shaped StatefulSet")
 
 	result, err := kubeClient.GetStatefulSet(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.Name()))
@@ -2220,6 +2188,8 @@ func TestReconcileAppDB_ReshapesReAdoptedStatefulSet(t *testing.T) {
 	}
 	assert.Contains(t, containerNames, util.MongodbContainerName, "pod template must be rewritten to the internal-AppDB shape")
 	assert.NotContains(t, containerNames, util.DatabaseContainerName, "the MongoDB-CR container must not survive the reshape")
+	assert.NotContains(t, result.Annotations, util.AppDBReverseMigrationReadyAnnotation, "reverse migration annotation must be cleared after STS reshape")
+	assert.NotContains(t, result.Annotations, util.AppDBMigrationReadyAnnotation, "forward migration annotation must not be present after STS reshape")
 }
 
 func TestEnsureAppDBStatefulSetOwnership(t *testing.T) {
@@ -2260,15 +2230,16 @@ func TestEnsureAppDBStatefulSetOwnership(t *testing.T) {
 			expectedReverseAnnotation: true,
 		},
 		{
-			name:  "ownerless with release request: adopts and clears annotations",
+			name:  "ownerless with release request: adopts and keeps reverse annotation for reshape",
 			omUID: "om-uid-1111",
 			sts: func(testOm *omv1.MongoDBOpsManager) appsv1.StatefulSet {
 				return DefaultStatefulSetBuilder().SetName(testOm.Spec.AppDB.Name()).
 					SetOwnerReferences(nil).
 					SetAnnotations(map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}).Build()
 			},
-			expectedOwned:      true,
-			expectedOMOwnerRef: true,
+			expectedOwned:             true,
+			expectedOMOwnerRef:        true,
+			expectedReverseAnnotation: true,
 		},
 		{
 			name:  "ownerless with stale forward annotation: adopts and clears it",

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -137,7 +137,7 @@ func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(
 		return "", xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
-	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil), nil
+	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, "", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-256"}), nil
 }
 
 type externalAppDBRefObject struct {

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -65,16 +64,14 @@ func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx co
 		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
 	}
 
-	objectKey := kube.ObjectKey(opsManager.Namespace, ref.Name)
-
-	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref, objectKey)
+	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
-		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
+		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
 	role := refObject.GetRole()
 	if role != mdbv1.RoleAppDB {
-		return xerrors.Errorf("externalApplicationDatabaseRef %s must have spec.role set to %q", objectKey, mdbv1.RoleAppDB)
+		return xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
 	}
 
 	// TODO maybe other validations e.g. SCRAM, TLS?
@@ -136,10 +133,9 @@ func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(
 		return "", xerrors.Errorf("failed to read shared password secret: %w", err)
 	}
 
-	objectKey := kube.ObjectKey(opsManager.Namespace, ref.Name)
-	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref, objectKey)
+	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
-		return "", xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
+		return "", xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
 	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil), nil
@@ -155,10 +151,11 @@ type ExternalAppDB interface {
 	GetRole() string
 }
 
-func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalApplicationDatabaseRef, objectKey client.ObjectKey) (ExternalAppDB, error) {
+func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalApplicationDatabaseRef) (ExternalAppDB, error) {
 	switch ref.Kind {
 	case "MongoDB":
 		mongodb := &mdbv1.MongoDB{}
+		objectKey := kube.ObjectKey(ref.Namespace, ref.Name)
 		if err := e.client.Get(ctx, objectKey, mongodb); err != nil {
 			if apiErrors.IsNotFound(err) {
 				return nil, xerrors.Errorf("externalApplicationDatabaseRef points to MongoDB %s which does not exist", objectKey)

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/connectionstring"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
@@ -131,11 +131,10 @@ func (e *ReconcileExternalAppDBReplicaSet) requestAppDBForwardMigration(ctx cont
 func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
 	ref := opsManager.Spec.ExternalApplicationDatabaseRef
 
-	passwordSecret := corev1.Secret{}
-	if err := e.client.Get(ctx, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)), &passwordSecret); err != nil {
+	password, err := secret.ReadKey(ctx, e.SecretClient, util.OpsManagerPasswordKey, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)))
+	if err != nil {
 		return "", xerrors.Errorf("failed to read shared password secret: %w", err)
 	}
-	password := string(passwordSecret.Data[util.OpsManagerPasswordKey])
 
 	objectKey := kube.ObjectKey(opsManager.Namespace, ref.Name)
 	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref, objectKey)

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -59,7 +59,7 @@ func (e *ReconcileExternalAppDBReplicaSet) BuildAppDBConnectionURL(ctx context.C
 
 // validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
 func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
-	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	ref := opsManager.Spec.ExternalAppDBRef
 	if ref == nil {
 		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
 	}
@@ -84,7 +84,7 @@ func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx co
 //   - foreign-owned (a MongoDB CR) or already detached: no-op - the CR owns the StatefulSet
 func (e *ReconcileExternalAppDBReplicaSet) ensureAppDBStatefulSetOwnership(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
 	sts := appsv1.StatefulSet{}
-	stsKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.ExternalApplicationDatabaseRef.Name)
+	stsKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.ExternalAppDBRef.Name)
 	if err := e.client.Get(ctx, stsKey, &sts); err != nil {
 		if apiErrors.IsNotFound(err) {
 			return nil // Fresh Start, nothing to detach
@@ -125,7 +125,7 @@ func (e *ReconcileExternalAppDBReplicaSet) requestAppDBForwardMigration(ctx cont
 // the shared mongodb-ops-manager password secret, computes the connection string directly via
 // BuildConnectionString.
 func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
-	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	ref := opsManager.Spec.ExternalAppDBRef
 
 	password, err := secret.ReadKey(ctx, e.SecretClient, util.OpsManagerPasswordKey, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)))
 	if err != nil {
@@ -150,7 +150,7 @@ type ExternalAppDB interface {
 	GetRole() string
 }
 
-func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalApplicationDatabaseRef) (ExternalAppDB, error) {
+func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalAppDBRef) (ExternalAppDB, error) {
 	switch ref.Kind {
 	case "MongoDB":
 		mongodb := &mdbv1.MongoDB{}

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -74,7 +74,6 @@ func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx co
 		return xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
 	}
 
-	// TODO maybe other validations e.g. SCRAM, TLS?
 	return nil
 }
 

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -1,0 +1,176 @@
+package operator
+
+import (
+	"context"
+	"slices"
+
+	"go.uber.org/zap"
+	"golang.org/x/xerrors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
+	mdbstatus "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/connectionstring"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/workflow"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+// ReconcileExternalAppDBReplicaSet implements AppDBReconciler for OpsManager resources using
+// spec.externalApplicationDatabaseRef. It never reads opsManager.Spec.AppDB — all AppDB
+// state comes from the referenced MongoDB CR instead.
+type ReconcileExternalAppDBReplicaSet struct {
+	*ReconcileCommonController
+	log *zap.SugaredLogger
+}
+
+func (r *OpsManagerReconciler) createNewExternalAppDBReconciler(log *zap.SugaredLogger) *ReconcileExternalAppDBReplicaSet {
+	return &ReconcileExternalAppDBReplicaSet{
+		ReconcileCommonController: r.ReconcileCommonController,
+		log:                       log,
+	}
+}
+
+// ReconcileAppDB validates the externalApplicationDatabaseRef, performs the one-time
+// detach-and-adopt migration of any pre-existing internal AppDB (idempotent, no-op once
+// complete), and establishes a watch on the referenced CR.
+func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error) {
+	if err := e.validateExternalAppDBReference(ctx, opsManager); err != nil {
+		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error validating externalApplicationDatabaseRef: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
+	}
+
+	if err := e.ensureAppDBStatefulSetOwnership(ctx, opsManager); err != nil {
+		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error detaching internal AppDB StatefulSet: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
+	}
+
+	return e.updateStatus(ctx, opsManager, workflow.Disabled(), e.log, mdbstatus.NewOMPartOption(mdbstatus.AppDb))
+}
+
+// BuildAppDBConnectionURL computes the AppDB connection string from the referenced MongoDB CR.
+func (e *ReconcileExternalAppDBReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
+	return e.computeExternalAppDBConnectionString(ctx, opsManager)
+}
+
+// validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
+func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	if ref == nil {
+		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
+	}
+
+	objectKey := kube.ObjectKey(opsManager.Namespace, ref.Name)
+
+	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref, objectKey)
+	if err != nil {
+		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
+	}
+
+	role := refObject.GetRole()
+	if role != mdbv1.RoleAppDB {
+		return xerrors.Errorf("externalApplicationDatabaseRef %s must have spec.role set to %q", objectKey, mdbv1.RoleAppDB)
+	}
+
+	// TODO maybe other validations e.g. SCRAM, TLS?
+	return nil
+}
+
+// ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
+//   - absent: nothing to detach - Fresh Start, the referenced CR creates its own StatefulSet
+//   - owned by this OM: strip OM's OwnerReference and set util.AppDBMigrationReadyAnnotation
+//     so the referenced MongoDB CR can adopt
+//   - foreign-owned (a MongoDB CR) or already detached: no-op - the CR owns the StatefulSet
+func (e *ReconcileExternalAppDBReplicaSet) ensureAppDBStatefulSetOwnership(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+	sts := appsv1.StatefulSet{}
+	stsKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.ExternalApplicationDatabaseRef.Name)
+	if err := e.client.Get(ctx, stsKey, &sts); err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil // Fresh Start, nothing to detach
+		}
+		return xerrors.Errorf("failed to fetch StatefulSet %s: %w", stsKey.Name, err)
+	}
+
+	ownedByThisOM := slices.ContainsFunc(sts.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.UID == opsManager.UID
+	})
+
+	// If not owned by this Ops Manager, no-op
+	if !ownedByThisOM {
+		return nil
+	}
+
+	// Request forward migration if owned by this Ops Manager
+	return e.requestAppDBForwardMigration(ctx, sts)
+}
+
+func (e *ReconcileExternalAppDBReplicaSet) requestAppDBForwardMigration(ctx context.Context, sts appsv1.StatefulSet) error {
+	sts.OwnerReferences = nil
+
+	if sts.Annotations == nil {
+		sts.Annotations = map[string]string{}
+	}
+	sts.Annotations[util.AppDBMigrationReadyAnnotation] = trueString
+	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
+
+	if err := e.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to strip OwnerReferences and annotate StatefulSet %s: %w", sts.GetName(), err)
+	}
+
+	return nil
+}
+
+// computeExternalAppDBConnectionString fetches the referenced MongoDB CR and
+// the shared mongodb-ops-manager password secret, computes the connection string directly via
+// BuildConnectionString.
+func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
+	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+
+	passwordSecret := corev1.Secret{}
+	if err := e.client.Get(ctx, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)), &passwordSecret); err != nil {
+		return "", xerrors.Errorf("failed to read shared password secret: %w", err)
+	}
+	password := string(passwordSecret.Data[util.OpsManagerPasswordKey])
+
+	objectKey := kube.ObjectKey(opsManager.Namespace, ref.Name)
+	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref, objectKey)
+	if err != nil {
+		return "", xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
+	}
+
+	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil), nil
+}
+
+type externalAppDBRefObject struct {
+	connectionstring.ConnectionStringBuilder
+	mdbv1.DbCommonSpec
+}
+
+type ExternalAppDB interface {
+	connectionstring.ConnectionStringBuilder
+	GetRole() string
+}
+
+func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalApplicationDatabaseRef, objectKey client.ObjectKey) (ExternalAppDB, error) {
+	switch ref.Kind {
+	case "MongoDB":
+		mongodb := &mdbv1.MongoDB{}
+		if err := e.client.Get(ctx, objectKey, mongodb); err != nil {
+			if apiErrors.IsNotFound(err) {
+				return nil, xerrors.Errorf("externalApplicationDatabaseRef points to MongoDB %s which does not exist", objectKey)
+			}
+			return nil, xerrors.Errorf("failed to fetch referenced MongoDB %s: %w", objectKey, err)
+		}
+		return &externalAppDBRefObject{
+			ConnectionStringBuilder: mongodb,
+			DbCommonSpec:            mongodb.Spec.DbCommonSpec,
+		}, nil
+	}
+
+	return nil, xerrors.Errorf("externalApplicationDatabaseRef.kind %q is not supported", ref.Kind)
+}

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -104,8 +104,9 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 
 func validExternalAppDBRef() *omv1.ExternalApplicationDatabaseRef {
 	return &omv1.ExternalApplicationDatabaseRef{
-		Name: "test-om-db",
-		Kind: "MongoDB",
+		Name:      "test-om-db",
+		Kind:      "MongoDB",
+		Namespace: mock.TestNamespace,
 	}
 }
 

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -54,7 +54,7 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 		},
 		{
 			name: "referenced MongoDB does not exist",
-			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 				Name: "test-om-db",
 				Kind: "MongoDB",
 			}),
@@ -62,7 +62,7 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 		},
 		{
 			name: "referenced MongoDB does not have role AppDB",
-			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 				Name: "test-om-db",
 				Kind: "MongoDB",
 			}),
@@ -73,7 +73,7 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 		},
 		{
 			name: "referenced MongoDB is valid",
-			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 				Name: "test-om-db",
 				Kind: "MongoDB",
 			}),
@@ -81,7 +81,7 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 		},
 		{
 			name: "unsupported kind",
-			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 				Name: "test-om-db",
 				Kind: "SomethingElse",
 			}),
@@ -102,8 +102,8 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 	}
 }
 
-func validExternalAppDBRef() *omv1.ExternalApplicationDatabaseRef {
-	return &omv1.ExternalApplicationDatabaseRef{
+func validExternalAppDBRef() *omv1.ExternalAppDBRef {
+	return &omv1.ExternalAppDBRef{
 		Name:      "test-om-db",
 		Kind:      "MongoDB",
 		Namespace: mock.TestNamespace,
@@ -208,7 +208,7 @@ func TestComputeExternalAppDBConnectionString_WritesFixedSecret(t *testing.T) {
 		Build()
 	externalAppDB.Spec.Role = mdbv1.RoleAppDB
 
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 		Name: "test-om-db",
 		Kind: "MongoDB",
 	})

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -195,60 +195,6 @@ func TestEnsureAppDBStatefulSetOwnership_IsIdempotent(t *testing.T) {
 	assert.Equal(t, "true", resultSts.Annotations[util.AppDBMigrationReadyAnnotation])
 }
 
-// TestEnsureAppDBStatefulSetOwnership_OnlyStripsHealthyAppDBMemberClusters proves the strip step iterates the
-// AppDB's own healthy member clusters (ReconcileAppDbReplicaSet.GetHealthyMemberClusters), not the
-// operator-wide set of every registered member cluster. memberClusterUnrelatedToAppDB is
-// registered operator-wide (e.g. used by some other multi-cluster resource) but isn't part of
-// this AppDB's ClusterSpecList, so it's given a nil client: if the strip loop touched it, calling
-// Get on a nil client.Client would panic.
-func TestEnsureAppDBStatefulSetOwnership_OnlyStripsHealthyAppDBMemberClusters(t *testing.T) {
-	ctx := context.Background()
-
-	memberClusterName := "kind-e2e-cluster-1"
-	memberClusterName2 := "kind-e2e-cluster-2"
-	memberClusterUnrelatedToAppDB := "kind-e2e-cluster-unrelated"
-
-	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	globalMemberClustersMap := getFakeMultiClusterMapWithClusters([]string{memberClusterName, memberClusterName2}, omConnectionFactory)
-	globalMemberClustersMap[memberClusterUnrelatedToAppDB] = nil
-
-	appDBClusterSpecItems := mdbv1.ClusterSpecList{
-		{ClusterName: memberClusterName, Members: 1},
-		{ClusterName: memberClusterName2, Members: 1},
-	}
-
-	testOm := withExternalAppDBRef(
-		DefaultOpsManagerBuilder().
-			SetName("test-om").
-			SetAppDBTopology(mdbv1.ClusterTopologyMultiCluster).
-			SetAppDbMembers(0).
-			SetAppDBClusterSpecList(appDBClusterSpecItems).
-			Build(),
-		validExternalAppDBRef(),
-	)
-	mdb := validExternalAppDBMongoDB()
-
-	sts := appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-om-db",
-			Namespace:       mock.TestNamespace,
-			OwnerReferences: kube.BaseOwnerReference(testOm),
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas: ptr.To(int32(3)),
-		},
-	}
-
-	reconciler, _, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, globalMemberClustersMap, omConnectionFactory, architectures.NonStatic)
-	require.NoError(t, reconciler.client.Create(ctx, mdb))
-	require.NoError(t, reconciler.client.Create(ctx, &sts))
-
-	require.NotPanics(t, func() {
-		err := reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm)
-		assert.NoError(t, err)
-	})
-}
-
 func TestComputeExternalAppDBConnectionString_WritesFixedSecret(t *testing.T) {
 	ctx := context.Background()
 

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -1,0 +1,372 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/mock"
+	"github.com/mongodb/mongodb-kubernetes/pkg/images"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
+)
+
+func newOpsManagerReconcilerForValidation(objects ...client.Object) *OpsManagerReconciler {
+	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(objects...)
+	return NewOpsManagerReconciler(context.Background(), kubeClient, map[string]client.Client{}, images.ImageUrls{}, "", "", architectures.Static, omConnectionFactory.GetConnectionFunc, nil, nil)
+}
+
+func TestValidateExternalAppDBReference(t *testing.T) {
+	ctx := context.Background()
+
+	validMongoDB := mdbv1.NewReplicaSetBuilder().
+		SetName("test-om-db").
+		SetNamespace(mock.TestNamespace).
+		SetVersion("6.0.0").
+		Build()
+	validMongoDB.Spec.Role = mdbv1.RoleAppDB
+
+	tests := []struct {
+		name          string
+		om            *omv1.MongoDBOpsManager
+		objects       []client.Object
+		expectedError string
+	}{
+		{
+			name:          "no externalApplicationDatabaseRef is an error",
+			om:            DefaultOpsManagerBuilder().Build(),
+			expectedError: "externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference",
+		},
+		{
+			name: "referenced MongoDB does not exist",
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+				Name: "test-om-db",
+				Kind: "MongoDB",
+			}),
+			expectedError: "failed to fetch externalApplicationDatabaseRef my-namespace/test-om-db: externalApplicationDatabaseRef points to MongoDB my-namespace/test-om-db which does not exist",
+		},
+		{
+			name: "referenced MongoDB does not have role AppDB",
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+				Name: "test-om-db",
+				Kind: "MongoDB",
+			}),
+			objects: []client.Object{
+				mdbv1.NewReplicaSetBuilder().SetName("test-om-db").SetNamespace(mock.TestNamespace).SetVersion("6.0.0").Build(),
+			},
+			expectedError: `externalApplicationDatabaseRef my-namespace/test-om-db must have spec.role set to "AppDB"`,
+		},
+		{
+			name: "referenced MongoDB is valid",
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+				Name: "test-om-db",
+				Kind: "MongoDB",
+			}),
+			objects: []client.Object{validMongoDB},
+		},
+		{
+			name: "unsupported kind",
+			om: withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+				Name: "test-om-db",
+				Kind: "SomethingElse",
+			}),
+			expectedError: `failed to fetch externalApplicationDatabaseRef my-namespace/test-om-db: externalApplicationDatabaseRef.kind "SomethingElse" is not supported`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := newOpsManagerReconcilerForValidation(tt.objects...)
+			err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func validExternalAppDBRef() *omv1.ExternalApplicationDatabaseRef {
+	return &omv1.ExternalApplicationDatabaseRef{
+		Name: "test-om-db",
+		Kind: "MongoDB",
+	}
+}
+
+func validExternalAppDBMongoDB() *mdbv1.MongoDB {
+	mdb := mdbv1.NewReplicaSetBuilder().
+		SetName("test-om-db").
+		SetNamespace(mock.TestNamespace).
+		SetVersion("6.0.0").
+		Build()
+	mdb.Spec.Role = mdbv1.RoleAppDB
+	return mdb
+}
+
+func TestEnsureAppDBStatefulSetOwnership_StripsOwnerReferencesAndAnnotates(t *testing.T) {
+	ctx := context.Background()
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().SetName("test-om").Build(), validExternalAppDBRef())
+	mdb := validExternalAppDBMongoDB()
+
+	sts := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-om-db",
+			Namespace:       mock.TestNamespace,
+			OwnerReferences: kube.BaseOwnerReference(testOm),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To(int32(3)),
+		},
+	}
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, mdb))
+	require.NoError(t, reconciler.client.Create(ctx, &sts))
+
+	err := reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm)
+	assert.NoError(t, err)
+
+	resultSts := appsv1.StatefulSet{}
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, "test-om-db"), &resultSts))
+	assert.Empty(t, resultSts.OwnerReferences)
+	assert.Equal(t, "true", resultSts.Annotations[util.AppDBMigrationReadyAnnotation])
+}
+
+func TestEnsureAppDBStatefulSetOwnership_NoOpWhenNoStatefulSetExists(t *testing.T) {
+	ctx := context.Background()
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().SetName("test-om").Build(), validExternalAppDBRef())
+	mdb := validExternalAppDBMongoDB()
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, _, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, mdb))
+
+	err := reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm)
+	assert.NoError(t, err, "Fresh Start: no internal AppDB StatefulSet ever existed, detach must be a no-op")
+}
+
+func TestEnsureAppDBStatefulSetOwnership_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().SetName("test-om").Build(), validExternalAppDBRef())
+	mdb := validExternalAppDBMongoDB()
+
+	sts := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-om-db",
+			Namespace:       mock.TestNamespace,
+			OwnerReferences: kube.BaseOwnerReference(testOm),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To(int32(3)),
+		},
+	}
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, mdb))
+	require.NoError(t, reconciler.client.Create(ctx, &sts))
+
+	require.NoError(t, reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm))
+	require.NoError(t, reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm))
+
+	resultSts := appsv1.StatefulSet{}
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, "test-om-db"), &resultSts))
+	assert.Empty(t, resultSts.OwnerReferences)
+	assert.Equal(t, "true", resultSts.Annotations[util.AppDBMigrationReadyAnnotation])
+}
+
+// TestEnsureAppDBStatefulSetOwnership_OnlyStripsHealthyAppDBMemberClusters proves the strip step iterates the
+// AppDB's own healthy member clusters (ReconcileAppDbReplicaSet.GetHealthyMemberClusters), not the
+// operator-wide set of every registered member cluster. memberClusterUnrelatedToAppDB is
+// registered operator-wide (e.g. used by some other multi-cluster resource) but isn't part of
+// this AppDB's ClusterSpecList, so it's given a nil client: if the strip loop touched it, calling
+// Get on a nil client.Client would panic.
+func TestEnsureAppDBStatefulSetOwnership_OnlyStripsHealthyAppDBMemberClusters(t *testing.T) {
+	ctx := context.Background()
+
+	memberClusterName := "kind-e2e-cluster-1"
+	memberClusterName2 := "kind-e2e-cluster-2"
+	memberClusterUnrelatedToAppDB := "kind-e2e-cluster-unrelated"
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	globalMemberClustersMap := getFakeMultiClusterMapWithClusters([]string{memberClusterName, memberClusterName2}, omConnectionFactory)
+	globalMemberClustersMap[memberClusterUnrelatedToAppDB] = nil
+
+	appDBClusterSpecItems := mdbv1.ClusterSpecList{
+		{ClusterName: memberClusterName, Members: 1},
+		{ClusterName: memberClusterName2, Members: 1},
+	}
+
+	testOm := withExternalAppDBRef(
+		DefaultOpsManagerBuilder().
+			SetName("test-om").
+			SetAppDBTopology(mdbv1.ClusterTopologyMultiCluster).
+			SetAppDbMembers(0).
+			SetAppDBClusterSpecList(appDBClusterSpecItems).
+			Build(),
+		validExternalAppDBRef(),
+	)
+	mdb := validExternalAppDBMongoDB()
+
+	sts := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-om-db",
+			Namespace:       mock.TestNamespace,
+			OwnerReferences: kube.BaseOwnerReference(testOm),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To(int32(3)),
+		},
+	}
+
+	reconciler, _, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, globalMemberClustersMap, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, mdb))
+	require.NoError(t, reconciler.client.Create(ctx, &sts))
+
+	require.NotPanics(t, func() {
+		err := reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm)
+		assert.NoError(t, err)
+	})
+}
+
+func TestComputeExternalAppDBConnectionString_WritesFixedSecret(t *testing.T) {
+	ctx := context.Background()
+
+	externalAppDB := mdbv1.NewReplicaSetBuilder().
+		SetName("test-om-db").
+		SetNamespace(mock.TestNamespace).
+		SetVersion("6.0.0").
+		SetMembers(3).
+		EnableAuth([]mdbv1.AuthMode{util.SCRAM}).
+		Build()
+	externalAppDB.Spec.Role = mdbv1.RoleAppDB
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+		Name: "test-om-db",
+		Kind: "MongoDB",
+	})
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
+	require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
+		SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
+		SetNamespace(testOm.Namespace).
+		SetField(util.OpsManagerPasswordKey, "test-password").
+		Build()))
+
+	helper, err := NewOpsManagerReconcilerHelper(ctx, reconciler, testOm, reconciler.memberClustersMap, zap.S())
+	require.NoError(t, err)
+
+	connString, err := reconciler.createNewExternalAppDBReconciler(zap.S()).computeExternalAppDBConnectionString(ctx, testOm)
+	require.NoError(t, err)
+	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
+	assert.Contains(t, connString, "test-password")
+
+	for _, memberCluster := range helper.getHealthyMemberClusters() {
+		require.NoError(t, reconciler.ensureAppDBConnectionStringInMemberCluster(ctx, testOm, connString, memberCluster, zap.S()))
+	}
+
+	result := corev1.Secret{}
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()), &result))
+	assert.Contains(t, string(result.Data[util.AppDbConnectionStringKey]), util.OpsManagerMongoDBUserName)
+}
+
+func TestEnsureAppDBStatefulSetOwnership_OnlyDetachesOMOwnedStatefulSet(t *testing.T) {
+	// real UIDs needed: the ownership check compares OwnerReference UIDs, and empty test UIDs
+	// ("" == "") would make every StatefulSet look OM-owned
+	const omUID = "om-uid-1111"
+	const crUID = "cr-uid-2222"
+
+	tests := []struct {
+		name             string
+		stsOwnerRefs     func(testOm *omv1.MongoDBOpsManager) []metav1.OwnerReference
+		expectedDetached bool
+	}{
+		{
+			name: "OM-owned StatefulSet is stripped and annotated",
+			stsOwnerRefs: func(testOm *omv1.MongoDBOpsManager) []metav1.OwnerReference {
+				return kube.BaseOwnerReference(testOm)
+			},
+			expectedDetached: true,
+		},
+		{
+			name: "CR-owned StatefulSet (fresh start) is untouched",
+			stsOwnerRefs: func(testOm *omv1.MongoDBOpsManager) []metav1.OwnerReference {
+				return []metav1.OwnerReference{{
+					APIVersion: "mongodb.com/v1",
+					Kind:       "MongoDB",
+					Name:       "test-om-db",
+					UID:        crUID,
+				}}
+			},
+			expectedDetached: false,
+		},
+		{
+			name: "ownerRef-free StatefulSet (already detached and consumed) is not re-annotated",
+			stsOwnerRefs: func(testOm *omv1.MongoDBOpsManager) []metav1.OwnerReference {
+				return nil
+			},
+			expectedDetached: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().SetName("test-om").Build(), validExternalAppDBRef())
+			testOm.UID = types.UID(omUID)
+			mdb := validExternalAppDBMongoDB()
+
+			originalOwnerRefs := tt.stsOwnerRefs(testOm)
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-om-db",
+					Namespace:       mock.TestNamespace,
+					OwnerReferences: originalOwnerRefs,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+			}
+
+			omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+			reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+			require.NoError(t, reconciler.client.Create(ctx, mdb))
+			require.NoError(t, reconciler.client.Create(ctx, &sts))
+
+			require.NoError(t, reconciler.createNewExternalAppDBReconciler(zap.S()).ensureAppDBStatefulSetOwnership(ctx, testOm))
+
+			resultSts := appsv1.StatefulSet{}
+			require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, "test-om-db"), &resultSts))
+
+			if tt.expectedDetached {
+				assert.Empty(t, resultSts.OwnerReferences)
+				assert.Equal(t, "true", resultSts.Annotations[util.AppDBMigrationReadyAnnotation])
+			} else {
+				assert.Equal(t, originalOwnerRefs, resultSts.OwnerReferences)
+				assert.NotContains(t, resultSts.Annotations, util.AppDBMigrationReadyAnnotation)
+			}
+		})
+	}
+}

--- a/controllers/operator/appdbreplicaset_reconciler.go
+++ b/controllers/operator/appdbreplicaset_reconciler.go
@@ -9,12 +9,13 @@ import (
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 )
 
-// AppDBReconciler abstracts the AppDB reconciliation strategy. The internal
-// AppDB reconciler (ReconcileAppDbReplicaSet) is the sole implementation today;
-// future implementations can use alternative AppDB backends without changing the
-// Ops Manager controller.
+// AppDBReconciler is implemented by both the ReconcileAppDbReplicaSet (internal AppDB reconciler
+// backed by opsManager.Spec.AppDB) and the ReconcileExternalAppDBReplicaSet (backed by
+// opsManager.Spec.ExternalApplicationDatabaseRef).
 type AppDBReconciler interface {
-	// ReconcileAppDB brings the AppDB to the desired state.
+	// ReconcileAppDB brings the AppDB (internal StatefulSet, or external CR reference)
+	// to the desired state. Returns the same (reconcile.Result, error) contract as the
+	// rest of the controller's workflow.Status.ReconcileResult() calls.
 	ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error)
 
 	// BuildAppDBConnectionURL returns the MongoDB connection string OpsManager/BackupDaemon

--- a/controllers/operator/appdbreplicaset_reconciler.go
+++ b/controllers/operator/appdbreplicaset_reconciler.go
@@ -11,7 +11,7 @@ import (
 
 // AppDBReconciler is implemented by both the ReconcileAppDbReplicaSet (internal AppDB reconciler
 // backed by opsManager.Spec.AppDB) and the ReconcileExternalAppDBReplicaSet (backed by
-// opsManager.Spec.ExternalApplicationDatabaseRef).
+// opsManager.Spec.ExternalAppDBRef).
 type AppDBReconciler interface {
 	// ReconcileAppDB brings the AppDB (internal StatefulSet, or external CR reference)
 	// to the desired state. Returns the same (reconcile.Result, error) contract as the

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -315,7 +315,6 @@ type WatcherResource interface {
 }
 
 // SetupCommonWatchers is the common shared method for all controller to watch the following resources:
-//   - OM related cm and secret
 //   - TLS related secrets, if enabled, this includes x509 internal authentication secrets
 //
 // Note: everything is watched under the same namespace as the objectKey
@@ -1036,6 +1035,9 @@ func publishAutomationConfigFirst(ctx context.Context, getter kubernetesClient.C
 	}
 
 	databaseContainer := container.GetByName(util.DatabaseContainerName, currentSts.Spec.Template.Spec.Containers)
+	if databaseContainer == nil {
+		return false
+	}
 	volumeMounts := databaseContainer.VolumeMounts
 
 	if !mdb.Spec.Security.IsTLSEnabled() && wasTLSSecretMounted(ctx, getter, currentSts, mdb, log) {

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -1034,6 +1034,11 @@ func publishAutomationConfigFirst(ctx context.Context, getter kubernetesClient.C
 		return false
 	}
 
+	if currentSts.Annotations[util.AppDBMigrationReadyAnnotation] == trueString {
+		log.Debugf("Statefulset %s has the forward migration ready annotation set to true.", currentSts.Name)
+		return false
+	}
+
 	databaseContainer := container.GetByName(util.DatabaseContainerName, currentSts.Spec.Template.Spec.Containers)
 	if databaseContainer == nil {
 		return false

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -284,8 +284,7 @@ func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
 	// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
 	// fixed here.
 	if opsManager.IsInternalAppDB() {
-		opsManager.Spec.AppDB.GetCAConfigMapName()
-		return ""
+		return opsManager.Spec.AppDB.GetCAConfigMapName()
 	}
 
 	return ""

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -283,10 +283,12 @@ func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
 	// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
 	// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
 	// fixed here.
-	if opsManager.Spec.ExternalAppDBRef != nil {
+	if opsManager.IsInternalAppDB() {
+		opsManager.Spec.AppDB.GetCAConfigMapName()
 		return ""
 	}
-	return opsManager.Spec.AppDB.GetCAConfigMapName()
+
+	return ""
 }
 
 // getSharedOpsManagerOptions returns the options that are shared between both the OpsManager

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -279,6 +279,10 @@ func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secre
 // appDBTlsCAConfigMapName returns the AppDB CA ConfigMap name for internal AppDB mode,
 // or empty string when externalApplicationDatabaseRef is set (Spec.AppDB is nil).
 func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
+	// TODO(CLOUDP-TBD): AppDBTlsCAConfigMapName is computed from the internal AppDB spec
+	// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
+	// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
+	// fixed here.
 	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
 		return ""
 	}
@@ -289,13 +293,9 @@ func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
 // and BackupDaemon StatefulSets
 func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 	return OpsManagerStatefulSetOptions{
-		OwnerReference:      opsManager.OwnerReferenceForMemberCluster(),
-		OwnerName:           opsManager.Name,
-		HTTPSCertSecretName: opsManager.TLSCertificateSecretName(),
-		// TODO(CLOUDP-TBD): AppDBTlsCAConfigMapName is computed from the internal AppDB spec
-		// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
-		// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
-		// fixed here.
+		OwnerReference:          opsManager.OwnerReferenceForMemberCluster(),
+		OwnerName:               opsManager.Name,
+		HTTPSCertSecretName:     opsManager.TLSCertificateSecretName(),
 		AppDBTlsCAConfigMapName: appDBTlsCAConfigMapName(opsManager),
 		EnvVars:                 opsManagerConfigurationToEnvVars(opsManager),
 		Namespace:               opsManager.Namespace,

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -276,14 +276,27 @@ func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secre
 	return omSts, nil
 }
 
+// appDBTlsCAConfigMapName returns the AppDB CA ConfigMap name for internal AppDB mode,
+// or empty string when externalApplicationDatabaseRef is set (Spec.AppDB is nil).
+func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
+	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+		return ""
+	}
+	return opsManager.Spec.AppDB.GetCAConfigMapName()
+}
+
 // getSharedOpsManagerOptions returns the options that are shared between both the OpsManager
 // and BackupDaemon StatefulSets
 func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 	return OpsManagerStatefulSetOptions{
-		OwnerReference:          opsManager.OwnerReferenceForMemberCluster(),
-		OwnerName:               opsManager.Name,
-		HTTPSCertSecretName:     opsManager.TLSCertificateSecretName(),
-		AppDBTlsCAConfigMapName: opsManager.Spec.AppDB.GetCAConfigMapName(),
+		OwnerReference:      opsManager.OwnerReferenceForMemberCluster(),
+		OwnerName:           opsManager.Name,
+		HTTPSCertSecretName: opsManager.TLSCertificateSecretName(),
+		// TODO(CLOUDP-TBD): AppDBTlsCAConfigMapName is computed from the internal AppDB spec
+		// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
+		// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
+		// fixed here.
+		AppDBTlsCAConfigMapName: appDBTlsCAConfigMapName(opsManager),
 		EnvVars:                 opsManagerConfigurationToEnvVars(opsManager),
 		Namespace:               opsManager.Namespace,
 		Labels:                  opsManager.Labels,

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -283,7 +283,7 @@ func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
 	// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
 	// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
 	// fixed here.
-	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+	if opsManager.Spec.ExternalAppDBRef != nil {
 		return ""
 	}
 	return opsManager.Spec.AppDB.GetCAConfigMapName()

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -429,7 +429,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	appDbReconciler, appDBReconcilerErr := r.createAppDBReconcile(ctx, opsManager, log)
 	if appDBReconcilerErr != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", err)), log, opsManagerExtraStatusParams)
+		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", appDBReconcilerErr)), log, opsManagerExtraStatusParams)
 	}
 
 	result, err := appDbReconciler.ReconcileAppDB(ctx, opsManager)

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -485,7 +485,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
-		if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+		if opsManager.Spec.ExternalAppDBRef == nil {
 			for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
 				path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
 				vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
@@ -507,7 +507,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 }
 
 func (r *OpsManagerReconciler) createAppDBReconcile(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (AppDBReconciler, error) {
-	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+	if opsManager.Spec.ExternalAppDBRef != nil {
 		return r.createNewExternalAppDBReconciler(log), nil
 	}
 
@@ -924,7 +924,7 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
 	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
 	// Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not fixed here.
-	if reconcilerHelper.opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+	if reconcilerHelper.opsManager.Spec.ExternalAppDBRef == nil {
 		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
 			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 		}
@@ -986,10 +986,10 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
 	// The order matters here, since appDB and opsManager share the same reconcile ObjectKey being opsmanager crd
 	// That means we need to remove first, which SetupCommonWatchers or RemoveDependentWatchedResources does, then register additional watches
-	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+	if opsManager.Spec.ExternalAppDBRef != nil {
 		r.resourceWatcher.RemoveDependentWatchedResources(opsManager.ObjectKey())
 
-		r.resourceWatcher.AddWatchedResourceIfNotAdded(opsManager.Spec.ExternalApplicationDatabaseRef.Name, opsManager.Namespace, watch.MongoDB, kube.ObjectKeyFromApiObject(opsManager))
+		r.resourceWatcher.AddWatchedResourceIfNotAdded(opsManager.Spec.ExternalAppDBRef.Name, opsManager.Namespace, watch.MongoDB, kube.ObjectKeyFromApiObject(opsManager))
 	} else {
 		r.SetupCommonWatchers(opsManager.Spec.AppDB, nil, nil, opsManager.Spec.AppDB.GetName())
 	}
@@ -2072,7 +2072,7 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 		}
 	}
 
-	if opsManager.Spec.ExternalApplicationDatabaseRef == nil && opsManager.Spec.AppDB.IsMultiCluster() {
+	if opsManager.Spec.ExternalAppDBRef == nil && opsManager.Spec.AppDB.IsMultiCluster() {
 		appDbHelper, err := NewReadOnlyAppDBReconcilerHelper(ctx, opsManager, r.ReconcileCommonController, r.memberClustersMap, log)
 		if err != nil {
 			log.Errorf("Error initializing AppDB reconciler helper: %s", err)

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -427,8 +427,6 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	emptyResult := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
 	retryResult := reconcile.Result{RequeueAfter: time.Second}
 
-	r.configureWatchersForDynamicResources(ctx, opsManager, log)
-
 	appDbReconciler, appDBReconcilerErr := r.createAppDBReconcile(ctx, opsManager, log)
 	if appDBReconcilerErr != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", err)), log, opsManagerExtraStatusParams)

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -485,7 +485,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
-		if opsManager.Spec.ExternalAppDBRef == nil {
+		if opsManager.IsInternalAppDB() {
 			for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
 				path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
 				vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
@@ -507,11 +507,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 }
 
 func (r *OpsManagerReconciler) createAppDBReconcile(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (AppDBReconciler, error) {
-	if opsManager.Spec.ExternalAppDBRef != nil {
-		return r.createNewExternalAppDBReconciler(log), nil
+	if opsManager.IsInternalAppDB() {
+		return r.createNewAppDBReconciler(ctx, opsManager, log)
 	}
 
-	return r.createNewAppDBReconciler(ctx, opsManager, log)
+	return r.createNewExternalAppDBReconciler(log), nil
 }
 
 // ensureSharedGlobalResources ensures that resources that are shared across watched namespaces (e.g. secrets) are in sync
@@ -924,7 +924,7 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
 	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
 	// Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not fixed here.
-	if reconcilerHelper.opsManager.Spec.ExternalAppDBRef == nil {
+	if reconcilerHelper.opsManager.IsInternalAppDB() {
 		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
 			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 		}
@@ -986,12 +986,12 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
 	// The order matters here, since appDB and opsManager share the same reconcile ObjectKey being opsmanager crd
 	// That means we need to remove first, which SetupCommonWatchers or RemoveDependentWatchedResources does, then register additional watches
-	if opsManager.Spec.ExternalAppDBRef != nil {
+	if opsManager.IsInternalAppDB() {
+		r.SetupCommonWatchers(opsManager.Spec.AppDB, nil, nil, opsManager.Spec.AppDB.GetName())
+	} else {
 		r.resourceWatcher.RemoveDependentWatchedResources(opsManager.ObjectKey())
 
 		r.resourceWatcher.AddWatchedResourceIfNotAdded(opsManager.Spec.ExternalAppDBRef.Name, opsManager.Namespace, watch.MongoDB, kube.ObjectKeyFromApiObject(opsManager))
-	} else {
-		r.SetupCommonWatchers(opsManager.Spec.AppDB, nil, nil, opsManager.Spec.AppDB.GetName())
 	}
 
 	if opsManager.IsTLSEnabled() {
@@ -2072,7 +2072,7 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 		}
 	}
 
-	if opsManager.Spec.ExternalAppDBRef == nil && opsManager.Spec.AppDB.IsMultiCluster() {
+	if opsManager.IsInternalAppDB() && opsManager.Spec.AppDB.IsMultiCluster() {
 		appDbHelper, err := NewReadOnlyAppDBReconcilerHelper(ctx, opsManager, r.ReconcileCommonController, r.memberClustersMap, log)
 		if err != nil {
 			log.Errorf("Error initializing AppDB reconciler helper: %s", err)

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -421,14 +421,16 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring shared global resources %w", err)), log, opsManagerExtraStatusParams)
 	}
 
+	r.configureWatchersForDynamicResources(ctx, opsManager, log)
+
 	// 1. Reconcile AppDB
 	emptyResult := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
 	retryResult := reconcile.Result{RequeueAfter: time.Second}
 
 	r.configureWatchersForDynamicResources(ctx, opsManager, log)
 
-	appDbReconciler, err := r.createNewAppDBReconciler(ctx, opsManager, log)
-	if err != nil {
+	appDbReconciler, appDBReconcilerErr := r.createAppDBReconcile(ctx, opsManager, log)
+	if appDBReconcilerErr != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", err)), log, opsManagerExtraStatusParams)
 	}
 
@@ -485,9 +487,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
-		for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
-			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+		if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+			for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
+				path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
+				vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+			}
 		}
 
 		for k, val := range vaultMap {
@@ -502,6 +506,14 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	log.Info("Finished reconciliation for MongoDbOpsManager!")
 	// success
 	return workflow.OK().ReconcileResult()
+}
+
+func (r *OpsManagerReconciler) createAppDBReconcile(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (AppDBReconciler, error) {
+	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+		return r.createNewExternalAppDBReconciler(log), nil
+	}
+
+	return r.createNewAppDBReconciler(ctx, opsManager, log)
 }
 
 // ensureSharedGlobalResources ensures that resources that are shared across watched namespaces (e.g. secrets) are in sync
@@ -911,11 +923,17 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
-		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
-	}
-	if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
-		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
+	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
+	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
+	if reconcilerHelper.opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
+			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
+		}
+		// TODO(CLOUDP-TBD): same deferred TLS/CA parity gap — GetCAConfigMapName() is computed from
+		// the internal AppDB spec even in external-AppDB mode.
+		if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
+			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
+		}
 	}
 
 	// override the versions directory (defaults to "/opt/mongodb/mms/mongodb-releases/")
@@ -969,8 +987,13 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 }
 
 func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
-	appDBReplicaSet := opsManager.Spec.AppDB
-	r.SetupCommonWatchers(appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
+	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+		r.resourceWatcher.RemoveDependentWatchedResources(opsManager.ObjectKey())
+
+		r.resourceWatcher.AddWatchedResourceIfNotAdded(opsManager.Spec.ExternalApplicationDatabaseRef.Name, opsManager.Namespace, watch.MongoDB, kube.ObjectKeyFromApiObject(opsManager))
+	} else {
+		r.SetupCommonWatchers(opsManager.Spec.AppDB, nil, nil, opsManager.Spec.AppDB.GetName())
+	}
 
 	if opsManager.IsTLSEnabled() {
 		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
@@ -2047,12 +2070,13 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 		}
 	}
 
-	if opsManager.Spec.AppDB.IsMultiCluster() {
+	if opsManager.Spec.ExternalApplicationDatabaseRef == nil && opsManager.Spec.AppDB.IsMultiCluster() {
 		appDbHelper, err := NewReadOnlyAppDBReconcilerHelper(ctx, opsManager, r.ReconcileCommonController, r.memberClustersMap, log)
 		if err != nil {
 			log.Errorf("Error initializing AppDB reconciler helper: %s", err)
 			return
 		}
+
 		for _, memberCluster := range appDbHelper.GetHealthyMemberClusters() {
 			if err := r.deleteClusterResources(ctx, memberCluster.Client, memberCluster.Name, opsManager, log); err != nil {
 				log.Warnf("Failed to delete dependant AppDB resources in cluster %s: %s", memberCluster.Name, err.Error())

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -923,12 +923,11 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 
 	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
 	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
+	// Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not fixed here.
 	if reconcilerHelper.opsManager.Spec.ExternalApplicationDatabaseRef == nil {
 		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
 			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 		}
-		// TODO(CLOUDP-TBD): same deferred TLS/CA parity gap — GetCAConfigMapName() is computed from
-		// the internal AppDB spec even in external-AppDB mode.
 		if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
 			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 		}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -421,14 +421,16 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring shared global resources %w", err)), log, opsManagerExtraStatusParams)
 	}
 
+	r.configureWatchersForDynamicResources(ctx, opsManager, log)
+
 	// 1. Reconcile AppDB
 	emptyResult := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
 	retryResult := reconcile.Result{RequeueAfter: time.Second}
 
 	r.configureWatchersForDynamicResources(ctx, opsManager, log)
 
-	appDbReconciler, err := r.createNewAppDBReconciler(ctx, opsManager, log)
-	if err != nil {
+	appDbReconciler, appDBReconcilerErr := r.createAppDBReconcile(ctx, opsManager, log)
+	if appDBReconcilerErr != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", err)), log, opsManagerExtraStatusParams)
 	}
 
@@ -485,9 +487,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
-		for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
-			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+		if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+			for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
+				path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
+				vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+			}
 		}
 
 		for k, val := range vaultMap {
@@ -502,6 +506,14 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	log.Info("Finished reconciliation for MongoDbOpsManager!")
 	// success
 	return workflow.OK().ReconcileResult()
+}
+
+func (r *OpsManagerReconciler) createAppDBReconcile(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (AppDBReconciler, error) {
+	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+		return r.createNewExternalAppDBReconciler(log), nil
+	}
+
+	return r.createNewAppDBReconciler(ctx, opsManager, log)
 }
 
 // ensureSharedGlobalResources ensures that resources that are shared across watched namespaces (e.g. secrets) are in sync
@@ -911,11 +923,17 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
-		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
-	}
-	if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
-		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
+	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
+	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
+	if reconcilerHelper.opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
+			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
+		}
+		// TODO(CLOUDP-TBD): same deferred TLS/CA parity gap — GetCAConfigMapName() is computed from
+		// the internal AppDB spec even in external-AppDB mode.
+		if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
+			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
+		}
 	}
 
 	// override the versions directory (defaults to "/opt/mongodb/mms/mongodb-releases/")
@@ -970,9 +988,14 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 
 func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
 	// The order matters here, since appDB and opsManager share the same reconcile ObjectKey being opsmanager crd
-	// That means we need to remove first, which SetupCommonWatchers does, then register additional watches
-	appDBReplicaSet := opsManager.Spec.AppDB
-	r.SetupCommonWatchers(appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
+	// That means we need to remove first, which SetupCommonWatchers or RemoveDependentWatchedResources does, then register additional watches
+	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
+		r.resourceWatcher.RemoveDependentWatchedResources(opsManager.ObjectKey())
+
+		r.resourceWatcher.AddWatchedResourceIfNotAdded(opsManager.Spec.ExternalApplicationDatabaseRef.Name, opsManager.Namespace, watch.MongoDB, kube.ObjectKeyFromApiObject(opsManager))
+	} else {
+		r.SetupCommonWatchers(opsManager.Spec.AppDB, nil, nil, opsManager.Spec.AppDB.GetName())
+	}
 
 	if opsManager.IsTLSEnabled() {
 		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
@@ -2052,12 +2075,13 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 		}
 	}
 
-	if opsManager.Spec.AppDB.IsMultiCluster() {
+	if opsManager.Spec.ExternalApplicationDatabaseRef == nil && opsManager.Spec.AppDB.IsMultiCluster() {
 		appDbHelper, err := NewReadOnlyAppDBReconcilerHelper(ctx, opsManager, r.ReconcileCommonController, r.memberClustersMap, log)
 		if err != nil {
 			log.Errorf("Error initializing AppDB reconciler helper: %s", err)
 			return
 		}
+
 		for _, memberCluster := range appDbHelper.GetHealthyMemberClusters() {
 			if err := r.deleteClusterResources(ctx, memberCluster.Client, memberCluster.Name, opsManager, log); err != nil {
 				log.Warnf("Failed to delete dependant AppDB resources in cluster %s: %s", memberCluster.Name, err.Error())

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -1416,6 +1416,9 @@ func addAppDBTLSResources(ctx context.Context, client client.Client, secretName 
 }
 
 func withExternalAppDBRef(om *omv1.MongoDBOpsManager, ref *omv1.ExternalApplicationDatabaseRef) *omv1.MongoDBOpsManager {
+	if ref.Namespace == "" {
+		ref.Namespace = om.Namespace
+	}
 	om.Spec.ExternalApplicationDatabaseRef = ref
 	return om
 }

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -1415,11 +1415,11 @@ func addAppDBTLSResources(ctx context.Context, client client.Client, secretName 
 	_ = client.Create(ctx, certSecret)
 }
 
-func withExternalAppDBRef(om *omv1.MongoDBOpsManager, ref *omv1.ExternalApplicationDatabaseRef) *omv1.MongoDBOpsManager {
+func withExternalAppDBRef(om *omv1.MongoDBOpsManager, ref *omv1.ExternalAppDBRef) *omv1.MongoDBOpsManager {
 	if ref.Namespace == "" {
 		ref.Namespace = om.Namespace
 	}
-	om.Spec.ExternalApplicationDatabaseRef = ref
+	om.Spec.ExternalAppDBRef = ref
 	return om
 }
 
@@ -1433,7 +1433,7 @@ func TestOpsManagerReconcile_ExternalAppDBRef_SkipsInternalAppDBReconciliation(t
 		Build()
 	externalAppDB.Spec.Role = mdbv1.RoleAppDB
 
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 		Name: "test-om-db",
 		Kind: "MongoDB",
 	})
@@ -1456,7 +1456,7 @@ func TestOpsManagerReconcile_NoExternalAppDBRef_StillReconcilesInternalAppDB(t *
 		AddOplogStoreConfig("oplog-store-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).
 		AddBlockStoreConfig("block-store-config-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).
 		Build()
-	require.Nil(t, testOm.Spec.ExternalApplicationDatabaseRef)
+	require.Nil(t, testOm.Spec.ExternalAppDBRef)
 
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
 	reconciler, client, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
@@ -1472,7 +1472,7 @@ func TestOpsManagerReconcile_NoExternalAppDBRef_StillReconcilesInternalAppDB(t *
 func TestOpsManagerReconcile_InvalidExternalAppDBRef_FailsReconcile(t *testing.T) {
 	ctx := context.Background()
 
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 		Name: "wrong-name",
 		Kind: "MongoDB",
 	})
@@ -1503,7 +1503,7 @@ func TestReconcile_ExternalAppDBRef_NeverCreatesInternalPasswordSecret(t *testin
 		Build()
 	externalAppDB.Spec.Role = mdbv1.RoleAppDB
 
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 		Name: "test-om-db",
 		Kind: "MongoDB",
 	})

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -18,6 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
@@ -1412,6 +1413,121 @@ func addAppDBTLSResources(ctx context.Context, client client.Client, secretName 
 
 	certSecret.Data = certs
 	_ = client.Create(ctx, certSecret)
+}
+
+func withExternalAppDBRef(om *omv1.MongoDBOpsManager, ref *omv1.ExternalApplicationDatabaseRef) *omv1.MongoDBOpsManager {
+	om.Spec.ExternalApplicationDatabaseRef = ref
+	return om
+}
+
+func TestOpsManagerReconcile_ExternalAppDBRef_SkipsInternalAppDBReconciliation(t *testing.T) {
+	ctx := context.Background()
+
+	externalAppDB := mdbv1.NewReplicaSetBuilder().
+		SetName("test-om-db").
+		SetNamespace(mock.TestNamespace).
+		SetVersion("6.0.0").
+		Build()
+	externalAppDB.Spec.Role = mdbv1.RoleAppDB
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+		Name: "test-om-db",
+		Kind: "MongoDB",
+	})
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
+
+	_, err := reconciler.Reconcile(ctx, requestFromObject(testOm))
+	require.NoError(t, err)
+
+	appDBSts := appsv1.StatefulSet{}
+	err = kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.Spec.AppDB.Name()), &appDBSts)
+	assert.True(t, apiErrors.IsNotFound(err), "expected internal AppDB StatefulSet to not be created, got err=%v", err)
+}
+
+func TestOpsManagerReconcile_NoExternalAppDBRef_StillReconcilesInternalAppDB(t *testing.T) {
+	ctx := context.Background()
+	testOm := DefaultOpsManagerBuilder().
+		AddOplogStoreConfig("oplog-store-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).
+		AddBlockStoreConfig("block-store-config-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).
+		Build()
+	require.Nil(t, testOm.Spec.ExternalApplicationDatabaseRef)
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, client, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	configureBackupResources(ctx, client, testOm)
+
+	checkOMReconciliationSuccessful(ctx, t, reconciler, testOm, reconciler.client)
+
+	appDBSts := appsv1.StatefulSet{}
+	err := client.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.Spec.AppDB.Name()), &appDBSts)
+	require.NoError(t, err, "internal AppDB StatefulSet should still be created when externalApplicationDatabaseRef is not set")
+}
+
+func TestOpsManagerReconcile_InvalidExternalAppDBRef_FailsReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+		Name: "wrong-name",
+		Kind: "MongoDB",
+	})
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+
+	res, err := reconciler.Reconcile(ctx, requestFromObject(testOm))
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKeyFromApiObject(testOm), testOm))
+	assert.Equal(t, status.PhaseFailed, testOm.GetPhase())
+
+	appDBSts := appsv1.StatefulSet{}
+	err = kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.Spec.AppDB.Name()), &appDBSts)
+	assert.True(t, apiErrors.IsNotFound(err), "expected internal AppDB StatefulSet to not be created when validation fails")
+}
+
+func TestReconcile_ExternalAppDBRef_NeverCreatesInternalPasswordSecret(t *testing.T) {
+	ctx := context.Background()
+
+	externalAppDB := mdbv1.NewReplicaSetBuilder().
+		SetName("test-om-db").
+		SetNamespace(mock.TestNamespace).
+		SetVersion("6.0.0").
+		SetMembers(3).
+		Build()
+	externalAppDB.Spec.Role = mdbv1.RoleAppDB
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+		Name: "test-om-db",
+		Kind: "MongoDB",
+	})
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
+	require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
+		SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
+		SetNamespace(testOm.Namespace).
+		SetField(util.OpsManagerPasswordKey, "test-password").
+		Build()))
+
+	_, _ = reconciler.Reconcile(ctx, requestFromObject(testOm))
+
+	// the shared password secret ("test-om-db-om-password") is the same secret
+	// GetOpsManagerUserPasswordSecretName() would compute for internal AppDB, since
+	// externalApplicationDatabaseRef.Name is required to equal AppDBSpec.Name(). If
+	// ensureAppDbPassword had run unconditionally, it would either overwrite this
+	// value or fail to find automation-config resources it expects — asserting the
+	// pre-seeded password is unchanged proves that internal path never ran.
+	assert.Equal(t, testOm.Spec.AppDB.GetOpsManagerUserPasswordSecretName(), omv1.OpsManagerUserPasswordSecretName("test-om-db"),
+		"test assumption: internal and shared password secret names must coincide")
+
+	result := corev1.Secret{}
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, omv1.OpsManagerUserPasswordSecretName("test-om-db")), &result))
+	assert.Equal(t, "test-password", string(result.Data[util.OpsManagerPasswordKey]))
 }
 
 func addOMTLSResources(ctx context.Context, client client.Client, secretName string) {

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
@@ -25,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 	rolev1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/role"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
 	mdbstatus "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
@@ -34,6 +36,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/om/host"
 	"github.com/mongodb/mongodb-kubernetes/controllers/om/replicaset"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/agents"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/certs"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/connection"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/construct"
@@ -50,10 +53,13 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/annotations"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/configmap"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/generate"
 	util_int "github.com/mongodb/mongodb-kubernetes/pkg/util/int"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
@@ -109,7 +115,7 @@ func (r *ReconcileMongoDbReplicaSet) newReconcilerHelper(
 		log:        log,
 	}
 
-	if err := helper.initialize(ctx); err != nil {
+	if err := helper.initialize(); err != nil {
 		return nil, err
 	}
 
@@ -162,7 +168,7 @@ func (r *ReplicaSetReconcilerHelper) getVaultAnnotations() map[string]string {
 	return vaultMap
 }
 
-func (r *ReplicaSetReconcilerHelper) initialize(ctx context.Context) error {
+func (r *ReplicaSetReconcilerHelper) initialize() error {
 	state, err := r.readState()
 	if err != nil {
 		return xerrors.Errorf("failed to initialize replica set state: %w", err)
@@ -211,6 +217,17 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 
 	if status := ensureSupportedOpsManagerVersion(conn); status.Phase() != mdbstatus.PhaseRunning {
 		return r.updateStatus(ctx, status)
+	}
+
+	if rs.Spec.Role == mdbv1.RoleAppDB {
+		appDBStatefulSetOwnershipStatus := r.ensureAppDBStatefulSetOwnership(ctx, rs)
+		if !appDBStatefulSetOwnershipStatus.IsOK() {
+			return r.updateStatus(ctx, appDBStatefulSetOwnershipStatus)
+		}
+
+		if err := r.claimAppDBRoleSecrets(ctx, rs); err != nil {
+			return r.updateStatus(ctx, workflow.Failed(err))
+		}
 	}
 
 	reconciler.SetupCommonWatchers(rs, nil, nil, rs.Name)
@@ -719,6 +736,15 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 		return workflow.Failed(err)
 	}
 
+	if rs.Spec.Role == mdbv1.RoleAppDB {
+		if err := r.ensureAppDBRoleUser(ctx, rs, conn); err != nil {
+			return workflow.Failed(err)
+		}
+		if err := r.ensureAppDBRoleKeyfile(ctx, rs, conn); err != nil {
+			return workflow.Failed(err)
+		}
+	}
+
 	if err := om.WaitForReadyState(conn, processNames, isRecovering, log); err != nil {
 		return workflow.Failed(err)
 	}
@@ -747,11 +773,230 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 	return workflow.OK()
 }
 
+// ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
+//   - absent: nothing to detach - Fresh Start, the MongoDB reconciler creates its own StatefulSet
+//   - if util.AppDBMigrationReadyAnnotation is present - Forward Migration, reclaim the AppDB Statefulset
+//   - if util.AppDBReverseMigrationReadyAnnotation is present - Reverse Migration,
+//     release the AppDB Statefulset, so the Ops Manager can reclaim it
+//   - foreign-owned: block reconciliation until the ownership is resolved
+func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context.Context, mdb *mdbv1.MongoDB) workflow.Status {
+	sts := appsv1.StatefulSet{}
+	if err := r.reconciler.client.Get(ctx, kube.ObjectKey(mdb.Namespace, mdb.Name), &sts); err != nil {
+		if errors.IsNotFound(err) {
+			return workflow.OK() // No existing StatefulSet, nothing to detach - Fresh Start
+		}
+		return workflow.Failed(xerrors.Errorf("failed to fetch StatefulSet during ownership check: %w", err))
+	}
+
+	ownedByThisMongoDB := slices.ContainsFunc(sts.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.UID == mdb.UID
+	})
+
+	// Forward Migration, reclaim the AppDB Statefulset
+	if sts.Annotations[util.AppDBMigrationReadyAnnotation] == trueString {
+		if len(sts.OwnerReferences) == 0 || ownedByThisMongoDB {
+			if err := r.reclaimAppDBStatefulsetOwnership(ctx, mdb, sts); err != nil {
+				return workflow.Failed(err)
+			}
+
+			return workflow.OK()
+		}
+
+		return workflow.Failed(xerrors.New("Cannot take ownership of the AppDB Statefulset: it has other owner"))
+	}
+
+	// Reverse Migration, release the AppDB Statefulset
+	if sts.Annotations[util.AppDBReverseMigrationReadyAnnotation] == trueString {
+		if ownedByThisMongoDB {
+			if err := r.releaseAppDBStatefulsetOwnership(ctx, sts); err != nil {
+				return workflow.Failed(err)
+			}
+		}
+		return workflow.Pending("This AppDB resource is under Reverse Migration to Ops Manager CR")
+	}
+
+	if !ownedByThisMongoDB {
+		return workflow.Pending("Cannot take ownership of the AppDB Statefulset: Configure spec.externalApplicationDatabaseRef under Ops Manager CR or delete this resource")
+	}
+
+	return workflow.OK()
+}
+
+func (r *ReplicaSetReconcilerHelper) reclaimAppDBStatefulsetOwnership(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) error {
+	sts.OwnerReferences = kube.BaseOwnerReference(mdb)
+	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
+	delete(sts.Annotations, util.AppDBMigrationReadyAnnotation)
+	if err := r.reconciler.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to reclaim StatefulSet %s: %w", sts.GetName(), err)
+	}
+
+	return nil
+}
+
+func (r *ReplicaSetReconcilerHelper) releaseAppDBStatefulsetOwnership(ctx context.Context, sts appsv1.StatefulSet) error {
+	sts.OwnerReferences = nil
+	if err := r.reconciler.client.Update(ctx, &sts); err != nil {
+		return xerrors.Errorf("failed to strip OwnerReferences from StatefulSet %s: %w", sts.GetName(), err)
+	}
+
+	return nil
+}
+
+// ensureAppDBRoleUser creates the shared mongodb-ops-manager user in the AppDB CR's project,
+// matching the internal AppDB reconciler's password secret shape. The secret name is derived
+// from the CR's own name (required by the naming convention to equal <om-name>-db).
+func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, mdb *mdbv1.MongoDB, conn om.Connection) error {
+	if mdb.Spec.Role != mdbv1.RoleAppDB {
+		return nil
+	}
+
+	secretName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
+	secretObjectKey := kube.ObjectKey(mdb.Namespace, secretName)
+
+	existingData, err := secret.ReadStringData(ctx, r.reconciler.SecretClient, secretObjectKey)
+	if err != nil && !secret.SecretNotExist(err) {
+		return xerrors.Errorf("failed to check for existing password secret: %w", err)
+	}
+
+	password := existingData[util.OpsManagerPasswordKey]
+	if password != "" {
+	} else {
+		password, err = generate.RandomFixedLengthStringOfSize(20)
+		if err != nil {
+			return xerrors.Errorf("failed to generate password: %w", err)
+		}
+
+		newSecret := secret.Builder().
+			SetName(secretName).
+			SetNamespace(mdb.Namespace).
+			SetField(util.OpsManagerPasswordKey, password).
+			SetOwnerReferences(kube.BaseOwnerReference(mdb)).
+			Build()
+
+		if err := r.reconciler.CreateSecret(ctx, newSecret); err != nil {
+			return xerrors.Errorf("failed to create password secret: %w", err)
+		}
+	}
+
+	// Inject the mongodb-ops-manager user into OM's automation config via read-modify-write.
+	return conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
+		omUser := om.MongoDBUser{
+			Username:                   util.OpsManagerMongoDBUserName,
+			Database:                   util.DefaultUserDatabase,
+			Roles:                      []*om.Role{},
+			AuthenticationRestrictions: []string{},
+			Mechanisms:                 []string{},
+		}
+		for _, role := range []string{"readWriteAnyDatabase", "dbAdminAnyDatabase", "clusterMonitor", "backup", "restore", "hostManager"} {
+			omUser.AddRole(&om.Role{Role: role, Database: "admin"})
+		}
+		if err := authentication.ConfigureScramCredentials(&omUser, password, ac); err != nil {
+			return xerrors.Errorf("error generating SCRAM credentials for %s: %w", util.OpsManagerMongoDBUserName, err)
+		}
+		ac.Auth.EnsureUser(omUser)
+		return nil
+	}, r.log)
+}
+
+// ensureAppDBRoleKeyfile keeps the AppDB project's cluster keyfile in sync with the shared
+// "<name>-keyfile" secret so migrations don't mix keyfile generations. The CR's project must
+// be dedicated to this AppDB — co-hosted deployments would be rolled by the key change.
+// The user is responsible for cleaning up the project after migration.
+func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context, mdb *mdbv1.MongoDB, conn om.Connection) error {
+	if mdb.Spec.Role != mdbv1.RoleAppDB {
+		return nil
+	}
+
+	secretName := fmt.Sprintf("%s-keyfile", mdb.Name)
+	secretObjectKey := kube.ObjectKey(mdb.Namespace, secretName)
+
+	existingData, err := secret.ReadStringData(ctx, r.reconciler.SecretClient, secretObjectKey)
+	if err != nil && !secret.SecretNotExist(err) {
+		return xerrors.Errorf("failed to check for existing keyfile secret: %w", err)
+	}
+	sharedKey := existingData[constants.AgentKeyfileKey]
+
+	var projectKey string
+	if err := conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
+		if sharedKey != "" {
+			ac.Auth.Key = sharedKey
+			return nil
+		}
+		if err := ac.EnsureKeyFileContents(); err != nil {
+			return xerrors.Errorf("failed to ensure keyfile contents: %w", err)
+		}
+		projectKey = ac.Auth.Key
+		return nil
+	}, r.log); err != nil {
+		return err
+	}
+
+	if sharedKey == "" {
+		newSecret := secret.Builder().
+			SetName(secretName).
+			SetNamespace(mdb.Namespace).
+			SetField(constants.AgentKeyfileKey, projectKey).
+			SetOwnerReferences(kube.BaseOwnerReference(mdb)).
+			Build()
+		if err := r.reconciler.CreateSecret(ctx, newSecret); err != nil {
+			return xerrors.Errorf("failed to create keyfile secret: %w", err)
+		}
+	}
+	return nil
+}
+
+// claimAppDBRoleSecrets claims ownership of the shared user and keyfile secrets for an AppDB-role CR.
+// It tolerates secrets that don't exist yet (they will be created by ensureAppDBRoleUser/Keyfile later).
+func (r *ReplicaSetReconcilerHelper) claimAppDBRoleSecrets(ctx context.Context, mdb *mdbv1.MongoDB) error {
+	if mdb.Spec.Role != mdbv1.RoleAppDB {
+		return nil
+	}
+
+	passwordSecretName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
+	keyfileSecretName := fmt.Sprintf("%s-keyfile", mdb.Name)
+
+	for _, name := range []string{passwordSecretName, keyfileSecretName} {
+		s := corev1.Secret{}
+		if err := r.reconciler.client.Get(ctx, kube.ObjectKey(mdb.Namespace, name), &s); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return xerrors.Errorf("failed to fetch secret %s: %w", name, err)
+		}
+		if err := r.claimSecretForCR(ctx, mdb, name); err != nil {
+			return xerrors.Errorf("failed to claim secret %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// claimSecretForCR sets this CR's OwnerReference on a shared handover secret it did not create.
+func (r *ReplicaSetReconcilerHelper) claimSecretForCR(ctx context.Context, mdb *mdbv1.MongoDB, name string) error {
+	s := corev1.Secret{}
+	if err := r.reconciler.client.Get(ctx, kube.ObjectKey(mdb.Namespace, name), &s); err != nil {
+		return xerrors.Errorf("failed to fetch secret %s while claiming ownership: %w", name, err)
+	}
+	for _, ref := range s.OwnerReferences {
+		if ref.UID == mdb.UID {
+			return nil
+		}
+	}
+	s.OwnerReferences = kube.BaseOwnerReference(mdb)
+	if err := r.reconciler.client.Update(ctx, &s); err != nil {
+		return xerrors.Errorf("failed to claim secret %s: %w", name, err)
+	}
+	return nil
+}
+
 func (r *ReplicaSetReconcilerHelper) OnDelete(ctx context.Context, obj runtime.Object, log *zap.SugaredLogger) error {
 	rs := obj.(*mdbv1.MongoDB)
 
-	if err := r.cleanOpsManagerState(ctx, rs, log); err != nil {
-		return err
+	// AppDB-role CR deletion is a reverse-migration handover, not a deprovision: the project
+	// is left stale and the user is responsible for cleaning it up after migration.
+	if rs.Spec.Role != mdbv1.RoleAppDB {
+		if err := r.cleanOpsManagerState(ctx, rs, log); err != nil {
+			return err
+		}
 	}
 
 	r.reconciler.resourceWatcher.RemoveDependentWatchedResources(rs.ObjectKey())

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -845,9 +845,6 @@ func (r *ReplicaSetReconcilerHelper) releaseAppDBStatefulsetOwnership(ctx contex
 	return nil
 }
 
-// ensureAppDBRoleUser creates the shared mongodb-ops-manager user in the AppDB CR's project,
-// matching the internal AppDB reconciler's password secret shape. The secret name is derived
-// from the CR's own name (required by the naming convention to equal <om-name>-db).
 func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, mdb *mdbv1.MongoDB, conn om.Connection) error {
 	if mdb.Spec.Role != mdbv1.RoleAppDB {
 		return nil
@@ -856,14 +853,11 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, md
 	secretName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
 	secretObjectKey := kube.ObjectKey(mdb.Namespace, secretName)
 
-	existingData, err := secret.ReadStringData(ctx, r.reconciler.SecretClient, secretObjectKey)
+	password, err := secret.ReadKey(ctx, r.reconciler.SecretClient, util.OpsManagerPasswordKey, secretObjectKey)
 	if err != nil && !secret.SecretNotExist(err) {
-		return xerrors.Errorf("failed to check for existing password secret: %w", err)
+		return xerrors.Errorf("failed to read password secret %s: %w", secretName, err)
 	}
-
-	password := existingData[util.OpsManagerPasswordKey]
-	if password != "" {
-	} else {
+	if password == "" {
 		password, err = generate.RandomFixedLengthStringOfSize(20)
 		if err != nil {
 			return xerrors.Errorf("failed to generate password: %w", err)
@@ -876,8 +870,8 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, md
 			SetOwnerReferences(kube.BaseOwnerReference(mdb)).
 			Build()
 
-		if err := r.reconciler.CreateSecret(ctx, newSecret); err != nil {
-			return xerrors.Errorf("failed to create password secret: %w", err)
+		if err := secret.CreateOrUpdate(ctx, r.reconciler.SecretClient, newSecret); err != nil {
+			return xerrors.Errorf("failed to create/update password secret: %w", err)
 		}
 	}
 
@@ -890,8 +884,8 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, md
 			AuthenticationRestrictions: []string{},
 			Mechanisms:                 []string{},
 		}
-		for _, role := range []string{"readWriteAnyDatabase", "dbAdminAnyDatabase", "clusterMonitor", "backup", "restore", "hostManager"} {
-			omUser.AddRole(&om.Role{Role: role, Database: "admin"})
+		for _, r := range omv1.AppDBUserRoles {
+			omUser.AddRole(&om.Role{Role: r.Name, Database: r.Database})
 		}
 		if err := authentication.ConfigureScramCredentials(&omUser, password, ac); err != nil {
 			return xerrors.Errorf("error generating SCRAM credentials for %s: %w", util.OpsManagerMongoDBUserName, err)
@@ -901,10 +895,6 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, md
 	}, r.log)
 }
 
-// ensureAppDBRoleKeyfile keeps the AppDB project's cluster keyfile in sync with the shared
-// "<name>-keyfile" secret so migrations don't mix keyfile generations. The CR's project must
-// be dedicated to this AppDB — co-hosted deployments would be rolled by the key change.
-// The user is responsible for cleaning up the project after migration.
 func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context, mdb *mdbv1.MongoDB, conn om.Connection) error {
 	if mdb.Spec.Role != mdbv1.RoleAppDB {
 		return nil
@@ -913,11 +903,10 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context,
 	secretName := fmt.Sprintf("%s-keyfile", mdb.Name)
 	secretObjectKey := kube.ObjectKey(mdb.Namespace, secretName)
 
-	existingData, err := secret.ReadStringData(ctx, r.reconciler.SecretClient, secretObjectKey)
+	sharedKey, err := secret.ReadKey(ctx, r.reconciler.SecretClient, constants.AgentKeyfileKey, secretObjectKey)
 	if err != nil && !secret.SecretNotExist(err) {
-		return xerrors.Errorf("failed to check for existing keyfile secret: %w", err)
+		return xerrors.Errorf("failed to read keyfile secret %s: %w", secretName, err)
 	}
-	sharedKey := existingData[constants.AgentKeyfileKey]
 
 	var projectKey string
 	if err := conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
@@ -941,8 +930,8 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context,
 			SetField(constants.AgentKeyfileKey, projectKey).
 			SetOwnerReferences(kube.BaseOwnerReference(mdb)).
 			Build()
-		if err := r.reconciler.CreateSecret(ctx, newSecret); err != nil {
-			return xerrors.Errorf("failed to create keyfile secret: %w", err)
+		if err := secret.CreateOrUpdate(ctx, r.reconciler.SecretClient, newSecret); err != nil {
+			return xerrors.Errorf("failed to create/update keyfile secret: %w", err)
 		}
 	}
 	return nil

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -948,13 +948,6 @@ func (r *ReplicaSetReconcilerHelper) claimAppDBRoleSecrets(ctx context.Context, 
 	keyfileSecretName := fmt.Sprintf("%s-keyfile", mdb.Name)
 
 	for _, name := range []string{passwordSecretName, keyfileSecretName} {
-		s := corev1.Secret{}
-		if err := r.reconciler.client.Get(ctx, kube.ObjectKey(mdb.Namespace, name), &s); err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
-			return xerrors.Errorf("failed to fetch secret %s: %w", name, err)
-		}
 		if err := r.claimSecretForCR(ctx, mdb, name); err != nil {
 			return xerrors.Errorf("failed to claim secret %s: %w", name, err)
 		}
@@ -966,6 +959,9 @@ func (r *ReplicaSetReconcilerHelper) claimAppDBRoleSecrets(ctx context.Context, 
 func (r *ReplicaSetReconcilerHelper) claimSecretForCR(ctx context.Context, mdb *mdbv1.MongoDB, name string) error {
 	s := corev1.Secret{}
 	if err := r.reconciler.client.Get(ctx, kube.ObjectKey(mdb.Namespace, name), &s); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return xerrors.Errorf("failed to fetch secret %s while claiming ownership: %w", name, err)
 	}
 	for _, ref := range s.OwnerReferences {

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -219,7 +219,7 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 		return r.updateStatus(ctx, status)
 	}
 
-	if rs.Spec.Role == mdbv1.RoleAppDB {
+	if rs.IsRoleAppDB() {
 		appDBStatefulSetOwnershipStatus := r.ensureAppDBStatefulSetOwnership(ctx, rs)
 		if !appDBStatefulSetOwnershipStatus.IsOK() {
 			return r.updateStatus(ctx, appDBStatefulSetOwnershipStatus)
@@ -736,7 +736,7 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 		return workflow.Failed(err)
 	}
 
-	if rs.Spec.Role == mdbv1.RoleAppDB {
+	if rs.IsRoleAppDB() {
 		if err := r.ensureAppDBRoleUser(ctx, rs, conn); err != nil {
 			return workflow.Failed(err)
 		}
@@ -846,10 +846,6 @@ func (r *ReplicaSetReconcilerHelper) releaseAppDBStatefulsetOwnership(ctx contex
 }
 
 func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, mdb *mdbv1.MongoDB, conn om.Connection) error {
-	if mdb.Spec.Role != mdbv1.RoleAppDB {
-		return nil
-	}
-
 	secretName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
 	secretObjectKey := kube.ObjectKey(mdb.Namespace, secretName)
 
@@ -896,10 +892,6 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleUser(ctx context.Context, md
 }
 
 func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context, mdb *mdbv1.MongoDB, conn om.Connection) error {
-	if mdb.Spec.Role != mdbv1.RoleAppDB {
-		return nil
-	}
-
 	secretName := fmt.Sprintf("%s-keyfile", mdb.Name)
 	secretObjectKey := kube.ObjectKey(mdb.Namespace, secretName)
 
@@ -981,7 +973,7 @@ func (r *ReplicaSetReconcilerHelper) OnDelete(ctx context.Context, obj runtime.O
 
 	// AppDB-role CR deletion is a reverse-migration handover, not a deprovision: the project
 	// is left stale and the user is responsible for cleaning it up after migration.
-	if rs.Spec.Role != mdbv1.RoleAppDB {
+	if !rs.IsRoleAppDB() {
 		if err := r.cleanOpsManagerState(ctx, rs, log); err != nil {
 			return err
 		}

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -794,11 +794,14 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 
 	// Forward Migration, reclaim the AppDB Statefulset
 	if sts.Annotations[util.AppDBMigrationReadyAnnotation] == trueString {
-		if len(sts.OwnerReferences) == 0 || ownedByThisMongoDB {
+		if len(sts.OwnerReferences) == 0 {
 			if err := r.reclaimAppDBStatefulsetOwnership(ctx, mdb, sts); err != nil {
 				return workflow.Failed(err)
 			}
+			return workflow.OK()
+		}
 
+		if ownedByThisMongoDB {
 			return workflow.OK()
 		}
 
@@ -824,8 +827,8 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 
 func (r *ReplicaSetReconcilerHelper) reclaimAppDBStatefulsetOwnership(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) error {
 	sts.OwnerReferences = kube.BaseOwnerReference(mdb)
+	// stale reverse annotation cleanup
 	delete(sts.Annotations, util.AppDBReverseMigrationReadyAnnotation)
-	delete(sts.Annotations, util.AppDBMigrationReadyAnnotation)
 	if err := r.reconciler.client.Update(ctx, &sts); err != nil {
 		return xerrors.Errorf("failed to reclaim StatefulSet %s: %w", sts.GetName(), err)
 	}

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -1986,7 +1986,7 @@ func TestConsumeAdoptionSignal(t *testing.T) {
 		sts *appsv1.StatefulSet
 	}{
 		{
-			name: "removes migration-ready annotation during adoption",
+			name: "keeps migration-ready annotation during adoption for reshape",
 			sts: ptr.To(DefaultStatefulSetBuilder().SetName("my-om-db").
 				SetOwnerReferences(nil).
 				SetAnnotations(map[string]string{util.AppDBMigrationReadyAnnotation: "true", "other": "kept"}).Build()),
@@ -2011,12 +2011,13 @@ func TestConsumeAdoptionSignal(t *testing.T) {
 
 			ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
 
-			if tt.name == "removes migration-ready annotation during adoption" {
+			if tt.name == "keeps migration-ready annotation during adoption for reshape" {
 				result := appsv1.StatefulSet{}
 				require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, mdb.Name), &result))
-				assert.NotContains(t, result.Annotations, util.AppDBMigrationReadyAnnotation,
-					"the migration-ready annotation must be consumed on adoption, or the OM controller would re-adopt prematurely on reverse migration")
-				assert.True(t, ownershipStatus.IsOK(), "should own the STS after consuming migration signal")
+				assert.Contains(t, result.Annotations, util.AppDBMigrationReadyAnnotation,
+					"the migration-ready annotation must persist after adoption for STS reshape detection")
+				assert.Contains(t, result.Annotations, "other", "unrelated annotations must be preserved")
+				assert.True(t, ownershipStatus.IsOK(), "should own the STS after adoption")
 			} else if tt.name == "no-op when annotation absent" {
 				result := appsv1.StatefulSet{}
 				require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, mdb.Name), &result))

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -1691,20 +1691,18 @@ func TestEnsureAppDBRoleKeyfile(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		role        string
 		existingKey string // pre-seeded "<name>-keyfile" secret contents; "" = secret absent
 		projectKey  string // pre-existing project automation-config key; "" = none
 	}{
-		{name: "existing secret overrides a differing project key", role: mdbv1.RoleAppDB, existingKey: sharedKey, projectKey: projectGeneratedKey},
-		{name: "existing secret with matching project key stays in place", role: mdbv1.RoleAppDB, existingKey: sharedKey, projectKey: sharedKey},
-		{name: "absent secret is seeded from the project key", role: mdbv1.RoleAppDB, projectKey: projectGeneratedKey},
-		{name: "absent secret and no project key: key generated and persisted", role: mdbv1.RoleAppDB},
-		{name: "non-AppDB role is skipped", role: ""},
+		{name: "existing secret overrides a differing project key", existingKey: sharedKey, projectKey: projectGeneratedKey},
+		{name: "existing secret with matching project key stays in place", existingKey: sharedKey, projectKey: sharedKey},
+		{name: "absent secret is seeded from the project key", projectKey: projectGeneratedKey},
+		{name: "absent secret and no project key: key generated and persisted"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(tt.role).Build()
+			mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
 			reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
 			helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
 			conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
@@ -1732,15 +1730,7 @@ func TestEnsureAppDBRoleKeyfile(t *testing.T) {
 			ac, err := conn.ReadAutomationConfig()
 			require.NoError(t, err)
 			sec := corev1.Secret{}
-			secretErr := kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, keyfileSecretName), &sec)
-
-			if tt.role != mdbv1.RoleAppDB {
-				assert.Equal(t, tt.projectKey, ac.Auth.Key, "non-AppDB CRs must not touch the project key")
-				assert.True(t, apiErrors.IsNotFound(secretErr), "non-AppDB CRs must not create the keyfile secret")
-				return
-			}
-
-			require.NoError(t, secretErr)
+			require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, keyfileSecretName), &sec))
 			persistedKey := string(sec.Data[constants.AgentKeyfileKey])
 			if tt.existingKey != "" {
 				assert.Equal(t, tt.existingKey, ac.Auth.Key, "the shared secret's key must win over the project key")
@@ -2034,26 +2024,6 @@ func assertAppDBRoleUserRolesAndCreds(t *testing.T, createdUser *om.MongoDBUser)
 	assert.ElementsMatch(t, expectedAppDBRoleUserRoles, createdUser.Roles)
 	require.NotNil(t, createdUser.ScramSha256Creds)
 	require.NotNil(t, createdUser.ScramSha1Creds)
-}
-
-func TestEnsureAppDBRoleUser_NoOpWhenRoleNotSet(t *testing.T) {
-	ctx := context.Background()
-	mdb := DefaultReplicaSetBuilder().SetName("my-plain-rs").Build()
-	reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
-	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
-	conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
-
-	err := helper.ensureAppDBRoleUser(ctx, mdb, conn)
-	assert.NoError(t, err)
-
-	ac, err := conn.ReadAutomationConfig()
-	require.NoError(t, err)
-	_, createdUser := ac.Auth.GetUser(util.OpsManagerMongoDBUserName, util.DefaultUserDatabase)
-	assert.Nil(t, createdUser)
-
-	sec := corev1.Secret{}
-	err = kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, omv1.OpsManagerUserPasswordSecretName(mdb.Name)), &sec)
-	assert.True(t, apiErrors.IsNotFound(err))
 }
 
 func TestReleaseStatefulSetIfRequested(t *testing.T) {

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status/pvc"
@@ -45,8 +46,10 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/images"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 )
@@ -1304,6 +1307,11 @@ func (b *ReplicaSetBuilder) SetAuthentication(auth *mdbv1.Authentication) *Repli
 	return b
 }
 
+func (b *ReplicaSetBuilder) SetRole(role string) *ReplicaSetBuilder {
+	b.Spec.Role = role
+	return b
+}
+
 func (b *ReplicaSetBuilder) SetRoles(roles []mdbv1.MongoDBRole) *ReplicaSetBuilder {
 	if b.Spec.Security == nil {
 		b.Spec.Security = &mdbv1.Security{}
@@ -1408,6 +1416,16 @@ func (b *ReplicaSetBuilder) ExposedExternally(specOverride *corev1.ServiceSpec, 
 	if len(annotationsOverride) > 0 {
 		b.Spec.ExternalAccessConfiguration.ExternalService.Annotations = annotationsOverride
 	}
+	return b
+}
+
+func (b *ReplicaSetBuilder) SetFinalizers(finalizers []string) *ReplicaSetBuilder {
+	b.Finalizers = finalizers
+	return b
+}
+
+func (b *ReplicaSetBuilder) SetDeletionTimestamp(t metav1.Time) *ReplicaSetBuilder {
+	b.DeletionTimestamp = &t
 	return b
 }
 
@@ -1594,6 +1612,16 @@ func TestPublishAutomationConfigFirst(t *testing.T) {
 			},
 			expectedPublishACFirst: true,
 		},
+		{
+			name:        "AppDB-role with existing STS",
+			existingSts: baseTestStatefulSet("test-appdb", 3),
+			mdb: func() mdbv1.MongoDB {
+				m := baseTestMongoDB("test-appdb", 3)
+				m.Spec.Role = mdbv1.RoleAppDB
+				return m
+			}(),
+			expectedPublishACFirst: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1655,4 +1683,520 @@ func TestApplySearchOverrides_ResolvesPinnedClusterIndex(t *testing.T) {
 
 	c := mock.NewEmptyFakeClientBuilder().WithObjects(newPinnedSearch()).Build()
 	assert.Contains(t, applyOverrides(t, c), "rs-search-search-7-")
+}
+
+func TestEnsureAppDBRoleKeyfile(t *testing.T) {
+	const sharedKey = "shared-keyfile-contents"
+	const projectGeneratedKey = "project-generated-key"
+
+	tests := []struct {
+		name        string
+		role        string
+		existingKey string // pre-seeded "<name>-keyfile" secret contents; "" = secret absent
+		projectKey  string // pre-existing project automation-config key; "" = none
+	}{
+		{name: "existing secret overrides a differing project key", role: mdbv1.RoleAppDB, existingKey: sharedKey, projectKey: projectGeneratedKey},
+		{name: "existing secret with matching project key stays in place", role: mdbv1.RoleAppDB, existingKey: sharedKey, projectKey: sharedKey},
+		{name: "absent secret is seeded from the project key", role: mdbv1.RoleAppDB, projectKey: projectGeneratedKey},
+		{name: "absent secret and no project key: key generated and persisted", role: mdbv1.RoleAppDB},
+		{name: "non-AppDB role is skipped", role: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(tt.role).Build()
+			reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+			helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+			conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
+
+			if tt.projectKey != "" {
+				require.NoError(t, conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
+					ac.Auth.Key = tt.projectKey
+					return nil
+				}, zap.S()))
+			}
+			keyfileSecretName := fmt.Sprintf("%s-keyfile", mdb.Name)
+			if tt.existingKey != "" {
+				existing := secret.Builder().
+					SetName(keyfileSecretName).
+					SetNamespace(mdb.Namespace).
+					SetField(constants.AgentKeyfileKey, tt.existingKey).
+					Build()
+				require.NoError(t, kubeClient.CreateSecret(ctx, existing))
+			}
+
+			require.NoError(t, helper.ensureAppDBRoleKeyfile(ctx, mdb, conn))
+			// second call must be stable: same key in the AC and the secret (determinism)
+			require.NoError(t, helper.ensureAppDBRoleKeyfile(ctx, mdb, conn))
+
+			ac, err := conn.ReadAutomationConfig()
+			require.NoError(t, err)
+			sec := corev1.Secret{}
+			secretErr := kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, keyfileSecretName), &sec)
+
+			if tt.role != mdbv1.RoleAppDB {
+				assert.Equal(t, tt.projectKey, ac.Auth.Key, "non-AppDB CRs must not touch the project key")
+				assert.True(t, apiErrors.IsNotFound(secretErr), "non-AppDB CRs must not create the keyfile secret")
+				return
+			}
+
+			require.NoError(t, secretErr)
+			persistedKey := string(sec.Data[constants.AgentKeyfileKey])
+			if tt.existingKey != "" {
+				assert.Equal(t, tt.existingKey, ac.Auth.Key, "the shared secret's key must win over the project key")
+				assert.Equal(t, tt.existingKey, persistedKey)
+			} else {
+				require.NotEmpty(t, ac.Auth.Key)
+				if tt.projectKey != "" {
+					assert.Equal(t, tt.projectKey, ac.Auth.Key, "an existing project key must be reused, not regenerated")
+				}
+				assert.Equal(t, ac.Auth.Key, persistedKey, "the project key must be persisted into the shared secret")
+			}
+		})
+	}
+}
+
+func TestEnsureAppDBRoleUser_CreatesSharedPasswordSecret(t *testing.T) {
+	ctx := context.Background()
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+	conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
+
+	err := helper.ensureAppDBRoleUser(ctx, mdb, conn)
+	assert.NoError(t, err)
+
+	sec := corev1.Secret{}
+	err = kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, omv1.OpsManagerUserPasswordSecretName(mdb.Name)), &sec)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sec.Data[util.OpsManagerPasswordKey])
+
+	ac, err := conn.ReadAutomationConfig()
+	require.NoError(t, err)
+	_, createdUser := ac.Auth.GetUser(util.OpsManagerMongoDBUserName, util.DefaultUserDatabase)
+	require.NotNil(t, createdUser)
+	assert.Equal(t, util.OpsManagerMongoDBUserName, createdUser.Username)
+	assertAppDBRoleUserRolesAndCreds(t, createdUser)
+}
+
+func TestEnsureAppDBRoleUser_ReusesExistingPassword(t *testing.T) {
+	ctx := context.Background()
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+	conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
+
+	existing := secret.Builder().
+		SetName(omv1.OpsManagerUserPasswordSecretName("my-om-db")).
+		SetNamespace(mdb.Namespace).
+		SetField(util.OpsManagerPasswordKey, "pre-existing-password").
+		Build()
+	require.NoError(t, kubeClient.CreateSecret(ctx, existing))
+
+	err := helper.ensureAppDBRoleUser(ctx, mdb, conn)
+	assert.NoError(t, err)
+
+	result := corev1.Secret{}
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, omv1.OpsManagerUserPasswordSecretName("my-om-db")), &result))
+	assert.Equal(t, "pre-existing-password", string(result.Data[util.OpsManagerPasswordKey]))
+
+	ac, err := conn.ReadAutomationConfig()
+	require.NoError(t, err)
+	_, createdUser := ac.Auth.GetUser(util.OpsManagerMongoDBUserName, util.DefaultUserDatabase)
+	require.NotNil(t, createdUser)
+	assertAppDBRoleUserRolesAndCreds(t, createdUser)
+}
+
+// expectedAppDBRoleUserRoles mirrors the roles granted to the AppDB Ops Manager user in
+// AppDBSpec.GetAuthUsers (api/mongodb/v1/om/appdb_types.go).
+var expectedAppDBRoleUserRoles = []*om.Role{
+	{Role: "readWriteAnyDatabase", Database: "admin"},
+	{Role: "dbAdminAnyDatabase", Database: "admin"},
+	{Role: "clusterMonitor", Database: "admin"},
+	{Role: "backup", Database: "admin"},
+	{Role: "restore", Database: "admin"},
+	{Role: "hostManager", Database: "admin"},
+}
+
+// someOtherOwnerReference builds an OwnerReference belonging to a different object than the
+// one under test (e.g. the MongoDBOpsManager CR that used to own the internal AppDB StatefulSet),
+// used to simulate a "foreign" StatefulSet that has not yet been detached.
+func someOtherOwnerReference() []metav1.OwnerReference {
+	return []metav1.OwnerReference{
+		{
+			APIVersion: "mongodb.com/v1",
+			Kind:       "MongoDBOpsManager",
+			Name:       "some-other-owner",
+			UID:        types.UID(uuid.New().String()),
+			Controller: ptr.To(true),
+		},
+	}
+}
+
+// StatefulSetBuilder builds appsv1.StatefulSet fixtures for adoption-gate tests.
+type StatefulSetBuilder struct {
+	sts appsv1.StatefulSet
+}
+
+func DefaultStatefulSetBuilder() *StatefulSetBuilder {
+	return &StatefulSetBuilder{sts: appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: mock.TestNamespace},
+		// Spec.Replicas must be non-nil: the fake client's Get interceptor
+		// (mock.markStatefulSetsReady) unconditionally dereferences it.
+		Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
+	}}
+}
+
+func (b *StatefulSetBuilder) SetName(name string) *StatefulSetBuilder {
+	b.sts.Name = name
+	return b
+}
+
+func (b *StatefulSetBuilder) SetOwnerReferences(refs []metav1.OwnerReference) *StatefulSetBuilder {
+	b.sts.OwnerReferences = refs
+	return b
+}
+
+func (b *StatefulSetBuilder) SetAnnotations(annotations map[string]string) *StatefulSetBuilder {
+	b.sts.Annotations = annotations
+	return b
+}
+
+func (b *StatefulSetBuilder) Build() appsv1.StatefulSet {
+	return b.sts
+}
+
+func statusMessage(s workflow.Status) string {
+	if opt, exists := status.GetOption(s.StatusOptions(), status.MessageOption{}); exists {
+		return opt.(status.MessageOption).Message
+	}
+	return ""
+}
+
+func TestAdoptionGate_BlocksWithoutAnnotation(t *testing.T) {
+	ctx := context.Background()
+	sts := DefaultStatefulSetBuilder().SetName("my-om-db").
+		SetOwnerReferences(someOtherOwnerReference()).Build() // foreign STS, no annotation
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	require.NoError(t, kubeClient.Create(ctx, &sts))
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+	ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+	assert.False(t, ownershipStatus.IsOK(), "foreign STS without migration annotation must block adoption")
+	assert.Contains(t, statusMessage(ownershipStatus), "Cannot take ownership of the AppDB Statefulset")
+}
+
+func TestAdoptionGate_BlocksWithAnnotationButOwnerRefStillPresent(t *testing.T) {
+	ctx := context.Background()
+	sts := DefaultStatefulSetBuilder().SetName("my-om-db").
+		SetOwnerReferences(someOtherOwnerReference()).
+		SetAnnotations(map[string]string{util.AppDBMigrationReadyAnnotation: "true"}).Build()
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	require.NoError(t, kubeClient.Create(ctx, &sts))
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+	ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+	assert.False(t, ownershipStatus.IsOK(), "must stay blocked while the foreign OwnerReference is still present, even with the annotation")
+	assert.Equal(t, status.PhaseFailed, ownershipStatus.Phase())
+	assert.Contains(t, statusMessage(ownershipStatus), "it has other owner")
+}
+
+func TestAdoptionGate_ProceedsWhenBothSignalsSatisfied(t *testing.T) {
+	ctx := context.Background()
+	sts := DefaultStatefulSetBuilder().SetName("my-om-db").
+		SetOwnerReferences(nil).
+		SetAnnotations(map[string]string{util.AppDBMigrationReadyAnnotation: "true"}).Build()
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	require.NoError(t, kubeClient.Create(ctx, &sts))
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+	ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+	assert.True(t, ownershipStatus.IsOK(), "adoption should proceed when migration-ready annotation is present and no foreign owners")
+}
+
+func TestAdoptionGate_BlocksWithForeignOwners(t *testing.T) {
+	tests := []struct {
+		name      string
+		ownerRefs []metav1.OwnerReference
+	}{
+		{
+			name: "OM-owned StatefulSet blocks adoption",
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: "mongodb.com/v1", Kind: "MongoDBOpsManager", Name: "my-om", UID: "om-uid-1111",
+			}},
+		},
+		{
+			name: "non-OM foreign owner blocks adoption",
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: "v1", Kind: "ConfigMap", Name: "some-unrelated-owner", UID: "cm-uid-3333",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			sts := DefaultStatefulSetBuilder().SetName("my-om-db").SetOwnerReferences(tt.ownerRefs).Build()
+			mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+			reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+			require.NoError(t, kubeClient.Create(ctx, &sts))
+			helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+			ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+			assert.False(t, ownershipStatus.IsOK())
+			assert.Contains(t, statusMessage(ownershipStatus), "Cannot take ownership of the AppDB Statefulset")
+		})
+	}
+}
+
+func TestAdoptionGate_NoGateWhenNoExistingStatefulSet(t *testing.T) {
+	ctx := context.Background()
+	mdb := DefaultReplicaSetBuilder().SetName("fresh-start-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, _, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+	ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+	assert.True(t, ownershipStatus.IsOK(), "Fresh Start: no StatefulSet exists yet, adoption succeeds")
+}
+
+func TestOnDelete_AppDBRoleSkipsOpsManagerCleanup(t *testing.T) {
+	ctx := context.Background()
+	rs := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).
+		EnableAuth().SetAuthModes([]mdbv1.AuthMode{"SCRAM"}).Build()
+	rs.Spec.Security.Authentication.IgnoreUnknownUsers = true
+	reconciler, fakeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", rs, architectures.NonStatic)
+	checkReconcileSuccessful(ctx, t, reconciler, rs, fakeClient)
+	mockedOmConn := omConnectionFactory.GetConnection().(*om.MockedOmConnection)
+	mockedOmConn.CleanHistory()
+
+	require.NoError(t, reconciler.OnDelete(ctx, rs, zap.S()))
+
+	// deletion of an AppDB-role CR is a handover to internal AppDB management, not a deprovision:
+	// removing the replica set from the project would make the agents shut down every mongod at
+	// once, taking the AppDB (and the Ops Manager depending on it) down mid-migration
+	mockedOmConn.CheckOperationsDidntHappen(t, reflect.ValueOf(mockedOmConn.ReadUpdateDeployment))
+}
+
+func TestConsumeAdoptionSignal(t *testing.T) {
+	tests := []struct {
+		name string
+		// sts builds the pre-existing StatefulSet; nil means it doesn't exist (Fresh Start)
+		sts *appsv1.StatefulSet
+	}{
+		{
+			name: "removes migration-ready annotation during adoption",
+			sts: ptr.To(DefaultStatefulSetBuilder().SetName("my-om-db").
+				SetOwnerReferences(nil).
+				SetAnnotations(map[string]string{util.AppDBMigrationReadyAnnotation: "true", "other": "kept"}).Build()),
+		},
+		{
+			name: "no-op when annotation absent",
+			sts:  ptr.To(DefaultStatefulSetBuilder().SetName("my-om-db").SetOwnerReferences(nil).Build()),
+		},
+		{
+			name: "no-op when StatefulSet does not exist",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+			reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+			if tt.sts != nil {
+				require.NoError(t, kubeClient.Create(ctx, tt.sts))
+			}
+			helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+			ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+
+			if tt.name == "removes migration-ready annotation during adoption" {
+				result := appsv1.StatefulSet{}
+				require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, mdb.Name), &result))
+				assert.NotContains(t, result.Annotations, util.AppDBMigrationReadyAnnotation,
+					"the migration-ready annotation must be consumed on adoption, or the OM controller would re-adopt prematurely on reverse migration")
+				assert.True(t, ownershipStatus.IsOK(), "should own the STS after consuming migration signal")
+			} else if tt.name == "no-op when annotation absent" {
+				result := appsv1.StatefulSet{}
+				require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, mdb.Name), &result))
+				assert.False(t, ownershipStatus.IsOK(), "STS with no ownerRefs and no migration signals cannot be adopted")
+				assert.Contains(t, statusMessage(ownershipStatus), "Cannot take ownership of the AppDB Statefulset")
+			} else if tt.name == "no-op when StatefulSet does not exist" {
+				assert.True(t, ownershipStatus.IsOK(), "Fresh Start case: ownership succeeds without STS")
+			}
+		})
+	}
+}
+
+func assertAppDBRoleUserRolesAndCreds(t *testing.T, createdUser *om.MongoDBUser) {
+	assert.ElementsMatch(t, expectedAppDBRoleUserRoles, createdUser.Roles)
+	require.NotNil(t, createdUser.ScramSha256Creds)
+	require.NotNil(t, createdUser.ScramSha1Creds)
+}
+
+func TestEnsureAppDBRoleUser_NoOpWhenRoleNotSet(t *testing.T) {
+	ctx := context.Background()
+	mdb := DefaultReplicaSetBuilder().SetName("my-plain-rs").Build()
+	reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+	conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
+
+	err := helper.ensureAppDBRoleUser(ctx, mdb, conn)
+	assert.NoError(t, err)
+
+	ac, err := conn.ReadAutomationConfig()
+	require.NoError(t, err)
+	_, createdUser := ac.Auth.GetUser(util.OpsManagerMongoDBUserName, util.DefaultUserDatabase)
+	assert.Nil(t, createdUser)
+
+	sec := corev1.Secret{}
+	err = kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, omv1.OpsManagerUserPasswordSecretName(mdb.Name)), &sec)
+	assert.True(t, apiErrors.IsNotFound(err))
+}
+
+func TestReleaseStatefulSetIfRequested(t *testing.T) {
+	tests := []struct {
+		name              string
+		annotations       map[string]string
+		crOwned           bool
+		expectedOwned     bool
+		expectedOwnerRefs int
+	}{
+		{
+			name:              "release requested on owned StatefulSet: strips ownerRef",
+			annotations:       map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"},
+			crOwned:           true,
+			expectedOwned:     false,
+			expectedOwnerRefs: 0,
+		},
+		{
+			name:              "release requested on already-released StatefulSet: stays released",
+			annotations:       map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"},
+			expectedOwned:     false,
+			expectedOwnerRefs: 0,
+		},
+		{
+			name:              "no release request: untouched",
+			crOwned:           true,
+			expectedOwned:     true,
+			expectedOwnerRefs: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+			mdb.UID = types.UID("cr-uid-2222")
+			reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+			helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+			var refs []metav1.OwnerReference
+			if tt.crOwned {
+				refs = kube.BaseOwnerReference(mdb)
+			}
+			sts := DefaultStatefulSetBuilder().SetName(mdb.Name).SetOwnerReferences(refs).SetAnnotations(tt.annotations).Build()
+			require.NoError(t, kubeClient.Create(ctx, &sts))
+
+			ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+			assert.Equal(t, tt.expectedOwned, ownershipStatus.IsOK())
+			if !tt.expectedOwned {
+				assert.Contains(t, statusMessage(ownershipStatus), "under Reverse Migration")
+			}
+
+			result := appsv1.StatefulSet{}
+			require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, mdb.Name), &result))
+			assert.Len(t, result.OwnerReferences, tt.expectedOwnerRefs)
+		})
+	}
+}
+
+func TestAdoptionGate_ForwardMigrationTakesPrecedence(t *testing.T) {
+	ctx := context.Background()
+	sts := DefaultStatefulSetBuilder().SetName("my-om-db").
+		SetOwnerReferences(nil).
+		SetAnnotations(map[string]string{
+			util.AppDBMigrationReadyAnnotation:        "true",
+			util.AppDBReverseMigrationReadyAnnotation: "true",
+		}).Build()
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	require.NoError(t, kubeClient.Create(ctx, &sts))
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+	ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
+	assert.True(t, ownershipStatus.IsOK(), "forward migration takes precedence: reclaim ownership even if reverse is also requested")
+}
+
+func TestEnsureAppDBRoleSecrets_ClaimedByCR(t *testing.T) {
+	// forward migration: the secrets pre-exist (created by internal AppDB, ownerRefs stripped by
+	// detach); the CR must claim them so its eventual deletion (fallback path) GCs them together
+	// with the StatefulSet
+	ctx := context.Background()
+	mdb := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).Build()
+	mdb.UID = types.UID("cr-uid-2222")
+	reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+	helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+	conn := omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
+
+	passwordName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
+	keyfileName := fmt.Sprintf("%s-keyfile", mdb.Name)
+	for name, field := range map[string]string{passwordName: util.OpsManagerPasswordKey, keyfileName: constants.AgentKeyfileKey} {
+		s := secret.Builder().SetName(name).SetNamespace(mdb.Namespace).SetField(field, "pre-existing").Build()
+		require.NoError(t, kubeClient.CreateSecret(ctx, s))
+	}
+
+	require.NoError(t, helper.claimAppDBRoleSecrets(ctx, mdb))
+	require.NoError(t, helper.ensureAppDBRoleUser(ctx, mdb, conn))
+	require.NoError(t, helper.ensureAppDBRoleKeyfile(ctx, mdb, conn))
+
+	for _, name := range []string{passwordName, keyfileName} {
+		s := corev1.Secret{}
+		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(mdb.Namespace, name), &s))
+		require.Len(t, s.OwnerReferences, 1, name)
+		assert.Equal(t, mdb.UID, s.OwnerReferences[0].UID, "secret %s must be claimed by the CR", name)
+	}
+}
+
+func TestReconcile_ReleasedAppDBRoleCRDoesNotReclaimSecrets(t *testing.T) {
+	// regression: the release check must run before the ensureAppDBRole* claim steps - a released
+	// CR re-claiming the OM-owned handover secrets would garbage-collect them on its deletion,
+	// rotating the keyfile under a running internal AppDB
+	ctx := context.Background()
+	rs := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).
+		EnableAuth().SetAuthModes([]mdbv1.AuthMode{"SCRAM"}).Build()
+	rs.Spec.Security.Authentication.IgnoreUnknownUsers = true
+	rs.UID = types.UID("cr-uid-2222")
+	reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", rs, architectures.NonStatic)
+
+	omOwnerRef := []metav1.OwnerReference{{
+		APIVersion: "mongodb.com/v1", Kind: "MongoDBOpsManager", Name: "my-om", UID: "om-uid-1111",
+	}}
+	sts := DefaultStatefulSetBuilder().SetName(rs.Name).
+		SetOwnerReferences(kube.BaseOwnerReference(rs)).
+		SetAnnotations(map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}).Build()
+	require.NoError(t, kubeClient.Create(ctx, &sts))
+
+	passwordName := omv1.OpsManagerUserPasswordSecretName(rs.Name)
+	keyfileName := fmt.Sprintf("%s-keyfile", rs.Name)
+	for name, field := range map[string]string{passwordName: util.OpsManagerPasswordKey, keyfileName: constants.AgentKeyfileKey} {
+		s := secret.Builder().SetName(name).SetNamespace(rs.Namespace).SetField(field, "om-owned").SetOwnerReferences(omOwnerRef).Build()
+		require.NoError(t, kubeClient.CreateSecret(ctx, s))
+	}
+
+	res, err := reconciler.Reconcile(ctx, requestFromObject(rs))
+	require.NoError(t, err)
+	assert.NotEqual(t, reconcile.Result{}, res)
+
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKeyFromApiObject(rs), rs))
+	assert.Equal(t, status.PhasePending, rs.Status.Phase)
+	assert.Contains(t, rs.Status.Message, "under Reverse Migration")
+
+	for _, name := range []string{passwordName, keyfileName} {
+		s := corev1.Secret{}
+		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(rs.Namespace, name), &s))
+		require.Len(t, s.OwnerReferences, 1, name)
+		assert.Equal(t, types.UID("om-uid-1111"), s.OwnerReferences[0].UID,
+			"secret %s must stay OM-owned while the CR is released", name)
+	}
 }

--- a/controllers/operator/watch/predicates.go
+++ b/controllers/operator/watch/predicates.go
@@ -63,7 +63,7 @@ func PredicatesForOpsManager() predicate.Funcs {
 					}
 				}
 
-				if oldResource.Spec.ExternalApplicationDatabaseRef == nil {
+				if oldResource.Spec.ExternalAppDBRef == nil {
 					for _, e := range oldResource.Spec.AppDB.GetSecretsMountedIntoPod() {
 						if oldResource.GetAnnotations()[e] != newResource.GetAnnotations()[e] {
 							return true

--- a/controllers/operator/watch/predicates.go
+++ b/controllers/operator/watch/predicates.go
@@ -63,9 +63,11 @@ func PredicatesForOpsManager() predicate.Funcs {
 					}
 				}
 
-				for _, e := range oldResource.Spec.AppDB.GetSecretsMountedIntoPod() {
-					if oldResource.GetAnnotations()[e] != newResource.GetAnnotations()[e] {
-						return true
+				if oldResource.Spec.ExternalApplicationDatabaseRef == nil {
+					for _, e := range oldResource.Spec.AppDB.GetSecretsMountedIntoPod() {
+						if oldResource.GetAnnotations()[e] != newResource.GetAnnotations()[e] {
+							return true
+						}
 					}
 				}
 				return false
@@ -131,6 +133,12 @@ func PredicatesForStatefulSet() predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldSts := e.ObjectOld.(*appsv1.StatefulSet)
 			newSts := e.ObjectNew.(*appsv1.StatefulSet)
+
+			// the reverse-migration release request is an annotation-only update; without letting
+			// it through, the AppDB-role MongoDB CR never learns it must release its StatefulSet
+			if oldSts.Annotations[util.AppDBReverseMigrationReadyAnnotation] != newSts.Annotations[util.AppDBReverseMigrationReadyAnnotation] {
+				return true
+			}
 
 			val, ok := newSts.Annotations["type"]
 

--- a/controllers/operator/watch/predicates_test.go
+++ b/controllers/operator/watch/predicates_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -14,7 +15,10 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
 	"github.com/mongodb/mongodb-kubernetes/pkg/handler"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
+
+const vaultSecretBackendEnvVar = "SECRET_BACKEND"
 
 func TestPredicatesForUser(t *testing.T) {
 	t.Run("No reconciliation for MongoDBUser if statuses are not equal", func(t *testing.T) {
@@ -48,6 +52,13 @@ func TestPredicatesForOpsManager(t *testing.T) {
 		newOm := oldOm.DeepCopy()
 		newOm.Spec.Replicas = 2
 		assert.True(t, PredicatesForOpsManager().Update(event.UpdateEvent{ObjectOld: oldOm, ObjectNew: newOm}))
+	})
+	t.Run("No reconciliation for MongoDBOpsManager with ExternalApplicationDatabaseRef when vault backend and nothing meaningful changed", func(t *testing.T) {
+		t.Setenv(vaultSecretBackendEnvVar, "VAULT_BACKEND")
+		oldOm := omv1.NewOpsManagerBuilder().Build()
+		oldOm.Spec.ExternalApplicationDatabaseRef = &omv1.ExternalApplicationDatabaseRef{Name: "external-appdb"}
+		newOm := oldOm.DeepCopy()
+		assert.False(t, PredicatesForOpsManager().Update(event.UpdateEvent{ObjectOld: oldOm, ObjectNew: newOm}))
 	})
 }
 
@@ -139,6 +150,59 @@ func TestPredicatesForMultiClusterSearchResource(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, tc.eval())
+		})
+	}
+}
+
+func TestPredicatesForStatefulSet(t *testing.T) {
+	buildSts := func(annotations map[string]string, readyReplicas int32) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-om-db", Annotations: annotations},
+			Status:     appsv1.StatefulSetStatus{ReadyReplicas: readyReplicas},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		oldSts          *appsv1.StatefulSet
+		newSts          *appsv1.StatefulSet
+		expectedForward bool
+	}{
+		{
+			name:            "reverse-migration release request added: forwarded",
+			oldSts:          buildSts(nil, 3),
+			newSts:          buildSts(map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}, 3),
+			expectedForward: true,
+		},
+		{
+			name:            "reverse-migration release request removed: forwarded",
+			oldSts:          buildSts(map[string]string{util.AppDBReverseMigrationReadyAnnotation: "true"}, 3),
+			newSts:          buildSts(nil, 3),
+			expectedForward: true,
+		},
+		{
+			name:            "unrelated annotation change: filtered",
+			oldSts:          buildSts(map[string]string{"type": "Replicaset"}, 3),
+			newSts:          buildSts(map[string]string{"type": "Replicaset", "unrelated": "x"}, 3),
+			expectedForward: false,
+		},
+		{
+			name:            "readiness change with type Replicaset: forwarded",
+			oldSts:          buildSts(map[string]string{"type": "Replicaset"}, 2),
+			newSts:          buildSts(map[string]string{"type": "Replicaset"}, 3),
+			expectedForward: true,
+		},
+		{
+			name:            "readiness change without type annotation: filtered",
+			oldSts:          buildSts(nil, 2),
+			newSts:          buildSts(nil, 3),
+			expectedForward: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedForward,
+				PredicatesForStatefulSet().Update(event.UpdateEvent{ObjectOld: tt.oldSts, ObjectNew: tt.newSts}))
 		})
 	}
 }

--- a/controllers/operator/watch/predicates_test.go
+++ b/controllers/operator/watch/predicates_test.go
@@ -53,10 +53,10 @@ func TestPredicatesForOpsManager(t *testing.T) {
 		newOm.Spec.Replicas = 2
 		assert.True(t, PredicatesForOpsManager().Update(event.UpdateEvent{ObjectOld: oldOm, ObjectNew: newOm}))
 	})
-	t.Run("No reconciliation for MongoDBOpsManager with ExternalApplicationDatabaseRef when vault backend and nothing meaningful changed", func(t *testing.T) {
+	t.Run("No reconciliation for MongoDBOpsManager with ExternalAppDBRef when vault backend and nothing meaningful changed", func(t *testing.T) {
 		t.Setenv(vaultSecretBackendEnvVar, "VAULT_BACKEND")
 		oldOm := omv1.NewOpsManagerBuilder().Build()
-		oldOm.Spec.ExternalApplicationDatabaseRef = &omv1.ExternalApplicationDatabaseRef{Name: "external-appdb"}
+		oldOm.Spec.ExternalAppDBRef = &omv1.ExternalAppDBRef{Name: "external-appdb"}
 		newOm := oldOm.DeepCopy()
 		assert.False(t, PredicatesForOpsManager().Update(event.UpdateEvent{ObjectOld: oldOm, ObjectNew: newOm}))
 	})

--- a/controllers/operator/workflow/disabled.go
+++ b/controllers/operator/workflow/disabled.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 // disabledStatus indicates that the subresource is not enabled
@@ -10,7 +11,7 @@ type disabledStatus struct {
 }
 
 func Disabled() *disabledStatus {
-	return &disabledStatus{okStatus: &okStatus{}}
+	return &disabledStatus{okStatus: &okStatus{requeueAfter: util.TWENTY_FOUR_HOURS}}
 }
 
 func (d disabledStatus) Phase() status.Phase {

--- a/controllers/operator/workflow/status_test.go
+++ b/controllers/operator/workflow/status_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/xerrors"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 func TestOnErrorPrepend(t *testing.T) {
@@ -19,4 +22,9 @@ func TestOnErrorPrepend(t *testing.T) {
 	failedValidationResult := Invalid("my failed validation")
 	failedDecoratedValidationResult := failedValidationResult.OnErrorPrepend("failed wrapper").(*invalidStatus)
 	assert.Equal(t, "failed wrapper my failed validation", failedDecoratedValidationResult.msg)
+}
+
+func TestDisabledReconcileResult(t *testing.T) {
+	disabledResult, _ := Disabled().ReconcileResult()
+	assert.Equal(t, reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}, disabledResult)
 }

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_db.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_db.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  # must match the "<om-name>-db" naming convention required by
+  # spec.externalApplicationDatabaseRef (see MongoDBOpsManagerReconciler.validateExternalAppDBReference)
+  name: om-external-appdb-db
+spec:
+  members: 3
+  version: 4.4.20-ent
+  type: ReplicaSet
+  role: AppDB
+  opsManager:
+    configMapRef:
+      name: om-external-appdb-db-config
+  credentials: my-credentials
+  persistent: true
+  security:
+    authentication:
+      enabled: true
+      modes: ["SCRAM"]
+      ignoreUnknownUsers: true

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_db.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_db.yaml
@@ -15,8 +15,3 @@ spec:
       name: om-external-appdb-db-config
   credentials: my-credentials
   persistent: true
-  security:
-    authentication:
-      enabled: true
-      modes: ["SCRAM"]
-      ignoreUnknownUsers: true

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_meta_om.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_meta_om.yaml
@@ -1,0 +1,28 @@
+apiVersion: mongodb.com/v1
+kind: MongoDBOpsManager
+metadata:
+  name: meta-om
+spec:
+  replicas: 1
+  version: 5.0.1
+  adminCredentials: ops-manager-admin-secret
+
+  applicationDatabase:
+    members: 3
+    version: 4.4.20-ent
+
+  backup:
+    enabled: false
+
+  # adding this just to avoid wizard when opening OM UI
+  configuration:
+    automation.versions.source: mongodb
+    mms.adminEmailAddr: cloud-manager-support@mongodb.com
+    mms.fromEmailAddr: cloud-manager-support@mongodb.com
+    mms.ignoreInitialUiSetup: "true"
+    mms.mail.hostname: email-smtp.us-east-1.amazonaws.com
+    mms.mail.port: "465"
+    mms.mail.ssl: "true"
+    mms.mail.transport: smtp
+    mms.minimumTLSVersion: TLSv1.2
+    mms.replyToEmailAddr: cloud-manager-support@mongodb.com

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_primary_om.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_primary_om.yaml
@@ -1,0 +1,28 @@
+apiVersion: mongodb.com/v1
+kind: MongoDBOpsManager
+metadata:
+  name: primary-om
+spec:
+  replicas: 1
+  version: 5.0.1
+  adminCredentials: ops-manager-admin-secret
+
+  applicationDatabase:
+    members: 3
+    version: 4.4.20-ent
+
+  backup:
+    enabled: false
+
+  # adding this just to avoid wizard when opening OM UI
+  configuration:
+    automation.versions.source: mongodb
+    mms.adminEmailAddr: cloud-manager-support@mongodb.com
+    mms.fromEmailAddr: cloud-manager-support@mongodb.com
+    mms.ignoreInitialUiSetup: "true"
+    mms.mail.hostname: email-smtp.us-east-1.amazonaws.com
+    mms.mail.port: "465"
+    mms.mail.ssl: "true"
+    mms.mail.transport: smtp
+    mms.minimumTLSVersion: TLSv1.2
+    mms.replyToEmailAddr: cloud-manager-support@mongodb.com

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_primary_om_no_appdb.yaml
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/fixtures/om_external_appdb_primary_om_no_appdb.yaml
@@ -1,0 +1,27 @@
+apiVersion: mongodb.com/v1
+kind: MongoDBOpsManager
+metadata:
+  name: primary-om
+spec:
+  replicas: 1
+  version: 5.0.1
+  adminCredentials: ops-manager-admin-secret
+
+  # no spec.applicationDatabase: this OM is created with externalApplicationDatabaseRef
+  # set from the start (true Fresh Start, Procedure 1) and never has an internal AppDB
+
+  backup:
+    enabled: false
+
+  # adding this just to avoid wizard when opening OM UI
+  configuration:
+    automation.versions.source: mongodb
+    mms.adminEmailAddr: cloud-manager-support@mongodb.com
+    mms.fromEmailAddr: cloud-manager-support@mongodb.com
+    mms.ignoreInitialUiSetup: "true"
+    mms.mail.hostname: email-smtp.us-east-1.amazonaws.com
+    mms.mail.port: "465"
+    mms.mail.ssl: "true"
+    mms.mail.transport: smtp
+    mms.minimumTLSVersion: TLSv1.2
+    mms.replyToEmailAddr: cloud-manager-support@mongodb.com

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
@@ -1,0 +1,215 @@
+from typing import ClassVar, Optional
+
+import pytest
+from kubernetes import client as k8s_client
+from kubernetes.client.rest import ApiException
+from kubetester import read_secret, try_load
+from kubetester.kubetester import KubernetesTester
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb import MongoDB
+from kubetester.opsmanager import MongoDBOpsManager
+from kubetester.phase import Phase
+from pytest import fixture
+from tests.opsmanager.om_external_appdb_test_helpers import (
+    appdb_role_resource,
+    assert_project_exists,
+    assert_sentinel_doc_present,
+    configure_appdb_role_mongodb,
+    meta_om_resource,
+    password_secret_name,
+    read_om_pod_restart_counts,
+    ref_kind_for_appdb,
+    write_sentinel_doc,
+)
+
+"""
+E2E test coverage for External AppDB via MongoDB CR reference:
+  - Procedure 2: Forward Migration (from an existing internal AppDB)
+  - Procedure 3: Reverse Migration (fallback path - delete MongoDB CR first)
+
+The classes form one continuous story on a single Primary OM, in order:
+  1. TestDeployInitialState - Prerequisite: deploy the management plane (Meta OM) and
+     the Primary OM with internal AppDB
+  2. TestSentinelDocSurvivesForwardMigration - Procedure 2: Forward Migration from an
+     existing internal AppDB to an external AppDB (MongoDB CR with role: AppDB)
+  3. TestReverseMigrationAfterForwardMigration - Procedure 3: Reverse Migration (fallback
+     path) — the MongoDB CR is deleted FIRST, then the OM is reconfigured to internal AppDB.
+     The StatefulSet and shared secrets are garbage-collected; the AppDB is recreated from
+     scratch with retained PVCs.
+
+See om_external_appdb_fresh.py for Procedure 1 (Fresh Start) and Procedure 3 (graceful
+reverse migration — the MongoDB CR is kept and the OM adopts the STS).
+"""
+
+OM_NAME = "primary-om"
+DB_NAME = f"{OM_NAME}-db"  # must match the operator's required "<om-name>-db" naming convention
+
+
+@fixture(scope="module")
+def meta_om(namespace: str, custom_version: Optional[str], custom_appdb_version: str) -> MongoDBOpsManager:
+    return meta_om_resource(namespace, custom_version, custom_appdb_version)
+
+
+@fixture(scope="module")
+def primary_om(namespace: str, custom_version: Optional[str], custom_appdb_version: str) -> MongoDBOpsManager:
+    resource = MongoDBOpsManager.from_yaml(yaml_fixture("om_external_appdb_primary_om.yaml"), namespace=namespace)
+    resource.set_version(custom_version)
+    resource.set_appdb_version(custom_appdb_version)
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="module")
+def external_appdb(namespace: str, custom_mdb_version: str) -> MongoDB:
+    resource = appdb_role_resource(namespace, custom_mdb_version, name=DB_NAME)
+    try_load(resource)
+    return resource
+
+
+@pytest.mark.e2e_om_external_appdb_forward
+class TestDeployInitialState:
+    """Deploys the management-plane Ops Manager and the primary Ops Manager with internal AppDB."""
+
+    def test_deploy_meta_om(self, meta_om: MongoDBOpsManager):
+        meta_om.update()
+        meta_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+    def test_create_om_with_internal_appdb(self, primary_om: MongoDBOpsManager):
+        primary_om.update()
+        primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+        primary_om.appdb_status().assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@pytest.mark.e2e_om_external_appdb_forward
+class TestSentinelDocSurvivesForwardMigration:
+    """Procedure 2: start with internal AppDB, write a sentinel doc, create the MongoDB (role: AppDB)
+    CR named "<om-name>-db", set externalApplicationDatabaseRef, and wait for adoption. Restart-count
+    assertion is unconditional (not "at most one") because Open Item 1 in the design doc has been
+    verified for the default-port case by Task 0's spike: AppDBSpec.BuildConnectionURL and
+    MongoDB.BuildConnectionString produce identical output, so the computed connection string value
+    does not change across the switch and no connectionStringHash-triggered restart is expected.
+    The non-default-port case remains an open caveat and is out of scope for this fixture (default port)."""
+
+    restart_counts_before: ClassVar[dict[str, int]]
+    password_secret_before: ClassVar[dict[str, str]]
+    connection_string_before: ClassVar[str]
+
+    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager):
+        write_sentinel_doc(primary_om.read_appdb_connection_url())
+
+    def test_capture_state_before_migration(self, primary_om: MongoDBOpsManager, namespace: str):
+        self.__class__.restart_counts_before = read_om_pod_restart_counts(primary_om)
+        self.__class__.password_secret_before = read_secret(namespace, password_secret_name(OM_NAME))
+        self.__class__.connection_string_before = primary_om.read_appdb_connection_url()
+
+    def test_create_external_appdb(self, external_appdb: MongoDB, meta_om: MongoDBOpsManager, namespace: str):
+        configure_appdb_role_mongodb(external_appdb, meta_om, namespace)
+        external_appdb.update()
+
+    def test_external_appdb_pending_before_ref_set(self, external_appdb: MongoDB):
+        # the STS already exists (owned by the OM's internal AppDB); the AppDB CR can't
+        # adopt it until the OM sets externalApplicationDatabaseRef and detaches it
+        external_appdb.assert_reaches_phase(
+            Phase.Pending,
+            msg_regexp="Cannot take ownership of the AppDB Statefulset",
+            timeout=300,
+        )
+
+    def test_set_external_appdb_ref(self, primary_om: MongoDBOpsManager):
+        primary_om.load()
+        primary_om["spec"]["externalApplicationDatabaseRef"] = {"name": DB_NAME, "kind": ref_kind_for_appdb()}
+        primary_om.update()
+
+    def test_external_appdb_reaches_running(self, external_appdb: MongoDB):
+        external_appdb.assert_reaches_phase(Phase.Running, timeout=900)
+
+    def test_om_reaches_running(self, primary_om: MongoDBOpsManager):
+        primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+    def test_sentinel_doc_survives(self, primary_om: MongoDBOpsManager):
+        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+
+    def test_connection_string_unchanged_after_forward_migration(self, primary_om: MongoDBOpsManager):
+        # same hosts + same password => the computed connection string value must not
+        # change across the forward migration (and therefore OM pods never roll)
+        assert primary_om.read_appdb_connection_url() == self.connection_string_before
+
+    def test_password_secret_unchanged_after_forward_migration(self, namespace: str):
+        password_secret_now = read_secret(namespace, password_secret_name(OM_NAME))
+        assert password_secret_now == self.password_secret_before
+
+
+@pytest.mark.e2e_om_external_appdb_forward
+class TestReverseMigrationAfterForwardMigration:
+    """Procedure 3 v2 fallback path, continuing from TestSentinelDocSurvivesForwardMigration's end
+    state (a completed Forward Migration): the MongoDB CR is deleted FIRST - plain Kubernetes
+    deletion, no finalizer. The StatefulSet and shared secrets are garbage-collected and the AppDB
+    (and OM) take a downtime window; the retained PVCs preserve the data. Reconfiguring the OM
+    afterwards recreates the AppDB from scratch, re-binding the PVCs - the sentinel document must
+    survive. Credential rotation is an accepted property of this path, so no password/keyfile
+    stability is asserted."""
+
+    def test_reverse_migration_delete_mongodb_first(self, external_appdb: MongoDB, namespace: str):
+        external_appdb.delete()
+
+        def cr_is_gone():
+            try:
+                k8s_client.CustomObjectsApi().get_namespaced_custom_object(
+                    "mongodb.com", "v1", namespace, "mongodb", DB_NAME
+                )
+                return False
+            except ApiException as e:
+                if e.status == 404:
+                    return True
+                raise
+
+        KubernetesTester.wait_until(cr_is_gone, timeout=300)
+
+    def test_statefulset_garbage_collected(self, namespace: str):
+        # plain deletion: the CR-owned StatefulSet goes with it; the OM in external mode reports
+        # Failed on ref validation during the gap (tolerated, not asserted)
+        def sts_is_gone():
+            try:
+                k8s_client.AppsV1Api().read_namespaced_stateful_set(DB_NAME, namespace)
+                return False
+            except ApiException as e:
+                if e.status == 404:
+                    return True
+                raise
+
+        KubernetesTester.wait_until(sts_is_gone, timeout=300)
+
+    def test_shared_secrets_garbage_collected(self, namespace: str):
+        # the CR's OwnerReference on the shared secrets triggers their GC on CR deletion
+        for name in [password_secret_name(OM_NAME), f"{DB_NAME}-keyfile"]:
+
+            def secret_is_gone():
+                try:
+                    k8s_client.CoreV1Api().read_namespaced_secret(name, namespace)
+                    return False
+                except ApiException as e:
+                    if e.status == 404:
+                        return True
+                    raise
+
+            KubernetesTester.wait_until(secret_is_gone, timeout=300)
+
+    def test_reverse_migration_reconfigure_om(self, primary_om: MongoDBOpsManager):
+        primary_om.load()
+        # update() sends a JSON merge patch: a locally deleted key is absent from the patch body
+        # and the server keeps it - only an explicit null removes the field
+        primary_om["spec"]["externalApplicationDatabaseRef"] = None
+        primary_om.update()
+
+    def test_internal_appdb_management_resumes(self, primary_om: MongoDBOpsManager):
+        # recreate-from-scratch: the new StatefulSet re-binds the retained PVCs by name
+        primary_om.appdb_status().assert_reaches_phase(Phase.Running, timeout=900, ignore_errors=True)
+        primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900, ignore_errors=True)
+
+    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager):
+        # the data-preservation proof: written before the forward migration, survives CR deletion
+        # and the recreate because the PVCs were retained
+        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+
+    def test_project_still_exists_after_reverse_migration(self, meta_om: MongoDBOpsManager):
+        assert_project_exists(meta_om, DB_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
@@ -12,6 +12,7 @@ from kubetester.phase import Phase
 from pytest import fixture
 from tests.opsmanager.om_external_appdb_test_helpers import (
     appdb_role_resource,
+    assert_no_migration_annotations,
     assert_project_exists,
     assert_sentinel_doc_present,
     configure_appdb_role_mongodb,
@@ -126,6 +127,9 @@ class TestSentinelDocSurvivesForwardMigration:
     def test_om_reaches_running(self, primary_om: MongoDBOpsManager):
         primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
 
+    def test_no_migration_annotations_after_forward_migration(self, namespace: str):
+        assert_no_migration_annotations(namespace, DB_NAME)
+
     def test_sentinel_doc_survives(self, primary_om: MongoDBOpsManager):
         assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
 
@@ -205,6 +209,9 @@ class TestReverseMigrationAfterForwardMigration:
         # recreate-from-scratch: the new StatefulSet re-binds the retained PVCs by name
         primary_om.appdb_status().assert_reaches_phase(Phase.Running, timeout=900, ignore_errors=True)
         primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900, ignore_errors=True)
+
+    def test_no_migration_annotations_after_reverse_migration(self, namespace: str):
+        assert_no_migration_annotations(namespace, DB_NAME)
 
     def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager):
         # the data-preservation proof: written before the forward migration, survives CR deletion

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
@@ -86,6 +86,7 @@ class TestSentinelDocSurvivesForwardMigration:
     CR named "<om-name>-db", set externalApplicationDatabaseRef, and wait for adoption."""
 
     password_secret_before: ClassVar[dict[str, str]]
+    keyfile_secret_before: ClassVar[dict[str, str]]
     connection_string_before: ClassVar[str]
 
     def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager):
@@ -93,6 +94,7 @@ class TestSentinelDocSurvivesForwardMigration:
 
     def test_capture_state_before_migration(self, primary_om: MongoDBOpsManager, namespace: str):
         self.__class__.password_secret_before = read_secret(namespace, password_secret_name(OM_NAME))
+        self.__class__.keyfile_secret_before = read_secret(namespace, f"{DB_NAME}-keyfile")
         self.__class__.connection_string_before = primary_om.read_appdb_connection_url()
 
     def test_create_external_appdb(self, external_appdb: MongoDB, meta_om: MongoDBOpsManager, namespace: str):
@@ -133,6 +135,10 @@ class TestSentinelDocSurvivesForwardMigration:
     def test_password_secret_unchanged_after_forward_migration(self, namespace: str):
         password_secret_now = read_secret(namespace, password_secret_name(OM_NAME))
         assert password_secret_now == self.password_secret_before
+
+    def test_keyfile_secret_unchanged_after_forward_migration(self, namespace: str):
+        keyfile_secret_now = read_secret(namespace, f"{DB_NAME}-keyfile")
+        assert keyfile_secret_now == self.keyfile_secret_before
 
 
 @pytest.mark.e2e_om_external_appdb_forward

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
@@ -18,7 +18,6 @@ from tests.opsmanager.om_external_appdb_test_helpers import (
     configure_appdb_role_mongodb,
     meta_om_resource,
     password_secret_name,
-    read_om_pod_restart_counts,
     ref_kind_for_appdb,
     write_sentinel_doc,
 )
@@ -84,14 +83,8 @@ class TestDeployInitialState:
 @pytest.mark.e2e_om_external_appdb_forward
 class TestSentinelDocSurvivesForwardMigration:
     """Procedure 2: start with internal AppDB, write a sentinel doc, create the MongoDB (role: AppDB)
-    CR named "<om-name>-db", set externalApplicationDatabaseRef, and wait for adoption. Restart-count
-    assertion is unconditional (not "at most one") because Open Item 1 in the design doc has been
-    verified for the default-port case by Task 0's spike: AppDBSpec.BuildConnectionURL and
-    MongoDB.BuildConnectionString produce identical output, so the computed connection string value
-    does not change across the switch and no connectionStringHash-triggered restart is expected.
-    The non-default-port case remains an open caveat and is out of scope for this fixture (default port)."""
+    CR named "<om-name>-db", set externalApplicationDatabaseRef, and wait for adoption."""
 
-    restart_counts_before: ClassVar[dict[str, int]]
     password_secret_before: ClassVar[dict[str, str]]
     connection_string_before: ClassVar[str]
 
@@ -99,7 +92,6 @@ class TestSentinelDocSurvivesForwardMigration:
         write_sentinel_doc(primary_om.read_appdb_connection_url())
 
     def test_capture_state_before_migration(self, primary_om: MongoDBOpsManager, namespace: str):
-        self.__class__.restart_counts_before = read_om_pod_restart_counts(primary_om)
         self.__class__.password_secret_before = read_secret(namespace, password_secret_name(OM_NAME))
         self.__class__.connection_string_before = primary_om.read_appdb_connection_url()
 

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_fresh.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_fresh.py
@@ -1,0 +1,223 @@
+from typing import ClassVar, Optional
+
+import pymongo
+import pytest
+from kubernetes import client as k8s_client
+from kubernetes.client.rest import ApiException
+from kubetester import read_secret, try_load
+from kubetester.kubetester import KubernetesTester
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb import MongoDB
+from kubetester.opsmanager import MongoDBOpsManager
+from kubetester.phase import Phase
+from pytest import fixture
+from tests.opsmanager.om_external_appdb_test_helpers import (
+    appdb_role_resource,
+    assert_owned_by_mongodb,
+    assert_owned_by_ops_manager,
+    assert_project_exists,
+    assert_sentinel_doc_present,
+    configure_appdb_role_mongodb,
+    meta_om_resource,
+    password_secret_name,
+    ref_kind_for_appdb,
+    write_sentinel_doc,
+)
+
+"""
+E2E test coverage for External AppDB via MongoDB CR reference:
+  - Procedure 1: Fresh Start
+  - Procedure 3: Reverse Migration (graceful)
+
+The classes form one continuous story on a single Primary OM, in order:
+  1. TestDeployMetaOpsManager - Prerequisite: deploy the management plane (Meta OM)
+  2. TestFreshStartExternalAppDB - Procedure 1: Fresh Start (the Primary OM CR has no
+     spec.applicationDatabase and never had an internal AppDB)
+  3. TestReverseMigrationAfterFreshStart - Procedure 3: Reverse Migration (graceful) back to internal AppDB
+     handled by the Primary OM CR spec.applicationDatabase. Here we first remove
+     spec.externalApplicationDatabaseRef, add spec.applicationDatabase and wait for Primary OM to
+     migrate to internal AppDB. After that we delete detached MongoDB CR (External AppDB).
+
+See om_external_appdb_forward.py for Procedure 2 (Forward Migration) and the Procedure 3 (Reverse Migration)
+with significant difference: For reverse migration we first remove the MongoDB CR (External AppDB) and test
+if the Primary OM can adopt the internal AppDB.
+"""
+OM_NAME = "primary-om"
+DB_NAME = f"{OM_NAME}-db"  # must match the operator's required "<om-name>-db" naming convention
+
+
+@fixture(scope="module")
+def meta_om(namespace: str, custom_version: Optional[str], custom_appdb_version: str) -> MongoDBOpsManager:
+    return meta_om_resource(namespace, custom_version, custom_appdb_version)
+
+
+@fixture(scope="module")
+def primary_om(namespace: str, custom_version: Optional[str]) -> MongoDBOpsManager:
+    resource = MongoDBOpsManager.from_yaml(
+        yaml_fixture("om_external_appdb_primary_om_no_appdb.yaml"),
+        namespace=namespace,
+    )
+    resource.set_version(custom_version)
+    resource["spec"]["externalApplicationDatabaseRef"] = {"name": DB_NAME, "kind": ref_kind_for_appdb()}
+    try_load(resource)
+    return resource
+
+
+@fixture(scope="module")
+def external_appdb(namespace: str, custom_mdb_version: str) -> MongoDB:
+    resource = appdb_role_resource(namespace, custom_mdb_version, name=DB_NAME)
+    try_load(resource)
+    return resource
+
+
+@pytest.mark.e2e_om_external_appdb_fresh
+class TestDeployMetaOpsManager:
+    """Deploys the management-plane Ops Manager the AppDB-role MongoDB CRs are configured against."""
+
+    def test_deploy_meta_om(self, meta_om: MongoDBOpsManager):
+        meta_om.update()
+        meta_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+        meta_om.appdb_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@pytest.mark.e2e_om_external_appdb_fresh
+class TestFreshStartExternalAppDB:
+    """Procedure 1: create the External AppDB (MongoDB role: AppDB) CR managed by Meta OM, then create the Primary
+    OM CR with spec.externalApplicationDatabaseRef set from the start and no spec.applicationDatabase -
+    no internal AppDB ever exists for this OM CR."""
+
+    def test_create_appdb_role_mongodb(self, external_appdb: MongoDB, meta_om: MongoDBOpsManager, namespace: str):
+        configure_appdb_role_mongodb(external_appdb, meta_om, namespace)
+        external_appdb.update()
+        external_appdb.assert_reaches_phase(Phase.Running, timeout=900)
+
+    def test_create_om_with_ref_and_no_internal_appdb(self, primary_om: MongoDBOpsManager):
+        primary_om.update()
+        primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+        primary_om.appdb_status().assert_reaches_phase(Phase.Disabled, timeout=600)
+
+    def test_external_appdb_statefulset_created(self, namespace: str):
+        # the StatefulSet belongs solely to the MongoDB CR - the OM controller must never have
+        # touched its ownership in the fresh-start flow
+        sts = k8s_client.AppsV1Api().read_namespaced_stateful_set(DB_NAME, namespace)
+        assert_owned_by_mongodb(sts.metadata, DB_NAME)
+
+    def test_password_secret(self, namespace: str):
+        # ownership follows the AppDB's manager: in the fresh start the MongoDB CR created the
+        # shared password secret, so it must carry the CR's OwnerReference
+        sec = k8s_client.CoreV1Api().read_namespaced_secret(password_secret_name(OM_NAME), namespace)
+        assert_owned_by_mongodb(sec.metadata, DB_NAME)
+        assert "password" in read_secret(namespace, password_secret_name(OM_NAME))
+
+    def test_connection_string_secret(self, primary_om: MongoDBOpsManager, namespace: str):
+        # the connection-string secret is created by the OM controller (never by the referenced
+        # CR, per the design) and intentionally carries no OwnerReferences
+        cnx_string = primary_om.read_appdb_connection_url()
+        expected_hosts = {f"{DB_NAME}-{i}.{DB_NAME}-svc.{namespace}.svc.cluster.local:27017" for i in range(3)}
+
+        # the URI itself must name the referenced CR's pods - not merely "work" via server discovery
+        parsed = pymongo.uri_parser.parse_uri(cnx_string)
+        assert {f"{host}:{port}" for host, port in parsed["nodelist"]} == expected_hosts
+
+        client = pymongo.MongoClient(cnx_string, serverSelectionTimeoutMS=30000)
+        try:
+            hello = client.admin.command("hello")
+            assert hello["setName"] == DB_NAME
+            assert set(hello["hosts"]) == expected_hosts
+        finally:
+            client.close()
+
+
+@pytest.mark.e2e_om_external_appdb_fresh
+class TestReverseMigrationAfterFreshStart:
+    """Procedure 3: Reconfiguring the OM (remove spec.externalApplicationDatabaseRef, add
+    spec.applicationDatabase) triggers the release handshake; the MongoDB CR is deleted only after the
+    handover completes, and must not disturb anything the OM now owns."""
+
+    connection_string_before: ClassVar[str]
+    shared_secret_uids: ClassVar[dict[str, str]]
+    shared_secret_data: ClassVar[dict[str, dict]]
+
+    # every shared handover secret the OM claims at adoption; all of them would be
+    # garbage-collected by the CR deletion if the ownership transfer failed
+    SHARED_SECRET_NAMES = [f"{DB_NAME}-om-password", f"{DB_NAME}-keyfile"]
+
+    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager):
+        write_sentinel_doc(primary_om.read_appdb_connection_url())
+
+    def test_capture_secrets_before_reverse_migration(self, primary_om: MongoDBOpsManager, namespace: str):
+        # graceful path: same hosts + same password => the computed connection string value must
+        # never change (and therefore Primary OM pods never roll)
+        self.__class__.connection_string_before = primary_om.read_appdb_connection_url()
+        secrets = {
+            name: k8s_client.CoreV1Api().read_namespaced_secret(name, namespace) for name in self.SHARED_SECRET_NAMES
+        }
+        self.__class__.shared_secret_uids = {name: s.metadata.uid for name, s in secrets.items()}
+        self.__class__.shared_secret_data = {name: s.data for name, s in secrets.items()}
+
+    def _assert_shared_secrets_claimed_and_unchanged(self, namespace: str):
+        for name in self.SHARED_SECRET_NAMES:
+            sec = k8s_client.CoreV1Api().read_namespaced_secret(name, namespace)
+            assert sec.metadata.uid == self.shared_secret_uids[name], f"secret {name} was recreated"
+            assert sec.data == self.shared_secret_data[name], f"secret {name} contents changed"
+            assert_owned_by_ops_manager(sec.metadata, OM_NAME)
+
+    def test_reverse_migration_reconfigure_om(self, primary_om: MongoDBOpsManager, custom_appdb_version: str):
+        primary_om.load()
+        primary_om["spec"]["externalApplicationDatabaseRef"] = None
+        primary_om["spec"]["applicationDatabase"] = {"members": 3, "version": custom_appdb_version}
+        primary_om.update()
+
+    def test_external_appdb_is_unmanaged(self, external_appdb: MongoDB):
+        # the released message shows only in the short window before the OM adopts; afterwards
+        # the adoption gate reports the "unmanaged" message - both prove the release happened
+        external_appdb.assert_reaches_phase(
+            Phase.Pending,
+            msg_regexp="Cannot take ownership of the AppDB Statefulset: Configure spec.externalApplicationDatabaseRef under Ops Manager CR or delete this resource",
+            timeout=300,
+        )
+
+    def test_internal_appdb_management_resumes(self, primary_om: MongoDBOpsManager):
+        primary_om.appdb_status().assert_reaches_phase(Phase.Running, timeout=900)
+        primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=900)
+
+    def test_internal_appdb_statefulset_created(self, namespace: str):
+        # after adoption the StatefulSet belongs solely to the Ops Manager
+        sts = k8s_client.AppsV1Api().read_namespaced_stateful_set(DB_NAME, namespace)
+        assert_owned_by_ops_manager(sts.metadata, OM_NAME)
+
+    def test_om_secrets_only_updated_owner_reference(self, primary_om: MongoDBOpsManager, namespace: str):
+        # the OM-claimed shared secrets must survive the handover with identical contents; only
+        # their ownership changed (MongoDB CR -> Ops Manager)
+        self._assert_shared_secrets_claimed_and_unchanged(namespace)
+        assert primary_om.read_appdb_connection_url() == self.connection_string_before
+
+    def test_delete_mongodb_cr_after_handover(self, external_appdb: MongoDB, namespace: str):
+        external_appdb.delete()
+
+        def cr_is_gone():
+            try:
+                k8s_client.CustomObjectsApi().get_namespaced_custom_object(
+                    "mongodb.com", "v1", namespace, "mongodb", DB_NAME
+                )
+                return False
+            except ApiException as e:
+                if e.status == 404:
+                    return True
+                raise
+
+        KubernetesTester.wait_until(cr_is_gone, timeout=300)
+
+    def test_om_unaffected_by_cr_deletion(self, primary_om: MongoDBOpsManager, namespace: str):
+        # the deletion is post-handover cleanup: statuses must not dip, the shared secrets and
+        # the connection string must be untouched
+        primary_om.appdb_status().assert_reaches_phase(Phase.Running, timeout=120)
+        primary_om.om_status().assert_reaches_phase(Phase.Running, timeout=120)
+        self._assert_shared_secrets_claimed_and_unchanged(namespace)
+        assert primary_om.read_appdb_connection_url() == self.connection_string_before
+
+    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager):
+        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+
+    def test_project_still_exists_after_reverse_migration(self, meta_om: MongoDBOpsManager):
+        assert_project_exists(meta_om, DB_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_fresh.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_fresh.py
@@ -13,6 +13,7 @@ from kubetester.phase import Phase
 from pytest import fixture
 from tests.opsmanager.om_external_appdb_test_helpers import (
     appdb_role_resource,
+    assert_no_migration_annotations,
     assert_owned_by_mongodb,
     assert_owned_by_ops_manager,
     assert_project_exists,
@@ -101,6 +102,7 @@ class TestFreshStartExternalAppDB:
         # touched its ownership in the fresh-start flow
         sts = k8s_client.AppsV1Api().read_namespaced_stateful_set(DB_NAME, namespace)
         assert_owned_by_mongodb(sts.metadata, DB_NAME)
+        assert_no_migration_annotations(namespace, DB_NAME)
 
     def test_password_secret(self, namespace: str):
         # ownership follows the AppDB's manager: in the fresh start the MongoDB CR created the
@@ -185,6 +187,7 @@ class TestReverseMigrationAfterFreshStart:
         # after adoption the StatefulSet belongs solely to the Ops Manager
         sts = k8s_client.AppsV1Api().read_namespaced_stateful_set(DB_NAME, namespace)
         assert_owned_by_ops_manager(sts.metadata, OM_NAME)
+        assert_no_migration_annotations(namespace, DB_NAME)
 
     def test_om_secrets_only_updated_owner_reference(self, primary_om: MongoDBOpsManager, namespace: str):
         # the OM-claimed shared secrets must survive the handover with identical contents; only

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
@@ -1,0 +1,105 @@
+from typing import Optional
+
+import pymongo
+from kubetester import try_load
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb import MongoDB
+from kubetester.opsmanager import MongoDBOpsManager
+
+SENTINEL_DOC = {"_id": "external-appdb-sentinel", "marker": "survived-migration"}
+TEST_DB = "sentinelDb"
+TEST_COLLECTION = "sentinelCollection"
+META_OM_NAME = "meta-om"
+
+
+def password_secret_name(om_name: str) -> str:
+    return f"{om_name}-db-om-password"
+
+
+def ref_kind_for_appdb() -> str:
+    return "MongoDB"
+
+
+def _assert_single_controller_owner_reference(metadata, kind: str, name: str):
+    refs = metadata.owner_references or []
+    assert len(refs) == 1, f"{metadata.name} must have exactly one ownerReference, got {refs}"
+    assert refs[0].kind == kind
+    assert refs[0].name == name
+    assert refs[0].controller
+
+
+def assert_owned_by_mongodb(metadata, name: str):
+    """Asserts the resource is owned solely by the external AppDB MongoDB CR."""
+    _assert_single_controller_owner_reference(metadata, ref_kind_for_appdb(), name)
+
+
+def assert_owned_by_ops_manager(metadata, name: str):
+    """Asserts the resource is owned solely by the MongoDBOpsManager resource."""
+    _assert_single_controller_owner_reference(metadata, "MongoDBOpsManager", name)
+
+
+def appdb_role_resource(namespace: str, custom_mdb_version: str, name: str) -> MongoDB:
+    """Constructs the MongoDB(role: AppDB) CR that spec.externalApplicationDatabaseRef points at."""
+    resource = MongoDB.from_yaml(yaml_fixture("om_external_appdb_db.yaml"), name=name, namespace=namespace)
+    resource.set_version(custom_mdb_version)
+    return resource
+
+
+def meta_om_resource(namespace: str, custom_version: Optional[str], custom_appdb_version: str) -> MongoDBOpsManager:
+    """Builds the management-plane Ops Manager ("Meta OM")
+    that owns the projects managing the External AppDB MongoDB CR. Deployment happens in each module's
+    TestDeployMetaOpsManager class, not here."""
+    resource = MongoDBOpsManager.from_yaml(
+        yaml_fixture("om_external_appdb_meta_om.yaml"),
+        name=META_OM_NAME,
+        namespace=namespace,
+    )
+    resource.set_version(custom_version)
+    resource.set_appdb_version(custom_appdb_version)
+
+    try_load(resource)
+
+    return resource
+
+
+def configure_appdb_role_mongodb(mdb: MongoDB, meta_om: MongoDBOpsManager, namespace: str) -> MongoDB:
+    """Points the External AppDB CR's project/credentials at the Meta OM."""
+    config_map_name = meta_om.get_or_create_mongodb_connection_config_map(mdb.name, f"{mdb.name}-project")
+
+    mdb["spec"]["opsManager"]["configMapRef"]["name"] = config_map_name
+    mdb["spec"]["credentials"] = meta_om.api_key_secret(namespace)
+
+    return mdb
+
+
+def write_sentinel_doc(cnx_string: str):
+    client = pymongo.MongoClient(cnx_string)
+    try:
+        client[TEST_DB][TEST_COLLECTION].insert_one(dict(SENTINEL_DOC))
+    finally:
+        client.close()
+
+
+def assert_sentinel_doc_present(cnx_string: str):
+    client = pymongo.MongoClient(cnx_string)
+    try:
+        found = client[TEST_DB][TEST_COLLECTION].find_one({"_id": SENTINEL_DOC["_id"]})
+        assert found is not None, "sentinel document did not survive the migration"
+        assert found["marker"] == SENTINEL_DOC["marker"]
+    finally:
+        client.close()
+
+
+def read_om_pod_restart_counts(ops_manager: MongoDBOpsManager) -> dict[str, int]:
+    """Maps Primary OM pod name -> sum of container restartCounts across all its containers."""
+    counts = {}
+    for api_client, pod in ops_manager.read_om_pods():
+        total = sum(cs.restart_count for cs in (pod.status.container_statuses or []))
+        counts[pod.metadata.name] = total
+    return counts
+
+
+def assert_project_exists(meta_om: MongoDBOpsManager, appdb_name: str):
+    """Verifies the AppDB CR's project still exists on the Meta OM after reverse migration."""
+    tester = meta_om.get_om_tester(project_name=f"{appdb_name}-project")
+    tester.assert_group_exists()

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import pymongo
+from kubernetes import client as k8s_client
 from kubetester import try_load
 from kubetester.kubetester import fixture as yaml_fixture
 from kubetester.mongodb import MongoDB
@@ -103,3 +104,10 @@ def assert_project_exists(meta_om: MongoDBOpsManager, appdb_name: str):
     """Verifies the AppDB CR's project still exists on the Meta OM after reverse migration."""
     tester = meta_om.get_om_tester(project_name=f"{appdb_name}-project")
     tester.assert_group_exists()
+
+
+def assert_no_migration_annotations(namespace: str, sts_name: str):
+    sts = k8s_client.AppsV1Api().read_namespaced_stateful_set(sts_name, namespace)
+    annotations = sts.metadata.annotations or {}
+    assert "mongodb.com/appdb-migration-ready" not in annotations
+    assert "mongodb.com/appdb-reverse-migration-ready" not in annotations

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
@@ -91,15 +91,6 @@ def assert_sentinel_doc_present(cnx_string: str):
         client.close()
 
 
-def read_om_pod_restart_counts(ops_manager: MongoDBOpsManager) -> dict[str, int]:
-    """Maps Primary OM pod name -> sum of container restartCounts across all its containers."""
-    counts = {}
-    for api_client, pod in ops_manager.read_om_pods():
-        total = sum(cs.restart_count for cs in (pod.status.container_statuses or []))
-        counts[pod.metadata.name] = total
-    return counts
-
-
 def assert_project_exists(meta_om: MongoDBOpsManager, appdb_name: str):
     """Verifies the AppDB CR's project still exists on the Meta OM after reverse migration."""
     tester = meta_om.get_om_tester(project_name=f"{appdb_name}-project")

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -313,7 +313,7 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 			omClusters := len(item.Spec.ClusterSpecList)
 			var appDBClusters int
 			var appDBExternalDomains string
-			if item.Spec.ExternalApplicationDatabaseRef == nil {
+			if item.Spec.ExternalAppDBRef == nil {
 				appDBClusters = len(item.Spec.AppDB.ClusterSpecList)
 				appDBExternalDomains = getExternalDomainPropertyForAppDB(item)
 			}

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -311,7 +311,12 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 		for _, item := range omList.Items {
 			// Detect enterprise
 			omClusters := len(item.Spec.ClusterSpecList)
-			appDBClusters := len(item.Spec.AppDB.ClusterSpecList)
+			var appDBClusters int
+			var appDBExternalDomains string
+			if item.Spec.ExternalApplicationDatabaseRef == nil {
+				appDBClusters = len(item.Spec.AppDB.ClusterSpecList)
+				appDBExternalDomains = getExternalDomainPropertyForAppDB(item)
+			}
 			properties := DeploymentUsageSnapshotProperties{
 				DeploymentUID:            string(item.UID),
 				OperatorID:               operatorUUID,
@@ -319,7 +324,7 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 				IsMultiCluster:           item.Spec.IsMultiCluster(),
 				Type:                     "OpsManager",
 				IsRunningEnterpriseImage: images.IsEnterpriseImage(mongodbImage),
-				ExternalDomains:          getExternalDomainPropertyForOpsManager(item),
+				ExternalDomains:          appDBExternalDomains,
 			}
 
 			if omClusters > 0 {
@@ -545,7 +550,7 @@ func getExternalDomainPropertyForMongoDBMulti(mdb mdbmultiv1.MongoDBMultiCluster
 	return mapExternalDomainConfigurationToEnum(isUniformExternalDomainSpecified, isClusterSpecificExternalDomainSpecified)
 }
 
-func getExternalDomainPropertyForOpsManager(om omv1.MongoDBOpsManager) string {
+func getExternalDomainPropertyForAppDB(om omv1.MongoDBOpsManager) string {
 	isUniformExternalDomainSpecified := om.Spec.AppDB.GetExternalDomain() != nil
 
 	isClusterSpecificExternalDomainSpecified := isExternalDomainSpecifiedInClusterSpecList(om.Spec.AppDB.ClusterSpecList)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -315,6 +315,19 @@ const (
 	LastAchievedRsMemberIds = "mongodb.com/v1.lastAchievedRsMemberIds"
 	LastConfiguredRoles     = "mongodb.com/v1.lastConfiguredRoles"
 
+	// AppDBMigrationReadyAnnotation marks the internal AppDB StatefulSet as fully detached from
+	// the MongoDBOpsManager resource, allowing the referenced MongoDB resource to
+	// adopt it (see checkAdoptionGate).
+	AppDBMigrationReadyAnnotation = "mongodb.com/appdb-migration-ready"
+
+	// AppDBReverseMigrationReadyAnnotation is the reverse-migration release request: set by the
+	// internal AppDB reconciler on a StatefulSet still owned by a MongoDB CR, answered by the
+	// MongoDB controller stripping its OwnerReference, and removed at adoption
+	// (ensureAppDBStatefulSetOwnership). Removal happens at adoption (not at migration
+	// completion), symmetric with the forward direction's consumeAdoptionSignal: from adoption
+	// onward the OwnerReference is the authoritative state.
+	AppDBReverseMigrationReadyAnnotation = "mongodb.com/appdb-reverse-migration-ready"
+
 	// SecretVolumeName is the name of the volume resource.
 	SecretVolumeName = "secret-certs"
 

--- a/pkg/vault/vaultwatcher/vaultsecretwatch.go
+++ b/pkg/vault/vaultwatcher/vaultsecretwatch.go
@@ -75,13 +75,15 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 			if triggeredReconciliation {
 				break
 			}
-			for _, secretName := range om.Spec.AppDB.GetSecretsMountedIntoPod() {
-				path := fmt.Sprintf("%s/%s/%s", vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)
+			if om.Spec.ExternalApplicationDatabaseRef == nil {
+				for _, secretName := range om.Spec.AppDB.GetSecretsMountedIntoPod() {
+					path := fmt.Sprintf("%s/%s/%s", vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName)
+					latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)
 
-				if latestResourceVersion > currentResourceVersion {
-					watchChannel <- event.GenericEvent{Object: &omList.Items[n]}
-					break
+					if latestResourceVersion > currentResourceVersion {
+						watchChannel <- event.GenericEvent{Object: &omList.Items[n]}
+						break
+					}
 				}
 			}
 		}

--- a/pkg/vault/vaultwatcher/vaultsecretwatch.go
+++ b/pkg/vault/vaultwatcher/vaultsecretwatch.go
@@ -75,7 +75,7 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 			if triggeredReconciliation {
 				break
 			}
-			if om.Spec.ExternalApplicationDatabaseRef == nil {
+			if om.Spec.ExternalAppDBRef == nil {
 				for _, secretName := range om.Spec.AppDB.GetSecretsMountedIntoPod() {
 					path := fmt.Sprintf("%s/%s/%s", vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName)
 					latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)


### PR DESCRIPTION
# Summary

Stacked on #1439 (API). Adds the business logic for the external Application Database feature (CLOUDP-429011), MongoDB-only — a `Kind` other than `MongoDB` (e.g. `MongoDBMultiCluster`) in `externalApplicationDatabaseRef` is rejected by the controller until multi support arrives in a later iteration:

- External AppDB reconciliation: fresh start and forward/reverse migration, ownership arbitration between Ops Manager and the MongoDB CR serving as AppDB.
- e2e coverage: fresh-start and forward-migration tests with fixtures + evergreen tasks (single-cluster).

## Proof of Work

- `go build ./...` green; `go test ./api/... ./controllers/... ./pkg/...` green (63 packages)
- e2e files statically verified (py_compile + fixture existence); not run locally

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? 
  - [x] (ships in parent #1439; `skip-changelog` label applied here)
