### PR TITLE
Populate the GH_TOKEN before gh usage

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -683,6 +683,9 @@ task_groups:
   - name: check_ocp_version_drift_task_group
     setup_group:
       - func: clone
+      - command: github.generate_token
+        params:
+          expansion_name: GH_TOKEN
       - func: setup_openshift_client
       - func: setup_gh
     tasks:


### PR DESCRIPTION
# Summary

We installed `gh` before calling the script, but did not populate `GH_TOKEN`, so the task failed:
https://spruce.corp.mongodb.com/version/6a6a13a1ea4e0e0007857f8f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Echeck_ocp_version_drift%24
```
gh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.
```

## Proof of Work

✅ [Test patch exercising the fixed check_ocp_version_drift](https://spruce.corp.mongodb.com/version/6a6b0c7e75e62b00077c75d9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed