### PR TITLE
CLOUDP-429011 - Extract AppDBReconciler interface (refactor)

### DIFF
--- a/changelog/20260804_fix_external_appdb_forward_migration_password.md
+++ b/changelog/20260804_fix_external_appdb_forward_migration_password.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-08-04
+---
+
+* **MongoDBOpsManager**: `spec.applicationDatabase.passwordSecretKeyRef` now fails reconciliation when the referenced secret does not exist, instead of silently generating a random password.

--- a/changelog/20260804_fix_external_appdb_forward_migration_password.md
+++ b/changelog/20260804_fix_external_appdb_forward_migration_password.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-08-04
 ---
 
-* **MongoDBOpsManager**: `spec.applicationDatabase.passwordSecretKeyRef` now fails reconciliation when the referenced secret does not exist, instead of silently generating a random password.
+* **MongoDBOpsManager**:  `MongoDBOpsManager` resource now fails reconciliation, when the secret referenced by the field `spec.applicationDatabase.passwordSecretKeyRef` does not exist, instead of silently generating a random password.

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -1727,7 +1727,8 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 	if err != nil {
 		if secret.SecretNotExist(err) {
 			if passwordRef != nil && passwordRef.Name != "" {
-				return "", xerrors.Errorf("password secret %s referenced by spec.applicationDatabase.passwordSecretKeyRef does not exist", passwordRef.Name)
+				secretObjectKey := kube.ObjectKey(opsManager.Namespace, passwordRef.Name)
+				return "", xerrors.Errorf("password secret %s referenced by spec.applicationDatabase.passwordSecretKeyRef does not exist", secretObjectKey)
 			}
 			log.Debugf("Generated AppDB password and storing in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
 			return r.generatePasswordAndCreateSecret(ctx, opsManager, log)
@@ -1757,13 +1758,14 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 func (r *ReconcileAppDbReplicaSet) readAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
 	passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef
 	if passwordRef != nil && passwordRef.Name != "" {
-		if passwordRef.Key == "" {
-			passwordRef.Key = "password"
+		passwordKey := "password"
+		if passwordRef.Key != "" {
+			passwordKey = passwordRef.Key
 		}
 
 		secretObjectKey := kube.ObjectKey(opsManager.Namespace, passwordRef.Name)
 		log.Debugf("Reading AppDB password from secret %s", secretObjectKey)
-		return secret.ReadKey(ctx, r.SecretClient, passwordRef.Key, secretObjectKey)
+		return secret.ReadKey(ctx, r.SecretClient, passwordKey, secretObjectKey)
 	}
 
 	secretObjectKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -840,9 +840,10 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...), status.NewPVCsStatusOptionEmptyStatus())
 }
 
-// BuildAppDBConnectionURL returns the connection string to the AppDB, ensuring the Ops Manager user password exists.
+// BuildAppDBConnectionURL returns the connection string to the AppDB, reading the Ops Manager user password.
+// It assumes ReconcileAppDB has already been called and the password secret exists.
 func (r *ReconcileAppDbReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	password, err := r.ensureAppDbPassword(ctx, opsManager, log)
+	password, err := r.readAppDbPassword(ctx, opsManager)
 	if err != nil {
 		return "", xerrors.Errorf("Error getting AppDB password: %w", err)
 	}
@@ -1720,23 +1721,22 @@ func (r *ReconcileAppDbReplicaSet) generatePasswordAndCreateSecret(ctx context.C
 // ensureAppDbPassword will return the password that was specified by the user, or the auto generated password stored in
 // the secret (generate it and store in secret otherwise)
 func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef
-	if passwordRef != nil && passwordRef.Name != "" { // there is a secret specified for the Ops Manager user
-		if passwordRef.Key == "" {
-			passwordRef.Key = "password"
-		}
-		password, err := secret.ReadKey(ctx, r.SecretClient, passwordRef.Key, kube.ObjectKey(opsManager.Namespace, passwordRef.Name))
-		if err != nil {
-			if secret.SecretNotExist(err) {
-				log.Debugf("Generated AppDB password and storing in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
-				return r.generatePasswordAndCreateSecret(ctx, opsManager, log)
+	password, err := r.readAppDbPassword(ctx, opsManager)
+	if err != nil {
+		if secret.SecretNotExist(err) {
+			if passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef; passwordRef != nil && passwordRef.Name != "" {
+				return "", xerrors.Errorf("password secret %s referenced by spec.applicationDatabase.passwordSecretKeyRef does not exist", passwordRef.Name)
 			}
-			return "", err
+			log.Debugf("Generated AppDB password and storing in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
+			return r.generatePasswordAndCreateSecret(ctx, opsManager, log)
 		}
+		return "", err
+	}
 
+	// User-provided password ref path: watch the secret and clean up the auto-generated one.
+	if passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef; passwordRef != nil && passwordRef.Name != "" {
 		log.Debugf("Reading password from secret/%s", passwordRef.Name)
 
-		// watch for any changes on the user provided password
 		r.resourceWatcher.AddWatchedResourceIfNotAdded(
 			passwordRef.Name,
 			opsManager.Namespace,
@@ -1744,34 +1744,28 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 			kube.ObjectKeyFromApiObject(opsManager),
 		)
 
-		// delete the auto generated password, we don't need it anymore. We can just generate a new one if
-		// the user password is deleted
 		log.Debugf("Deleting Operator managed password secret/%s from namespace %s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName(), opsManager.Namespace)
 		if err := r.DeleteSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())); err != nil && !secret.SecretNotExist(err) {
 			return "", err
 		}
-		return password, nil
+	} else {
+		log.Debugf("Using auto generated AppDB password stored in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
 	}
 
-	// otherwise we'll ensure the auto generated password exists
-	secretObjectKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
-	appDbPasswordSecretStringData, err := secret.ReadStringData(ctx, r.SecretClient, secretObjectKey)
+	return password, nil
+}
 
-	if secret.SecretNotExist(err) {
-		// create the password
-		if password, err := r.generatePasswordAndCreateSecret(ctx, opsManager, log); err != nil {
-			return "", err
-		} else {
-			log.Debugf("Using auto generated AppDB password stored in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
-			return password, nil
+func (r *ReconcileAppDbReplicaSet) readAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
+	passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef
+	if passwordRef != nil && passwordRef.Name != "" {
+		if passwordRef.Key == "" {
+			passwordRef.Key = "password"
 		}
-	} else if err != nil {
-		// any other error
-		return "", err
+		return secret.ReadKey(ctx, r.SecretClient, passwordRef.Key, kube.ObjectKey(opsManager.Namespace, passwordRef.Name))
 	}
-	log.
-		Debugf("Using auto generated AppDB password stored in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
-	return appDbPasswordSecretStringData[util.OpsManagerPasswordKey], nil
+
+	secretObjectKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
+	return secret.ReadKey(ctx, r.SecretClient, util.OpsManagerPasswordKey, secretObjectKey)
 }
 
 // ensureAppDbAgentApiKey makes sure there is an agent API key for the AppDB automation agent

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -843,7 +843,7 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 // BuildAppDBConnectionURL returns the connection string to the AppDB, reading the Ops Manager user password.
 // It assumes ReconcileAppDB has already been called and the password secret exists.
 func (r *ReconcileAppDbReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	password, err := r.readAppDbPassword(ctx, opsManager)
+	password, err := r.readAppDbPassword(ctx, opsManager, log)
 	if err != nil {
 		return "", xerrors.Errorf("Error getting AppDB password: %w", err)
 	}
@@ -1721,10 +1721,12 @@ func (r *ReconcileAppDbReplicaSet) generatePasswordAndCreateSecret(ctx context.C
 // ensureAppDbPassword will return the password that was specified by the user, or the auto generated password stored in
 // the secret (generate it and store in secret otherwise)
 func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	password, err := r.readAppDbPassword(ctx, opsManager)
+	passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef
+
+	password, err := r.readAppDbPassword(ctx, opsManager, log)
 	if err != nil {
 		if secret.SecretNotExist(err) {
-			if passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef; passwordRef != nil && passwordRef.Name != "" {
+			if passwordRef != nil && passwordRef.Name != "" {
 				return "", xerrors.Errorf("password secret %s referenced by spec.applicationDatabase.passwordSecretKeyRef does not exist", passwordRef.Name)
 			}
 			log.Debugf("Generated AppDB password and storing in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
@@ -1734,8 +1736,7 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 	}
 
 	// User-provided password ref path: watch the secret and clean up the auto-generated one.
-	if passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef; passwordRef != nil && passwordRef.Name != "" {
-		log.Debugf("Reading password from secret/%s", passwordRef.Name)
+	if passwordRef != nil && passwordRef.Name != "" {
 
 		r.resourceWatcher.AddWatchedResourceIfNotAdded(
 			passwordRef.Name,
@@ -1748,23 +1749,25 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 		if err := r.DeleteSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())); err != nil && !secret.SecretNotExist(err) {
 			return "", err
 		}
-	} else {
-		log.Debugf("Using auto generated AppDB password stored in secret/%s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
 	}
 
 	return password, nil
 }
 
-func (r *ReconcileAppDbReplicaSet) readAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
+func (r *ReconcileAppDbReplicaSet) readAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
 	passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef
 	if passwordRef != nil && passwordRef.Name != "" {
 		if passwordRef.Key == "" {
 			passwordRef.Key = "password"
 		}
-		return secret.ReadKey(ctx, r.SecretClient, passwordRef.Key, kube.ObjectKey(opsManager.Namespace, passwordRef.Name))
+
+		secretObjectKey := kube.ObjectKey(opsManager.Namespace, passwordRef.Name)
+		log.Debugf("Reading AppDB password from secret %s", secretObjectKey)
+		return secret.ReadKey(ctx, r.SecretClient, passwordRef.Key, secretObjectKey)
 	}
 
 	secretObjectKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())
+	log.Debugf("Using auto generated AppDB password stored in secret %s", secretObjectKey)
 	return secret.ReadKey(ctx, r.SecretClient, util.OpsManagerPasswordKey, secretObjectKey)
 }
 

--- a/controllers/operator/appdbreplicaset_reconciler.go
+++ b/controllers/operator/appdbreplicaset_reconciler.go
@@ -1,0 +1,23 @@
+package operator
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
+)
+
+// AppDBReconciler abstracts the AppDB reconciliation strategy. The internal
+// AppDB reconciler (ReconcileAppDbReplicaSet) is the sole implementation today;
+// future implementations can use alternative AppDB backends without changing the
+// Ops Manager controller.
+type AppDBReconciler interface {
+	// ReconcileAppDB brings the AppDB to the desired state.
+	ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error)
+
+	// BuildAppDBConnectionURL returns the MongoDB connection string OpsManager/BackupDaemon
+	// should use to reach the AppDB.
+	BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error)
+}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -422,21 +422,10 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// 1. Reconcile AppDB
-	emptyResult, _ := workflow.OK().ReconcileResult()
+	emptyResult := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
 	retryResult := reconcile.Result{RequeueAfter: time.Second}
 
-	// TODO: make SetupCommonWatchers support opsmanager watcher setup
-	// The order matters here, since appDB and opsManager share the same reconcile ObjectKey being opsmanager crd
-	// That means we need to remove first, which SetupCommonWatchers does, then register additional watches
-	appDBReplicaSet := opsManager.Spec.AppDB
-	r.SetupCommonWatchers(&appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
-
-	// We need to remove the watches on the top of the reconcile since we might add resources with the same key below.
-	if opsManager.IsTLSEnabled() {
-		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
-	}
-	// register backup
-	r.watchMongoDBResourcesReferencedByBackup(ctx, opsManager, log)
+	r.configureWatchersForDynamicResources(ctx, opsManager, log)
 
 	appDbReconciler, err := r.createNewAppDBReconciler(ctx, opsManager, log)
 	if err != nil {
@@ -493,11 +482,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if vault.IsVaultSecretBackend() {
 		vaultMap := make(map[string]string)
 		for _, s := range opsManager.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), appDBReplicaSet.Namespace, s)
+			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
 		for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), appDBReplicaSet.Namespace, s)
+			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
 
@@ -977,6 +966,17 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 	}
 
 	return mutatedSts, nil
+}
+
+func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
+	appDBReplicaSet := opsManager.Spec.AppDB
+	r.SetupCommonWatchers(&appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
+
+	if opsManager.IsTLSEnabled() {
+		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
+	}
+
+	r.watchMongoDBResourcesReferencedByBackup(ctx, opsManager, log)
 }
 
 func (r *OpsManagerReconciler) watchMongoDBResourcesReferencedByKmip(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
@@ -2068,7 +2068,7 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 	log.Info("Cleaned up Ops Manager related resources.")
 }
 
-func (r *OpsManagerReconciler) createNewAppDBReconciler(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (*ReconcileAppDbReplicaSet, error) {
+func (r *OpsManagerReconciler) createNewAppDBReconciler(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (AppDBReconciler, error) {
 	return NewAppDBReplicaSetReconciler(ctx, r.imageUrls, r.initDatabaseVersion, opsManager, r.ReconcileCommonController, r.omConnectionFactory, r.memberClustersMap, r.defaultArchitecture, log)
 }
 

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -969,6 +969,8 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 }
 
 func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
+	// The order matters here, since appDB and opsManager share the same reconcile ObjectKey being opsmanager crd
+	// That means we need to remove first, which SetupCommonWatchers does, then register additional watches
 	appDBReplicaSet := opsManager.Spec.AppDB
 	r.SetupCommonWatchers(&appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
 

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -422,21 +422,10 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// 1. Reconcile AppDB
-	emptyResult, _ := workflow.OK().ReconcileResult()
+	emptyResult := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
 	retryResult := reconcile.Result{RequeueAfter: time.Second}
 
-	// TODO: make SetupCommonWatchers support opsmanager watcher setup
-	// The order matters here, since appDB and opsManager share the same reconcile ObjectKey being opsmanager crd
-	// That means we need to remove first, which SetupCommonWatchers does, then register additional watches
-	appDBReplicaSet := opsManager.Spec.AppDB
-	r.SetupCommonWatchers(&appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
-
-	// We need to remove the watches on the top of the reconcile since we might add resources with the same key below.
-	if opsManager.IsTLSEnabled() {
-		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
-	}
-	// register backup
-	r.watchMongoDBResourcesReferencedByBackup(ctx, opsManager, log)
+	r.configureWatchersForDynamicResources(ctx, opsManager, log)
 
 	appDbReconciler, err := r.createNewAppDBReconciler(ctx, opsManager, log)
 	if err != nil {
@@ -493,11 +482,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if vault.IsVaultSecretBackend() {
 		vaultMap := make(map[string]string)
 		for _, s := range opsManager.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), appDBReplicaSet.Namespace, s)
+			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
 		for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), appDBReplicaSet.Namespace, s)
+			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), opsManager.Namespace, s)
 			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
 		}
 
@@ -977,6 +966,17 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 	}
 
 	return mutatedSts, nil
+}
+
+func (r *OpsManagerReconciler) configureWatchersForDynamicResources(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
+	appDBReplicaSet := opsManager.Spec.AppDB
+	r.SetupCommonWatchers(&appDBReplicaSet, nil, nil, appDBReplicaSet.GetName())
+
+	if opsManager.IsTLSEnabled() {
+		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
+	}
+
+	r.watchMongoDBResourcesReferencedByBackup(ctx, opsManager, log)
 }
 
 func (r *OpsManagerReconciler) watchMongoDBResourcesReferencedByKmip(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
@@ -2065,7 +2065,7 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 	log.Info("Cleaned up Ops Manager related resources.")
 }
 
-func (r *OpsManagerReconciler) createNewAppDBReconciler(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (*ReconcileAppDbReplicaSet, error) {
+func (r *OpsManagerReconciler) createNewAppDBReconciler(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (AppDBReconciler, error) {
 	return NewAppDBReplicaSetReconciler(ctx, r.imageUrls, r.initDatabaseVersion, opsManager, r.ReconcileCommonController, r.omConnectionFactory, r.memberClustersMap, r.defaultArchitecture, log)
 }
 

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -456,12 +456,26 @@ func TestOpsManagerGeneratesAppDBPassword_IfNotProvided(t *testing.T) {
 	assert.Len(t, password, 12, "auto generated password should have a size of 12")
 }
 
+func TestEnsureAppDbPassword_ErrorWhenPasswordSecretKeyRefNotFound(t *testing.T) {
+	ctx := context.Background()
+	testOm := DefaultOpsManagerBuilder().SetAppDBPassword("my-secret", "password").Build()
+	kubeManager, omConnectionFactory := mock.NewDefaultFakeClient(testOm)
+	appDBReconciler, err := newAppDbReconciler(ctx, kubeManager, testOm, omConnectionFactory.GetConnectionFunc, zap.S())
+	require.NoError(t, err)
+
+	password, err := appDBReconciler.ensureAppDbPassword(ctx, testOm, zap.S())
+
+	assert.Error(t, err)
+	assert.Empty(t, password)
+	assert.Contains(t, err.Error(), "my-secret")
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
 func TestOpsManagerUsersPassword_SpecifiedInSpec(t *testing.T) {
 	ctx := context.Background()
-	log := zap.S()
 	testOm := DefaultOpsManagerBuilder().SetAppDBPassword("my-secret", "password").Build()
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, client, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	_, client, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
 
 	s := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: testOm.Spec.AppDB.PasswordSecretKeyRef.Name, Namespace: testOm.Namespace},
@@ -476,7 +490,7 @@ func TestOpsManagerUsersPassword_SpecifiedInSpec(t *testing.T) {
 
 	require.NoError(t, err)
 
-	appDBReconciler, err := reconciler.createNewAppDBReconciler(ctx, testOm, log)
+	appDBReconciler, err := newAppDbReconciler(ctx, client, testOm, omConnectionFactory.GetConnectionFunc, zap.S())
 	require.NoError(t, err)
 	password, err := appDBReconciler.ensureAppDbPassword(ctx, testOm, zap.S())
 


### PR DESCRIPTION
# Summary

Pure refactor extracting the `AppDBReconciler` interface and related helper methods from the internal AppDB reconciler, plus a fix for `ensureAppDbPassword` when `PasswordSecretKeyRef` is set but the referenced secret doesn't exist.

- Introduces `AppDBReconciler` interface in `controllers/operator/appdbreplicaset_reconciler.go`
- `createNewAppDBReconciler` returns `AppDBReconciler` instead of the concrete `*ReconcileAppDbReplicaSet`
- Extracts `readAppDbPassword` from `ensureAppDbPassword` for reuse
- Extracts watcher setup into `configureWatchersForDynamicResources`
- Changes `emptyResult` to explicit `reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}`
- **Fix**: `ensureAppDbPassword` now returns an error instead of silently generating a random password when `spec.appDB.passwordSecretKeyRef` is set but the referenced secret does not exist. This prevents the controller from falling back to an auto-generated password when the user has explicitly configured a custom secret — the user must create the secret first, and the reconcile will requeue on the next attempt.

This is the base of a 3-PR stack; API surface arrives in #1439, reconciliation logic in #1440.

## Proof of Work

- `go vet ./...` green
- `go test ./controllers/operator/` green (including new `TestEnsureAppDbPassword_ErrorWhenPasswordSecretKeyRefNotFound`)
- `pre-commit run golangci-lint-full --all-files` Passed

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? (skip-changelog — pure refactor, no functional impact)