### PR TITLE
KUBE-268: Include GCP cleanup in periodic teardown

### DIFF
--- a/.evergreen-periodic-builds.yaml
+++ b/.evergreen-periodic-builds.yaml
@@ -22,12 +22,26 @@ tasks:
     commands:
       - func: teardown_cloud_qa_all
 
+  - name: periodic_gcp_cleanup
+    commands:
+      - func: clone
+      - func: setup_gcloud_cli
+      - command: subprocess.exec
+        params:
+          working_dir: src/github.com/mongodb/mongodb-kubernetes
+          add_to_path:
+            - ${workdir}/google-cloud-sdk/bin
+          binary: scripts/evergreen/periodic-cleanup-gcp.sh
+          env:
+            MDB_GKE_PROJECT: "scratch-kubernetes-team"
+
 task_groups:
   - name: periodic_teardown_task_group
     <<: *setup_group
     tasks:
       - periodic_teardown_aws
       - periodic_teardown_cloudqa
+      - periodic_gcp_cleanup
 
 buildvariants:
   - name: periodic_teardown

--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -197,19 +197,6 @@ tasks:
       - func: test_code_snippets
       - func: archive_snippets_output
 
-  - name: periodic_gcp_cleanup
-    commands:
-      - func: clone
-      - func: setup_gcloud_cli
-      - command: subprocess.exec
-        params:
-          working_dir: src/github.com/mongodb/mongodb-kubernetes
-          add_to_path:
-            - ${workdir}/google-cloud-sdk/bin
-          binary: scripts/evergreen/periodic-cleanup-gcp.sh
-          env:
-            MDB_GKE_PROJECT: "scratch-kubernetes-team"
-
 task_groups:
   - name: gke_code_snippets_task_group
     <<: *setup_and_teardown_group_gke_code_snippets
@@ -286,13 +273,3 @@ buildvariants:
     <<: *base_om8_dependency
     tasks:
       - name: kind_multi_cluster_code_snippets_task_group
-
-  - name: periodic_gcp_cleanup
-    display_name: periodic_gcp_cleanup
-    tags: [ "periodic_teardown" ]
-    allowed_requesters: [ "cron", "patch" ]
-    cron: "0 6 * * *"
-    run_on:
-      - ubuntu2404-small
-    tasks:
-      - periodic_gcp_cleanup


### PR DESCRIPTION
# Summary

The GCP reaper was defined as a standalone snippets cron variant, but the active `periodic_teardown` configuration only ran the AWS and CloudQA cleanup tasks. This change moves `periodic_gcp_cleanup` into the active `periodic_teardown_task_group` and removes the duplicate standalone variant, giving periodic cleanup one execution path.

## Proof of Work

- Evergreen `periodic_teardown` passed, including `periodic_gcp_cleanup`, `periodic_teardown_aws`, and `periodic_teardown_cloudqa`: https://spruce.corp.mongodb.com/version/6a71de33e58cac0007fb9349/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
- `make precommit` passed.
- `bash -n scripts/evergreen/periodic-cleanup-gcp.sh` passed.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? (skip-changelog label; CI configuration only)

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->