### PR TITLE
Introduce envtest for Go tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,9 +351,10 @@ kustomize:
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
 # envtest: local Kubernetes control plane (etcd + kube-apiserver) used by Go tests
-# (see test/envtest). ENVTEST_K8S_VERSION tracks the minimum supported Kubernetes
-# version from kubernetes-versions.json.
-ENVTEST_K8S_VERSION ?= 1.34.x
+# (see test/envtest). ENVTEST_K8S_VERSION defaults to the minimum supported Kubernetes
+# version from kubernetes-versions.json, reduced to a minor-version wildcard (e.g.
+# 1.34.3 -> 1.34.x) so that setup-envtest resolves the latest available patch release.
+ENVTEST_K8S_VERSION ?= $(shell jq -r '.kubernetes.min' kubernetes-versions.json | cut -d. -f1-2).x
 SETUP_ENVTEST = $(shell pwd)/bin/setup-envtest
 ENVTEST_ASSETS_DIR = $(shell pwd)/bin/envtest
 # setup-envtest (a downloader for the envtest binaries) is versioned independently of

--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,28 @@ KUSTOMIZE ?= $(shell which kustomize 2>/dev/null || echo $(shell pwd)/bin/kustom
 kustomize:
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
+# envtest: local Kubernetes control plane (etcd + kube-apiserver) used by Go tests
+# (see test/envtest). ENVTEST_K8S_VERSION tracks the minimum supported Kubernetes
+# version from kubernetes-versions.json.
+ENVTEST_K8S_VERSION ?= 1.34.x
+SETUP_ENVTEST = $(shell pwd)/bin/setup-envtest
+ENVTEST_ASSETS_DIR = $(shell pwd)/bin/envtest
+# setup-envtest (a downloader for the envtest binaries) is versioned independently of
+# controller-runtime; the module only publishes tags since v0.24.0.
+SETUP_ENVTEST_VERSION ?= v0.24.1
+
+# Download setup-envtest locally if necessary
+setup-envtest:
+	$(call go-install-tool,$(SETUP_ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION))
+
+# Download the envtest binaries (etcd, kube-apiserver, kubectl); idempotent
+envtest-assets: setup-envtest
+	$(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
+
+# Print the envtest binaries path on stdout (used to set KUBEBUILDER_ASSETS)
+envtest-assets-path: setup-envtest
+	@$(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path
+
 # go-install-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-install-tool

--- a/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
@@ -3,6 +3,7 @@ package search_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,14 +17,20 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/test/envtest/env"
 )
 
+// TestMain boots one envtest control plane shared by all tests in this package
+// (see test/envtest/env). Future envtest-based tests in this package should use
+// env.Shared(t) instead of starting their own environment.
+func TestMain(m *testing.M) {
+	os.Exit(env.RunShared(m, env.WithCRDs("mongodb.com_mongodbsearch.yaml")))
+}
+
 // TestMongoDBSearchCELValidation proves that the CEL validation rules defined on
 // the MongoDBSearch CRD are enforced by a real Kubernetes API server (booted
 // locally via envtest). It covers both create-time rules and the oldSelf-based
 // transition rule, neither of which can be exercised by plain Go unit tests.
 func TestMongoDBSearchCELValidation(t *testing.T) {
 	ctx := context.Background()
-	testEnv := env.Start(t, env.WithCRDs("mongodb.com_mongodbsearch.yaml"))
-	k8sClient := testEnv.Client
+	k8sClient := env.Shared(t).Client
 
 	newSearch := func(name string, clusters ...searchv1.ClusterSpec) *searchv1.MongoDBSearch {
 		return &searchv1.MongoDBSearch{

--- a/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
@@ -2,6 +2,7 @@ package search_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,20 +32,25 @@ func TestMongoDBSearchCELValidation(t *testing.T) {
 		}
 	}
 
-	t.Run("valid minimal spec is accepted", func(t *testing.T) {
-		search := newSearch("valid", searchv1.ClusterSpec{})
-		require.NoError(t, k8sClient.Create(ctx, search))
-		require.NoError(t, k8sClient.Delete(ctx, search))
-	})
-
-	rejectionTests := []struct {
-		name          string
-		clusters      []searchv1.ClusterSpec
+	tests := []struct {
+		name string
+		// create is the spec.clusters value submitted on create.
+		create []searchv1.ClusterSpec
+		// update, when non-nil, replaces spec.clusters in an update after a
+		// successful create; the expectation then applies to that update
+		// (for oldSelf-based transition rules).
+		update []searchv1.ClusterSpec
+		// errorContains is the expected CEL validation message;
+		// empty means the operation must succeed.
 		errorContains string
 	}{
 		{
+			name:   "valid minimal spec is accepted",
+			create: []searchv1.ClusterSpec{{}},
+		},
+		{
 			name: "loadBalancer must set exactly one of managed or unmanaged",
-			clusters: []searchv1.ClusterSpec{{
+			create: []searchv1.ClusterSpec{{
 				LoadBalancer: &searchv1.LoadBalancerConfig{
 					Managed:   &searchv1.ManagedLBConfig{},
 					Unmanaged: &searchv1.UnmanagedLBConfig{},
@@ -54,7 +60,7 @@ func TestMongoDBSearchCELValidation(t *testing.T) {
 		},
 		{
 			name: "cluster names are required when more than one cluster is specified",
-			clusters: []searchv1.ClusterSpec{
+			create: []searchv1.ClusterSpec{
 				{Index: ptr.To(int32(0))},
 				{Index: ptr.To(int32(1))},
 			},
@@ -62,30 +68,37 @@ func TestMongoDBSearchCELValidation(t *testing.T) {
 		},
 		{
 			name: "cluster index must be unique",
-			clusters: []searchv1.ClusterSpec{
+			create: []searchv1.ClusterSpec{
 				{Name: "cluster-a", Index: ptr.To(int32(0))},
 				{Name: "cluster-b", Index: ptr.To(int32(0))},
 			},
 			errorContains: "clusters[].index must be unique when set",
 		},
+		{
+			name:          "cluster name is immutable for an existing index",
+			create:        []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(0))}},
+			update:        []searchv1.ClusterSpec{{Name: "cluster-b", Index: ptr.To(int32(0))}},
+			errorContains: "clusters[].name is immutable for an existing cluster index",
+		},
 	}
-	for _, tc := range rejectionTests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := k8sClient.Create(ctx, newSearch("invalid", tc.clusters...))
+			search := newSearch(fmt.Sprintf("case-%d", i), tc.create...)
+			err := k8sClient.Create(ctx, search)
+
+			if tc.update != nil {
+				require.NoError(t, err)
+				search.Spec.Clusters = tc.update
+				err = k8sClient.Update(ctx, search)
+			}
+
+			if tc.errorContains == "" {
+				require.NoError(t, err)
+				return
+			}
 			require.Error(t, err)
 			assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got: %v", err)
 			assert.Contains(t, err.Error(), tc.errorContains)
 		})
 	}
-
-	t.Run("cluster name is immutable for an existing index", func(t *testing.T) {
-		search := newSearch("immutable-name", searchv1.ClusterSpec{Name: "cluster-a", Index: ptr.To(int32(0))})
-		require.NoError(t, k8sClient.Create(ctx, search))
-
-		search.Spec.Clusters[0].Name = "cluster-b"
-		err := k8sClient.Update(ctx, search)
-		require.Error(t, err)
-		assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got: %v", err)
-		assert.Contains(t, err.Error(), "clusters[].name is immutable for an existing cluster index")
-	})
 }

--- a/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
@@ -1,0 +1,91 @@
+package search_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	searchv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/search"
+	"github.com/mongodb/mongodb-kubernetes/test/envtest/env"
+)
+
+// TestMongoDBSearchCELValidation proves that the CEL validation rules defined on
+// the MongoDBSearch CRD are enforced by a real Kubernetes API server (booted
+// locally via envtest). It covers both create-time rules and the oldSelf-based
+// transition rule, neither of which can be exercised by plain Go unit tests.
+func TestMongoDBSearchCELValidation(t *testing.T) {
+	ctx := context.Background()
+	testEnv := env.Start(t, env.WithCRDs("mongodb.com_mongodbsearch.yaml"))
+	k8sClient := testEnv.Client
+
+	newSearch := func(name string, clusters ...searchv1.ClusterSpec) *searchv1.MongoDBSearch {
+		return &searchv1.MongoDBSearch{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec:       searchv1.MongoDBSearchSpec{Clusters: clusters},
+		}
+	}
+
+	t.Run("valid minimal spec is accepted", func(t *testing.T) {
+		search := newSearch("valid", searchv1.ClusterSpec{})
+		require.NoError(t, k8sClient.Create(ctx, search))
+		require.NoError(t, k8sClient.Delete(ctx, search))
+	})
+
+	rejectionTests := []struct {
+		name          string
+		clusters      []searchv1.ClusterSpec
+		errorContains string
+	}{
+		{
+			name: "loadBalancer must set exactly one of managed or unmanaged",
+			clusters: []searchv1.ClusterSpec{{
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed:   &searchv1.ManagedLBConfig{},
+					Unmanaged: &searchv1.UnmanagedLBConfig{},
+				},
+			}},
+			errorContains: "exactly one of managed or unmanaged must be set",
+		},
+		{
+			name: "cluster names are required when more than one cluster is specified",
+			clusters: []searchv1.ClusterSpec{
+				{Index: ptr.To(int32(0))},
+				{Index: ptr.To(int32(1))},
+			},
+			errorContains: "clusters[].name must be set and unique when more than one cluster is specified",
+		},
+		{
+			name: "cluster index must be unique",
+			clusters: []searchv1.ClusterSpec{
+				{Name: "cluster-a", Index: ptr.To(int32(0))},
+				{Name: "cluster-b", Index: ptr.To(int32(0))},
+			},
+			errorContains: "clusters[].index must be unique when set",
+		},
+	}
+	for _, tc := range rejectionTests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k8sClient.Create(ctx, newSearch("invalid", tc.clusters...))
+			require.Error(t, err)
+			assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got: %v", err)
+			assert.Contains(t, err.Error(), tc.errorContains)
+		})
+	}
+
+	t.Run("cluster name is immutable for an existing index", func(t *testing.T) {
+		search := newSearch("immutable-name", searchv1.ClusterSpec{Name: "cluster-a", Index: ptr.To(int32(0))})
+		require.NoError(t, k8sClient.Create(ctx, search))
+
+		search.Spec.Clusters[0].Name = "cluster-b"
+		err := k8sClient.Update(ctx, search)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got: %v", err)
+		assert.Contains(t, err.Error(), "clusters[].name is immutable for an existing cluster index")
+	})
+}

--- a/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go
@@ -2,7 +2,6 @@ package search_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -32,9 +31,9 @@ func TestMongoDBSearchCELValidation(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := env.Shared(t).Client
 
-	newSearch := func(name string, clusters ...searchv1.ClusterSpec) *searchv1.MongoDBSearch {
+	newSearch := func(clusters ...searchv1.ClusterSpec) *searchv1.MongoDBSearch {
 		return &searchv1.MongoDBSearch{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cel-", Namespace: "default"},
 			Spec:       searchv1.MongoDBSearchSpec{Clusters: clusters},
 		}
 	}
@@ -88,9 +87,9 @@ func TestMongoDBSearchCELValidation(t *testing.T) {
 			errorContains: "clusters[].name is immutable for an existing cluster index",
 		},
 	}
-	for i, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			search := newSearch(fmt.Sprintf("case-%d", i), tc.create...)
+			search := newSearch(tc.create...)
 			err := k8sClient.Create(ctx, search)
 
 			if tc.update != nil {

--- a/docs/dev/envtest.md
+++ b/docs/dev/envtest.md
@@ -11,15 +11,15 @@ The envtest binaries are provisioned automatically by all unit test entry points
 once into `bin/envtest/` and exposed to `go test` via `KUBEBUILDER_ASSETS`.
 
 To run a test package directly (or from an IDE), provision the binaries once —
-the `env.Start` helper locates them in `bin/envtest/` on its own:
+the `env` helper locates them in `bin/envtest/` on its own:
 
 ```shell
 make envtest-assets
 go test -v ./api/mongodb/v1/search/...   # or any other package with envtest tests
 ```
 
-`ENVTEST_K8S_VERSION` (Makefile) tracks the minimum supported Kubernetes version from
-`kubernetes-versions.json`; override with `make envtest-assets ENVTEST_K8S_VERSION=1.35.x`.
+`ENVTEST_K8S_VERSION` (Makefile) is derived from the minimum supported Kubernetes version
+in `kubernetes-versions.json`; override with `make envtest-assets ENVTEST_K8S_VERSION=1.35.x`.
 
 ## Writing a new envtest test
 
@@ -29,9 +29,12 @@ registered. It works from any package — co-locate CEL tests next to the API ty
 define the rules (see below), or use it from controller tests:
 
 ```go
+func TestMain(m *testing.M) {
+    os.Exit(env.RunShared(m, env.WithCRDs("mongodb.com_mongodbsearch.yaml")))
+}
+
 func TestSomething(t *testing.T) {
-    testEnv := env.Start(t, env.WithCRDs("mongodb.com_mongodbsearch.yaml"))
-    k8sClient := testEnv.Client
+    k8sClient := env.Shared(t).Client
     // ... create/update objects, assert API server behaviour
 }
 ```
@@ -39,8 +42,14 @@ func TestSomething(t *testing.T) {
 Guidelines:
 
 - Each test *package* boots its own control plane (`go test` compiles every package
-  into a separate binary, so environments cannot be shared across packages). Call
-  `env.Start` once per top-level test and share it across subtests to keep boot cost low.
+  into a separate binary, so environments cannot be shared across packages). One boot
+  takes a few seconds, so **boot exactly once per package** from `TestMain` with
+  `env.RunShared` and access the environment from every test via `env.Shared(t)`:
+  ```go
+  func TestMain(m *testing.M) {
+      os.Exit(env.RunShared(m, env.WithCRDs("mongodb.com_mongodbsearch.yaml")))
+  }
+  ```
 - Pass `env.WithCRDs(...)` to install only the CRDs the test needs (faster boot);
   omit it to install all of `config/crd/bases`.
 - Missing binaries or CRD paths fail the test immediately — this is deliberate, so CI

--- a/docs/dev/envtest.md
+++ b/docs/dev/envtest.md
@@ -1,0 +1,52 @@
+# envtest-based Go tests
+
+[envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) boots a local
+Kubernetes control plane (etcd + kube-apiserver) for Go tests, letting them run against
+a real API server — e.g. to verify CRD CEL validation rules — without a cluster.
+
+## Running
+
+The envtest binaries are provisioned automatically by all unit test entry points
+(`make golang-tests`, `make test`, CI's `unit_tests_golang` task); they are downloaded
+once into `bin/envtest/` and exposed to `go test` via `KUBEBUILDER_ASSETS`.
+
+To run a test package directly (or from an IDE), provision the binaries once —
+the `env.Start` helper locates them in `bin/envtest/` on its own:
+
+```shell
+make envtest-assets
+go test -v ./api/mongodb/v1/search/...   # or any other package with envtest tests
+```
+
+`ENVTEST_K8S_VERSION` (Makefile) tracks the minimum supported Kubernetes version from
+`kubernetes-versions.json`; override with `make envtest-assets ENVTEST_K8S_VERSION=1.35.x`.
+
+## Writing a new envtest test
+
+Use the shared helper in `test/envtest/env` — it starts the control plane, installs the
+CRDs from `config/crd/bases` and returns a client with the `mongodb.com/v1` scheme
+registered. It works from any package — co-locate CEL tests next to the API types that
+define the rules (see below), or use it from controller tests:
+
+```go
+func TestSomething(t *testing.T) {
+    testEnv := env.Start(t, env.WithCRDs("mongodb.com_mongodbsearch.yaml"))
+    k8sClient := testEnv.Client
+    // ... create/update objects, assert API server behaviour
+}
+```
+
+Guidelines:
+
+- Each test *package* boots its own control plane (`go test` compiles every package
+  into a separate binary, so environments cannot be shared across packages). Call
+  `env.Start` once per top-level test and share it across subtests to keep boot cost low.
+- Pass `env.WithCRDs(...)` to install only the CRDs the test needs (faster boot);
+  omit it to install all of `config/crd/bases`.
+- Missing binaries or CRD paths fail the test immediately — this is deliberate, so CI
+  can never silently skip envtest coverage.
+- envtest runs no controllers: objects are stored and validated, but nothing reconciles
+  them, and namespaces cannot be deleted.
+
+See `api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go` for a complete example:
+it verifies the CEL rules declared on the `MongoDBSearch` type in the very same package.

--- a/scripts/evergreen/unit-tests-golang.sh
+++ b/scripts/evergreen/unit-tests-golang.sh
@@ -6,6 +6,12 @@ set -x
 
 source scripts/dev/set_env_context.sh
 
+# Provision the envtest binaries (etcd + kube-apiserver) used by envtest-based Go tests
+# (see test/envtest) and expose them to `go test` via KUBEBUILDER_ASSETS.
+make envtest-assets
+KUBEBUILDER_ASSETS="$(make -s envtest-assets-path)"
+export KUBEBUILDER_ASSETS
+
 USE_RACE_SWITCH=""
 if [[ "${USE_RACE:-"false"}" = "true" ]]; then
   USE_RACE_SWITCH="-race"

--- a/test/envtest/env/env.go
+++ b/test/envtest/env/env.go
@@ -1,0 +1,121 @@
+// Package env provides a shared bootstrap for envtest-based Go tests: it starts
+// a local Kubernetes control plane (etcd + kube-apiserver), installs the
+// project's CRDs and returns a client connected to it.
+//
+// Each Go test package that needs an API server starts its own control plane:
+// `go test` compiles every package into a separate binary, so a control plane
+// cannot be shared across packages. To keep the boot cost (a few seconds) low,
+// start one environment per top-level test and share it across subtests.
+//
+// The binaries are provisioned by `make envtest-assets`; the unit test entry
+// points (make golang-tests, scripts/evergreen/unit-tests-golang.sh) run it
+// automatically and export KUBEBUILDER_ASSETS.
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
+)
+
+// TestEnv is a running envtest control plane together with the means to talk to it.
+type TestEnv struct {
+	// Environment is the underlying envtest environment.
+	Environment *envtest.Environment
+	// Config is the rest.Config for the local API server; use it to build
+	// managers or additional clients (e.g. in controller tests).
+	Config *rest.Config
+	// Client is a controller-runtime client with the mongodb.com/v1 scheme registered.
+	Client client.Client
+}
+
+// Option customises the control plane before it starts.
+type Option func(*envtest.Environment)
+
+// WithCRDs restricts CRD installation to the given yaml files from
+// config/crd/bases (e.g. "mongodb.com_mongodbsearch.yaml") instead of
+// installing every CRD in the repository. Fewer CRDs means a faster boot.
+func WithCRDs(crdFileNames ...string) Option {
+	return func(e *envtest.Environment) {
+		e.CRDDirectoryPaths = make([]string, 0, len(crdFileNames))
+		for _, name := range crdFileNames {
+			e.CRDDirectoryPaths = append(e.CRDDirectoryPaths, filepath.Join(crdBasesDir(), name))
+		}
+	}
+}
+
+// Start boots a local Kubernetes control plane, installs the CRDs (all of
+// config/crd/bases unless WithCRDs is given) and returns the running TestEnv.
+// The control plane is stopped automatically when the test finishes.
+//
+// The test fails immediately if the envtest binaries are missing;
+// run `make envtest-assets` to download them.
+func Start(t *testing.T, opts ...Option) *TestEnv {
+	t.Helper()
+
+	environment := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdBasesDir()},
+		ErrorIfCRDPathMissing: true,
+		// Allow running tests directly (go test, IDE) without KUBEBUILDER_ASSETS,
+		// as long as `make envtest-assets` has been run once.
+		BinaryAssetsDirectory: binaryAssetsDir(),
+	}
+	for _, opt := range opts {
+		opt(environment)
+	}
+
+	cfg, err := environment.Start()
+	require.NoError(t, err, "failed to start the envtest control plane; run `make envtest-assets` to download the required binaries")
+	t.Cleanup(func() {
+		require.NoError(t, environment.Stop(), "failed to stop the envtest control plane")
+	})
+
+	scheme := kruntime.NewScheme()
+	require.NoError(t, mdbv1.AddToScheme(scheme))
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	return &TestEnv{Environment: environment, Config: cfg, Client: k8sClient}
+}
+
+// crdBasesDir returns the absolute path to config/crd/bases.
+func crdBasesDir() string {
+	return filepath.Join(repoRoot(), "config", "crd", "bases")
+}
+
+// binaryAssetsDir returns the first version directory under bin/envtest/k8s
+// provisioned by `make envtest-assets`, so that tests run directly (go test,
+// IDE) work without extra setup. KUBEBUILDER_ASSETS, when set (the unit test
+// entry points export it), takes precedence over this field inside envtest.
+// An empty result leaves envtest's own defaults untouched.
+func binaryAssetsDir() string {
+	k8sDir := filepath.Join(repoRoot(), "bin", "envtest", "k8s")
+	entries, err := os.ReadDir(k8sDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(k8sDir, entry.Name())
+		}
+	}
+	return ""
+}
+
+// repoRoot returns the absolute path to the repository root, derived from this
+// file's location so that tests work from any package, at any depth.
+func repoRoot() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+}

--- a/test/envtest/env/env.go
+++ b/test/envtest/env/env.go
@@ -4,8 +4,10 @@
 //
 // Each Go test package that needs an API server starts its own control plane:
 // `go test` compiles every package into a separate binary, so a control plane
-// cannot be shared across packages. To keep the boot cost (a few seconds) low,
-// start one environment per top-level test and share it across subtests.
+// cannot be shared across packages. Within a package, boot exactly once from
+// TestMain via RunShared (the plain Go equivalent of Ginkgo's BeforeSuite) and
+// access the environment from every test via Shared — this keeps the boot cost
+// (a few seconds) at one per package no matter how many tests are added.
 //
 // The binaries are provisioned by `make envtest-assets`; the unit test entry
 // points (make golang-tests, scripts/evergreen/unit-tests-golang.sh) run it
@@ -13,6 +15,7 @@
 package env
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -54,15 +57,47 @@ func WithCRDs(crdFileNames ...string) Option {
 	}
 }
 
-// Start boots a local Kubernetes control plane, installs the CRDs (all of
-// config/crd/bases unless WithCRDs is given) and returns the running TestEnv.
-// The control plane is stopped automatically when the test finishes.
-//
-// The test fails immediately if the envtest binaries are missing;
-// run `make envtest-assets` to download them.
-func Start(t *testing.T, opts ...Option) *TestEnv {
-	t.Helper()
+// shared is the package-wide environment started by RunShared.
+var shared *TestEnv
 
+// RunShared boots a single control plane shared by all tests in the package,
+// runs the package's tests and tears the control plane down. It is the plain
+// Go equivalent of Ginkgo's BeforeSuite/AfterSuite, used from the package's
+// TestMain:
+//
+//	func TestMain(m *testing.M) {
+//		os.Exit(env.RunShared(m, env.WithCRDs("mongodb.com_mongodbsearch.yaml")))
+//	}
+//
+// Tests access the environment through Shared.
+func RunShared(m *testing.M, opts ...Option) int {
+	testEnv, err := start(opts...)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to start the envtest control plane; run `make envtest-assets` to download the required binaries: %v\n", err)
+		return 1
+	}
+	shared = testEnv
+
+	code := m.Run()
+
+	if err := testEnv.Environment.Stop(); err != nil && code == 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to stop the envtest control plane: %v\n", err)
+		code = 1
+	}
+	return code
+}
+
+// Shared returns the package-wide environment started by RunShared in the
+// package's TestMain. It fails the test immediately if RunShared was not used.
+func Shared(t *testing.T) *TestEnv {
+	t.Helper()
+	require.NotNil(t, shared, "no shared envtest environment; call env.RunShared from the package's TestMain")
+	return shared
+}
+
+// start boots the control plane and builds the client; RunShared stops it
+// after m.Run.
+func start(opts ...Option) (*TestEnv, error) {
 	environment := &envtest.Environment{
 		CRDDirectoryPaths:     []string{crdBasesDir()},
 		ErrorIfCRDPathMissing: true,
@@ -75,18 +110,21 @@ func Start(t *testing.T, opts ...Option) *TestEnv {
 	}
 
 	cfg, err := environment.Start()
-	require.NoError(t, err, "failed to start the envtest control plane; run `make envtest-assets` to download the required binaries")
-	t.Cleanup(func() {
-		require.NoError(t, environment.Stop(), "failed to stop the envtest control plane")
-	})
+	if err != nil {
+		return nil, err
+	}
 
 	scheme := kruntime.NewScheme()
-	require.NoError(t, mdbv1.AddToScheme(scheme))
+	if err := mdbv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 
 	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 
-	return &TestEnv{Environment: environment, Config: cfg, Client: k8sClient}
+	return &TestEnv{Environment: environment, Config: cfg, Client: k8sClient}, nil
 }
 
 // crdBasesDir returns the absolute path to config/crd/bases.

--- a/test/envtest/env/env.go
+++ b/test/envtest/env/env.go
@@ -82,7 +82,7 @@ func RunShared(m *testing.M, opts ...Option) int {
 
 	if err := testEnv.Environment.Stop(); err != nil && code == 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "failed to stop the envtest control plane: %v\n", err)
-		code = 1
+		return 1
 	}
 	return code
 }


### PR DESCRIPTION
# Summary

Introduces [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) (local etcd + kube-apiserver) for Go tests, so API-server-level behaviour can be tested without a cluster. Binaries are provisioned by `make envtest-assets` (wired into `scripts/evergreen/unit-tests-golang.sh`, so `make golang-tests` / CI get them automatically), with a shared helper package in `test/envtest/env` for use from any package. No existing tests were changed.

As a proof of concept, adds a test verifying the CEL validation rules of the MongoDBSearch CRD against a real API server, co-located with the types in `api/mongodb/v1/search`. See `docs/dev/envtest.md` for usage.

## Proof of Work

- `make golang-tests` green: 2978 tests, including the new `TestMongoDBSearchCELValidation` (5 CEL cases: valid spec accepted, `managed`/`unmanaged` XOR, cluster name required-and-unique, index uniqueness, name immutability via `oldSelf`)
- `make precommit` green
- e2e: N/A (no runtime change — tooling and test files only)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?