### PR TITLE
CLOUDP-407997: Fix signature publishing

### DIFF
--- a/ci/internal/release/images_promote_test.go
+++ b/ci/internal/release/images_promote_test.go
@@ -31,6 +31,13 @@ func (f *fakeRegistry) CopyWithTags(srcRef, dstRepo string, tags []string) error
 	return nil
 }
 
+func (f *fakeRegistry) CopySignatures(srcRef, dstRepo string) error {
+	if err := f.fail[srcRef]; err != nil {
+		return err
+	}
+	return nil
+}
+
 func (f *fakeRegistry) ListTags(repo string) ([]string, error) {
 	return nil, errors.New("fakeRegistry.ListTags not implemented")
 }

--- a/ci/internal/release/promote.go
+++ b/ci/internal/release/promote.go
@@ -109,5 +109,8 @@ func Promote(inputs PromoteInputs, host string, reg Registry) (PromoteResult, er
 	if err := reg.CopyWithTags(inputs.Image, inputs.Repo, []string{latestTag}); err != nil {
 		return PromoteResult{}, fmt.Errorf("promote %s (latest): %w", inputs.Image, err)
 	}
+	if err := reg.CopySignatures(inputs.Image, inputs.Repo); err != nil {
+		return PromoteResult{}, fmt.Errorf("promote %s (signatures): %w", inputs.Image, err)
+	}
 	return result, nil
 }

--- a/ci/internal/release/publish.go
+++ b/ci/internal/release/publish.go
@@ -101,6 +101,9 @@ func Publish(inputs PublishInputs, host string, reg Registry) (PublishResult, er
 	if err := reg.CopyWithTags(srcRef, inputs.ProdRepo, []string{marker}); err != nil {
 		return PublishResult{}, fmt.Errorf("publish %s (%s): %w", srcRef, marker, err)
 	}
+	if err := reg.CopySignatures(srcRef, inputs.ProdRepo); err != nil {
+		return PublishResult{}, fmt.Errorf("publish %s (signatures): %w", srcRef, err)
+	}
 	return result, nil
 }
 

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -50,6 +50,16 @@ type cRegistry struct {
 	insecure bool
 }
 
+// signatureTagFor returns the cosign "simple signing" sibling tag name for an
+// image digest: the digest with ":" replaced by "-", plus a ".sig" suffix.
+// This is cosign's default tag-based signature storage scheme, used when
+// COSIGN_REPOSITORY points at the image's own repository (see
+// scripts/release/build/image_signing.py) rather than the OCI 1.1 referrers
+// API.
+func signatureTagFor(digest v1.Hash) string {
+	return strings.ReplaceAll(digest.String(), ":", "-") + ".sig"
+}
+
 func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) error {
 	src, err := name.ParseReference(srcRef, t.nameOpts()...)
 	if err != nil {
@@ -88,6 +98,44 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 				return fmt.Errorf("write image %s: %w", tag, err)
 			}
 		}
+	}
+	if err := t.copySignature(src, desc.Digest, dstRepo); err != nil {
+		return fmt.Errorf("copy signature for %s: %w", srcRef, err)
+	}
+	return nil
+}
+
+// copySignature copies the cosign signature sibling tag (if the source image
+// was signed) from src's repository to dstRepo, under the same
+// digest-derived tag name (see signatureTagFor). The signature tag encodes
+// the image's digest, so one copy covers every tag CopyWithTags applied to
+// that same digest (e.g. both :{version} and :latest). If the source has no
+// signature tag (the image wasn't signed — signing is optional per image,
+// see build_info.json's per-image "sign" field), this is a silent no-op.
+func (t *cRegistry) copySignature(src name.Reference, digest v1.Hash, dstRepo string) error {
+	sigTag := signatureTagFor(digest)
+
+	srcSigRef := src.Context().Tag(sigTag)
+	sigDesc, err := remote.Get(srcSigRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("get signature %s: %w", srcSigRef, err)
+	}
+
+	sigImg, err := sigDesc.Image()
+	if err != nil {
+		return fmt.Errorf("read signature image %s: %w", srcSigRef, err)
+	}
+
+	dstSigRef, err := name.NewTag(fmt.Sprintf("%s/%s:%s", t.host, dstRepo, sigTag), t.nameOpts()...)
+	if err != nil {
+		return fmt.Errorf("parse signature target tag %s: %w", sigTag, err)
+	}
+	if err := remote.Write(dstSigRef, sigImg, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+		return fmt.Errorf("write signature %s: %w", sigTag, err)
 	}
 	return nil
 }

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -50,12 +50,6 @@ type cRegistry struct {
 	insecure bool
 }
 
-// signatureTagFor returns the cosign "simple signing" sibling tag name for an
-// image digest: the digest with ":" replaced by "-", plus a ".sig" suffix.
-// This is cosign's default tag-based signature storage scheme, used when
-// COSIGN_REPOSITORY points at the image's own repository (see
-// scripts/release/build/image_signing.py) rather than the OCI 1.1 referrers
-// API.
 func signatureTagFor(digest v1.Hash) string {
 	return strings.ReplaceAll(digest.String(), ":", "-") + ".sig"
 }
@@ -95,23 +89,17 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 			}
 		} else {
 			if err := remote.Write(dst, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-				return fmt.Errorf("write image %s: %w", tag, err)
+				return fmt.Errorf("failed to write image %s: %w", tag, err)
 			}
 		}
 	}
 	if err := t.copySignature(src, desc.Digest, dstRepo); err != nil {
-		return fmt.Errorf("copy signature for %s: %w", srcRef, err)
+		return fmt.Errorf("copy signature failed for %s: %w", srcRef, err)
 	}
 	return nil
 }
 
-// copySignature copies the cosign signature sibling tag (if the source image
-// was signed) from src's repository to dstRepo, under the same
-// digest-derived tag name (see signatureTagFor). The signature tag encodes
-// the image's digest, so one copy covers every tag CopyWithTags applied to
-// that same digest (e.g. both :{version} and :latest). If the source has no
-// signature tag (the image wasn't signed — signing is optional per image,
-// see build_info.json's per-image "sign" field), this is a silent no-op.
+// copySignature copies the cosign signature sibling tag
 func (t *cRegistry) copySignature(src name.Reference, digest v1.Hash, dstRepo string) error {
 	sigTag := signatureTagFor(digest)
 

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -24,6 +24,10 @@ var ErrTagNotFound = errors.New("tag not found")
 type Registry interface {
 	// CopyWithTags copies srcRef to dstRepo under each of the given tags.
 	CopyWithTags(srcRef string, dstRepo string, tags []string) error
+	// CopySignatures copies the cosign signature for srcRef's digest (and,
+	// if srcRef is a multiarch index, for each child manifest digest too)
+	// from srcRef's repository to dstRepo, under the registry's own host.
+	CopySignatures(srcRef string, dstRepo string) error
 	// ListTags returns all tags for the given image repository reference.
 	ListTags(repo string) ([]string, error)
 	// Digest returns the manifest digest for ref (a full "host/repo:tag"
@@ -94,11 +98,31 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 			}
 		}
 	}
+	return nil
+}
+
+// CopySignatures copies the cosign signature for srcRef's digest (and, if
+// srcRef is a multiarch index, for each child manifest digest too) from
+// srcRef's repository to dstRepo.
+func (t *cRegistry) CopySignatures(srcRef string, dstRepo string) error {
+	src, err := name.ParseReference(srcRef, t.nameOpts()...)
+	if err != nil {
+		return fmt.Errorf("failed to parse source ref %s: %w", srcRef, err)
+	}
+	desc, err := remote.Get(src, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("failed to get %s: %w", srcRef, err)
+	}
+
 	if err := t.copySignature(src, desc.Digest, dstRepo); err != nil {
 		return fmt.Errorf("failed to copy signature for %s: %w", srcRef, err)
 	}
 
-	if idx != nil {
+	if desc.MediaType.IsIndex() {
+		idx, err := desc.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("failed to get index %s: %w", srcRef, err)
+		}
 		idxManifest, err := idx.IndexManifest()
 		if err != nil {
 			return fmt.Errorf("failed to read index manifest for %s: %w", srcRef, err)

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -3,6 +3,7 @@ package release
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -121,6 +122,7 @@ func (t *cRegistry) copySignature(src name.Reference, digest v1.Hash, dstRepo st
 	if err != nil {
 		var terr *transport.Error
 		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			log.Printf("no signature found for %s, skipping copy (image may be unsigned or an unsigned child manifest)", srcSigRef)
 			return nil
 		}
 		return fmt.Errorf("get signature %s: %w", srcSigRef, err)

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -58,11 +58,11 @@ func signatureTagFor(digest v1.Hash) string {
 func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) error {
 	src, err := name.ParseReference(srcRef, t.nameOpts()...)
 	if err != nil {
-		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+		return fmt.Errorf("failed to parse source ref %s: %w", srcRef, err)
 	}
 	desc, err := remote.Get(src, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		return fmt.Errorf("get %s: %w", srcRef, err)
+		return fmt.Errorf("failed to get %s: %w", srcRef, err)
 	}
 
 	var img v1.Image
@@ -70,23 +70,23 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 	if desc.MediaType.IsIndex() {
 		idx, err = desc.ImageIndex()
 		if err != nil {
-			return fmt.Errorf("get index %s: %w", srcRef, err)
+			return fmt.Errorf("failed to get index %s: %w", srcRef, err)
 		}
 	} else {
 		img, err = desc.Image()
 		if err != nil {
-			return fmt.Errorf("get image %s: %w", srcRef, err)
+			return fmt.Errorf("failed to get image %s: %w", srcRef, err)
 		}
 	}
 
 	for _, tag := range tags {
 		dst, err := name.NewTag(fmt.Sprintf("%s/%s:%s", t.host, dstRepo, tag), t.nameOpts()...)
 		if err != nil {
-			return fmt.Errorf("parse target tag %s: %w", tag, err)
+			return fmt.Errorf("failed to parse target tag %s: %w", tag, err)
 		}
 		if idx != nil {
 			if err := remote.WriteIndex(dst, idx, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-				return fmt.Errorf("write index %s: %w", tag, err)
+				return fmt.Errorf("failed to write index %s: %w", tag, err)
 			}
 		} else {
 			if err := remote.Write(dst, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
@@ -95,17 +95,17 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 		}
 	}
 	if err := t.copySignature(src, desc.Digest, dstRepo); err != nil {
-		return fmt.Errorf("copy signature failed for %s: %w", srcRef, err)
+		return fmt.Errorf("failed to copy signature for %s: %w", srcRef, err)
 	}
 
 	if idx != nil {
 		idxManifest, err := idx.IndexManifest()
 		if err != nil {
-			return fmt.Errorf("read index manifest for %s: %w", srcRef, err)
+			return fmt.Errorf("failed to read index manifest for %s: %w", srcRef, err)
 		}
 		for _, m := range idxManifest.Manifests {
 			if err := t.copySignature(src, m.Digest, dstRepo); err != nil {
-				return fmt.Errorf("copy signature failed for %s (child %s): %w", srcRef, m.Digest, err)
+				return fmt.Errorf("failed to copy signature for %s (child %s): %w", srcRef, m.Digest, err)
 			}
 		}
 	}
@@ -125,20 +125,20 @@ func (t *cRegistry) copySignature(src name.Reference, digest v1.Hash, dstRepo st
 			log.Printf("no signature found for %s, skipping copy (image may be unsigned or an unsigned child manifest)", srcSigRef)
 			return nil
 		}
-		return fmt.Errorf("get signature %s: %w", srcSigRef, err)
+		return fmt.Errorf("failed to get signature %s: %w", srcSigRef, err)
 	}
 
 	sigImg, err := sigDesc.Image()
 	if err != nil {
-		return fmt.Errorf("read signature image %s: %w", srcSigRef, err)
+		return fmt.Errorf("failed to read signature image %s: %w", srcSigRef, err)
 	}
 
 	dstSigRef, err := name.NewTag(fmt.Sprintf("%s/%s:%s", t.host, dstRepo, sigTag), t.nameOpts()...)
 	if err != nil {
-		return fmt.Errorf("parse signature target tag %s: %w", sigTag, err)
+		return fmt.Errorf("failed to parse signature target tag %s: %w", sigTag, err)
 	}
 	if err := remote.Write(dstSigRef, sigImg, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-		return fmt.Errorf("write signature %s: %w", sigTag, err)
+		return fmt.Errorf("failed to write signature %s: %w", sigTag, err)
 	}
 	return nil
 }

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -96,6 +96,19 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 	if err := t.copySignature(src, desc.Digest, dstRepo); err != nil {
 		return fmt.Errorf("copy signature failed for %s: %w", srcRef, err)
 	}
+
+	if idx != nil {
+		idxManifest, err := idx.IndexManifest()
+		if err != nil {
+			return fmt.Errorf("read index manifest for %s: %w", srcRef, err)
+		}
+		for _, m := range idxManifest.Manifests {
+			if err := t.copySignature(src, m.Digest, dstRepo); err != nil {
+				return fmt.Errorf("copy signature failed for %s (child %s): %w", srcRef, m.Digest, err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/ci/internal/release/registry_test.go
+++ b/ci/internal/release/registry_test.go
@@ -50,3 +50,82 @@ func TestCRegistry_CopyWithTags(t *testing.T) {
 		assert.Equal(t, dstDesc.Digest, wantDigest, "digest mismatch for tag %s", tag)
 	}
 }
+
+func TestCRegistry_CopyWithTags_CopiesSignatureIfPresent(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err, "failed to parse test server url")
+	host := u.Host
+
+	fakeImg, err := random.Image(1024, 2)
+	require.NoError(t, err, "failed to create random fake image")
+
+	imgDigest, err := fakeImg.Digest()
+	require.NoError(t, err, "failed to get src digest")
+
+	srcRefStr := host + "/source-repo:v1"
+	srcRef, err := name.ParseReference(srcRefStr, name.Insecure)
+	require.NoError(t, err, "failed to parse src ref")
+	require.NoError(t, remote.Write(srcRef, fakeImg), "failed to write source image")
+
+	// Simulate a cosign signature: a sibling tag in the SAME repo, named
+	// after the image's own digest.
+	sigTag := signatureTagFor(imgDigest)
+	fakeSig, err := random.Image(512, 1)
+	require.NoError(t, err, "failed to create fake signature image")
+	wantSigDigest, err := fakeSig.Digest()
+	require.NoError(t, err, "failed to get signature digest")
+
+	sigRef, err := name.ParseReference(host+"/source-repo:"+sigTag, name.Insecure)
+	require.NoError(t, err, "failed to parse signature ref")
+	require.NoError(t, remote.Write(sigRef, fakeSig), "failed to write signature image")
+
+	reg := &cRegistry{host: host, insecure: true}
+	tags := []string{"latest", "v1.0.0"}
+
+	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", tags),
+		"CopyWithTags failed")
+
+	// The signature tag name is derived from the (unchanged) image digest,
+	// so a single copy covers every applied tag.
+	dstSigRef, err := name.ParseReference(host+"/target-repo:"+sigTag, name.Insecure)
+	require.NoError(t, err, "failed to parse dst signature ref")
+
+	dstSigDesc, err := remote.Get(dstSigRef)
+	require.NoError(t, err, "signature was not copied to target repo")
+	assert.Equal(t, wantSigDigest, dstSigDesc.Digest, "signature digest mismatch")
+}
+
+func TestCRegistry_CopyWithTags_NoSignatureIsNotAnError(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err, "failed to parse test server url")
+	host := u.Host
+
+	fakeImg, err := random.Image(1024, 2)
+	require.NoError(t, err, "failed to create random fake image")
+
+	imgDigest, err := fakeImg.Digest()
+	require.NoError(t, err, "failed to get src digest")
+
+	srcRefStr := host + "/unsigned-repo:v1"
+	srcRef, err := name.ParseReference(srcRefStr, name.Insecure)
+	require.NoError(t, err, "failed to parse src ref")
+	require.NoError(t, remote.Write(srcRef, fakeImg), "failed to write source image")
+
+	reg := &cRegistry{host: host, insecure: true}
+
+	require.NoError(t, reg.CopyWithTags(host+"/unsigned-repo:v1", "target-repo-unsigned", []string{"latest"}),
+		"CopyWithTags should succeed even when no signature exists")
+
+	// Confirm no signature tag was created at the destination either.
+	sigTag := signatureTagFor(imgDigest)
+	dstSigRef, err := name.ParseReference(host+"/target-repo-unsigned:"+sigTag, name.Insecure)
+	require.NoError(t, err, "failed to parse dst signature ref")
+	_, err = remote.Get(dstSigRef)
+	assert.Error(t, err, "expected no signature tag to exist at destination")
+}

--- a/ci/internal/release/registry_test.go
+++ b/ci/internal/release/registry_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestCRegistry_CopyWithTags(t *testing.T) {
@@ -96,6 +98,69 @@ func TestCRegistry_CopyWithTags_CopiesSignatureIfPresent(t *testing.T) {
 	dstSigDesc, err := remote.Get(dstSigRef)
 	require.NoError(t, err, "signature was not copied to target repo")
 	assert.Equal(t, wantSigDigest, dstSigDesc.Digest, "signature digest mismatch")
+}
+
+func TestCRegistry_CopyWithTags_CopiesSignaturesForIndexAndChildManifests(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err, "failed to parse test server url")
+	host := u.Host
+
+	// Build a fake multiarch index with 2 child manifests.
+	idx, err := random.Index(1024, 2, 2)
+	require.NoError(t, err, "failed to create random index")
+
+	idxDigest, err := idx.Digest()
+	require.NoError(t, err, "failed to get index digest")
+
+	// Write index to source repo under v1 tag.
+	srcRefStr := host + "/source-repo:v1"
+	srcRef, err := name.ParseReference(srcRefStr, name.Insecure)
+	require.NoError(t, err, "failed to parse src ref")
+	require.NoError(t, remote.WriteIndex(srcRef, idx), "failed to write source index")
+
+	// Get child manifest digests.
+	idxManifest, err := idx.IndexManifest()
+	require.NoError(t, err, "failed to get index manifest")
+	require.Len(t, idxManifest.Manifests, 2, "expected 2 child manifests")
+
+	// Write signature images for index digest and each child digest.
+	wantSigDigests := make(map[string]string) // sigTag -> wantSigDigest
+
+	allDigests := []v1.Hash{idxDigest}
+	for _, m := range idxManifest.Manifests {
+		allDigests = append(allDigests, m.Digest)
+	}
+	for _, d := range allDigests {
+		sigTag := signatureTagFor(d)
+		fakeSig, err := random.Image(512, 1)
+		require.NoError(t, err, "failed to create fake signature image")
+		sigDigest, err := fakeSig.Digest()
+		require.NoError(t, err, "failed to get signature digest")
+		wantSigDigests[sigTag] = sigDigest.String()
+
+		sigRef, err := name.ParseReference(host+"/source-repo:"+sigTag, name.Insecure)
+		require.NoError(t, err, "failed to parse signature ref")
+		require.NoError(t, remote.Write(sigRef, fakeSig), "failed to write signature image")
+	}
+
+	reg := &cRegistry{host: host, insecure: true}
+
+	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", []string{"latest"}),
+		"CopyWithTags failed")
+
+	// Assert that the signature for the index digest AND each child digest
+	// were copied to the destination.
+	for sigTag, wantDigest := range wantSigDigests {
+		dstSigRef, err := name.ParseReference(host+"/target-repo:"+sigTag, name.Insecure)
+		require.NoError(t, err, "failed to parse dst signature ref for %s", sigTag)
+
+		dstSigDesc, err := remote.Get(dstSigRef)
+		require.NoError(t, err, "signature %s was not copied to target repo", sigTag)
+		assert.Equal(t, wantDigest, dstSigDesc.Digest.String(), "signature digest mismatch for %s", sigTag)
+	}
 }
 
 func TestCRegistry_CopyWithTags_NoSignatureIsNotAnError(t *testing.T) {

--- a/ci/internal/release/registry_test.go
+++ b/ci/internal/release/registry_test.go
@@ -53,7 +53,7 @@ func TestCRegistry_CopyWithTags(t *testing.T) {
 	}
 }
 
-func TestCRegistry_CopyWithTags_CopiesSignatureIfPresent(t *testing.T) {
+func TestCRegistry_CopySignatures_CopiesSignatureIfPresent(t *testing.T) {
 	s := httptest.NewServer(registry.New())
 	defer s.Close()
 
@@ -85,10 +85,13 @@ func TestCRegistry_CopyWithTags_CopiesSignatureIfPresent(t *testing.T) {
 	require.NoError(t, remote.Write(sigRef, fakeSig), "failed to write signature image")
 
 	reg := &cRegistry{host: host, insecure: true}
-	tags := []string{"latest", "v1.0.0"}
 
-	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", tags),
+	// Copy manifest first so the destination repo exists for the signature.
+	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", []string{"latest", "v1.0.0"}),
 		"CopyWithTags failed")
+
+	require.NoError(t, reg.CopySignatures(host+"/source-repo:v1", "target-repo"),
+		"CopySignatures failed")
 
 	// The signature tag name is derived from the (unchanged) image digest,
 	// so a single copy covers every applied tag.
@@ -100,7 +103,7 @@ func TestCRegistry_CopyWithTags_CopiesSignatureIfPresent(t *testing.T) {
 	assert.Equal(t, wantSigDigest, dstSigDesc.Digest, "signature digest mismatch")
 }
 
-func TestCRegistry_CopyWithTags_CopiesSignaturesForIndexAndChildManifests(t *testing.T) {
+func TestCRegistry_CopySignatures_CopiesSignaturesForIndexAndChildManifests(t *testing.T) {
 	s := httptest.NewServer(registry.New())
 	defer s.Close()
 
@@ -148,8 +151,12 @@ func TestCRegistry_CopyWithTags_CopiesSignaturesForIndexAndChildManifests(t *tes
 
 	reg := &cRegistry{host: host, insecure: true}
 
+	// Copy manifest first so the destination repo exists for the signature.
 	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", []string{"latest"}),
 		"CopyWithTags failed")
+
+	require.NoError(t, reg.CopySignatures(host+"/source-repo:v1", "target-repo"),
+		"CopySignatures failed")
 
 	// Assert that the signature for the index digest AND each child digest
 	// were copied to the destination.
@@ -163,7 +170,7 @@ func TestCRegistry_CopyWithTags_CopiesSignaturesForIndexAndChildManifests(t *tes
 	}
 }
 
-func TestCRegistry_CopyWithTags_NoSignatureIsNotAnError(t *testing.T) {
+func TestCRegistry_CopySignatures_NoSignatureIsNotAnError(t *testing.T) {
 	s := httptest.NewServer(registry.New())
 	defer s.Close()
 
@@ -186,6 +193,9 @@ func TestCRegistry_CopyWithTags_NoSignatureIsNotAnError(t *testing.T) {
 
 	require.NoError(t, reg.CopyWithTags(host+"/unsigned-repo:v1", "target-repo-unsigned", []string{"latest"}),
 		"CopyWithTags should succeed even when no signature exists")
+
+	require.NoError(t, reg.CopySignatures(host+"/unsigned-repo:v1", "target-repo-unsigned"),
+		"CopySignatures should succeed even when no signature exists")
 
 	// Confirm no signature tag was created at the destination either.
 	sigTag := signatureTagFor(imgDigest)

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -202,6 +202,7 @@ def sign_image(repository: str, tag: str) -> None:
         f"--use-signing-config=false",
         f"--new-bundle-format=false",
         f"--tlog-upload=false",
+        "--recursive",
         image_ref,
     ]
     command = build_cosign_docker_command(additional_args, cosign_command)


### PR DESCRIPTION
# Summary

Signatures are computer at build time and need to be copied over both at promotion and at final publish time. This PR ensures that behavior.

## Proof of Work

CI

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
