### PR TITLE
CLOUDP-429011 - Add TLS/CA parity for external AppDB (resolve referenced MongoDB CR's TLS)

### DIFF
--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -189,7 +189,9 @@ type ExternalApplicationDatabaseRef struct {
 	Kind string `json:"kind"`
 
 	// Transient fields
-	Namespace string `json:"-"`
+	Namespace       string `json:"-"`
+	IsTLSEnabled    bool   `json:"-"`
+	CAConfigMapName string `json:"-"`
 }
 
 type Logging struct {
@@ -310,16 +312,20 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 	return ""
 }
 
-func (ms MongoDBOpsManagerSpec) GetAppDbCA() string {
+func (ms MongoDBOpsManagerSpec) GetAppDBCAConfigMapName() string {
 	if ms.ExternalApplicationDatabaseRef != nil {
-		return ""
+		return ms.ExternalApplicationDatabaseRef.CAConfigMapName
 	}
 
-	if ms.AppDB.Security != nil && ms.AppDB.Security.TLSConfig != nil {
-		return ms.AppDB.Security.TLSConfig.CA
+	return ms.AppDB.GetCAConfigMapName()
+}
+
+func (ms MongoDBOpsManagerSpec) IsAppDBTLSEnabled() bool {
+	if ms.ExternalApplicationDatabaseRef != nil {
+		return ms.ExternalApplicationDatabaseRef.IsTLSEnabled
 	}
 
-	return ""
+	return ms.AppDB.GetSecurity().IsTLSEnabled()
 }
 
 func (ms *MongoDBOpsManagerSpec) IsMultiCluster() bool {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -190,7 +190,9 @@ type ExternalAppDBRef struct {
 	Kind string `json:"kind"`
 
 	// Transient fields
-	Namespace string `json:"-"`
+	Namespace       string `json:"-"`
+	IsTLSEnabled    bool   `json:"-"`
+	CAConfigMapName string `json:"-"`
 }
 
 type Logging struct {
@@ -311,16 +313,20 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 	return ""
 }
 
-func (ms MongoDBOpsManagerSpec) GetAppDbCA() string {
+func (ms MongoDBOpsManagerSpec) GetAppDBCAConfigMapName() string {
 	if ms.ExternalAppDBRef != nil {
-		return ""
+		return ms.ExternalAppDBRef.CAConfigMapName
 	}
 
-	if ms.AppDB.Security != nil && ms.AppDB.Security.TLSConfig != nil {
-		return ms.AppDB.Security.TLSConfig.CA
+	return ms.AppDB.GetCAConfigMapName()
+}
+
+func (ms MongoDBOpsManagerSpec) IsAppDBTLSEnabled() bool {
+	if ms.ExternalAppDBRef != nil {
+		return ms.ExternalAppDBRef.IsTLSEnabled
 	}
 
-	return ""
+	return ms.AppDB.GetSecurity().IsTLSEnabled()
 }
 
 func (ms *MongoDBOpsManagerSpec) IsMultiCluster() bool {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -190,9 +190,7 @@ type ExternalAppDBRef struct {
 	Kind string `json:"kind"`
 
 	// Transient fields
-	Namespace       string `json:"-"`
-	IsTLSEnabled    bool   `json:"-"`
-	CAConfigMapName string `json:"-"`
+	Namespace string `json:"-"`
 }
 
 type Logging struct {
@@ -311,22 +309,6 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 		return ms.Security.TLS.CA
 	}
 	return ""
-}
-
-func (ms MongoDBOpsManagerSpec) GetAppDBCAConfigMapName() string {
-	if ms.ExternalAppDBRef != nil {
-		return ms.ExternalAppDBRef.CAConfigMapName
-	}
-
-	return ms.AppDB.GetCAConfigMapName()
-}
-
-func (ms MongoDBOpsManagerSpec) IsAppDBTLSEnabled() bool {
-	if ms.ExternalAppDBRef != nil {
-		return ms.ExternalAppDBRef.IsTLSEnabled
-	}
-
-	return ms.AppDB.GetSecurity().IsTLSEnabled()
 }
 
 func (ms *MongoDBOpsManagerSpec) IsMultiCluster() bool {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -189,9 +189,7 @@ type ExternalApplicationDatabaseRef struct {
 	Kind string `json:"kind"`
 
 	// Transient fields
-	Namespace       string `json:"-"`
-	IsTLSEnabled    bool   `json:"-"`
-	CAConfigMapName string `json:"-"`
+	Namespace string `json:"-"`
 }
 
 type Logging struct {
@@ -310,22 +308,6 @@ func (ms MongoDBOpsManagerSpec) GetOpsManagerCA() string {
 		return ms.Security.TLS.CA
 	}
 	return ""
-}
-
-func (ms MongoDBOpsManagerSpec) GetAppDBCAConfigMapName() string {
-	if ms.ExternalApplicationDatabaseRef != nil {
-		return ms.ExternalApplicationDatabaseRef.CAConfigMapName
-	}
-
-	return ms.AppDB.GetCAConfigMapName()
-}
-
-func (ms MongoDBOpsManagerSpec) IsAppDBTLSEnabled() bool {
-	if ms.ExternalApplicationDatabaseRef != nil {
-		return ms.ExternalApplicationDatabaseRef.IsTLSEnabled
-	}
-
-	return ms.AppDB.GetSecurity().IsTLSEnabled()
 }
 
 func (ms *MongoDBOpsManagerSpec) IsMultiCluster() bool {

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -662,7 +662,7 @@ func (om *MongoDBOpsManager) InitDefaultFields() {
 		om.Spec.Backup.Members = 1
 	}
 
-	if om.Spec.ExternalAppDBRef == nil {
+	if om.IsInternalAppDB() {
 		if om.Spec.AppDB == nil {
 			om.Spec.AppDB = &AppDBSpec{}
 		}
@@ -773,7 +773,7 @@ func (om *MongoDBOpsManager) UpdateStatus(phase status.Phase, statusOptions ...s
 }
 
 func (om *MongoDBOpsManager) updateStatusAppDb(phase status.Phase, statusOptions ...status.Option) {
-	if om.Spec.ExternalAppDBRef != nil {
+	if !om.IsInternalAppDB() {
 		om.Status.AppDbStatus = AppDbStatus{}
 		om.Status.AppDbStatus.UpdateCommonFields(phase, om.GetGeneration(), statusOptions...)
 		return

--- a/api/mongodb/v1/om/opsmanager_validation.go
+++ b/api/mongodb/v1/om/opsmanager_validation.go
@@ -292,7 +292,7 @@ func (om *MongoDBOpsManager) RunValidations() []v1.ValidationResult {
 	}
 
 	// AppDB validators apply only to an internal AppDB
-	if om.Spec.ExternalAppDBRef == nil && om.Spec.AppDB != nil {
+	if om.IsInternalAppDB() && om.Spec.AppDB != nil {
 		validators = append(validators,
 			validAppDBVersion,
 			connectivityIsNotConfigurable,
@@ -316,7 +316,7 @@ func (om *MongoDBOpsManager) RunValidations() []v1.ValidationResult {
 		}
 	}
 
-	if om.Spec.ExternalAppDBRef != nil {
+	if !om.IsInternalAppDB() {
 		expectedName := om.Name + "-db"
 		if om.Spec.ExternalAppDBRef.Name != expectedName {
 			validationResults = append(validationResults, v1.OpsManagerResourceValidationError(fmt.Sprintf("spec.externalApplicationDatabaseRef.name must be %s", expectedName), status.OpsManager))

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -956,14 +956,20 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...), status.NewPVCsStatusOptionEmptyStatus())
 }
 
-// BuildAppDBConnectionURL returns the connection string to the AppDB, reading the Ops Manager user password.
+// GetAppDBConfig returns the connection string to the AppDB and the TLS configuration.
 // It assumes ReconcileAppDB has already been called and the password secret exists.
-func (r *ReconcileAppDbReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileAppDbReplicaSet) GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (*AppDBConfig, error) {
 	password, err := r.readAppDbPassword(ctx, opsManager, log)
 	if err != nil {
-		return "", xerrors.Errorf("Error getting AppDB password: %w", err)
+		return nil, xerrors.Errorf("Error getting AppDB password: %w", err)
 	}
-	return buildMongoConnectionUrl(opsManager, password, r.getCurrentStatefulsetHostnames(opsManager)), nil
+	connectionString := buildMongoConnectionUrl(opsManager, password, r.getCurrentStatefulsetHostnames(opsManager))
+
+	return &AppDBConfig{
+		IsTLSEnabled:     opsManager.Spec.AppDB.GetSecurity().IsTLSEnabled(),
+		CAConfigMapName:  opsManager.Spec.AppDB.GetCAConfigMapName(),
+		ConnectionString: connectionString,
+	}, nil
 }
 
 // buildMongoConnectionUrl returns a connection URL to the appdb.

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -956,14 +956,20 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...), status.NewPVCsStatusOptionEmptyStatus())
 }
 
-// BuildAppDBConnectionURL returns the connection string to the AppDB, reading the Ops Manager user password.
+// GetAppDBConfig returns the connection string to the AppDB and the TLS configuration.
 // It assumes ReconcileAppDB has already been called and the password secret exists.
-func (r *ReconcileAppDbReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileAppDbReplicaSet) GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (*AppDBConfig, error) {
 	password, err := r.readAppDbPassword(ctx, opsManager)
 	if err != nil {
-		return "", xerrors.Errorf("Error getting AppDB password: %w", err)
+		return nil, xerrors.Errorf("Error getting AppDB password: %w", err)
 	}
-	return buildMongoConnectionUrl(opsManager, password, r.getCurrentStatefulsetHostnames(opsManager)), nil
+	connectionString := buildMongoConnectionUrl(opsManager, password, r.getCurrentStatefulsetHostnames(opsManager))
+
+	return &AppDBConfig{
+		IsTLSEnabled:     opsManager.Spec.AppDB.GetSecurity().IsTLSEnabled(),
+		CAConfigMapName:  opsManager.Spec.AppDB.GetCAConfigMapName(),
+		ConnectionString: connectionString,
+	}, nil
 }
 
 // buildMongoConnectionUrl returns a connection URL to the appdb.

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -2140,9 +2140,9 @@ func TestReconcileAppDbReplicaSet_BuildAppDBConnectionURL(t *testing.T) {
 		SetField(util.OpsManagerPasswordKey, "test-password").
 		Build()))
 
-	connString, err := appDbReconciler.BuildAppDBConnectionURL(ctx, testOm, zap.S())
+	cfg, err := appDbReconciler.GetAppDBConfig(ctx, testOm, zap.S())
 	require.NoError(t, err)
-	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
+	assert.Contains(t, cfg.ConnectionString, util.OpsManagerMongoDBUserName)
 }
 
 // TestReconcileAppDB_ReshapesReAdoptedStatefulSet reproduces the reverse-migration state right

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -2140,9 +2140,9 @@ func TestReconcileAppDbReplicaSet_BuildAppDBConnectionURL(t *testing.T) {
 		SetField(util.OpsManagerPasswordKey, "test-password").
 		Build()))
 
-	connString, err := appDbReconciler.BuildAppDBConnectionURL(ctx, testOm, zap.S())
+	cfg, err := appDbReconciler.GetAppDBConfig(ctx, testOm)
 	require.NoError(t, err)
-	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
+	assert.Contains(t, cfg.ConnectionString, util.OpsManagerMongoDBUserName)
 }
 
 // TestReconcileAppDB_ReshapesReAdoptedStatefulSet reproduces the reverse-migration state right

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -41,14 +41,9 @@ func (r *OpsManagerReconciler) createNewExternalAppDBReconciler(log *zap.Sugared
 // detach-and-adopt migration of any pre-existing internal AppDB (idempotent, no-op once
 // complete), and establishes a watch on the referenced CR.
 func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error) {
-	refObject, err := e.validateExternalAppDBReference(ctx, opsManager)
-	if err != nil {
+	if err := e.validateExternalAppDBReference(ctx, opsManager); err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error validating externalApplicationDatabaseRef: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
 	}
-
-	// Set TLS configuration so that it is easily retrievable later in Ops Manager reconciler
-	opsManager.Spec.ExternalApplicationDatabaseRef.IsTLSEnabled = refObject.IsTLSEnabled()
-	opsManager.Spec.ExternalApplicationDatabaseRef.CAConfigMapName = refObject.GetCAConfigMapName()
 
 	if err := e.ensureAppDBStatefulSetOwnership(ctx, opsManager); err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error detaching internal AppDB StatefulSet: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
@@ -57,29 +52,46 @@ func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, o
 	return e.updateStatus(ctx, opsManager, workflow.Disabled(), e.log, mdbstatus.NewOMPartOption(mdbstatus.AppDb))
 }
 
-// BuildAppDBConnectionURL computes the AppDB connection string from the referenced MongoDB CR.
-func (e *ReconcileExternalAppDBReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	return e.computeExternalAppDBConnectionString(ctx, opsManager)
-}
-
-// validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
-func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (ExternalAppDB, error) {
+// GetAppDBConfig computes the AppDB configuration including connection string and TLS settings from the referenced MongoDB CR.
+func (e *ReconcileExternalAppDBReplicaSet) GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (*AppDBConfig, error) {
 	ref := opsManager.Spec.ExternalApplicationDatabaseRef
-	if ref == nil {
-		return nil, xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
-	}
-
 	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
-	role := refObject.GetRole()
-	if role != mdbv1.RoleAppDB {
-		return nil, xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
+	password, err := secret.ReadKey(ctx, e.SecretClient, util.OpsManagerPasswordKey, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read shared password secret: %w", err)
 	}
 
-	return refObject, nil
+	connectionString := refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil)
+
+	return &AppDBConfig{
+		IsTLSEnabled:     refObject.IsTLSEnabled(),
+		CAConfigMapName:  refObject.GetCAConfigMapName(),
+		ConnectionString: connectionString,
+	}, nil
+}
+
+// validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
+func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	if ref == nil {
+		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
+	}
+
+	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
+	if err != nil {
+		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+
+	role := refObject.GetRole()
+	if role != mdbv1.RoleAppDB {
+		return xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
+	}
+
+	return nil
 }
 
 // ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
@@ -124,25 +136,6 @@ func (e *ReconcileExternalAppDBReplicaSet) requestAppDBForwardMigration(ctx cont
 	}
 
 	return nil
-}
-
-// computeExternalAppDBConnectionString fetches the referenced MongoDB CR and
-// the shared mongodb-ops-manager password secret, computes the connection string directly via
-// BuildConnectionString.
-func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
-	ref := opsManager.Spec.ExternalApplicationDatabaseRef
-
-	password, err := secret.ReadKey(ctx, e.SecretClient, util.OpsManagerPasswordKey, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)))
-	if err != nil {
-		return "", xerrors.Errorf("failed to read shared password secret: %w", err)
-	}
-
-	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
-	if err != nil {
-		return "", xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
-	}
-
-	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil), nil
 }
 
 type externalAppDBRefObject struct {

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -42,9 +41,14 @@ func (r *OpsManagerReconciler) createNewExternalAppDBReconciler(log *zap.Sugared
 // detach-and-adopt migration of any pre-existing internal AppDB (idempotent, no-op once
 // complete), and establishes a watch on the referenced CR.
 func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error) {
-	if err := e.validateExternalAppDBReference(ctx, opsManager); err != nil {
+	refObject, err := e.validateExternalAppDBReference(ctx, opsManager)
+	if err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error validating externalApplicationDatabaseRef: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
 	}
+
+	// Set TLS configuration so that it is easily retrievable later in Ops Manager reconciler
+	opsManager.Spec.ExternalApplicationDatabaseRef.IsTLSEnabled = refObject.IsTLSEnabled()
+	opsManager.Spec.ExternalApplicationDatabaseRef.CAConfigMapName = refObject.GetCAConfigMapName()
 
 	if err := e.ensureAppDBStatefulSetOwnership(ctx, opsManager); err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error detaching internal AppDB StatefulSet: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
@@ -59,23 +63,23 @@ func (e *ReconcileExternalAppDBReplicaSet) BuildAppDBConnectionURL(ctx context.C
 }
 
 // validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
-func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (ExternalAppDB, error) {
 	ref := opsManager.Spec.ExternalApplicationDatabaseRef
 	if ref == nil {
-		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
+		return nil, xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
 	}
 
 	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
-		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
+		return nil, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
 	role := refObject.GetRole()
 	if role != mdbv1.RoleAppDB {
-		return xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
+		return nil, xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
 	}
 
-	return nil
+	return refObject, nil
 }
 
 // ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
@@ -139,31 +143,6 @@ func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(
 	}
 
 	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil), nil
-}
-
-// resolveAppDBTLSConfig returns the CA ConfigMap name and TLS-enabled flag that OpsManager and the
-// Backup Daemon should use to trust the AppDB's TLS certificate. For the internally-managed AppDB it
-// reads opsManager.Spec.AppDB; for an external AppDB it reads the referenced MongoDB CR's security config.
-func resolveAppDBTLSConfig(ctx context.Context, c client.Client, opsManager *omv1.MongoDBOpsManager) (caConfigMapName string, tlsEnabled bool, err error) {
-	if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
-		if opsManager.Spec.AppDB == nil {
-			return "", false, nil
-		}
-		return opsManager.Spec.AppDB.GetCAConfigMapName(), opsManager.Spec.AppDB.IsSecurityTLSConfigEnabled(), nil
-	}
-
-	ref := opsManager.Spec.ExternalApplicationDatabaseRef
-	if ref.Kind != "MongoDB" {
-		return "", false, xerrors.Errorf("externalApplicationDatabaseRef.kind %q is not supported", ref.Kind)
-	}
-	mongodb := &mdbv1.MongoDB{}
-	objectKey := kube.ObjectKey(ref.Namespace, ref.Name)
-	if err := c.Get(ctx, objectKey, mongodb); err != nil {
-		return "", false, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
-	}
-
-	refObject := &externalAppDBRefObject{ConnectionStringBuilder: mongodb, DbCommonSpec: mongodb.Spec.DbCommonSpec}
-	return refObject.GetCAConfigMapName(), refObject.IsTLSEnabled(), nil
 }
 
 type externalAppDBRefObject struct {

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -140,14 +141,56 @@ func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(
 	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, connectionstring.SchemeMongoDB, nil), nil
 }
 
+// resolveAppDBTLSConfig returns the CA ConfigMap name and TLS-enabled flag that OpsManager and the
+// Backup Daemon should use to trust the AppDB's TLS certificate. For the internally-managed AppDB it
+// reads opsManager.Spec.AppDB; for an external AppDB it reads the referenced MongoDB CR's security config.
+func resolveAppDBTLSConfig(ctx context.Context, c client.Client, opsManager *omv1.MongoDBOpsManager) (caConfigMapName string, tlsEnabled bool, err error) {
+	if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+		if opsManager.Spec.AppDB == nil {
+			return "", false, nil
+		}
+		return opsManager.Spec.AppDB.GetCAConfigMapName(), opsManager.Spec.AppDB.IsSecurityTLSConfigEnabled(), nil
+	}
+
+	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	if ref.Kind != "MongoDB" {
+		return "", false, xerrors.Errorf("externalApplicationDatabaseRef.kind %q is not supported", ref.Kind)
+	}
+	mongodb := &mdbv1.MongoDB{}
+	objectKey := kube.ObjectKey(ref.Namespace, ref.Name)
+	if err := c.Get(ctx, objectKey, mongodb); err != nil {
+		return "", false, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
+	}
+
+	refObject := &externalAppDBRefObject{ConnectionStringBuilder: mongodb, DbCommonSpec: mongodb.Spec.DbCommonSpec}
+	return refObject.GetCAConfigMapName(), refObject.IsTLSEnabled(), nil
+}
+
 type externalAppDBRefObject struct {
 	connectionstring.ConnectionStringBuilder
 	mdbv1.DbCommonSpec
 }
 
+// GetCAConfigMapName returns the name of the ConfigMap holding the CA certificate that OpsManager
+// should trust when connecting to the external AppDB over TLS ("" if TLS is off).
+func (o *externalAppDBRefObject) GetCAConfigMapName() string {
+	security := o.GetSecurity()
+	if security.TLSConfig != nil {
+		return security.TLSConfig.CA
+	}
+	return ""
+}
+
+// IsTLSEnabled reports whether the referenced CR has TLS enabled.
+func (o *externalAppDBRefObject) IsTLSEnabled() bool {
+	return o.IsSecurityTLSConfigEnabled()
+}
+
 type ExternalAppDB interface {
 	connectionstring.ConnectionStringBuilder
 	GetRole() string
+	GetCAConfigMapName() string
+	IsTLSEnabled() bool
 }
 
 func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalApplicationDatabaseRef) (ExternalAppDB, error) {

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -140,14 +141,56 @@ func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(
 	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, "", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-256"}), nil
 }
 
+// resolveAppDBTLSConfig returns the CA ConfigMap name and TLS-enabled flag that OpsManager and the
+// Backup Daemon should use to trust the AppDB's TLS certificate. For the internally-managed AppDB it
+// reads opsManager.Spec.AppDB; for an external AppDB it reads the referenced MongoDB CR's security config.
+func resolveAppDBTLSConfig(ctx context.Context, c client.Client, opsManager *omv1.MongoDBOpsManager) (caConfigMapName string, tlsEnabled bool, err error) {
+	if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
+		if opsManager.Spec.AppDB == nil {
+			return "", false, nil
+		}
+		return opsManager.Spec.AppDB.GetCAConfigMapName(), opsManager.Spec.AppDB.IsSecurityTLSConfigEnabled(), nil
+	}
+
+	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	if ref.Kind != "MongoDB" {
+		return "", false, xerrors.Errorf("externalApplicationDatabaseRef.kind %q is not supported", ref.Kind)
+	}
+	mongodb := &mdbv1.MongoDB{}
+	objectKey := kube.ObjectKey(ref.Namespace, ref.Name)
+	if err := c.Get(ctx, objectKey, mongodb); err != nil {
+		return "", false, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
+	}
+
+	refObject := &externalAppDBRefObject{ConnectionStringBuilder: mongodb, DbCommonSpec: mongodb.Spec.DbCommonSpec}
+	return refObject.GetCAConfigMapName(), refObject.IsTLSEnabled(), nil
+}
+
 type externalAppDBRefObject struct {
 	connectionstring.ConnectionStringBuilder
 	mdbv1.DbCommonSpec
 }
 
+// GetCAConfigMapName returns the name of the ConfigMap holding the CA certificate that OpsManager
+// should trust when connecting to the external AppDB over TLS ("" if TLS is off).
+func (o *externalAppDBRefObject) GetCAConfigMapName() string {
+	security := o.GetSecurity()
+	if security.TLSConfig != nil {
+		return security.TLSConfig.CA
+	}
+	return ""
+}
+
+// IsTLSEnabled reports whether the referenced CR has TLS enabled.
+func (o *externalAppDBRefObject) IsTLSEnabled() bool {
+	return o.IsSecurityTLSConfigEnabled()
+}
+
 type ExternalAppDB interface {
 	connectionstring.ConnectionStringBuilder
 	GetRole() string
+	GetCAConfigMapName() string
+	IsTLSEnabled() bool
 }
 
 func (e *ReconcileExternalAppDBReplicaSet) fetchExternalAppDBRefObject(ctx context.Context, ref *omv1.ExternalAppDBRef) (ExternalAppDB, error) {

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -42,9 +41,14 @@ func (r *OpsManagerReconciler) createNewExternalAppDBReconciler(log *zap.Sugared
 // detach-and-adopt migration of any pre-existing internal AppDB (idempotent, no-op once
 // complete), and establishes a watch on the referenced CR.
 func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error) {
-	if err := e.validateExternalAppDBReference(ctx, opsManager); err != nil {
+	refObject, err := e.validateExternalAppDBReference(ctx, opsManager)
+	if err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error validating externalApplicationDatabaseRef: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
 	}
+
+	// Set TLS configuration so that it is easily retrievable later in Ops Manager reconciler
+	opsManager.Spec.ExternalAppDBRef.IsTLSEnabled = refObject.IsTLSEnabled()
+	opsManager.Spec.ExternalAppDBRef.CAConfigMapName = refObject.GetCAConfigMapName()
 
 	if err := e.ensureAppDBStatefulSetOwnership(ctx, opsManager); err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error detaching internal AppDB StatefulSet: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
@@ -59,23 +63,23 @@ func (e *ReconcileExternalAppDBReplicaSet) BuildAppDBConnectionURL(ctx context.C
 }
 
 // validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
-func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (ExternalAppDB, error) {
 	ref := opsManager.Spec.ExternalAppDBRef
 	if ref == nil {
-		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
+		return nil, xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
 	}
 
 	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
-		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
+		return nil, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
 	role := refObject.GetRole()
 	if role != mdbv1.RoleAppDB {
-		return xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
+		return nil, xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
 	}
 
-	return nil
+	return refObject, nil
 }
 
 // ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
@@ -139,31 +143,6 @@ func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(
 	}
 
 	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, "", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-256"}), nil
-}
-
-// resolveAppDBTLSConfig returns the CA ConfigMap name and TLS-enabled flag that OpsManager and the
-// Backup Daemon should use to trust the AppDB's TLS certificate. For the internally-managed AppDB it
-// reads opsManager.Spec.AppDB; for an external AppDB it reads the referenced MongoDB CR's security config.
-func resolveAppDBTLSConfig(ctx context.Context, c client.Client, opsManager *omv1.MongoDBOpsManager) (caConfigMapName string, tlsEnabled bool, err error) {
-	if opsManager.Spec.ExternalApplicationDatabaseRef == nil {
-		if opsManager.Spec.AppDB == nil {
-			return "", false, nil
-		}
-		return opsManager.Spec.AppDB.GetCAConfigMapName(), opsManager.Spec.AppDB.IsSecurityTLSConfigEnabled(), nil
-	}
-
-	ref := opsManager.Spec.ExternalApplicationDatabaseRef
-	if ref.Kind != "MongoDB" {
-		return "", false, xerrors.Errorf("externalApplicationDatabaseRef.kind %q is not supported", ref.Kind)
-	}
-	mongodb := &mdbv1.MongoDB{}
-	objectKey := kube.ObjectKey(ref.Namespace, ref.Name)
-	if err := c.Get(ctx, objectKey, mongodb); err != nil {
-		return "", false, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s: %w", objectKey, err)
-	}
-
-	refObject := &externalAppDBRefObject{ConnectionStringBuilder: mongodb, DbCommonSpec: mongodb.Spec.DbCommonSpec}
-	return refObject.GetCAConfigMapName(), refObject.IsTLSEnabled(), nil
 }
 
 type externalAppDBRefObject struct {

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -54,7 +54,7 @@ func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, o
 
 // GetAppDBConfig computes the AppDB configuration including connection string and TLS settings from the referenced MongoDB CR.
 func (e *ReconcileExternalAppDBReplicaSet) GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, _ *zap.SugaredLogger) (*AppDBConfig, error) {
-	ref := opsManager.Spec.ExternalApplicationDatabaseRef
+	ref := opsManager.Spec.ExternalAppDBRef
 	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)

--- a/controllers/operator/appdbreplicaset_external_reconciler.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler.go
@@ -41,14 +41,9 @@ func (r *OpsManagerReconciler) createNewExternalAppDBReconciler(log *zap.Sugared
 // detach-and-adopt migration of any pre-existing internal AppDB (idempotent, no-op once
 // complete), and establishes a watch on the referenced CR.
 func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error) {
-	refObject, err := e.validateExternalAppDBReference(ctx, opsManager)
-	if err != nil {
+	if err := e.validateExternalAppDBReference(ctx, opsManager); err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error validating externalApplicationDatabaseRef: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
 	}
-
-	// Set TLS configuration so that it is easily retrievable later in Ops Manager reconciler
-	opsManager.Spec.ExternalAppDBRef.IsTLSEnabled = refObject.IsTLSEnabled()
-	opsManager.Spec.ExternalAppDBRef.CAConfigMapName = refObject.GetCAConfigMapName()
 
 	if err := e.ensureAppDBStatefulSetOwnership(ctx, opsManager); err != nil {
 		return e.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error detaching internal AppDB StatefulSet: %w", err)), e.log, mdbstatus.NewOMPartOption(mdbstatus.OpsManager))
@@ -57,29 +52,46 @@ func (e *ReconcileExternalAppDBReplicaSet) ReconcileAppDB(ctx context.Context, o
 	return e.updateStatus(ctx, opsManager, workflow.Disabled(), e.log, mdbstatus.NewOMPartOption(mdbstatus.AppDb))
 }
 
-// BuildAppDBConnectionURL computes the AppDB connection string from the referenced MongoDB CR.
-func (e *ReconcileExternalAppDBReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
-	return e.computeExternalAppDBConnectionString(ctx, opsManager)
-}
-
-// validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
-func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (ExternalAppDB, error) {
-	ref := opsManager.Spec.ExternalAppDBRef
-	if ref == nil {
-		return nil, xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
-	}
-
+// GetAppDBConfig computes the AppDB configuration including connection string and TLS settings from the referenced MongoDB CR.
+func (e *ReconcileExternalAppDBReplicaSet) GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, _ *zap.SugaredLogger) (*AppDBConfig, error) {
+	ref := opsManager.Spec.ExternalApplicationDatabaseRef
 	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
 	}
 
-	role := refObject.GetRole()
-	if role != mdbv1.RoleAppDB {
-		return nil, xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
+	password, err := secret.ReadKey(ctx, e.SecretClient, util.OpsManagerPasswordKey, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read shared password secret: %w", err)
 	}
 
-	return refObject, nil
+	connectionString := refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, "", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-256"})
+
+	return &AppDBConfig{
+		IsTLSEnabled:     refObject.IsTLSEnabled(),
+		CAConfigMapName:  refObject.GetCAConfigMapName(),
+		ConnectionString: connectionString,
+	}, nil
+}
+
+// validateExternalAppDBReference validates that opsManager's spec.externalApplicationDatabaseRef
+func (e *ReconcileExternalAppDBReplicaSet) validateExternalAppDBReference(ctx context.Context, opsManager *omv1.MongoDBOpsManager) error {
+	ref := opsManager.Spec.ExternalAppDBRef
+	if ref == nil {
+		return xerrors.Errorf("externalApplicationDatabaseRef is nil, must be set to a valid MongoDB reference")
+	}
+
+	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
+	if err != nil {
+		return xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+
+	role := refObject.GetRole()
+	if role != mdbv1.RoleAppDB {
+		return xerrors.Errorf("externalApplicationDatabaseRef %s/%s must have spec.role set to %q", ref.Namespace, ref.Name, mdbv1.RoleAppDB)
+	}
+
+	return nil
 }
 
 // ensureAppDBStatefulSetOwnership arbitrates ownership of the AppDB StatefulSet at the start of reconcile:
@@ -124,25 +136,6 @@ func (e *ReconcileExternalAppDBReplicaSet) requestAppDBForwardMigration(ctx cont
 	}
 
 	return nil
-}
-
-// computeExternalAppDBConnectionString fetches the referenced MongoDB CR and
-// the shared mongodb-ops-manager password secret, computes the connection string directly via
-// BuildConnectionString.
-func (e *ReconcileExternalAppDBReplicaSet) computeExternalAppDBConnectionString(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, error) {
-	ref := opsManager.Spec.ExternalAppDBRef
-
-	password, err := secret.ReadKey(ctx, e.SecretClient, util.OpsManagerPasswordKey, kube.ObjectKey(opsManager.Namespace, omv1.OpsManagerUserPasswordSecretName(ref.Name)))
-	if err != nil {
-		return "", xerrors.Errorf("failed to read shared password secret: %w", err)
-	}
-
-	refObject, err := e.fetchExternalAppDBRefObject(ctx, ref)
-	if err != nil {
-		return "", xerrors.Errorf("failed to fetch externalApplicationDatabaseRef %s/%s: %w", ref.Namespace, ref.Name, err)
-	}
-
-	return refObject.BuildConnectionString(util.OpsManagerMongoDBUserName, password, "", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-256"}), nil
 }
 
 type externalAppDBRefObject struct {

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -92,11 +92,13 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reconciler := newOpsManagerReconcilerForValidation(tt.objects...)
-			err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
+			externalAppDB, err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
+				require.NotNil(t, externalAppDB)
 			} else {
 				require.EqualError(t, err, tt.expectedError)
+				require.Nil(t, externalAppDB)
 			}
 		})
 	}

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -92,13 +92,11 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reconciler := newOpsManagerReconcilerForValidation(tt.objects...)
-			externalAppDB, err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
+			err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
-				require.NotNil(t, externalAppDB)
 			} else {
 				require.EqualError(t, err, tt.expectedError)
-				require.Nil(t, externalAppDB)
 			}
 		})
 	}
@@ -198,47 +196,80 @@ func TestEnsureAppDBStatefulSetOwnership_IsIdempotent(t *testing.T) {
 	assert.Equal(t, "true", resultSts.Annotations[util.AppDBMigrationReadyAnnotation])
 }
 
-func TestComputeExternalAppDBConnectionString_WritesFixedSecret(t *testing.T) {
+func TestGetAppDBConfig_ExternalAppDB(t *testing.T) {
 	ctx := context.Background()
 
-	externalAppDB := mdbv1.NewReplicaSetBuilder().
-		SetName("test-om-db").
-		SetNamespace(mock.TestNamespace).
-		SetVersion("6.0.0").
-		SetMembers(3).
-		EnableAuth([]mdbv1.AuthMode{util.SCRAM}).
-		Build()
-	externalAppDB.Spec.Role = mdbv1.RoleAppDB
-
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
-		Name: "test-om-db",
-		Kind: "MongoDB",
-	})
-
-	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
-	require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
-	require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
-		SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
-		SetNamespace(testOm.Namespace).
-		SetField(util.OpsManagerPasswordKey, "test-password").
-		Build()))
-
-	helper, err := NewOpsManagerReconcilerHelper(ctx, reconciler, testOm, reconciler.memberClustersMap, zap.S())
-	require.NoError(t, err)
-
-	connString, err := reconciler.createNewExternalAppDBReconciler(zap.S()).computeExternalAppDBConnectionString(ctx, testOm)
-	require.NoError(t, err)
-	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
-	assert.Contains(t, connString, "test-password")
-
-	for _, memberCluster := range helper.getHealthyMemberClusters() {
-		require.NoError(t, reconciler.ensureAppDBConnectionStringInMemberCluster(ctx, testOm, connString, memberCluster, zap.S()))
+	tests := []struct {
+		name                    string
+		enableTLS               bool
+		caConfigMapName         string
+		expectedIsTLSEnabled    bool
+		expectedCAConfigMapName string
+	}{
+		{
+			name:                    "TLS disabled returns empty CA and disabled flag",
+			expectedIsTLSEnabled:    false,
+			expectedCAConfigMapName: "",
+		},
+		{
+			name:                    "TLS enabled with CA returns resolved TLS config",
+			enableTLS:               true,
+			caConfigMapName:         "app-db-issuer-ca",
+			expectedIsTLSEnabled:    true,
+			expectedCAConfigMapName: "app-db-issuer-ca",
+		},
 	}
 
-	result := corev1.Secret{}
-	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()), &result))
-	assert.Contains(t, string(result.Data[util.AppDbConnectionStringKey]), util.OpsManagerMongoDBUserName)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := mdbv1.NewReplicaSetBuilder().
+				SetName("test-om-db").
+				SetNamespace(mock.TestNamespace).
+				SetVersion("6.0.0").
+				SetMembers(3).
+				EnableAuth([]mdbv1.AuthMode{util.SCRAM})
+			if tt.enableTLS {
+				builder = builder.SetSecurityTLSEnabled()
+			}
+			externalAppDB := builder.Build()
+			externalAppDB.Spec.Role = mdbv1.RoleAppDB
+			if tt.enableTLS {
+				externalAppDB.Spec.Security.TLSConfig.CA = tt.caConfigMapName
+			}
+
+			testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+				Name: "test-om-db",
+				Kind: "MongoDB",
+			})
+
+			omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+			reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+			require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
+			require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
+				SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
+				SetNamespace(testOm.Namespace).
+				SetField(util.OpsManagerPasswordKey, "test-password").
+				Build()))
+
+			helper, err := NewOpsManagerReconcilerHelper(ctx, reconciler, testOm, reconciler.memberClustersMap, zap.S())
+			require.NoError(t, err)
+
+			cfg, err := reconciler.createNewExternalAppDBReconciler(zap.S()).GetAppDBConfig(ctx, testOm)
+			require.NoError(t, err)
+			assert.Contains(t, cfg.ConnectionString, util.OpsManagerMongoDBUserName)
+			assert.Contains(t, cfg.ConnectionString, "test-password")
+			assert.Equal(t, tt.expectedIsTLSEnabled, cfg.IsTLSEnabled)
+			assert.Equal(t, tt.expectedCAConfigMapName, cfg.CAConfigMapName)
+
+			for _, memberCluster := range helper.getHealthyMemberClusters() {
+				require.NoError(t, reconciler.ensureAppDBConnectionStringInMemberCluster(ctx, testOm, cfg.ConnectionString, memberCluster, zap.S()))
+			}
+
+			result := corev1.Secret{}
+			require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()), &result))
+			assert.Contains(t, string(result.Data[util.AppDbConnectionStringKey]), util.OpsManagerMongoDBUserName)
+		})
+	}
 }
 
 func TestEnsureAppDBStatefulSetOwnership_OnlyDetachesOMOwnedStatefulSet(t *testing.T) {

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -92,13 +92,11 @@ func TestValidateExternalAppDBReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reconciler := newOpsManagerReconcilerForValidation(tt.objects...)
-			externalAppDB, err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
+			err := reconciler.createNewExternalAppDBReconciler(zap.S()).validateExternalAppDBReference(ctx, tt.om)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
-				require.NotNil(t, externalAppDB)
 			} else {
 				require.EqualError(t, err, tt.expectedError)
-				require.Nil(t, externalAppDB)
 			}
 		})
 	}
@@ -198,47 +196,80 @@ func TestEnsureAppDBStatefulSetOwnership_IsIdempotent(t *testing.T) {
 	assert.Equal(t, "true", resultSts.Annotations[util.AppDBMigrationReadyAnnotation])
 }
 
-func TestComputeExternalAppDBConnectionString_WritesFixedSecret(t *testing.T) {
+func TestGetAppDBConfig_ExternalAppDB(t *testing.T) {
 	ctx := context.Background()
 
-	externalAppDB := mdbv1.NewReplicaSetBuilder().
-		SetName("test-om-db").
-		SetNamespace(mock.TestNamespace).
-		SetVersion("6.0.0").
-		SetMembers(3).
-		EnableAuth([]mdbv1.AuthMode{util.SCRAM}).
-		Build()
-	externalAppDB.Spec.Role = mdbv1.RoleAppDB
-
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
-		Name: "test-om-db",
-		Kind: "MongoDB",
-	})
-
-	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
-	require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
-	require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
-		SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
-		SetNamespace(testOm.Namespace).
-		SetField(util.OpsManagerPasswordKey, "test-password").
-		Build()))
-
-	helper, err := NewOpsManagerReconcilerHelper(ctx, reconciler, testOm, reconciler.memberClustersMap, zap.S())
-	require.NoError(t, err)
-
-	connString, err := reconciler.createNewExternalAppDBReconciler(zap.S()).computeExternalAppDBConnectionString(ctx, testOm)
-	require.NoError(t, err)
-	assert.Contains(t, connString, util.OpsManagerMongoDBUserName)
-	assert.Contains(t, connString, "test-password")
-
-	for _, memberCluster := range helper.getHealthyMemberClusters() {
-		require.NoError(t, reconciler.ensureAppDBConnectionStringInMemberCluster(ctx, testOm, connString, memberCluster, zap.S()))
+	tests := []struct {
+		name                    string
+		enableTLS               bool
+		caConfigMapName         string
+		expectedIsTLSEnabled    bool
+		expectedCAConfigMapName string
+	}{
+		{
+			name:                    "TLS disabled returns empty CA and disabled flag",
+			expectedIsTLSEnabled:    false,
+			expectedCAConfigMapName: "",
+		},
+		{
+			name:                    "TLS enabled with CA returns resolved TLS config",
+			enableTLS:               true,
+			caConfigMapName:         "app-db-issuer-ca",
+			expectedIsTLSEnabled:    true,
+			expectedCAConfigMapName: "app-db-issuer-ca",
+		},
 	}
 
-	result := corev1.Secret{}
-	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()), &result))
-	assert.Contains(t, string(result.Data[util.AppDbConnectionStringKey]), util.OpsManagerMongoDBUserName)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := mdbv1.NewReplicaSetBuilder().
+				SetName("test-om-db").
+				SetNamespace(mock.TestNamespace).
+				SetVersion("6.0.0").
+				SetMembers(3).
+				EnableAuth([]mdbv1.AuthMode{util.SCRAM})
+			if tt.enableTLS {
+				builder = builder.SetSecurityTLSEnabled()
+			}
+			externalAppDB := builder.Build()
+			externalAppDB.Spec.Role = mdbv1.RoleAppDB
+			if tt.enableTLS {
+				externalAppDB.Spec.Security.TLSConfig.CA = tt.caConfigMapName
+			}
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
+				Name: "test-om-db",
+				Kind: "MongoDB",
+			})
+
+			omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+			reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+			require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
+			require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
+				SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
+				SetNamespace(testOm.Namespace).
+				SetField(util.OpsManagerPasswordKey, "test-password").
+				Build()))
+
+			helper, err := NewOpsManagerReconcilerHelper(ctx, reconciler, testOm, reconciler.memberClustersMap, zap.S())
+			require.NoError(t, err)
+
+			cfg, err := reconciler.createNewExternalAppDBReconciler(zap.S()).GetAppDBConfig(ctx, testOm, zap.S())
+			require.NoError(t, err)
+			assert.Contains(t, cfg.ConnectionString, util.OpsManagerMongoDBUserName)
+			assert.Contains(t, cfg.ConnectionString, "test-password")
+			assert.Equal(t, tt.expectedIsTLSEnabled, cfg.IsTLSEnabled)
+			assert.Equal(t, tt.expectedCAConfigMapName, cfg.CAConfigMapName)
+
+			for _, memberCluster := range helper.getHealthyMemberClusters() {
+				require.NoError(t, reconciler.ensureAppDBConnectionStringInMemberCluster(ctx, testOm, cfg.ConnectionString, memberCluster, zap.S()))
+			}
+
+			result := corev1.Secret{}
+			require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()), &result))
+			assert.Contains(t, string(result.Data[util.AppDbConnectionStringKey]), util.OpsManagerMongoDBUserName)
+		})
+	}
 }
 
 func TestEnsureAppDBStatefulSetOwnership_OnlyDetachesOMOwnedStatefulSet(t *testing.T) {

--- a/controllers/operator/appdbreplicaset_external_reconciler_test.go
+++ b/controllers/operator/appdbreplicaset_external_reconciler_test.go
@@ -237,7 +237,7 @@ func TestGetAppDBConfig_ExternalAppDB(t *testing.T) {
 				externalAppDB.Spec.Security.TLSConfig.CA = tt.caConfigMapName
 			}
 
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
+			testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 				Name: "test-om-db",
 				Kind: "MongoDB",
 			})

--- a/controllers/operator/appdbreplicaset_reconciler.go
+++ b/controllers/operator/appdbreplicaset_reconciler.go
@@ -3,11 +3,16 @@ package operator
 import (
 	"context"
 
-	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 )
+
+type AppDBConfig struct {
+	IsTLSEnabled     bool
+	CAConfigMapName  string
+	ConnectionString string
+}
 
 // AppDBReconciler is implemented by both the ReconcileAppDbReplicaSet (internal AppDB reconciler
 // backed by opsManager.Spec.AppDB) and the ReconcileExternalAppDBReplicaSet (backed by
@@ -18,7 +23,7 @@ type AppDBReconciler interface {
 	// rest of the controller's workflow.Status.ReconcileResult() calls.
 	ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error)
 
-	// BuildAppDBConnectionURL returns the MongoDB connection string OpsManager/BackupDaemon
-	// should use to reach the AppDB.
-	BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error)
+	// GetAppDBConfig returns the AppDB configuration including MongoDB connection string OpsManager/BackupDaemon
+	// TLS settings etc.
+	GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (*AppDBConfig, error)
 }

--- a/controllers/operator/appdbreplicaset_reconciler.go
+++ b/controllers/operator/appdbreplicaset_reconciler.go
@@ -9,6 +9,12 @@ import (
 	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
 )
 
+type AppDBConfig struct {
+	IsTLSEnabled     bool
+	CAConfigMapName  string
+	ConnectionString string
+}
+
 // AppDBReconciler is implemented by both the ReconcileAppDbReplicaSet (internal AppDB reconciler
 // backed by opsManager.Spec.AppDB) and the ReconcileExternalAppDBReplicaSet (backed by
 // opsManager.Spec.ExternalAppDBRef).
@@ -18,7 +24,7 @@ type AppDBReconciler interface {
 	// rest of the controller's workflow.Status.ReconcileResult() calls.
 	ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (reconcile.Result, error)
 
-	// BuildAppDBConnectionURL returns the MongoDB connection string OpsManager/BackupDaemon
-	// should use to reach the AppDB.
-	BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error)
+	// GetAppDBConfig returns the AppDB configuration including MongoDB connection string OpsManager/BackupDaemon
+	// TLS settings etc.
+	GetAppDBConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (*AppDBConfig, error)
 }

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -93,6 +93,15 @@ func WithConnectionStringHash(hash string) func(opts *OpsManagerStatefulSetOptio
 	}
 }
 
+// WithAppDBTLSCAConfigMapName injects the effective AppDB CA ConfigMap name (resolved by the
+// controller from either the internal AppDB spec or an external AppDB's referenced CR) so the
+// OpsManager and Backup Daemon pods mount the correct CA to trust the AppDB's TLS certificate.
+func WithAppDBTLSCAConfigMapName(name string) func(opts *OpsManagerStatefulSetOptions) {
+	return func(opts *OpsManagerStatefulSetOptions) {
+		opts.AppDBTlsCAConfigMapName = name
+	}
+}
+
 func WithVaultConfig(config vault.VaultConfiguration) func(opts *OpsManagerStatefulSetOptions) {
 	return func(opts *OpsManagerStatefulSetOptions) {
 		opts.VaultConfig = config

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -183,6 +183,12 @@ func WithOMDefaultArchitecture(defaultArchitecture architectures.DefaultArchitec
 	}
 }
 
+func WithAppDBTLSCAConfigMapName(name string) func(opts *OpsManagerStatefulSetOptions) {
+	return func(opts *OpsManagerStatefulSetOptions) {
+		opts.AppDBTlsCAConfigMapName = name
+	}
+}
+
 // updateHTTPSCertSecret updates the fields for the OpsManager HTTPS certificate in case the provided secret is of type kubernetes.io/tls.
 func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(ctx context.Context, centralClusterSecretClient secrets.SecretClient, memberCluster multicluster.MemberCluster, ownerReferences []metav1.OwnerReference, log *zap.SugaredLogger) error {
 	// Return immediately if no Certificate is provided
@@ -280,14 +286,13 @@ func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secre
 // and BackupDaemon StatefulSets
 func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 	return OpsManagerStatefulSetOptions{
-		OwnerReference:          opsManager.OwnerReferenceForMemberCluster(),
-		OwnerName:               opsManager.Name,
-		HTTPSCertSecretName:     opsManager.TLSCertificateSecretName(),
-		AppDBTlsCAConfigMapName: opsManager.Spec.GetAppDBCAConfigMapName(),
-		EnvVars:                 opsManagerConfigurationToEnvVars(opsManager),
-		Namespace:               opsManager.Namespace,
-		Labels:                  opsManager.Labels,
-		StsLabels:               opsManager.GetOwnerLabels(),
+		OwnerReference:      opsManager.OwnerReferenceForMemberCluster(),
+		OwnerName:           opsManager.Name,
+		HTTPSCertSecretName: opsManager.TLSCertificateSecretName(),
+		EnvVars:             opsManagerConfigurationToEnvVars(opsManager),
+		Namespace:           opsManager.Namespace,
+		Labels:              opsManager.Labels,
+		StsLabels:           opsManager.GetOwnerLabels(),
 	}
 }
 

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -93,15 +93,6 @@ func WithConnectionStringHash(hash string) func(opts *OpsManagerStatefulSetOptio
 	}
 }
 
-// WithAppDBTLSCAConfigMapName injects the effective AppDB CA ConfigMap name (resolved by the
-// controller from either the internal AppDB spec or an external AppDB's referenced CR) so the
-// OpsManager and Backup Daemon pods mount the correct CA to trust the AppDB's TLS certificate.
-func WithAppDBTLSCAConfigMapName(name string) func(opts *OpsManagerStatefulSetOptions) {
-	return func(opts *OpsManagerStatefulSetOptions) {
-		opts.AppDBTlsCAConfigMapName = name
-	}
-}
-
 func WithVaultConfig(config vault.VaultConfiguration) func(opts *OpsManagerStatefulSetOptions) {
 	return func(opts *OpsManagerStatefulSetOptions) {
 		opts.VaultConfig = config
@@ -285,19 +276,6 @@ func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secre
 	return omSts, nil
 }
 
-// appDBTlsCAConfigMapName returns the AppDB CA ConfigMap name for internal AppDB mode,
-// or empty string when externalApplicationDatabaseRef is set (Spec.AppDB is nil).
-func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
-	// TODO(CLOUDP-TBD): AppDBTlsCAConfigMapName is computed from the internal AppDB spec
-	// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
-	// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
-	// fixed here.
-	if opsManager.Spec.ExternalApplicationDatabaseRef != nil {
-		return ""
-	}
-	return opsManager.Spec.AppDB.GetCAConfigMapName()
-}
-
 // getSharedOpsManagerOptions returns the options that are shared between both the OpsManager
 // and BackupDaemon StatefulSets
 func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
@@ -305,7 +283,7 @@ func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerSt
 		OwnerReference:          opsManager.OwnerReferenceForMemberCluster(),
 		OwnerName:               opsManager.Name,
 		HTTPSCertSecretName:     opsManager.TLSCertificateSecretName(),
-		AppDBTlsCAConfigMapName: appDBTlsCAConfigMapName(opsManager),
+		AppDBTlsCAConfigMapName: opsManager.Spec.GetAppDBCAConfigMapName(),
 		EnvVars:                 opsManagerConfigurationToEnvVars(opsManager),
 		Namespace:               opsManager.Namespace,
 		Labels:                  opsManager.Labels,

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -93,15 +93,6 @@ func WithConnectionStringHash(hash string) func(opts *OpsManagerStatefulSetOptio
 	}
 }
 
-// WithAppDBTLSCAConfigMapName injects the effective AppDB CA ConfigMap name (resolved by the
-// controller from either the internal AppDB spec or an external AppDB's referenced CR) so the
-// OpsManager and Backup Daemon pods mount the correct CA to trust the AppDB's TLS certificate.
-func WithAppDBTLSCAConfigMapName(name string) func(opts *OpsManagerStatefulSetOptions) {
-	return func(opts *OpsManagerStatefulSetOptions) {
-		opts.AppDBTlsCAConfigMapName = name
-	}
-}
-
 func WithVaultConfig(config vault.VaultConfiguration) func(opts *OpsManagerStatefulSetOptions) {
 	return func(opts *OpsManagerStatefulSetOptions) {
 		opts.VaultConfig = config
@@ -285,20 +276,6 @@ func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secre
 	return omSts, nil
 }
 
-// appDBTlsCAConfigMapName returns the AppDB CA ConfigMap name for internal AppDB mode,
-// or empty string when externalApplicationDatabaseRef is set (Spec.AppDB is nil).
-func appDBTlsCAConfigMapName(opsManager *omv1.MongoDBOpsManager) string {
-	// TODO(CLOUDP-TBD): AppDBTlsCAConfigMapName is computed from the internal AppDB spec
-	// even in external-AppDB mode, so OM/BackupDaemon won't trust the external CR's actual
-	// CA. Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not
-	// fixed here.
-	if opsManager.IsInternalAppDB() {
-		return opsManager.Spec.AppDB.GetCAConfigMapName()
-	}
-
-	return ""
-}
-
 // getSharedOpsManagerOptions returns the options that are shared between both the OpsManager
 // and BackupDaemon StatefulSets
 func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
@@ -306,7 +283,7 @@ func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerSt
 		OwnerReference:          opsManager.OwnerReferenceForMemberCluster(),
 		OwnerName:               opsManager.Name,
 		HTTPSCertSecretName:     opsManager.TLSCertificateSecretName(),
-		AppDBTlsCAConfigMapName: appDBTlsCAConfigMapName(opsManager),
+		AppDBTlsCAConfigMapName: opsManager.Spec.GetAppDBCAConfigMapName(),
 		EnvVars:                 opsManagerConfigurationToEnvVars(opsManager),
 		Namespace:               opsManager.Namespace,
 		Labels:                  opsManager.Labels,

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -437,7 +437,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 		return result, err
 	}
 
-	appDBConnectionString, err := appDbReconciler.BuildAppDBConnectionURL(ctx, opsManager, log)
+	appDBConfig, err := appDbReconciler.GetAppDBConfig(ctx, opsManager, log)
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
@@ -447,17 +447,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
 
-	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
-		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
-			return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)), log, opsManagerExtraStatusParams)
-		}
-	}
-
 	initOpsManagerImage := images.ContainerImage(r.imageUrls, util.InitOpsManagerImageUrl, r.initOpsManagerImageVersion)
 	opsManagerImage := images.ContainerImage(r.imageUrls, util.OpsManagerImageUrl, opsManager.Spec.Version)
 
 	// 2. Reconcile Ops Manager
-	status, omAdmin := r.reconcileOpsManager(ctx, opsManagerReconcilerHelper, opsManager, appDBConnectionString, initOpsManagerImage, opsManagerImage, log)
+	status, omAdmin := r.reconcileOpsManager(ctx, opsManagerReconcilerHelper, opsManager, appDBConfig, initOpsManagerImage, opsManagerImage, log)
 	if !status.IsOK() {
 		return r.updateStatus(ctx, opsManager, status, log, opsManagerExtraStatusParams, mdbstatus.NewBaseUrlOption(opsManager.CentralURL()))
 	}
@@ -470,7 +464,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// 3. Reconcile Backup Daemon
-	if status := r.reconcileBackupDaemon(ctx, opsManagerReconcilerHelper, opsManager, omAdmin, appDBConnectionString, initOpsManagerImage, opsManagerImage, log); !status.IsOK() {
+	if status := r.reconcileBackupDaemon(ctx, opsManagerReconcilerHelper, opsManager, omAdmin, appDBConfig, initOpsManagerImage, opsManagerImage, log); !status.IsOK() {
 		return r.updateStatus(ctx, opsManager, status, log, mdbstatus.NewOMPartOption(mdbstatus.Backup))
 	}
 
@@ -554,11 +548,17 @@ func createOrUpdateSecretIfNotFound(ctx context.Context, secretGetUpdaterCreator
 	return nil
 }
 
-func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, appDBConnectionString, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (workflow.Status, api.OpsManagerAdmin) {
+func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, appDBConfig *AppDBConfig, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (workflow.Status, api.OpsManagerAdmin) {
 	var genKeySecretMap map[string][]byte
 	var err error
 	if genKeySecretMap, err = r.ensureGenKeyInOperatorCluster(ctx, opsManager, log); err != nil {
 		return workflow.Failed(xerrors.Errorf("error in ensureGenKeyInOperatorCluster: %w", err)), nil
+	}
+
+	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
+		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConfig.ConnectionString, memberCluster, log); err != nil {
+			return workflow.Failed(xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)), nil
+		}
 	}
 
 	if err := r.replicateGenKeyInMemberClusters(ctx, reconcilerHelper, genKeySecretMap); err != nil {
@@ -569,7 +569,7 @@ func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcil
 		return workflow.Failed(xerrors.Errorf("error in replicateTLSCAInMemberClusters: %w", err)), nil
 	}
 
-	if err := r.replicateAppDBTLSCAInMemberClusters(ctx, reconcilerHelper); err != nil {
+	if err := r.replicateAppDBTLSCAInMemberClusters(ctx, reconcilerHelper, appDBConfig); err != nil {
 		return workflow.Failed(xerrors.Errorf("error in replicateAppDBTLSCAInMemberClusters: %w", err)), nil
 	}
 
@@ -588,7 +588,7 @@ func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcil
 	// Prepare Ops Manager StatefulSets in parallel in all member clusters
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
-		mutatedSts, err := r.createOpsManagerStatefulsetInMemberCluster(ctx, reconcilerHelper, appDBConnectionString, memberCluster, initOpsManagerImage, opsManagerImage, log)
+		mutatedSts, err := r.createOpsManagerStatefulsetInMemberCluster(ctx, reconcilerHelper, appDBConfig, memberCluster, initOpsManagerImage, opsManagerImage, log)
 		if err != nil {
 			return workflow.Failed(xerrors.Errorf("error creating Ops Manager statefulset in member cluster %s: %w", memberCluster.Name, err)), nil
 		}
@@ -706,7 +706,7 @@ func (r *OpsManagerReconciler) stopBackupDaemonIfNeeded(ctx context.Context, rec
 	return nil
 }
 
-func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConnectionString, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConfig *AppDBConfig, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) workflow.Status {
 	backupStatusPartOption := mdbstatus.NewOMPartOption(mdbstatus.Backup)
 
 	// If backup is not enabled, we check whether it is still configured in OM to update the status.
@@ -734,7 +734,7 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
 		// Prepare Backup Daemon StatefulSet (create and wait)
-		mutatedSts, err := r.createBackupDaemonStatefulset(ctx, reconcilerHelper, appDBConnectionString, memberCluster, initOpsManagerImage, opsManagerImage, log)
+		mutatedSts, err := r.createBackupDaemonStatefulset(ctx, reconcilerHelper, appDBConfig, memberCluster, initOpsManagerImage, opsManagerImage, log)
 		if err != nil {
 			// Check if it is a k8s error or a custom one
 			var statefulSetIsRecreatingError create.StatefulSetIsRecreating
@@ -751,7 +751,7 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 	}
 
 	// Configure Backup using API
-	if status := r.prepareBackupInOpsManager(ctx, reconcilerHelper, opsManager, omAdmin, appDBConnectionString, log); !status.IsOK() {
+	if status := r.prepareBackupInOpsManager(ctx, reconcilerHelper, opsManager, omAdmin, appDBConfig, log); !status.IsOK() {
 		return status
 	}
 
@@ -820,10 +820,10 @@ func hashConnectionString(connectionString string) string {
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hashBytes[:])
 }
 
-func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConnectionString string, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
 	opsManager := reconcilerHelper.opsManager
 
-	r.ensureConfiguration(reconcilerHelper, log)
+	r.ensureConfiguration(reconcilerHelper, appDBConfig, log)
 
 	var vaultConfig vault.VaultConfiguration
 	if r.VaultClient != nil {
@@ -839,13 +839,14 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 	sts, err := construct.OpsManagerStatefulSet(ctx, r.SecretClient, opsManager, memberCluster, log,
 		construct.WithInitOpsManagerImage(initOpsManagerImage),
 		construct.WithOpsManagerImage(opsManagerImage),
-		construct.WithConnectionStringHash(hashConnectionString(appDBConnectionString)),
+		construct.WithConnectionStringHash(hashConnectionString(appDBConfig.ConnectionString)),
 		construct.WithVaultConfig(vaultConfig),
 		construct.WithKmipConfig(ctx, opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.OpsManagerMembersForMemberCluster(memberCluster)),
 		construct.WithDebugPort(debugPort),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
+		construct.WithAppDBTLSCAConfigMapName(appDBConfig.CAConfigMapName),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("error building OpsManager stateful set: %w", err)
@@ -917,15 +918,15 @@ func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClu
 }
 
 // ensureConfiguration makes sure the mandatory configuration is specified.
-func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerReconcilerHelper, log *zap.SugaredLogger) {
+func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig, log *zap.SugaredLogger) {
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	if reconcilerHelper.opsManager.Spec.IsAppDBTLSEnabled() {
+	if appDBConfig.IsTLSEnabled {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 	}
 
-	if reconcilerHelper.opsManager.Spec.GetAppDBCAConfigMapName() != "" {
+	if appDBConfig.CAConfigMapName != "" {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 	}
 
@@ -944,12 +945,12 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 // Note, that the idea of creating two statefulsets for Ops Manager and Backup Daemon in parallel hasn't worked out
 // as the daemon in this case just hangs silently (in practice it's ok to start it in ~1 min after start of OM though
 // we will just start them sequentially)
-func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConnectionString string, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
-	if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, reconcilerHelper.opsManager, appDBConnectionString, memberCluster, log); err != nil {
+func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+	if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, reconcilerHelper.opsManager, appDBConfig.ConnectionString, memberCluster, log); err != nil {
 		return nil, xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)
 	}
 
-	r.ensureConfiguration(reconcilerHelper, log)
+	r.ensureConfiguration(reconcilerHelper, appDBConfig, log)
 
 	var vaultConfig vault.VaultConfiguration
 	if r.VaultClient != nil {
@@ -960,12 +961,13 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 	sts, err := construct.BackupDaemonStatefulSet(ctx, r.SecretClient, reconcilerHelper.opsManager, memberCluster, log,
 		construct.WithInitOpsManagerImage(initOpsManagerImage),
 		construct.WithOpsManagerImage(opsManagerImage),
-		construct.WithConnectionStringHash(hashConnectionString(appDBConnectionString)),
+		construct.WithConnectionStringHash(hashConnectionString(appDBConfig.ConnectionString)),
 		construct.WithVaultConfig(vaultConfig),
 		construct.WithKmipConfig(ctx, reconcilerHelper.opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetBackupStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.BackupDaemonMembersForMemberCluster(memberCluster)),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
+		construct.WithAppDBTLSCAConfigMapName(appDBConfig.CAConfigMapName),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("error building stateful set: %w", err)
@@ -1241,12 +1243,12 @@ func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Cont
 	return nil
 }
 
-func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
-	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName() == "" {
+func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig) error {
+	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || appDBConfig.CAConfigMapName == "" {
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName())
+	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, appDBConfig.CAConfigMapName)
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1425,7 +1427,7 @@ func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager
 }
 
 // prepareBackupInOpsManager makes the changes to backup admin configuration based on the Ops Manager spec
-func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConfig *AppDBConfig, log *zap.SugaredLogger) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1466,10 +1468,10 @@ func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, re
 	status := r.ensureOplogStoresInOpsManager(ctx, opsManager, omAdmin, log)
 
 	// 3. S3 Oplog Configs
-	status = status.Merge(r.ensureS3OplogStoresInOpsManager(ctx, opsManager, omAdmin, appDBConnectionString, log))
+	status = status.Merge(r.ensureS3OplogStoresInOpsManager(ctx, opsManager, omAdmin, appDBConfig, log))
 
 	// 4. S3 Configs
-	status = status.Merge(r.ensureS3ConfigurationInOpsManager(ctx, opsManager, omAdmin, appDBConnectionString, log))
+	status = status.Merge(r.ensureS3ConfigurationInOpsManager(ctx, opsManager, omAdmin, appDBConfig, log))
 
 	// 5. Block store configs
 	status = status.Merge(r.ensureBlockStoresInOpsManager(ctx, opsManager, omAdmin, log))
@@ -1547,7 +1549,7 @@ func (r *OpsManagerReconciler) ensureOplogStoresInOpsManager(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, s3OplogAdmin api.S3OplogStoreAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, s3OplogAdmin api.S3OplogStoreAdmin, appDBConfig *AppDBConfig, log *zap.SugaredLogger) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1561,7 +1563,7 @@ func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Conte
 	s3OperatorOplogConfigs := opsManager.Spec.Backup.S3OplogStoreConfigs
 	configsToCreate := identifiable.SetDifferenceGeneric(s3OperatorOplogConfigs, opsManagerS3OpLogConfigs)
 	for _, v := range configsToCreate {
-		omConfig, status := r.buildOMS3Config(ctx, opsManager, v.(omv1.S3Config), true, appDBConnectionString)
+		omConfig, status := r.buildOMS3Config(ctx, opsManager, v.(omv1.S3Config), true, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1577,7 +1579,7 @@ func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Conte
 	for _, v := range configsToUpdate {
 		omConfig := v[0].(backup.S3Config)
 		operatorConfig := v[1].(omv1.S3Config)
-		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, true, appDBConnectionString)
+		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, true, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1666,7 +1668,7 @@ func (r *OpsManagerReconciler) ensureBlockStoresInOpsManager(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.S3StoreBlockStoreAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.S3StoreBlockStoreAdmin, appDBConfig *AppDBConfig, log *zap.SugaredLogger) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1679,7 +1681,7 @@ func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Con
 	operatorS3Configs := opsManager.Spec.Backup.S3Configs
 	configsToCreate := identifiable.SetDifferenceGeneric(operatorS3Configs, opsManagerS3Configs)
 	for _, config := range configsToCreate {
-		omConfig, status := r.buildOMS3Config(ctx, opsManager, config.(omv1.S3Config), false, appDBConnectionString)
+		omConfig, status := r.buildOMS3Config(ctx, opsManager, config.(omv1.S3Config), false, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1696,7 +1698,7 @@ func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Con
 	for _, v := range configsToUpdate {
 		omConfig := v[0].(backup.S3Config)
 		operatorConfig := v[1].(omv1.S3Config)
-		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, false, appDBConnectionString)
+		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, false, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1784,7 +1786,7 @@ func shouldUseAppDb(config omv1.S3Config) bool {
 }
 
 // buildAppDbOMS3Config creates a backup.S3Config which is configured to use The AppDb.
-func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConnectionString string) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, connectionString string, caConfigMapName string) (backup.S3Config, workflow.Status) {
 	var s3Creds *backup.S3Credentials
 
 	if !config.IRSAEnabled {
@@ -1800,17 +1802,17 @@ func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv
 		Name:     config.S3BucketName,
 	}
 
-	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, om, isOpLog)
+	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, om, caConfigMapName, isOpLog)
 	if err != nil {
 		return backup.S3Config{}, workflow.Failed(xerrors.New(err.Error()))
 	}
 
-	return backup.NewS3Config(om, config, appDBConnectionString, customCAOpts, bucket, s3Creds), workflow.OK()
+	return backup.NewS3Config(om, config, connectionString, customCAOpts, bucket, s3Creds), workflow.OK()
 }
 
 // buildMongoDbOMS3Config creates a backup.S3Config which is configured to use a referenced
 // MongoDB resource.
-func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, caConfigMapName string) (backup.S3Config, workflow.Status) {
 	mongodb, status := r.getMongoDbForS3Config(ctx, opsManager, config)
 	if !status.IsOK() {
 		return backup.S3Config{}, status
@@ -1842,7 +1844,7 @@ func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsMa
 		Name:     config.S3BucketName,
 	}
 
-	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, opsManager, isOpLog)
+	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, opsManager, caConfigMapName, isOpLog)
 	if err != nil {
 		return backup.S3Config{}, workflow.Failed(err)
 	}
@@ -1852,7 +1854,7 @@ func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsMa
 
 // readCustomCAFilePathsAndContents returns the filepath and contents of the custom CA which is used to configure
 // the S3Store.
-func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Context, opsManager *omv1.MongoDBOpsManager, isOpLog bool) ([]backup.S3CustomCertificate, error) {
+func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Context, opsManager *omv1.MongoDBOpsManager, caConfigMapName string, isOpLog bool) ([]backup.S3CustomCertificate, error) {
 	var customCertificates []backup.S3CustomCertificate
 	var err error
 
@@ -1866,8 +1868,8 @@ func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Cont
 		return customCertificates, err
 	}
 
-	if opsManager.Spec.GetAppDBCAConfigMapName() != "" {
-		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, opsManager.Spec.GetAppDBCAConfigMapName()))
+	if caConfigMapName != "" {
+		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, caConfigMapName))
 		if err != nil {
 			return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
 		}
@@ -1902,11 +1904,11 @@ func getCAs(ctx context.Context, s3Config []omv1.S3Config, ns string, client sec
 
 // buildOMS3Config builds the OM API S3 config from the Operator OM CR configuration. This involves some logic to
 // get the mongo URI, which points to either the external resource or to the AppDB
-func (r *OpsManagerReconciler) buildOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConnectionString string) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConfig *AppDBConfig) (backup.S3Config, workflow.Status) {
 	if shouldUseAppDb(config) {
-		return r.buildAppDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConnectionString)
+		return r.buildAppDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConfig.ConnectionString, appDBConfig.CAConfigMapName)
 	}
-	return r.buildMongoDbOMS3Config(ctx, opsManager, config, isOpLog)
+	return r.buildMongoDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConfig.CAConfigMapName)
 }
 
 // getMongoDbForS3Config returns the referenced MongoDB resource which should be used when configuring the backup config.

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -437,7 +437,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 		return result, err
 	}
 
-	appDBConnectionString, err := appDbReconciler.BuildAppDBConnectionURL(ctx, opsManager, log)
+	appDBConfig, err := appDbReconciler.GetAppDBConfig(ctx, opsManager)
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
@@ -447,17 +447,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
 
-	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
-		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
-			return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)), log, opsManagerExtraStatusParams)
-		}
-	}
-
 	initOpsManagerImage := images.ContainerImage(r.imageUrls, util.InitOpsManagerImageUrl, r.initOpsManagerImageVersion)
 	opsManagerImage := images.ContainerImage(r.imageUrls, util.OpsManagerImageUrl, opsManager.Spec.Version)
 
 	// 2. Reconcile Ops Manager
-	status, omAdmin := r.reconcileOpsManager(ctx, opsManagerReconcilerHelper, opsManager, appDBConnectionString, initOpsManagerImage, opsManagerImage, log)
+	status, omAdmin := r.reconcileOpsManager(ctx, opsManagerReconcilerHelper, opsManager, appDBConfig, initOpsManagerImage, opsManagerImage, log)
 	if !status.IsOK() {
 		return r.updateStatus(ctx, opsManager, status, log, opsManagerExtraStatusParams, mdbstatus.NewBaseUrlOption(opsManager.CentralURL()))
 	}
@@ -470,7 +464,7 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// 3. Reconcile Backup Daemon
-	if status := r.reconcileBackupDaemon(ctx, opsManagerReconcilerHelper, opsManager, omAdmin, appDBConnectionString, initOpsManagerImage, opsManagerImage, log); !status.IsOK() {
+	if status := r.reconcileBackupDaemon(ctx, opsManagerReconcilerHelper, opsManager, omAdmin, appDBConfig, initOpsManagerImage, opsManagerImage, log); !status.IsOK() {
 		return r.updateStatus(ctx, opsManager, status, log, mdbstatus.NewOMPartOption(mdbstatus.Backup))
 	}
 
@@ -554,11 +548,17 @@ func createOrUpdateSecretIfNotFound(ctx context.Context, secretGetUpdaterCreator
 	return nil
 }
 
-func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, appDBConnectionString, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (workflow.Status, api.OpsManagerAdmin) {
+func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, appDBConfig *AppDBConfig, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (workflow.Status, api.OpsManagerAdmin) {
 	var genKeySecretMap map[string][]byte
 	var err error
 	if genKeySecretMap, err = r.ensureGenKeyInOperatorCluster(ctx, opsManager, log); err != nil {
 		return workflow.Failed(xerrors.Errorf("error in ensureGenKeyInOperatorCluster: %w", err)), nil
+	}
+
+	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
+		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConfig.ConnectionString, memberCluster, log); err != nil {
+			return workflow.Failed(xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)), nil
+		}
 	}
 
 	if err := r.replicateGenKeyInMemberClusters(ctx, reconcilerHelper, genKeySecretMap); err != nil {
@@ -569,7 +569,7 @@ func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcil
 		return workflow.Failed(xerrors.Errorf("error in replicateTLSCAInMemberClusters: %w", err)), nil
 	}
 
-	if err := r.replicateAppDBTLSCAInMemberClusters(ctx, reconcilerHelper); err != nil {
+	if err := r.replicateAppDBTLSCAInMemberClusters(ctx, reconcilerHelper, appDBConfig); err != nil {
 		return workflow.Failed(xerrors.Errorf("error in replicateAppDBTLSCAInMemberClusters: %w", err)), nil
 	}
 
@@ -588,7 +588,7 @@ func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcil
 	// Prepare Ops Manager StatefulSets in parallel in all member clusters
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
-		mutatedSts, err := r.createOpsManagerStatefulsetInMemberCluster(ctx, reconcilerHelper, appDBConnectionString, memberCluster, initOpsManagerImage, opsManagerImage, log)
+		mutatedSts, err := r.createOpsManagerStatefulsetInMemberCluster(ctx, reconcilerHelper, appDBConfig, memberCluster, initOpsManagerImage, opsManagerImage, log)
 		if err != nil {
 			return workflow.Failed(xerrors.Errorf("error creating Ops Manager statefulset in member cluster %s: %w", memberCluster.Name, err)), nil
 		}
@@ -706,7 +706,7 @@ func (r *OpsManagerReconciler) stopBackupDaemonIfNeeded(ctx context.Context, rec
 	return nil
 }
 
-func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConnectionString, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConfig *AppDBConfig, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) workflow.Status {
 	backupStatusPartOption := mdbstatus.NewOMPartOption(mdbstatus.Backup)
 
 	// If backup is not enabled, we check whether it is still configured in OM to update the status.
@@ -734,7 +734,7 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
 		// Prepare Backup Daemon StatefulSet (create and wait)
-		mutatedSts, err := r.createBackupDaemonStatefulset(ctx, reconcilerHelper, appDBConnectionString, memberCluster, initOpsManagerImage, opsManagerImage, log)
+		mutatedSts, err := r.createBackupDaemonStatefulset(ctx, reconcilerHelper, appDBConfig, memberCluster, initOpsManagerImage, opsManagerImage, log)
 		if err != nil {
 			// Check if it is a k8s error or a custom one
 			var statefulSetIsRecreatingError create.StatefulSetIsRecreating
@@ -751,7 +751,7 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 	}
 
 	// Configure Backup using API
-	if status := r.prepareBackupInOpsManager(ctx, reconcilerHelper, opsManager, omAdmin, appDBConnectionString, log); !status.IsOK() {
+	if status := r.prepareBackupInOpsManager(ctx, reconcilerHelper, opsManager, omAdmin, appDBConfig, log); !status.IsOK() {
 		return status
 	}
 
@@ -820,10 +820,10 @@ func hashConnectionString(connectionString string) string {
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hashBytes[:])
 }
 
-func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConnectionString string, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
 	opsManager := reconcilerHelper.opsManager
 
-	r.ensureConfiguration(reconcilerHelper, log)
+	r.ensureConfiguration(reconcilerHelper, appDBConfig, log)
 
 	var vaultConfig vault.VaultConfiguration
 	if r.VaultClient != nil {
@@ -839,13 +839,14 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 	sts, err := construct.OpsManagerStatefulSet(ctx, r.SecretClient, opsManager, memberCluster, log,
 		construct.WithInitOpsManagerImage(initOpsManagerImage),
 		construct.WithOpsManagerImage(opsManagerImage),
-		construct.WithConnectionStringHash(hashConnectionString(appDBConnectionString)),
+		construct.WithConnectionStringHash(hashConnectionString(appDBConfig.ConnectionString)),
 		construct.WithVaultConfig(vaultConfig),
 		construct.WithKmipConfig(ctx, opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.OpsManagerMembersForMemberCluster(memberCluster)),
 		construct.WithDebugPort(debugPort),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
+		construct.WithAppDBTLSCAConfigMapName(appDBConfig.CAConfigMapName),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("error building OpsManager stateful set: %w", err)
@@ -917,15 +918,15 @@ func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClu
 }
 
 // ensureConfiguration makes sure the mandatory configuration is specified.
-func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerReconcilerHelper, log *zap.SugaredLogger) {
+func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig, log *zap.SugaredLogger) {
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	if reconcilerHelper.opsManager.Spec.IsAppDBTLSEnabled() {
+	if appDBConfig.IsTLSEnabled {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 	}
 
-	if reconcilerHelper.opsManager.Spec.GetAppDBCAConfigMapName() != "" {
+	if appDBConfig.CAConfigMapName != "" {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 	}
 
@@ -944,12 +945,12 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 // Note, that the idea of creating two statefulsets for Ops Manager and Backup Daemon in parallel hasn't worked out
 // as the daemon in this case just hangs silently (in practice it's ok to start it in ~1 min after start of OM though
 // we will just start them sequentially)
-func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConnectionString string, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
-	if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, reconcilerHelper.opsManager, appDBConnectionString, memberCluster, log); err != nil {
+func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+	if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, reconcilerHelper.opsManager, appDBConfig.ConnectionString, memberCluster, log); err != nil {
 		return nil, xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)
 	}
 
-	r.ensureConfiguration(reconcilerHelper, log)
+	r.ensureConfiguration(reconcilerHelper, appDBConfig, log)
 
 	var vaultConfig vault.VaultConfiguration
 	if r.VaultClient != nil {
@@ -960,12 +961,13 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 	sts, err := construct.BackupDaemonStatefulSet(ctx, r.SecretClient, reconcilerHelper.opsManager, memberCluster, log,
 		construct.WithInitOpsManagerImage(initOpsManagerImage),
 		construct.WithOpsManagerImage(opsManagerImage),
-		construct.WithConnectionStringHash(hashConnectionString(appDBConnectionString)),
+		construct.WithConnectionStringHash(hashConnectionString(appDBConfig.ConnectionString)),
 		construct.WithVaultConfig(vaultConfig),
 		construct.WithKmipConfig(ctx, reconcilerHelper.opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetBackupStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.BackupDaemonMembersForMemberCluster(memberCluster)),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
+		construct.WithAppDBTLSCAConfigMapName(appDBConfig.CAConfigMapName),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("error building stateful set: %w", err)
@@ -1239,12 +1241,12 @@ func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Cont
 	return nil
 }
 
-func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
-	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName() == "" {
+func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, appDBConfig *AppDBConfig) error {
+	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || appDBConfig.CAConfigMapName == "" {
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName())
+	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, appDBConfig.CAConfigMapName)
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1423,7 +1425,7 @@ func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager
 }
 
 // prepareBackupInOpsManager makes the changes to backup admin configuration based on the Ops Manager spec
-func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConfig *AppDBConfig, log *zap.SugaredLogger) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1464,10 +1466,10 @@ func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, re
 	status := r.ensureOplogStoresInOpsManager(ctx, opsManager, omAdmin, log)
 
 	// 3. S3 Oplog Configs
-	status = status.Merge(r.ensureS3OplogStoresInOpsManager(ctx, opsManager, omAdmin, appDBConnectionString, log))
+	status = status.Merge(r.ensureS3OplogStoresInOpsManager(ctx, opsManager, omAdmin, appDBConfig, log))
 
 	// 4. S3 Configs
-	status = status.Merge(r.ensureS3ConfigurationInOpsManager(ctx, opsManager, omAdmin, appDBConnectionString, log))
+	status = status.Merge(r.ensureS3ConfigurationInOpsManager(ctx, opsManager, omAdmin, appDBConfig, log))
 
 	// 5. Block store configs
 	status = status.Merge(r.ensureBlockStoresInOpsManager(ctx, opsManager, omAdmin, log))
@@ -1545,7 +1547,7 @@ func (r *OpsManagerReconciler) ensureOplogStoresInOpsManager(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, s3OplogAdmin api.S3OplogStoreAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, s3OplogAdmin api.S3OplogStoreAdmin, appDBConfig *AppDBConfig, log *zap.SugaredLogger) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1559,7 +1561,7 @@ func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Conte
 	s3OperatorOplogConfigs := opsManager.Spec.Backup.S3OplogStoreConfigs
 	configsToCreate := identifiable.SetDifferenceGeneric(s3OperatorOplogConfigs, opsManagerS3OpLogConfigs)
 	for _, v := range configsToCreate {
-		omConfig, status := r.buildOMS3Config(ctx, opsManager, v.(omv1.S3Config), true, appDBConnectionString)
+		omConfig, status := r.buildOMS3Config(ctx, opsManager, v.(omv1.S3Config), true, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1575,7 +1577,7 @@ func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Conte
 	for _, v := range configsToUpdate {
 		omConfig := v[0].(backup.S3Config)
 		operatorConfig := v[1].(omv1.S3Config)
-		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, true, appDBConnectionString)
+		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, true, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1664,7 +1666,7 @@ func (r *OpsManagerReconciler) ensureBlockStoresInOpsManager(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.S3StoreBlockStoreAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.S3StoreBlockStoreAdmin, appDBConfig *AppDBConfig, log *zap.SugaredLogger) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1677,7 +1679,7 @@ func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Con
 	operatorS3Configs := opsManager.Spec.Backup.S3Configs
 	configsToCreate := identifiable.SetDifferenceGeneric(operatorS3Configs, opsManagerS3Configs)
 	for _, config := range configsToCreate {
-		omConfig, status := r.buildOMS3Config(ctx, opsManager, config.(omv1.S3Config), false, appDBConnectionString)
+		omConfig, status := r.buildOMS3Config(ctx, opsManager, config.(omv1.S3Config), false, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1694,7 +1696,7 @@ func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Con
 	for _, v := range configsToUpdate {
 		omConfig := v[0].(backup.S3Config)
 		operatorConfig := v[1].(omv1.S3Config)
-		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, false, appDBConnectionString)
+		operatorView, status := r.buildOMS3Config(ctx, opsManager, operatorConfig, false, appDBConfig)
 		if !status.IsOK() {
 			return status
 		}
@@ -1782,7 +1784,7 @@ func shouldUseAppDb(config omv1.S3Config) bool {
 }
 
 // buildAppDbOMS3Config creates a backup.S3Config which is configured to use The AppDb.
-func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConnectionString string) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, connectionString string, caConfigMapName string) (backup.S3Config, workflow.Status) {
 	var s3Creds *backup.S3Credentials
 
 	if !config.IRSAEnabled {
@@ -1798,17 +1800,17 @@ func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv
 		Name:     config.S3BucketName,
 	}
 
-	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, om, isOpLog)
+	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, om, caConfigMapName, isOpLog)
 	if err != nil {
 		return backup.S3Config{}, workflow.Failed(xerrors.New(err.Error()))
 	}
 
-	return backup.NewS3Config(om, config, appDBConnectionString, customCAOpts, bucket, s3Creds), workflow.OK()
+	return backup.NewS3Config(om, config, connectionString, customCAOpts, bucket, s3Creds), workflow.OK()
 }
 
 // buildMongoDbOMS3Config creates a backup.S3Config which is configured to use a referenced
 // MongoDB resource.
-func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, caConfigMapName string) (backup.S3Config, workflow.Status) {
 	mongodb, status := r.getMongoDbForS3Config(ctx, opsManager, config)
 	if !status.IsOK() {
 		return backup.S3Config{}, status
@@ -1840,7 +1842,7 @@ func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsMa
 		Name:     config.S3BucketName,
 	}
 
-	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, opsManager, isOpLog)
+	customCAOpts, err := r.readCustomCAFilePathsAndContents(ctx, opsManager, caConfigMapName, isOpLog)
 	if err != nil {
 		return backup.S3Config{}, workflow.Failed(err)
 	}
@@ -1850,7 +1852,7 @@ func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsMa
 
 // readCustomCAFilePathsAndContents returns the filepath and contents of the custom CA which is used to configure
 // the S3Store.
-func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Context, opsManager *omv1.MongoDBOpsManager, isOpLog bool) ([]backup.S3CustomCertificate, error) {
+func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Context, opsManager *omv1.MongoDBOpsManager, caConfigMapName string, isOpLog bool) ([]backup.S3CustomCertificate, error) {
 	var customCertificates []backup.S3CustomCertificate
 	var err error
 
@@ -1864,8 +1866,8 @@ func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Cont
 		return customCertificates, err
 	}
 
-	if opsManager.Spec.GetAppDBCAConfigMapName() != "" {
-		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, opsManager.Spec.GetAppDBCAConfigMapName()))
+	if caConfigMapName != "" {
+		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, caConfigMapName))
 		if err != nil {
 			return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
 		}
@@ -1900,11 +1902,11 @@ func getCAs(ctx context.Context, s3Config []omv1.S3Config, ns string, client sec
 
 // buildOMS3Config builds the OM API S3 config from the Operator OM CR configuration. This involves some logic to
 // get the mongo URI, which points to either the external resource or to the AppDB
-func (r *OpsManagerReconciler) buildOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConnectionString string) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConfig *AppDBConfig) (backup.S3Config, workflow.Status) {
 	if shouldUseAppDb(config) {
-		return r.buildAppDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConnectionString)
+		return r.buildAppDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConfig.ConnectionString, appDBConfig.CAConfigMapName)
 	}
-	return r.buildMongoDbOMS3Config(ctx, opsManager, config, isOpLog)
+	return r.buildMongoDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConfig.CAConfigMapName)
 }
 
 // getMongoDbForS3Config returns the referenced MongoDB resource which should be used when configuring the backup config.

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -135,6 +135,12 @@ type OpsManagerReconcilerHelper struct {
 	memberClusters  []multicluster.MemberCluster
 	stateStore      *StateStore[OMDeploymentState]
 	deploymentState *OMDeploymentState
+
+	// appDBCAConfigMapName and appDBTLSEnabled hold the AppDB TLS configuration resolved once per
+	// reconcile. For an internally-managed AppDB they come from opsManager.Spec.AppDB; for an external
+	// AppDB they come from the referenced MongoDB CR's security config.
+	appDBCAConfigMapName string
+	appDBTLSEnabled      bool
 }
 
 func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*OpsManagerReconcilerHelper, error) {
@@ -446,6 +452,13 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
+
+	appDBCAConfigMapName, appDBTLSEnabled, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
+	if err != nil {
+		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error resolving AppDB TLS configuration: %w", err)), log, opsManagerExtraStatusParams)
+	}
+	opsManagerReconcilerHelper.appDBCAConfigMapName = appDBCAConfigMapName
+	opsManagerReconcilerHelper.appDBTLSEnabled = appDBTLSEnabled
 
 	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
 		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
@@ -844,6 +857,7 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 		construct.WithKmipConfig(ctx, opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.OpsManagerMembersForMemberCluster(memberCluster)),
+		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithDebugPort(debugPort),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
@@ -921,16 +935,13 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
-	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
-	// Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not fixed here.
-	if reconcilerHelper.opsManager.IsInternalAppDB() {
-		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
-			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
-		}
-		if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
-			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
-		}
+	// AppDB TLS/CA is resolved once per reconcile (see resolveAppDBTLSConfig): for an internal AppDB
+	// from opsManager.Spec.AppDB, for an external AppDB from the referenced CR's security config.
+	if reconcilerHelper.appDBTLSEnabled {
+		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
+	}
+	if reconcilerHelper.appDBCAConfigMapName != "" {
+		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 	}
 
 	// override the versions directory (defaults to "/opt/mongodb/mms/mongodb-releases/")
@@ -969,6 +980,7 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 		construct.WithKmipConfig(ctx, reconcilerHelper.opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetBackupStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.BackupDaemonMembersForMemberCluster(memberCluster)),
+		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
 	if err != nil {
@@ -1246,11 +1258,11 @@ func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Cont
 }
 
 func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
-	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.opsManager.Spec.GetAppDbCA() == "" {
+	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.appDBCAConfigMapName == "" {
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDbCA())
+	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.appDBCAConfigMapName)
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1870,8 +1882,12 @@ func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Cont
 		return customCertificates, err
 	}
 
-	if opsManager.Spec.GetAppDbCA() != "" {
-		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, opsManager.Spec.GetAppDbCA()))
+	appDBCAConfigMapName, _, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
+	if err != nil {
+		return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
+	}
+	if appDBCAConfigMapName != "" {
+		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, appDBCAConfigMapName))
 		if err != nil {
 			return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
 		}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -135,6 +135,12 @@ type OpsManagerReconcilerHelper struct {
 	memberClusters  []multicluster.MemberCluster
 	stateStore      *StateStore[OMDeploymentState]
 	deploymentState *OMDeploymentState
+
+	// appDBCAConfigMapName and appDBTLSEnabled hold the AppDB TLS configuration resolved once per
+	// reconcile. For an internally-managed AppDB they come from opsManager.Spec.AppDB; for an external
+	// AppDB they come from the referenced MongoDB CR's security config.
+	appDBCAConfigMapName string
+	appDBTLSEnabled      bool
 }
 
 func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*OpsManagerReconcilerHelper, error) {
@@ -446,6 +452,13 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
+
+	appDBCAConfigMapName, appDBTLSEnabled, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
+	if err != nil {
+		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error resolving AppDB TLS configuration: %w", err)), log, opsManagerExtraStatusParams)
+	}
+	opsManagerReconcilerHelper.appDBCAConfigMapName = appDBCAConfigMapName
+	opsManagerReconcilerHelper.appDBTLSEnabled = appDBTLSEnabled
 
 	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
 		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
@@ -844,6 +857,7 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 		construct.WithKmipConfig(ctx, opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.OpsManagerMembersForMemberCluster(memberCluster)),
+		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithDebugPort(debugPort),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
@@ -921,16 +935,13 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	// TODO(CLOUDP-TBD): reflects internal AppDB's TLS setting even in external-AppDB mode —
-	// same deferred TLS/CA parity gap as opsmanager_construction.go's AppDBTlsCAConfigMapName.
-	// Tracked as a separate PR (TLS/CA parity for externalApplicationDatabaseRef) — not fixed here.
-	if reconcilerHelper.opsManager.Spec.ExternalApplicationDatabaseRef == nil {
-		if reconcilerHelper.opsManager.Spec.AppDB.Security.IsTLSEnabled() {
-			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
-		}
-		if reconcilerHelper.opsManager.Spec.AppDB.GetCAConfigMapName() != "" {
-			setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
-		}
+	// AppDB TLS/CA is resolved once per reconcile (see resolveAppDBTLSConfig): for an internal AppDB
+	// from opsManager.Spec.AppDB, for an external AppDB from the referenced CR's security config.
+	if reconcilerHelper.appDBTLSEnabled {
+		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
+	}
+	if reconcilerHelper.appDBCAConfigMapName != "" {
+		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 	}
 
 	// override the versions directory (defaults to "/opt/mongodb/mms/mongodb-releases/")
@@ -969,6 +980,7 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 		construct.WithKmipConfig(ctx, reconcilerHelper.opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetBackupStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.BackupDaemonMembersForMemberCluster(memberCluster)),
+		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
 	if err != nil {
@@ -1244,11 +1256,11 @@ func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Cont
 }
 
 func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
-	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.opsManager.Spec.GetAppDbCA() == "" {
+	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.appDBCAConfigMapName == "" {
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDbCA())
+	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.appDBCAConfigMapName)
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1868,8 +1880,12 @@ func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Cont
 		return customCertificates, err
 	}
 
-	if opsManager.Spec.GetAppDbCA() != "" {
-		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, opsManager.Spec.GetAppDbCA()))
+	appDBCAConfigMapName, _, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
+	if err != nil {
+		return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
+	}
+	if appDBCAConfigMapName != "" {
+		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, appDBCAConfigMapName))
 		if err != nil {
 			return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
 		}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -135,12 +135,6 @@ type OpsManagerReconcilerHelper struct {
 	memberClusters  []multicluster.MemberCluster
 	stateStore      *StateStore[OMDeploymentState]
 	deploymentState *OMDeploymentState
-
-	// appDBCAConfigMapName and appDBTLSEnabled hold the AppDB TLS configuration resolved once per
-	// reconcile. For an internally-managed AppDB they come from opsManager.Spec.AppDB; for an external
-	// AppDB they come from the referenced MongoDB CR's security config.
-	appDBCAConfigMapName string
-	appDBTLSEnabled      bool
 }
 
 func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*OpsManagerReconcilerHelper, error) {
@@ -452,13 +446,6 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
-
-	appDBCAConfigMapName, appDBTLSEnabled, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
-	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error resolving AppDB TLS configuration: %w", err)), log, opsManagerExtraStatusParams)
-	}
-	opsManagerReconcilerHelper.appDBCAConfigMapName = appDBCAConfigMapName
-	opsManagerReconcilerHelper.appDBTLSEnabled = appDBTLSEnabled
 
 	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
 		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
@@ -857,7 +844,6 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 		construct.WithKmipConfig(ctx, opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.OpsManagerMembersForMemberCluster(memberCluster)),
-		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithDebugPort(debugPort),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
@@ -935,12 +921,11 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	// AppDB TLS/CA is resolved once per reconcile (see resolveAppDBTLSConfig): for an internal AppDB
-	// from opsManager.Spec.AppDB, for an external AppDB from the referenced CR's security config.
-	if reconcilerHelper.appDBTLSEnabled {
+	if reconcilerHelper.opsManager.Spec.IsAppDBTLSEnabled() {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 	}
-	if reconcilerHelper.appDBCAConfigMapName != "" {
+
+	if reconcilerHelper.opsManager.Spec.GetAppDBCAConfigMapName() != "" {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 	}
 
@@ -980,7 +965,6 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 		construct.WithKmipConfig(ctx, reconcilerHelper.opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetBackupStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.BackupDaemonMembersForMemberCluster(memberCluster)),
-		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
 	if err != nil {
@@ -1258,11 +1242,11 @@ func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Cont
 }
 
 func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
-	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.appDBCAConfigMapName == "" {
+	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName() == "" {
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.appDBCAConfigMapName)
+	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName())
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1882,12 +1866,8 @@ func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Cont
 		return customCertificates, err
 	}
 
-	appDBCAConfigMapName, _, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
-	if err != nil {
-		return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
-	}
-	if appDBCAConfigMapName != "" {
-		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, appDBCAConfigMapName))
+	if opsManager.Spec.GetAppDBCAConfigMapName() != "" {
+		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, opsManager.Spec.GetAppDBCAConfigMapName()))
 		if err != nil {
 			return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
 		}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -135,12 +135,6 @@ type OpsManagerReconcilerHelper struct {
 	memberClusters  []multicluster.MemberCluster
 	stateStore      *StateStore[OMDeploymentState]
 	deploymentState *OMDeploymentState
-
-	// appDBCAConfigMapName and appDBTLSEnabled hold the AppDB TLS configuration resolved once per
-	// reconcile. For an internally-managed AppDB they come from opsManager.Spec.AppDB; for an external
-	// AppDB they come from the referenced MongoDB CR's security config.
-	appDBCAConfigMapName string
-	appDBTLSEnabled      bool
 }
 
 func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*OpsManagerReconcilerHelper, error) {
@@ -452,13 +446,6 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if err != nil {
 		return r.updateStatus(ctx, opsManager, workflow.Failed(err), log, opsManagerExtraStatusParams)
 	}
-
-	appDBCAConfigMapName, appDBTLSEnabled, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
-	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error resolving AppDB TLS configuration: %w", err)), log, opsManagerExtraStatusParams)
-	}
-	opsManagerReconcilerHelper.appDBCAConfigMapName = appDBCAConfigMapName
-	opsManagerReconcilerHelper.appDBTLSEnabled = appDBTLSEnabled
 
 	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
 		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
@@ -857,7 +844,6 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 		construct.WithKmipConfig(ctx, opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.OpsManagerMembersForMemberCluster(memberCluster)),
-		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithDebugPort(debugPort),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
@@ -935,12 +921,11 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 	// update the central URL
 	setConfigProperty(reconcilerHelper.opsManager, util.MmsCentralUrlPropKey, reconcilerHelper.opsManager.CentralURL(), log)
 
-	// AppDB TLS/CA is resolved once per reconcile (see resolveAppDBTLSConfig): for an internal AppDB
-	// from opsManager.Spec.AppDB, for an external AppDB from the referenced CR's security config.
-	if reconcilerHelper.appDBTLSEnabled {
+	if reconcilerHelper.opsManager.Spec.IsAppDBTLSEnabled() {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoSSL, "true", log)
 	}
-	if reconcilerHelper.appDBCAConfigMapName != "" {
+
+	if reconcilerHelper.opsManager.Spec.GetAppDBCAConfigMapName() != "" {
 		setConfigProperty(reconcilerHelper.opsManager, util.MmsMongoCA, omv1.GetAppDBCaPemPath(), log)
 	}
 
@@ -980,7 +965,6 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 		construct.WithKmipConfig(ctx, reconcilerHelper.opsManager, r.client, log),
 		construct.WithStsOverride(clusterSpecItem.GetBackupStatefulSetSpecOverride()),
 		construct.WithReplicas(reconcilerHelper.BackupDaemonMembersForMemberCluster(memberCluster)),
-		construct.WithAppDBTLSCAConfigMapName(reconcilerHelper.appDBCAConfigMapName),
 		construct.WithOMDefaultArchitecture(r.defaultArchitecture),
 	)
 	if err != nil {
@@ -1256,11 +1240,11 @@ func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Cont
 }
 
 func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
-	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.appDBCAConfigMapName == "" {
+	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName() == "" {
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.appDBCAConfigMapName)
+	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDBCAConfigMapName())
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1880,12 +1864,8 @@ func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Cont
 		return customCertificates, err
 	}
 
-	appDBCAConfigMapName, _, err := resolveAppDBTLSConfig(ctx, r.client, opsManager)
-	if err != nil {
-		return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
-	}
-	if appDBCAConfigMapName != "" {
-		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, appDBCAConfigMapName))
+	if opsManager.Spec.GetAppDBCAConfigMapName() != "" {
+		cmContents, err := configmap.ReadKey(ctx, r.client, "ca-pem", kube.ObjectKey(opsManager.Namespace, opsManager.Spec.GetAppDBCAConfigMapName()))
 		if err != nil {
 			return []backup.S3CustomCertificate{}, xerrors.New(err.Error())
 		}

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -1546,7 +1546,7 @@ func TestOpsManagerReconcile_ExternalAppDBRef_TLS_MountsAppDBCAVolume(t *testing
 	externalAppDB.Spec.Role = mdbv1.RoleAppDB
 	externalAppDB.Spec.Security.TLSConfig.CA = "app-db-issuer-ca"
 
-	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalAppDBRef{
 		Name: "test-om-db",
 		Kind: "MongoDB",
 	})

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -822,7 +822,7 @@ func TestOpsManagerBackupAssignmentLabels(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	reconciler.prepareBackupInOpsManager(ctx, reconcilerHelper, testOm, mockedAdmin, "", zap.S())
+	reconciler.prepareBackupInOpsManager(ctx, reconcilerHelper, testOm, mockedAdmin, &AppDBConfig{}, zap.S())
 	blockStoreConfigs, _ := mockedAdmin.ReadBlockStoreConfigs()
 	oplogConfigs, _ := mockedAdmin.ReadOplogStoreConfigs()
 	s3Configs, _ := mockedAdmin.ReadS3Configs()
@@ -855,7 +855,7 @@ func TestOpsManagerBackupObjectLock(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	reconciler.prepareBackupInOpsManager(ctx, reconcilerHelper, testOm, mockedAdmin, "", zap.S())
+	reconciler.prepareBackupInOpsManager(ctx, reconcilerHelper, testOm, mockedAdmin, &AppDBConfig{}, zap.S())
 	s3Configs, _ := mockedAdmin.ReadS3Configs()
 	// then
 	assert.Equal(t, true, *s3Configs[0].ObjectLockEnabled)
@@ -881,7 +881,7 @@ func TestOpsManagerBackupObjectLockNotSentWhenUnset(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	reconciler.prepareBackupInOpsManager(ctx, reconcilerHelper, testOm, mockedAdmin, "", zap.S())
+	reconciler.prepareBackupInOpsManager(ctx, reconcilerHelper, testOm, mockedAdmin, &AppDBConfig{}, zap.S())
 	s3Configs, _ := mockedAdmin.ReadS3Configs()
 	// then
 	assert.Nil(t, s3Configs[0].ObjectLockEnabled)
@@ -1531,6 +1531,50 @@ func TestReconcile_ExternalAppDBRef_NeverCreatesInternalPasswordSecret(t *testin
 	result := corev1.Secret{}
 	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, omv1.OpsManagerUserPasswordSecretName("test-om-db")), &result))
 	assert.Equal(t, "test-password", string(result.Data[util.OpsManagerPasswordKey]))
+}
+
+func TestOpsManagerReconcile_ExternalAppDBRef_TLS_MountsAppDBCAVolume(t *testing.T) {
+	ctx := context.Background()
+
+	externalAppDB := mdbv1.NewReplicaSetBuilder().
+		SetName("test-om-db").
+		SetNamespace(mock.TestNamespace).
+		SetVersion("6.0.0").
+		SetMembers(3).
+		SetSecurityTLSEnabled().
+		Build()
+	externalAppDB.Spec.Role = mdbv1.RoleAppDB
+	externalAppDB.Spec.Security.TLSConfig.CA = "app-db-issuer-ca"
+
+	testOm := withExternalAppDBRef(DefaultOpsManagerBuilder().Build(), &omv1.ExternalApplicationDatabaseRef{
+		Name: "test-om-db",
+		Kind: "MongoDB",
+	})
+
+	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
+	reconciler, kubeClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	require.NoError(t, reconciler.client.Create(ctx, externalAppDB))
+	require.NoError(t, reconciler.client.CreateSecret(ctx, secret.Builder().
+		SetName(omv1.OpsManagerUserPasswordSecretName("test-om-db")).
+		SetNamespace(testOm.Namespace).
+		SetField(util.OpsManagerPasswordKey, "test-password").
+		Build()))
+
+	_, err := reconciler.Reconcile(ctx, requestFromObject(testOm))
+	require.NoError(t, err)
+
+	omSts := appsv1.StatefulSet{}
+	require.NoError(t, kubeClient.Get(ctx, kube.ObjectKey(testOm.Namespace, testOm.Name), &omSts))
+
+	var caVolume *corev1.Volume
+	for i := range omSts.Spec.Template.Spec.Volumes {
+		if omSts.Spec.Template.Spec.Volumes[i].Name == "appdb-ca-certificate" {
+			caVolume = &omSts.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	require.NotNil(t, caVolume, "expected appdb-ca-certificate volume on OM StatefulSet when external AppDB has TLS enabled")
+	require.NotNil(t, caVolume.ConfigMap)
+	assert.Equal(t, "app-db-issuer-ca", caVolume.ConfigMap.Name)
 }
 
 func addOMTLSResources(ctx context.Context, client client.Client, secretName string) {

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -932,10 +932,6 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context,
 // claimAppDBRoleSecrets claims ownership of the shared user and keyfile secrets for an AppDB-role CR.
 // It tolerates secrets that don't exist yet (they will be created by ensureAppDBRoleUser/Keyfile later).
 func (r *ReplicaSetReconcilerHelper) claimAppDBRoleSecrets(ctx context.Context, mdb *mdbv1.MongoDB) error {
-	if mdb.Spec.Role != mdbv1.RoleAppDB {
-		return nil
-	}
-
 	passwordSecretName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
 	keyfileSecretName := fmt.Sprintf("%s-keyfile", mdb.Name)
 

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -940,10 +940,6 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBRoleKeyfile(ctx context.Context,
 // claimAppDBRoleSecrets claims ownership of the shared user and keyfile secrets for an AppDB-role CR.
 // It tolerates secrets that don't exist yet (they will be created by ensureAppDBRoleUser/Keyfile later).
 func (r *ReplicaSetReconcilerHelper) claimAppDBRoleSecrets(ctx context.Context, mdb *mdbv1.MongoDB) error {
-	if mdb.Spec.Role != mdbv1.RoleAppDB {
-		return nil
-	}
-
 	passwordSecretName := omv1.OpsManagerUserPasswordSecretName(mdb.Name)
 	keyfileSecretName := fmt.Sprintf("%s-keyfile", mdb.Name)
 

--- a/controllers/operator/watch/predicates.go
+++ b/controllers/operator/watch/predicates.go
@@ -63,7 +63,7 @@ func PredicatesForOpsManager() predicate.Funcs {
 					}
 				}
 
-				if oldResource.Spec.ExternalAppDBRef == nil {
+				if oldResource.IsInternalAppDB() {
 					for _, e := range oldResource.Spec.AppDB.GetSecretsMountedIntoPod() {
 						if oldResource.GetAnnotations()[e] != newResource.GetAnnotations()[e] {
 							return true

--- a/controllers/operator/workflow/pending.go
+++ b/controllers/operator/workflow/pending.go
@@ -14,6 +14,7 @@ import (
 type pendingStatus struct {
 	commonStatus
 	retryInSeconds int
+	requeue        bool
 }
 
 func Pending(msg string, params ...interface{}) *pendingStatus {
@@ -41,7 +42,7 @@ func (p *pendingStatus) WithAdditionalOptions(options ...status.Option) *pending
 }
 
 func (p *pendingStatus) ReconcileResult() (reconcile.Result, error) {
-	return reconcile.Result{RequeueAfter: time.Second * time.Duration(p.retryInSeconds)}, nil
+	return reconcile.Result{RequeueAfter: time.Second * time.Duration(p.retryInSeconds), Requeue: p.requeue}, nil
 }
 
 func (p *pendingStatus) IsOK() bool {
@@ -88,6 +89,7 @@ func mergedPending(p1, p2 *pendingStatus) *pendingStatus {
 }
 
 func (p *pendingStatus) Requeue() Status {
-	p.retryInSeconds = 1
+	p.requeue = true
+	p.retryInSeconds = 0
 	return p
 }

--- a/controllers/operator/workflow/pending.go
+++ b/controllers/operator/workflow/pending.go
@@ -14,7 +14,6 @@ import (
 type pendingStatus struct {
 	commonStatus
 	retryInSeconds int
-	requeue        bool
 }
 
 func Pending(msg string, params ...interface{}) *pendingStatus {
@@ -42,7 +41,7 @@ func (p *pendingStatus) WithAdditionalOptions(options ...status.Option) *pending
 }
 
 func (p *pendingStatus) ReconcileResult() (reconcile.Result, error) {
-	return reconcile.Result{RequeueAfter: time.Second * time.Duration(p.retryInSeconds), Requeue: p.requeue}, nil
+	return reconcile.Result{RequeueAfter: time.Second * time.Duration(p.retryInSeconds)}, nil
 }
 
 func (p *pendingStatus) IsOK() bool {
@@ -89,7 +88,6 @@ func mergedPending(p1, p2 *pendingStatus) *pendingStatus {
 }
 
 func (p *pendingStatus) Requeue() Status {
-	p.requeue = true
-	p.retryInSeconds = 0
+	p.retryInSeconds = 1
 	return p
 }

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
@@ -10,8 +10,10 @@ from kubetester.mongodb import MongoDB
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture
+from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.opsmanager.om_external_appdb_test_helpers import (
     appdb_role_resource,
+    appdb_tls_security,
     assert_no_migration_annotations,
     assert_project_exists,
     assert_sentinel_doc_present,
@@ -51,17 +53,41 @@ def meta_om(namespace: str, custom_version: Optional[str], custom_appdb_version:
 
 
 @fixture(scope="module")
-def primary_om(namespace: str, custom_version: Optional[str], custom_appdb_version: str) -> MongoDBOpsManager:
+def appdb_ca_configmap(app_db_issuer_ca_configmap: str) -> str:
+    # same CA used by the internal AppDB (before forward migration) and the external MongoDB CR
+    # (after), so the computed connection string is identical across the switch and OM pods don't roll.
+    return app_db_issuer_ca_configmap
+
+
+@fixture(scope="module")
+def appdb_cert_prefix(namespace: str, issuer: str) -> str:
+    # "appdb-<DB_NAME>-cert"; the internal AppDB and the MongoDB CR share DB_NAME and this prefix, so
+    # they resolve to the same member cert secret across forward migration.
+    return create_appdb_certs(namespace, issuer, DB_NAME)
+
+
+@fixture(scope="module")
+def primary_om(
+    namespace: str,
+    custom_version: Optional[str],
+    custom_appdb_version: str,
+    appdb_ca_configmap: str,
+    appdb_cert_prefix: str,
+) -> MongoDBOpsManager:
     resource = MongoDBOpsManager.from_yaml(yaml_fixture("om_external_appdb_primary_om.yaml"), namespace=namespace)
     resource.set_version(custom_version)
     resource.set_appdb_version(custom_appdb_version)
+    # start with a TLS-enabled internal AppDB so that after forward migration to the (also TLS)
+    # external CR the connection string (ssl=true, same hosts) is unchanged.
+    resource["spec"]["applicationDatabase"]["security"] = appdb_tls_security(appdb_ca_configmap, appdb_cert_prefix)
     try_load(resource)
     return resource
 
 
 @fixture(scope="module")
-def external_appdb(namespace: str, custom_mdb_version: str) -> MongoDB:
+def external_appdb(namespace: str, custom_mdb_version: str, appdb_cert_prefix: str, appdb_ca_configmap: str) -> MongoDB:
     resource = appdb_role_resource(namespace, custom_mdb_version, name=DB_NAME)
+    resource.configure_custom_tls(appdb_ca_configmap, appdb_cert_prefix)
     try_load(resource)
     return resource
 
@@ -89,8 +115,11 @@ class TestSentinelDocSurvivesForwardMigration:
     keyfile_secret_before: ClassVar[dict[str, str]]
     connection_string_before: ClassVar[str]
 
-    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager):
-        write_sentinel_doc(primary_om.read_appdb_connection_url())
+    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
+        cnx_string = primary_om.read_appdb_connection_url()
+        # the internal AppDB is TLS-enabled, so its connection string must request TLS
+        assert "ssl=true" in cnx_string
+        write_sentinel_doc(cnx_string, tls_ca_file=issuer_ca_filepath)
 
     def test_capture_state_before_migration(self, primary_om: MongoDBOpsManager, namespace: str):
         self.__class__.password_secret_before = read_secret(namespace, password_secret_name(OM_NAME))
@@ -124,8 +153,11 @@ class TestSentinelDocSurvivesForwardMigration:
     def test_no_migration_annotations_after_forward_migration(self, namespace: str):
         assert_no_migration_annotations(namespace, DB_NAME)
 
-    def test_sentinel_doc_survives(self, primary_om: MongoDBOpsManager):
-        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+    def test_sentinel_doc_survives(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
+        cnx_string = primary_om.read_appdb_connection_url()
+        # after forward migration the external CR is also TLS, so the string still requests TLS
+        assert "ssl=true" in cnx_string
+        assert_sentinel_doc_present(cnx_string, tls_ca_file=issuer_ca_filepath)
 
     def test_connection_string_unchanged_after_forward_migration(self, primary_om: MongoDBOpsManager):
         # same hosts + same password => the computed connection string value must not
@@ -211,10 +243,11 @@ class TestReverseMigrationAfterForwardMigration:
     def test_no_migration_annotations_after_reverse_migration(self, namespace: str):
         assert_no_migration_annotations(namespace, DB_NAME)
 
-    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager):
+    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
         # the data-preservation proof: written before the forward migration, survives CR deletion
-        # and the recreate because the PVCs were retained
-        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+        # and the recreate because the PVCs were retained. The internal AppDB security (TLS) is
+        # inherited from the OM spec's applicationDatabase, so the reconnect is over TLS.
+        assert_sentinel_doc_present(primary_om.read_appdb_connection_url(), tls_ca_file=issuer_ca_filepath)
 
     def test_project_still_exists_after_reverse_migration(self, meta_om: MongoDBOpsManager):
         assert_project_exists(meta_om, DB_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_forward.py
@@ -10,8 +10,10 @@ from kubetester.mongodb import MongoDB
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture
+from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.opsmanager.om_external_appdb_test_helpers import (
     appdb_role_resource,
+    appdb_tls_security,
     assert_no_migration_annotations,
     assert_project_exists,
     assert_sentinel_doc_present,
@@ -51,17 +53,41 @@ def meta_om(namespace: str, custom_version: Optional[str], custom_appdb_version:
 
 
 @fixture(scope="module")
-def primary_om(namespace: str, custom_version: Optional[str], custom_appdb_version: str) -> MongoDBOpsManager:
+def appdb_ca_configmap(app_db_issuer_ca_configmap: str) -> str:
+    # same CA used by the internal AppDB (before forward migration) and the external MongoDB CR
+    # (after), so the computed connection string is identical across the switch and OM pods don't roll.
+    return app_db_issuer_ca_configmap
+
+
+@fixture(scope="module")
+def appdb_cert_prefix(namespace: str, issuer: str) -> str:
+    # "appdb-<DB_NAME>-cert"; the internal AppDB and the MongoDB CR share DB_NAME and this prefix, so
+    # they resolve to the same member cert secret across forward migration.
+    return create_appdb_certs(namespace, issuer, DB_NAME)
+
+
+@fixture(scope="module")
+def primary_om(
+    namespace: str,
+    custom_version: Optional[str],
+    custom_appdb_version: str,
+    appdb_ca_configmap: str,
+    appdb_cert_prefix: str,
+) -> MongoDBOpsManager:
     resource = MongoDBOpsManager.from_yaml(yaml_fixture("om_external_appdb_primary_om.yaml"), namespace=namespace)
     resource.set_version(custom_version)
     resource.set_appdb_version(custom_appdb_version)
+    # start with a TLS-enabled internal AppDB so that after forward migration to the (also TLS)
+    # external CR the connection string (ssl=true, same hosts) is unchanged.
+    resource["spec"]["applicationDatabase"]["security"] = appdb_tls_security(appdb_ca_configmap, appdb_cert_prefix)
     try_load(resource)
     return resource
 
 
 @fixture(scope="module")
-def external_appdb(namespace: str, custom_mdb_version: str) -> MongoDB:
+def external_appdb(namespace: str, custom_mdb_version: str, appdb_cert_prefix: str, appdb_ca_configmap: str) -> MongoDB:
     resource = appdb_role_resource(namespace, custom_mdb_version, name=DB_NAME)
+    resource.configure_custom_tls(appdb_ca_configmap, appdb_cert_prefix)
     try_load(resource)
     return resource
 
@@ -88,8 +114,11 @@ class TestSentinelDocSurvivesForwardMigration:
     password_secret_before: ClassVar[dict[str, str]]
     connection_string_before: ClassVar[str]
 
-    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager):
-        write_sentinel_doc(primary_om.read_appdb_connection_url())
+    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
+        cnx_string = primary_om.read_appdb_connection_url()
+        # the internal AppDB is TLS-enabled, so its connection string must request TLS
+        assert "ssl=true" in cnx_string
+        write_sentinel_doc(cnx_string, tls_ca_file=issuer_ca_filepath)
 
     def test_capture_state_before_migration(self, primary_om: MongoDBOpsManager, namespace: str):
         self.__class__.password_secret_before = read_secret(namespace, password_secret_name(OM_NAME))
@@ -122,8 +151,11 @@ class TestSentinelDocSurvivesForwardMigration:
     def test_no_migration_annotations_after_forward_migration(self, namespace: str):
         assert_no_migration_annotations(namespace, DB_NAME)
 
-    def test_sentinel_doc_survives(self, primary_om: MongoDBOpsManager):
-        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+    def test_sentinel_doc_survives(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
+        cnx_string = primary_om.read_appdb_connection_url()
+        # after forward migration the external CR is also TLS, so the string still requests TLS
+        assert "ssl=true" in cnx_string
+        assert_sentinel_doc_present(cnx_string, tls_ca_file=issuer_ca_filepath)
 
     def test_connection_string_unchanged_after_forward_migration(self, primary_om: MongoDBOpsManager):
         # same hosts + same password => the computed connection string value must not
@@ -205,10 +237,11 @@ class TestReverseMigrationAfterForwardMigration:
     def test_no_migration_annotations_after_reverse_migration(self, namespace: str):
         assert_no_migration_annotations(namespace, DB_NAME)
 
-    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager):
+    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
         # the data-preservation proof: written before the forward migration, survives CR deletion
-        # and the recreate because the PVCs were retained
-        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+        # and the recreate because the PVCs were retained. The internal AppDB security (TLS) is
+        # inherited from the OM spec's applicationDatabase, so the reconnect is over TLS.
+        assert_sentinel_doc_present(primary_om.read_appdb_connection_url(), tls_ca_file=issuer_ca_filepath)
 
     def test_project_still_exists_after_reverse_migration(self, meta_om: MongoDBOpsManager):
         assert_project_exists(meta_om, DB_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_fresh.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_fresh.py
@@ -11,6 +11,7 @@ from kubetester.mongodb import MongoDB
 from kubetester.opsmanager import MongoDBOpsManager
 from kubetester.phase import Phase
 from pytest import fixture
+from tests.common.cert.cert_issuer import create_appdb_certs
 from tests.opsmanager.om_external_appdb_test_helpers import (
     appdb_role_resource,
     assert_no_migration_annotations,
@@ -65,8 +66,24 @@ def primary_om(namespace: str, custom_version: Optional[str]) -> MongoDBOpsManag
 
 
 @fixture(scope="module")
-def external_appdb(namespace: str, custom_mdb_version: str) -> MongoDB:
+def appdb_ca_configmap(app_db_issuer_ca_configmap: str) -> str:
+    # ConfigMap "app-db-issuer-ca" (key ca-pem) from the test issuer's CA; the external AppDB CR
+    # advertises it via security.tls.ca and the operator threads it into OM. Reused by the internal
+    # AppDB after reverse migration.
+    return app_db_issuer_ca_configmap
+
+
+@fixture(scope="module")
+def appdb_cert_prefix(namespace: str, issuer: str) -> str:
+    # Creates "appdb-<DB_NAME>-cert". The MongoDB CR and the internal AppDB share DB_NAME and this
+    # prefix, so the adopted StatefulSet reuses the same certs across reverse migration.
+    return create_appdb_certs(namespace, issuer, DB_NAME)
+
+
+@fixture(scope="module")
+def external_appdb(namespace: str, custom_mdb_version: str, appdb_cert_prefix: str, appdb_ca_configmap: str) -> MongoDB:
     resource = appdb_role_resource(namespace, custom_mdb_version, name=DB_NAME)
+    resource.configure_custom_tls(appdb_ca_configmap, appdb_cert_prefix)
     try_load(resource)
     return resource
 
@@ -111,17 +128,20 @@ class TestFreshStartExternalAppDB:
         assert_owned_by_mongodb(sec.metadata, DB_NAME)
         assert "password" in read_secret(namespace, password_secret_name(OM_NAME))
 
-    def test_connection_string_secret(self, primary_om: MongoDBOpsManager, namespace: str):
+    def test_connection_string_secret(self, primary_om: MongoDBOpsManager, namespace: str, issuer_ca_filepath: str):
         # the connection-string secret is created by the OM controller (never by the referenced
         # CR, per the design) and intentionally carries no OwnerReferences
         cnx_string = primary_om.read_appdb_connection_url()
+        # the referenced CR has TLS enabled, so the operator-computed connection string must request TLS
+        assert "ssl=true" in cnx_string
+
         expected_hosts = {f"{DB_NAME}-{i}.{DB_NAME}-svc.{namespace}.svc.cluster.local:27017" for i in range(3)}
 
         # the URI itself must name the referenced CR's pods - not merely "work" via server discovery
         parsed = pymongo.uri_parser.parse_uri(cnx_string)
         assert {f"{host}:{port}" for host, port in parsed["nodelist"]} == expected_hosts
 
-        client = pymongo.MongoClient(cnx_string, serverSelectionTimeoutMS=30000)
+        client = pymongo.MongoClient(cnx_string, tlsCAFile=issuer_ca_filepath, serverSelectionTimeoutMS=30000)
         try:
             hello = client.admin.command("hello")
             assert hello["setName"] == DB_NAME
@@ -144,8 +164,8 @@ class TestReverseMigrationAfterFreshStart:
     # garbage-collected by the CR deletion if the ownership transfer failed
     SHARED_SECRET_NAMES = [f"{DB_NAME}-om-password", f"{DB_NAME}-keyfile"]
 
-    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager):
-        write_sentinel_doc(primary_om.read_appdb_connection_url())
+    def test_write_sentinel_doc(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
+        write_sentinel_doc(primary_om.read_appdb_connection_url(), tls_ca_file=issuer_ca_filepath)
 
     def test_capture_secrets_before_reverse_migration(self, primary_om: MongoDBOpsManager, namespace: str):
         # graceful path: same hosts + same password => the computed connection string value must
@@ -164,10 +184,22 @@ class TestReverseMigrationAfterFreshStart:
             assert sec.data == self.shared_secret_data[name], f"secret {name} contents changed"
             assert_owned_by_ops_manager(sec.metadata, OM_NAME)
 
-    def test_reverse_migration_reconfigure_om(self, primary_om: MongoDBOpsManager, custom_appdb_version: str):
+    def test_reverse_migration_reconfigure_om(
+        self,
+        primary_om: MongoDBOpsManager,
+        custom_appdb_version: str,
+        appdb_ca_configmap: str,
+        appdb_cert_prefix: str,
+    ):
         primary_om.load()
         primary_om["spec"]["externalApplicationDatabaseRef"] = None
-        primary_om["spec"]["applicationDatabase"] = {"members": 3, "version": custom_appdb_version}
+        # the internal AppDB keeps TLS with the same CA/certs as the external CR, so the computed
+        # connection string (ssl=true + same hosts) is unchanged and the migration stays graceful.
+        primary_om["spec"]["applicationDatabase"] = {
+            "members": 3,
+            "version": custom_appdb_version,
+            "security": {"certsSecretPrefix": appdb_cert_prefix, "tls": {"ca": appdb_ca_configmap}},
+        }
         primary_om.update()
 
     def test_external_appdb_is_unmanaged(self, external_appdb: MongoDB):
@@ -219,8 +251,8 @@ class TestReverseMigrationAfterFreshStart:
         self._assert_shared_secrets_claimed_and_unchanged(namespace)
         assert primary_om.read_appdb_connection_url() == self.connection_string_before
 
-    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager):
-        assert_sentinel_doc_present(primary_om.read_appdb_connection_url())
+    def test_sentinel_doc_survives_reverse_migration(self, primary_om: MongoDBOpsManager, issuer_ca_filepath: str):
+        assert_sentinel_doc_present(primary_om.read_appdb_connection_url(), tls_ca_file=issuer_ca_filepath)
 
     def test_project_still_exists_after_reverse_migration(self, meta_om: MongoDBOpsManager):
         assert_project_exists(meta_om, DB_NAME)

--- a/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
+++ b/docker/mongodb-kubernetes-tests/tests/opsmanager/om_external_appdb_test_helpers.py
@@ -12,6 +12,17 @@ TEST_DB = "sentinelDb"
 TEST_COLLECTION = "sentinelCollection"
 META_OM_NAME = "meta-om"
 
+# Default cert secret prefix used by create_appdb_certs (tests/common/cert/cert_issuer.py). Both the
+# external AppDB MongoDB CR and the internal AppDB resolve their member cert secret to
+# "<APPDB_CERT_PREFIX>-<appdb-name>-cert", so an adopted StatefulSet reuses the same certs.
+APPDB_CERT_PREFIX = "appdb"
+
+
+def appdb_tls_security(ca_configmap: str, cert_prefix: str = APPDB_CERT_PREFIX) -> dict:
+    """Returns the spec.applicationDatabase.security block enabling TLS for the internal AppDB,
+    mirroring fixtures/om_ops_manager_backup_tls.yaml."""
+    return {"certsSecretPrefix": cert_prefix, "tls": {"ca": ca_configmap}}
+
 
 def password_secret_name(om_name: str) -> str:
     return f"{om_name}-db-om-password"
@@ -73,16 +84,23 @@ def configure_appdb_role_mongodb(mdb: MongoDB, meta_om: MongoDBOpsManager, names
     return mdb
 
 
-def write_sentinel_doc(cnx_string: str):
-    client = pymongo.MongoClient(cnx_string)
+def _sentinel_client(cnx_string: str, tls_ca_file: Optional[str]) -> pymongo.MongoClient:
+    # a TLS AppDB connection string contains ssl=true, so pymongo needs the CA to verify the server.
+    if tls_ca_file is not None:
+        return pymongo.MongoClient(cnx_string, tlsCAFile=tls_ca_file, serverSelectionTimeoutMS=30000)
+    return pymongo.MongoClient(cnx_string)
+
+
+def write_sentinel_doc(cnx_string: str, tls_ca_file: Optional[str] = None):
+    client = _sentinel_client(cnx_string, tls_ca_file)
     try:
         client[TEST_DB][TEST_COLLECTION].insert_one(dict(SENTINEL_DOC))
     finally:
         client.close()
 
 
-def assert_sentinel_doc_present(cnx_string: str):
-    client = pymongo.MongoClient(cnx_string)
+def assert_sentinel_doc_present(cnx_string: str, tls_ca_file: Optional[str] = None):
+    client = _sentinel_client(cnx_string, tls_ca_file)
     try:
         found = client[TEST_DB][TEST_COLLECTION].find_one({"_id": SENTINEL_DOC["_id"]})
         assert found is not None, "sentinel document did not survive the migration"

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -313,7 +313,7 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 			omClusters := len(item.Spec.ClusterSpecList)
 			var appDBClusters int
 			var appDBExternalDomains string
-			if item.Spec.ExternalAppDBRef == nil {
+			if item.IsInternalAppDB() {
 				appDBClusters = len(item.Spec.AppDB.ClusterSpecList)
 				appDBExternalDomains = getExternalDomainPropertyForAppDB(item)
 			}

--- a/pkg/vault/vaultwatcher/vaultsecretwatch.go
+++ b/pkg/vault/vaultwatcher/vaultsecretwatch.go
@@ -75,7 +75,7 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 			if triggeredReconciliation {
 				break
 			}
-			if om.Spec.ExternalAppDBRef == nil {
+			if om.IsInternalAppDB() {
 				for _, secretName := range om.Spec.AppDB.GetSecretsMountedIntoPod() {
 					path := fmt.Sprintf("%s/%s/%s", vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName)
 					latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)


### PR DESCRIPTION
# Summary

When an OpsManager uses `spec.externalApplicationDatabaseRef`, the operator previously ignored the referenced CR's TLS settings — OM/BackupDaemon pods had no AppDB CA volume and no `ssl=true`/`mms.mongoCa` configuration. This PR resolves TLS/CA from the referenced MongoDB/MongoDBMultiCluster CR and threads it through the OM/BackupDaemon StatefulSet construction, configuration, and S3 backup pipeline.

Key changes:
- Replaced `BuildAppDBConnectionURL` with `GetAppDBConfig` on the `AppDBReconciler` interface, returning connection string + TLS enabled flag + CA ConfigMap name (works for both internal and external AppDB).
- Removed `GetAppDbCA()` and the `appDBTlsCAConfigMapName` helper that hardcoded `""` for external-AppDB mode; CA is now resolved from the referenced CR via `WithAppDBTLSCAConfigMapName`.
- E2E tests (`om_external_appdb_forward.py`, `om_external_appdb_fresh.py`) now exercise TLS-enabled external AppDB through forward and reverse migrations.

## Proof of Work

- `TestGetAppDBConfig_ExternalAppDB` — table-driven TLS on/off cases.
- `TestOpsManagerReconcile_ExternalAppDBRef_TLS_MountsAppDBCAVolume` — verifies CA volume on OM StatefulSet.
- E2E: sentinel-doc survives forward and reverse migration with TLS-enabled AppDB.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details