### PR TITLE
CLOUDP-407997: Start Recoding Architecture Decisions

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,44 @@
+# ADR 0001: Record Architecture Decisions
+
+* **Status:** Accepted
+* **Date:** 2026-08-05
+* **Deciders:** Engineering Team
+
+---
+
+## Context
+
+As this project evolves, we make significant architectural, design, and infrastructure decisions.
+
+Historically, the context, trade-offs, and reasoning behind these decisions tend to get lost in pull request threads, chat messages, or verbal discussions. This leads to two major issues:
+1. **Human Friction:** Future developers (and current ones, months later) lack visibility into *why* a decision was made, leading to accidental regressions or repeated debates.
+2. **AI Context Blindness:** AI coding assistants and autonomous agents reading the codebase lack visibility into architectural constraints, leading them to suggest refactors or patterns that violate core engineering rules.
+
+We need a lightweight, version-controlled mechanism to record architectural decisions alongside the code.
+
+---
+
+## Decision
+
+We will use **Architectural Decision Records (ADRs)** as described by Michael Nygard to capture significant design and technical decisions.
+
+### Rules of Engagement:
+1. **Location:** All ADRs will be stored in `docs/adr/` at the root of the repository.
+2. **Naming Standard:** Files will follow the pattern `NNNN-kebab-case-title.md` (e.g., `0002-immutable-ci-cd-pipeline.md`), sequentially zero-padded to four digits.
+3. **Format:** Each record will follow a standard Markdown template containing: **Context**, **Decision**, and **Consequences** (including trade-offs and mitigations).
+4. **Immutability:** Once an ADR is marked as `Accepted`, it is historical record. If a decision changes later, we do not edit the old ADR—we author a new ADR that explicitly supersedes or deprecates the original.
+5. **AI Integration:** The `docs/adr/` directory will serve as a primary context source for LLMs and AI coding assistants working in this repository.
+
+---
+
+## Consequences
+
+### Positive
+* **Preserved Context:** The rationale behind complex code structures, CI pipelines, and infrastructure choices remains accessible directly within the repo.
+* **Effective AI Grounding:** AI tools can consult `docs/adr/` to respect team constraints and architectural guardrails automatically.
+* **Asynchronous Governance:** Design decisions can be reviewed and merged via standard Pull Requests.
+
+### Trade-offs & Mitigations
+* **Process Overhead:** Writing ADRs adds a small time investment to design choices.
+  * *Mitigation:* Keep ADRs short, lightweight, and focused strictly on decisions that carry trade-offs or strict constraints. Simple implementation details do not require an ADR.
+

--- a/docs/adr/0002-ci-immutable-build-pipeline.md
+++ b/docs/adr/0002-ci-immutable-build-pipeline.md
@@ -1,0 +1,57 @@
+# ADR 0001: Immutable Build Artifacts and Zero-Rebuild CI/CD Pipeline
+
+* **Status:** Accepted
+* **Date:** 2026-08-05
+* **Deciders:** Engineering / DevOps Team
+
+---
+
+## Context
+
+In standard CI/CD setups, rebuilding source code or recalculating version tags at release time introduces non-determinism. Dependencies can drift, tests can flake during urgent deployments, and the code running in production might not strictly match the exact binary that passed testing.
+
+To guarantee fast, predictable, and audit-safe deployments, we need clear, unbreakable invariants governing how code transitions from a Pull Request (PR) to production.
+
+---
+
+## Decision
+
+We adopt a **Build-Once, Zero-Rebuild Release Pipeline** enforced by three core invariants and one explicit operational override.
+
+### 1. Self-Contained PRs & Pre-Determined Versioning (PR Stage)
+* Code submitted in a PR must be completely release-ready and up to date with the target branch.
+* The PR must already know and encode its own release version. No version-bump commits or metadata fixes are permitted at or after release time.
+* If a version or configuration fix is needed, it must happen within the PR *before* merging.
+
+### 2. Immutable Promotion and Pinning (Merge Stage)
+* Merging code triggers automated build and test suites.
+* **Only commits and built artifacts (e.g., container images) that pass all required tests are marked as release-able.**
+* Passing artifacts are explicitly promoted, pinned, and tagged in the registry. Non-promoted builds cannot be deployed to production.
+
+### 3. Zero-Rebuild, Zero-Retest Releases (Release Stage)
+* Releasing to production strictly means deploying an already-promoted artifact and tagging the corresponding passed commit.
+* Releases **must never** re-compile code, re-build images, or re-run test suites. What was tested at merge time is *literally* what runs in production.
+
+### Operational Caveat: Manual Promotion Override
+* In rare scenarios where a test fails due to an external infrastructure issue, non-fixable dependency, or known non-blocking flake that does not impact release quality, authorized team members may manually promote a commit/artifact.
+* Manual overrides must be explicitly logged with context explaining why the failing test was deemed non-impacting.
+
+---
+
+## Consequences
+
+### Positive
+* **100% Deterministic Deployments:** The exact bit-for-bit container/binary tested during CI is what lands in production.
+* **Ultra-Fast Releases:** Deployments take seconds instead of minutes because compilation and test runs are already complete.
+* **Clear AI Guardrails:** AI agents generating PRs or CI configurations have an unambiguous contract: *resolve versioning and testing left (at PR time), because post-merge environments are immutable.*
+
+### Trade-offs & Mitigations
+
+* **Registry Storage Footprint**
+  * *Risk:* Pinning built artifacts for every passing merge could cause unbounded storage growth in the container registry.
+  * *Mitigation:* Bounded by automated registry retention policies (e.g., FIFO cleanup, age expiration, or storage caps). Because releases strictly target recent or near-latest promoted commits, long-term retention of older intermediate images is unnecessary.
+
+* **PR Discipline & Developer Friction**
+  * *Risk:* Requiring code and versioning to be 100% release-ready at PR time shifts operational friction to developers.
+  * *Mitigation:* Heavy use of pre-commit hooks, local validation, and automated CI fixers. CI checks block any PR merging if formatting or versioning rules are violated, removing manual guesswork for the author.
+


### PR DESCRIPTION
# Summary

This is both a proposal to start using ADRs Architecture Decision Records on key design decisions and a first use of that to record the CI release invariants we are adopting from now on.

## Proof of Work

N/A

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
