### PR TITLE
CLOUDP 407997: Support test releases

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -608,6 +608,8 @@ functions:
   publish_helm_chart:
     - command: subprocess.exec
       params:
+        include_expansions_in_env:
+          - dryrun_registry_override
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         binary: scripts/release/publish_helm_chart.sh
 

--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -25,6 +25,10 @@ tasks:
             source .generated/context.export.env
             registry_override=""
             if [[ "${IS_DRYRUN}" == "true" ]]; then
+              if [[ -z "${dryrun_registry_override:-}" ]]; then
+                echo "ERROR: IS_DRYRUN=true but dryrun_registry_override is unset" >&2
+                exit 1
+              fi
               registry_override="${dryrun_registry_override}"
             fi
             scripts/mckci release publish images --commit "${revision}" --latest-marker latest --registry-override "${registry_override}"

--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -23,7 +23,11 @@ tasks:
           working_dir: src/github.com/mongodb/mongodb-kubernetes
           script: |
             source .generated/context.export.env
-            scripts/mckci release publish images --commit "${revision}" --latest-marker latest
+            registry_override=""
+            if [[ "${IS_DRYRUN}" == "true" ]]; then
+              registry_override="${dryrun_registry_override}"
+            fi
+            scripts/mckci release publish images --commit "${revision}" --latest-marker latest --registry-override "${registry_override}"
 
   # Runs after the publish task succeeds: pushes the final "X.Y.Z" tag (which
   # is not itself a trigger) and deletes "new-X.Y.Z".

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -307,7 +307,9 @@ git_tag_aliases:
     task: ".*"
   # New process: publishes the already-promoted images for the given commit
   # without rebuilding or retesting. See .evergreen-release-publish.yml.
-  - git_tag: "^new-(\\d+\\.)?(\\d+\\.)?(\\d+)$"
+  # The optional "test-" infix marks a dry run: targets an override registry
+  # instead of the real production one, still gated on the same tasks.
+  - git_tag: "^new-(test-)?(\\d+\\.)?(\\d+\\.)?(\\d+)$"
     variant_tags: [ "release-publish" ]
     task: ".*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
         description: 'Expected release version implied by the given commit (version at release.json .mongodbOperator field). The release fails if they do not match.'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run: publish to an override test registry instead of the real production one, tag "new-test-X.Y.Z" instead of "new-X.Y.Z", draft the GitHub release under "test-X.Y.Z", and never publish it. Requires the Evergreen project var "dryrun_registry_override" to be set.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   create_tag_and_draft_release:
@@ -65,21 +70,34 @@ jobs:
 
       - name: Generate draft release
         run: |
-          gh release create $VERSION --target $COMMIT_SHA --draft --latest --notes-file release_notes_final.md --title "Release of MCK $VERSION"
+          release_tag="$VERSION"
+          release_title="Release of MCK $VERSION"
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            release_tag="test-$VERSION"
+            release_title="[TEST] Release of MCK $VERSION"
+          fi
+          gh release create "$release_tag" --target "$COMMIT_SHA" --draft --latest --notes-file release_notes_final.md --title "$release_title"
         env:
           VERSION: ${{ steps.verify_release_commit.outputs.version }}
           COMMIT_SHA: ${{ steps.verify_release_commit.outputs.commit }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create git tag
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git tag -a "new-$VERSION" -m "Release of MCK $VERSION" $COMMIT_SHA
-          git push origin "new-$VERSION"
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            tag="new-test-$VERSION"
+          else
+            tag="new-$VERSION"
+          fi
+          git tag -a "$tag" -m "Release of MCK $VERSION" "$COMMIT_SHA"
+          git push origin "$tag"
         env:
           VERSION: ${{ steps.verify_release_commit.outputs.version }}
           COMMIT_SHA: ${{ steps.verify_release_commit.outputs.commit }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   wait_for_evergreen_and_prep_pr:
@@ -124,6 +142,7 @@ jobs:
 
   publish_release:
     name: Publish Release
+    if: ${{ github.event.inputs.dry_run != 'true' }} # Hard stop: never publish on dry runs
     environment: production # Manual gate
     runs-on: ubuntu-latest
     needs: wait_for_evergreen_and_prep_pr

--- a/ci/internal/cli/release_publish.go
+++ b/ci/internal/cli/release_publish.go
@@ -101,12 +101,13 @@ version.`,
 
 func newPublishImagesCmd() *cobra.Command {
 	var (
-		buildInfo    string
-		releaseJSON  string
-		commit       string
-		latestMarker string
-		force        bool
-		dryRun       bool
+		buildInfo        string
+		releaseJSON      string
+		commit           string
+		latestMarker     string
+		registryOverride string
+		force            bool
+		dryRun           bool
 	)
 
 	cmd := &cobra.Command{
@@ -135,7 +136,7 @@ published version.`,
 			if err != nil {
 				return err
 			}
-			results, err := release.PublishImages(images, commit, latestMarker, force, dryRun, release.DefaultRegistryConnector)
+			results, err := release.PublishImages(images, commit, latestMarker, registryOverride, force, dryRun, release.DefaultRegistryConnector)
 			if err != nil {
 				return err
 			}
@@ -163,6 +164,7 @@ published version.`,
 	cmd.Flags().StringVar(&releaseJSON, "release-json", "release.json", "path to release.json")
 	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to publish")
 	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().StringVar(&registryOverride, "registry-override", "", "if set, replaces every image's release-registry host+namespace with this prefix (keeping each image's own repo name suffix) — for testing against a non-production registry; e.g. \"quay.io/my-test-org\"")
 	cmd.Flags().BoolVar(&force, "force", false, "publish every image even if any production tag already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 

--- a/ci/internal/release/images_publish.go
+++ b/ci/internal/release/images_publish.go
@@ -17,7 +17,19 @@ type ImagesPublishResult struct {
 	Infos       []string
 }
 
-func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, connect RegistryConnector) ([]ImagesPublishResult, error) {
+// overrideRepoPrefix replaces everything in originalRepo up to and including
+// the last "/" with override, keeping the final path segment (the
+// image-specific repo name) intact so multiple images pushed under the same
+// override don't collide with each other.
+func overrideRepoPrefix(override, originalRepo string) string {
+	name := originalRepo
+	if idx := strings.LastIndex(originalRepo, "/"); idx != -1 {
+		name = originalRepo[idx+1:]
+	}
+	return strings.TrimSuffix(override, "/") + "/" + name
+}
+
+func PublishImages(images []ReleaseImage, commit, latestMarker, registryOverride string, force, dryRun bool, connect RegistryConnector) ([]ImagesPublishResult, error) {
 	if commit == "" {
 		return nil, errors.New("commit is required")
 	}
@@ -29,17 +41,22 @@ func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dr
 	}
 
 	type prepared struct {
-		img      ReleaseImage
-		reg      Registry
-		host     string
-		prodPath string
-		version  string
+		img         ReleaseImage
+		reg         Registry
+		host        string
+		prodPath    string
+		version     string
+		releaseRepo string
 	}
 
 	prep := make([]prepared, 0, len(images))
 	var conflicts []string
 	for _, img := range images {
-		host, path := splitHostRepo(img.ReleaseRepo)
+		releaseRepo := img.ReleaseRepo
+		if registryOverride != "" {
+			releaseRepo = overrideRepoPrefix(registryOverride, img.ReleaseRepo)
+		}
+		host, path := splitHostRepo(releaseRepo)
 		reg := connect(host)
 
 		_, version, err := resolvePromoted(img.StagingRepo, commit, latestMarker, reg)
@@ -56,7 +73,7 @@ func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dr
 		if conflict != "" {
 			conflicts = append(conflicts, fmt.Sprintf("%s: %s", img.Name, conflict))
 		}
-		prep = append(prep, prepared{img: img, reg: reg, host: host, prodPath: path, version: version})
+		prep = append(prep, prepared{img: img, reg: reg, host: host, prodPath: path, version: version, releaseRepo: releaseRepo})
 	}
 	if len(conflicts) > 0 && !force {
 		return nil, fmt.Errorf("refusing to publish images; tag conflicts found (use --force to override):\n%s", strings.Join(conflicts, "\n"))
@@ -78,7 +95,7 @@ func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dr
 		results = append(results, ImagesPublishResult{
 			Name:        p.img.Name,
 			StagingRepo: p.img.StagingRepo,
-			ProdRepo:    p.img.ReleaseRepo,
+			ProdRepo:    p.releaseRepo,
 			Commit:      result.Commit,
 			Version:     result.Version,
 			Tags:        result.AppliedTags,

--- a/ci/internal/release/images_publish_test.go
+++ b/ci/internal/release/images_publish_test.go
@@ -33,7 +33,7 @@ func TestPublishImages(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: rpStaging, ReleaseRepo: rpProd, Version: "1.0.24"},
 	}
 
-	results, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)
+	results, err := PublishImages(images, "abc1234", "latest", "", false, false, insecureConnect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -45,6 +45,42 @@ func TestPublishImages(t *testing.T) {
 	assertTagDigest(t, opProd, "latest", opDigest)
 	assertTagDigest(t, rpProd, "1.0.24", rpDigest)
 	assertTagDigest(t, rpProd, "latest", rpDigest)
+}
+
+func TestPublishImagesRegistryOverride(t *testing.T) {
+	stagingSrv := httptest.NewServer(registry.New())
+	defer stagingSrv.Close()
+	prodSrv := httptest.NewServer(registry.New())
+	defer prodSrv.Close()
+
+	stagingHost := strings.TrimPrefix(stagingSrv.URL, "http://")
+	prodHost := strings.TrimPrefix(prodSrv.URL, "http://")
+
+	opStaging := stagingHost + "/staging/mongodb-kubernetes"
+	// ReleaseRepo intentionally points at the real prod host/namespace; the
+	// override should replace it entirely except for the trailing repo name.
+	opProd := "quay.io/mongodb/mongodb-kubernetes"
+
+	opDigest := pushImage(t, fmt.Sprintf("%s:%s", opStaging, PromotedTagFor("abc1234", "1.9.2")), name.Insecure)
+
+	images := []ReleaseImage{
+		{Name: "operator", StagingRepo: opStaging, ReleaseRepo: opProd, Version: "1.9.2", IsAnchor: true},
+	}
+
+	override := prodHost + "/test-namespace"
+	results, err := PublishImages(images, "abc1234", "latest", override, false, false, insecureConnect)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(results))
+	}
+	wantProdRepo := prodHost + "/test-namespace/mongodb-kubernetes"
+	if results[0].ProdRepo != wantProdRepo {
+		t.Fatalf("ProdRepo: got %q, want %q", results[0].ProdRepo, wantProdRepo)
+	}
+	assertTagDigest(t, wantProdRepo, "1.9.2", opDigest)
+	assertTagDigest(t, wantProdRepo, "latest", opDigest)
 }
 
 func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
@@ -64,7 +100,7 @@ func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: stagingHost + "/staging/mongodb-kubernetes-readinessprobe", ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
 	}
 
-	_, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)
+	_, err := PublishImages(images, "abc1234", "latest", "", false, false, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected hard failure mentioning readiness-probe, got %v", err)
 	}
@@ -72,7 +108,7 @@ func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
 
 func TestPublishImagesCommitRequired(t *testing.T) {
 	images := []ReleaseImage{{Name: "operator", StagingRepo: "h/staging/op", ReleaseRepo: "h/op"}}
-	_, err := PublishImages(images, "", "", false, false, insecureConnect)
+	_, err := PublishImages(images, "", "", "", false, false, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "commit") {
 		t.Fatalf("expected commit error, got %v", err)
 	}
@@ -102,7 +138,7 @@ func TestPublishImagesRefusesAllOnAnyConflict(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: rpStaging, ReleaseRepo: rpProd, Version: "1.0.24"},
 	}
 
-	_, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)
+	_, err := PublishImages(images, "abc1234", "latest", "", false, false, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected conflict error mentioning readiness-probe, got %v", err)
 	}
@@ -111,7 +147,7 @@ func TestPublishImagesRefusesAllOnAnyConflict(t *testing.T) {
 		t.Error("operator production tag should not exist: images must be refused before any writes")
 	}
 
-	results, err := PublishImages(images, "abc1234", "latest", true, false, insecureConnect)
+	results, err := PublishImages(images, "abc1234", "latest", "", true, false, insecureConnect)
 	if err != nil {
 		t.Fatalf("force: unexpected error: %v", err)
 	}

--- a/scripts/dev/contexts/evg-private-context
+++ b/scripts/dev/contexts/evg-private-context
@@ -82,6 +82,16 @@ export VERSION_ID="${version_id:-"unknown"}"
 GIT_TAG="${triggered_by_git_tag:-}"
 GIT_TAG="${GIT_TAG#old-}"
 GIT_TAG="${GIT_TAG#new-}"
+# A "test-" prefix (only ever paired with "new-") marks a dry-run release:
+# publish to an override registry instead of the real production one, and
+# never push/publish real-facing artifacts (tags, GH releases). Strip it so
+# GIT_TAG remains a plain "X.Y.Z" version everywhere downstream.
+IS_DRYRUN="false"
+if [[ "${GIT_TAG}" == test-* ]]; then
+    IS_DRYRUN="true"
+    GIT_TAG="${GIT_TAG#test-}"
+fi
+export IS_DRYRUN
 export GIT_TAG
 
 # var used in pipeline.py to determine if we're running on EVG host

--- a/scripts/evergreen/push_release_tag.sh
+++ b/scripts/evergreen/push_release_tag.sh
@@ -21,7 +21,15 @@ fi
 
 remote="https://x-access-token:${GH_TOKEN:-}@github.com/mongodb/mongodb-kubernetes.git"
 
-git tag -a "${version}" -m "Release of MCK ${version}" "${revision}"
-git push "${remote}" "refs/tags/${version}"
+# A "test-" prefix (only ever paired with the "new-" trigger prefix) marks a
+# dry run: the trigger tag is deleted as usual, but the real, human-facing
+# "X.Y.Z" tag must never be pushed, since it would disturb other PRs' next-
+# version computation.
+if [[ "${prefix}" == "new-" && "${version}" == test-* ]]; then
+  echo "dry run detected (trigger tag '${trigger_tag}'), skipping push of real release tag"
+else
+  git tag -a "${version}" -m "Release of MCK ${version}" "${revision}"
+  git push "${remote}" "refs/tags/${version}"
+fi
 git push "${remote}" ":refs/tags/${trigger_tag}"
 

--- a/scripts/release/kubectl_mongodb/promote_kubectl_plugin.py
+++ b/scripts/release/kubectl_mongodb/promote_kubectl_plugin.py
@@ -57,7 +57,12 @@ def main():
 
     if os.environ.get("SKIP_GITHUB_RELEASE_UPLOAD", "false").lower() == "false":
         github_artifacts = artifacts_tar + [checksum_file]
-        upload_assets_to_github_release(github_artifacts, release_version)
+        # Dry runs draft the GitHub release under a "test-{version}" tag rather
+        # than the real "{version}" one (see .github/workflows/release.yml), so
+        # assets must be attached there instead.
+        is_dryrun = os.environ.get("IS_DRYRUN", "false").lower() == "true"
+        github_release_tag = f"test-{release_version}" if is_dryrun else release_version
+        upload_assets_to_github_release(github_artifacts, github_release_tag)
 
 
 # get_commit_from_tag gets the commit associated with a release tag, so that we can use that

--- a/scripts/release/publish_helm_chart.py
+++ b/scripts/release/publish_helm_chart.py
@@ -24,7 +24,20 @@ def run_command(command: list[str]):
         )
 
 
-def publish_helm_chart(chart_name: str, chart_info: HelmChartInfo, operator_version: str):
+def override_repo_prefix(override: str, original_repo: str) -> str:
+    """Replaces everything in original_repo up to and including the last "/"
+    with override, keeping the final path segment (the chart's own name)
+    intact so publishing under an override doesn't collide with other
+    charts/repos. E.g. override_repo_prefix("myregistry/mypath",
+    "quay.io/mongodb/helm-charts") == "myregistry/mypath/helm-charts".
+    """
+    name = original_repo.rsplit("/", 1)[-1]
+    return f"{override.rstrip('/')}/{name}"
+
+
+def publish_helm_chart(
+    chart_name: str, chart_info: HelmChartInfo, operator_version: str, registry_override: str = None
+):
     try:
         # If version_prefix is not specified, use the operator_version as is.
         if chart_info.version_prefix is not None:
@@ -41,6 +54,9 @@ def publish_helm_chart(chart_name: str, chart_info: HelmChartInfo, operator_vers
         repositories = [chart_info.repository]
         if chart_info.secondary_repositories:
             repositories += chart_info.secondary_repositories
+
+        if registry_override:
+            repositories = [override_repo_prefix(registry_override, repo) for repo in repositories]
 
         for repo in repositories:
             oci_registry = f"oci://{repo}"
@@ -78,12 +94,26 @@ Options: {", ".join(SUPPORTED_SCENARIOS)}. For '{BuildScenario.DEVELOPMENT}' the
         type=str,
         help="Operator version to use when publishing helm chart",
     )
+    parser.add_argument(
+        "--registry-override",
+        metavar="",
+        action="store",
+        required=False,
+        default=None,
+        type=str,
+        help='TESTING ONLY: if set (as "{registry}/{path}"), replaces the chart\'s OCI registry+namespace with this prefix, keeping the chart name as the final path segment (e.g. override "myregistry/mypath" turns quay.io/mongodb/helm-charts into myregistry/mypath/helm-charts) — lets a test run publish without touching the real production repo.',
+    )
     args = parser.parse_args()
 
     build_scenario = args.build_scenario
     build_info = load_build_info(build_scenario)
 
-    return publish_helm_chart(MONGODB_KUBERNETES_CHART, build_info.helm_charts[MONGODB_KUBERNETES_CHART], args.version)
+    return publish_helm_chart(
+        MONGODB_KUBERNETES_CHART,
+        build_info.helm_charts[MONGODB_KUBERNETES_CHART],
+        args.version,
+        args.registry_override,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/release/publish_helm_chart.sh
+++ b/scripts/release/publish_helm_chart.sh
@@ -8,4 +8,9 @@ set -Eeou pipefail
 
 source scripts/dev/set_env_context.sh
 
-scripts/dev/run_python.sh scripts/release/publish_helm_chart.py --build-scenario "${BUILD_SCENARIO}" --version "${OPERATOR_VERSION}"
+registry_override=""
+if [[ "${IS_DRYRUN:-false}" == "true" ]]; then
+  registry_override="${dryrun_registry_override}"
+fi
+
+scripts/dev/run_python.sh scripts/release/publish_helm_chart.py --build-scenario "${BUILD_SCENARIO}" --version "${OPERATOR_VERSION}" --registry-override "${registry_override}"

--- a/scripts/release/publish_helm_chart.sh
+++ b/scripts/release/publish_helm_chart.sh
@@ -10,6 +10,10 @@ source scripts/dev/set_env_context.sh
 
 registry_override=""
 if [[ "${IS_DRYRUN:-false}" == "true" ]]; then
+  if [[ -z "${dryrun_registry_override:-}" ]]; then
+    echo "ERROR: IS_DRYRUN=true but dryrun_registry_override is unset" >&2
+    exit 1
+  fi
   registry_override="${dryrun_registry_override}"
 fi
 

--- a/scripts/release/release_info.py
+++ b/scripts/release/release_info.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import sys
 
 from lib.base_logger import logger
 from scripts.release.build.build_info import (
@@ -171,6 +172,13 @@ def latest_search_version(release_data):
 
 
 if __name__ == "__main__":
+    # This records real production digests (quay.io/mongodb/*) for the GitHub
+    # release assets, so it is meaningless (and would fail) against a
+    # dry-run's redirected registry: skip entirely.
+    if os.environ.get("IS_DRYRUN", "false").lower() == "true":
+        logger.info("IS_DRYRUN is set, skipping add_releaseinfo_to_github_assets")
+        sys.exit(0)
+
     parser = argparse.ArgumentParser(
         description="Create relevant release artifacts information in JSON format.",
         formatter_class=argparse.RawTextHelpFormatter,


### PR DESCRIPTION
# Summary

Add some tweaks in the new release process so we can test releases without publishing for real.

It is split in 3 commits that can be reviewed separately:
1) Add a flag to **mckci** to override the publish repo target.
2) Add a similar flag to OCI helm chart releases code.
3) Add the wiring in the GitHub workflow and evergreen release code to support dry-run releases, leveraging the override options just added in.

## Proof of Work

Needs to merge to test it.

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
