### PR TITLE
Enforce a 140-char max line length via golines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,7 @@ formatters:
     - gci
     - gofmt
     - gofumpt
+    - golines
   settings:
     gci:
       # Section configuration to compare against.
@@ -151,5 +152,16 @@ formatters:
       # Module path which contains the source code being formatted.
       # Default: ""
       module-path: github.com/mongodb/mongodb-kubernetes
+    golines:
+      # Target maximum line length. golines only breaks where Go syntax allows a clean
+      # split (params, call args, composite literal elements, method chains), so long
+      # string literals, comments and +kubebuilder markers are left untouched.
+      # Default: 100
+      max-len: 140
+      # Default: 4
+      tab-len: 4
+      # Comments are prose, not code: leave author line breaks alone.
+      # Default: false
+      shorten-comments: false
   exclusions:
     generated: lax

--- a/api/mongodb/v1/mdb/mongodb_types.go
+++ b/api/mongodb/v1/mdb/mongodb_types.go
@@ -78,8 +78,8 @@ const (
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="The type of MongoDB deployment. One of 'ReplicaSet', 'ShardedCluster' and 'Standalone'."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The time since the MongoDB resource was created."
 type MongoDB struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `              json:",inline"`
+	metav1.ObjectMeta `              json:"metadata,omitempty"`
 	// +optional
 	Status MongoDbStatus `json:"status"`
 	Spec   MongoDbSpec   `json:"spec"`
@@ -260,10 +260,18 @@ func GetLastAdditionalMongodConfigByType(lastSpec *MongoDbSpec, configType Addit
 // GetLastAdditionalMongodConfigByType returns the last successfully achieved AdditionalMongodConfigType for the given component.
 func (m *MongoDB) GetLastAdditionalMongodConfigByType(configType AdditionalMongodConfigType) (*AdditionalMongodConfig, error) {
 	if m.Spec.GetResourceType() == ReplicaSet {
-		panic(errors.Errorf("this method cannot be used from ReplicaSet controller; use non-method GetLastAdditionalMongodConfigByType and pass lastSpec from the deployment state."))
+		panic(
+			errors.Errorf(
+				"this method cannot be used from ReplicaSet controller; use non-method GetLastAdditionalMongodConfigByType and pass lastSpec from the deployment state.",
+			),
+		)
 	}
 	if m.Spec.GetResourceType() == ShardedCluster {
-		panic(errors.Errorf("this method cannot be used from ShardedCluster controller; use non-method GetLastAdditionalMongodConfigByType and pass lastSpec from the deployment state."))
+		panic(
+			errors.Errorf(
+				"this method cannot be used from ShardedCluster controller; use non-method GetLastAdditionalMongodConfigByType and pass lastSpec from the deployment state.",
+			),
+		)
 	}
 	lastSpec, err := m.GetLastSpec()
 	if err != nil || lastSpec == nil {
@@ -337,8 +345,8 @@ type DbSpec interface {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type MongoDBList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta `          json:",inline"`
+	metav1.ListMeta `          json:"metadata"`
 	Items           []MongoDB `json:"items"`
 }
 
@@ -392,7 +400,7 @@ type DbCommonSpec struct {
 	Agent                       AgentConfig `json:"agent,omitempty"`
 	// +kubebuilder:validation:Format="hostname"
 	ClusterDomain  string `json:"clusterDomain,omitempty"`
-	ConnectionSpec `json:",inline"`
+	ConnectionSpec `            json:",inline"`
 
 	// +kubebuilder:validation:Enum=DEBUG;INFO;WARN;ERROR;FATAL
 	LogLevel LogLevel `json:"logLevel,omitempty"`
@@ -745,7 +753,7 @@ type PrivateCloudConfig struct {
 // note, that the fields are marked as 'omitempty' as otherwise they are shown for AppDB
 // which is not good
 type ConnectionSpec struct {
-	SharedConnectionSpec `json:",inline"`
+	SharedConnectionSpec `       json:",inline"`
 	// Name of the Secret holding credentials information
 	// +kubebuilder:validation:Required
 	Credentials string `json:"credentials"`
@@ -1678,7 +1686,11 @@ func newSecurity() *Security {
 }
 
 // BuildConnectionString returns a string with a connection string for this resource.
-func (m *MongoDB) BuildConnectionString(username, password string, scheme connectionstring.Scheme, connectionParams map[string]string) string {
+func (m *MongoDB) BuildConnectionString(
+	username, password string,
+	scheme connectionstring.Scheme,
+	connectionParams map[string]string,
+) string {
 	builder := NewMongoDBConnectionStringBuilder(*m, nil)
 	return builder.BuildConnectionString(username, password, scheme, connectionParams)
 }
@@ -1688,7 +1700,11 @@ func (m *MongoDB) GetAuthenticationModes() []string {
 }
 
 func (m *MongoDB) CalculateFeatureCompatibilityVersion() string {
-	return fcv.CalculateFeatureCompatibilityVersion(m.Spec.Version, m.Status.FeatureCompatibilityVersion, m.Spec.FeatureCompatibilityVersion)
+	return fcv.CalculateFeatureCompatibilityVersion(
+		m.Spec.Version,
+		m.Status.FeatureCompatibilityVersion,
+		m.Spec.FeatureCompatibilityVersion,
+	)
 }
 
 func (m *MongoDB) ShardNames() []string {
@@ -1776,7 +1792,11 @@ func NewMongoDBConnectionStringBuilder(mdb MongoDB, hostnames []string) *MongoDB
 	}
 }
 
-func (m *MongoDBConnectionStringBuilder) BuildConnectionString(username, password string, scheme connectionstring.Scheme, connectionParams map[string]string) string {
+func (m *MongoDBConnectionStringBuilder) BuildConnectionString(
+	username, password string,
+	scheme connectionstring.Scheme,
+	connectionParams map[string]string,
+) string {
 	name := m.Name
 	if m.Spec.ResourceType == ShardedCluster {
 		name = m.MongosRsName()

--- a/api/mongodb/v1/mdb/mongodb_types_test.go
+++ b/api/mongodb/v1/mdb/mongodb_types_test.go
@@ -183,7 +183,12 @@ func TestMongoDB_ConnectionURL_NotSecure(t *testing.T) {
 		cnx)
 
 	// Connection parameters. The default one is overridden
-	cnx = rs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"})
+	cnx = rs.BuildConnectionString(
+		"",
+		"",
+		connectionstring.SchemeMongoDB,
+		map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"},
+	)
 	assert.Equal(t, "mongodb://test-mdb-0.test-mdb-svc.testNS.svc.cluster.local:27017,"+
 		"test-mdb-1.test-mdb-svc.testNS.svc.cluster.local:27017,test-mdb-2.test-mdb-svc.testNS.svc.cluster.local:27017/"+
 		"?connectTimeoutMS=30000&readPreference=secondary&replicaSet=test-mdb&serverSelectionTimeoutMS=20000",
@@ -271,7 +276,12 @@ func TestMongoDB_ConnectionURL_Secure(t *testing.T) {
 
 	// Caller can override any connection parameters, e.g."authMechanism"
 	rs = NewReplicaSetBuilder().SetMembers(2).EnableAuth([]AuthMode{util.SCRAM}).Build()
-	cnx = rs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-1"})
+	cnx = rs.BuildConnectionString(
+		"the_user",
+		"the_passwd",
+		connectionstring.SchemeMongoDB,
+		map[string]string{"authMechanism": "SCRAM-SHA-1"},
+	)
 	assert.Equal(t, "mongodb://the_user:the_passwd@test-mdb-0.test-mdb-svc.testNS.svc.cluster.local:27017,"+
 		"test-mdb-1.test-mdb-svc.testNS.svc.cluster.local:27017/?authMechanism=SCRAM-SHA-1&authSource=admin&"+
 		"connectTimeoutMS=20000&replicaSet=test-mdb&serverSelectionTimeoutMS=20000",
@@ -508,7 +518,9 @@ func TestUpdateStatus_DoesNotSetProjectIdWhenOptionAbsent(t *testing.T) {
 func TestAdditionalMongodConfigMarshalJSON(t *testing.T) {
 	mdb := MongoDB{Spec: MongoDbSpec{DbCommonSpec: DbCommonSpec{Version: "4.2.1"}}}
 	mdb.InitDefaults()
-	mdb.Spec.AdditionalMongodConfig = &AdditionalMongodConfig{object: map[string]interface{}{"net": map[string]interface{}{"port": "30000"}}}
+	mdb.Spec.AdditionalMongodConfig = &AdditionalMongodConfig{
+		object: map[string]interface{}{"net": map[string]interface{}{"port": "30000"}},
+	}
 
 	marshal, err := json.Marshal(mdb.Spec)
 	assert.NoError(t, err)

--- a/api/mongodb/v1/mdb/mongodb_validation.go
+++ b/api/mongodb/v1/mdb/mongodb_validation.go
@@ -265,7 +265,11 @@ func oidcProviderConfigIssuerURIValidator(config OIDCProviderConfig) func(DbComm
 		}
 
 		if url.Scheme != "https" {
-			return v1.ValidationWarning("IssuerURI %s in OIDC provider config %q in not secure endpoint", url.String(), config.ConfigurationName)
+			return v1.ValidationWarning(
+				"IssuerURI %s in OIDC provider config %q in not secure endpoint",
+				url.String(),
+				config.ConfigurationName,
+			)
 		}
 
 		return v1.ValidationSuccess()
@@ -276,7 +280,10 @@ func oidcProviderConfigClientIdValidator(config OIDCProviderConfig) func(DbCommo
 	return func(_ DbCommonSpec) v1.ValidationResult {
 		if config.AuthorizationMethod == OIDCAuthorizationMethodWorkforceIdentityFederation {
 			if config.ClientId == nil || *config.ClientId == "" {
-				return v1.ValidationError("ClientId has to be specified in OIDC provider config %q with Workforce Identity Federation", config.ConfigurationName)
+				return v1.ValidationError(
+					"ClientId has to be specified in OIDC provider config %q with Workforce Identity Federation",
+					config.ConfigurationName,
+				)
 			}
 		} else if config.AuthorizationMethod == OIDCAuthorizationMethodWorkloadIdentityFederation {
 			if config.ClientId != nil {
@@ -292,7 +299,10 @@ func oidcProviderConfigRequestedScopesValidator(config OIDCProviderConfig) func(
 	return func(_ DbCommonSpec) v1.ValidationResult {
 		if config.AuthorizationMethod == OIDCAuthorizationMethodWorkloadIdentityFederation {
 			if len(config.RequestedScopes) > 0 {
-				return v1.ValidationWarning("RequestedScopes will be ignored in OIDC provider config %q with Workload Identity Federation", config.ConfigurationName)
+				return v1.ValidationWarning(
+					"RequestedScopes will be ignored in OIDC provider config %q with Workload Identity Federation",
+					config.ConfigurationName,
+				)
 			}
 		}
 
@@ -304,7 +314,10 @@ func oidcProviderConfigAuthorizationTypeValidator(config OIDCProviderConfig) fun
 	return func(_ DbCommonSpec) v1.ValidationResult {
 		if config.AuthorizationType == OIDCAuthorizationTypeGroupMembership {
 			if config.GroupsClaim == nil || *config.GroupsClaim == "" {
-				return v1.ValidationError("GroupsClaim has to be specified in OIDC provider config %q when using Group Membership authorization", config.ConfigurationName)
+				return v1.ValidationError(
+					"GroupsClaim has to be specified in OIDC provider config %q when using Group Membership authorization",
+					config.ConfigurationName,
+				)
 			}
 		} else if config.AuthorizationType == OIDCAuthorizationTypeUserID {
 			if config.GroupsClaim != nil {
@@ -339,7 +352,10 @@ func additionalMongodConfig(ms MongoDbSpec) v1.ValidationResult {
 	}
 	// Standalone or ReplicaSet
 	if ms.ShardSpec != nil || ms.ConfigSrvSpec != nil || ms.MongosSpec != nil {
-		return v1.ValidationError("'spec.mongos', 'spec.configSrv', 'spec.shard' cannot be specified if type of MongoDB is %s", ms.ResourceType)
+		return v1.ValidationError(
+			"'spec.mongos', 'spec.configSrv', 'spec.shard' cannot be specified if type of MongoDB is %s",
+			ms.ResourceType,
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -356,7 +372,9 @@ func agentModeIsSetIfMoreThanADeploymentAuthModeIsSet(d DbCommonSpec) v1.Validat
 		return v1.ValidationSuccess()
 	}
 	if len(d.Security.Authentication.Modes) > 1 && d.Security.Authentication.Agents.Mode == "" {
-		return v1.ValidationError("spec.security.authentication.agents.mode must be specified if more than one entry is present in spec.security.authentication.modes")
+		return v1.ValidationError(
+			"spec.security.authentication.agents.mode must be specified if more than one entry is present in spec.security.authentication.modes",
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -366,8 +384,11 @@ func ldapGroupDnIsSetIfLdapAuthzIsEnabledAndAgentsAreExternal(d DbCommonSpec) v1
 		return v1.ValidationSuccess()
 	}
 	auth := d.Security.Authentication
-	if auth.Ldap.AuthzQueryTemplate != "" && auth.Agents.AutomationLdapGroupDN == "" && stringutil.Contains([]string{"X509", "LDAP"}, auth.Agents.Mode) {
-		return v1.ValidationError("automationLdapGroupDN must be specified if LDAP authorization is used and agent auth mode is $external (x509 or LDAP)")
+	if auth.Ldap.AuthzQueryTemplate != "" && auth.Agents.AutomationLdapGroupDN == "" &&
+		stringutil.Contains([]string{"X509", "LDAP"}, auth.Agents.Mode) {
+		return v1.ValidationError(
+			"automationLdapGroupDN must be specified if LDAP authorization is used and agent auth mode is $external (x509 or LDAP)",
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -457,7 +478,11 @@ func ValidateFCV(fcvStringPointer *string) v1.ValidationResult {
 
 		splitted := strings.Split(fcvString, ".")
 		if len(splitted) != 2 {
-			return v1.ValidationError("invalid feature compatibility version %q, possible values are: '%s' or 'major.minor'", fcvString, util.AlwaysMatchVersionFCV)
+			return v1.ValidationError(
+				"invalid feature compatibility version %q, possible values are: '%s' or 'major.minor'",
+				fcvString,
+				util.AlwaysMatchVersionFCV,
+			)
 		}
 
 		_, err := fcv.FeatureCompatibilityVersionToSemverFormat(fcvString)
@@ -596,7 +621,11 @@ func ValidateMemberClusterIsSubsetOfKubeConfig(ms ClusterSpecList) v1.Validation
 		}
 	}
 	if len(notPresentClusters) > 0 {
-		return v1.ValidationWarning("The following clusters specified in ClusterSpecList is not present in Kubeconfig: %s, instead - the following are: %+v", notPresentClusters, clusterNames)
+		return v1.ValidationWarning(
+			"The following clusters specified in ClusterSpecList is not present in Kubeconfig: %s, instead - the following are: %+v",
+			notPresentClusters,
+			clusterNames,
+		)
 	}
 	return v1.ValidationSuccess()
 }

--- a/api/mongodb/v1/mdb/mongodb_validation_test.go
+++ b/api/mongodb/v1/mdb/mongodb_validation_test.go
@@ -119,7 +119,11 @@ func TestMongoDB_MultipleAuthsButNoAgentAuth_Error(t *testing.T) {
 		},
 	}
 	_, err := validator.ValidateCreate(ctx, rs)
-	assert.Errorf(t, err, "spec.security.authentication.agents.mode must be specified if more than one entry is present in spec.security.authentication.modes")
+	assert.Errorf(
+		t,
+		err,
+		"spec.security.authentication.agents.mode must be specified if more than one entry is present in spec.security.authentication.modes",
+	)
 }
 
 func TestMongoDB_ResourceTypeImmutable(t *testing.T) {
@@ -257,14 +261,23 @@ func TestScramSha1AuthValidation(t *testing.T) {
 			ErrorExpected: true,
 		},
 		"Valid MongoDB with SCRAM-SHA-1": {
-			MongoDB:       NewReplicaSetBuilder().EnableAuth([]AuthMode{util.SCRAMSHA1, util.MONGODBCR}).EnableAgentAuth(util.MONGODBCR).Build(),
+			MongoDB: NewReplicaSetBuilder().EnableAuth([]AuthMode{util.SCRAMSHA1, util.MONGODBCR}).
+				EnableAgentAuth(util.MONGODBCR).
+				Build(),
 			ErrorExpected: false,
 		},
 	}
 	for testName, testConfig := range tests {
 		t.Run(testName, func(t *testing.T) {
 			validationResult := scramSha1AuthValidation(testConfig.MongoDB.Spec.DbCommonSpec)
-			assert.Equal(t, testConfig.ErrorExpected, v1.ValidationSuccess() != validationResult, "Expected %v, got %v", testConfig.ErrorExpected, validationResult)
+			assert.Equal(
+				t,
+				testConfig.ErrorExpected,
+				v1.ValidationSuccess() != validationResult,
+				"Expected %v, got %v",
+				testConfig.ErrorExpected,
+				validationResult,
+			)
 		})
 	}
 }

--- a/api/mongodb/v1/mdb/mongodbbuilder.go
+++ b/api/mongodb/v1/mdb/mongodbbuilder.go
@@ -67,7 +67,11 @@ func NewClusterBuilder() *MongoDBBuilder {
 	return mongodb
 }
 
-func (b *MongoDBBuilder) ExposedExternally(specOverride *corev1.ServiceSpec, annotationsOverride map[string]string, externalDomain *string) *MongoDBBuilder {
+func (b *MongoDBBuilder) ExposedExternally(
+	specOverride *corev1.ServiceSpec,
+	annotationsOverride map[string]string,
+	externalDomain *string,
+) *MongoDBBuilder {
 	b.mdb.Spec.ExternalAccessConfiguration = &ExternalAccessConfiguration{}
 	b.mdb.Spec.ExternalAccessConfiguration.ExternalDomain = externalDomain
 	if specOverride != nil {

--- a/api/mongodb/v1/mdb/podspecbuilder.go
+++ b/api/mongodb/v1/mdb/podspecbuilder.go
@@ -106,7 +106,9 @@ func (p *PodSpecWrapperBuilder) SetSinglePersistence(builder *PersistenceConfigB
 	return p
 }
 
-func (p *PodSpecWrapperBuilder) SetMultiplePersistence(dataBuilder, journalBuilder, logsBuilder *PersistenceConfigBuilder) *PodSpecWrapperBuilder {
+func (p *PodSpecWrapperBuilder) SetMultiplePersistence(
+	dataBuilder, journalBuilder, logsBuilder *PersistenceConfigBuilder,
+) *PodSpecWrapperBuilder {
 	if p.spec.Persistence == nil {
 		p.spec.Persistence = &v1.Persistence{}
 	}

--- a/api/mongodb/v1/mdb/sharded_cluster_validation.go
+++ b/api/mongodb/v1/mdb/sharded_cluster_validation.go
@@ -55,7 +55,9 @@ func mandatorySingleClusterFieldsAreSpecified(m MongoDB) v1.ValidationResult {
 	if m.Spec.MongodsPerShardCount == 0 ||
 		m.Spec.MongosCount == 0 ||
 		m.Spec.ConfigServerCount == 0 {
-		return v1.ValidationError("The following fields must be specified in single cluster topology: mongodsPerShardCount, mongosCount, configServerCount")
+		return v1.ValidationError(
+			"The following fields must be specified in single cluster topology: mongodsPerShardCount, mongosCount, configServerCount",
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -138,7 +140,10 @@ func validateShardOverrideClusterSpecList(clusterSpecList []ClusterSpecItemOverr
 	for _, clusterSpec := range clusterSpecList {
 		// Note that it is okay for a shard override clusterSpecList to have Members = 0
 		if clusterSpec.ClusterName == "" {
-			return true, v1.ValidationError("shard override for shards %+v has an empty clusterName in clusterSpecList, this field must be specified", shardNames)
+			return true, v1.ValidationError(
+				"shard override for shards %+v has an empty clusterName in clusterSpecList, this field must be specified",
+				shardNames,
+			)
 		}
 		// This check is performed for overrides cluster spec lists as well
 		if len(clusterSpec.MemberConfig) > 0 && clusterSpec.Members != nil &&
@@ -163,7 +168,10 @@ func shardOverridesShardNamesUnique(m MongoDB) v1.ValidationResult {
 	for _, shardOverride := range m.Spec.ShardOverrides {
 		for _, shardName := range shardOverride.ShardNames {
 			if idSet[shardName] && shardName != "" {
-				return v1.ValidationError("spec.shardOverride[*].shardNames elements must be unique in shardOverrides, shardName %s is a duplicate", shardName)
+				return v1.ValidationError(
+					"spec.shardOverride[*].shardNames elements must be unique in shardOverrides, shardName %s is a duplicate",
+					shardName,
+				)
 			}
 			idSet[shardName] = true
 		}
@@ -175,7 +183,12 @@ func shardOverridesShardNamesCorrectValues(m MongoDB) v1.ValidationResult {
 	for _, shardOverride := range m.Spec.ShardOverrides {
 		for _, shardName := range shardOverride.ShardNames {
 			if !validateShardName(shardName, m.Spec.ShardCount, m.Name) {
-				return v1.ValidationError("name %s is incorrect, it must follow the following format: %s-{shard index} with shardIndex < %d (shardCount)", shardName, m.Name, m.Spec.ShardCount)
+				return v1.ValidationError(
+					"name %s is incorrect, it must follow the following format: %s-{shard index} with shardIndex < %d (shardCount)",
+					shardName,
+					m.Name,
+					m.Spec.ShardCount,
+				)
 			}
 		}
 	}
@@ -244,19 +257,31 @@ func noIgnoredFieldUsed(m MongoDB) []v1.ValidationResult {
 
 	for _, clusterSpec := range m.Spec.ShardSpec.ClusterSpecList {
 		if clusterSpec.PodSpec != nil && clusterSpec.PodSpec.PodTemplateWrapper.PodTemplate != nil {
-			appendValidationWarning(&warnings, "spec.shard.clusterSpecList.podSpec.podTemplate", "spec.shard.clusterSpecList.statefulSetConfiguration")
+			appendValidationWarning(
+				&warnings,
+				"spec.shard.clusterSpecList.podSpec.podTemplate",
+				"spec.shard.clusterSpecList.statefulSetConfiguration",
+			)
 		}
 	}
 
 	for _, clusterSpec := range m.Spec.ConfigSrvSpec.ClusterSpecList {
 		if clusterSpec.PodSpec != nil && clusterSpec.PodSpec.PodTemplateWrapper.PodTemplate != nil {
-			appendValidationWarning(&warnings, "spec.configSrv.clusterSpecList.podSpec.podTemplate", "spec.configSrv.clusterSpecList.statefulSetConfiguration")
+			appendValidationWarning(
+				&warnings,
+				"spec.configSrv.clusterSpecList.podSpec.podTemplate",
+				"spec.configSrv.clusterSpecList.statefulSetConfiguration",
+			)
 		}
 	}
 
 	for _, clusterSpec := range m.Spec.MongosSpec.ClusterSpecList {
 		if clusterSpec.PodSpec != nil && clusterSpec.PodSpec.PodTemplateWrapper.PodTemplate != nil {
-			appendValidationWarning(&warnings, "spec.mongos.clusterSpecList.podSpec.podTemplate", "spec.mongos.clusterSpecList.statefulSetConfiguration")
+			appendValidationWarning(
+				&warnings,
+				"spec.mongos.clusterSpecList.podSpec.podTemplate",
+				"spec.mongos.clusterSpecList.statefulSetConfiguration",
+			)
 		}
 	}
 
@@ -275,7 +300,11 @@ func noIgnoredFieldUsed(m MongoDB) []v1.ValidationResult {
 
 		for _, clusterSpec := range shardOverride.ClusterSpecList {
 			if clusterSpec.PodSpec != nil && clusterSpec.PodSpec.PodTemplateWrapper.PodTemplate != nil {
-				appendValidationWarning(&warnings, "spec.shardOverrides.clusterSpecList.podSpec.podTemplate", "spec.shardOverrides.clusterSpecList.statefulSetConfiguration")
+				appendValidationWarning(
+					&warnings,
+					"spec.shardOverrides.clusterSpecList.podSpec.podTemplate",
+					"spec.shardOverrides.clusterSpecList.statefulSetConfiguration",
+				)
 			}
 		}
 	}

--- a/api/mongodb/v1/mdb/sharded_cluster_validation_test.go
+++ b/api/mongodb/v1/mdb/sharded_cluster_validation_test.go
@@ -49,7 +49,11 @@ func TestMandatorySingleClusterFieldsAreSpecified(t *testing.T) {
 	scSingle.Spec.MongosCount = 0
 	_, err := validator.ValidateCreate(ctx, scSingle)
 	require.Error(t, err)
-	assert.Equal(t, "The following fields must be specified in single cluster topology: mongodsPerShardCount, mongosCount, configServerCount", err.Error())
+	assert.Equal(
+		t,
+		"The following fields must be specified in single cluster topology: mongodsPerShardCount, mongosCount, configServerCount",
+		err.Error(),
+	)
 }
 
 func TestShardOverridesAreCorrect(t *testing.T) {
@@ -464,7 +468,13 @@ func assertWarningExists(t *testing.T, warnings status.Warnings, expectedWarning
 
 	// If not found, print the list of warnings and fail the test
 	if !found {
-		assert.Fail(t, "Expected warning not found", "Expected warning: %q, but it was not found in warnings: %v", expectedWarning, warnings)
+		assert.Fail(
+			t,
+			"Expected warning not found",
+			"Expected warning: %q, but it was not found in warnings: %v",
+			expectedWarning,
+			warnings,
+		)
 	}
 }
 

--- a/api/mongodb/v1/mdbmulti/mongodb_multi_types.go
+++ b/api/mongodb/v1/mdbmulti/mongodb_multi_types.go
@@ -48,8 +48,8 @@ const (
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Current state of the MongoDB deployment."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The time since the MongoDBMultiCluster resource was created."
 type MongoDBMultiCluster struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `                   json:",inline"`
+	metav1.ObjectMeta `                   json:"metadata,omitempty"`
 	// +optional
 	Status MongoDBMultiStatus `json:"status"`
 	Spec   MongoDBMultiSpec   `json:"spec"`
@@ -80,7 +80,16 @@ func (m *MongoDBMultiCluster) GetMultiClusterAgentHostnames() ([]string, error) 
 	}
 
 	for _, spec := range clusterSpecList {
-		hostnames = append(hostnames, dns.GetMultiClusterProcessHostnames(m.Name, m.Namespace, m.ClusterNum(spec.ClusterName), spec.Members, m.Spec.GetClusterDomain(), m.Spec.GetExternalDomainForMemberCluster(spec.ClusterName))...)
+		hostnames = append(
+			hostnames,
+			dns.GetMultiClusterProcessHostnames(
+				m.Name,
+				m.Namespace,
+				m.ClusterNum(spec.ClusterName),
+				spec.Members,
+				m.Spec.GetClusterDomain(),
+				m.Spec.GetExternalDomainForMemberCluster(spec.ClusterName),
+			)...)
 	}
 	return hostnames, nil
 }
@@ -188,8 +197,8 @@ func (m *MongoDBMultiCluster) GetKind() string {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type MongoDBMultiClusterList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta `                      json:",inline"`
+	metav1.ListMeta `                      json:"metadata"`
 	Items           []MongoDBMultiCluster `json:"items"`
 }
 
@@ -632,10 +641,23 @@ func (m *MongoDBMultiCluster) ClusterNum(clusterName string) int {
 //
 // Not yet functional, because m.Service() is not defined. Waiting for CLOUDP-105817
 // to complete.
-func (m *MongoDBMultiCluster) BuildConnectionString(username, password string, scheme connectionstring.Scheme, connectionParams map[string]string) string {
+func (m *MongoDBMultiCluster) BuildConnectionString(
+	username, password string,
+	scheme connectionstring.Scheme,
+	connectionParams map[string]string,
+) string {
 	hostnames := make([]string, 0)
 	for _, spec := range m.Spec.GetClusterSpecList() {
-		hostnames = append(hostnames, dns.GetMultiClusterProcessHostnames(m.Name, m.Namespace, m.ClusterNum(spec.ClusterName), spec.Members, m.Spec.GetClusterDomain(), nil)...)
+		hostnames = append(
+			hostnames,
+			dns.GetMultiClusterProcessHostnames(
+				m.Name,
+				m.Namespace,
+				m.ClusterNum(spec.ClusterName),
+				spec.Members,
+				m.Spec.GetClusterDomain(),
+				nil,
+			)...)
 	}
 	builder := connectionstring.Builder().
 		SetName(m.Name).
@@ -684,5 +706,9 @@ func (m *MongoDBMultiCluster) IsInChangeVersion() bool {
 }
 
 func (m *MongoDBMultiCluster) CalculateFeatureCompatibilityVersion() string {
-	return fcv.CalculateFeatureCompatibilityVersion(m.Spec.Version, m.Status.FeatureCompatibilityVersion, m.Spec.FeatureCompatibilityVersion)
+	return fcv.CalculateFeatureCompatibilityVersion(
+		m.Spec.Version,
+		m.Status.FeatureCompatibilityVersion,
+		m.Spec.FeatureCompatibilityVersion,
+	)
 }

--- a/api/mongodb/v1/mdbmulti/mongodbmulti_validation.go
+++ b/api/mongodb/v1/mdbmulti/mongodbmulti_validation.go
@@ -19,7 +19,10 @@ func (m MongoDBMultiClusterValidator) ValidateCreate(_ context.Context, obj runt
 	return nil, obj.(*MongoDBMultiCluster).ProcessValidationsOnReconcile(nil)
 }
 
-func (m MongoDBMultiClusterValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+func (m MongoDBMultiClusterValidator) ValidateUpdate(
+	_ context.Context,
+	oldObj, newObj runtime.Object,
+) (warnings admission.Warnings, err error) {
 	return nil, newObj.(*MongoDBMultiCluster).ProcessValidationsOnReconcile(oldObj.(*MongoDBMultiCluster))
 }
 

--- a/api/mongodb/v1/mdbmulti/mongodbmultibuilder.go
+++ b/api/mongodb/v1/mdbmulti/mongodbmultibuilder.go
@@ -106,7 +106,10 @@ func (m *MultiReplicaSetBuilder) SetClusterSpecList(clusters []string) *MultiRep
 	return m
 }
 
-func (m *MultiReplicaSetBuilder) SetExternalAccess(configuration mdbv1.ExternalAccessConfiguration, externalDomainTemplate *string) *MultiReplicaSetBuilder {
+func (m *MultiReplicaSetBuilder) SetExternalAccess(
+	configuration mdbv1.ExternalAccessConfiguration,
+	externalDomainTemplate *string,
+) *MultiReplicaSetBuilder {
 	m.Spec.ExternalAccessConfiguration = &configuration
 
 	for i := range m.Spec.ClusterSpecList {

--- a/api/mongodb/v1/om/appdb_types.go
+++ b/api/mongodb/v1/om/appdb_types.go
@@ -489,7 +489,12 @@ func (m *AppDBSpec) GetMemberClusterSpecByName(memberClusterName string) mdbv1.C
 	panic(fmt.Errorf("cluster with name %s could not be found in AppDB's clusterSpecList", memberClusterName))
 }
 
-func (m *AppDBSpec) BuildConnectionURL(username, password string, scheme connectionstring.Scheme, connectionParams map[string]string, multiClusterHostnames []string) string {
+func (m *AppDBSpec) BuildConnectionURL(
+	username, password string,
+	scheme connectionstring.Scheme,
+	connectionParams map[string]string,
+	multiClusterHostnames []string,
+) string {
 	builder := connectionstring.Builder().
 		SetName(m.Name()).
 		SetNamespace(m.Namespace).

--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -58,14 +58,18 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The time since the MongoDBOpsManager resource was created."
 // +kubebuilder:printcolumn:name="Warnings",type="string",JSONPath=".status.warnings",description="Warnings."
 type MongoDBOpsManager struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `                        json:",inline"`
+	metav1.ObjectMeta `                        json:"metadata,omitempty"`
 	Spec              MongoDBOpsManagerSpec `json:"spec"`
 	// +optional
 	Status MongoDBOpsManagerStatus `json:"status"`
 }
 
-func (om *MongoDBOpsManager) GetAppDBProjectConfig(ctx context.Context, secretClient secrets.SecretClient, client kubernetesClient.Client) (mdbv1.ProjectConfig, error) {
+func (om *MongoDBOpsManager) GetAppDBProjectConfig(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	client kubernetesClient.Client,
+) (mdbv1.ProjectConfig, error) {
 	if om.IsTLSEnabled() {
 		opsManagerCA := om.Spec.GetOpsManagerCA()
 		cm, err := client.GetConfigMap(ctx, kube.ObjectKey(om.Namespace, opsManagerCA))
@@ -93,8 +97,8 @@ func (om *MongoDBOpsManager) GetAppDBProjectConfig(ctx context.Context, secretCl
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type MongoDBOpsManagerList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta `                    json:",inline"`
+	metav1.ListMeta `                    json:"metadata"`
 	Items           []MongoDBOpsManager `json:"items"`
 }
 
@@ -304,7 +308,10 @@ func (ms *MongoDBOpsManagerSpec) GetBackupClusterStatusList() []status.OMCluster
 	clusterStatuses := make([]status.OMClusterStatusItem, 0)
 	for _, item := range ms.ClusterSpecList {
 		if item.Backup != nil {
-			clusterStatuses = append(clusterStatuses, status.OMClusterStatusItem{ClusterName: item.ClusterName, Replicas: item.Backup.Members})
+			clusterStatuses = append(
+				clusterStatuses,
+				status.OMClusterStatusItem{ClusterName: item.ClusterName, Replicas: item.Backup.Members},
+			)
 		}
 	}
 	return clusterStatuses
@@ -877,12 +884,20 @@ func (om *MongoDBOpsManager) GetStatusPath(options ...status.Option) string {
 // To ensure backward compatibility, it checks if a secret key is present with the old format name({$ops-manager-name}-admin-key),
 // if not it returns the new name format ({$ops-manager-namespace}-${ops-manager-name}-admin-key), to have multiple om deployments
 // with the same name.
-func (om *MongoDBOpsManager) APIKeySecretName(ctx context.Context, client secrets.SecretClientInterface, operatorSecretPath string) (string, error) {
+func (om *MongoDBOpsManager) APIKeySecretName(
+	ctx context.Context,
+	client secrets.SecretClientInterface,
+	operatorSecretPath string,
+) (string, error) {
 	oldAPISecretName := fmt.Sprintf("%s-admin-key", om.Name)
 	operatorNamespace := env.ReadOrPanic(util.CurrentNamespace) // nolint:forbidigo
 	oldAPIKeySecretNamespacedName := types.NamespacedName{Name: oldAPISecretName, Namespace: operatorNamespace}
 
-	_, err := client.ReadSecret(ctx, oldAPIKeySecretNamespacedName, fmt.Sprintf("%s/%s/%s", operatorSecretPath, operatorNamespace, oldAPISecretName))
+	_, err := client.ReadSecret(
+		ctx,
+		oldAPIKeySecretNamespacedName,
+		fmt.Sprintf("%s/%s/%s", operatorSecretPath, operatorNamespace, oldAPISecretName),
+	)
 	if err != nil {
 		if secret.SecretNotExist(err) {
 			return fmt.Sprintf("%s-%s-admin-key", om.Namespace, om.Name), nil
@@ -950,7 +965,14 @@ func (om *MongoDBOpsManager) CentralURL() string {
 }
 
 func (om *MongoDBOpsManager) BackupDaemonFQDNs() []string {
-	hostnames, _ := dns.GetDNSNames(om.BackupDaemonStatefulSetName(), om.BackupDaemonServiceName(), om.Namespace, om.Spec.GetClusterDomain(), om.Spec.Backup.Members, nil)
+	hostnames, _ := dns.GetDNSNames(
+		om.BackupDaemonStatefulSetName(),
+		om.BackupDaemonServiceName(),
+		om.Namespace,
+		om.Spec.GetClusterDomain(),
+		om.Spec.Backup.Members,
+		nil,
+	)
 	return hostnames
 }
 
@@ -994,7 +1016,11 @@ func (om *MongoDBOpsManager) GetPreviousVersion() string {
 }
 
 func (om *MongoDBOpsManager) CalculateFeatureCompatibilityVersion() string {
-	return fcv.CalculateFeatureCompatibilityVersion(om.Spec.AppDB.Version, om.Status.AppDbStatus.FeatureCompatibilityVersion, om.Spec.AppDB.FeatureCompatibilityVersion)
+	return fcv.CalculateFeatureCompatibilityVersion(
+		om.Spec.AppDB.Version,
+		om.Status.AppDbStatus.FeatureCompatibilityVersion,
+		om.Spec.AppDB.FeatureCompatibilityVersion,
+	)
 }
 
 // GetSecretsMountedIntoPod returns the list of strings mounted into the pod that we need to watch.

--- a/api/mongodb/v1/om/opsmanager_validation.go
+++ b/api/mongodb/v1/om/opsmanager_validation.go
@@ -30,7 +30,10 @@ func (m MongoDBOpsManagerValidator) ValidateCreate(_ context.Context, obj runtim
 	return nil, obj.(*MongoDBOpsManager).ProcessValidationsWebhook()
 }
 
-func (m MongoDBOpsManagerValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+func (m MongoDBOpsManagerValidator) ValidateUpdate(
+	_ context.Context,
+	oldObj, newObj runtime.Object,
+) (warnings admission.Warnings, err error) {
 	return nil, newObj.(*MongoDBOpsManager).ProcessValidationsWebhook()
 }
 
@@ -49,7 +52,10 @@ func errorNotConfigurableForAppDB(field string) v1.ValidationResult {
 func validOmVersion(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	_, err := versionutil.StringToSemverVersion(os.Version)
 	if err != nil {
-		return v1.OpsManagerResourceValidationError(fmt.Sprintf("'%s' is an invalid value for spec.version: %s", os.Version, err), status.OpsManager)
+		return v1.OpsManagerResourceValidationError(
+			fmt.Sprintf("'%s' is an invalid value for spec.version: %s", os.Version, err),
+			status.OpsManager,
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -58,7 +64,10 @@ func validAppDBVersion(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	version := os.AppDB.GetMongoDBVersion()
 	_, err := semver.Make(version)
 	if err != nil {
-		return v1.OpsManagerResourceValidationError(fmt.Sprintf("'%s' is an invalid value for spec.applicationDatabase.version: %s", version, err), status.AppDb)
+		return v1.OpsManagerResourceValidationError(
+			fmt.Sprintf("'%s' is an invalid value for spec.applicationDatabase.version: %s", version, err),
+			status.AppDb,
+		)
 	}
 
 	return v1.ValidationSuccess()
@@ -114,7 +123,11 @@ func s3StoreMongodbUserSpecifiedNoMongoResource(os MongoDBOpsManagerSpec) v1.Val
 	for _, config := range os.Backup.S3Configs {
 		if config.MongoDBUserRef != nil && config.MongoDBResourceRef == nil {
 			return v1.OpsManagerResourceValidationError(
-				fmt.Sprintf("'mongodbResourceRef' must be specified if 'mongodbUserRef' is configured (S3 Store: %s)", config.Name), status.OpsManager,
+				fmt.Sprintf(
+					"'mongodbResourceRef' must be specified if 'mongodbUserRef' is configured (S3 Store: %s)",
+					config.Name,
+				),
+				status.OpsManager,
 			)
 		}
 	}
@@ -127,7 +140,10 @@ func kmipValidation(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	}
 
 	if _, _, err := net.SplitHostPort(os.Backup.Encryption.Kmip.Server.URL); err != nil {
-		return v1.OpsManagerResourceValidationError(fmt.Sprintf("kmip url can not be splitted into host and port, see %v", err), status.OpsManager)
+		return v1.OpsManagerResourceValidationError(
+			fmt.Sprintf("kmip url can not be splitted into host and port, see %v", err),
+			status.OpsManager,
+		)
 	}
 
 	if len(os.Backup.Encryption.Kmip.Server.CA) == 0 {
@@ -140,7 +156,10 @@ func kmipValidation(os MongoDBOpsManagerSpec) v1.ValidationResult {
 func validateEmptyClusterSpecListSingleCluster(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	if !os.AppDB.IsMultiCluster() {
 		if len(os.AppDB.ClusterSpecList) > 0 {
-			return v1.OpsManagerResourceValidationError("Single cluster AppDB deployment should have empty clusterSpecList", status.OpsManager)
+			return v1.OpsManagerResourceValidationError(
+				"Single cluster AppDB deployment should have empty clusterSpecList",
+				status.OpsManager,
+			)
 		}
 	}
 	return v1.ValidationSuccess()
@@ -149,7 +168,10 @@ func validateEmptyClusterSpecListSingleCluster(os MongoDBOpsManagerSpec) v1.Vali
 func validateTopologyIsSpecified(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	if len(os.ClusterSpecList) > 0 {
 		if !os.IsMultiCluster() {
-			return v1.OpsManagerResourceValidationError("Topology 'MultiCluster' must be specified while setting a not empty spec.clusterSpecList", status.OpsManager)
+			return v1.OpsManagerResourceValidationError(
+				"Topology 'MultiCluster' must be specified while setting a not empty spec.clusterSpecList",
+				status.OpsManager,
+			)
 		}
 	}
 	return v1.ValidationSuccess()
@@ -163,7 +185,10 @@ func featureCompatibilityVersionValidation(os MongoDBOpsManagerSpec) v1.Validati
 func validateClusterSpecList(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	if os.IsMultiCluster() {
 		if len(os.ClusterSpecList) == 0 {
-			return v1.OpsManagerResourceValidationError("At least one ClusterSpecList entry must be specified for MultiCluster mode OM", status.OpsManager)
+			return v1.OpsManagerResourceValidationError(
+				"At least one ClusterSpecList entry must be specified for MultiCluster mode OM",
+				status.OpsManager,
+			)
 		}
 		if os.Backup != nil && os.Backup.Enabled {
 			backupMembersConfigured := false
@@ -174,7 +199,10 @@ func validateClusterSpecList(os MongoDBOpsManagerSpec) v1.ValidationResult {
 				}
 			}
 			if !backupMembersConfigured {
-				return v1.OpsManagerResourceValidationError("At least one ClusterSpecList item must have backup members configured", status.OpsManager)
+				return v1.OpsManagerResourceValidationError(
+					"At least one ClusterSpecList item must have backup members configured",
+					status.OpsManager,
+				)
 			}
 		}
 	}
@@ -236,7 +264,11 @@ func validateBackupS3Stores(os MongoDBOpsManagerSpec) v1.ValidationResult {
 		for _, config := range backup.S3Configs {
 			if config.IRSAEnabled {
 				if config.S3SecretRef != nil {
-					return v1.OpsManagerResourceValidationWarning("'s3SecretRef' must not be specified if using IRSA (S3 Store: %s)", status.OpsManager, config.Name)
+					return v1.OpsManagerResourceValidationWarning(
+						"'s3SecretRef' must not be specified if using IRSA (S3 Store: %s)",
+						status.OpsManager,
+						config.Name,
+					)
 				}
 			} else if config.S3SecretRef == nil || config.S3SecretRef.Name == "" {
 				return v1.OpsManagerResourceValidationError("'s3SecretRef' must be specified if not using IRSA (S3 Store: %s)", status.OpsManager, config.Name)
@@ -250,7 +282,11 @@ func validateBackupS3Stores(os MongoDBOpsManagerSpec) v1.ValidationResult {
 		for _, oplogStoreConfig := range backup.S3OplogStoreConfigs {
 			if oplogStoreConfig.IRSAEnabled {
 				if oplogStoreConfig.S3SecretRef != nil {
-					return v1.OpsManagerResourceValidationWarning("'s3SecretRef' must not be specified if using IRSA (S3 OpLog Store: %s)", status.OpsManager, oplogStoreConfig.Name)
+					return v1.OpsManagerResourceValidationWarning(
+						"'s3SecretRef' must not be specified if using IRSA (S3 OpLog Store: %s)",
+						status.OpsManager,
+						oplogStoreConfig.Name,
+					)
 				}
 			} else if oplogStoreConfig.S3SecretRef == nil || oplogStoreConfig.S3SecretRef.Name == "" {
 				return v1.OpsManagerResourceValidationError("'s3SecretRef' must be specified if not using IRSA (S3 OpLog Store: %s)", status.OpsManager, oplogStoreConfig.Name)
@@ -265,7 +301,10 @@ func validateBackupS3Stores(os MongoDBOpsManagerSpec) v1.ValidationResult {
 
 func warnMonitoringAgentStartupParameters(os MongoDBOpsManagerSpec) v1.ValidationResult {
 	if len(os.AppDB.MonitoringAgent.StartupParameters) > 0 {
-		return v1.OpsManagerResourceValidationWarning("spec.appDB.monitoringAgent.startupOptions is deprecated and has no effect; the monitoring agent now runs inside the automation agent. Configure agent options, including log level and rotation, via spec.appDB.agent and remove spec.appDB.monitoringAgent from your configuration", status.AppDb)
+		return v1.OpsManagerResourceValidationWarning(
+			"spec.appDB.monitoringAgent.startupOptions is deprecated and has no effect; the monitoring agent now runs inside the automation agent. Configure agent options, including log level and rotation, via spec.appDB.agent and remove spec.appDB.monitoringAgent from your configuration",
+			status.AppDb,
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -276,7 +315,10 @@ func warnMonitoringAgentContainer(os MongoDBOpsManagerSpec) v1.ValidationResult 
 	}
 	for _, c := range os.AppDB.PodSpec.PodTemplateWrapper.PodTemplate.Spec.Containers {
 		if c.Name == "mongodb-agent-monitoring" {
-			return v1.OpsManagerResourceValidationWarning("spec.appDB.podSpec.podTemplate contains a deprecated 'mongodb-agent-monitoring' container; it will be removed automatically — remove it from your configuration", status.AppDb)
+			return v1.OpsManagerResourceValidationWarning(
+				"spec.appDB.podSpec.podTemplate contains a deprecated 'mongodb-agent-monitoring' container; it will be removed automatically — remove it from your configuration",
+				status.AppDb,
+			)
 		}
 	}
 	return v1.ValidationSuccess()

--- a/api/mongodb/v1/om/opsmanagerbuilder.go
+++ b/api/mongodb/v1/om/opsmanagerbuilder.go
@@ -20,7 +20,11 @@ func NewOpsManagerBuilder() *OpsManagerBuilder {
 }
 
 func NewOpsManagerBuilderDefault() *OpsManagerBuilder {
-	return NewOpsManagerBuilder().SetName("default-om").SetVersion("4.4.1").SetAppDbMembers(3).SetAppDbPodSpec(*DefaultAppDbBuilder().Build().PodSpec).SetAppDbVersion("4.2.20")
+	return NewOpsManagerBuilder().SetName("default-om").
+		SetVersion("4.4.1").
+		SetAppDbMembers(3).
+		SetAppDbPodSpec(*DefaultAppDbBuilder().Build().PodSpec).
+		SetAppDbVersion("4.2.20")
 }
 
 func NewOpsManagerBuilderFromResource(resource MongoDBOpsManager) *OpsManagerBuilder {

--- a/api/mongodb/v1/search/mongodbsearch_types.go
+++ b/api/mongodb/v1/search/mongodbsearch_types.go
@@ -670,8 +670,8 @@ type MongoDBSearch struct {
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type MongoDBSearchList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta `                json:",inline"`
+	metav1.ListMeta `                json:"metadata"`
 	Items           []MongoDBSearch `json:"items"`
 }
 
@@ -1175,7 +1175,10 @@ func (s *MongoDBSearch) ResolveSizingForClusterShard(clusterName, shardName stri
 		resolved.JVMFlags = override.JVMFlags
 	}
 	if override.StatefulSetConfiguration != nil {
-		resolved.StatefulSetConfiguration = mergeStatefulSetConfiguration(resolved.StatefulSetConfiguration, override.StatefulSetConfiguration)
+		resolved.StatefulSetConfiguration = mergeStatefulSetConfiguration(
+			resolved.StatefulSetConfiguration,
+			override.StatefulSetConfiguration,
+		)
 	}
 	return resolved, nil
 }
@@ -1408,7 +1411,12 @@ func (s *MongoDBSearch) ValidateOperatorPerClusterIndices() error {
 			return fmt.Errorf("running one operator per cluster requires index on every spec.clusters[] entry (missing on %q)", c.Name)
 		}
 		if prev, dup := seen[*c.Index]; dup {
-			return fmt.Errorf("index %d is set on more than one spec.clusters[] entry (%q and %q); pinned indices must be distinct", *c.Index, prev, c.Name)
+			return fmt.Errorf(
+				"index %d is set on more than one spec.clusters[] entry (%q and %q); pinned indices must be distinct",
+				*c.Index,
+				prev,
+				c.Name,
+			)
 		}
 		seen[*c.Index] = c.Name
 	}

--- a/api/mongodb/v1/search/mongodbsearch_types_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_types_test.go
@@ -396,7 +396,14 @@ func TestMongoDBSearch_LocalizeToCluster(t *testing.T) {
 	}{
 		{name: "nil slice is a no-op", clusters: nil, localize: "us-east", wantOK: true, wantNil: true},
 		{name: "empty slice is a no-op", clusters: []ClusterSpec{}, localize: "us-east", wantOK: true, wantLen: 0},
-		{name: "match narrows to 1-element slice", clusters: twoClusters(), localize: "us-west", wantOK: true, wantLen: 1, wantFirst: "us-west"},
+		{
+			name:      "match narrows to 1-element slice",
+			clusters:  twoClusters(),
+			localize:  "us-west",
+			wantOK:    true,
+			wantLen:   1,
+			wantFirst: "us-west",
+		},
 		{name: "no match leaves slice unmodified", clusters: twoClusters(), localize: "ap-south", wantOK: false, wantLen: 2},
 	}
 	for _, tc := range tests {

--- a/api/mongodb/v1/search/mongodbsearch_validation.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation.go
@@ -176,7 +176,11 @@ func validateLBConfig(s *MongoDBSearch) v1.ValidationResult {
 			return v1.ValidationError("spec.clusters[%d].loadBalancer must have exactly one of 'managed' or 'unmanaged' set", i)
 		}
 		if lb.Managed != nil && lb.Unmanaged != nil {
-			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed and spec.clusters[%d].loadBalancer.unmanaged are mutually exclusive", i, i)
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed and spec.clusters[%d].loadBalancer.unmanaged are mutually exclusive",
+				i,
+				i,
+			)
 		}
 		if lb.Managed != nil {
 			managedCount++
@@ -185,10 +189,16 @@ func validateLBConfig(s *MongoDBSearch) v1.ValidationResult {
 		}
 	}
 	if withLB > 0 && withLB != len(s.Spec.Clusters) {
-		return v1.ValidationError("spec.clusters[].loadBalancer must be set on every cluster or on none; %d of %d clusters set it", withLB, len(s.Spec.Clusters))
+		return v1.ValidationError(
+			"spec.clusters[].loadBalancer must be set on every cluster or on none; %d of %d clusters set it",
+			withLB,
+			len(s.Spec.Clusters),
+		)
 	}
 	if managedCount > 0 && unmanagedCount > 0 {
-		return v1.ValidationError("spec.clusters[].loadBalancer mode must be the same on every cluster; managed and unmanaged cannot be mixed")
+		return v1.ValidationError(
+			"spec.clusters[].loadBalancer mode must be the same on every cluster; managed and unmanaged cannot be mixed",
+		)
 	}
 	return v1.ValidationSuccess()
 }
@@ -200,7 +210,11 @@ func validateUnmanagedLBConfig(s *MongoDBSearch) v1.ValidationResult {
 			continue
 		}
 		if c.LoadBalancer.Unmanaged.Endpoint == "" {
-			return v1.ValidationError("spec.clusters[%d].loadBalancer.unmanaged.endpoint must be specified when spec.clusters[%d].loadBalancer.unmanaged is configured", i, i)
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.unmanaged.endpoint must be specified when spec.clusters[%d].loadBalancer.unmanaged is configured",
+				i,
+				i,
+			)
 		}
 	}
 	return v1.ValidationSuccess()
@@ -217,7 +231,10 @@ func validateManagedLBExternalHostname(s *MongoDBSearch) v1.ValidationResult {
 			continue
 		}
 		if c.LoadBalancer.Managed.ExternalHostname == "" {
-			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.externalHostname must be specified when using managed load balancer with an external MongoDB source", i)
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed.externalHostname must be specified when using managed load balancer with an external MongoDB source",
+				i,
+			)
 		}
 	}
 	return v1.ValidationSuccess()
@@ -236,10 +253,17 @@ func validateRouterHostname(s *MongoDBSearch) v1.ValidationResult {
 			continue
 		}
 		if c.LoadBalancer.Managed.RouterHostname == "" {
-			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.routerHostname must be specified when using managed load balancer with an external sharded MongoDB source", i)
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed.routerHostname must be specified when using managed load balancer with an external sharded MongoDB source",
+				i,
+			)
 		}
 		if strings.Contains(c.LoadBalancer.Managed.RouterHostname, ShardNamePlaceholder) {
-			return v1.ValidationError("spec.clusters[%d].loadBalancer.managed.routerHostname must not contain %s; it is the shard-agnostic endpoint for mongos", i, ShardNamePlaceholder)
+			return v1.ValidationError(
+				"spec.clusters[%d].loadBalancer.managed.routerHostname must not contain %s; it is the shard-agnostic endpoint for mongos",
+				i,
+				ShardNamePlaceholder,
+			)
 		}
 	}
 	return v1.ValidationSuccess()
@@ -269,7 +293,11 @@ func validateUnmanagedEndpointTemplate(s *MongoDBSearch) v1.ValidationResult {
 		// endpoint, so the template is required and must carry more than the placeholder.
 		if s.IsExternalSourceSharded() {
 			if !hasTemplate {
-				return v1.ValidationError("%s must contain at least one %s placeholder to differentiate between shards", path, ShardNamePlaceholder)
+				return v1.ValidationError(
+					"%s must contain at least one %s placeholder to differentiate between shards",
+					path,
+					ShardNamePlaceholder,
+				)
 			}
 			if isPlaceholderOnly(endpoint) {
 				return v1.ValidationError("%s must contain more than just the %s placeholder", path, ShardNamePlaceholder)
@@ -411,7 +439,13 @@ func validateJVMFlags(s *MongoDBSearch) v1.ValidationResult {
 		for oi, o := range c.ShardOverrides {
 			for i, flag := range o.JVMFlags {
 				if reason := invalidJVMFlagReason(flag); reason != "" {
-					return v1.ValidationError("MongoDBSearch resource is invalid, spec.clusters[%d].shardOverrides[%d].jvmFlags[%d] %s", ci, oi, i, reason)
+					return v1.ValidationError(
+						"MongoDBSearch resource is invalid, spec.clusters[%d].shardOverrides[%d].jvmFlags[%d] %s",
+						ci,
+						oi,
+						i,
+						reason,
+					)
 				}
 			}
 		}
@@ -488,11 +522,15 @@ func validateX509AuthConfig(s *MongoDBSearch) v1.ValidationResult {
 	}
 
 	if s.Spec.Source.PasswordSecretRef != nil {
-		return v1.ValidationError("x509 and password authentication are mutually exclusive: spec.source.x509 and spec.source.passwordSecretRef cannot both be set")
+		return v1.ValidationError(
+			"x509 and password authentication are mutually exclusive: spec.source.x509 and spec.source.passwordSecretRef cannot both be set",
+		)
 	}
 
 	if s.Spec.Source.Username != nil {
-		return v1.ValidationError("x509 and password authentication are mutually exclusive: spec.source.x509 and spec.source.username cannot both be set")
+		return v1.ValidationError(
+			"x509 and password authentication are mutually exclusive: spec.source.x509 and spec.source.username cannot both be set",
+		)
 	}
 
 	return v1.ValidationSuccess()
@@ -762,7 +800,9 @@ func validateShardOverrides(s *MongoDBSearch) v1.ValidationResult {
 	}
 
 	if !s.IsExternalSourceSharded() {
-		return v1.ValidationError("spec.clusters[].shardOverrides is only supported for external sharded sources (spec.source.external.shardedCluster)")
+		return v1.ValidationError(
+			"spec.clusters[].shardOverrides is only supported for external sharded sources (spec.source.external.shardedCluster)",
+		)
 	}
 
 	declared := make(map[string]struct{})
@@ -777,13 +817,18 @@ func validateShardOverrides(s *MongoDBSearch) v1.ValidationResult {
 				if _, ok := declared[name]; !ok {
 					return v1.ValidationError(
 						"spec.clusters[%d].shardOverrides[%d] references unknown shardName %q; it must exist in spec.source.external.shardedCluster.shards",
-						ci, oi, name,
+						ci,
+						oi,
+						name,
 					)
 				}
 				if first, dup := seen[name]; dup {
 					return v1.ValidationError(
 						"spec.clusters[%d]: shardName %q appears in more than one shardOverrides entry (entries %d and %d); a shard may be overridden at most once per cluster",
-						ci, name, first, oi,
+						ci,
+						name,
+						first,
+						oi,
 					)
 				}
 				seen[name] = oi

--- a/api/mongodb/v1/search/mongodbsearch_validation_test.go
+++ b/api/mongodb/v1/search/mongodbsearch_validation_test.go
@@ -330,9 +330,12 @@ func TestValidateMCExternalHostnames(t *testing.T) {
 			errorContains: "{shardName}",
 		},
 		{
-			name:      "MC sharded shardName as name component is allowed",
-			hostnames: []string{"search-us-east-{shardName}-proxy.lb.example.com:443", "search-eu-west-{shardName}-proxy.lb.example.com:443"},
-			sharded:   true,
+			name: "MC sharded shardName as name component is allowed",
+			hostnames: []string{
+				"search-us-east-{shardName}-proxy.lb.example.com:443",
+				"search-eu-west-{shardName}-proxy.lb.example.com:443",
+			},
+			sharded: true,
 		},
 		{
 			name:      "MC sharded shared hostname across clusters allowed (cross-AZ failover)",
@@ -365,7 +368,12 @@ func TestValidateRouterHostname(t *testing.T) {
 	mkSearch := func(routerHostnames []string, sharded bool) *MongoDBSearch {
 		clusters := make([]ClusterSpec, 0, len(routerHostnames))
 		for i, rh := range routerHostnames {
-			c := ClusterSpec{Name: "cluster-" + strconv.Itoa(i), LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{ExternalHostname: "{shardName}.c" + strconv.Itoa(i) + ".example.com", RouterHostname: rh}}}
+			c := ClusterSpec{
+				Name: "cluster-" + strconv.Itoa(i),
+				LoadBalancer: &LoadBalancerConfig{
+					Managed: &ManagedLBConfig{ExternalHostname: "{shardName}.c" + strconv.Itoa(i) + ".example.com", RouterHostname: rh},
+				},
+			}
 			clusters = append(clusters, c)
 		}
 		s := &MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}, Spec: MongoDBSearchSpec{Clusters: clusters}}
@@ -386,7 +394,12 @@ func TestValidateRouterHostname(t *testing.T) {
 	}{
 		{name: "sharded with routerHostname set", routerHostnames: []string{"search.example.com:443"}, sharded: true},
 		{name: "sharded missing routerHostname rejected", routerHostnames: []string{""}, sharded: true, errorContains: "must be specified"},
-		{name: "sharded routerHostname with shardName placeholder rejected", routerHostnames: []string{"{shardName}.search.example.com:443"}, sharded: true, errorContains: "must not contain"},
+		{
+			name:            "sharded routerHostname with shardName placeholder rejected",
+			routerHostnames: []string{"{shardName}.search.example.com:443"},
+			sharded:         true,
+			errorContains:   "must not contain",
+		},
 		// Not an external sharded source → validator is a no-op even if unset.
 		{name: "non-sharded source ignored", routerHostnames: []string{""}, sharded: false},
 	}
@@ -465,8 +478,25 @@ func TestValidateExternalHostnameDNSLength(t *testing.T) {
 		{
 			// Each label fits 63, but the FQDN exceeds 253.
 			// 5 x 60-char labels + 4 dots = 304 > 253.
-			name:          "FQDN > 253 rejected",
-			hostnames:     []string{strings.Repeat("c", 60) + "." + strings.Repeat("a", 60) + "." + strings.Repeat("b", 60) + "." + strings.Repeat("c", 60) + "." + strings.Repeat("d", 60) + ".lb.example.com:443"},
+			name: "FQDN > 253 rejected",
+			hostnames: []string{
+				strings.Repeat(
+					"c",
+					60,
+				) + "." + strings.Repeat(
+					"a",
+					60,
+				) + "." + strings.Repeat(
+					"b",
+					60,
+				) + "." + strings.Repeat(
+					"c",
+					60,
+				) + "." + strings.Repeat(
+					"d",
+					60,
+				) + ".lb.example.com:443",
+			},
 			errorContains: "invalid DNS subdomain",
 		},
 		{
@@ -781,8 +811,13 @@ func TestValidateLBConfig(t *testing.T) {
 			errorContains: "exactly one of 'managed' or 'unmanaged'",
 		},
 		{
-			name:          "both managed and unmanaged rejected",
-			clusters:      []ClusterSpec{{Name: "a", LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}, Unmanaged: &UnmanagedLBConfig{Endpoint: "e:443"}}}},
+			name: "both managed and unmanaged rejected",
+			clusters: []ClusterSpec{
+				{
+					Name:         "a",
+					LoadBalancer: &LoadBalancerConfig{Managed: &ManagedLBConfig{}, Unmanaged: &UnmanagedLBConfig{Endpoint: "e:443"}},
+				},
+			},
 			errorContains: "mutually exclusive",
 		},
 		{

--- a/ci/internal/cli/release_promote.go
+++ b/ci/internal/cli/release_promote.go
@@ -55,8 +55,10 @@ from the newest promoted version.`,
 	cmd.Flags().StringVar(&version, "version", "", "version to encode in the promoted tag")
 	cmd.Flags().StringVar(&registryURL, "registry", "https://quay.io", "target OCI registry base URL")
 	cmd.Flags().StringVar(&repo, "repo", "mongodb/mongodb-kubernetes-operator", "target image repository")
-	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
-	cmd.Flags().BoolVar(&force, "force", false, "overwrite the promoted-{commit}-{version} tag even if it already points at a different digest")
+	cmd.Flags().
+		StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().
+		BoolVar(&force, "force", false, "overwrite the promoted-{commit}-{version} tag even if it already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 
 	MustNotErr(cmd.MarkFlagRequired("image"))
@@ -100,7 +102,8 @@ doesn't steal the "latest" pointer away from the newest promoted version.`,
 	cmd.Flags().StringVar(&buildInfo, "build-info", "build_info.json", "path to build_info.json")
 	cmd.Flags().StringVar(&releaseJSON, "release-json", "release.json", "path to release.json")
 	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to encode in the promoted tags")
-	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().
+		StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
 	cmd.Flags().BoolVar(&force, "force", false, "promote every image even if any promoted tag already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 

--- a/ci/internal/cli/release_publish.go
+++ b/ci/internal/cli/release_publish.go
@@ -85,11 +85,13 @@ version.`,
 
 	// Staging and production must share the --registry host; the host in
 	// --staging-image is only used to derive the repo path.
-	cmd.Flags().StringVar(&stagingImage, "staging-image", "", "staging image repo, e.g. quay.io/mongodb/staging/mongodb-kubernetes (required)")
+	cmd.Flags().
+		StringVar(&stagingImage, "staging-image", "", "staging image repo, e.g. quay.io/mongodb/staging/mongodb-kubernetes (required)")
 	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to publish (default: latest promoted)")
 	cmd.Flags().StringVar(&registryURL, "registry", "https://quay.io", "production OCI registry base URL")
 	cmd.Flags().StringVar(&prodRepo, "prod-repo", "mongodb/mongodb-kubernetes-operator", "production image repository")
-	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().
+		StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite the :{version} production tag even if it already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 
@@ -162,7 +164,8 @@ published version.`,
 	cmd.Flags().StringVar(&buildInfo, "build-info", "build_info.json", "path to build_info.json")
 	cmd.Flags().StringVar(&releaseJSON, "release-json", "release.json", "path to release.json")
 	cmd.Flags().StringVar(&commit, "commit", "", "commit SHA to publish")
-	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
+	cmd.Flags().
+		StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
 	cmd.Flags().BoolVar(&force, "force", false, "publish every image even if any production tag already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
 

--- a/ci/internal/release/images_promote.go
+++ b/ci/internal/release/images_promote.go
@@ -41,7 +41,12 @@ func shortCommit(commit string) string {
 // commit-tagged source image is missing), so a broken merge build does not
 // silently promote a partial image set. connect resolves a Registry for an image's
 // host; the CLI passes DefaultRegistryConnector and tests inject a fake.
-func PromoteImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, connect RegistryConnector) ([]ImagesPromoteResult, error) {
+func PromoteImages(
+	images []ReleaseImage,
+	commit, latestMarker string,
+	force, dryRun bool,
+	connect RegistryConnector,
+) ([]ImagesPromoteResult, error) {
 	if commit == "" {
 		return nil, errors.New("commit is required")
 	}
@@ -81,7 +86,10 @@ func PromoteImages(images []ReleaseImage, commit, latestMarker string, force, dr
 		prep = append(prep, prepared{img: img, reg: reg, host: host, repoPath: path, srcRef: srcRef, versionTag: versionTag})
 	}
 	if len(conflicts) > 0 && !force {
-		return nil, fmt.Errorf("refusing to promote images; tag conflicts found (use --force if the tags needs overwriting):\n%s", strings.Join(conflicts, "\n"))
+		return nil, fmt.Errorf(
+			"refusing to promote images; tag conflicts found (use --force if the tags needs overwriting):\n%s",
+			strings.Join(conflicts, "\n"),
+		)
 	}
 
 	results := make([]ImagesPromoteResult, 0, len(images))

--- a/ci/internal/release/images_publish.go
+++ b/ci/internal/release/images_publish.go
@@ -17,7 +17,12 @@ type ImagesPublishResult struct {
 	Infos       []string
 }
 
-func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, connect RegistryConnector) ([]ImagesPublishResult, error) {
+func PublishImages(
+	images []ReleaseImage,
+	commit, latestMarker string,
+	force, dryRun bool,
+	connect RegistryConnector,
+) ([]ImagesPublishResult, error) {
 	if commit == "" {
 		return nil, errors.New("commit is required")
 	}
@@ -59,7 +64,10 @@ func PublishImages(images []ReleaseImage, commit, latestMarker string, force, dr
 		prep = append(prep, prepared{img: img, reg: reg, host: host, prodPath: path, version: version})
 	}
 	if len(conflicts) > 0 && !force {
-		return nil, fmt.Errorf("refusing to publish images; tag conflicts found (use --force to override):\n%s", strings.Join(conflicts, "\n"))
+		return nil, fmt.Errorf(
+			"refusing to publish images; tag conflicts found (use --force to override):\n%s",
+			strings.Join(conflicts, "\n"),
+		)
 	}
 
 	results := make([]ImagesPublishResult, 0, len(images))

--- a/ci/internal/release/images_publish_test.go
+++ b/ci/internal/release/images_publish_test.go
@@ -61,7 +61,12 @@ func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
 
 	images := []ReleaseImage{
 		{Name: "operator", StagingRepo: opStaging, ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes", Version: "1.9.2", IsAnchor: true},
-		{Name: "readiness-probe", StagingRepo: stagingHost + "/staging/mongodb-kubernetes-readinessprobe", ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
+		{
+			Name:        "readiness-probe",
+			StagingRepo: stagingHost + "/staging/mongodb-kubernetes-readinessprobe",
+			ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes-readinessprobe",
+			Version:     "1.0.24",
+		},
 	}
 
 	_, err := PublishImages(images, "abc1234", "latest", false, false, insecureConnect)

--- a/ci/internal/release/promote_test.go
+++ b/ci/internal/release/promote_test.go
@@ -196,7 +196,11 @@ func TestPromoteRefusesStompedTag(t *testing.T) {
 	})
 
 	t.Run("proceeds with force", func(t *testing.T) {
-		result, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", Force: true}, host, reg)
+		result, err := Promote(
+			PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", Force: true},
+			host,
+			reg,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/ci/internal/release/publish_test.go
+++ b/ci/internal/release/publish_test.go
@@ -34,7 +34,11 @@ func TestPublish(t *testing.T) {
 	reg := DefaultRegistryConnector(srv.URL)
 
 	t.Run("publish with explicit commit", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		result, err := Publish(
+			PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest"},
+			host,
+			reg,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -123,7 +127,11 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("dry-run returns result without copying", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", DryRun: true}, host, reg)
+		result, err := Publish(
+			PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", DryRun: true},
+			host,
+			reg,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -228,7 +236,11 @@ func TestPublishRefusesStompedVersionTag(t *testing.T) {
 	})
 
 	t.Run("proceeds with force", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", Force: true}, host, reg)
+		result, err := Publish(
+			PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", Force: true},
+			host,
+			reg,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/kubectl-mongodb/multicluster/recover/recover.go
+++ b/cmd/kubectl-mongodb/multicluster/recover/recover.go
@@ -15,17 +15,28 @@ import (
 
 func init() {
 	RecoverCmd.Flags().StringVar(&common.MemberClusters, "member-clusters", "", "Comma separated list of member clusters. [required]")
-	RecoverCmd.Flags().StringVar(&RecoverFlags.ServiceAccount, "service-account", "mongodb-kubernetes-operator-multi-cluster", "Name of the service account which should be used for the Operator to communicate with the member clusters. [optional, default: mongodb-kubernetes-operator-multi-cluster]")
-	RecoverCmd.Flags().StringVar(&RecoverFlags.CentralCluster, "central-cluster", "", "The central cluster the operator will be deployed in. [required]")
-	RecoverCmd.Flags().StringVar(&RecoverFlags.MemberClusterNamespace, "member-cluster-namespace", "", "The namespace the member cluster resources will be deployed to. [required]")
-	RecoverCmd.Flags().StringVar(&RecoverFlags.CentralClusterNamespace, "central-cluster-namespace", "", "The namespace the Operator will be deployed to. [required]")
-	RecoverCmd.Flags().BoolVar(&RecoverFlags.Cleanup, "cleanup", false, "Delete all previously created resources except for namespaces. [optional default: false]")
-	RecoverCmd.Flags().BoolVar(&RecoverFlags.ClusterScoped, "cluster-scoped", false, "Create ClusterRole and ClusterRoleBindings for member clusters. [optional default: false]")
-	RecoverCmd.Flags().StringVar(&RecoverFlags.OperatorName, "operator-name", common.DefaultOperatorName, "Name used to identify the deployment of the operator. [optional, default: mongodb-kubernetes-operator]")
-	RecoverCmd.Flags().BoolVar(&RecoverFlags.InstallDatabaseRoles, "install-database-roles", false, "Install the ServiceAccounts and Roles required for running database workloads in the member clusters. [optional default: false]")
-	RecoverCmd.Flags().StringVar(&RecoverFlags.SourceCluster, "source-cluster", "", "The source cluster for recovery. This has to be one of the healthy member cluster that is the source of truth for new cluster configuration. [required]")
-	RecoverCmd.Flags().BoolVar(&RecoverFlags.CreateServiceAccountSecrets, "create-service-account-secrets", true, "Create service account token secrets. [optional default: true]")
-	RecoverCmd.Flags().StringVar(&common.MemberClustersApiServers, "member-clusters-api-servers", "", "Comma separated list of api servers addresses. [optional, default will take addresses from KUBECONFIG env var]")
+	RecoverCmd.Flags().
+		StringVar(&RecoverFlags.ServiceAccount, "service-account", "mongodb-kubernetes-operator-multi-cluster", "Name of the service account which should be used for the Operator to communicate with the member clusters. [optional, default: mongodb-kubernetes-operator-multi-cluster]")
+	RecoverCmd.Flags().
+		StringVar(&RecoverFlags.CentralCluster, "central-cluster", "", "The central cluster the operator will be deployed in. [required]")
+	RecoverCmd.Flags().
+		StringVar(&RecoverFlags.MemberClusterNamespace, "member-cluster-namespace", "", "The namespace the member cluster resources will be deployed to. [required]")
+	RecoverCmd.Flags().
+		StringVar(&RecoverFlags.CentralClusterNamespace, "central-cluster-namespace", "", "The namespace the Operator will be deployed to. [required]")
+	RecoverCmd.Flags().
+		BoolVar(&RecoverFlags.Cleanup, "cleanup", false, "Delete all previously created resources except for namespaces. [optional default: false]")
+	RecoverCmd.Flags().
+		BoolVar(&RecoverFlags.ClusterScoped, "cluster-scoped", false, "Create ClusterRole and ClusterRoleBindings for member clusters. [optional default: false]")
+	RecoverCmd.Flags().
+		StringVar(&RecoverFlags.OperatorName, "operator-name", common.DefaultOperatorName, "Name used to identify the deployment of the operator. [optional, default: mongodb-kubernetes-operator]")
+	RecoverCmd.Flags().
+		BoolVar(&RecoverFlags.InstallDatabaseRoles, "install-database-roles", false, "Install the ServiceAccounts and Roles required for running database workloads in the member clusters. [optional default: false]")
+	RecoverCmd.Flags().
+		StringVar(&RecoverFlags.SourceCluster, "source-cluster", "", "The source cluster for recovery. This has to be one of the healthy member cluster that is the source of truth for new cluster configuration. [required]")
+	RecoverCmd.Flags().
+		BoolVar(&RecoverFlags.CreateServiceAccountSecrets, "create-service-account-secrets", true, "Create service account token secrets. [optional default: true]")
+	RecoverCmd.Flags().
+		StringVar(&common.MemberClustersApiServers, "member-clusters-api-servers", "", "Comma separated list of api servers addresses. [optional, default will take addresses from KUBECONFIG env var]")
 }
 
 // RecoverCmd represents the recover command
@@ -46,7 +57,12 @@ kubectl-mongodb multicluster recover --central-cluster="operator-cluster" --memb
 			os.Exit(1)
 		}
 
-		clientMap, err := common.CreateClientMap(RecoverFlags.MemberClusters, RecoverFlags.CentralCluster, common.LoadKubeConfigFilePath(), common.GetKubernetesClient)
+		clientMap, err := common.CreateClientMap(
+			RecoverFlags.MemberClusters,
+			RecoverFlags.CentralCluster,
+			common.LoadKubeConfigFilePath(),
+			common.GetKubernetesClient,
+		)
 		if err != nil {
 			fmt.Printf("failed to create clientset map: %s", err)
 			os.Exit(1)
@@ -67,8 +83,20 @@ kubectl-mongodb multicluster recover --central-cluster="operator-cluster" --memb
 var RecoverFlags = common.Flags{}
 
 func parseRecoverFlags(args []string) error {
-	if slices.Contains([]string{common.MemberClusters, RecoverFlags.ServiceAccount, RecoverFlags.CentralCluster, RecoverFlags.MemberClusterNamespace, RecoverFlags.CentralClusterNamespace, RecoverFlags.SourceCluster}, "") {
-		return xerrors.Errorf("non empty values are required for [service-account, member-clusters, central-cluster, member-cluster-namespace, central-cluster-namespace, source-cluster]")
+	if slices.Contains(
+		[]string{
+			common.MemberClusters,
+			RecoverFlags.ServiceAccount,
+			RecoverFlags.CentralCluster,
+			RecoverFlags.MemberClusterNamespace,
+			RecoverFlags.CentralClusterNamespace,
+			RecoverFlags.SourceCluster,
+		},
+		"",
+	) {
+		return xerrors.Errorf(
+			"non empty values are required for [service-account, member-clusters, central-cluster, member-cluster-namespace, central-cluster-namespace, source-cluster]",
+		)
 	}
 
 	RecoverFlags.MemberClusters = strings.Split(common.MemberClusters, ",")
@@ -79,7 +107,11 @@ func parseRecoverFlags(args []string) error {
 	if strings.TrimSpace(common.MemberClustersApiServers) != "" {
 		RecoverFlags.MemberClusterApiServerUrls = strings.Split(common.MemberClustersApiServers, ",")
 		if len(RecoverFlags.MemberClusterApiServerUrls) != len(RecoverFlags.MemberClusters) {
-			return xerrors.Errorf("expected %d addresses in member-clusters-api-servers parameter but got %d", len(RecoverFlags.MemberClusters), len(RecoverFlags.MemberClusterApiServerUrls))
+			return xerrors.Errorf(
+				"expected %d addresses in member-clusters-api-servers parameter but got %d",
+				len(RecoverFlags.MemberClusters),
+				len(RecoverFlags.MemberClusterApiServerUrls),
+			)
 		}
 	}
 

--- a/cmd/kubectl-mongodb/multicluster/setup/setup.go
+++ b/cmd/kubectl-mongodb/multicluster/setup/setup.go
@@ -17,19 +17,32 @@ import (
 
 func init() {
 	SetupCmd.Flags().StringVar(&common.MemberClusters, "member-clusters", "", "Comma separated list of member clusters. [required]")
-	SetupCmd.Flags().StringVar(&setupFlags.ServiceAccount, "service-account", "mongodb-kubernetes-operator-multi-cluster", "Name of the service account which should be used for the Operator to communicate with the member clusters. [optional, default: mongodb-kubernetes-operator-multi-cluster]")
-	SetupCmd.Flags().StringVar(&setupFlags.CentralCluster, "central-cluster", "", "The central cluster the operator will be deployed in. [required]")
-	SetupCmd.Flags().StringVar(&setupFlags.MemberClusterNamespace, "member-cluster-namespace", "", "The namespace the member cluster resources will be deployed to. [required]")
-	SetupCmd.Flags().StringVar(&setupFlags.CentralClusterNamespace, "central-cluster-namespace", "", "The namespace the Operator will be deployed to. [required]")
-	SetupCmd.Flags().StringVar(&setupFlags.OperatorName, "operator-name", common.DefaultOperatorName, "Name used to identify the deployment of the operator. [optional, default: mongodb-kubernetes-operator]")
-	SetupCmd.Flags().BoolVar(&setupFlags.Cleanup, "cleanup", false, "Delete all previously created resources except for namespaces. [optional default: false]")
-	SetupCmd.Flags().BoolVar(&setupFlags.ClusterScoped, "cluster-scoped", false, "Create ClusterRole and ClusterRoleBindings for member clusters. [optional default: false]")
-	SetupCmd.Flags().BoolVar(&setupFlags.CreateTelemetryClusterRoles, "create-telemetry-roles", true, "Create ClusterRole and ClusterRoleBindings for member clusters for telemetry. [optional default: true]")
-	SetupCmd.Flags().BoolVar(&setupFlags.CreateMongoDBRolesClusterRole, "create-mongodb-roles-cluster-role", true, "Create ClusterRole and ClusterRoleBinding for central cluster for ClusterMongoDBRole resources. [optional default: true]")
-	SetupCmd.Flags().BoolVar(&setupFlags.InstallDatabaseRoles, "install-database-roles", false, "Install the ServiceAccounts and Roles required for running database workloads in the member clusters. [optional default: false]")
-	SetupCmd.Flags().BoolVar(&setupFlags.CreateServiceAccountSecrets, "create-service-account-secrets", true, "Create service account token secrets. [optional default: true]")
-	SetupCmd.Flags().StringVar(&setupFlags.ImagePullSecrets, "image-pull-secrets", "", "Name of the secret for imagePullSecrets to set in created service accounts")
-	SetupCmd.Flags().StringVar(&common.MemberClustersApiServers, "member-clusters-api-servers", "", "Comma separated list of api servers addresses. [optional, default will take addresses from KUBECONFIG env var]")
+	SetupCmd.Flags().
+		StringVar(&setupFlags.ServiceAccount, "service-account", "mongodb-kubernetes-operator-multi-cluster", "Name of the service account which should be used for the Operator to communicate with the member clusters. [optional, default: mongodb-kubernetes-operator-multi-cluster]")
+	SetupCmd.Flags().
+		StringVar(&setupFlags.CentralCluster, "central-cluster", "", "The central cluster the operator will be deployed in. [required]")
+	SetupCmd.Flags().
+		StringVar(&setupFlags.MemberClusterNamespace, "member-cluster-namespace", "", "The namespace the member cluster resources will be deployed to. [required]")
+	SetupCmd.Flags().
+		StringVar(&setupFlags.CentralClusterNamespace, "central-cluster-namespace", "", "The namespace the Operator will be deployed to. [required]")
+	SetupCmd.Flags().
+		StringVar(&setupFlags.OperatorName, "operator-name", common.DefaultOperatorName, "Name used to identify the deployment of the operator. [optional, default: mongodb-kubernetes-operator]")
+	SetupCmd.Flags().
+		BoolVar(&setupFlags.Cleanup, "cleanup", false, "Delete all previously created resources except for namespaces. [optional default: false]")
+	SetupCmd.Flags().
+		BoolVar(&setupFlags.ClusterScoped, "cluster-scoped", false, "Create ClusterRole and ClusterRoleBindings for member clusters. [optional default: false]")
+	SetupCmd.Flags().
+		BoolVar(&setupFlags.CreateTelemetryClusterRoles, "create-telemetry-roles", true, "Create ClusterRole and ClusterRoleBindings for member clusters for telemetry. [optional default: true]")
+	SetupCmd.Flags().
+		BoolVar(&setupFlags.CreateMongoDBRolesClusterRole, "create-mongodb-roles-cluster-role", true, "Create ClusterRole and ClusterRoleBinding for central cluster for ClusterMongoDBRole resources. [optional default: true]")
+	SetupCmd.Flags().
+		BoolVar(&setupFlags.InstallDatabaseRoles, "install-database-roles", false, "Install the ServiceAccounts and Roles required for running database workloads in the member clusters. [optional default: false]")
+	SetupCmd.Flags().
+		BoolVar(&setupFlags.CreateServiceAccountSecrets, "create-service-account-secrets", true, "Create service account token secrets. [optional default: true]")
+	SetupCmd.Flags().
+		StringVar(&setupFlags.ImagePullSecrets, "image-pull-secrets", "", "Name of the secret for imagePullSecrets to set in created service accounts")
+	SetupCmd.Flags().
+		StringVar(&common.MemberClustersApiServers, "member-clusters-api-servers", "", "Comma separated list of api servers addresses. [optional, default will take addresses from KUBECONFIG env var]")
 }
 
 // SetupCmd represents the setup command
@@ -54,7 +67,12 @@ kubectl-mongodb multicluster setup --central-cluster="operator-cluster" --member
 			fmt.Println(utils.GetBuildInfoString(buildInfo))
 		}
 
-		clientMap, err := common.CreateClientMap(setupFlags.MemberClusters, setupFlags.CentralCluster, common.LoadKubeConfigFilePath(), common.GetKubernetesClient)
+		clientMap, err := common.CreateClientMap(
+			setupFlags.MemberClusters,
+			setupFlags.CentralCluster,
+			common.LoadKubeConfigFilePath(),
+			common.GetKubernetesClient,
+		)
 		if err != nil {
 			fmt.Printf("failed to create clientset map: %s", err)
 			os.Exit(1)
@@ -75,8 +93,19 @@ kubectl-mongodb multicluster setup --central-cluster="operator-cluster" --member
 var setupFlags = common.Flags{}
 
 func parseSetupFlags() error {
-	if slices.Contains([]string{common.MemberClusters, setupFlags.ServiceAccount, setupFlags.CentralCluster, setupFlags.MemberClusterNamespace, setupFlags.CentralClusterNamespace}, "") {
-		return xerrors.Errorf("non empty values are required for [service-account, member-clusters, central-cluster, member-cluster-namespace, central-cluster-namespace]")
+	if slices.Contains(
+		[]string{
+			common.MemberClusters,
+			setupFlags.ServiceAccount,
+			setupFlags.CentralCluster,
+			setupFlags.MemberClusterNamespace,
+			setupFlags.CentralClusterNamespace,
+		},
+		"",
+	) {
+		return xerrors.Errorf(
+			"non empty values are required for [service-account, member-clusters, central-cluster, member-cluster-namespace, central-cluster-namespace]",
+		)
 	}
 
 	setupFlags.MemberClusters = strings.Split(common.MemberClusters, ",")
@@ -84,7 +113,11 @@ func parseSetupFlags() error {
 	if strings.TrimSpace(common.MemberClustersApiServers) != "" {
 		setupFlags.MemberClusterApiServerUrls = strings.Split(common.MemberClustersApiServers, ",")
 		if len(setupFlags.MemberClusterApiServerUrls) != len(setupFlags.MemberClusters) {
-			return xerrors.Errorf("expected %d addresses in member-clusters-api-servers parameter but got %d", len(setupFlags.MemberClusters), len(setupFlags.MemberClusterApiServerUrls))
+			return xerrors.Errorf(
+				"expected %d addresses in member-clusters-api-servers parameter but got %d",
+				len(setupFlags.MemberClusters),
+				len(setupFlags.MemberClusterApiServerUrls),
+			)
 		}
 	}
 

--- a/controllers/om/api/admin.go
+++ b/controllers/om/api/admin.go
@@ -156,7 +156,12 @@ func (a *DefaultOmAdmin) ReadDaemonConfig(hostName, headDbDir string) (backup.Da
 }
 
 func (a *DefaultOmAdmin) UpdateDaemonConfig(config backup.DaemonConfig) error {
-	_, _, err := a.put("admin/backup/daemon/configs/%s/%s", config, url.QueryEscape(config.Machine.MachineHostName), url.QueryEscape(config.Machine.HeadRootDirectory))
+	_, _, err := a.put(
+		"admin/backup/daemon/configs/%s/%s",
+		config,
+		url.QueryEscape(config.Machine.MachineHostName),
+		url.QueryEscape(config.Machine.HeadRootDirectory),
+	)
 	if err != nil {
 		return err
 	}

--- a/controllers/om/api/digest.go
+++ b/controllers/om/api/digest.go
@@ -64,7 +64,16 @@ func getDigestAuthorization(digestParts map[string]string, method string, url st
 	nonceCount := 1
 	cnonce := getCnonce()
 	response := util.MD5Hex(fmt.Sprintf("%s:%s:%v:%s:%s:%s", ha1, d["nonce"], nonceCount, cnonce, d["qop"], ha2))
-	authorization := fmt.Sprintf(`Digest username="%s", realm="%s", nonce="%s", uri="%s", cnonce="%s", nc=%v, qop=%s, response="%s", algorithm="MD5"`,
-		user, d["realm"], d["nonce"], url, cnonce, nonceCount, d["qop"], response)
+	authorization := fmt.Sprintf(
+		`Digest username="%s", realm="%s", nonce="%s", uri="%s", cnonce="%s", nc=%v, qop=%s, response="%s", algorithm="MD5"`,
+		user,
+		d["realm"],
+		d["nonce"],
+		url,
+		cnonce,
+		nonceCount,
+		d["qop"],
+		response,
+	)
 	return authorization
 }

--- a/controllers/om/automation_config.go
+++ b/controllers/om/automation_config.go
@@ -453,7 +453,11 @@ func AuthSecretName(mdbName string) string {
 // EnsurePassword makes sure that there is an Automation Agent password
 // that the agents will use to communicate with the deployments. The password
 // is returned, so it can be provided to the other agents.
-func (ac *AutomationConfig) EnsurePassword(ctx context.Context, k8sClient secret.GetUpdateCreator, mdbNamespacedName types.NamespacedName) (string, error) {
+func (ac *AutomationConfig) EnsurePassword(
+	ctx context.Context,
+	k8sClient secret.GetUpdateCreator,
+	mdbNamespacedName types.NamespacedName,
+) (string, error) {
 	secretName := AuthSecretName(mdbNamespacedName.Name)
 	secretNamespacedName := client.ObjectKey{Name: secretName, Namespace: mdbNamespacedName.Namespace}
 	var password string
@@ -488,7 +492,12 @@ func (ac *AutomationConfig) EnsurePassword(ctx context.Context, k8sClient secret
 		Build()
 
 	if err := secret.CreateOrUpdateIfNeeded(ctx, k8sClient, passwordSecret); err != nil {
-		return "", fmt.Errorf("failed to update password field in shared secret %s/%s: %w", secretNamespacedName.Namespace, secretNamespacedName.Name, err)
+		return "", fmt.Errorf(
+			"failed to update password field in shared secret %s/%s: %w",
+			secretNamespacedName.Namespace,
+			secretNamespacedName.Name,
+			err,
+		)
 	}
 	ac.Auth.AutoPwd = password
 	return password, nil

--- a/controllers/om/automation_status.go
+++ b/controllers/om/automation_status.go
@@ -129,8 +129,14 @@ func checkAutomationStatusIsGoal(as *AutomationStatus, relevantProcesses []strin
 	}
 
 	if len(goalsNotAchievedMap) > 0 {
-		return false, fmt.Sprintf("%d processes waiting to reach automation config goal state (version=%d): %s, %d processes reached goal state: %s",
-			len(goalsNotAchievedMap), as.GoalVersion, goalsNotAchievedMsgList, len(goalsAchievedMsgList), goalsAchievedMsgList)
+		return false, fmt.Sprintf(
+			"%d processes waiting to reach automation config goal state (version=%d): %s, %d processes reached goal state: %s",
+			len(goalsNotAchievedMap),
+			as.GoalVersion,
+			goalsNotAchievedMsgList,
+			len(goalsAchievedMsgList),
+			goalsAchievedMsgList,
+		)
 	} else if len(goalsAchievedMap) == 0 {
 		return true, "there were no processes in automation config matched with the processes to wait for"
 	} else {

--- a/controllers/om/backup/backup.go
+++ b/controllers/om/backup/backup.go
@@ -73,7 +73,13 @@ type HostClusterReader interface {
 
 // StopBackupIfEnabled tries to find backup configuration for specified resource (can be Replica Set or Sharded Cluster -
 // Ops Manager doesn't backup Standalones) and disable it.
-func StopBackupIfEnabled(readUpdater ConfigHostReadUpdater, hostClusterReader HostClusterReader, name string, resourceType MongoDbResourceType, log *zap.SugaredLogger) error {
+func StopBackupIfEnabled(
+	readUpdater ConfigHostReadUpdater,
+	hostClusterReader HostClusterReader,
+	name string,
+	resourceType MongoDbResourceType,
+	log *zap.SugaredLogger,
+) error {
 	response, err := readUpdater.ReadBackupConfigs()
 	if err != nil {
 		// If the operator can't read BackupConfigs, it might indicate that the Pods were removed before establishing

--- a/controllers/om/backup/mongodbresource_backup.go
+++ b/controllers/om/backup/mongodbresource_backup.go
@@ -29,7 +29,17 @@ type ConfigReaderUpdater interface {
 
 // EnsureBackupConfigurationInOpsManager updates the backup configuration based on the MongoDB resource
 // specification.
-func EnsureBackupConfigurationInOpsManager(ctx context.Context, mdb ConfigReaderUpdater, secretsReader secrets.SecretClient, projectId string, configReadUpdater ConfigHostReadUpdater, groupConfigReader GroupConfigReader, groupConfigUpdater GroupConfigUpdater, log *zap.SugaredLogger, backupEnableDelay time.Duration) (workflow.Status, []status.Option) {
+func EnsureBackupConfigurationInOpsManager(
+	ctx context.Context,
+	mdb ConfigReaderUpdater,
+	secretsReader secrets.SecretClient,
+	projectId string,
+	configReadUpdater ConfigHostReadUpdater,
+	groupConfigReader GroupConfigReader,
+	groupConfigUpdater GroupConfigUpdater,
+	log *zap.SugaredLogger,
+	backupEnableDelay time.Duration,
+) (workflow.Status, []status.Option) {
 	if mdb.GetBackupSpec() == nil {
 		return workflow.OK(), nil
 	}
@@ -55,7 +65,13 @@ func EnsureBackupConfigurationInOpsManager(ctx context.Context, mdb ConfigReader
 	return ensureBackupConfigStatuses(mdb, projectConfigs, desiredConfig, log, configReadUpdater, backupEnableDelay)
 }
 
-func ensureGroupConfig(ctx context.Context, mdb ConfigReaderUpdater, secretsReader secrets.SecretClient, reader GroupConfigReader, updater GroupConfigUpdater) error {
+func ensureGroupConfig(
+	ctx context.Context,
+	mdb ConfigReaderUpdater,
+	secretsReader secrets.SecretClient,
+	reader GroupConfigReader,
+	updater GroupConfigUpdater,
+) error {
 	if mdb.GetBackupSpec() == nil || (mdb.GetBackupSpec().AssignmentLabels == nil && mdb.GetBackupSpec().Encryption == nil) {
 		return nil
 	}
@@ -71,7 +87,9 @@ func ensureGroupConfig(ctx context.Context, mdb ConfigReaderUpdater, secretsRead
 	requiresUpdate := false
 
 	if kmip != nil {
-		desiredPath := util.KMIPClientSecretsHome + "/" + kmip.Client.ClientCertificateSecretName(mdb.GetName()) + kmip.Client.ClientCertificateSecretKeyName()
+		desiredPath := util.KMIPClientSecretsHome + "/" + kmip.Client.ClientCertificateSecretName(
+			mdb.GetName(),
+		) + kmip.Client.ClientCertificateSecretKeyName()
 		if config.KmipClientCertPath == nil || desiredPath != *config.KmipClientCertPath {
 			config.KmipClientCertPath = &desiredPath
 			requiresUpdate = true
@@ -107,7 +125,14 @@ func ensureGroupConfig(ctx context.Context, mdb ConfigReaderUpdater, secretsRead
 }
 
 // ensureBackupConfigStatuses makes sure that every config in the project has reached the desired state.
-func ensureBackupConfigStatuses(mdb ConfigReaderUpdater, projectConfigs []*Config, desiredConfig *Config, log *zap.SugaredLogger, configReadUpdater ConfigHostReadUpdater, backupEnableDelay time.Duration) (workflow.Status, []status.Option) {
+func ensureBackupConfigStatuses(
+	mdb ConfigReaderUpdater,
+	projectConfigs []*Config,
+	desiredConfig *Config,
+	log *zap.SugaredLogger,
+	configReadUpdater ConfigHostReadUpdater,
+	backupEnableDelay time.Duration,
+) (workflow.Status, []status.Option) {
 	for _, config := range projectConfigs {
 		var result workflow.Status = workflow.OK()
 
@@ -148,7 +173,8 @@ func ensureBackupConfigStatuses(mdb ConfigReaderUpdater, projectConfigs []*Confi
 
 		intermediateStepRequired := desiredStatus != desiredConfig.Status
 		if intermediateStepRequired {
-			result = workflow.Pending("Backup configuration %s requires intermediate step to reach desired status", config.ClusterId).Requeue()
+			result = workflow.Pending("Backup configuration %s requires intermediate step to reach desired status", config.ClusterId).
+				Requeue()
 		}
 
 		desiredConfig.Status = desiredStatus
@@ -196,7 +222,9 @@ func ensureBackupConfigStatuses(mdb ConfigReaderUpdater, projectConfigs []*Confi
 			if err != nil {
 				return workflow.Failed(err), nil
 			}
-			return workflow.Pending("Backup configuration %s has not yet reached the desired status", updatedConfig.ClusterId).WithRetry(1), statusOpts
+			return workflow.Pending("Backup configuration %s has not yet reached the desired status", updatedConfig.ClusterId).
+					WithRetry(1),
+				statusOpts
 		}
 
 		log.Debugf("Backup has reached the desired state of %s", desiredConfig.Status)
@@ -246,7 +274,12 @@ func applyShardedClusterBackupEnableDelay(mdb status.Reader, backupEnableDelay t
 	return workflow.Pending(BackupEnableDelayPendingMessage)
 }
 
-func updateSnapshotSchedule(specSnapshotSchedule *mdbv1.SnapshotSchedule, configReadUpdater ConfigHostReadUpdater, config *Config, log *zap.SugaredLogger) error {
+func updateSnapshotSchedule(
+	specSnapshotSchedule *mdbv1.SnapshotSchedule,
+	configReadUpdater ConfigHostReadUpdater,
+	config *Config,
+	log *zap.SugaredLogger,
+) error {
 	if specSnapshotSchedule == nil {
 		return nil
 	}

--- a/controllers/om/backup/s3config.go
+++ b/controllers/om/backup/s3config.go
@@ -99,7 +99,14 @@ type S3Credentials struct {
 	SecretKey string `json:"awsSecretKey"`
 }
 
-func NewS3Config(opsManager *omv1.MongoDBOpsManager, s3Config omv1.S3Config, uri string, s3CustomCertificates []S3CustomCertificate, bucket S3Bucket, s3Creds *S3Credentials) S3Config {
+func NewS3Config(
+	opsManager *omv1.MongoDBOpsManager,
+	s3Config omv1.S3Config,
+	uri string,
+	s3CustomCertificates []S3CustomCertificate,
+	bucket S3Bucket,
+	s3Creds *S3Credentials,
+) S3Config {
 	authMode := IAM
 	cred := S3Credentials{}
 

--- a/controllers/om/backup/snapshot_schedule.go
+++ b/controllers/om/backup/snapshot_schedule.go
@@ -56,16 +56,46 @@ func mergeExistingScheduleWithSpec(existingSnapshotSchedule SnapshotSchedule, sp
 	snapshotSchedule := SnapshotSchedule{}
 	snapshotSchedule.ClusterID = existingSnapshotSchedule.ClusterID
 	snapshotSchedule.GroupID = existingSnapshotSchedule.GroupID
-	snapshotSchedule.ClusterCheckpointIntervalMin = pickFirstIfNotNil(specSnapshotSchedule.ClusterCheckpointIntervalMin, existingSnapshotSchedule.ClusterCheckpointIntervalMin)
-	snapshotSchedule.DailySnapshotRetentionDays = pickFirstIfNotNil(specSnapshotSchedule.DailySnapshotRetentionDays, existingSnapshotSchedule.DailySnapshotRetentionDays)
-	snapshotSchedule.FullIncrementalDayOfWeek = pickFirstIfNotNil(specSnapshotSchedule.FullIncrementalDayOfWeek, existingSnapshotSchedule.FullIncrementalDayOfWeek)
-	snapshotSchedule.MonthlySnapshotRetentionMonths = pickFirstIfNotNil(specSnapshotSchedule.MonthlySnapshotRetentionMonths, existingSnapshotSchedule.MonthlySnapshotRetentionMonths)
-	snapshotSchedule.PointInTimeWindowHours = pickFirstIfNotNil(specSnapshotSchedule.PointInTimeWindowHours, existingSnapshotSchedule.PointInTimeWindowHours)
-	snapshotSchedule.ReferenceHourOfDay = pickFirstIfNotNil(specSnapshotSchedule.ReferenceHourOfDay, existingSnapshotSchedule.ReferenceHourOfDay)
-	snapshotSchedule.ReferenceMinuteOfHour = pickFirstIfNotNil(specSnapshotSchedule.ReferenceMinuteOfHour, existingSnapshotSchedule.ReferenceMinuteOfHour)
-	snapshotSchedule.SnapshotIntervalHours = pickFirstIfNotNil(specSnapshotSchedule.SnapshotIntervalHours, existingSnapshotSchedule.SnapshotIntervalHours)
-	snapshotSchedule.SnapshotRetentionDays = pickFirstIfNotNil(specSnapshotSchedule.SnapshotRetentionDays, existingSnapshotSchedule.SnapshotRetentionDays)
-	snapshotSchedule.WeeklySnapshotRetentionWeeks = pickFirstIfNotNil(specSnapshotSchedule.WeeklySnapshotRetentionWeeks, existingSnapshotSchedule.WeeklySnapshotRetentionWeeks)
+	snapshotSchedule.ClusterCheckpointIntervalMin = pickFirstIfNotNil(
+		specSnapshotSchedule.ClusterCheckpointIntervalMin,
+		existingSnapshotSchedule.ClusterCheckpointIntervalMin,
+	)
+	snapshotSchedule.DailySnapshotRetentionDays = pickFirstIfNotNil(
+		specSnapshotSchedule.DailySnapshotRetentionDays,
+		existingSnapshotSchedule.DailySnapshotRetentionDays,
+	)
+	snapshotSchedule.FullIncrementalDayOfWeek = pickFirstIfNotNil(
+		specSnapshotSchedule.FullIncrementalDayOfWeek,
+		existingSnapshotSchedule.FullIncrementalDayOfWeek,
+	)
+	snapshotSchedule.MonthlySnapshotRetentionMonths = pickFirstIfNotNil(
+		specSnapshotSchedule.MonthlySnapshotRetentionMonths,
+		existingSnapshotSchedule.MonthlySnapshotRetentionMonths,
+	)
+	snapshotSchedule.PointInTimeWindowHours = pickFirstIfNotNil(
+		specSnapshotSchedule.PointInTimeWindowHours,
+		existingSnapshotSchedule.PointInTimeWindowHours,
+	)
+	snapshotSchedule.ReferenceHourOfDay = pickFirstIfNotNil(
+		specSnapshotSchedule.ReferenceHourOfDay,
+		existingSnapshotSchedule.ReferenceHourOfDay,
+	)
+	snapshotSchedule.ReferenceMinuteOfHour = pickFirstIfNotNil(
+		specSnapshotSchedule.ReferenceMinuteOfHour,
+		existingSnapshotSchedule.ReferenceMinuteOfHour,
+	)
+	snapshotSchedule.SnapshotIntervalHours = pickFirstIfNotNil(
+		specSnapshotSchedule.SnapshotIntervalHours,
+		existingSnapshotSchedule.SnapshotIntervalHours,
+	)
+	snapshotSchedule.SnapshotRetentionDays = pickFirstIfNotNil(
+		specSnapshotSchedule.SnapshotRetentionDays,
+		existingSnapshotSchedule.SnapshotRetentionDays,
+	)
+	snapshotSchedule.WeeklySnapshotRetentionWeeks = pickFirstIfNotNil(
+		specSnapshotSchedule.WeeklySnapshotRetentionWeeks,
+		existingSnapshotSchedule.WeeklySnapshotRetentionWeeks,
+	)
 
 	return snapshotSchedule
 }

--- a/controllers/om/deployment.go
+++ b/controllers/om/deployment.go
@@ -143,7 +143,11 @@ func (d Deployment) MergeStandalone(standaloneMongo Process, specArgs26, prevArg
 
 // MergeReplicaSet merges the "operator" replica set and its members to the "OM" deployment ("d"). If "alien" RS members are
 // removed after merge - corresponding processes are removed as well.
-func (d Deployment) MergeReplicaSet(operatorRs ReplicaSetWithProcesses, specArgs26, prevArgs26 map[string]interface{}, l *zap.SugaredLogger) {
+func (d Deployment) MergeReplicaSet(
+	operatorRs ReplicaSetWithProcesses,
+	specArgs26, prevArgs26 map[string]interface{},
+	l *zap.SugaredLogger,
+) {
 	log := l.With("replicaSet", operatorRs.Rs.Name())
 
 	r := d.getReplicaSetByName(operatorRs.Rs.Name())
@@ -442,7 +446,11 @@ func (d Deployment) GetProcessNames(kind interface{}, name string) []string {
 
 // ConfigureInternalClusterAuthentication configures all processes in processNames to have the corresponding
 // clusterAuthenticationMode enabled
-func (d Deployment) ConfigureInternalClusterAuthentication(processNames []string, clusterAuthenticationMode string, internalClusterPath string) {
+func (d Deployment) ConfigureInternalClusterAuthentication(
+	processNames []string,
+	clusterAuthenticationMode string,
+	internalClusterPath string,
+) {
 	for _, p := range processNames {
 		if process := d.getProcessByName(p); process != nil {
 			process.ConfigureClusterAuthMode(clusterAuthenticationMode, internalClusterPath)
@@ -467,7 +475,12 @@ func (d Deployment) GetInternalClusterFilePath(processNames []string) string {
 }
 
 // SetInternalClusterFilePathOnlyIfItThePathHasChanged sets the internal cluster path for the given process names only if it has changed and has been set before.
-func (d Deployment) SetInternalClusterFilePathOnlyIfItThePathHasChanged(names []string, filePath string, clusterAuth string, isRecovering bool) {
+func (d Deployment) SetInternalClusterFilePathOnlyIfItThePathHasChanged(
+	names []string,
+	filePath string,
+	clusterAuth string,
+	isRecovering bool,
+) {
 	if currPath := d.GetInternalClusterFilePath(names); isRecovering || currPath != filePath && currPath != "" {
 		d.ConfigureInternalClusterAuthentication(names, clusterAuth, filePath)
 	}
@@ -748,7 +761,8 @@ func (d Deployment) mergeMongosProcesses(opts DeploymentShardedClusterMergeOptio
 		}
 	}
 	// Making sure changes to existing mongos processes are propagated to new ones
-	if cntMongosProcesses := len(d.getMongosProcessesNames(opts.Name)); cntMongosProcesses > 0 && cntMongosProcesses < len(opts.MongosProcesses) {
+	if cntMongosProcesses := len(d.getMongosProcessesNames(opts.Name)); cntMongosProcesses > 0 &&
+		cntMongosProcesses < len(opts.MongosProcesses) {
 		if err := d.copyFirstProcessToNewPositions(opts.MongosProcesses, cntMongosProcesses, log); err != nil {
 			// I guess this error is not so serious to fail the whole process - mongoses will be scaled up anyway
 			log.Error("Failed to copy first mongos process (so new mongos processes may miss Ops Manager changes done to "+

--- a/controllers/om/deployment/testing_utils.go
+++ b/controllers/om/deployment/testing_utils.go
@@ -33,7 +33,15 @@ func CreateFromReplicaSet(mongoDBImage string, forceEnterprise bool, rs *mdb.Mon
 	}
 
 	d.MergeReplicaSet(
-		replicaset.BuildFromStatefulSet(mongoDBImage, forceEnterprise, sts, rs.GetSpec(), rs.Status.FeatureCompatibilityVersion, "", architectures.NonStatic),
+		replicaset.BuildFromStatefulSet(
+			mongoDBImage,
+			forceEnterprise,
+			sts,
+			rs.GetSpec(),
+			rs.Status.FeatureCompatibilityVersion,
+			"",
+			architectures.NonStatic,
+		),
 		rs.Spec.AdditionalMongodConfig.ToMap(),
 		lastConfig.ToMap(),
 		zap.S(),

--- a/controllers/om/deployment_test.go
+++ b/controllers/om/deployment_test.go
@@ -63,7 +63,18 @@ func TestMergeReplicaSet(t *testing.T) {
 
 	// Now the deployment "gets updated" from external - new node is added and one is removed - this should be fixed
 	// by merge
-	newProcess := NewMongodProcess("foo", "bar", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, &mdbv1.NewStandaloneBuilder().Build().Spec, "", nil, "", architectures.NonStatic)
+	newProcess := NewMongodProcess(
+		"foo",
+		"bar",
+		"fake-mongoDBImage",
+		false,
+		&mdbv1.AdditionalMongodConfig{},
+		&mdbv1.NewStandaloneBuilder().Build().Spec,
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	d.getProcesses()[0]["processType"] = ProcessTypeMongos                            // this will be overriden
 	d.getProcesses()[1].EnsureNetConfig()["MaxIncomingConnections"] = 20              // this will be left as-is
@@ -522,9 +533,21 @@ func TestConfigureMonitoringTls(t *testing.T) {
 	}
 
 	expectedMonitoringVersions := []interface{}{
-		map[string]interface{}{"hostname": "my-rs-0.some.host", "name": MonitoringAgentDefaultVersion, "additionalParams": expectedAdditionalParams},
-		map[string]interface{}{"hostname": "my-rs-1.some.host", "name": MonitoringAgentDefaultVersion, "additionalParams": expectedAdditionalParams},
-		map[string]interface{}{"hostname": "my-rs-2.some.host", "name": MonitoringAgentDefaultVersion, "additionalParams": expectedAdditionalParams},
+		map[string]interface{}{
+			"hostname":         "my-rs-0.some.host",
+			"name":             MonitoringAgentDefaultVersion,
+			"additionalParams": expectedAdditionalParams,
+		},
+		map[string]interface{}{
+			"hostname":         "my-rs-1.some.host",
+			"name":             MonitoringAgentDefaultVersion,
+			"additionalParams": expectedAdditionalParams,
+		},
+		map[string]interface{}{
+			"hostname":         "my-rs-2.some.host",
+			"name":             MonitoringAgentDefaultVersion,
+			"additionalParams": expectedAdditionalParams,
+		},
 	}
 	assert.Equal(t, expectedMonitoringVersions, d.getMonitoringVersions())
 
@@ -546,9 +569,21 @@ func TestConfigureMonitoringTLSDisable(t *testing.T) {
 		"sslTrustedServerCertificates": util.CAFilePathInContainer,
 	}
 	expectedMonitoringVersionsWithTls := []interface{}{
-		map[string]interface{}{"hostname": "my-rs-0.some.host", "name": MonitoringAgentDefaultVersion, "additionalParams": expectedAdditionalParams},
-		map[string]interface{}{"hostname": "my-rs-1.some.host", "name": MonitoringAgentDefaultVersion, "additionalParams": expectedAdditionalParams},
-		map[string]interface{}{"hostname": "my-rs-2.some.host", "name": MonitoringAgentDefaultVersion, "additionalParams": expectedAdditionalParams},
+		map[string]interface{}{
+			"hostname":         "my-rs-0.some.host",
+			"name":             MonitoringAgentDefaultVersion,
+			"additionalParams": expectedAdditionalParams,
+		},
+		map[string]interface{}{
+			"hostname":         "my-rs-1.some.host",
+			"name":             MonitoringAgentDefaultVersion,
+			"additionalParams": expectedAdditionalParams,
+		},
+		map[string]interface{}{
+			"hostname":         "my-rs-2.some.host",
+			"name":             MonitoringAgentDefaultVersion,
+			"additionalParams": expectedAdditionalParams,
+		},
 	}
 	assert.Equal(t, expectedMonitoringVersionsWithTls, d.getMonitoringVersions())
 
@@ -644,7 +679,13 @@ func checkReplicaSetCheckExtraProcesses(t *testing.T, d Deployment, expectedRs R
 	}
 	assert.Equalf(t, len(expectedRs.Processes), found, "Not all  %s replicaSet processes are found!", expectedRs.Rs.Name())
 	if checkExtraProcesses {
-		assert.Equalf(t, len(expectedRs.Processes), totalMongods, "Some excessive mongod processes are found for %s replicaSet!", expectedRs.Rs.Name())
+		assert.Equalf(
+			t,
+			len(expectedRs.Processes),
+			totalMongods,
+			"Some excessive mongod processes are found for %s replicaSet!",
+			expectedRs.Rs.Name(),
+		)
 	}
 }
 
@@ -684,7 +725,13 @@ func checkMongoSProcesses(t *testing.T, allProcesses []Process, expectedMongosPr
 	assert.Equal(t, len(expectedMongosProcesses), totalMongoses, "Some excessive mongos processes are found!")
 }
 
-func checkShardedClusterRemoved(t *testing.T, d Deployment, sc ShardedCluster, configRs ReplicaSetWithProcesses, shards []ReplicaSetWithProcesses) {
+func checkShardedClusterRemoved(
+	t *testing.T,
+	d Deployment,
+	sc ShardedCluster,
+	configRs ReplicaSetWithProcesses,
+	shards []ReplicaSetWithProcesses,
+) {
 	assert.Nil(t, d.getShardedClusterByName(sc.Name()))
 
 	checkReplicaSetRemoved(t, d, configRs)
@@ -757,7 +804,18 @@ func buildRsByProcesses(rsName string, processes []Process) ReplicaSetWithProces
 }
 
 func createStandalone() Process {
-	return NewMongodProcess("merchantsStandalone", "mongo1.some.host", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, defaultMongoDBVersioned("3.6.3"), "", nil, "", architectures.NonStatic)
+	return NewMongodProcess(
+		"merchantsStandalone",
+		"mongo1.some.host",
+		"fake-mongoDBImage",
+		false,
+		&mdbv1.AdditionalMongodConfig{},
+		defaultMongoDBVersioned("3.6.3"),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 }
 
 func createMongosProcesses(num int, name, clusterName string) []Process {
@@ -765,7 +823,18 @@ func createMongosProcesses(num int, name, clusterName string) []Process {
 
 	for i := 0; i < num; i++ {
 		idx := strconv.Itoa(i)
-		mongosProcesses[i] = NewMongosProcess(name+idx, "mongoS"+idx+".some.host", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, defaultMongoDBVersioned("3.6.3"), "", nil, "", architectures.NonStatic)
+		mongosProcesses[i] = NewMongosProcess(
+			name+idx,
+			"mongoS"+idx+".some.host",
+			"fake-mongoDBImage",
+			false,
+			&mdbv1.AdditionalMongodConfig{},
+			defaultMongoDBVersioned("3.6.3"),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		)
 		if clusterName != "" {
 			mongosProcesses[i].setCluster(clusterName)
 		}
@@ -781,7 +850,18 @@ func createReplicaSetProcessesCount(count int, rsName string) []Process {
 	rsMembers := make([]Process, count)
 
 	for i := 0; i < count; i++ {
-		rsMembers[i] = NewMongodProcess(fmt.Sprintf("%s-%d", rsName, i), fmt.Sprintf("%s-%d.some.host", rsName, i), "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, defaultMongoDBVersioned("3.6.3"), "", nil, "", architectures.NonStatic)
+		rsMembers[i] = NewMongodProcess(
+			fmt.Sprintf("%s-%d", rsName, i),
+			fmt.Sprintf("%s-%d.some.host", rsName, i),
+			"fake-mongoDBImage",
+			false,
+			&mdbv1.AdditionalMongodConfig{},
+			defaultMongoDBVersioned("3.6.3"),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		)
 		// Note that we don't specify the replicaset config for process
 	}
 	return rsMembers
@@ -791,7 +871,18 @@ func createReplicaSetProcessesCountEnt(count int, rsName string) []Process {
 	rsMembers := make([]Process, count)
 
 	for i := 0; i < count; i++ {
-		rsMembers[i] = NewMongodProcess(fmt.Sprintf("%s-%d", rsName, i), fmt.Sprintf("%s-%d.some.host", rsName, i), "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, defaultMongoDBVersioned("3.6.3-ent"), "", nil, "", architectures.NonStatic)
+		rsMembers[i] = NewMongodProcess(
+			fmt.Sprintf("%s-%d", rsName, i),
+			fmt.Sprintf("%s-%d.some.host", rsName, i),
+			"fake-mongoDBImage",
+			false,
+			&mdbv1.AdditionalMongodConfig{},
+			defaultMongoDBVersioned("3.6.3-ent"),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		)
 		// Note that we don't specify the replicaset config for process
 	}
 	return rsMembers

--- a/controllers/om/depshardedcluster_test.go
+++ b/controllers/om/depshardedcluster_test.go
@@ -110,7 +110,20 @@ func TestMergeShardedCluster_ReplicaSetsModified(t *testing.T) {
 	// These OM changes must be overriden
 	(*d.getReplicaSetByName("cluster-0"))["protocolVersion"] = util.Int32Ref(2)
 	(*d.getReplicaSetByName("configSrv")).addMember(
-		NewMongodProcess("foo", "bar", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, mdbv1.NewStandaloneBuilder().Build().GetSpec(), "", nil, "", architectures.NonStatic), "", automationconfig.MemberOptions{},
+		NewMongodProcess(
+			"foo",
+			"bar",
+			"fake-mongoDBImage",
+			false,
+			&mdbv1.AdditionalMongodConfig{},
+			mdbv1.NewStandaloneBuilder().Build().GetSpec(),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		),
+		"",
+		automationconfig.MemberOptions{},
 	)
 	(*d.getReplicaSetByName("cluster-2")).setMembers(d.getReplicaSetByName("cluster-2").Members()[0:2])
 
@@ -527,5 +540,11 @@ func TestRemoveShardedClusterByName(t *testing.T) {
 
 	// Then check that the sharded cluster and all replica sets were removed
 	shards2 := createShards("otherShard")
-	checkShardedClusterRemoved(t, d, NewShardedCluster("otherCluster", configRs2.Rs.Name(), shards2), createConfigSrvRs("otherConfigSrv", false), shards2)
+	checkShardedClusterRemoved(
+		t,
+		d,
+		NewShardedCluster("otherCluster", configRs2.Rs.Name(), shards2),
+		createConfigSrvRs("otherConfigSrv", false),
+		shards2,
+	)
 }

--- a/controllers/om/fullreplicaset.go
+++ b/controllers/om/fullreplicaset.go
@@ -50,7 +50,13 @@ func determineNextProcessIdStartingPoint(desiredProcesses []Process, existingPro
 // NewMultiClusterReplicaSetWithProcesses Creates processes for a multi cluster deployment.
 // This function ensures that new processes which are added never have an overlapping _id with any existing process.
 // existing _ids are re-used, and when new processes are added, a new higher number is used.
-func NewMultiClusterReplicaSetWithProcesses(rs ReplicaSet, processes []Process, memberOptions []automationconfig.MemberOptions, existingProcessIds map[string]int, connectivity *mdbv1.MongoDBConnectivity) ReplicaSetWithProcesses {
+func NewMultiClusterReplicaSetWithProcesses(
+	rs ReplicaSet,
+	processes []Process,
+	memberOptions []automationconfig.MemberOptions,
+	existingProcessIds map[string]int,
+	connectivity *mdbv1.MongoDBConnectivity,
+) ReplicaSetWithProcesses {
 	newId := determineNextProcessIdStartingPoint(processes, existingProcessIds)
 	rs.clearMembers()
 	for idx, p := range processes {

--- a/controllers/om/fullreplicaset_test.go
+++ b/controllers/om/fullreplicaset_test.go
@@ -275,7 +275,13 @@ func TestNewMultiClusterReplicaSetWithProcesses(t *testing.T) {
 			if existingProcessIds == nil {
 				existingProcessIds = map[string]int{}
 			}
-			actual := NewMultiClusterReplicaSetWithProcesses(NewReplicaSet("mdb-multi", "5.0.5"), tt.processes, tt.memberOptions, existingProcessIds, nil)
+			actual := NewMultiClusterReplicaSetWithProcesses(
+				NewReplicaSet("mdb-multi", "5.0.5"),
+				tt.processes,
+				tt.memberOptions,
+				existingProcessIds,
+				nil,
+			)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/controllers/om/mockedomclient.go
+++ b/controllers/om/mockedomclient.go
@@ -561,7 +561,10 @@ func (oc *MockedOmConnection) ReadProjectsInOrganization(orgID string, page int)
 	if err != nil {
 		return nil, err
 	}
-	response := &ProjectsResponse{Groups: oc.OrganizationsWithGroups[org], OMPaginated: OMPaginated{TotalCount: len(oc.OrganizationsWithGroups[org])}}
+	response := &ProjectsResponse{
+		Groups:      oc.OrganizationsWithGroups[org],
+		OMPaginated: OMPaginated{TotalCount: len(oc.OrganizationsWithGroups[org])},
+	}
 	return response, nil
 }
 

--- a/controllers/om/omclient.go
+++ b/controllers/om/omclient.go
@@ -205,8 +205,11 @@ func (oc *HTTPOmConnection) ReadUpdateAgentsLogRotation(logRotateSetting mdbv1.A
 		}
 
 		// We only support process configuration for OM larger than 7.0.4 or 6.0.24
-		if !oc.OpsManagerVersion().IsCloudManager() && !omVersion.GTE(semver.MustParse("7.0.4")) && !omVersion.GTE(semver.MustParse("6.0.24")) {
-			return xerrors.Errorf("configuring log rotation for mongod processes is supported only with Cloud Manager or Ops Manager with versions >= 7.0.4 or >= 6.0.24")
+		if !oc.OpsManagerVersion().IsCloudManager() && !omVersion.GTE(semver.MustParse("7.0.4")) &&
+			!omVersion.GTE(semver.MustParse("6.0.24")) {
+			return xerrors.Errorf(
+				"configuring log rotation for mongod processes is supported only with Cloud Manager or Ops Manager with versions >= 7.0.4 or >= 6.0.24",
+			)
 		}
 
 		// We only retrieve the first process, since logRotation is configured the same for all processes
@@ -236,7 +239,11 @@ func (oc *HTTPOmConnection) ReadUpdateAgentsLogRotation(logRotateSetting mdbv1.A
 	return err
 }
 
-func updateProcessLogRotateIfChanged(logRotateSettingFromCRD *automationconfig.CrdLogRotate, logRotationSettingFromWire map[string]interface{}, updateLogRotationSetting func(logRotateSetting automationconfig.AcLogRotate) ([]byte, error)) error {
+func updateProcessLogRotateIfChanged(
+	logRotateSettingFromCRD *automationconfig.CrdLogRotate,
+	logRotationSettingFromWire map[string]interface{},
+	updateLogRotationSetting func(logRotateSetting automationconfig.AcLogRotate) ([]byte, error),
+) error {
 	logRotationToSetInAC := automationconfig.ConvertCrdLogRotateToAC(logRotateSettingFromCRD)
 	if logRotationToSetInAC == nil {
 		return nil
@@ -798,7 +805,10 @@ func (oc *HTTPOmConnection) UpdateMonitoringAgentConfig(mat *MonitoringAgentConf
 	return nil, nil
 }
 
-func (oc *HTTPOmConnection) ReadUpdateMonitoringAgentConfig(modifyMonitoringAgentFunction func(*MonitoringAgentConfig) error, log *zap.SugaredLogger) error {
+func (oc *HTTPOmConnection) ReadUpdateMonitoringAgentConfig(
+	modifyMonitoringAgentFunction func(*MonitoringAgentConfig) error,
+	log *zap.SugaredLogger,
+) error {
 	if log == nil {
 		log = zap.S()
 	}

--- a/controllers/om/process.go
+++ b/controllers/om/process.go
@@ -93,13 +93,27 @@ func NewProcessFromInterface(i interface{}) Process {
 	return i.(map[string]interface{})
 }
 
-func NewMongosProcess(name, hostName, mongoDBImage string, forceEnterprise bool, additionalMongodConfig *mdbv1.AdditionalMongodConfig, spec mdbv1.DbSpec, certificateFilePath string, annotations map[string]string, fcv string, defaultArchitecture architectures.DefaultArchitecture) Process {
+func NewMongosProcess(
+	name, hostName, mongoDBImage string,
+	forceEnterprise bool,
+	additionalMongodConfig *mdbv1.AdditionalMongodConfig,
+	spec mdbv1.DbSpec,
+	certificateFilePath string,
+	annotations map[string]string,
+	fcv string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) Process {
 	if additionalMongodConfig == nil {
 		additionalMongodConfig = mdbv1.NewEmptyAdditionalMongodConfig()
 	}
 
 	architecture := architectures.GetArchitecture(annotations, defaultArchitecture)
-	processVersion := architectures.GetMongoVersionForAutomationConfig(mongoDBImage, spec.GetMongoDBVersion(), forceEnterprise, architecture)
+	processVersion := architectures.GetMongoVersionForAutomationConfig(
+		mongoDBImage,
+		spec.GetMongoDBVersion(),
+		forceEnterprise,
+		architecture,
+	)
 	p := createProcess(
 		WithName(name),
 		WithHostname(hostName),
@@ -119,13 +133,27 @@ func NewMongosProcess(name, hostName, mongoDBImage string, forceEnterprise bool,
 	return p
 }
 
-func NewMongodProcess(name, hostName, mongoDBImage string, forceEnterprise bool, additionalConfig *mdbv1.AdditionalMongodConfig, spec mdbv1.DbSpec, certificateFilePath string, annotations map[string]string, fcv string, defaultArchitecture architectures.DefaultArchitecture) Process {
+func NewMongodProcess(
+	name, hostName, mongoDBImage string,
+	forceEnterprise bool,
+	additionalConfig *mdbv1.AdditionalMongodConfig,
+	spec mdbv1.DbSpec,
+	certificateFilePath string,
+	annotations map[string]string,
+	fcv string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) Process {
 	if additionalConfig == nil {
 		additionalConfig = mdbv1.NewEmptyAdditionalMongodConfig()
 	}
 
 	architecture := architectures.GetArchitecture(annotations, defaultArchitecture)
-	processVersion := architectures.GetMongoVersionForAutomationConfig(mongoDBImage, spec.GetMongoDBVersion(), forceEnterprise, architecture)
+	processVersion := architectures.GetMongoVersionForAutomationConfig(
+		mongoDBImage,
+		spec.GetMongoDBVersion(),
+		forceEnterprise,
+		architecture,
+	)
 	p := createProcess(
 		WithName(name),
 		WithHostname(hostName),

--- a/controllers/om/process/om_process.go
+++ b/controllers/om/process/om_process.go
@@ -12,31 +12,83 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
 )
 
-func CreateMongodProcessesWithLimit(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, dbSpec mdbv1.DbSpec, limit int, fcv string, tlsCertPath string, defaultArchitecture architectures.DefaultArchitecture) []om.Process {
+func CreateMongodProcessesWithLimit(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	dbSpec mdbv1.DbSpec,
+	limit int,
+	fcv string,
+	tlsCertPath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) []om.Process {
 	hostnames, names := dns.GetDnsForStatefulSetReplicasSpecified(set, dbSpec.GetClusterDomain(), limit, dbSpec.GetExternalDomain())
 	processes := make([]om.Process, len(hostnames))
 
 	for idx, hostname := range hostnames {
-		processes[idx] = om.NewMongodProcess(names[idx], hostname, mongoDBImage, forceEnterprise, dbSpec.GetAdditionalMongodConfig(), dbSpec, tlsCertPath, set.Annotations, fcv, defaultArchitecture)
+		processes[idx] = om.NewMongodProcess(
+			names[idx],
+			hostname,
+			mongoDBImage,
+			forceEnterprise,
+			dbSpec.GetAdditionalMongodConfig(),
+			dbSpec,
+			tlsCertPath,
+			set.Annotations,
+			fcv,
+			defaultArchitecture,
+		)
 	}
 
 	return processes
 }
 
 // CreateMongodProcessesFromMongoDB creates mongod processes directly from MongoDB resource without StatefulSet
-func CreateMongodProcessesFromMongoDB(mongoDBImage string, forceEnterprise bool, mdb *mdbv1.MongoDB, limit int, fcv string, tlsCertPath string, defaultArchitecture architectures.DefaultArchitecture) []om.Process {
-	hostnames, names := dns.GetDNSNames(mdb.Name, mdb.ServiceName(), mdb.Namespace, mdb.Spec.GetClusterDomain(), limit, mdb.Spec.DbCommonSpec.GetExternalDomain())
+func CreateMongodProcessesFromMongoDB(
+	mongoDBImage string,
+	forceEnterprise bool,
+	mdb *mdbv1.MongoDB,
+	limit int,
+	fcv string,
+	tlsCertPath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) []om.Process {
+	hostnames, names := dns.GetDNSNames(
+		mdb.Name,
+		mdb.ServiceName(),
+		mdb.Namespace,
+		mdb.Spec.GetClusterDomain(),
+		limit,
+		mdb.Spec.DbCommonSpec.GetExternalDomain(),
+	)
 	processes := make([]om.Process, len(hostnames))
 
 	for idx, hostname := range hostnames {
-		processes[idx] = om.NewMongodProcess(names[idx], hostname, mongoDBImage, forceEnterprise, mdb.Spec.GetAdditionalMongodConfig(), &mdb.Spec, tlsCertPath, mdb.Annotations, fcv, defaultArchitecture)
+		processes[idx] = om.NewMongodProcess(
+			names[idx],
+			hostname,
+			mongoDBImage,
+			forceEnterprise,
+			mdb.Spec.GetAdditionalMongodConfig(),
+			&mdb.Spec,
+			tlsCertPath,
+			mdb.Annotations,
+			fcv,
+			defaultArchitecture,
+		)
 	}
 
 	return processes
 }
 
 // CreateMongodProcessesWithLimitMulti creates the process array for automationConfig based on MultiCluster CR spec
-func CreateMongodProcessesWithLimitMulti(mongoDBImage string, forceEnterprise bool, mrs mdbmultiv1.MongoDBMultiCluster, certFileName string, defaultArchitecture architectures.DefaultArchitecture) ([]om.Process, error) {
+func CreateMongodProcessesWithLimitMulti(
+	mongoDBImage string,
+	forceEnterprise bool,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+	certFileName string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) ([]om.Process, error) {
 	hostnames := make([]string, 0)
 	clusterNums := make([]int, 0)
 	podNum := make([]int, 0)
@@ -46,7 +98,14 @@ func CreateMongodProcessesWithLimitMulti(mongoDBImage string, forceEnterprise bo
 	}
 
 	for _, spec := range clusterSpecList {
-		agentHostNames := dns.GetMultiClusterProcessHostnames(mrs.Name, mrs.Namespace, mrs.ClusterNum(spec.ClusterName), spec.Members, mrs.Spec.GetClusterDomain(), mrs.Spec.GetExternalDomainForMemberCluster(spec.ClusterName))
+		agentHostNames := dns.GetMultiClusterProcessHostnames(
+			mrs.Name,
+			mrs.Namespace,
+			mrs.ClusterNum(spec.ClusterName),
+			spec.Members,
+			mrs.Spec.GetClusterDomain(),
+			mrs.Spec.GetExternalDomainForMemberCluster(spec.ClusterName),
+		)
 		hostnames = append(hostnames, agentHostNames...)
 		for i := 0; i < len(agentHostNames); i++ {
 			clusterNums = append(clusterNums, mrs.ClusterNum(spec.ClusterName))
@@ -56,7 +115,18 @@ func CreateMongodProcessesWithLimitMulti(mongoDBImage string, forceEnterprise bo
 
 	processes := make([]om.Process, len(hostnames))
 	for idx := range hostnames {
-		processes[idx] = om.NewMongodProcess(fmt.Sprintf("%s-%d-%d", mrs.Name, clusterNums[idx], podNum[idx]), hostnames[idx], mongoDBImage, forceEnterprise, mrs.Spec.GetAdditionalMongodConfig(), &mrs.Spec, certFileName, mrs.Annotations, mrs.CalculateFeatureCompatibilityVersion(), defaultArchitecture)
+		processes[idx] = om.NewMongodProcess(
+			fmt.Sprintf("%s-%d-%d", mrs.Name, clusterNums[idx], podNum[idx]),
+			hostnames[idx],
+			mongoDBImage,
+			forceEnterprise,
+			mrs.Spec.GetAdditionalMongodConfig(),
+			&mrs.Spec,
+			certFileName,
+			mrs.Annotations,
+			mrs.CalculateFeatureCompatibilityVersion(),
+			defaultArchitecture,
+		)
 	}
 
 	return processes, nil

--- a/controllers/om/process_test.go
+++ b/controllers/om/process_test.go
@@ -17,7 +17,18 @@ func TestCreateMongodProcess(t *testing.T) {
 	mongoDBImage := "mongodb/mongodb-enterprise-server"
 	t.Run("Create AgentLoggingMongodConfig", func(t *testing.T) {
 		spec := defaultMongoDBVersioned("4.0.5")
-		process := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", mongoDBImage, false, spec.GetAdditionalMongodConfig(), spec, "", nil, "4.0", architectures.NonStatic)
+		process := NewMongodProcess(
+			"trinity",
+			"trinity-0.trinity-svc.svc.cluster.local",
+			mongoDBImage,
+			false,
+			spec.GetAdditionalMongodConfig(),
+			spec,
+			"",
+			nil,
+			"4.0",
+			architectures.NonStatic,
+		)
 
 		assert.Equal(t, "trinity", process.Name())
 		assert.Equal(t, "trinity-0.trinity-svc.svc.cluster.local", process.HostName())
@@ -40,7 +51,18 @@ func TestCreateMongodProcess(t *testing.T) {
 			AddOption("storage.dbPath", "/some/other/data") // this will be overridden
 		rs := mdbv1.NewReplicaSetBuilder().SetAdditionalConfig(config).Build()
 
-		process := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", mongoDBImage, false, rs.Spec.AdditionalMongodConfig, rs.GetSpec(), "", nil, "", architectures.NonStatic)
+		process := NewMongodProcess(
+			"trinity",
+			"trinity-0.trinity-svc.svc.cluster.local",
+			mongoDBImage,
+			false,
+			rs.Spec.AdditionalMongodConfig,
+			rs.GetSpec(),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		)
 
 		assert.Equal(t, "inMemory", maputil.ReadMapValueAsInterface(process.Args(), "storage", "engine"))
 		assert.Equal(t, 500, maputil.ReadMapValueAsInterface(process.Args(), "setParameter", "connPoolMaxConnsPerHost"))
@@ -52,7 +74,18 @@ func TestCreateMongodProcessStatic(t *testing.T) {
 	mongoDBImage := "mongodb/mongodb-enterprise-server"
 	t.Run("Create AgentLoggingMongodConfig", func(t *testing.T) {
 		spec := defaultMongoDBVersioned("4.0.5")
-		process := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", mongoDBImage, false, spec.GetAdditionalMongodConfig(), spec, "", map[string]string{}, "4.0", architectures.Static)
+		process := NewMongodProcess(
+			"trinity",
+			"trinity-0.trinity-svc.svc.cluster.local",
+			mongoDBImage,
+			false,
+			spec.GetAdditionalMongodConfig(),
+			spec,
+			"",
+			map[string]string{},
+			"4.0",
+			architectures.Static,
+		)
 
 		assert.Equal(t, "trinity", process.Name())
 		assert.Equal(t, "trinity-0.trinity-svc.svc.cluster.local", process.HostName())
@@ -74,7 +107,18 @@ func TestCreateMongodProcessStatic(t *testing.T) {
 			AddOption("storage.dbPath", "/some/other/data") // this will be overridden
 		rs := mdbv1.NewReplicaSetBuilder().SetAdditionalConfig(config).Build()
 
-		process := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", mongoDBImage, false, rs.Spec.AdditionalMongodConfig, rs.GetSpec(), "", nil, "", architectures.Static)
+		process := NewMongodProcess(
+			"trinity",
+			"trinity-0.trinity-svc.svc.cluster.local",
+			mongoDBImage,
+			false,
+			rs.Spec.AdditionalMongodConfig,
+			rs.GetSpec(),
+			"",
+			nil,
+			"",
+			architectures.Static,
+		)
 
 		assert.Equal(t, "inMemory", maputil.ReadMapValueAsInterface(process.Args(), "storage", "engine"))
 		assert.Equal(t, 500, maputil.ReadMapValueAsInterface(process.Args(), "setParameter", "connPoolMaxConnsPerHost"))
@@ -150,7 +194,18 @@ func TestConfigureX509_Process(t *testing.T) {
 			},
 		},
 	}
-	process := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, mdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	process := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		&mdbv1.AdditionalMongodConfig{},
+		mdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	process.ConfigureClusterAuthMode("", "") // should not update fields
 	assert.NotContains(t, process.security(), "clusterAuthMode")
@@ -165,13 +220,35 @@ func TestCreateMongodProcess_SSL(t *testing.T) {
 	additionalConfig := mdbv1.NewAdditionalMongodConfig("net.ssl.mode", string(tls.Prefer))
 
 	mdb := mdbv1.NewStandaloneBuilder().SetVersion("3.6.4").SetFCVersion("3.6").SetAdditionalConfig(additionalConfig).Build()
-	process := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, additionalConfig, mdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	process := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		additionalConfig,
+		mdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 	assert.Equal(t, map[string]interface{}{"mode": string(tls.Disabled)}, process.TLSConfig())
 
 	mdb = mdbv1.NewStandaloneBuilder().SetVersion("3.6.4").SetFCVersion("3.6").SetAdditionalConfig(additionalConfig).
 		SetSecurityTLSEnabled().Build()
 
-	process = NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, additionalConfig, mdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	process = NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		additionalConfig,
+		mdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	assert.Equal(t, map[string]interface{}{
 		"mode":               string(tls.Prefer),
@@ -183,9 +260,24 @@ func TestCreateMongosProcess_SSL(t *testing.T) {
 	additionalConfig := mdbv1.NewAdditionalMongodConfig("net.ssl.mode", string(tls.Allow))
 	mdb := mdbv1.NewStandaloneBuilder().SetVersion("3.6.4").SetFCVersion("3.6").SetAdditionalConfig(additionalConfig).
 		SetSecurityTLSEnabled().Build()
-	process := NewMongosProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, additionalConfig, mdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	process := NewMongosProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		additionalConfig,
+		mdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
-	assert.Equal(t, map[string]interface{}{"mode": string(tls.Allow), "certificateKeyFile": "/mongodb-automation/server.pem"}, process.TLSConfig())
+	assert.Equal(
+		t,
+		map[string]interface{}{"mode": string(tls.Allow), "certificateKeyFile": "/mongodb-automation/server.pem"},
+		process.TLSConfig(),
+	)
 }
 
 func TestCreateMongodMongosProcess_TLSModeForDifferentSpecs(t *testing.T) {
@@ -206,14 +298,66 @@ func TestCreateMongodMongosProcess_TLSModeForDifferentSpecs(t *testing.T) {
 	additionalConfig := mdbv1.NewAdditionalMongodConfig("net.tls.mode", string(tls.Allow))
 
 	// standalone spec
-	assertTLSConfig(NewMongodProcess(name, host, "fake-mongoDBImage", false, additionalConfig, getSpec(mdbv1.NewStandaloneBuilder()), "", nil, "", architectures.NonStatic))
+	assertTLSConfig(
+		NewMongodProcess(
+			name,
+			host,
+			"fake-mongoDBImage",
+			false,
+			additionalConfig,
+			getSpec(mdbv1.NewStandaloneBuilder()),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		),
+	)
 
 	// replica set spec
-	assertTLSConfig(NewMongodProcess(name, host, "fake-mongoDBImage", false, additionalConfig, getSpec(mdbv1.NewReplicaSetBuilder()), "", nil, "", architectures.NonStatic))
+	assertTLSConfig(
+		NewMongodProcess(
+			name,
+			host,
+			"fake-mongoDBImage",
+			false,
+			additionalConfig,
+			getSpec(mdbv1.NewReplicaSetBuilder()),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		),
+	)
 
 	// sharded cluster spec
-	assertTLSConfig(NewMongosProcess(name, host, "fake-mongoDBImage", false, additionalConfig, getSpec(mdbv1.NewClusterBuilder()), "", nil, "", architectures.NonStatic))
-	assertTLSConfig(NewMongodProcess(name, host, "fake-mongoDBImage", false, additionalConfig, getSpec(mdbv1.NewClusterBuilder()), "", nil, "", architectures.NonStatic))
+	assertTLSConfig(
+		NewMongosProcess(
+			name,
+			host,
+			"fake-mongoDBImage",
+			false,
+			additionalConfig,
+			getSpec(mdbv1.NewClusterBuilder()),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		),
+	)
+	assertTLSConfig(
+		NewMongodProcess(
+			name,
+			host,
+			"fake-mongoDBImage",
+			false,
+			additionalConfig,
+			getSpec(mdbv1.NewClusterBuilder()),
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		),
+	)
 }
 
 // TestMergeMongodProcess_SSL verifies that merging for the process SSL settings keeps the Operator "owned" properties
@@ -226,8 +370,30 @@ func TestMergeMongodProcess_SSL(t *testing.T) {
 	omMdb := mdbv1.NewStandaloneBuilder().SetVersion("3.6.4").SetFCVersion("3.6").
 		SetAdditionalConfig(mdbv1.NewEmptyAdditionalMongodConfig()).Build()
 
-	operatorProcess := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, operatorMdb.GetSpec(), "", nil, "", architectures.NonStatic)
-	omProcess := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, omMdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	operatorProcess := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		&mdbv1.AdditionalMongodConfig{},
+		operatorMdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
+	omProcess := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		&mdbv1.AdditionalMongodConfig{},
+		omMdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 	omProcess.EnsureTLSConfig()["mode"] = "allowTLS"                      // this will be overridden
 	omProcess.EnsureTLSConfig()["PEMKeyFile"] = "/var/mongodb/server.pem" // this will be overridden
 	omProcess.EnsureTLSConfig()["sslOnNormalPorts"] = "true"              // this will be left as-is
@@ -247,11 +413,33 @@ func TestMergeMongodProcess_SSL(t *testing.T) {
 func TestMergeMongodProcess_MongodbOptions(t *testing.T) {
 	omMdb := mdbv1.NewStandaloneBuilder().SetAdditionalConfig(
 		mdbv1.NewAdditionalMongodConfig("storage.wiredTiger.engineConfig.cacheSizeGB", 3)).Build()
-	omProcess := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, omMdb.Spec.AdditionalMongodConfig, omMdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	omProcess := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		omMdb.Spec.AdditionalMongodConfig,
+		omMdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	operatorMdb := mdbv1.NewStandaloneBuilder().SetAdditionalConfig(
 		mdbv1.NewAdditionalMongodConfig("storage.wiredTiger.engineConfig.directoryForIndexes", "/some/dir")).Build()
-	operatorProcess := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, operatorMdb.Spec.AdditionalMongodConfig, operatorMdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	operatorProcess := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		operatorMdb.Spec.AdditionalMongodConfig,
+		operatorMdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	omProcess.mergeFrom(operatorProcess, nil, nil)
 
@@ -287,7 +475,18 @@ func TestMergeMongodProcess_AdditionalMongodConfig_CanBeRemoved(t *testing.T) {
 	prevAdditionalConfig.AddOption("some.other.option2", "value2")
 
 	omMdb := mdbv1.NewStandaloneBuilder().SetAdditionalConfig(prevAdditionalConfig).Build()
-	omProcess := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, omMdb.Spec.AdditionalMongodConfig, omMdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	omProcess := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		omMdb.Spec.AdditionalMongodConfig,
+		omMdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	specAdditionalConfig := mdbv1.NewEmptyAdditionalMongodConfig()
 	// we are changing the cacheSize to 4
@@ -296,7 +495,18 @@ func TestMergeMongodProcess_AdditionalMongodConfig_CanBeRemoved(t *testing.T) {
 	specAdditionalConfig.AddOption("some.other.option", "value")
 
 	operatorMdb := mdbv1.NewStandaloneBuilder().SetAdditionalConfig(specAdditionalConfig).Build()
-	operatorProcess := NewMongodProcess("trinity", "trinity-0.trinity-svc.svc.cluster.local", "fake-mongoDBImage", false, operatorMdb.Spec.AdditionalMongodConfig, operatorMdb.GetSpec(), "", nil, "", architectures.NonStatic)
+	operatorProcess := NewMongodProcess(
+		"trinity",
+		"trinity-0.trinity-svc.svc.cluster.local",
+		"fake-mongoDBImage",
+		false,
+		operatorMdb.Spec.AdditionalMongodConfig,
+		operatorMdb.GetSpec(),
+		"",
+		nil,
+		"",
+		architectures.NonStatic,
+	)
 
 	omProcess.mergeFrom(operatorProcess, specAdditionalConfig.ToMap(), prevAdditionalConfig.ToMap())
 

--- a/controllers/om/replicaset/om_replicaset.go
+++ b/controllers/om/replicaset/om_replicaset.go
@@ -11,15 +11,50 @@ import (
 
 // BuildFromStatefulSet returns a replica set that can be set in the Automation Config
 // based on the given StatefulSet and MongoDB resource.
-func BuildFromStatefulSet(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, dbSpec mdbv1.DbSpec, fcv string, tlsCertPath string, defaultArchitecture architectures.DefaultArchitecture) om.ReplicaSetWithProcesses {
-	return BuildFromStatefulSetWithReplicas(mongoDBImage, forceEnterprise, set, dbSpec, int(*set.Spec.Replicas), fcv, tlsCertPath, defaultArchitecture)
+func BuildFromStatefulSet(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	dbSpec mdbv1.DbSpec,
+	fcv string,
+	tlsCertPath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) om.ReplicaSetWithProcesses {
+	return BuildFromStatefulSetWithReplicas(
+		mongoDBImage,
+		forceEnterprise,
+		set,
+		dbSpec,
+		int(*set.Spec.Replicas),
+		fcv,
+		tlsCertPath,
+		defaultArchitecture,
+	)
 }
 
 // BuildFromStatefulSetWithReplicas returns a replica set that can be set in the Automation Config
 // based on the given StatefulSet and MongoDB spec. The amount of members is set by the replicas
 // parameter.
-func BuildFromStatefulSetWithReplicas(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, dbSpec mdbv1.DbSpec, replicas int, fcv string, tlsCertPath string, defaultArchitecture architectures.DefaultArchitecture) om.ReplicaSetWithProcesses {
-	members := process.CreateMongodProcessesWithLimit(mongoDBImage, forceEnterprise, set, dbSpec, replicas, fcv, tlsCertPath, defaultArchitecture)
+func BuildFromStatefulSetWithReplicas(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	dbSpec mdbv1.DbSpec,
+	replicas int,
+	fcv string,
+	tlsCertPath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) om.ReplicaSetWithProcesses {
+	members := process.CreateMongodProcessesWithLimit(
+		mongoDBImage,
+		forceEnterprise,
+		set,
+		dbSpec,
+		replicas,
+		fcv,
+		tlsCertPath,
+		defaultArchitecture,
+	)
 	replicaSet := om.NewReplicaSet(set.Name, dbSpec.GetMongoDBVersion())
 	rsWithProcesses := om.NewReplicaSetWithProcesses(replicaSet, members, dbSpec.GetMemberOptions())
 	rsWithProcesses.SetHorizons(dbSpec.GetHorizonConfig())
@@ -28,7 +63,15 @@ func BuildFromStatefulSetWithReplicas(mongoDBImage string, forceEnterprise bool,
 
 // BuildFromMongoDBWithReplicas returns a replica set that can be set in the Automation Config
 // based on the given MongoDB resource directly without requiring a StatefulSet.
-func BuildFromMongoDBWithReplicas(mongoDBImage string, forceEnterprise bool, mdb *mdbv1.MongoDB, replicas int, fcv string, tlsCertPath string, defaultArchitecture architectures.DefaultArchitecture) om.ReplicaSetWithProcesses {
+func BuildFromMongoDBWithReplicas(
+	mongoDBImage string,
+	forceEnterprise bool,
+	mdb *mdbv1.MongoDB,
+	replicas int,
+	fcv string,
+	tlsCertPath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) om.ReplicaSetWithProcesses {
 	members := process.CreateMongodProcessesFromMongoDB(mongoDBImage, forceEnterprise, mdb, replicas, fcv, tlsCertPath, defaultArchitecture)
 	replicaSet := om.NewReplicaSet(mdb.Name, mdb.Spec.GetMongoDBVersion())
 	rsWithProcesses := om.NewReplicaSetWithProcesses(replicaSet, members, mdb.Spec.GetMemberOptions())

--- a/controllers/om/replicaset_test.go
+++ b/controllers/om/replicaset_test.go
@@ -18,7 +18,18 @@ func makeMinimalRsWithProcesses() ReplicaSetWithProcesses {
 	processes := make([]Process, 3)
 	memberOptions := make([]automationconfig.MemberOptions, 3)
 	for i := range processes {
-		proc := NewMongodProcess("my-test-repl-"+strconv.Itoa(i), "my-test-repl-"+strconv.Itoa(i), "fake-mongoDBImage", false, &mdbv1.AdditionalMongodConfig{}, &mdb.Spec, "", nil, "", architectures.NonStatic)
+		proc := NewMongodProcess(
+			"my-test-repl-"+strconv.Itoa(i),
+			"my-test-repl-"+strconv.Itoa(i),
+			"fake-mongoDBImage",
+			false,
+			&mdbv1.AdditionalMongodConfig{},
+			&mdb.Spec,
+			"",
+			nil,
+			"",
+			architectures.NonStatic,
+		)
 		processes[i] = proc
 		replicaSetWithProcesses.addMember(proc, "", memberOptions[i])
 	}

--- a/controllers/operator/agents/agents.go
+++ b/controllers/operator/agents/agents.go
@@ -41,7 +41,13 @@ const RollingChangeArgs = "RollingChangeArgs"
 // Returns agent key that was either generated or reused from parameter agentKey.
 // We need to return the key, because in case it was generated here it has to be passed back on an agentKey argument when we're executing the
 // function over multiple clusters.
-func EnsureAgentKeySecretExists(ctx context.Context, secretClient secrets.SecretClient, agentKeyGenerator om.AgentKeyGenerator, namespace, agentKey, projectId, basePath string, log *zap.SugaredLogger) (string, error) {
+func EnsureAgentKeySecretExists(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	agentKeyGenerator om.AgentKeyGenerator,
+	namespace, agentKey, projectId, basePath string,
+	log *zap.SugaredLogger,
+) (string, error) {
 	secretName := ApiKeySecretName(projectId)
 	log = log.With("secret", secretName)
 	agentKeySecret, err := secretClient.ReadSecret(ctx, kube.ObjectKey(namespace, secretName), basePath)
@@ -84,7 +90,14 @@ func ApiKeySecretName(project string) string {
 }
 
 // WaitForRsAgentsToRegister waits until all the agents associated with the given StatefulSet have registered with Ops Manager.
-func WaitForRsAgentsToRegister(set appsv1.StatefulSet, members int, clusterName string, omConnection om.Connection, log *zap.SugaredLogger, rs *mdbv1.MongoDB) error {
+func WaitForRsAgentsToRegister(
+	set appsv1.StatefulSet,
+	members int,
+	clusterName string,
+	omConnection om.Connection,
+	log *zap.SugaredLogger,
+	rs *mdbv1.MongoDB,
+) error {
 	hostnames, _ := dns.GetDnsForStatefulSetReplicasSpecified(set, clusterName, members, rs.Spec.DbCommonSpec.GetExternalDomain())
 
 	log = log.With("statefulset", set.Name)
@@ -98,7 +111,14 @@ func WaitForRsAgentsToRegister(set appsv1.StatefulSet, members int, clusterName 
 
 // WaitForRsAgentsToRegisterByResource waits for RS agents to register using MongoDB resource directly without StatefulSet
 func WaitForRsAgentsToRegisterByResource(rs *mdbv1.MongoDB, members int, omConnection om.Connection, log *zap.SugaredLogger) error {
-	hostnames, _ := dns.GetDNSNames(rs.Name, rs.ServiceName(), rs.Namespace, rs.Spec.GetClusterDomain(), members, rs.Spec.DbCommonSpec.GetExternalDomain())
+	hostnames, _ := dns.GetDNSNames(
+		rs.Name,
+		rs.ServiceName(),
+		rs.Namespace,
+		rs.Spec.GetClusterDomain(),
+		members,
+		rs.Spec.DbCommonSpec.GetExternalDomain(),
+	)
 
 	log = log.With("mongodb", rs.Name)
 
@@ -235,7 +255,12 @@ func calculateProcessStateMap(processStatuses []om.ProcessStatus, agentStatuses 
 		}
 		lastPing, err := time.Parse(time.RFC3339, agentStatus.LastConf)
 		if err != nil {
-			return nil, xerrors.Errorf("wrong format for lastConf field: expected UTC format but the value is %s, agentStatus=%+v: %v", agentStatus.LastConf, agentStatus, err)
+			return nil, xerrors.Errorf(
+				"wrong format for lastConf field: expected UTC format but the value is %s, agentStatus=%+v: %v",
+				agentStatus.LastConf,
+				agentStatus,
+				err,
+			)
 		}
 		processState.LastAgentPing = lastPing
 
@@ -287,7 +312,11 @@ func agentCheck(omConnection om.Connection, agentHostnames []string, log *zap.Su
 
 	var msg string
 	if len(registeredHostnamesList) == 0 {
-		return fmt.Sprintf("None of %d expected agents has registered with OM, expected hostnames: %+v", len(agentHostnames), agentHostnames), false
+		return fmt.Sprintf(
+			"None of %d expected agents has registered with OM, expected hostnames: %+v",
+			len(agentHostnames),
+			agentHostnames,
+		), false
 	} else if len(registeredHostnamesList) == len(agentHostnames) {
 		return fmt.Sprintf("All of %d expected agents have registered with OM, hostnames: %+v", len(registeredHostnamesList), registeredHostnamesList), true
 	} else {

--- a/controllers/operator/agents/upgrade.go
+++ b/controllers/operator/agents/upgrade.go
@@ -47,7 +47,13 @@ type ClientSecret struct {
 // for all existing MongoDB resources before proceeding. This could be a critical thing when the major version OM upgrade
 // happens and all existing MongoDBs are required to get agents upgraded (otherwise the "You need to upgrade the
 // automation agent before publishing other changes" error happens for automation config pushes from the Operator)
-func UpgradeAllIfNeeded(ctx context.Context, cs ClientSecret, omConnectionFactory om.ConnectionFactory, watchNamespace []string, isMulti bool) {
+func UpgradeAllIfNeeded(
+	ctx context.Context,
+	cs ClientSecret,
+	omConnectionFactory om.ConnectionFactory,
+	watchNamespace []string,
+	isMulti bool,
+) {
 	mux.Lock()
 	defer mux.Unlock()
 
@@ -91,7 +97,13 @@ type dbCommonWithNamespace struct {
 	mdbv1.DbCommonSpec
 }
 
-func doUpgrade(ctx context.Context, cmGetter configmap.Getter, secretGetter secrets.SecretClient, factory om.ConnectionFactory, mdbs []dbCommonWithNamespace) error {
+func doUpgrade(
+	ctx context.Context,
+	cmGetter configmap.Getter,
+	secretGetter secrets.SecretClient,
+	factory om.ConnectionFactory,
+	mdbs []dbCommonWithNamespace,
+) error {
 	for _, mdb := range mdbs {
 		log := zap.S().With(string(mdb.ResourceType), mdb.objectKey)
 		conn, err := connectToMongoDB(ctx, cmGetter, secretGetter, factory, mdb, log)
@@ -106,11 +118,18 @@ func doUpgrade(ctx context.Context, cmGetter configmap.Getter, secretGetter secr
 		}
 		version, err := conn.UpgradeAgentsToLatest()
 		if err != nil {
-			log.Warnf("Failed to schedule Agent upgrade: %s, this could be due do ongoing Automation Config publishing in Ops Manager and will get fixed during next trial", err)
+			log.Warnf(
+				"Failed to schedule Agent upgrade: %s, this could be due do ongoing Automation Config publishing in Ops Manager and will get fixed during next trial",
+				err,
+			)
 			continue
 		}
 		if currentVersion != version && currentVersion != "" {
-			log.Debugf("Submitted the request to Ops Manager to upgrade the agents from %s to the latest version (%s)", currentVersion, version)
+			log.Debugf(
+				"Submitted the request to Ops Manager to upgrade the agents from %s to the latest version (%s)",
+				currentVersion,
+				version,
+			)
 		}
 	}
 	return nil
@@ -121,7 +140,12 @@ func doUpgrade(ctx context.Context, cmGetter configmap.Getter, secretGetter secr
 //
 // If the `watchNamespace` contains only the "" string, the MongoDB resources
 // will be searched in every Namespace of the cluster.
-func readAllMongoDBs(ctx context.Context, cl kubernetesClient.Client, watchNamespace []string, isMulti bool) ([]dbCommonWithNamespace, error) {
+func readAllMongoDBs(
+	ctx context.Context,
+	cl kubernetesClient.Client,
+	watchNamespace []string,
+	isMulti bool,
+) ([]dbCommonWithNamespace, error) {
 	var namespaces []string
 
 	// 1. Find which Namespaces to look for MongoDB resources
@@ -168,8 +192,20 @@ func readAllMongoDBs(ctx context.Context, cl kubernetesClient.Client, watchNames
 	return mdbs, nil
 }
 
-func connectToMongoDB(ctx context.Context, cmGetter configmap.Getter, secretGetter secrets.SecretClient, factory om.ConnectionFactory, mdb dbCommonWithNamespace, log *zap.SugaredLogger) (om.Connection, error) {
-	projectConfig, err := project.ReadProjectConfig(ctx, cmGetter, kube.ObjectKey(mdb.objectKey.Namespace, mdb.GetProject()), mdb.objectKey.Name)
+func connectToMongoDB(
+	ctx context.Context,
+	cmGetter configmap.Getter,
+	secretGetter secrets.SecretClient,
+	factory om.ConnectionFactory,
+	mdb dbCommonWithNamespace,
+	log *zap.SugaredLogger,
+) (om.Connection, error) {
+	projectConfig, err := project.ReadProjectConfig(
+		ctx,
+		cmGetter,
+		kube.ObjectKey(mdb.objectKey.Namespace, mdb.GetProject()),
+		mdb.objectKey.Name,
+	)
 	if err != nil {
 		return nil, xerrors.Errorf("error reading Project Config: %w", err)
 	}

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -97,7 +97,7 @@ type CommonDeploymentState struct {
 }
 
 type AppDBDeploymentState struct {
-	CommonDeploymentState     `json:",inline"`
+	CommonDeploymentState     `               json:",inline"`
 	LastAppliedMemberSpec     map[string]int `json:"lastAppliedMemberSpec"`
 	LastAppliedMongoDBVersion string         `json:"lastAppliedMongoDBVersion"`
 }
@@ -121,7 +121,17 @@ type ReconcileAppDbReplicaSet struct {
 	defaultArchitecture architectures.DefaultArchitecture
 }
 
-func NewAppDBReplicaSetReconciler(ctx context.Context, imageUrls images.ImageUrls, initDatabaseVersion string, opsManager *omv1.MongoDBOpsManager, commonController *ReconcileCommonController, omConnectionFactory om.ConnectionFactory, globalMemberClustersMap map[string]client.Client, defaultArchitecture architectures.DefaultArchitecture, log *zap.SugaredLogger) (*ReconcileAppDbReplicaSet, error) {
+func NewAppDBReplicaSetReconciler(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseVersion string,
+	opsManager *omv1.MongoDBOpsManager,
+	commonController *ReconcileCommonController,
+	omConnectionFactory om.ConnectionFactory,
+	globalMemberClustersMap map[string]client.Client,
+	defaultArchitecture architectures.DefaultArchitecture,
+	log *zap.SugaredLogger,
+) (*ReconcileAppDbReplicaSet, error) {
 	helper, err := NewAppDBReconcilerHelper(ctx, opsManager, commonController, globalMemberClustersMap, log)
 	if err != nil {
 		return nil, err
@@ -151,17 +161,36 @@ type AppDBReconcilerHelper struct {
 	readOnly bool
 }
 
-func NewAppDBReconcilerHelper(ctx context.Context, opsManager *omv1.MongoDBOpsManager, commonController *ReconcileCommonController, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*AppDBReconcilerHelper, error) {
+func NewAppDBReconcilerHelper(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	commonController *ReconcileCommonController,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+) (*AppDBReconcilerHelper, error) {
 	return newAppDBReconcilerHelper(ctx, opsManager, commonController, globalMemberClustersMap, false, log)
 }
 
 // NewReadOnlyAppDBReconcilerHelper builds the helper without writing any state back to the cluster,
 // for callers that only need the member cluster topology (e.g. OnDelete cleanup).
-func NewReadOnlyAppDBReconcilerHelper(ctx context.Context, opsManager *omv1.MongoDBOpsManager, commonController *ReconcileCommonController, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*AppDBReconcilerHelper, error) {
+func NewReadOnlyAppDBReconcilerHelper(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	commonController *ReconcileCommonController,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+) (*AppDBReconcilerHelper, error) {
 	return newAppDBReconcilerHelper(ctx, opsManager, commonController, globalMemberClustersMap, true, log)
 }
 
-func newAppDBReconcilerHelper(ctx context.Context, opsManager *omv1.MongoDBOpsManager, commonController *ReconcileCommonController, globalMemberClustersMap map[string]client.Client, readOnly bool, log *zap.SugaredLogger) (*AppDBReconcilerHelper, error) {
+func newAppDBReconcilerHelper(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	commonController *ReconcileCommonController,
+	globalMemberClustersMap map[string]client.Client,
+	readOnly bool,
+	log *zap.SugaredLogger,
+) (*AppDBReconcilerHelper, error) {
 	helper := &AppDBReconcilerHelper{
 		centralClient:   commonController.client,
 		secretClient:    commonController.SecretClient,
@@ -267,7 +296,12 @@ func (r *ReconcileAppDbReplicaSet) ensureResourcesForArchitectureChange(ctx cont
 
 // initializeStateStore initializes the deploymentState field by reading it from a state config map.
 // In case there is no state config map, the new state map is created and saved after performing migration of the existing state data (see migrateToNewDeploymentState).
-func (r *AppDBReconcilerHelper) initializeStateStore(ctx context.Context, appDBSpec omv1.AppDBSpec, omAnnotations map[string]string, log *zap.SugaredLogger) error {
+func (r *AppDBReconcilerHelper) initializeStateStore(
+	ctx context.Context,
+	appDBSpec omv1.AppDBSpec,
+	omAnnotations map[string]string,
+	log *zap.SugaredLogger,
+) error {
 	r.deploymentState = NewAppDBDeploymentState()
 
 	r.stateStore = NewStateStore[AppDBDeploymentState](&appDBSpec, r.ownerReferences, r.centralClient)
@@ -350,7 +384,12 @@ func (r *AppDBReconcilerHelper) initializeStateStore(ctx context.Context, appDBS
 //   - cluster-3, idx=2, members=3 (removed cluster, idx and previous members from map)
 //   - cluster-10, idx=3, members=10 (assigns a new index that is the next available index (0,1,2 are taken))
 //   - cluster-5, idx=4, members=5 (assigns a new index that is the next available index (0,1,2,3 are taken))
-func (r *AppDBReconcilerHelper) initializeMemberClusters(ctx context.Context, appDBSpec omv1.AppDBSpec, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) error {
+func (r *AppDBReconcilerHelper) initializeMemberClusters(
+	ctx context.Context,
+	appDBSpec omv1.AppDBSpec,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+) error {
 	if appDBSpec.IsMultiCluster() {
 		if len(globalMemberClustersMap) == 0 {
 			return xerrors.Errorf("member clusters have to be initialized for MultiCluster AppDB topology")
@@ -366,7 +405,14 @@ func (r *AppDBReconcilerHelper) initializeMemberClusters(ctx context.Context, ap
 			return r.deploymentState.LastAppliedMemberSpec[memberClusterName]
 		}
 
-		r.memberClusters = createMemberClusterListFromClusterSpecList(appDBSpec.GetClusterSpecList(), globalMemberClustersMap, log, r.deploymentState.ClusterMapping, getLastAppliedMemberCountFunc, false)
+		r.memberClusters = createMemberClusterListFromClusterSpecList(
+			appDBSpec.GetClusterSpecList(),
+			globalMemberClustersMap,
+			log,
+			r.deploymentState.ClusterMapping,
+			getLastAppliedMemberCountFunc,
+			false,
+		)
 
 		if !r.readOnly {
 			if err := r.saveAppDBState(ctx, appDBSpec, log); err != nil {
@@ -440,7 +486,14 @@ func (r *AppDBReconcilerHelper) writeLegacyStateConfigMaps(ctx context.Context, 
 	return nil
 }
 
-func createMemberClusterListFromClusterSpecList(clusterSpecList mdbv1.ClusterSpecList, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger, memberClusterMapping map[string]int, getLastAppliedMemberCountFunc func(memberClusterName string) int, legacyMemberCluster bool) []multicluster.MemberCluster {
+func createMemberClusterListFromClusterSpecList(
+	clusterSpecList mdbv1.ClusterSpecList,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+	memberClusterMapping map[string]int,
+	getLastAppliedMemberCountFunc func(memberClusterName string) int,
+	legacyMemberCluster bool,
+) []multicluster.MemberCluster {
 	var memberClusters []multicluster.MemberCluster
 	specClusterMap := map[string]struct{}{}
 	for _, clusterSpecItem := range clusterSpecList {
@@ -530,7 +583,11 @@ func (r *AppDBReconcilerHelper) getLegacyLastAppliedMemberSpec(ctx context.Conte
 	existingConfigMap := corev1.ConfigMap{}
 	err := r.centralClient.Get(ctx, kube.ObjectKey(spec.Namespace, spec.LastAppliedMemberSpecConfigMapName()), &existingConfigMap)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to read last applied member spec config map %s: %w", spec.LastAppliedMemberSpecConfigMapName(), err)
+		return nil, xerrors.Errorf(
+			"failed to read last applied member spec config map %s: %w",
+			spec.LastAppliedMemberSpecConfigMapName(),
+			err,
+		)
 	} else {
 		for clusterName, replicasStr := range existingConfigMap.Data {
 			replicas, err := strconv.Atoi(replicasStr)
@@ -545,7 +602,12 @@ func (r *AppDBReconcilerHelper) getLegacyLastAppliedMemberSpec(ctx context.Conte
 }
 
 // getLegacyMemberClusterMapping is reading the cluster mapping from the old config map where it has been stored before introducing the deployment state config map.
-func getLegacyMemberClusterMapping(ctx context.Context, namespace string, configMapName string, centralClient kubernetesClient.Client) (map[string]int, error) {
+func getLegacyMemberClusterMapping(
+	ctx context.Context,
+	namespace string,
+	configMapName string,
+	centralClient kubernetesClient.Client,
+) (map[string]int, error) {
 	// read existing config map
 	existingMapping := map[string]int{}
 	existingConfigMap, err := centralClient.GetConfigMap(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace})
@@ -572,13 +634,20 @@ func (r *AppDBReconcilerHelper) updateMemberClusterMapping(spec omv1.AppDBSpec) 
 		return
 	}
 
-	r.deploymentState.ClusterMapping = multicluster.AssignIndexesForMemberClusterNames(r.deploymentState.ClusterMapping, util.Transform(spec.GetClusterSpecList(), func(clusterSpecItem mdbv1.ClusterSpecItem) string {
-		return clusterSpecItem.ClusterName
-	}))
+	r.deploymentState.ClusterMapping = multicluster.AssignIndexesForMemberClusterNames(
+		r.deploymentState.ClusterMapping,
+		util.Transform(spec.GetClusterSpecList(), func(clusterSpecItem mdbv1.ClusterSpecItem) string {
+			return clusterSpecItem.ClusterName
+		}),
+	)
 }
 
 // shouldReconcileAppDB returns a boolean indicating whether or not the reconciliation for this set of processes should occur.
-func (r *ReconcileAppDbReplicaSet) shouldReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
+func (r *ReconcileAppDbReplicaSet) shouldReconcileAppDB(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (bool, error) {
 	memberCluster := r.helper.getMemberCluster(r.helper.getNameOfFirstMemberCluster())
 	currentAc, err := automationconfig.ReadFromSecret(ctx, memberCluster.Client, types.NamespacedName{
 		Namespace: opsManager.GetNamespace(),
@@ -635,12 +704,24 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	log.Infow("ReplicaSet.Status", "status", opsManager.Status.AppDbStatus)
 
 	if err := r.ensureResourcesForArchitectureChange(ctx, opsManager); err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring resources for upgrade from 1 to 3 container AppDB: %w", err)), log, appDbStatusOption)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Error ensuring resources for upgrade from 1 to 3 container AppDB: %w", err)),
+			log,
+			appDbStatusOption,
+		)
 	}
 
 	opsManagerUserPassword, err := r.ensureAppDbPassword(ctx, opsManager, log)
 	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring Ops Manager user password: %w", err)), log, appDbStatusOption)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Error ensuring Ops Manager user password: %w", err)),
+			log,
+			appDbStatusOption,
+		)
 	}
 
 	// We cannot allow removing cluster specification if the cluster is not scaled down to zero.
@@ -655,10 +736,18 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	// This could be the case if we want to disable a process to perform a manual backup of the AppDB.
 	shouldReconcile, err := r.shouldReconcileAppDB(ctx, opsManager, log)
 	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error determining AppDB reconciliation state: %w", err)), log, appDbStatusOption)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Error determining AppDB reconciliation state: %w", err)),
+			log,
+			appDbStatusOption,
+		)
 	}
 	if !shouldReconcile {
-		log.Info("Skipping reconciliation for AppDB because at least one of the processes has been disabled. To reconcile the AppDB all process need to be enabled in automation config")
+		log.Info(
+			"Skipping reconciliation for AppDB because at least one of the processes has been disabled. To reconcile the AppDB all process need to be enabled in automation config",
+		)
 		return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption)
 	}
 
@@ -695,13 +784,24 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 		// are not ready and trying to connect to the ops-manager service timeout, a persistent error is when the "ops-manager-admin-key" is corrupted, in this case
 		// any API call to ops-manager will fail(including the configuration of AppDB monitoring), this error should be reflected to the user in the "OPSMANAGER" status.
 		if strings.Contains(err.Error(), "401 (Unauthorized)") {
-			return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("The admin-key secret might be corrupted: %w", err)), log, omStatusOption)
+			return r.updateStatus(
+				ctx,
+				opsManager,
+				workflow.Failed(xerrors.Errorf("The admin-key secret might be corrupted: %w", err)),
+				log,
+				omStatusOption,
+			)
 		}
 	}
 
 	appdbOpts := construct.AppDBStatefulSetOptions{
 		InitAppDBImage: images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseVersion),
-		MongodbImage:   images.GetOfficialImage(r.imageUrls, opsManager.Spec.AppDB.Version, opsManager.GetAnnotations(), r.defaultArchitecture),
+		MongodbImage: images.GetOfficialImage(
+			r.imageUrls,
+			opsManager.Spec.AppDB.Version,
+			opsManager.GetAnnotations(),
+			r.defaultArchitecture,
+		),
 		CustomAgentURL: r.customAgentURL,
 	}
 	if architectures.IsRunningStaticArchitecture(opsManager.Annotations, r.defaultArchitecture) {
@@ -712,7 +812,14 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 			agentVersion, err := r.getAgentVersion(nil, opsManager.Spec.Version, true, log)
 			if err != nil {
 				log.Errorf("Impossible to get agent version, please override the agent image by providing a pod template")
-				return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Failed to get agent version: %w. Please use spec.statefulSet to supply proper Agent version", err)), log)
+				return r.updateStatus(
+					ctx,
+					opsManager,
+					workflow.Failed(
+						xerrors.Errorf("Failed to get agent version: %w. Please use spec.statefulSet to supply proper Agent version", err),
+					),
+					log,
+				)
 			}
 			appdbOpts.AgentImage = images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, agentVersion)
 		}
@@ -747,7 +854,14 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	}
 	appdbOpts.VaultConfig = vaultConfig
 
-	prometheusCertHash, err := certs.EnsureTLSCertsForPrometheus(ctx, r.SecretClient, opsManager.GetNamespace(), opsManager.Spec.AppDB.Prometheus, certs.AppDB, log)
+	prometheusCertHash, err := certs.EnsureTLSCertsForPrometheus(
+		ctx,
+		r.SecretClient,
+		opsManager.GetNamespace(),
+		opsManager.Spec.AppDB.Prometheus,
+		certs.AppDB,
+		log,
+	)
 	if err != nil {
 		// Do not fail on errors generating certs for Prometheus
 		log.Errorf("can't create a PEM-Format Secret for Prometheus certificates: %s", err)
@@ -756,7 +870,13 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 
 	allStatefulSetsExist, err := r.allStatefulSetsExist(ctx, opsManager, log)
 	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("failed to check the state of all stateful sets: %w", err)), log, appDbStatusOption)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("failed to check the state of all stateful sets: %w", err)),
+			log,
+			appDbStatusOption,
+		)
 	}
 
 	publishAutomationConfigFirst := r.publishAutomationConfigFirst(opsManager, allStatefulSetsExist, log)
@@ -777,11 +897,22 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	// We keep updating annotations for backward compatibility (e.g operator downgrade), so we write the
 	// lastAppliedMongoDBVersion both in the state and in annotations below
 	// here it doesn't matter for which cluster we'll generate the name - only AppDB's MongoDB version is used there, which is the same in all clusters
-	versionedImplForMemberCluster := opsManager.GetVersionedImplForMemberCluster(r.helper.getMemberClusterIndex(r.helper.getNameOfFirstMemberCluster()))
-	log.Debugf("Storing LastAppliedMongoDBVersion %s in annotations and deployment state", versionedImplForMemberCluster.GetMongoDBVersionForAnnotation())
+	versionedImplForMemberCluster := opsManager.GetVersionedImplForMemberCluster(
+		r.helper.getMemberClusterIndex(r.helper.getNameOfFirstMemberCluster()),
+	)
+	log.Debugf(
+		"Storing LastAppliedMongoDBVersion %s in annotations and deployment state",
+		versionedImplForMemberCluster.GetMongoDBVersionForAnnotation(),
+	)
 	r.helper.deploymentState.LastAppliedMongoDBVersion = versionedImplForMemberCluster.GetMongoDBVersionForAnnotation()
 	if err := annotations.UpdateLastAppliedMongoDBVersion(ctx, versionedImplForMemberCluster, r.helper.centralClient); err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Could not save current state as an annotation: %w", err)), log, omStatusOption)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Could not save current state as an annotation: %w", err)),
+			log,
+			omStatusOption,
+		)
 	}
 
 	appDBScalers := []interfaces.MultiClusterReplicaSetScaler{}
@@ -794,11 +925,23 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 		if opsManager.Spec.AppDB.IsMultiCluster() && replicasThisReconcile != specReplicas {
 			achievedDesiredScaling = false
 		}
-		log.Debugf("Scaling status for memberCluster: %s, replicasThisReconcile=%d, specReplicas=%d, achievedDesiredScaling=%t", member.Name, replicasThisReconcile, specReplicas, achievedDesiredScaling)
+		log.Debugf(
+			"Scaling status for memberCluster: %s, replicasThisReconcile=%d, specReplicas=%d, achievedDesiredScaling=%t",
+			member.Name,
+			replicasThisReconcile,
+			specReplicas,
+			achievedDesiredScaling,
+		)
 	}
 
 	if err := r.helper.saveAppDBState(ctx, opsManager.Spec.AppDB, log); err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Could not save deployment state: %w", err)), log, omStatusOption)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Could not save deployment state: %w", err)),
+			log,
+			omStatusOption,
+		)
 	}
 
 	if podVars.ProjectID == "" {
@@ -806,7 +949,14 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 		// requeues after Ops Manager has been fully configured.
 		log.Infof("Requeuing reconciliation to configure Monitoring in Ops Manager.")
 
-		return r.updateStatus(ctx, opsManager, workflow.Pending("Enabling monitoring").Requeue(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...))
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Pending("Enabling monitoring").Requeue(),
+			log,
+			appDbStatusOption,
+			status.AppDBMemberOptions(appDBScalers...),
+		)
 	}
 
 	// We need to check for status compared to the spec because the scaler will report desired replicas to be different than what's present in the spec when the
@@ -818,7 +968,14 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 	}
 
 	if !achievedDesiredScaling || scale.AnyAreStillScaling(rsScalers...) {
-		return r.updateStatus(ctx, opsManager, workflow.Pending("Continuing scaling operation on AppDB %d", 1), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...))
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Pending("Continuing scaling operation on AppDB %d", 1),
+			log,
+			appDbStatusOption,
+			status.AppDBMemberOptions(appDBScalers...),
+		)
 	}
 
 	// set the annotation to AppDB that forced reconfigure is performed to indicate to customers
@@ -831,17 +988,35 @@ func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManage
 
 		err := annotations.SetAnnotations(ctx, opsManager, annotationsToAdd, r.client)
 		if err != nil {
-			return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Failed to save force reconfigure annotation err: %s", err)), log, omStatusOption)
+			return r.updateStatus(
+				ctx,
+				opsManager,
+				workflow.Failed(xerrors.Errorf("Failed to save force reconfigure annotation err: %s", err)),
+				log,
+				omStatusOption,
+			)
 		}
 	}
 
 	log.Infof("Finished reconciliation for AppDB ReplicaSet!")
 
-	return r.updateStatus(ctx, opsManager, workflow.OK(), log, appDbStatusOption, status.AppDBMemberOptions(appDBScalers...), status.NewPVCsStatusOptionEmptyStatus())
+	return r.updateStatus(
+		ctx,
+		opsManager,
+		workflow.OK(),
+		log,
+		appDbStatusOption,
+		status.AppDBMemberOptions(appDBScalers...),
+		status.NewPVCsStatusOptionEmptyStatus(),
+	)
 }
 
 // BuildAppDBConnectionURL returns the connection string to the AppDB, ensuring the Ops Manager user password exists.
-func (r *ReconcileAppDbReplicaSet) BuildAppDBConnectionURL(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileAppDbReplicaSet) BuildAppDBConnectionURL(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (string, error) {
 	password, err := r.ensureAppDbPassword(ctx, opsManager, log)
 	if err != nil {
 		return "", xerrors.Errorf("Error getting AppDB password: %w", err)
@@ -869,7 +1044,10 @@ func (r *ReconcileAppDbReplicaSet) blockNonEmptyClusterSpecItemRemoval(appDBSpec
 		}
 
 		if !slices.ContainsFunc(appDBSpec.GetClusterSpecList(), searchFunc) && memberCluster.Replicas > 0 {
-			return xerrors.Errorf("Cannot remove member cluster %s with non-zero members count. Please scale down members to zero first", memberCluster.Name)
+			return xerrors.Errorf(
+				"Cannot remove member cluster %s with non-zero members count. Please scale down members to zero first",
+				memberCluster.Name,
+			)
 		}
 	}
 
@@ -887,7 +1065,14 @@ func (r *AppDBReconcilerHelper) getNameOfFirstMemberCluster() string {
 	return firstMemberClusterName
 }
 
-func (r *ReconcileAppDbReplicaSet) deployAutomationConfigAndWaitForAgentsReachGoalState(ctx context.Context, log *zap.SugaredLogger, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, allStatefulSetsExist bool, appdbOpts construct.AppDBStatefulSetOptions) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) deployAutomationConfigAndWaitForAgentsReachGoalState(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	opsManager *omv1.MongoDBOpsManager,
+	podVars *env.PodEnvVars,
+	allStatefulSetsExist bool,
+	appdbOpts construct.AppDBStatefulSetOptions,
+) workflow.Status {
 	configVersion, workflowStatus := r.deployAutomationConfigOnHealthyClusters(ctx, log, opsManager, podVars, appdbOpts)
 	if !workflowStatus.IsOK() {
 		return workflowStatus
@@ -901,7 +1086,13 @@ func (r *ReconcileAppDbReplicaSet) deployAutomationConfigAndWaitForAgentsReachGo
 	return r.allAgentsReachedGoalState(ctx, opsManager, configVersion, log)
 }
 
-func (r *ReconcileAppDbReplicaSet) deployAutomationConfigOnHealthyClusters(ctx context.Context, log *zap.SugaredLogger, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, appdbOpts construct.AppDBStatefulSetOptions) (int, workflow.Status) {
+func (r *ReconcileAppDbReplicaSet) deployAutomationConfigOnHealthyClusters(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	opsManager *omv1.MongoDBOpsManager,
+	podVars *env.PodEnvVars,
+	appdbOpts construct.AppDBStatefulSetOptions,
+) (int, workflow.Status) {
 	configVersions := map[int]struct{}{}
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		if configVersion, workflowStatus := r.deployAutomationConfig(ctx, opsManager, podVars, appdbOpts.PrometheusTLSCertHash, memberCluster, log); !workflowStatus.IsOK() {
@@ -1002,7 +1193,11 @@ func getPlaceholderReplacer(appdb omv1.AppDBSpec, memberCluster multicluster.Mem
 		mdbv1.ReplicaSet)
 }
 
-func (r *ReconcileAppDbReplicaSet) publishAutomationConfigFirst(opsManager *omv1.MongoDBOpsManager, allStatefulSetsExist bool, log *zap.SugaredLogger) bool {
+func (r *ReconcileAppDbReplicaSet) publishAutomationConfigFirst(
+	opsManager *omv1.MongoDBOpsManager,
+	allStatefulSetsExist bool,
+	log *zap.SugaredLogger,
+) bool {
 	// The only case when we push the StatefulSet first is when we are ensuring TLS for the already existing AppDB
 	// TODO this feels insufficient. Shouldn't we check if there is actual change in TLS settings requiring to push sts first? Now it will always publish sts first when TLS enabled
 	automationConfigFirst := !allStatefulSetsExist || !opsManager.Spec.AppDB.GetSecurity().IsTLSEnabled()
@@ -1036,7 +1231,11 @@ func getDomain(service, namespace, clusterName string) string {
 // This means that the secret referenced can either already contain a concatenation of certificate and private key
 // or it can be of type kubernetes.io/tls. In this case the operator will read the tls.crt and tls.key entries, and it will
 // generate a new secret containing their concatenation
-func (r *ReconcileAppDbReplicaSet) ensureTLSSecretAndCreatePEMIfNeeded(ctx context.Context, om *omv1.MongoDBOpsManager, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) ensureTLSSecretAndCreatePEMIfNeeded(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	rs := om.Spec.AppDB
 	if !rs.IsSecurityTLSConfigEnabled() {
 		return workflow.OK()
@@ -1075,7 +1274,18 @@ func (r *ReconcileAppDbReplicaSet) ensureTLSSecretAndCreatePEMIfNeeded(ctx conte
 		var data string
 		for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 			if om.Spec.AppDB.IsMultiCluster() {
-				data, err = certs.VerifyTLSSecretForStatefulSet(secretData, certs.AppDBMultiClusterReplicaSetConfig(om, scalers.GetAppDBScaler(om, memberCluster.Name, r.helper.getMemberClusterIndex(memberCluster.Name), r.helper.memberClusters)))
+				data, err = certs.VerifyTLSSecretForStatefulSet(
+					secretData,
+					certs.AppDBMultiClusterReplicaSetConfig(
+						om,
+						scalers.GetAppDBScaler(
+							om,
+							memberCluster.Name,
+							r.helper.getMemberClusterIndex(memberCluster.Name),
+							r.helper.memberClusters,
+						),
+					),
+				)
 			} else {
 				data, err = certs.VerifyTLSSecretForStatefulSet(secretData, certs.AppDBReplicaSetConfig(om))
 			}
@@ -1093,9 +1303,20 @@ func (r *ReconcileAppDbReplicaSet) ensureTLSSecretAndCreatePEMIfNeeded(ctx conte
 
 		var errs error
 		for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
-			err = certs.CreateOrUpdatePEMSecretWithPreviousCert(ctx, memberCluster.SecretClient, kube.ObjectKey(om.Namespace, secretName), secretHash, data, nil, certs.AppDB)
+			err = certs.CreateOrUpdatePEMSecretWithPreviousCert(
+				ctx,
+				memberCluster.SecretClient,
+				kube.ObjectKey(om.Namespace, secretName),
+				secretHash,
+				data,
+				nil,
+				certs.AppDB,
+			)
 			if err != nil {
-				errs = multierror.Append(errs, xerrors.Errorf("can't create concatenated PEM certificate in cluster %s: %w", memberCluster.Name, err))
+				errs = multierror.Append(
+					errs,
+					xerrors.Errorf("can't create concatenated PEM certificate in cluster %s: %w", memberCluster.Name, err),
+				)
 				continue
 			}
 		}
@@ -1107,7 +1328,11 @@ func (r *ReconcileAppDbReplicaSet) ensureTLSSecretAndCreatePEMIfNeeded(ctx conte
 	return workflow.OK()
 }
 
-func (r *ReconcileAppDbReplicaSet) replicateTLSCAConfigMap(ctx context.Context, om *omv1.MongoDBOpsManager, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) replicateTLSCAConfigMap(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	appDBSpec := om.Spec.AppDB
 	if !appDBSpec.IsMultiCluster() || !appDBSpec.IsSecurityTLSConfigEnabled() {
 		return workflow.OK()
@@ -1132,7 +1357,12 @@ func (r *ReconcileAppDbReplicaSet) replicateTLSCAConfigMap(ctx context.Context, 
 	return workflow.OK()
 }
 
-func (r *ReconcileAppDbReplicaSet) replicateSSLMMSCAConfigMap(ctx context.Context, om *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) replicateSSLMMSCAConfigMap(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	podVars *env.PodEnvVars,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	appDBSpec := om.Spec.AppDB
 	if !appDBSpec.IsMultiCluster() || !construct.ShouldMountSSLMMSCAConfigMap(podVars) {
 		log.Debug("Skipping replication of SSLMMSCAConfigMap.")
@@ -1164,7 +1394,13 @@ func (r *ReconcileAppDbReplicaSet) replicateSSLMMSCAConfigMap(ctx context.Contex
 // No optimistic concurrency control is done - there cannot be a concurrent reconciliation for the same Ops Manager
 // object and the probability that the user will edit the config map manually in the same time is extremely low
 // returns the version of AutomationConfig just published
-func (r *ReconcileAppDbReplicaSet) publishAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, automationConfig automationconfig.AutomationConfig, secretName string, secretsClient secrets.SecretClient) (int, error) {
+func (r *ReconcileAppDbReplicaSet) publishAutomationConfig(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	automationConfig automationconfig.AutomationConfig,
+	secretName string,
+	secretsClient secrets.SecretClient,
+) (int, error) {
 	ac, err := automationconfig.EnsureSecret(ctx, secretsClient, kube.ObjectKey(opsManager.Namespace, secretName), nil, automationConfig)
 	if err != nil {
 		return -1, err
@@ -1175,11 +1411,19 @@ func (r *ReconcileAppDbReplicaSet) publishAutomationConfig(ctx context.Context, 
 // getExistingAutomationConfig retrieves the existing automation config from the member clusters.
 // This method retrieves the most recent automation config version to handle the case when adding a new cluster from scratch.
 // This is required to avoid a situation where adding a new cluster assumes the automation is created from scratch.
-func (r *ReconcileAppDbReplicaSet) getExistingAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, secretName string) (automationconfig.AutomationConfig, error) {
+func (r *ReconcileAppDbReplicaSet) getExistingAutomationConfig(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	secretName string,
+) (automationconfig.AutomationConfig, error) {
 	latestVersion := -1
 	latestAc := automationconfig.AutomationConfig{}
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
-		ac, err := automationconfig.ReadFromSecret(ctx, memberCluster.Client, types.NamespacedName{Name: secretName, Namespace: opsManager.Namespace})
+		ac, err := automationconfig.ReadFromSecret(
+			ctx,
+			memberCluster.Client,
+			types.NamespacedName{Name: secretName, Namespace: opsManager.Namespace},
+		)
 		if err != nil {
 			return automationconfig.AutomationConfig{}, err
 		}
@@ -1191,7 +1435,14 @@ func (r *ReconcileAppDbReplicaSet) getExistingAutomationConfig(ctx context.Conte
 	return latestAc, nil
 }
 
-func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, prometheusCertHash string, memberClusterName string, log *zap.SugaredLogger) (automationconfig.AutomationConfig, error) {
+func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	podVars *env.PodEnvVars,
+	prometheusCertHash string,
+	memberClusterName string,
+	log *zap.SugaredLogger,
+) (automationconfig.AutomationConfig, error) {
 	rs := opsManager.Spec.AppDB
 	domain := getDomain(rs.ServiceName(), opsManager.Namespace, opsManager.Spec.GetClusterDomain())
 
@@ -1231,7 +1482,9 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 	replicasThisReconciliation := 0
 	// we want to use all member clusters to maintain the same process list despite having some clusters down
 	for _, memberCluster := range r.helper.getAllMemberClusters() {
-		replicasThisReconciliation += scale.ReplicasThisReconciliation(scalers.GetAppDBScaler(opsManager, memberCluster.Name, memberCluster.Index, r.helper.memberClusters))
+		replicasThisReconciliation += scale.ReplicasThisReconciliation(
+			scalers.GetAppDBScaler(opsManager, memberCluster.Name, memberCluster.Index, r.helper.memberClusters),
+		)
 	}
 
 	builder := automationconfig.NewBuilder().
@@ -1289,7 +1542,12 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 			}
 
 			if opsManager.Spec.AppDB.AutomationAgent.Mongod.HasLoggingConfigured() {
-				automationconfig.ConfigureAgentConfiguration(systemLog, opsManager.Spec.AppDB.AutomationAgent.Mongod.LogRotate, opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate, p)
+				automationconfig.ConfigureAgentConfiguration(
+					systemLog,
+					opsManager.Spec.AppDB.AutomationAgent.Mongod.LogRotate,
+					opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate,
+					p,
+				)
 			} else {
 				automationconfig.ConfigureAgentConfiguration(systemLog, opsManager.Spec.AppDB.AutomationAgent.LogRotate, opsManager.Spec.AppDB.AutomationAgent.Mongod.AuditLogRotate, p)
 			}
@@ -1346,7 +1604,13 @@ func (r *ReconcileAppDbReplicaSet) buildAppDbAutomationConfig(ctx context.Contex
 			return fmt.Sprintf("{Id=%d, Host=%s}", member.Id, member.Host)
 		})
 	}
-	log.Debugf("Created automation config object (in-memory) for cluster=%s, total process count=%d, process hostnames=%+v, replicaset config=%+v", memberClusterName, replicasThisReconciliation, processHostnames, replicaSetMembers)
+	log.Debugf(
+		"Created automation config object (in-memory) for cluster=%s, total process count=%d, process hostnames=%+v, replicaset config=%+v",
+		memberClusterName,
+		replicasThisReconciliation,
+		processHostnames,
+		replicaSetMembers,
+	)
 
 	// this is for force reconfigure. This sets "currentVersion: -1" in automation config
 	// when forceReconfig is triggered.
@@ -1377,7 +1641,9 @@ func shouldPerformForcedReconfigure(annotations map[string]string) bool {
 	return false
 }
 
-func getExistingAutomationReplicaSetMembers(automationConfig automationconfig.AutomationConfig) (map[string]automationconfig.ReplicaSetMember, int) {
+func getExistingAutomationReplicaSetMembers(
+	automationConfig automationconfig.AutomationConfig,
+) (map[string]automationconfig.ReplicaSetMember, int) {
 	nextId := 0
 	existingMembers := map[string]automationconfig.ReplicaSetMember{}
 	if len(automationConfig.ReplicaSets) != 1 {
@@ -1402,14 +1668,33 @@ func (r *ReconcileAppDbReplicaSet) generateProcessHostnames(opsManager *omv1.Mon
 	return hostnames
 }
 
-func (r *ReconcileAppDbReplicaSet) generateProcessHostnamesForCluster(opsManager *omv1.MongoDBOpsManager, memberCluster multicluster.MemberCluster) []string {
-	members := scale.ReplicasThisReconciliation(scalers.GetAppDBScaler(opsManager, memberCluster.Name, r.helper.getMemberClusterIndex(memberCluster.Name), r.helper.memberClusters))
+func (r *ReconcileAppDbReplicaSet) generateProcessHostnamesForCluster(
+	opsManager *omv1.MongoDBOpsManager,
+	memberCluster multicluster.MemberCluster,
+) []string {
+	members := scale.ReplicasThisReconciliation(
+		scalers.GetAppDBScaler(opsManager, memberCluster.Name, r.helper.getMemberClusterIndex(memberCluster.Name), r.helper.memberClusters),
+	)
 
 	if opsManager.Spec.AppDB.IsMultiCluster() {
-		return dns.GetMultiClusterProcessHostnames(opsManager.Spec.AppDB.GetName(), opsManager.GetNamespace(), memberCluster.Index, members, opsManager.Spec.AppDB.GetClusterDomain(), opsManager.Spec.AppDB.GetExternalDomainForMemberCluster(memberCluster.Name))
+		return dns.GetMultiClusterProcessHostnames(
+			opsManager.Spec.AppDB.GetName(),
+			opsManager.GetNamespace(),
+			memberCluster.Index,
+			members,
+			opsManager.Spec.AppDB.GetClusterDomain(),
+			opsManager.Spec.AppDB.GetExternalDomainForMemberCluster(memberCluster.Name),
+		)
 	}
 
-	hostnames, _ := dns.GetDNSNames(opsManager.Spec.AppDB.GetName(), opsManager.Spec.AppDB.ServiceName(), opsManager.GetNamespace(), opsManager.Spec.AppDB.GetClusterDomain(), members, opsManager.Spec.AppDB.GetExternalDomain())
+	hostnames, _ := dns.GetDNSNames(
+		opsManager.Spec.AppDB.GetName(),
+		opsManager.Spec.AppDB.ServiceName(),
+		opsManager.GetNamespace(),
+		opsManager.Spec.AppDB.GetClusterDomain(),
+		members,
+		opsManager.Spec.AppDB.GetExternalDomain(),
+	)
 	return hostnames
 }
 
@@ -1429,7 +1714,10 @@ func (r *ReconcileAppDbReplicaSet) generateProcessList(opsManager *omv1.MongoDBO
 	return processList
 }
 
-func (r *ReconcileAppDbReplicaSet) generateMemberOptions(opsManager *omv1.MongoDBOpsManager, previousMembers map[string]automationconfig.ReplicaSetMember) []automationconfig.MemberOptions {
+func (r *ReconcileAppDbReplicaSet) generateMemberOptions(
+	opsManager *omv1.MongoDBOpsManager,
+	previousMembers map[string]automationconfig.ReplicaSetMember,
+) []automationconfig.MemberOptions {
 	var memberOptionsList []automationconfig.MemberOptions
 	for _, memberCluster := range r.helper.getAllMemberClusters() {
 		hostnames := r.generateProcessHostnamesForCluster(opsManager, memberCluster)
@@ -1475,7 +1763,12 @@ func (r *ReconcileAppDbReplicaSet) generateMemberOptions(opsManager *omv1.MongoD
 // buildPrometheusModification returns a `Modification` function that will add a
 // `prometheus` entry to the Automation Config if Prometheus has been enabled on
 // the Application Database (`spec.applicationDatabase.Prometheus`).
-func buildPrometheusModification(ctx context.Context, sClient secrets.SecretClient, om *omv1.MongoDBOpsManager, prometheusCertHash string) (automationconfig.Modification, error) {
+func buildPrometheusModification(
+	ctx context.Context,
+	sClient secrets.SecretClient,
+	om *omv1.MongoDBOpsManager,
+	prometheusCertHash string,
+) (automationconfig.Modification, error) {
 	if om.Spec.AppDB.Prometheus == nil {
 		return automationconfig.NOOP(), nil
 	}
@@ -1556,7 +1849,15 @@ func toMonitoringLogRotate(lr *mdbv1.LogRotateForBackupAndMonitoring) *automatio
 	}
 }
 
-func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.SugaredLogger, tls bool, projectID string, agentAPIKey string, requireValidCert bool, logRotate *mdbv1.LogRotateForBackupAndMonitoring) {
+func configureMonitoring(
+	ac *automationconfig.AutomationConfig,
+	log *zap.SugaredLogger,
+	tls bool,
+	projectID string,
+	agentAPIKey string,
+	requireValidCert bool,
+	logRotate *mdbv1.LogRotateForBackupAndMonitoring,
+) {
 	if projectID == "" || agentAPIKey == "" {
 		ac.MonitoringVersions = []automationconfig.MonitoringVersion{}
 		return
@@ -1608,7 +1909,12 @@ func configureMonitoring(ac *automationconfig.AutomationConfig, log *zap.Sugared
 }
 
 // registerAppDBHostsWithProject uses the Hosts API to add each process in the AppDB to the project
-func (r *ReconcileAppDbReplicaSet) registerAppDBHostsWithProject(hostnames []string, conn om.Connection, opsManagerPassword string, log *zap.SugaredLogger) error {
+func (r *ReconcileAppDbReplicaSet) registerAppDBHostsWithProject(
+	hostnames []string,
+	conn om.Connection,
+	opsManagerPassword string,
+	log *zap.SugaredLogger,
+) error {
 	getHostsResult, err := conn.GetHosts()
 	if err != nil {
 		return xerrors.Errorf("error fetching existing hosts: %w", err)
@@ -1666,7 +1972,13 @@ func (r *ReconcileAppDbReplicaSet) registerAppDBHostsWithProject(hostnames []str
 
 // addPreferredHostnames will add the hostnames as preferred in Ops Manager
 // Ops Manager does not check for duplicates, so we need to treat it here.
-func (r *ReconcileAppDbReplicaSet) addPreferredHostnames(ctx context.Context, conn om.Connection, opsManager *omv1.MongoDBOpsManager, agentApiKey string, hostnames []string) error {
+func (r *ReconcileAppDbReplicaSet) addPreferredHostnames(
+	ctx context.Context,
+	conn om.Connection,
+	opsManager *omv1.MongoDBOpsManager,
+	agentApiKey string,
+	hostnames []string,
+) error {
 	existingPreferredHostnames, err := conn.GetPreferredHostnames(agentApiKey)
 	if err != nil {
 		return err
@@ -1688,7 +2000,11 @@ func (r *ReconcileAppDbReplicaSet) addPreferredHostnames(ctx context.Context, co
 	return nil
 }
 
-func (r *ReconcileAppDbReplicaSet) generatePasswordAndCreateSecret(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileAppDbReplicaSet) generatePasswordAndCreateSecret(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (string, error) {
 	// create the password
 	password, err := generate.RandomFixedLengthStringOfSize(12)
 	if err != nil {
@@ -1719,7 +2035,11 @@ func (r *ReconcileAppDbReplicaSet) generatePasswordAndCreateSecret(ctx context.C
 
 // ensureAppDbPassword will return the password that was specified by the user, or the auto generated password stored in
 // the secret (generate it and store in secret otherwise)
-func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (string, error) {
 	passwordRef := opsManager.Spec.AppDB.PasswordSecretKeyRef
 	if passwordRef != nil && passwordRef.Name != "" { // there is a secret specified for the Ops Manager user
 		if passwordRef.Key == "" {
@@ -1746,8 +2066,13 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 
 		// delete the auto generated password, we don't need it anymore. We can just generate a new one if
 		// the user password is deleted
-		log.Debugf("Deleting Operator managed password secret/%s from namespace %s", opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName(), opsManager.Namespace)
-		if err := r.DeleteSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())); err != nil && !secret.SecretNotExist(err) {
+		log.Debugf(
+			"Deleting Operator managed password secret/%s from namespace %s",
+			opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName(),
+			opsManager.Namespace,
+		)
+		if err := r.DeleteSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName())); err != nil &&
+			!secret.SecretNotExist(err) {
 			return "", err
 		}
 		return password, nil
@@ -1775,7 +2100,13 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbPassword(ctx context.Context, opsM
 }
 
 // ensureAppDbAgentApiKey makes sure there is an agent API key for the AppDB automation agent
-func (r *ReconcileAppDbReplicaSet) ensureAppDbAgentApiKey(ctx context.Context, opsManager *omv1.MongoDBOpsManager, conn om.Connection, projectID string, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileAppDbReplicaSet) ensureAppDbAgentApiKey(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	conn om.Connection,
+	projectID string,
+	log *zap.SugaredLogger,
+) (string, error) {
 	var appdbSecretPath string
 	if r.VaultClient != nil {
 		appdbSecretPath = r.VaultClient.AppDBSecretPath()
@@ -1795,7 +2126,13 @@ func (r *ReconcileAppDbReplicaSet) ensureAppDbAgentApiKey(ctx context.Context, o
 
 // tryConfigureMonitoringInOpsManager attempts to configure monitoring in Ops Manager. This might not be possible if Ops Manager
 // has not been created yet, if that is the case, an empty PodVars will be returned.
-func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, opsManagerUserPassword string, agentCertPath string, log *zap.SugaredLogger) (env.PodEnvVars, error) {
+func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	opsManagerUserPassword string,
+	agentCertPath string,
+	log *zap.SugaredLogger,
+) (env.PodEnvVars, error) {
 	var operatorVaultSecretPath string
 	if r.VaultClient != nil {
 		operatorVaultSecretPath = r.VaultClient.OperatorSecretPath()
@@ -1895,7 +2232,11 @@ func (r *ReconcileAppDbReplicaSet) tryConfigureMonitoringInOpsManager(ctx contex
 	}, nil
 }
 
-func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMap(ctx context.Context, opsManager *omv1.MongoDBOpsManager, projectID string) error {
+func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMap(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	projectID string,
+) error {
 	var errs error
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		if err := r.ensureProjectIDConfigMapForCluster(ctx, opsManager, projectID, memberCluster.Client); err != nil {
@@ -1907,7 +2248,12 @@ func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMap(ctx context.Context,
 	return errs
 }
 
-func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMapForCluster(ctx context.Context, opsManager *omv1.MongoDBOpsManager, projectID string, k8sClient kubernetesClient.Client) error {
+func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMapForCluster(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	projectID string,
+	k8sClient kubernetesClient.Client,
+) error {
 	cm := configmap.Builder().
 		SetName(opsManager.Spec.AppDB.ProjectIDConfigMapName()).
 		SetLabels(opsManager.GetOwnerLabels()).
@@ -1933,7 +2279,11 @@ func (r *ReconcileAppDbReplicaSet) ensureProjectIDConfigMapForCluster(ctx contex
 // In such a case, we cannot read the groupId from OM, so we fall back to the ConfigMap we created
 // before hand. This is required as with empty PodVars this would trigger an unintentional
 // rolling restart of the AppDB.
-func (r *ReconcileAppDbReplicaSet) readExistingPodVars(ctx context.Context, om *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (env.PodEnvVars, error) {
+func (r *ReconcileAppDbReplicaSet) readExistingPodVars(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (env.PodEnvVars, error) {
 	memberClient := r.helper.getMemberCluster(r.helper.getNameOfFirstMemberCluster()).Client
 	cm, err := memberClient.GetConfigMap(ctx, kube.ObjectKey(om.Namespace, om.Spec.AppDB.ProjectIDConfigMapName()))
 	if err != nil {
@@ -1941,7 +2291,11 @@ func (r *ReconcileAppDbReplicaSet) readExistingPodVars(ctx context.Context, om *
 	}
 	var projectId string
 	if projectId = cm.Data[util.AppDbProjectIdKey]; projectId == "" {
-		return env.PodEnvVars{}, xerrors.Errorf("ConfigMap %s did not have the key %s", om.Spec.AppDB.ProjectIDConfigMapName(), util.AppDbProjectIdKey)
+		return env.PodEnvVars{}, xerrors.Errorf(
+			"ConfigMap %s did not have the key %s",
+			om.Spec.AppDB.ProjectIDConfigMapName(),
+			util.AppDbProjectIdKey,
+		)
 	}
 
 	var operatorVaultSecretPath string
@@ -1974,14 +2328,24 @@ func (r *ReconcileAppDbReplicaSet) readExistingPodVars(ctx context.Context, om *
 	agentAPIKey, err := r.helper.getMemberCluster(r.helper.getNameOfFirstMemberCluster()).SecretClient.ReadSecretKey(
 		ctx, kube.ObjectKey(om.Namespace, agents.ApiKeySecretName(projectId)), appdbSecretPath, util.OmAgentApiKey)
 	if err != nil {
-		log.Warnf("Agent API key for project %s not readable yet (%v); AppDB monitoring will be configured once it is available", projectId, err)
+		log.Warnf(
+			"Agent API key for project %s not readable yet (%v); AppDB monitoring will be configured once it is available",
+			projectId,
+			err,
+		)
 		return podVars, nil
 	}
 	podVars.AgentAPIKey = agentAPIKey
 	return podVars, nil
 }
 
-func (r *ReconcileAppDbReplicaSet) publishACVersionAsConfigMap(ctx context.Context, cmName string, opsManager *omv1.MongoDBOpsManager, version int, memberCluster multicluster.MemberCluster) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) publishACVersionAsConfigMap(
+	ctx context.Context,
+	cmName string,
+	opsManager *omv1.MongoDBOpsManager,
+	version int,
+	memberCluster multicluster.MemberCluster,
+) workflow.Status {
 	acVersionConfigMap := configmap.Builder().
 		SetLabels(opsManager.GetOwnerLabels()).
 		SetOwnerReferences(opsManager.AppDBOwnerReferenceForMemberCluster()).
@@ -1998,7 +2362,14 @@ func (r *ReconcileAppDbReplicaSet) publishACVersionAsConfigMap(ctx context.Conte
 
 // deployAutomationConfig updates the Automation Config secret if necessary and waits for the pods to fall to "not ready"
 // In this case the next StatefulSet update will be safe as the rolling upgrade will wait for the pods to get ready
-func (r *ReconcileAppDbReplicaSet) deployAutomationConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, podVars *env.PodEnvVars, prometheusCertHash string, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger) (int, workflow.Status) {
+func (r *ReconcileAppDbReplicaSet) deployAutomationConfig(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	podVars *env.PodEnvVars,
+	prometheusCertHash string,
+	memberCluster multicluster.MemberCluster,
+	log *zap.SugaredLogger,
+) (int, workflow.Status) {
 	rs := opsManager.Spec.AppDB
 
 	config, err := r.buildAppDbAutomationConfig(ctx, opsManager, podVars, prometheusCertHash, memberCluster.Name, log)
@@ -2026,7 +2397,13 @@ func (r *ReconcileAppDbReplicaSet) GetAppDBUpdateStrategyType(om *omv1.MongoDBOp
 	return appsv1.OnDeleteStatefulSetStrategyType
 }
 
-func (r *ReconcileAppDbReplicaSet) deployStatefulSet(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger, podVars env.PodEnvVars, appdbOpts construct.AppDBStatefulSetOptions) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) deployStatefulSet(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+	podVars env.PodEnvVars,
+	appdbOpts construct.AppDBStatefulSetOptions,
+) workflow.Status {
 	if err := r.createServices(ctx, opsManager, log); err != nil {
 		return workflow.Failed(err)
 	}
@@ -2037,7 +2414,12 @@ func (r *ReconcileAppDbReplicaSet) deployStatefulSet(ctx context.Context, opsMan
 	// currentClusterSpecs map is maintained for scaling therefore we need to update it here
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range r.helper.getAllMemberClusters() {
-		scaler := scalers.GetAppDBScaler(opsManager, memberCluster.Name, r.helper.getMemberClusterIndex(memberCluster.Name), r.helper.memberClusters)
+		scaler := scalers.GetAppDBScaler(
+			opsManager,
+			memberCluster.Name,
+			r.helper.getMemberClusterIndex(memberCluster.Name),
+			r.helper.memberClusters,
+		)
 		if scaler.ScalingFirstTime() {
 			scalingFirstTime = true
 		}
@@ -2063,7 +2445,13 @@ func (r *ReconcileAppDbReplicaSet) deployStatefulSet(ctx context.Context, opsMan
 		}
 
 		expectedGeneration := mutatedSts.GetGeneration()
-		statefulsetStatus := statefulset.GetStatefulSetStatus(ctx, opsManager.Namespace, opsManager.Spec.AppDB.NameForCluster(memberCluster.Index), expectedGeneration, memberCluster.Client)
+		statefulsetStatus := statefulset.GetStatefulSetStatus(
+			ctx,
+			opsManager.Namespace,
+			opsManager.Spec.AppDB.NameForCluster(memberCluster.Index),
+			expectedGeneration,
+			memberCluster.Client,
+		)
 
 		if statefulsetStatus.IsOK() {
 			if err := statefulset.ResetUpdateStrategy(ctx, opsManager.GetVersionedImplForMemberCluster(r.helper.getMemberClusterIndex(memberCluster.Name)), memberCluster.Client); err != nil {
@@ -2112,7 +2500,12 @@ func (r *ReconcileAppDbReplicaSet) createServices(ctx context.Context, opsManage
 				placeholderReplacer := getPlaceholderReplacer(opsManager.Spec.AppDB, memberCluster, podIdx)
 
 				if processedAnnotations, replacedFlag, err := placeholderReplacer.ProcessMap(svc.Annotations); err != nil {
-					return xerrors.Errorf("failed to process annotations in external service %s in cluster %s: %w", svc.Name, memberCluster.Name, err)
+					return xerrors.Errorf(
+						"failed to process annotations in external service %s in cluster %s: %w",
+						svc.Name,
+						memberCluster.Name,
+						err,
+					)
 				} else if replacedFlag {
 					log.Debugf("Replaced placeholders in annotations in external service %s in cluster: %s. Annotations before: %+v, annotations after: %+v", svc.Name, memberCluster.Name, svc.Annotations, processedAnnotations)
 					svc.Annotations = processedAnnotations
@@ -2130,7 +2523,8 @@ func (r *ReconcileAppDbReplicaSet) createServices(ctx context.Context, opsManage
 			}
 
 			// Configures pod services for multi cluster deployments
-			if opsManager.Spec.AppDB.IsMultiCluster() && opsManager.Spec.AppDB.GetExternalDomainForMemberCluster(memberCluster.Name) == nil {
+			if opsManager.Spec.AppDB.IsMultiCluster() &&
+				opsManager.Spec.AppDB.GetExternalDomainForMemberCluster(memberCluster.Name) == nil {
 				svc := getAppDBPodService(opsManager.Spec.AppDB, memberCluster.Index, podIdx)
 				svc.Name = dns.GetMultiServiceName(opsManager.Spec.AppDB.Name(), memberCluster.Index, podIdx)
 				err := service.CreateOrUpdateService(ctx, memberCluster.Client, svc)
@@ -2145,7 +2539,13 @@ func (r *ReconcileAppDbReplicaSet) createServices(ctx context.Context, opsManage
 }
 
 // deployStatefulSetInMemberCluster updates the StatefulSet spec and returns its status (if it's ready or not)
-func (r *ReconcileAppDbReplicaSet) deployStatefulSetInMemberCluster(ctx context.Context, opsManager *omv1.MongoDBOpsManager, appDbSts appsv1.StatefulSet, memberClusterName string, log *zap.SugaredLogger) (*appsv1.StatefulSet, workflow.Status) {
+func (r *ReconcileAppDbReplicaSet) deployStatefulSetInMemberCluster(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	appDbSts appsv1.StatefulSet,
+	memberClusterName string,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, workflow.Status) {
 	workflowStatus := create.HandlePVCResize(ctx, r.helper.getMemberCluster(memberClusterName).Client, &appDbSts, log)
 	if !workflowStatus.IsOK() {
 		return nil, workflowStatus
@@ -2158,7 +2558,14 @@ func (r *ReconcileAppDbReplicaSet) deployStatefulSetInMemberCluster(ctx context.
 	}
 
 	serviceSelectorLabel := opsManager.Spec.AppDB.HeadlessServiceSelectorAppLabel(r.helper.getMemberCluster(memberClusterName).Index)
-	mutatedSts, err := create.AppDBInKubernetes(ctx, r.helper.getMemberCluster(memberClusterName).Client, opsManager, appDbSts, serviceSelectorLabel, log)
+	mutatedSts, err := create.AppDBInKubernetes(
+		ctx,
+		r.helper.getMemberCluster(memberClusterName).Client,
+		opsManager,
+		appDbSts,
+		serviceSelectorLabel,
+		log,
+	)
 	if err != nil {
 		return nil, workflow.Failed(xerrors.Errorf("failed to create AppDB StatefulSet in cluster %s: %w", memberClusterName, err))
 	}
@@ -2166,7 +2573,12 @@ func (r *ReconcileAppDbReplicaSet) deployStatefulSetInMemberCluster(ctx context.
 	return mutatedSts, workflow.OK()
 }
 
-func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalState(ctx context.Context, manager *omv1.MongoDBOpsManager, targetConfigVersion int, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalState(
+	ctx context.Context,
+	manager *omv1.MongoDBOpsManager,
+	targetConfigVersion int,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		var workflowStatus workflow.Status
 		if manager.Spec.AppDB.IsMultiCluster() {
@@ -2183,9 +2595,18 @@ func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalState(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalStateMultiCluster(ctx context.Context, manager *omv1.MongoDBOpsManager, targetConfigVersion int, memberClusterName string, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalStateMultiCluster(
+	ctx context.Context,
+	manager *omv1.MongoDBOpsManager,
+	targetConfigVersion int,
+	memberClusterName string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	memberClusterClient := r.helper.getMemberCluster(memberClusterName).Client
-	set, err := memberClusterClient.GetStatefulSet(ctx, manager.AppDBStatefulSetObjectKey(r.helper.getMemberClusterIndex(memberClusterName)))
+	set, err := memberClusterClient.GetStatefulSet(
+		ctx,
+		manager.AppDBStatefulSetObjectKey(r.helper.getMemberClusterIndex(memberClusterName)),
+	)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			return workflow.OK()
@@ -2205,7 +2626,13 @@ func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalStateMultiCluster(ctx con
 }
 
 // allAgentsReachedGoalState checks if all the AppDB Agents have reached the goal state.
-func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalStateSingleCluster(ctx context.Context, manager *omv1.MongoDBOpsManager, targetConfigVersion int, memberClusterName string, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileAppDbReplicaSet) allAgentsReachedGoalStateSingleCluster(
+	ctx context.Context,
+	manager *omv1.MongoDBOpsManager,
+	targetConfigVersion int,
+	memberClusterName string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	// We need to read the current StatefulSet to find the real number of pods - we cannot rely on OpsManager resource
 	set, err := r.client.GetStatefulSet(ctx, manager.AppDBStatefulSetObjectKey(r.helper.getMemberClusterIndex(memberClusterName)))
 	if err != nil {
@@ -2263,7 +2690,11 @@ func (r *ReconcileAppDbReplicaSet) getCurrentStatefulsetHostnames(opsManager *om
 	})
 }
 
-func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (bool, error) {
+func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (bool, error) {
 	allStsExist := true
 	for _, memberCluster := range r.helper.GetHealthyMemberClusters() {
 		stsName := opsManager.Spec.AppDB.NameForCluster(r.helper.getMemberClusterIndex(memberCluster.Name))
@@ -2285,7 +2716,11 @@ func (r *ReconcileAppDbReplicaSet) allStatefulSetsExist(ctx context.Context, ops
 // migrateToNewDeploymentState reads old config maps with the deployment state and writes them to the new deploymentState structure.
 // This function is intended to be called only in the absence of the new deployment state config map.
 // In this case, if the legacy config maps are also missing, then it means is a completely fresh deployments and this function does nothing.
-func (r *AppDBReconcilerHelper) migrateToNewDeploymentState(ctx context.Context, spec omv1.AppDBSpec, omAnnotations map[string]string) error {
+func (r *AppDBReconcilerHelper) migrateToNewDeploymentState(
+	ctx context.Context,
+	spec omv1.AppDBSpec,
+	omAnnotations map[string]string,
+) error {
 	if legacyMemberClusterMapping, err := getLegacyMemberClusterMapping(ctx, spec.Namespace, spec.ClusterMappingConfigMapName(), r.centralClient); err != nil {
 		if !apiErrors.IsNotFound(err) && spec.IsMultiCluster() {
 			return err

--- a/controllers/operator/appdbreplicaset_controller_multi_test.go
+++ b/controllers/operator/appdbreplicaset_controller_multi_test.go
@@ -84,7 +84,14 @@ func TestAppDB_MultiCluster(t *testing.T) {
 	tlsCertSecretName, tlsSecretPemHash := createAppDBTLSCert(ctx, t, kubeClient, appdb)
 	pemSecretName := tlsCertSecretName + "-pem"
 
-	reconciler, err := newAppDbMultiReconciler(ctx, kubeClient, opsManager, memberClusterMap, zap.S(), omConnectionFactory.GetConnectionFunc)
+	reconciler, err := newAppDbMultiReconciler(
+		ctx,
+		kubeClient,
+		opsManager,
+		memberClusterMap,
+		zap.S(),
+		omConnectionFactory.GetConnectionFunc,
+	)
 	require.NoError(t, err)
 
 	err = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, opsManagerUserPassword)
@@ -105,7 +112,13 @@ func TestAppDB_MultiCluster(t *testing.T) {
 	centralClusterChecks.checkConfigMapNotFound(ctx, appdb.ProjectIDConfigMapName())
 
 	for clusterIdx, clusterSpecItem := range clusterSpecItems {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, opsManager.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			opsManager.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 		memberClusterChecks.checkAutomationConfigSecret(ctx, appdb.AutomationConfigSecretName())
 		memberClusterChecks.checkAutomationConfigConfigMap(ctx, appdb.AutomationConfigConfigMapName())
 		memberClusterChecks.checkSecretNotFound(ctx, monitoringAutomationConfigSecretName(appdb))
@@ -115,8 +128,16 @@ func TestAppDB_MultiCluster(t *testing.T) {
 		memberClusterChecks.checkSecretNotFound(ctx, tlsCertSecretName)
 		memberClusterChecks.checkPEMSecret(ctx, pemSecretName, tlsSecretPemHash)
 
-		memberClusterChecks.checkStatefulSet(ctx, opsManager.Spec.AppDB.NameForCluster(reconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)), clusterSpecItem.Members)
-		memberClusterChecks.checkPerPodServices(ctx, opsManager.Spec.AppDB.NameForCluster(reconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)), clusterSpecItem.Members)
+		memberClusterChecks.checkStatefulSet(
+			ctx,
+			opsManager.Spec.AppDB.NameForCluster(reconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)),
+			clusterSpecItem.Members,
+		)
+		memberClusterChecks.checkPerPodServices(
+			ctx,
+			opsManager.Spec.AppDB.NameForCluster(reconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)),
+			clusterSpecItem.Members,
+		)
 	}
 
 	// OM API Key secret is required for enabling monitoring to OM
@@ -132,7 +153,13 @@ func TestAppDB_MultiCluster(t *testing.T) {
 	centralClusterChecks.checkConfigMapNotFound(ctx, appdb.ProjectIDConfigMapName())
 	agentAPIKey := ""
 	for clusterIdx, clusterSpecItem := range clusterSpecItems {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, opsManager.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			opsManager.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 		projectID := memberClusterChecks.checkProjectIDConfigMap(ctx, appdb.ProjectIDConfigMapName())
 		agentAPIKeyFromSecret := memberClusterChecks.checkAgentAPIKeySecret(ctx, projectID)
 		assert.NotEmpty(t, agentAPIKeyFromSecret)
@@ -217,7 +244,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 			"om-db-0-1",
 			"om-db-1-0",
 		}
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalClusterMap, memberClusterName, clusterSpecItems, expectedHostnames, expectedProcessNames, 1, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalClusterMap,
+			memberClusterName,
+			clusterSpecItems,
+			expectedHostnames,
+			expectedProcessNames,
+			1,
+			log,
+		)
 	})
 
 	t.Run("scale down second cluster to zero before removal", func(t *testing.T) {
@@ -241,7 +281,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 			"om-db-0-0",
 			"om-db-0-1",
 		}
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalClusterMap, memberClusterName, clusterSpecItems, expectedHostnames, expectedProcessNames, 1, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalClusterMap,
+			memberClusterName,
+			clusterSpecItems,
+			expectedHostnames,
+			expectedProcessNames,
+			1,
+			log,
+		)
 	})
 
 	t.Run("remove second cluster and add new one", func(t *testing.T) {
@@ -269,7 +322,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 		}
 
 		// 2 reconciles, remove 1 member from memberClusterName2 and add one from memberClusterName3
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalClusterMap, memberClusterName, clusterSpecItems, expectedHostnames, expectedProcessNames, 2, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalClusterMap,
+			memberClusterName,
+			clusterSpecItems,
+			expectedHostnames,
+			expectedProcessNames,
+			2,
+			log,
+		)
 	})
 
 	t.Run("add second cluster back to check indexes are preserved with different clusterSpecItem order", func(t *testing.T) {
@@ -305,11 +371,27 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 		}
 
 		// 2 reconciles to add 2 members of memberClusterName2
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalClusterMap, memberClusterName, clusterSpecItems, expectedHostnames, expectedProcessNames, 2, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalClusterMap,
+			memberClusterName,
+			clusterSpecItems,
+			expectedHostnames,
+			expectedProcessNames,
+			2,
+			log,
+		)
 	})
 
 	t.Run("remove second cluster from global cluster to simulate full-cluster failure", func(t *testing.T) {
-		globalMemberClusterMapWithoutCluster2 := getFakeMultiClusterMapWithClusters([]string{memberClusterName, memberClusterName3}, omConnectionFactory)
+		globalMemberClusterMapWithoutCluster2 := getFakeMultiClusterMapWithClusters(
+			[]string{memberClusterName, memberClusterName3},
+			omConnectionFactory,
+		)
 		// no changes to clusterSpecItems, nothing should be scaled, processes should be the same
 		clusterSpecItems := mdbv1.ClusterSpecList{
 			{
@@ -343,7 +425,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 		}
 
 		// nothing to be scaled
-		reconcileAppDBOnceAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalMemberClusterMapWithoutCluster2, memberClusterName, clusterSpecItems, false, expectedHostnames, expectedProcessNames, log)
+		reconcileAppDBOnceAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalMemberClusterMapWithoutCluster2,
+			memberClusterName,
+			clusterSpecItems,
+			false,
+			expectedHostnames,
+			expectedProcessNames,
+			log,
+		)
 
 		// Scale "failed" second cluster down to zero before removal
 		clusterSpecItems = mdbv1.ClusterSpecList{
@@ -376,7 +471,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 		}
 
 		// one process from memberClusterName2 should be removed
-		reconcileAppDBOnceAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalMemberClusterMapWithoutCluster2, memberClusterName, clusterSpecItems, true, expectedHostnames, expectedProcessNames, log)
+		reconcileAppDBOnceAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalMemberClusterMapWithoutCluster2,
+			memberClusterName,
+			clusterSpecItems,
+			true,
+			expectedHostnames,
+			expectedProcessNames,
+			log,
+		)
 
 		expectedHostnames = []string{
 			"om-db-0-0-svc.ns.svc.cluster.local",
@@ -392,7 +500,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 
 		// the last process from memberClusterName2 should be removed
 		// this should be final reconcile
-		reconcileAppDBOnceAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalMemberClusterMapWithoutCluster2, memberClusterName, clusterSpecItems, false, expectedHostnames, expectedProcessNames, log)
+		reconcileAppDBOnceAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalMemberClusterMapWithoutCluster2,
+			memberClusterName,
+			clusterSpecItems,
+			false,
+			expectedHostnames,
+			expectedProcessNames,
+			log,
+		)
 
 		// memberClusterName2 is removed
 		clusterSpecItems = mdbv1.ClusterSpecList{
@@ -419,7 +540,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 		}
 
 		// nothing to be scaled
-		reconcileAppDBOnceAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalMemberClusterMapWithoutCluster2, memberClusterName, clusterSpecItems, false, expectedHostnames, expectedProcessNames, log)
+		reconcileAppDBOnceAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalMemberClusterMapWithoutCluster2,
+			memberClusterName,
+			clusterSpecItems,
+			false,
+			expectedHostnames,
+			expectedProcessNames,
+			log,
+		)
 	})
 	t.Run("add second cluster back to check indexes are preserved with different clusterSpecItem order", func(t *testing.T) {
 		clusterSpecItems := mdbv1.ClusterSpecList{
@@ -454,7 +588,20 @@ func TestAppDB_MultiCluster_AutomationConfig(t *testing.T) {
 		}
 
 		// 2 reconciles to add 2 members of memberClusterName2
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, opsManager, globalClusterMap, memberClusterName, clusterSpecItems, expectedHostnames, expectedProcessNames, 2, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			opsManager,
+			globalClusterMap,
+			memberClusterName,
+			clusterSpecItems,
+			expectedHostnames,
+			expectedProcessNames,
+			2,
+			log,
+		)
 	})
 }
 
@@ -470,11 +617,23 @@ func assertExpectedHostnamesAndPreferred(t *testing.T, omConnection *om.MockedOm
 	}), "the AppDB preferred hostnames should have been added")
 }
 
-func assertExpectedProcesses(ctx context.Context, t *testing.T, memberClusterName string, reconciler *ReconcileAppDbReplicaSet, opsManager *omv1.MongoDBOpsManager, expectedHostnames []string, expectedProcessNames []string) {
-	ac, err := automationconfig.ReadFromSecret(ctx, reconciler.helper.getMemberCluster(memberClusterName).SecretClient, types.NamespacedName{
-		Namespace: opsManager.GetNamespace(),
-		Name:      opsManager.Spec.AppDB.AutomationConfigSecretName(),
-	})
+func assertExpectedProcesses(
+	ctx context.Context,
+	t *testing.T,
+	memberClusterName string,
+	reconciler *ReconcileAppDbReplicaSet,
+	opsManager *omv1.MongoDBOpsManager,
+	expectedHostnames []string,
+	expectedProcessNames []string,
+) {
+	ac, err := automationconfig.ReadFromSecret(
+		ctx,
+		reconciler.helper.getMemberCluster(memberClusterName).SecretClient,
+		types.NamespacedName{
+			Namespace: opsManager.GetNamespace(),
+			Name:      opsManager.Spec.AppDB.AutomationConfigSecretName(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedHostnames, util.Transform(ac.Processes, func(obj automationconfig.Process) string {
@@ -487,7 +646,20 @@ func assertExpectedProcesses(ctx context.Context, t *testing.T, memberClusterNam
 	assert.Equal(t, expectedHostnames, reconciler.getCurrentStatefulsetHostnames(opsManager))
 }
 
-func reconcileAppDBOnceAndCheckExpectedProcesses(ctx context.Context, t *testing.T, kubeClient client.Client, omConnectionFactoryFunc om.ConnectionFactory, opsManager *omv1.MongoDBOpsManager, memberClusterMap map[string]client.Client, memberClusterName string, clusterSpecItems mdbv1.ClusterSpecList, expectedRequeue bool, expectedHostnames []string, expectedProcessNames []string, log *zap.SugaredLogger) {
+func reconcileAppDBOnceAndCheckExpectedProcesses(
+	ctx context.Context,
+	t *testing.T,
+	kubeClient client.Client,
+	omConnectionFactoryFunc om.ConnectionFactory,
+	opsManager *omv1.MongoDBOpsManager,
+	memberClusterMap map[string]client.Client,
+	memberClusterName string,
+	clusterSpecItems mdbv1.ClusterSpecList,
+	expectedRequeue bool,
+	expectedHostnames []string,
+	expectedProcessNames []string,
+	log *zap.SugaredLogger,
+) {
 	opsManager.Spec.AppDB.ClusterSpecList = clusterSpecItems
 
 	reconciler, err := newAppDbMultiReconciler(ctx, kubeClient, opsManager, memberClusterMap, log, omConnectionFactoryFunc)
@@ -505,7 +677,17 @@ func reconcileAppDBOnceAndCheckExpectedProcesses(ctx context.Context, t *testing
 	assertExpectedProcesses(ctx, t, memberClusterName, reconciler, opsManager, expectedHostnames, expectedProcessNames)
 }
 
-func reconcileAppDBForExpectedNumberOfTimes(ctx context.Context, t *testing.T, kubeClient client.Client, omConnectionFactoryFunc *om.ConnectionFactory, opsManager *omv1.MongoDBOpsManager, memberClusterMap map[string]client.Client, clusterSpecItems mdbv1.ClusterSpecList, expectedReconciles int, log *zap.SugaredLogger) *ReconcileAppDbReplicaSet {
+func reconcileAppDBForExpectedNumberOfTimes(
+	ctx context.Context,
+	t *testing.T,
+	kubeClient client.Client,
+	omConnectionFactoryFunc *om.ConnectionFactory,
+	opsManager *omv1.MongoDBOpsManager,
+	memberClusterMap map[string]client.Client,
+	clusterSpecItems mdbv1.ClusterSpecList,
+	expectedReconciles int,
+	log *zap.SugaredLogger,
+) *ReconcileAppDbReplicaSet {
 	opsManager.Spec.AppDB.ClusterSpecList = clusterSpecItems
 
 	var reconciler *ReconcileAppDbReplicaSet
@@ -528,14 +710,59 @@ func reconcileAppDBForExpectedNumberOfTimes(ctx context.Context, t *testing.T, k
 	return reconciler
 }
 
-func reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(ctx context.Context, t *testing.T, kubeClient client.Client, omConnectionFactoryFunc om.ConnectionFactory, opsManager *omv1.MongoDBOpsManager, memberClusterMap map[string]client.Client, memberClusterName string, clusterSpecItems mdbv1.ClusterSpecList, expectedHostnames []string, expectedProcessNames []string, expectedReconciles int, log *zap.SugaredLogger) {
-	reconciler := reconcileAppDBForExpectedNumberOfTimes(ctx, t, kubeClient, &omConnectionFactoryFunc, opsManager, memberClusterMap, clusterSpecItems, expectedReconciles, log)
+func reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedProcesses(
+	ctx context.Context,
+	t *testing.T,
+	kubeClient client.Client,
+	omConnectionFactoryFunc om.ConnectionFactory,
+	opsManager *omv1.MongoDBOpsManager,
+	memberClusterMap map[string]client.Client,
+	memberClusterName string,
+	clusterSpecItems mdbv1.ClusterSpecList,
+	expectedHostnames []string,
+	expectedProcessNames []string,
+	expectedReconciles int,
+	log *zap.SugaredLogger,
+) {
+	reconciler := reconcileAppDBForExpectedNumberOfTimes(
+		ctx,
+		t,
+		kubeClient,
+		&omConnectionFactoryFunc,
+		opsManager,
+		memberClusterMap,
+		clusterSpecItems,
+		expectedReconciles,
+		log,
+	)
 
 	assertExpectedProcesses(ctx, t, memberClusterName, reconciler, opsManager, expectedHostnames, expectedProcessNames)
 }
 
-func reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(ctx context.Context, t *testing.T, kubeClient client.Client, omConnectionFactoryFunc om.ConnectionFactory, omConnectionFactory *om.CachedOMConnectionFactory, opsManager *omv1.MongoDBOpsManager, memberClusterMap map[string]client.Client, clusterSpecItems mdbv1.ClusterSpecList, expectedHostnames []string, expectedReconciles int, log *zap.SugaredLogger) {
-	reconcileAppDBForExpectedNumberOfTimes(ctx, t, kubeClient, &omConnectionFactoryFunc, opsManager, memberClusterMap, clusterSpecItems, expectedReconciles, log)
+func reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(
+	ctx context.Context,
+	t *testing.T,
+	kubeClient client.Client,
+	omConnectionFactoryFunc om.ConnectionFactory,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	opsManager *omv1.MongoDBOpsManager,
+	memberClusterMap map[string]client.Client,
+	clusterSpecItems mdbv1.ClusterSpecList,
+	expectedHostnames []string,
+	expectedReconciles int,
+	log *zap.SugaredLogger,
+) {
+	reconcileAppDBForExpectedNumberOfTimes(
+		ctx,
+		t,
+		kubeClient,
+		&omConnectionFactoryFunc,
+		opsManager,
+		memberClusterMap,
+		clusterSpecItems,
+		expectedReconciles,
+		log,
+	)
 
 	assertExpectedHostnamesAndPreferred(t, omConnectionFactory.GetConnection().(*om.MockedOmConnection), expectedHostnames)
 }
@@ -568,10 +795,20 @@ func TestNewAppDBReconcilerHelper(t *testing.T) {
 			SetAppDBTopology(mdbv1.ClusterTopologyMultiCluster).
 			Build()
 		kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
-		memberClusterMap := getFakeMultiClusterMapWithClusters([]string{memberClusterName1, memberClusterName2, memberClusterName3}, omConnectionFactory)
+		memberClusterMap := getFakeMultiClusterMapWithClusters(
+			[]string{memberClusterName1, memberClusterName2, memberClusterName3},
+			omConnectionFactory,
+		)
 
 		// deploy with all three clusters to persist the deployment state
-		reconciler, err := newAppDbMultiReconciler(ctx, kubeClient, opsManager, memberClusterMap, log, omConnectionFactory.GetConnectionFunc)
+		reconciler, err := newAppDbMultiReconciler(
+			ctx,
+			kubeClient,
+			opsManager,
+			memberClusterMap,
+			log,
+			omConnectionFactory.GetConnectionFunc,
+		)
 		require.NoError(t, err)
 		// simulate that member-cluster-3 had been deployed with one member before being removed from the spec
 		reconciler.helper.deploymentState.LastAppliedMemberSpec = map[string]int{memberClusterName3: 1}
@@ -580,7 +817,13 @@ func TestNewAppDBReconcilerHelper(t *testing.T) {
 		// member-cluster-3 is removed from the spec
 		opsManager.Spec.AppDB.ClusterSpecList = makeClusterSpecList(memberClusterName1, memberClusterName2)
 
-		helper, err := NewReadOnlyAppDBReconcilerHelper(ctx, opsManager, NewReconcileCommonController(ctx, kubeClient), memberClusterMap, log)
+		helper, err := NewReadOnlyAppDBReconcilerHelper(
+			ctx,
+			opsManager,
+			NewReconcileCommonController(ctx, kubeClient),
+			memberClusterMap,
+			log,
+		)
 		require.NoError(t, err)
 
 		assert.Equal(t, []string{memberClusterName1, memberClusterName2, memberClusterName3}, memberClusterNames(helper))
@@ -608,7 +851,13 @@ func TestNewAppDBReconcilerHelper(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		helper, err := NewReadOnlyAppDBReconcilerHelper(ctx, opsManager, NewReconcileCommonController(ctx, kubeClient), memberClusterMap, log)
+		helper, err := NewReadOnlyAppDBReconcilerHelper(
+			ctx,
+			opsManager,
+			NewReconcileCommonController(ctx, kubeClient),
+			memberClusterMap,
+			log,
+		)
 		require.NoError(t, err)
 
 		assert.Equal(t, []string{memberClusterName1, memberClusterName2}, memberClusterNames(helper))
@@ -655,7 +904,14 @@ func TestAppDB_MultiCluster_ClusterMapping(t *testing.T) {
 	memberClusterName3 := "member-cluster-3"
 	memberClusterName4 := "member-cluster-4"
 	memberClusterName5 := "member-cluster-5"
-	clusters := []string{centralClusterName, memberClusterName1, memberClusterName2, memberClusterName3, memberClusterName4, memberClusterName5}
+	clusters := []string{
+		centralClusterName,
+		memberClusterName1,
+		memberClusterName2,
+		memberClusterName3,
+		memberClusterName4,
+		memberClusterName5,
+	}
 
 	builder := DefaultOpsManagerBuilder().
 		SetAppDBClusterSpecList(makeClusterSpecList(memberClusterName1, memberClusterName2)).
@@ -865,8 +1121,22 @@ func TestAppDB_MultiCluster_KeepUpdatingLegacyState(t *testing.T) {
 			memberClusterName1: 1,
 			memberClusterName2: 1,
 		}
-		checkLegacyLastAppliedMemberSpec(ctx, t, reconciler.helper.centralClient, appdb.Namespace, appdb.Name(), expectedLastAppliedMemberSpec)
-		checkLegacyLastAppliedMongoDBVersion(ctx, t, reconciler.helper.centralClient, opsManager.Namespace, opsManager.GetName(), expectedLastAppliedMongoDBVersion)
+		checkLegacyLastAppliedMemberSpec(
+			ctx,
+			t,
+			reconciler.helper.centralClient,
+			appdb.Namespace,
+			appdb.Name(),
+			expectedLastAppliedMemberSpec,
+		)
+		checkLegacyLastAppliedMongoDBVersion(
+			ctx,
+			t,
+			reconciler.helper.centralClient,
+			opsManager.Namespace,
+			opsManager.GetName(),
+			expectedLastAppliedMongoDBVersion,
+		)
 	})
 
 	t.Run("check that legacy config maps are updated on reconcile when scaling", func(t *testing.T) {
@@ -896,8 +1166,22 @@ func TestAppDB_MultiCluster_KeepUpdatingLegacyState(t *testing.T) {
 			memberClusterName1: 1,
 			memberClusterName2: 0,
 		}
-		checkLegacyLastAppliedMemberSpec(ctx, t, reconciler.helper.centralClient, appdb.Namespace, appdb.Name(), expectedLastAppliedMemberSpec)
-		checkLegacyLastAppliedMongoDBVersion(ctx, t, reconciler.helper.centralClient, opsManager.Namespace, opsManager.GetName(), expectedLastAppliedMongoDBVersion)
+		checkLegacyLastAppliedMemberSpec(
+			ctx,
+			t,
+			reconciler.helper.centralClient,
+			appdb.Namespace,
+			appdb.Name(),
+			expectedLastAppliedMemberSpec,
+		)
+		checkLegacyLastAppliedMongoDBVersion(
+			ctx,
+			t,
+			reconciler.helper.centralClient,
+			opsManager.Namespace,
+			opsManager.GetName(),
+			expectedLastAppliedMongoDBVersion,
+		)
 	})
 
 	t.Run("check that legacy config maps are updated on reconcile when removing a cluster", func(t *testing.T) {
@@ -930,8 +1214,22 @@ func TestAppDB_MultiCluster_KeepUpdatingLegacyState(t *testing.T) {
 			memberClusterName2: 0,
 			memberClusterName3: 1,
 		}
-		checkLegacyLastAppliedMemberSpec(ctx, t, reconciler.helper.centralClient, appdb.Namespace, appdb.Name(), expectedLastAppliedMemberSpec)
-		checkLegacyLastAppliedMongoDBVersion(ctx, t, reconciler.helper.centralClient, opsManager.Namespace, opsManager.GetName(), expectedLastAppliedMongoDBVersion)
+		checkLegacyLastAppliedMemberSpec(
+			ctx,
+			t,
+			reconciler.helper.centralClient,
+			appdb.Namespace,
+			appdb.Name(),
+			expectedLastAppliedMemberSpec,
+		)
+		checkLegacyLastAppliedMongoDBVersion(
+			ctx,
+			t,
+			reconciler.helper.centralClient,
+			opsManager.Namespace,
+			opsManager.GetName(),
+			expectedLastAppliedMongoDBVersion,
+		)
 	})
 }
 
@@ -954,22 +1252,49 @@ func readDeploymentState[T any](ctx context.Context, t *testing.T, c client.Clie
 	return stateStruct
 }
 
-func checkClusterMapping(ctx context.Context, t *testing.T, c client.Client, namespace string, resourceName string, expectedMapping map[string]int) {
+func checkClusterMapping(
+	ctx context.Context,
+	t *testing.T,
+	c client.Client,
+	namespace string,
+	resourceName string,
+	expectedMapping map[string]int,
+) {
 	deploymentState := readDeploymentState[AppDBDeploymentState](ctx, t, c, namespace, resourceName)
 	assert.Equal(t, expectedMapping, deploymentState.ClusterMapping)
 }
 
-func checkLastAppliedMemberSpec(ctx context.Context, t *testing.T, c client.Client, namespace string, resourceName string, expectedMemberSpec map[string]int) {
+func checkLastAppliedMemberSpec(
+	ctx context.Context,
+	t *testing.T,
+	c client.Client,
+	namespace string,
+	resourceName string,
+	expectedMemberSpec map[string]int,
+) {
 	deploymentState := readDeploymentState[AppDBDeploymentState](ctx, t, c, namespace, resourceName)
 	assert.Equal(t, expectedMemberSpec, deploymentState.LastAppliedMemberSpec)
 }
 
-func checkLastAppliedMongoDBVersion(ctx context.Context, t *testing.T, c client.Client, namespace string, resourceName string, expectedVersion string) {
+func checkLastAppliedMongoDBVersion(
+	ctx context.Context,
+	t *testing.T,
+	c client.Client,
+	namespace string,
+	resourceName string,
+	expectedVersion string,
+) {
 	deploymentState := readDeploymentState[AppDBDeploymentState](ctx, t, c, namespace, resourceName)
 	assert.Equal(t, expectedVersion, deploymentState.LastAppliedMongoDBVersion)
 }
 
-func checkLegacyClusterMapping(ctx context.Context, t *testing.T, client client.Client, namespace, appdbName string, expectedData map[string]int) {
+func checkLegacyClusterMapping(
+	ctx context.Context,
+	t *testing.T,
+	client client.Client,
+	namespace, appdbName string,
+	expectedData map[string]int,
+) {
 	cm := &corev1.ConfigMap{}
 	err := client.Get(ctx, types.NamespacedName{Name: appdbName + "-cluster-mapping", Namespace: namespace}, cm)
 	require.NoError(t, err)
@@ -978,7 +1303,13 @@ func checkLegacyClusterMapping(ctx context.Context, t *testing.T, client client.
 	}
 }
 
-func checkLegacyLastAppliedMemberSpec(ctx context.Context, t *testing.T, client client.Client, namespace, appdbName string, expectedData map[string]int) {
+func checkLegacyLastAppliedMemberSpec(
+	ctx context.Context,
+	t *testing.T,
+	client client.Client,
+	namespace, appdbName string,
+	expectedData map[string]int,
+) {
 	cm := &corev1.ConfigMap{}
 	err := client.Get(ctx, types.NamespacedName{Name: appdbName + "-member-spec", Namespace: namespace}, cm)
 	require.NoError(t, err)
@@ -987,7 +1318,12 @@ func checkLegacyLastAppliedMemberSpec(ctx context.Context, t *testing.T, client 
 	}
 }
 
-func checkLegacyLastAppliedMongoDBVersion(ctx context.Context, t *testing.T, client client.Client, namespace, omName, expectedVersion string) {
+func checkLegacyLastAppliedMongoDBVersion(
+	ctx context.Context,
+	t *testing.T,
+	client client.Client,
+	namespace, omName, expectedVersion string,
+) {
 	opsManager := &omv1.MongoDBOpsManager{}
 	err := client.Get(ctx, types.NamespacedName{Name: omName, Namespace: namespace}, opsManager)
 	require.NoError(t, err)
@@ -1088,10 +1424,27 @@ func TestAppDBMultiClusterRemoveResources(t *testing.T) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
 	clusters = []string{"a", "b", "c"}
 	memberClusterMap := getFakeMultiClusterMapWithClusters(clusters, omConnectionFactory)
-	reconciler, _, _ := defaultTestOmReconciler(ctx, t, nil, "", "", opsManager, memberClusterMap, omConnectionFactory, architectures.NonStatic)
+	reconciler, _, _ := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		opsManager,
+		memberClusterMap,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 
 	// create opsmanager reconciler
-	appDBReconciler, _ := newAppDbMultiReconciler(ctx, kubeClient, opsManager, memberClusterMap, zap.S(), omConnectionFactory.GetConnectionFunc)
+	appDBReconciler, _ := newAppDbMultiReconciler(
+		ctx,
+		kubeClient,
+		opsManager,
+		memberClusterMap,
+		zap.S(),
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	// initially requeued as monitoring needs to be configured
 	_, err := appDBReconciler.ReconcileAppDB(ctx, opsManager)
@@ -1099,9 +1452,19 @@ func TestAppDBMultiClusterRemoveResources(t *testing.T) {
 
 	// check AppDB statefulset exists in cluster "a" and cluster "b"
 	for clusterIdx, clusterSpecItem := range opsManager.Spec.AppDB.ClusterSpecList {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, opsManager.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			opsManager.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 
-		memberClusterChecks.checkStatefulSet(ctx, opsManager.Spec.AppDB.NameForCluster(appDBReconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)), clusterSpecItem.Members)
+		memberClusterChecks.checkStatefulSet(
+			ctx,
+			opsManager.Spec.AppDB.NameForCluster(appDBReconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)),
+			clusterSpecItem.Members,
+		)
 	}
 
 	// delete the OM resource
@@ -1110,9 +1473,18 @@ func TestAppDBMultiClusterRemoveResources(t *testing.T) {
 
 	// assert STS objects in member cluster
 	for clusterIdx, clusterSpecItem := range opsManager.Spec.AppDB.ClusterSpecList {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, opsManager.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			opsManager.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 
-		memberClusterChecks.checkStatefulSetDoesNotExist(ctx, opsManager.Spec.AppDB.NameForCluster(appDBReconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)))
+		memberClusterChecks.checkStatefulSetDoesNotExist(
+			ctx,
+			opsManager.Spec.AppDB.NameForCluster(appDBReconciler.helper.getMemberClusterIndex(clusterSpecItem.ClusterName)),
+		)
 	}
 }
 
@@ -1264,7 +1636,19 @@ func TestAppDBMultiClusterTryConfigureMonitoring(t *testing.T) {
 			"om-db-0-1-svc.ns.svc.cluster.local",
 		}
 
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, omConnectionFactory, opsManager, globalClusterMap, clusterSpecItems, expectedHostnames, 1, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			omConnectionFactory,
+			opsManager,
+			globalClusterMap,
+			clusterSpecItems,
+			expectedHostnames,
+			1,
+			log,
+		)
 
 		// teardown
 		clearHostsAndPreferredHostnames(omConnectionFactory)
@@ -1289,7 +1673,19 @@ func TestAppDBMultiClusterTryConfigureMonitoring(t *testing.T) {
 			"om-db-1-2-svc.ns.svc.cluster.local",
 		}
 
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, omConnectionFactory, opsManager, globalClusterMap, clusterSpecItems, expectedHostnames, 3, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			omConnectionFactory,
+			opsManager,
+			globalClusterMap,
+			clusterSpecItems,
+			expectedHostnames,
+			3,
+			log,
+		)
 
 		// teardown
 		clearHostsAndPreferredHostnames(omConnectionFactory)
@@ -1316,7 +1712,19 @@ func TestAppDBMultiClusterTryConfigureMonitoring(t *testing.T) {
 			"om-db-1-2.custom.domain",
 		}
 
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, omConnectionFactory, opsManager, globalClusterMap, clusterSpecItems, expectedHostnames, 3, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			omConnectionFactory,
+			opsManager,
+			globalClusterMap,
+			clusterSpecItems,
+			expectedHostnames,
+			3,
+			log,
+		)
 
 		// teardown
 		clearHostsAndPreferredHostnames(omConnectionFactory)
@@ -1345,7 +1753,19 @@ func TestAppDBMultiClusterTryConfigureMonitoring(t *testing.T) {
 			"om-db-1-2.cluster-1.domain",
 		}
 
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, omConnectionFactory, opsManager, globalClusterMap, clusterSpecItems, expectedHostnames, 3, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			omConnectionFactory,
+			opsManager,
+			globalClusterMap,
+			clusterSpecItems,
+			expectedHostnames,
+			3,
+			log,
+		)
 
 		// teardown
 		clearHostsAndPreferredHostnames(omConnectionFactory)
@@ -1374,7 +1794,19 @@ func TestAppDBMultiClusterTryConfigureMonitoring(t *testing.T) {
 			"om-db-1-2.cluster-1.domain",
 		}
 
-		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(ctx, t, kubeClient, omConnectionFactory.GetConnectionFunc, omConnectionFactory, opsManager, globalClusterMap, clusterSpecItems, expectedHostnames, 3, log)
+		reconcileAppDBForExpectedNumberOfTimesAndCheckExpectedHostnames(
+			ctx,
+			t,
+			kubeClient,
+			omConnectionFactory.GetConnectionFunc,
+			omConnectionFactory,
+			opsManager,
+			globalClusterMap,
+			clusterSpecItems,
+			expectedHostnames,
+			3,
+			log,
+		)
 
 		// teardown
 		clearHostsAndPreferredHostnames(omConnectionFactory)
@@ -1939,7 +2371,14 @@ func TestAppDBMultiClusterServiceCreation_WithExternalName(t *testing.T) {
 			kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(opsManager)
 			memberClusterMap := getFakeMultiClusterMapWithClusters(memberClusters, omConnectionFactory)
 
-			reconciler, err := newAppDbMultiReconciler(ctx, kubeClient, opsManager, memberClusterMap, zap.S(), omConnectionFactory.GetConnectionFunc)
+			reconciler, err := newAppDbMultiReconciler(
+				ctx,
+				kubeClient,
+				opsManager,
+				memberClusterMap,
+				zap.S(),
+				omConnectionFactory.GetConnectionFunc,
+			)
 			require.NoError(t, err)
 
 			err = createOpsManagerUserPasswordSecret(ctx, kubeClient, opsManager, opsManagerUserPassword)
@@ -2223,7 +2662,14 @@ func TestReconcileAppDBBlockNonEmptyClusterSpecItemRemovalIntegration(t *testing
 			}
 			require.NoError(t, kubeClient.Create(ctx, &stateCM))
 
-			reconciler, err := newAppDbMultiReconciler(ctx, kubeClient, opsManager, memberClusterMap, zap.S(), omConnectionFactory.GetConnectionFunc)
+			reconciler, err := newAppDbMultiReconciler(
+				ctx,
+				kubeClient,
+				opsManager,
+				memberClusterMap,
+				zap.S(),
+				omConnectionFactory.GetConnectionFunc,
+			)
 			require.NoError(t, err)
 
 			createOMAPIKeySecret(ctx, t, reconciler.SecretClient, opsManager)

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -101,7 +101,13 @@ func TestMongoDB_ConnectionURL_DefaultCluster_AppDB(t *testing.T) {
 		"?authMechanism=SCRAM-SHA-256&authSource=admin&connectTimeoutMS=20000&replicaSet=test-om-db&serverSelectionTimeoutMS=20000", cnx)
 
 	// Connection parameters. The default one is overridden
-	cnx = appdb.BuildConnectionURL("user", "passwd", connectionstring.SchemeMongoDB, map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"}, nil)
+	cnx = appdb.BuildConnectionURL(
+		"user",
+		"passwd",
+		connectionstring.SchemeMongoDB,
+		map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"},
+		nil,
+	)
 	assert.Equal(t, "mongodb://user:passwd@test-om-db-0.test-om-db-svc.my-namespace.svc.cluster.local:27017,"+
 		"test-om-db-1.test-om-db-svc.my-namespace.svc.cluster.local:27017,test-om-db-2.test-om-db-svc.my-namespace.svc.cluster.local:27017/"+
 		"?authMechanism=SCRAM-SHA-256&authSource=admin&connectTimeoutMS=30000&readPreference=secondary&replicaSet=test-om-db&serverSelectionTimeoutMS=20000",
@@ -119,7 +125,13 @@ func TestMongoDB_ConnectionURL_OtherCluster_AppDB(t *testing.T) {
 		"?authMechanism=SCRAM-SHA-256&authSource=admin&connectTimeoutMS=20000&replicaSet=test-om-db&serverSelectionTimeoutMS=20000", cnx)
 
 	// Connection parameters. The default one is overridden
-	cnx = appdb.BuildConnectionURL("user", "passwd", connectionstring.SchemeMongoDB, map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"}, nil)
+	cnx = appdb.BuildConnectionURL(
+		"user",
+		"passwd",
+		connectionstring.SchemeMongoDB,
+		map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"},
+		nil,
+	)
 	assert.Equal(t, "mongodb://user:passwd@test-om-db-0.test-om-db-svc.my-namespace.svc.my-cluster:27017,"+
 		"test-om-db-1.test-om-db-svc.my-namespace.svc.my-cluster:27017,test-om-db-2.test-om-db-svc.my-namespace.svc.my-cluster:27017/"+
 		"?authMechanism=SCRAM-SHA-256&authSource=admin&connectTimeoutMS=30000&readPreference=secondary&replicaSet=test-om-db&serverSelectionTimeoutMS=20000",
@@ -162,13 +174,31 @@ func TestPublishAutomationConfigCreate(t *testing.T) {
 	automationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, zap.S())
 	assert.NoError(t, err)
 
-	version, err := reconciler.publishAutomationConfig(ctx, opsManager, automationConfig, appdb.AutomationConfigSecretName(), memberCluster.SecretClient)
+	version, err := reconciler.publishAutomationConfig(
+		ctx,
+		opsManager,
+		automationConfig,
+		appdb.AutomationConfigSecretName(),
+		memberCluster.SecretClient,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, version)
 
-	monitoringAutomationConfig, err := buildAutomationConfigForAppDb(ctx, builder, kubeClient, omConnectionFactory.GetConnectionFunc, zap.S())
+	monitoringAutomationConfig, err := buildAutomationConfigForAppDb(
+		ctx,
+		builder,
+		kubeClient,
+		omConnectionFactory.GetConnectionFunc,
+		zap.S(),
+	)
 	assert.NoError(t, err)
-	version, err = reconciler.publishAutomationConfig(ctx, opsManager, monitoringAutomationConfig, monitoringAutomationConfigSecretName(appdb), memberCluster.SecretClient)
+	version, err = reconciler.publishAutomationConfig(
+		ctx,
+		opsManager,
+		monitoringAutomationConfig,
+		monitoringAutomationConfigSecretName(appdb),
+		memberCluster.SecretClient,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, version)
 
@@ -228,7 +258,11 @@ func TestPublishAutomationConfig_Update(t *testing.T) {
 	_, err = reconciler.ReconcileAppDB(ctx, opsManager)
 	assert.NoError(t, err)
 
-	ac, err := automationconfig.ReadFromSecret(ctx, reconciler.client, kube.ObjectKey(opsManager.Namespace, appdb.AutomationConfigSecretName()))
+	ac, err := automationconfig.ReadFromSecret(
+		ctx,
+		reconciler.client,
+		kube.ObjectKey(opsManager.Namespace, appdb.AutomationConfigSecretName()),
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, ac.Version)
 
@@ -236,7 +270,11 @@ func TestPublishAutomationConfig_Update(t *testing.T) {
 	_, err = reconciler.ReconcileAppDB(ctx, opsManager)
 	assert.NoError(t, err)
 
-	ac, err = automationconfig.ReadFromSecret(ctx, reconciler.client, kube.ObjectKey(opsManager.Namespace, appdb.AutomationConfigSecretName()))
+	ac, err = automationconfig.ReadFromSecret(
+		ctx,
+		reconciler.client,
+		kube.ObjectKey(opsManager.Namespace, appdb.AutomationConfigSecretName()),
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, ac.Version)
 
@@ -252,7 +290,11 @@ func TestPublishAutomationConfig_Update(t *testing.T) {
 	_, err = reconciler.ReconcileAppDB(ctx, opsManager)
 	assert.NoError(t, err)
 
-	ac, err = automationconfig.ReadFromSecret(ctx, reconciler.client, kube.ObjectKey(opsManager.Namespace, appdb.AutomationConfigSecretName()))
+	ac, err = automationconfig.ReadFromSecret(
+		ctx,
+		reconciler.client,
+		kube.ObjectKey(opsManager.Namespace, appdb.AutomationConfigSecretName()),
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, ac.Version)
 }
@@ -489,7 +531,13 @@ func TestEnsureAppDbAgentApiKey(t *testing.T) {
 	require.NoError(t, err)
 
 	omConnectionFactory.GetConnection().(*om.MockedOmConnection).AgentAPIKey = "my-api-key"
-	_, err = reconciler.ensureAppDbAgentApiKey(ctx, opsManager, omConnectionFactory.GetConnection(), omConnectionFactory.GetConnection().GroupID(), zap.S())
+	_, err = reconciler.ensureAppDbAgentApiKey(
+		ctx,
+		opsManager,
+		omConnectionFactory.GetConnection(),
+		omConnectionFactory.GetConnection().GroupID(),
+		zap.S(),
+	)
 	assert.NoError(t, err)
 
 	secretName := agents.ApiKeySecretName(omConnectionFactory.GetConnection().GroupID())
@@ -515,7 +563,15 @@ func TestTryConfigureMonitoringInOpsManager(t *testing.T) {
 	assert.Empty(t, podVars.User)
 
 	opsManager.Spec.AppDB.Members = 5
-	appDbSts, err := construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	appDbSts, err := construct.AppDbStatefulSet(
+		*opsManager,
+		&podVars,
+		construct.AppDBStatefulSetOptions{},
+		appdbScaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	assert.NoError(t, err)
 
 	assert.Nil(t, findVolumeByName(appDbSts.Spec.Template.Spec.Volumes, construct.AgentAPIKeyVolumeName))
@@ -555,7 +611,15 @@ func TestTryConfigureMonitoringInOpsManager(t *testing.T) {
 
 	assertExpectedHostnamesAndPreferred(t, omConnectionFactory.GetConnection().(*om.MockedOmConnection), expectedHostnames)
 
-	appDbSts, err = construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	appDbSts, err = construct.AppDbStatefulSet(
+		*opsManager,
+		&podVars,
+		construct.AppDBStatefulSetOptions{},
+		appdbScaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	assert.NoError(t, err)
 
 	// Monitoring is enabled now (ProjectID populated), so the agent-api-key volume must be mounted
@@ -617,7 +681,15 @@ func TestTryConfigureMonitoringInOpsManagerWithCustomTemplate(t *testing.T) {
 
 	t.Run("do not override images while activating monitoring", func(t *testing.T) {
 		podVars := env.PodEnvVars{ProjectID: "something"}
-		appDbSts, err := construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+		appDbSts, err := construct.AppDbStatefulSet(
+			*opsManager,
+			&podVars,
+			construct.AppDBStatefulSetOptions{},
+			appdbScaler,
+			appsv1.OnDeleteStatefulSetStrategyType,
+			architectures.NonStatic,
+			zap.S(),
+		)
 		assert.NoError(t, err)
 		assert.NotNil(t, appDbSts)
 
@@ -640,7 +712,15 @@ func TestTryConfigureMonitoringInOpsManagerWithCustomTemplate(t *testing.T) {
 
 	t.Run("do not override images, but remove monitoring if not activated", func(t *testing.T) {
 		podVars := env.PodEnvVars{}
-		appDbSts, err := construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+		appDbSts, err := construct.AppDbStatefulSet(
+			*opsManager,
+			&podVars,
+			construct.AppDBStatefulSetOptions{},
+			appdbScaler,
+			appsv1.OnDeleteStatefulSetStrategyType,
+			architectures.NonStatic,
+			zap.S(),
+		)
 		assert.NoError(t, err)
 		assert.NotNil(t, appDbSts)
 
@@ -680,7 +760,15 @@ func TestTryConfigureMonitoringInOpsManagerWithExternalDomains(t *testing.T) {
 	assert.Empty(t, podVars.User)
 
 	opsManager.Spec.AppDB.Members = 5
-	appDbSts, err := construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	appDbSts, err := construct.AppDbStatefulSet(
+		*opsManager,
+		&podVars,
+		construct.AppDBStatefulSetOptions{},
+		appdbScaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	assert.NoError(t, err)
 
 	assert.Nil(t, findVolumeByName(appDbSts.Spec.Template.Spec.Volumes, construct.AgentAPIKeyVolumeName))
@@ -720,7 +808,15 @@ func TestTryConfigureMonitoringInOpsManagerWithExternalDomains(t *testing.T) {
 
 	assertExpectedHostnamesAndPreferred(t, omConnectionFactory.GetConnection().(*om.MockedOmConnection), expectedHostnames)
 
-	appDbSts, err = construct.AppDbStatefulSet(*opsManager, &podVars, construct.AppDBStatefulSetOptions{}, appdbScaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	appDbSts, err = construct.AppDbStatefulSet(
+		*opsManager,
+		&podVars,
+		construct.AppDBStatefulSetOptions{},
+		appdbScaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	assert.NoError(t, err)
 
 	// Monitoring is enabled now (ProjectID populated), so the agent-api-key volume must be mounted.
@@ -1441,10 +1537,23 @@ func TestAppDBSkipsReconciliation_IfAnyProcessesAreDisabled(t *testing.T) {
 		// if the automation is not there, we will always want to reconcile. Otherwise, we may not reconcile
 		// based on whether or not there are disabled processes.
 		if createAutomationConfig {
-			ac, err := reconciler.buildAppDbAutomationConfig(ctx, opsManager, nil, UnusedPrometheusConfiguration, multicluster.LegacyCentralClusterName, zap.S())
+			ac, err := reconciler.buildAppDbAutomationConfig(
+				ctx,
+				opsManager,
+				nil,
+				UnusedPrometheusConfiguration,
+				multicluster.LegacyCentralClusterName,
+				zap.S(),
+			)
 			assert.NoError(t, err)
 
-			_, err = reconciler.publishAutomationConfig(ctx, opsManager, ac, opsManager.Spec.AppDB.AutomationConfigSecretName(), memberCluster.SecretClient)
+			_, err = reconciler.publishAutomationConfig(
+				ctx,
+				opsManager,
+				ac,
+				opsManager.Spec.AppDB.AutomationConfigSecretName(),
+				memberCluster.SecretClient,
+			)
 			assert.NoError(t, err)
 		}
 		return reconciler
@@ -1603,7 +1712,13 @@ func performAppDBScalingTest(ctx context.Context, t *testing.T, startingMembers,
 	assert.Equal(t, finalMembers, opsManager.Status.AppDbStatus.Members)
 }
 
-func buildAutomationConfigForAppDb(ctx context.Context, builder *omv1.OpsManagerBuilder, kubeClient client.Client, omConnectionFactoryFunc om.ConnectionFactory, log *zap.SugaredLogger) (automationconfig.AutomationConfig, error) {
+func buildAutomationConfigForAppDb(
+	ctx context.Context,
+	builder *omv1.OpsManagerBuilder,
+	kubeClient client.Client,
+	omConnectionFactoryFunc om.ConnectionFactory,
+	log *zap.SugaredLogger,
+) (automationconfig.AutomationConfig, error) {
 	opsManager := builder.Build()
 
 	// Ensure the password exists for the Ops Manager User. The Ops Manager controller will have ensured this.
@@ -1613,7 +1728,14 @@ func buildAutomationConfigForAppDb(ctx context.Context, builder *omv1.OpsManager
 	if err != nil {
 		return automationconfig.AutomationConfig{}, err
 	}
-	return reconciler.buildAppDbAutomationConfig(ctx, opsManager, nil, UnusedPrometheusConfiguration, multicluster.LegacyCentralClusterName, zap.S())
+	return reconciler.buildAppDbAutomationConfig(
+		ctx,
+		opsManager,
+		nil,
+		UnusedPrometheusConfiguration,
+		multicluster.LegacyCentralClusterName,
+		zap.S(),
+	)
 }
 
 func checkDeploymentEqualToPublished(t *testing.T, expected automationconfig.AutomationConfig, s *corev1.Secret) {
@@ -1673,7 +1795,14 @@ func TestEnsureResourcesForArchitectureChange(t *testing.T) {
 		assert.NoError(t, err)
 
 		// create the automation config secret
-		err = client.CreateSecret(ctx, secret.Builder().SetNamespace(opsManager.Namespace).SetName(opsManager.Spec.AppDB.AutomationConfigSecretName()).SetField(automationconfig.ConfigKey, string(acBytes)).Build())
+		err = client.CreateSecret(
+			ctx,
+			secret.Builder().
+				SetNamespace(opsManager.Namespace).
+				SetName(opsManager.Spec.AppDB.AutomationConfigSecretName()).
+				SetField(automationconfig.ConfigKey, string(acBytes)).
+				Build(),
+		)
 		assert.NoError(t, err)
 
 		reconciler, err := newAppDbReconciler(ctx, client, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
@@ -1711,11 +1840,25 @@ func TestEnsureResourcesForArchitectureChange(t *testing.T) {
 		assert.NoError(t, err)
 
 		// create the automation config secret
-		err = client.CreateSecret(ctx, secret.Builder().SetNamespace(opsManager.Namespace).SetName(opsManager.Spec.AppDB.AutomationConfigSecretName()).SetField(automationconfig.ConfigKey, string(acBytes)).Build())
+		err = client.CreateSecret(
+			ctx,
+			secret.Builder().
+				SetNamespace(opsManager.Namespace).
+				SetName(opsManager.Spec.AppDB.AutomationConfigSecretName()).
+				SetField(automationconfig.ConfigKey, string(acBytes)).
+				Build(),
+		)
 		assert.NoError(t, err)
 
 		// create the old ops manager user password
-		err = client.CreateSecret(ctx, secret.Builder().SetNamespace(opsManager.Namespace).SetName(opsManager.Spec.AppDB.Name()+"-password").SetField("my-password", "jrJP7eUeyn").Build())
+		err = client.CreateSecret(
+			ctx,
+			secret.Builder().
+				SetNamespace(opsManager.Namespace).
+				SetName(opsManager.Spec.AppDB.Name()+"-password").
+				SetField("my-password", "jrJP7eUeyn").
+				Build(),
+		)
 		assert.NoError(t, err)
 
 		reconciler, err := newAppDbReconciler(ctx, client, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())
@@ -1726,7 +1869,10 @@ func TestEnsureResourcesForArchitectureChange(t *testing.T) {
 
 		t.Run("Scram credentials have been created", func(t *testing.T) {
 			ctx := context.Background()
-			scramCreds, err := client.GetSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.OpsManagerUserScramCredentialsName()))
+			scramCreds, err := client.GetSecret(
+				ctx,
+				kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.OpsManagerUserScramCredentialsName()),
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, ac.Auth.Users[0].ScramSha256Creds.Salt, string(scramCreds.Data["sha256-salt"]))
@@ -1740,7 +1886,10 @@ func TestEnsureResourcesForArchitectureChange(t *testing.T) {
 
 		t.Run("Ops Manager user password has been copied", func(t *testing.T) {
 			ctx := context.Background()
-			newOpsManagerUserPassword, err := client.GetSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName()))
+			newOpsManagerUserPassword, err := client.GetSecret(
+				ctx,
+				kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.GetOpsManagerUserPasswordSecretName()),
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, string(newOpsManagerUserPassword.Data["my-password"]), "jrJP7eUeyn")
 		})
@@ -1761,15 +1910,48 @@ func TestEnsureResourcesForArchitectureChange(t *testing.T) {
 	})
 }
 
-func newAppDbReconciler(ctx context.Context, c client.Client, opsManager *omv1.MongoDBOpsManager, omConnectionFactoryFunc om.ConnectionFactory, log *zap.SugaredLogger) (*ReconcileAppDbReplicaSet, error) {
+func newAppDbReconciler(
+	ctx context.Context,
+	c client.Client,
+	opsManager *omv1.MongoDBOpsManager,
+	omConnectionFactoryFunc om.ConnectionFactory,
+	log *zap.SugaredLogger,
+) (*ReconcileAppDbReplicaSet, error) {
 	commonController := NewReconcileCommonController(ctx, c)
-	return NewAppDBReplicaSetReconciler(ctx, nil, "", opsManager, commonController, omConnectionFactoryFunc, nil, architectures.NonStatic, log)
+	return NewAppDBReplicaSetReconciler(
+		ctx,
+		nil,
+		"",
+		opsManager,
+		commonController,
+		omConnectionFactoryFunc,
+		nil,
+		architectures.NonStatic,
+		log,
+	)
 }
 
-func newAppDbMultiReconciler(ctx context.Context, c client.Client, opsManager *omv1.MongoDBOpsManager, memberClusterMap map[string]client.Client, log *zap.SugaredLogger, omConnectionFactoryFunc om.ConnectionFactory) (*ReconcileAppDbReplicaSet, error) {
+func newAppDbMultiReconciler(
+	ctx context.Context,
+	c client.Client,
+	opsManager *omv1.MongoDBOpsManager,
+	memberClusterMap map[string]client.Client,
+	log *zap.SugaredLogger,
+	omConnectionFactoryFunc om.ConnectionFactory,
+) (*ReconcileAppDbReplicaSet, error) {
 	_ = c.Update(ctx, opsManager)
 	commonController := NewReconcileCommonController(ctx, c)
-	return NewAppDBReplicaSetReconciler(ctx, nil, "", opsManager, commonController, omConnectionFactoryFunc, memberClusterMap, architectures.NonStatic, log)
+	return NewAppDBReplicaSetReconciler(
+		ctx,
+		nil,
+		"",
+		opsManager,
+		commonController,
+		omConnectionFactoryFunc,
+		memberClusterMap,
+		architectures.NonStatic,
+		log,
+	)
 }
 
 func TestChangingFCVAppDB(t *testing.T) {
@@ -1805,21 +1987,38 @@ func createOpsManagerUserPasswordSecret(ctx context.Context, kubeClient client.C
 	return kubeClient.Create(ctx, &sec)
 }
 
-func readAutomationConfigSecret(ctx context.Context, t *testing.T, kubeClient client.Client, opsManager *omv1.MongoDBOpsManager) *corev1.Secret {
+func readAutomationConfigSecret(
+	ctx context.Context,
+	t *testing.T,
+	kubeClient client.Client,
+	opsManager *omv1.MongoDBOpsManager,
+) *corev1.Secret {
 	s := &corev1.Secret{}
 	key := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AppDB.AutomationConfigSecretName())
 	assert.NoError(t, kubeClient.Get(ctx, key, s))
 	return s
 }
 
-func readAutomationConfigMonitoringSecret(ctx context.Context, t *testing.T, kubeClient client.Client, opsManager *omv1.MongoDBOpsManager) *corev1.Secret {
+func readAutomationConfigMonitoringSecret(
+	ctx context.Context,
+	t *testing.T,
+	kubeClient client.Client,
+	opsManager *omv1.MongoDBOpsManager,
+) *corev1.Secret {
 	s := &corev1.Secret{}
 	key := kube.ObjectKey(opsManager.Namespace, monitoringAutomationConfigSecretName(opsManager.Spec.AppDB))
 	assert.NoError(t, kubeClient.Get(ctx, key, s))
 	return s
 }
 
-func createRunningAppDB(ctx context.Context, t *testing.T, startingMembers int, fakeClient kubernetesClient.Client, opsManager *omv1.MongoDBOpsManager, omConnectionFactory *om.CachedOMConnectionFactory) *ReconcileAppDbReplicaSet {
+func createRunningAppDB(
+	ctx context.Context,
+	t *testing.T,
+	startingMembers int,
+	fakeClient kubernetesClient.Client,
+	opsManager *omv1.MongoDBOpsManager,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+) *ReconcileAppDbReplicaSet {
 	err := createOpsManagerUserPasswordSecret(ctx, fakeClient, opsManager, "pass")
 	assert.NoError(t, err)
 	reconciler, err := newAppDbReconciler(ctx, fakeClient, opsManager, omConnectionFactory.GetConnectionFunc, zap.S())

--- a/controllers/operator/authentication/authentication.go
+++ b/controllers/operator/authentication/authentication.go
@@ -88,7 +88,14 @@ type UserOptions struct {
 
 // Configure will configure all the specified authentication Mechanisms. We need to ensure we wait for
 // the agents to reach ready state after each operation as prematurely updating the automation config can cause the agents to get stuck.
-func Configure(ctx context.Context, client kubernetesClient.Client, conn om.Connection, opts Options, isRecovering bool, log *zap.SugaredLogger) error {
+func Configure(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	isRecovering bool,
+	log *zap.SugaredLogger,
+) error {
 	log.Infow("ensuring correct deployment mechanisms", "ProcessNames", opts.ProcessNames, "Mechanisms", opts.Mechanisms)
 
 	// In case we're recovering, we can push all changes at once, because the mechanism is triggered after 20min by default.
@@ -157,7 +164,14 @@ func Configure(ctx context.Context, client kubernetesClient.Client, conn om.Conn
 
 // Disable disables all authentication mechanisms, and waits for the agents to reach goal state. It is still required to provide
 // automation agent username, password and keyfile contents to ensure a valid Automation Config.
-func Disable(ctx context.Context, client kubernetesClient.Client, conn om.Connection, opts Options, deleteUsers bool, log *zap.SugaredLogger) error {
+func Disable(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	deleteUsers bool,
+	log *zap.SugaredLogger,
+) error {
 	ac, err := conn.ReadAutomationConfig()
 	if err != nil {
 		return xerrors.Errorf("error reading automation config: %w", err)
@@ -274,7 +288,13 @@ func removeUnsupportedAgentMechanisms(conn om.Connection, opts Options, log *zap
 
 // enableAgentAuthentication determines which agent authentication mechanism should be configured
 // and enables it in Ops Manager
-func enableAgentAuthentication(ctx context.Context, client kubernetesClient.Client, conn om.Connection, opts Options, log *zap.SugaredLogger) error {
+func enableAgentAuthentication(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	log *zap.SugaredLogger,
+) error {
 	ac, err := conn.ReadAutomationConfig()
 	if err != nil {
 		return xerrors.Errorf("error reading automation config: %w", err)
@@ -381,7 +401,15 @@ func addOrRemoveAgentClientCertificate(conn om.Connection, opts Options, log *za
 }
 
 // ensureAgentAuthenticationIsConfigured will configure the agent authentication settings based on the desiredAgentAuthMechanism
-func ensureAgentAuthenticationIsConfigured(ctx context.Context, client kubernetesClient.Client, conn om.Connection, opts Options, ac *om.AutomationConfig, mechanism Mechanism, log *zap.SugaredLogger) error {
+func ensureAgentAuthenticationIsConfigured(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	ac *om.AutomationConfig,
+	mechanism Mechanism,
+	log *zap.SugaredLogger,
+) error {
 	if mechanism.IsAgentAuthenticationConfigured(ac, opts) {
 		log.Infof("Agent authentication mechanism %s is already configured", mechanism.GetName())
 		return nil
@@ -393,7 +421,13 @@ func ensureAgentAuthenticationIsConfigured(ctx context.Context, client kubernete
 
 // ensureDeploymentMechanisms configures the given AutomationConfig to allow deployments to
 // authenticate using the specified mechanisms
-func ensureDeploymentMechanisms(conn om.Connection, ac *om.AutomationConfig, mechanisms MechanismList, opts Options, log *zap.SugaredLogger) error {
+func ensureDeploymentMechanisms(
+	conn om.Connection,
+	ac *om.AutomationConfig,
+	mechanisms MechanismList,
+	opts Options,
+	log *zap.SugaredLogger,
+) error {
 	mechanismsToEnable := make([]Mechanism, 0)
 	for _, mechanism := range mechanisms {
 		if !mechanism.IsDeploymentAuthenticationConfigured(ac, opts) {
@@ -420,7 +454,12 @@ func ensureDeploymentMechanisms(conn om.Connection, ac *om.AutomationConfig, mec
 
 // ensureDeploymentMechanismsAreDisabled configures the given AutomationConfig to allow deployments to
 // authenticate using the specified mechanisms
-func ensureDeploymentMechanismsAreDisabled(conn om.Connection, ac *om.AutomationConfig, mechanismsToDisable MechanismList, log *zap.SugaredLogger) error {
+func ensureDeploymentMechanismsAreDisabled(
+	conn om.Connection,
+	ac *om.AutomationConfig,
+	mechanismsToDisable MechanismList,
+	log *zap.SugaredLogger,
+) error {
 	deploymentMechanismsToDisable := make([]Mechanism, 0)
 	for _, mechanism := range mechanismsToDisable {
 		if mechanism.IsDeploymentAuthenticationEnabled(ac) {

--- a/controllers/operator/authentication/authentication_mechanism.go
+++ b/controllers/operator/authentication/authentication_mechanism.go
@@ -15,7 +15,13 @@ import (
 
 // Mechanism is an interface that needs to be implemented for any Ops Manager authentication mechanism
 type Mechanism interface {
-	EnableAgentAuthentication(ctx context.Context, client kubernetesClient.Client, conn om.Connection, opts Options, log *zap.SugaredLogger) error
+	EnableAgentAuthentication(
+		ctx context.Context,
+		client kubernetesClient.Client,
+		conn om.Connection,
+		opts Options,
+		log *zap.SugaredLogger,
+	) error
 	DisableAgentAuthentication(conn om.Connection, log *zap.SugaredLogger) error
 	EnableDeploymentAuthentication(conn om.Connection, opts Options, log *zap.SugaredLogger) error
 	DisableDeploymentAuthentication(conn om.Connection, log *zap.SugaredLogger) error

--- a/controllers/operator/authentication/ldap.go
+++ b/controllers/operator/authentication/ldap.go
@@ -18,7 +18,13 @@ func (l *ldapAuthMechanism) GetName() MechanismName {
 	return LDAPPlain
 }
 
-func (l *ldapAuthMechanism) EnableAgentAuthentication(_ context.Context, _ kubernetesClient.Client, conn om.Connection, opts Options, log *zap.SugaredLogger) error {
+func (l *ldapAuthMechanism) EnableAgentAuthentication(
+	_ context.Context,
+	_ kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	log *zap.SugaredLogger,
+) error {
 	log.Info("Configuring LDAP authentication")
 	err := conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
 		if err := ac.EnsureKeyFileContents(); err != nil {

--- a/controllers/operator/authentication/oidc.go
+++ b/controllers/operator/authentication/oidc.go
@@ -22,7 +22,13 @@ func (o *oidcAuthMechanism) GetName() MechanismName {
 	return MongoDBOIDC
 }
 
-func (o *oidcAuthMechanism) EnableAgentAuthentication(_ context.Context, _ kubernetesClient.Client, _ om.Connection, _ Options, _ *zap.SugaredLogger) error {
+func (o *oidcAuthMechanism) EnableAgentAuthentication(
+	_ context.Context,
+	_ kubernetesClient.Client,
+	_ om.Connection,
+	_ Options,
+	_ *zap.SugaredLogger,
+) error {
 	return xerrors.Errorf("OIDC agent authentication is not supported")
 }
 

--- a/controllers/operator/authentication/scramsha.go
+++ b/controllers/operator/authentication/scramsha.go
@@ -21,7 +21,13 @@ func (s *automationConfigScramSha) GetName() MechanismName {
 	return s.MechanismName
 }
 
-func (s *automationConfigScramSha) EnableAgentAuthentication(ctx context.Context, client kubernetesClient.Client, conn om.Connection, opts Options, log *zap.SugaredLogger) error {
+func (s *automationConfigScramSha) EnableAgentAuthentication(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	log *zap.SugaredLogger,
+) error {
 	return conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
 		if err := configureScramAgentUsers(ctx, client, ac, opts); err != nil {
 			return err

--- a/controllers/operator/authentication/scramsha_credentials.go
+++ b/controllers/operator/authentication/scramsha_credentials.go
@@ -47,12 +47,18 @@ func isPasswordChanged(user *om.MongoDBUser, password string, acUser *om.MongoDB
 		// is actually changed
 		newScramSha256Creds, err := computeScramShaCreds(user.Username, password, sha256Salt, ScramSha256)
 		if err != nil {
-			return false, xerrors.Errorf("error generating scramSha256 creds to verify with already present user on automation config %w", err)
+			return false, xerrors.Errorf(
+				"error generating scramSha256 creds to verify with already present user on automation config %w",
+				err,
+			)
 		}
 
 		newScramSha1Creds, err := computeScramShaCreds(user.Username, password, sha1Salt, MongoDBCR)
 		if err != nil {
-			return false, xerrors.Errorf("error generating scramSha1 creds to verify with already present user on automation config %w", err)
+			return false, xerrors.Errorf(
+				"error generating scramSha1 creds to verify with already present user on automation config %w",
+				err,
+			)
 		}
 		return !newScramSha256Creds.Equals(*acUser.ScramSha256Creds) || !newScramSha1Creds.Equals(*acUser.ScramSha1Creds), nil
 	}
@@ -158,7 +164,11 @@ func hmacIteration(hashConstructor func() hash.Hash, input, salt []byte, iterati
 	// incorrect salt size will pass validation, but the credentials will be invalid. i.e. it will not
 	// be possible to auth with the password provided to create the credentials.
 	if len(salt) != hashSize-rfc5802MandatedSaltSize {
-		return nil, xerrors.Errorf("salt should have a size of %v bytes, but instead has a size of %v bytes", hashSize-rfc5802MandatedSaltSize, len(salt))
+		return nil, xerrors.Errorf(
+			"salt should have a size of %v bytes, but instead has a size of %v bytes",
+			hashSize-rfc5802MandatedSaltSize,
+			len(salt),
+		)
 	}
 
 	startKey := append(salt, 0, 0, 0, 1)
@@ -206,7 +216,12 @@ func generateStoredKey(hashConstructor func() hash.Hash, clientKey []byte) ([]by
 	return h.Sum(nil), nil
 }
 
-func generateSecrets(hashConstructor func() hash.Hash, password string, salt []byte, iterationCount int) (storedKey, serverKey []byte, err error) {
+func generateSecrets(
+	hashConstructor func() hash.Hash,
+	password string,
+	salt []byte,
+	iterationCount int,
+) (storedKey, serverKey []byte, err error) {
 	saltedPassword, err := generateSaltedPassword(hashConstructor, password, salt, iterationCount)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("error generating salted password: %w", err)
@@ -230,7 +245,11 @@ func generateSecrets(hashConstructor func() hash.Hash, password string, salt []b
 	return storedKey, serverKey, err
 }
 
-func generateB64EncodedSecrets(hashConstructor func() hash.Hash, password, b64EncodedSalt string, iterationCount int) (storedKey, serverKey string, err error) {
+func generateB64EncodedSecrets(
+	hashConstructor func() hash.Hash,
+	password, b64EncodedSalt string,
+	iterationCount int,
+) (storedKey, serverKey string, err error) {
 	salt, err := base64.StdEncoding.DecodeString(b64EncodedSalt)
 	if err != nil {
 		return "", "", xerrors.Errorf("error decoding salt: %w", err)
@@ -247,7 +266,12 @@ func generateB64EncodedSecrets(hashConstructor func() hash.Hash, password, b64En
 }
 
 // password should be encrypted in the case of SCRAM-SHA-1 and unencrypted in the case of SCRAM-SHA-256
-func computeScramCredentials(hashConstructor func() hash.Hash, iterationCount int, base64EncodedSalt string, password string) (*om.ScramShaCreds, error) {
+func computeScramCredentials(
+	hashConstructor func() hash.Hash,
+	iterationCount int,
+	base64EncodedSalt string,
+	password string,
+) (*om.ScramShaCreds, error) {
 	storedKey, serverKey, err := generateB64EncodedSecrets(hashConstructor, password, base64EncodedSalt, iterationCount)
 	if err != nil {
 		return nil, xerrors.Errorf("error generating SCRAM-SHA keys: %w", err)

--- a/controllers/operator/authentication/scramsha_credentials_test.go
+++ b/controllers/operator/authentication/scramsha_credentials_test.go
@@ -14,9 +14,33 @@ func TestScramSha1SecretsMatch(t *testing.T) {
 	// these were taken from MongoDB.  passwordHash is from authSchema
 	// 3. iterationCount, salt, storedKey, and serverKey are from
 	// authSchema 5 (after upgrading from authSchema 3)
-	assertSecretsMatch(t, sha1.New, "caeec61ba3b15b15b188d29e876514e8", 10, "S3cuk2Rnu/MlbewzxrmmVA==", "sYBa3XlSPKNrgjzhOuEuRlJY4dQ=", "zuAxRSQb3gZkbaB1IGlusK4jy1M=")
-	assertSecretsMatch(t, sha1.New, "4d9625b297999b3ca786d4a9622d04f1", 10, "kW9KbCQiCOll5Ljd44cjkQ==", "VJ8fFVHkPltibvT//mG/OWw44Hc=", "ceDRsgj9HezpZ4/vkZX8GZNNN50=")
-	assertSecretsMatch(t, sha1.New, "fd0a78e418dcef39f8c768222810b894", 10, "hhX6xsoID6FeWjXncuNgAg==", "TxgaZJ4cIn+S9EfTcc9IOEG7RGc=", "d6/qjwBs0qkPKfUAjSh5eemsySE=")
+	assertSecretsMatch(
+		t,
+		sha1.New,
+		"caeec61ba3b15b15b188d29e876514e8",
+		10,
+		"S3cuk2Rnu/MlbewzxrmmVA==",
+		"sYBa3XlSPKNrgjzhOuEuRlJY4dQ=",
+		"zuAxRSQb3gZkbaB1IGlusK4jy1M=",
+	)
+	assertSecretsMatch(
+		t,
+		sha1.New,
+		"4d9625b297999b3ca786d4a9622d04f1",
+		10,
+		"kW9KbCQiCOll5Ljd44cjkQ==",
+		"VJ8fFVHkPltibvT//mG/OWw44Hc=",
+		"ceDRsgj9HezpZ4/vkZX8GZNNN50=",
+	)
+	assertSecretsMatch(
+		t,
+		sha1.New,
+		"fd0a78e418dcef39f8c768222810b894",
+		10,
+		"hhX6xsoID6FeWjXncuNgAg==",
+		"TxgaZJ4cIn+S9EfTcc9IOEG7RGc=",
+		"d6/qjwBs0qkPKfUAjSh5eemsySE=",
+	)
 }
 
 func assertSecretsMatch(t *testing.T, hash func() hash.Hash, passwordHash string, iterationCount int, salt, storedKey, serverKey string) {

--- a/controllers/operator/authentication/x509.go
+++ b/controllers/operator/authentication/x509.go
@@ -18,7 +18,13 @@ func (x *connectionX509) GetName() MechanismName {
 	return MongoDBX509
 }
 
-func (x *connectionX509) EnableAgentAuthentication(_ context.Context, _ kubernetesClient.Client, conn om.Connection, opts Options, log *zap.SugaredLogger) error {
+func (x *connectionX509) EnableAgentAuthentication(
+	_ context.Context,
+	_ kubernetesClient.Client,
+	conn om.Connection,
+	opts Options,
+	log *zap.SugaredLogger,
+) error {
 	log.Info("Configuring x509 authentication")
 	err := conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
 		if err := ac.EnsureKeyFileContents(); err != nil {

--- a/controllers/operator/authentication_test.go
+++ b/controllers/operator/authentication_test.go
@@ -48,7 +48,19 @@ func TestX509CanBeEnabled_WhenThereAreOnlyTlsDeployments_ReplicaSet(t *testing.T
 
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 }
 
@@ -58,7 +70,19 @@ func TestX509ClusterAuthentication_CanBeEnabled_IfX509AuthenticationIsEnabled_Re
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 }
 
@@ -66,7 +90,16 @@ func TestX509ClusterAuthentication_CanBeEnabled_IfX509AuthenticationIsEnabled_Sh
 	ctx := context.Background()
 	scWithTls := test.DefaultClusterBuilder().EnableTLS().EnableX509().SetName("sc-with-tls").SetTLSCA("custom-ca").Build()
 
-	reconciler, _, client, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", scWithTls, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, client, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		scWithTls,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	addKubernetesTlsResources(ctx, client, scWithTls)
 
@@ -77,7 +110,16 @@ func TestX509CanBeEnabled_WhenThereAreOnlyTlsDeployments_ShardedCluster(t *testi
 	ctx := context.Background()
 	scWithTls := test.DefaultClusterBuilder().EnableTLS().EnableX509().SetName("sc-with-tls").SetTLSCA("custom-ca").Build()
 
-	reconciler, _, client, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", scWithTls, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, client, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		scWithTls,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	addKubernetesTlsResources(ctx, client, scWithTls)
 
@@ -91,7 +133,19 @@ func TestUpdateOmAuthentication_NoAuthenticationEnabled(t *testing.T) {
 	processNames := []string{"my-rs-0", "my-rs-1", "my-rs-2"}
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	r.updateOmAuthentication(ctx, conn, processNames, rs, "", "", "", false, zap.S())
 
 	ac, _ := conn.ReadAutomationConfig()
@@ -112,8 +166,30 @@ func TestUpdateOmAuthentication_EnableX509_TlsNotEnabled(t *testing.T) {
 	rs.Spec.Security.TLSConfig.Enabled = true
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, conn, []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
+	status, isMultiStageReconciliation := r.updateOmAuthentication(
+		ctx,
+		conn,
+		[]string{"my-rs-0", "my-rs-1", "my-rs-2"},
+		rs,
+		"",
+		"",
+		"",
+		false,
+		zap.S(),
+	)
 
 	assert.True(t, status.IsOK(), "configuring both options at once should not result in a failed status")
 	assert.True(t, isMultiStageReconciliation, "configuring both tls and x509 at once should result in a multi stage reconciliation")
@@ -122,10 +198,34 @@ func TestUpdateOmAuthentication_EnableX509_TlsNotEnabled(t *testing.T) {
 func TestUpdateOmAuthentication_EnableX509_WithTlsAlreadyEnabled(t *testing.T) {
 	ctx := context.Background()
 	rs := DefaultReplicaSetBuilder().SetName("my-rs").SetMembers(3).EnableTLS().Build()
-	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)))
+	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(
+		om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)),
+	)
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
+	status, isMultiStageReconciliation := r.updateOmAuthentication(
+		ctx,
+		omConnectionFactory.GetConnection(),
+		[]string{"my-rs-0", "my-rs-1", "my-rs-2"},
+		rs,
+		"",
+		"",
+		"",
+		false,
+		zap.S(),
+	)
 
 	assert.True(t, status.IsOK(), "configuring x509 when tls has already been enabled should not result in a failed status")
 	assert.False(t, isMultiStageReconciliation, "if tls is already enabled, we should be able to configure x509 is a single reconciliation")
@@ -137,11 +237,35 @@ func TestUpdateOmAuthentication_AuthenticationIsNotConfigured_IfAuthIsNotSet(t *
 
 	rs.Spec.Security.Authentication = nil
 
-	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)))
+	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(
+		om.NewMockedOmConnection(deployment.CreateFromReplicaSet("fake-mongoDBImage", false, rs)),
+	)
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
-	status, _ := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	status, _ := r.updateOmAuthentication(
+		ctx,
+		omConnectionFactory.GetConnection(),
+		[]string{"my-rs-0", "my-rs-1", "my-rs-2"},
+		rs,
+		"",
+		"",
+		"",
+		false,
+		zap.S(),
+	)
 	assert.True(t, status.IsOK(), "no authentication should have been configured")
 
 	ac, _ := omConnectionFactory.GetConnection().ReadAutomationConfig()
@@ -162,7 +286,19 @@ func TestUpdateOmAuthentication_DoesNotDisableAuth_IfAuthIsNotSet(t *testing.T) 
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
@@ -175,7 +311,19 @@ func TestUpdateOmAuthentication_DoesNotDisableAuth_IfAuthIsNotSet(t *testing.T) 
 
 	rs.Spec.Security.Authentication = nil
 
-	reconciler = newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler = newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 
@@ -197,7 +345,19 @@ func TestCanConfigureAuthenticationDisabled_WithNoModes(t *testing.T) {
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
@@ -209,11 +369,33 @@ func TestUpdateOmAuthentication_EnableX509_FromEmptyDeployment(t *testing.T) {
 	rs := DefaultReplicaSetBuilder().SetName("my-rs").SetMembers(3).EnableTLS().EnableAuth().EnableX509().Build()
 	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(om.NewDeployment()))
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	secretName := util.AgentSecretName
 	createAgentCSRs(t, ctx, r.client, secretName, certsv1.CertificateApproved)
 
-	status, isMultiStageReconciliation := r.updateOmAuthentication(ctx, omConnectionFactory.GetConnection(), []string{"my-rs-0", "my-rs-1", "my-rs-2"}, rs, "", "", "", false, zap.S())
+	status, isMultiStageReconciliation := r.updateOmAuthentication(
+		ctx,
+		omConnectionFactory.GetConnection(),
+		[]string{"my-rs-0", "my-rs-1", "my-rs-2"},
+		rs,
+		"",
+		"",
+		"",
+		false,
+		zap.S(),
+	)
 	assert.True(t, status.IsOK(), "configuring x509 and tls when there are no processes should not result in a failed status")
 	assert.False(t, isMultiStageReconciliation, "if we are enabling tls and x509 at once, this should be done in a single reconciliation")
 }
@@ -230,11 +412,29 @@ func TestX509AgentUserIsCorrectlyConfigured(t *testing.T) {
 
 	// configure x509/tls resources
 	addKubernetesTlsResources(ctx, kubeClient, rs)
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 
-	userReconciler := newMongoDBUserReconciler(ctx, kubeClient, omConnectionFactory.GetConnectionFunc, memberClusterMap, testBackupEnableDelay)
+	userReconciler := newMongoDBUserReconciler(
+		ctx,
+		kubeClient,
+		omConnectionFactory.GetConnectionFunc,
+		memberClusterMap,
+		testBackupEnableDelay,
+	)
 
 	actual, err := userReconciler.Reconcile(ctx, requestFromObject(x509User))
 	expected := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
@@ -266,11 +466,29 @@ func TestScramAgentUserIsCorrectlyConfigured(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 
-	userReconciler := newMongoDBUserReconciler(ctx, kubeClient, omConnectionFactory.GetConnectionFunc, memberClusterMap, testBackupEnableDelay)
+	userReconciler := newMongoDBUserReconciler(
+		ctx,
+		kubeClient,
+		omConnectionFactory.GetConnectionFunc,
+		memberClusterMap,
+		testBackupEnableDelay,
+	)
 
 	actual, err := userReconciler.Reconcile(ctx, requestFromObject(scramUser))
 	expected := reconcile.Result{RequeueAfter: util.TWENTY_FOUR_HOURS}
@@ -296,7 +514,19 @@ func TestScramAgentUser_IsNotOverridden(t *testing.T) {
 		}
 	})
 
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
 
@@ -315,7 +545,19 @@ func TestX509InternalClusterAuthentication_CanBeEnabledWithScram_ReplicaSet(t *t
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	addKubernetesTlsResources(ctx, r.client, rs)
 
 	checkReconcileSuccessful(ctx, t, r, rs, kubeClient)
@@ -334,7 +576,16 @@ func TestX509InternalClusterAuthentication_CanBeEnabledWithScram_ShardedCluster(
 		EnableX509InternalClusterAuth().
 		Build()
 
-	r, _, kubeClient, omConnectionFactory, _ := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	r, _, kubeClient, omConnectionFactory, _ := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	addKubernetesTlsResources(ctx, r.client, sc)
 	checkReconcileSuccessful(ctx, t, r, sc, kubeClient)
 
@@ -368,7 +619,19 @@ func TestConfigureLdapDeploymentAuthentication_WithScramAgentAuthentication(t *t
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	data := map[string]string{
 		"password": "LITZTOd6YiCV8j",
 	}
@@ -425,7 +688,19 @@ func TestConfigureLdapDeploymentAuthentication_WithCustomRole(t *testing.T) {
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	data := map[string]string{
 		"password": "LITZTOd6YiCV8j",
 	}
@@ -479,7 +754,19 @@ func TestConfigureLdapDeploymentAuthentication_WithAuthzQueryTemplate_AndUserToD
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	r := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	r := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	data := map[string]string{
 		"password": "LITZTOd6YiCV8j",
 	}
@@ -616,7 +903,10 @@ func createReplicaSetTLSData(ctx context.Context, client client.Client, mdb *mdb
 	}
 
 	agentCerts.Data = make(map[string][]byte)
-	agentCerts.Data["tls.crt"], agentCerts.Data["tls.key"] = createMockCertAndKeyBytes(subjectModifier, func(cert *x509.Certificate) { cert.Subject.CommonName = "mms-automation-agent" })
+	agentCerts.Data["tls.crt"], agentCerts.Data["tls.key"] = createMockCertAndKeyBytes(
+		subjectModifier,
+		func(cert *x509.Certificate) { cert.Subject.CommonName = "mms-automation-agent" },
+	)
 	_ = client.Create(ctx, agentCerts)
 }
 
@@ -690,12 +980,21 @@ func createShardedClusterTLSData(ctx context.Context, client kubernetesClient.Cl
 	}
 
 	agentCerts.Data = make(map[string][]byte)
-	agentCerts.Data["tls.crt"], agentCerts.Data["tls.key"] = createMockCertAndKeyBytes(subjectModifier, func(cert *x509.Certificate) { cert.Subject.CommonName = "mms-automation-agent" })
+	agentCerts.Data["tls.crt"], agentCerts.Data["tls.key"] = createMockCertAndKeyBytes(
+		subjectModifier,
+		func(cert *x509.Certificate) { cert.Subject.CommonName = "mms-automation-agent" },
+	)
 	_ = client.Create(ctx, agentCerts)
 }
 
 // createMultiClusterReplicaSetTLSData creates and populates secrets required for a TLS enabled MongoDBMultiCluster ReplicaSet.
-func createMultiClusterReplicaSetTLSData(t *testing.T, ctx context.Context, client client.Client, mdbm *mdbmulti.MongoDBMultiCluster, caName string) {
+func createMultiClusterReplicaSetTLSData(
+	t *testing.T,
+	ctx context.Context,
+	client client.Client,
+	mdbm *mdbmulti.MongoDBMultiCluster,
+	caName string,
+) {
 	// Create CA configmap
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -742,7 +1041,19 @@ func TestInvalidPEM_SecretDoesNotContainKey(t *testing.T) {
 		Build()
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
 	// Replace the secret with an empty one
@@ -756,7 +1067,14 @@ func TestInvalidPEM_SecretDoesNotContainKey(t *testing.T) {
 
 	_ = kubeClient.Update(ctx, secret)
 
-	err := certs.VerifyAndEnsureCertificatesForStatefulSet(ctx, reconciler.SecretClient, reconciler.SecretClient, fmt.Sprintf("%s-cert", rs.Name), certs.ReplicaSetConfig(*rs), nil)
+	err := certs.VerifyAndEnsureCertificatesForStatefulSet(
+		ctx,
+		reconciler.SecretClient,
+		reconciler.SecretClient,
+		fmt.Sprintf("%s-cert", rs.Name),
+		certs.ReplicaSetConfig(*rs),
+		nil,
+	)
 	assert.Equal(t, err.Error(), "the certificate is not complete\n")
 }
 
@@ -772,14 +1090,33 @@ func Test_NoAdditionalDomainsPresent(t *testing.T) {
 	rs.Spec.Security.TLSConfig.AdditionalCertificateDomains = []string{"foo"}
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
 	certSecret := &corev1.Secret{}
 
 	_ = kubeClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-cert", rs.Name), Namespace: rs.Namespace}, certSecret)
 
-	err := certs.VerifyAndEnsureCertificatesForStatefulSet(ctx, reconciler.SecretClient, reconciler.SecretClient, fmt.Sprintf("%s-cert", rs.Name), certs.ReplicaSetConfig(*rs), nil)
+	err := certs.VerifyAndEnsureCertificatesForStatefulSet(
+		ctx,
+		reconciler.SecretClient,
+		reconciler.SecretClient,
+		fmt.Sprintf("%s-cert", rs.Name),
+		certs.ReplicaSetConfig(*rs),
+		nil,
+	)
 	require.Error(t, err)
 	for i := 0; i < rs.Spec.Members; i++ {
 		expectedErrorMessage := fmt.Sprintf("domain %s-%d.foo is not contained in the list of DNSNames", rs.Name, i)
@@ -798,19 +1135,44 @@ func Test_NoExternalDomainPresent(t *testing.T) {
 	rs.Spec.ExternalAccessConfiguration = &mdbv1.ExternalAccessConfiguration{ExternalDomain: ptr.To("foo")}
 
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
-	reconciler := newReplicaSetReconciler(ctx, kubeClient, nil, "", "", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"",
+		"",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 	addKubernetesTlsResources(ctx, kubeClient, rs)
 
 	secret := &corev1.Secret{}
 
 	_ = kubeClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-cert", rs.Name), Namespace: rs.Namespace}, secret)
 
-	err := certs.VerifyAndEnsureCertificatesForStatefulSet(ctx, reconciler.SecretClient, reconciler.SecretClient, fmt.Sprintf("%s-cert", rs.Name), certs.ReplicaSetConfig(*rs), nil)
+	err := certs.VerifyAndEnsureCertificatesForStatefulSet(
+		ctx,
+		reconciler.SecretClient,
+		reconciler.SecretClient,
+		fmt.Sprintf("%s-cert", rs.Name),
+		certs.ReplicaSetConfig(*rs),
+		nil,
+	)
 	assert.Error(t, err)
 }
 
 // createAgentCSRs creates all the agent CSRs needed for x509 at the specified condition type
-func createAgentCSRs(t *testing.T, ctx context.Context, client kubernetesClient.Client, secretName string, conditionType certsv1.RequestConditionType) {
+func createAgentCSRs(
+	t *testing.T,
+	ctx context.Context,
+	client kubernetesClient.Client,
+	secretName string,
+	conditionType certsv1.RequestConditionType,
+) {
 	// create the secret the agent certs will exist in
 	certAuto, _ := os.ReadFile("testdata/certificates/cert_auto")
 

--- a/controllers/operator/backup_snapshot_schedule_test.go
+++ b/controllers/operator/backup_snapshot_schedule_test.go
@@ -20,16 +20,38 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
-func backupSnapshotScheduleTests(mdb backup.ConfigReaderUpdater, client client.Client, reconciler reconcile.Reconciler, omConnectionFactory *om.CachedOMConnectionFactory, clusterID string) func(t *testing.T) {
+func backupSnapshotScheduleTests(
+	mdb backup.ConfigReaderUpdater,
+	client client.Client,
+	reconciler reconcile.Reconciler,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	clusterID string,
+) func(t *testing.T) {
 	ctx := context.Background()
 	return func(t *testing.T) {
-		t.Run("Backup schedule is not read and not updated if not specified in spec", testBackupScheduleNotReadAndNotUpdatedIfNotSpecifiedInSpec(ctx, mdb, client, reconciler, omConnectionFactory, clusterID))
-		t.Run("Backup schedule is updated if specified in spec", testBackupScheduleIsUpdatedIfSpecifiedInSpec(ctx, mdb, client, reconciler, omConnectionFactory, clusterID))
-		t.Run("Backup schedule is not updated if not changed", testBackupScheduleNotUpdatedIfNotChanged(ctx, mdb, client, reconciler, omConnectionFactory, clusterID))
+		t.Run(
+			"Backup schedule is not read and not updated if not specified in spec",
+			testBackupScheduleNotReadAndNotUpdatedIfNotSpecifiedInSpec(ctx, mdb, client, reconciler, omConnectionFactory, clusterID),
+		)
+		t.Run(
+			"Backup schedule is updated if specified in spec",
+			testBackupScheduleIsUpdatedIfSpecifiedInSpec(ctx, mdb, client, reconciler, omConnectionFactory, clusterID),
+		)
+		t.Run(
+			"Backup schedule is not updated if not changed",
+			testBackupScheduleNotUpdatedIfNotChanged(ctx, mdb, client, reconciler, omConnectionFactory, clusterID),
+		)
 	}
 }
 
-func testBackupScheduleNotReadAndNotUpdatedIfNotSpecifiedInSpec(ctx context.Context, mdb backup.ConfigReaderUpdater, client client.Client, reconciler reconcile.Reconciler, omConnectionFactory *om.CachedOMConnectionFactory, clusterID string) func(t *testing.T) {
+func testBackupScheduleNotReadAndNotUpdatedIfNotSpecifiedInSpec(
+	ctx context.Context,
+	mdb backup.ConfigReaderUpdater,
+	client client.Client,
+	reconciler reconcile.Reconciler,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	clusterID string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		require.NoError(t, client.Get(ctx, kube.ObjectKeyFromApiObject(mdb), mdb))
 		insertDefaultBackupSchedule(t, omConnectionFactory, clusterID)
@@ -41,12 +63,25 @@ func testBackupScheduleNotReadAndNotUpdatedIfNotSpecifiedInSpec(ctx context.Cont
 
 		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CleanHistory()
 		checkReconcile(ctx, t, reconciler, mdb)
-		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CheckOperationsDidntHappen(t, reflect.ValueOf(omConnectionFactory.GetConnection().UpdateSnapshotSchedule))
-		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CheckOperationsDidntHappen(t, reflect.ValueOf(omConnectionFactory.GetConnection().ReadSnapshotSchedule))
+		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CheckOperationsDidntHappen(
+			t,
+			reflect.ValueOf(omConnectionFactory.GetConnection().UpdateSnapshotSchedule),
+		)
+		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CheckOperationsDidntHappen(
+			t,
+			reflect.ValueOf(omConnectionFactory.GetConnection().ReadSnapshotSchedule),
+		)
 	}
 }
 
-func testBackupScheduleIsUpdatedIfSpecifiedInSpec(ctx context.Context, mdb backup.ConfigReaderUpdater, client client.Client, reconciler reconcile.Reconciler, omConnectionFactory *om.CachedOMConnectionFactory, clusterID string) func(t *testing.T) {
+func testBackupScheduleIsUpdatedIfSpecifiedInSpec(
+	ctx context.Context,
+	mdb backup.ConfigReaderUpdater,
+	client client.Client,
+	reconciler reconcile.Reconciler,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	clusterID string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		require.NoError(t, client.Get(ctx, kube.ObjectKeyFromApiObject(mdb), mdb))
 		insertDefaultBackupSchedule(t, omConnectionFactory, clusterID)
@@ -76,7 +111,14 @@ func testBackupScheduleIsUpdatedIfSpecifiedInSpec(ctx context.Context, mdb backu
 	}
 }
 
-func testBackupScheduleNotUpdatedIfNotChanged(ctx context.Context, mdb backup.ConfigReaderUpdater, kubeClient client.Client, reconciler reconcile.Reconciler, omConnectionFactory *om.CachedOMConnectionFactory, clusterID string) func(t *testing.T) {
+func testBackupScheduleNotUpdatedIfNotChanged(
+	ctx context.Context,
+	mdb backup.ConfigReaderUpdater,
+	kubeClient client.Client,
+	reconciler reconcile.Reconciler,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	clusterID string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKeyFromApiObject(mdb), mdb))
 		insertDefaultBackupSchedule(t, omConnectionFactory, clusterID)
@@ -111,7 +153,10 @@ func testBackupScheduleNotUpdatedIfNotChanged(ctx context.Context, mdb backup.Co
 		checkReconcile(ctx, t, reconciler, mdb)
 		require.NoError(t, kubeClient.Get(ctx, kube.ObjectKeyFromApiObject(mdb), mdb))
 
-		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CheckOperationsDidntHappen(t, reflect.ValueOf(omConnectionFactory.GetConnection().UpdateSnapshotSchedule))
+		omConnectionFactory.GetConnection().(*om.MockedOmConnection).CheckOperationsDidntHappen(
+			t,
+			reflect.ValueOf(omConnectionFactory.GetConnection().UpdateSnapshotSchedule),
+		)
 
 		mdb.GetBackupSpec().SnapshotSchedule.FullIncrementalDayOfWeek = ptr.To("Monday")
 		err = kubeClient.Update(ctx, mdb)

--- a/controllers/operator/certs/cert_configurations.go
+++ b/controllers/operator/certs/cert_configurations.go
@@ -199,7 +199,9 @@ func AppDBReplicaSetConfig(om *omv1.MongoDBOpsManager) Options {
 	}
 
 	if mdb.GetSecurity().TLSConfig != nil {
-		opts.additionalCertificateDomains = append(opts.additionalCertificateDomains, mdb.GetSecurity().TLSConfig.AdditionalCertificateDomains...)
+		opts.additionalCertificateDomains = append(
+			opts.additionalCertificateDomains,
+			mdb.GetSecurity().TLSConfig.AdditionalCertificateDomains...)
 	}
 
 	return opts
@@ -219,7 +221,9 @@ func AppDBMultiClusterReplicaSetConfig(om *omv1.MongoDBOpsManager, scaler interf
 	}
 
 	if mdb.GetSecurity().TLSConfig != nil {
-		opts.additionalCertificateDomains = append(opts.additionalCertificateDomains, mdb.GetSecurity().TLSConfig.AdditionalCertificateDomains...)
+		opts.additionalCertificateDomains = append(
+			opts.additionalCertificateDomains,
+			mdb.GetSecurity().TLSConfig.AdditionalCertificateDomains...)
 	}
 
 	return opts

--- a/controllers/operator/certs/certificate_test.go
+++ b/controllers/operator/certs/certificate_test.go
@@ -130,7 +130,15 @@ func TestRotateCertificate(t *testing.T) {
 	pemSecretNamespacedName.Name = fmt.Sprintf("%s%s", secretNamespacedName.Name, OperatorGeneratedCertSuffix)
 
 	t.Run("Case 1: Enabling TLS", func(t *testing.T) {
-		err := CreateOrUpdatePEMSecretWithPreviousCert(ctx, fakeSecretClient, secretNamespacedName, certificateKey1, certificateValue1, []v1.OwnerReference{}, Unused)
+		err := CreateOrUpdatePEMSecretWithPreviousCert(
+			ctx,
+			fakeSecretClient,
+			secretNamespacedName,
+			certificateKey1,
+			certificateValue1,
+			[]v1.OwnerReference{},
+			Unused,
+		)
 		assert.NoError(t, err)
 
 		pemSecret, _ := fakeSecretClient.ReadSecret(ctx, pemSecretNamespacedName, Unused)
@@ -151,7 +159,15 @@ func TestRotateCertificate(t *testing.T) {
 
 		_ = fakeSecretClient.PutSecret(ctx, existingPem, Unused)
 
-		err := CreateOrUpdatePEMSecretWithPreviousCert(ctx, fakeSecretClient, secretNamespacedName, certificateKey1, certificateValue1, []v1.OwnerReference{}, Unused)
+		err := CreateOrUpdatePEMSecretWithPreviousCert(
+			ctx,
+			fakeSecretClient,
+			secretNamespacedName,
+			certificateKey1,
+			certificateValue1,
+			[]v1.OwnerReference{},
+			Unused,
+		)
 		assert.NoError(t, err)
 
 		pemSecret, _ := fakeSecretClient.ReadSecret(ctx, pemSecretNamespacedName, Unused)
@@ -173,7 +189,15 @@ func TestRotateCertificate(t *testing.T) {
 		_ = fakeSecretClient.PutSecret(ctx, existingPem, Unused)
 
 		// The rotation happens here because CreateOrUpdatePEMSecretWithPreviousCert is called with certificate 2, but the existing pem secret references certificate 1.
-		err := CreateOrUpdatePEMSecretWithPreviousCert(ctx, fakeSecretClient, secretNamespacedName, certificateKey2, certificateValue2, []v1.OwnerReference{}, Unused)
+		err := CreateOrUpdatePEMSecretWithPreviousCert(
+			ctx,
+			fakeSecretClient,
+			secretNamespacedName,
+			certificateKey2,
+			certificateValue2,
+			[]v1.OwnerReference{},
+			Unused,
+		)
 		assert.NoError(t, err)
 
 		pemSecret, _ := fakeSecretClient.ReadSecret(ctx, pemSecretNamespacedName, Unused)
@@ -198,7 +222,15 @@ func TestRotateCertificate(t *testing.T) {
 
 		_ = fakeSecretClient.PutSecret(ctx, existingPem, Unused)
 
-		err := CreateOrUpdatePEMSecretWithPreviousCert(ctx, fakeSecretClient, secretNamespacedName, certificateKey2, certificateValue2, []v1.OwnerReference{}, Unused)
+		err := CreateOrUpdatePEMSecretWithPreviousCert(
+			ctx,
+			fakeSecretClient,
+			secretNamespacedName,
+			certificateKey2,
+			certificateValue2,
+			[]v1.OwnerReference{},
+			Unused,
+		)
 		assert.NoError(t, err)
 
 		pemSecret, _ := fakeSecretClient.ReadSecret(ctx, pemSecretNamespacedName, Unused)
@@ -224,7 +256,15 @@ func TestRotateCertificate(t *testing.T) {
 
 		_ = fakeSecretClient.PutSecret(ctx, existingPem, Unused)
 
-		err := CreateOrUpdatePEMSecretWithPreviousCert(ctx, fakeSecretClient, secretNamespacedName, certificateKey3, certificateValue3, []v1.OwnerReference{}, Unused)
+		err := CreateOrUpdatePEMSecretWithPreviousCert(
+			ctx,
+			fakeSecretClient,
+			secretNamespacedName,
+			certificateKey3,
+			certificateValue3,
+			[]v1.OwnerReference{},
+			Unused,
+		)
 		assert.NoError(t, err)
 
 		pemSecret, _ := fakeSecretClient.ReadSecret(ctx, pemSecretNamespacedName, Unused)

--- a/controllers/operator/certs/certificates.go
+++ b/controllers/operator/certs/certificates.go
@@ -40,13 +40,28 @@ const (
 
 // CreateOrUpdatePEMSecretWithPreviousCert creates a PEM secret from the original secretName.
 // Additionally, this method verifies if there already exists a PEM secret, and it will merge them to be able to keep the newest and the previous certificate.
-func CreateOrUpdatePEMSecretWithPreviousCert(ctx context.Context, secretClient secrets.SecretClient, secretNamespacedName types.NamespacedName, certificateKey string, certificateValue string, ownerReferences []metav1.OwnerReference, podType certDestination) error {
+func CreateOrUpdatePEMSecretWithPreviousCert(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	secretNamespacedName types.NamespacedName,
+	certificateKey string,
+	certificateValue string,
+	ownerReferences []metav1.OwnerReference,
+	podType certDestination,
+) error {
 	path, err := getVaultBasePath(secretClient, podType)
 	if err != nil {
 		return err
 	}
 
-	secretData, err := updateSecretDataWithPreviousCert(ctx, secretClient, getOperatorGeneratedSecret(secretNamespacedName), certificateKey, certificateValue, path)
+	secretData, err := updateSecretDataWithPreviousCert(
+		ctx,
+		secretClient,
+		getOperatorGeneratedSecret(secretNamespacedName),
+		certificateKey,
+		certificateValue,
+		path,
+	)
 	if err != nil {
 		return err
 	}
@@ -55,7 +70,14 @@ func CreateOrUpdatePEMSecretWithPreviousCert(ctx context.Context, secretClient s
 }
 
 // CreateOrUpdatePEMSecret creates a PEM secret from the original secretName.
-func CreateOrUpdatePEMSecret(ctx context.Context, secretClient secrets.SecretClient, secretNamespacedName types.NamespacedName, secretData map[string]string, ownerReferences []metav1.OwnerReference, podType certDestination) error {
+func CreateOrUpdatePEMSecret(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	secretNamespacedName types.NamespacedName,
+	secretData map[string]string,
+	ownerReferences []metav1.OwnerReference,
+	podType certDestination,
+) error {
 	operatorGeneratedSecret := getOperatorGeneratedSecret(secretNamespacedName)
 
 	path, err := getVaultBasePath(secretClient, podType)
@@ -74,7 +96,14 @@ func CreateOrUpdatePEMSecret(ctx context.Context, secretClient secrets.SecretCli
 
 // updateSecretDataWithPreviousCert receives the new TLS certificate and returns the data for the new concatenated Pem Secret
 // This method read the existing -pem secret and creates the secret data such that it keeps the previous TLS certificate
-func updateSecretDataWithPreviousCert(ctx context.Context, secretClient secrets.SecretClient, operatorGeneratedSecret types.NamespacedName, certificateKey string, certificateValue string, basePath string) (map[string]string, error) {
+func updateSecretDataWithPreviousCert(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	operatorGeneratedSecret types.NamespacedName,
+	certificateKey string,
+	certificateValue string,
+	basePath string,
+) (map[string]string, error) {
 	newData := map[string]string{certificateKey: certificateValue}
 	newLatestHash := certificateKey
 
@@ -172,7 +201,13 @@ func VerifyTLSSecretForStatefulSet(secretData map[string][]byte, opts Options) (
 
 // VerifyAndEnsureCertificatesForStatefulSet ensures that the provided certificates are correct.
 // If the secret is of type kubernetes.io/tls, it creates a new secret containing the concatenation fo the tls.crt and tls.key fields
-func VerifyAndEnsureCertificatesForStatefulSet(ctx context.Context, secretReadClient, secretWriteClient secrets.SecretClient, secretName string, opts Options, log *zap.SugaredLogger) error {
+func VerifyAndEnsureCertificatesForStatefulSet(
+	ctx context.Context,
+	secretReadClient, secretWriteClient secrets.SecretClient,
+	secretName string,
+	opts Options,
+	log *zap.SugaredLogger,
+) error {
 	var err error
 	var secretData map[string][]byte
 	var s corev1.Secret
@@ -180,7 +215,9 @@ func VerifyAndEnsureCertificatesForStatefulSet(ctx context.Context, secretReadCl
 
 	if vault.IsVaultSecretBackend() {
 		databaseSecretPath = secretReadClient.VaultClient.DatabaseSecretPath()
-		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", databaseSecretPath, opts.Namespace, secretName))
+		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(
+			fmt.Sprintf("%s/%s/%s", databaseSecretPath, opts.Namespace, secretName),
+		)
 		if err != nil {
 			return err
 		}
@@ -207,7 +244,15 @@ func VerifyAndEnsureCertificatesForStatefulSet(ctx context.Context, secretReadCl
 	}
 
 	secretHash := enterprisepem.ReadHashFromSecret(ctx, secretReadClient, opts.Namespace, secretName, databaseSecretPath, log)
-	return CreateOrUpdatePEMSecretWithPreviousCert(ctx, secretWriteClient, kube.ObjectKey(opts.Namespace, secretName), secretHash, data, opts.OwnerReference, Database)
+	return CreateOrUpdatePEMSecretWithPreviousCert(
+		ctx,
+		secretWriteClient,
+		kube.ObjectKey(opts.Namespace, secretName),
+		secretHash,
+		data,
+		opts.OwnerReference,
+		Database,
+	)
 }
 
 // getPodNames returns the pod names based on the Cert Options provided.
@@ -283,7 +328,10 @@ func ValidateCertificates(ctx context.Context, secretGetter secret.Getter, name,
 				}
 				pemFile := enterprisepem.NewFileFromData(value)
 				if !pemFile.IsValid() {
-					return fmt.Sprintf("The Secret %s containing certificates is not valid. Entries must contain a certificate and a private key.", name), false
+					return fmt.Sprintf(
+						"The Secret %s containing certificates is not valid. Entries must contain a certificate and a private key.",
+						name,
+					), false
 				}
 			}
 		}
@@ -299,7 +347,12 @@ func ValidateCertificates(ctx context.Context, secretGetter secret.Getter, name,
 
 // VerifyAndEnsureClientCertificatesForAgentsAndTLSType ensures that agent certs are present and correct, and returns whether they are of the kubernetes.io/tls type.
 // If the secret is of type kubernetes.io/tls, it creates a new secret containing the concatenation fo the tls.crt and tls.key fields
-func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, secretReadClient, secretWriteClient secrets.SecretClient, secret types.NamespacedName, log *zap.SugaredLogger) error {
+func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(
+	ctx context.Context,
+	secretReadClient, secretWriteClient secrets.SecretClient,
+	secret types.NamespacedName,
+	log *zap.SugaredLogger,
+) error {
 	var secretData map[string][]byte
 	var s corev1.Secret
 	var err error
@@ -307,7 +360,9 @@ func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, s
 
 	if vault.IsVaultSecretBackend() {
 		databaseSecretPath = secretReadClient.VaultClient.DatabaseSecretPath()
-		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", secretReadClient.VaultClient.DatabaseSecretPath(), secret.Namespace, secret.Name))
+		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(
+			fmt.Sprintf("%s/%s/%s", secretReadClient.VaultClient.DatabaseSecretPath(), secret.Namespace, secret.Name),
+		)
 		if err != nil {
 			return err
 		}
@@ -334,7 +389,13 @@ func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, s
 
 // EnsureSSLCertsForStatefulSet contains logic to ensure that all of the
 // required SSL certs for a StatefulSet object exist.
-func EnsureSSLCertsForStatefulSet(ctx context.Context, secretReadClient, secretWriteClient secrets.SecretClient, ms mdbv1.Security, opts Options, log *zap.SugaredLogger) workflow.Status {
+func EnsureSSLCertsForStatefulSet(
+	ctx context.Context,
+	secretReadClient, secretWriteClient secrets.SecretClient,
+	ms mdbv1.Security,
+	opts Options,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !ms.IsTLSEnabled() {
 		// if there's no SSL certs to generate, return
 		return workflow.OK()
@@ -350,7 +411,14 @@ func EnsureSSLCertsForStatefulSet(ctx context.Context, secretReadClient, secretW
 //
 // For Prometheus we *only accept* certificates of type `corev1.SecretTypeTLS`
 // so they always need to be concatenated into PEM-format.
-func EnsureTLSCertsForPrometheus(ctx context.Context, secretClient secrets.SecretClient, namespace string, prom *v1.Prometheus, podType certDestination, log *zap.SugaredLogger) (string, error) {
+func EnsureTLSCertsForPrometheus(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	namespace string,
+	prom *v1.Prometheus,
+	podType certDestination,
+	log *zap.SugaredLogger,
+) (string, error) {
 	if prom == nil || prom.TLSSecretRef.Name == "" {
 		return "", nil
 	}
@@ -404,7 +472,15 @@ func EnsureTLSCertsForPrometheus(ctx context.Context, secretClient secrets.Secre
 	// we can improve this function by providing the Secret Data contents,
 	// instead of `secretClient`.
 	secretHash := enterprisepem.ReadHashFromSecret(ctx, secretClient, namespace, prom.TLSSecretRef.Name, secretPath, log)
-	err = CreateOrUpdatePEMSecretWithPreviousCert(ctx, secretClient, kube.ObjectKey(namespace, prom.TLSSecretRef.Name), secretHash, data, []metav1.OwnerReference{}, podType)
+	err = CreateOrUpdatePEMSecretWithPreviousCert(
+		ctx,
+		secretClient,
+		kube.ObjectKey(namespace, prom.TLSSecretRef.Name),
+		secretHash,
+		data,
+		[]metav1.OwnerReference{},
+		podType,
+	)
 	if err != nil {
 		return "", xerrors.Errorf("error creating hashed Secret: %w", err)
 	}
@@ -414,7 +490,13 @@ func EnsureTLSCertsForPrometheus(ctx context.Context, secretClient secrets.Secre
 
 // ValidateSelfManagedSSLCertsForStatefulSet ensures that a stateful set using
 // user-provided certificates has all of the relevant certificates in place.
-func ValidateSelfManagedSSLCertsForStatefulSet(ctx context.Context, secretReadClient, secretWriteClient secrets.SecretClient, secretName string, opts Options, log *zap.SugaredLogger) workflow.Status {
+func ValidateSelfManagedSSLCertsForStatefulSet(
+	ctx context.Context,
+	secretReadClient, secretWriteClient secrets.SecretClient,
+	secretName string,
+	opts Options,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	// A "Certs" attribute has been provided
 	// This means that the customer has provided with a secret name they have
 	// already populated with the certs and keys for this deployment.
@@ -422,7 +504,9 @@ func ValidateSelfManagedSSLCertsForStatefulSet(ctx context.Context, secretReadCl
 	// in which case, we'll keep reconciling until the object is created and is correct.
 	err := VerifyAndEnsureCertificatesForStatefulSet(ctx, secretReadClient, secretWriteClient, secretName, opts, log)
 	if err != nil {
-		return workflow.Failed(xerrors.Errorf("The secret object '%s' does not contain all the valid certificates needed: %w", secretName, err))
+		return workflow.Failed(
+			xerrors.Errorf("The secret object '%s' does not contain all the valid certificates needed: %w", secretName, err),
+		)
 	}
 
 	secretName = fmt.Sprintf("%s-pem", secretName)

--- a/controllers/operator/clusterchecks_test.go
+++ b/controllers/operator/clusterchecks_test.go
@@ -165,7 +165,15 @@ func (c *clusterChecks) checkServiceExists(ctx context.Context, serviceName stri
 	require.NoError(c.t, err, "clusterName: %s", c.clusterName)
 }
 
-func (c *clusterChecks) checkServiceAnnotations(ctx context.Context, statefulSetName string, expectedMembers int, sc *mdbv1.MongoDB, clusterName string, clusterIdx int, externalDomain string) {
+func (c *clusterChecks) checkServiceAnnotations(
+	ctx context.Context,
+	statefulSetName string,
+	expectedMembers int,
+	sc *mdbv1.MongoDB,
+	clusterName string,
+	clusterIdx int,
+	externalDomain string,
+) {
 	for podIdx := 0; podIdx < expectedMembers; podIdx++ {
 		svc := corev1.Service{}
 		serviceName := fmt.Sprintf("%s-%d-svc-external", statefulSetName, podIdx)
@@ -232,33 +240,78 @@ func (c *clusterChecks) checkStatefulSetDoesNotExist(ctx context.Context, statef
 
 func (c *clusterChecks) checkAgentCertsSecret(ctx context.Context, certificatesSecretsPrefix string, resourceName string) {
 	sec := corev1.Secret{}
-	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, util.AgentSecretName)), &sec)
+	err := c.kubeClient.Get(
+		ctx,
+		kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, util.AgentSecretName)),
+		&sec,
+	)
 	require.NoError(c.t, err, "clusterName: %s", c.clusterName)
 	require.Contains(c.t, sec.Data, util.LatestHashSecretKey, "clusterName: %s", c.clusterName)
 	require.Contains(c.t, sec.Data, string(sec.Data[util.LatestHashSecretKey]), "clusterName: %s", c.clusterName)
 }
 
-func (c *clusterChecks) checkMongosCertsSecret(ctx context.Context, certificatesSecretsPrefix string, resourceName string, shouldExist bool) {
+func (c *clusterChecks) checkMongosCertsSecret(
+	ctx context.Context,
+	certificatesSecretsPrefix string,
+	resourceName string,
+	shouldExist bool,
+) {
 	sec := corev1.Secret{}
-	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, "mongos-cert")), &sec)
+	err := c.kubeClient.Get(
+		ctx,
+		kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, "mongos-cert")),
+		&sec,
+	)
 	c.assertErrNotFound(err, shouldExist)
 }
 
-func (c *clusterChecks) checkConfigSrvCertsSecret(ctx context.Context, certificatesSecretsPrefix string, resourceName string, shouldExist bool) {
+func (c *clusterChecks) checkConfigSrvCertsSecret(
+	ctx context.Context,
+	certificatesSecretsPrefix string,
+	resourceName string,
+	shouldExist bool,
+) {
 	sec := corev1.Secret{}
-	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, "config-cert")), &sec)
+	err := c.kubeClient.Get(
+		ctx,
+		kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%s-pem", certificatesSecretsPrefix, resourceName, "config-cert")),
+		&sec,
+	)
 	c.assertErrNotFound(err, shouldExist)
 }
 
-func (c *clusterChecks) checkInternalClusterCertSecret(ctx context.Context, certificatesSecretsPrefix string, resourceName string, shardIdx int, shouldExist bool) {
+func (c *clusterChecks) checkInternalClusterCertSecret(
+	ctx context.Context,
+	certificatesSecretsPrefix string,
+	resourceName string,
+	shardIdx int,
+	shouldExist bool,
+) {
 	sec := corev1.Secret{}
-	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%d-%s-pem", certificatesSecretsPrefix, resourceName, shardIdx, util.ClusterFileName)), &sec)
+	err := c.kubeClient.Get(
+		ctx,
+		kube.ObjectKey(
+			c.namespace,
+			fmt.Sprintf("%s-%s-%d-%s-pem", certificatesSecretsPrefix, resourceName, shardIdx, util.ClusterFileName),
+		),
+		&sec,
+	)
 	c.assertErrNotFound(err, shouldExist)
 }
 
-func (c *clusterChecks) checkMemberCertSecret(ctx context.Context, certificatesSecretsPrefix string, resourceName string, shardIdx int, shouldExist bool) {
+func (c *clusterChecks) checkMemberCertSecret(
+	ctx context.Context,
+	certificatesSecretsPrefix string,
+	resourceName string,
+	shardIdx int,
+	shouldExist bool,
+) {
 	sec := corev1.Secret{}
-	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%d-cert-pem", certificatesSecretsPrefix, resourceName, shardIdx)), &sec)
+	err := c.kubeClient.Get(
+		ctx,
+		kube.ObjectKey(c.namespace, fmt.Sprintf("%s-%s-%d-cert-pem", certificatesSecretsPrefix, resourceName, shardIdx)),
+		&sec,
+	)
 	c.assertErrNotFound(err, shouldExist)
 }
 
@@ -278,7 +331,11 @@ func (c *clusterChecks) checkMMSCAConfigMap(ctx context.Context, configMapName s
 	assert.Contains(c.t, cm.Data, util.CaCertMMS, "clusterName: %s", c.clusterName)
 }
 
-func (c *clusterChecks) checkHostnameOverrideConfigMap(ctx context.Context, configMapName string, expectedPodNameToHostnameMap map[string]string) {
+func (c *clusterChecks) checkHostnameOverrideConfigMap(
+	ctx context.Context,
+	configMapName string,
+	expectedPodNameToHostnameMap map[string]string,
+) {
 	cm := corev1.ConfigMap{}
 	err := c.kubeClient.Get(ctx, kube.ObjectKey(c.namespace, configMapName), &cm)
 	require.NoError(c.t, err, "clusterName: %s", c.clusterName)

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -106,7 +106,12 @@ func NewReconcileCommonController(ctx context.Context, client client.Client) *Re
 	}
 }
 
-func (r *ReconcileCommonController) getRoleAnnotation(ctx context.Context, db mdbv1.DbCommonSpec, enableClusterMongoDBRoles bool, mongodbResourceNsName types.NamespacedName) (map[string]string, []string, error) {
+func (r *ReconcileCommonController) getRoleAnnotation(
+	ctx context.Context,
+	db mdbv1.DbCommonSpec,
+	enableClusterMongoDBRoles bool,
+	mongodbResourceNsName types.NamespacedName,
+) (map[string]string, []string, error) {
 	previousRoles, err := r.getRoleStrings(ctx, db, enableClusterMongoDBRoles, mongodbResourceNsName)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("Error retrieving configured roles: %w", err)
@@ -122,7 +127,12 @@ func (r *ReconcileCommonController) getRoleAnnotation(ctx context.Context, db md
 	return annotationToAdd, previousRoles, nil
 }
 
-func (r *ReconcileCommonController) getRoleStrings(ctx context.Context, db mdbv1.DbCommonSpec, enableClusterMongoDBRoles bool, mongodbResourceNsName types.NamespacedName) ([]string, error) {
+func (r *ReconcileCommonController) getRoleStrings(
+	ctx context.Context,
+	db mdbv1.DbCommonSpec,
+	enableClusterMongoDBRoles bool,
+	mongodbResourceNsName types.NamespacedName,
+) ([]string, error) {
 	roles, err := r.getRoles(ctx, db, enableClusterMongoDBRoles, mongodbResourceNsName)
 	if err != nil {
 		return []string{}, err
@@ -136,7 +146,12 @@ func (r *ReconcileCommonController) getRoleStrings(ctx context.Context, db mdbv1
 	return roleStrings, nil
 }
 
-func (r *ReconcileCommonController) getRoles(ctx context.Context, db mdbv1.DbCommonSpec, enableClusterMongoDBRoles bool, mongodbResourceNsName types.NamespacedName) ([]mdbv1.MongoDBRole, error) {
+func (r *ReconcileCommonController) getRoles(
+	ctx context.Context,
+	db mdbv1.DbCommonSpec,
+	enableClusterMongoDBRoles bool,
+	mongodbResourceNsName types.NamespacedName,
+) ([]mdbv1.MongoDBRole, error) {
 	localRoles := db.GetSecurity().Roles
 	roleRefs := db.GetSecurity().RoleRefs
 
@@ -147,7 +162,9 @@ func (r *ReconcileCommonController) getRoles(ctx context.Context, db mdbv1.DbCom
 	var roles []mdbv1.MongoDBRole
 	if len(roleRefs) > 0 {
 		if !enableClusterMongoDBRoles {
-			return nil, xerrors.Errorf("RoleRefs are not supported when ClusterMongoDBRoles are disabled. Please enable ClusterMongoDBRoles in the operator configuration. This can be done by setting the operator.enableClusterMongoDBRoles to true in the helm values file, which will automatically installed the necessary RBAC. Alternatively, it can be enabled by adding -watch-resource=clustermongodbroles flag to the operator deployment, and manually creating the necessary RBAC.")
+			return nil, xerrors.Errorf(
+				"RoleRefs are not supported when ClusterMongoDBRoles are disabled. Please enable ClusterMongoDBRoles in the operator configuration. This can be done by setting the operator.enableClusterMongoDBRoles to true in the helm values file, which will automatically installed the necessary RBAC. Alternatively, it can be enabled by adding -watch-resource=clustermongodbroles flag to the operator deployment, and manually creating the necessary RBAC.",
+			)
 		}
 		var err error
 		roles, err = r.getRoleRefs(ctx, roleRefs, mongodbResourceNsName, db.Version)
@@ -164,7 +181,15 @@ func (r *ReconcileCommonController) getRoles(ctx context.Context, db mdbv1.DbCom
 // ensureRoles will first check if both roles and roleRefs are populated. If both are, it will return an error, which is inline with the webhook validation rules.
 // Otherwise, if roles is populated, then it will extract the list of roles and check if they are already set in Ops Manager. If they are not, it will update the roles in Ops Manager.
 // If roleRefs is populated, it will extract the list of roles from the referenced resources and check if they are already set in Ops Manager. If they are not, it will update the roles in Ops Manager.
-func (r *ReconcileCommonController) ensureRoles(ctx context.Context, db mdbv1.DbCommonSpec, enableClusterMongoDBRoles bool, conn om.Connection, mongodbResourceNsName types.NamespacedName, previousRoles []string, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileCommonController) ensureRoles(
+	ctx context.Context,
+	db mdbv1.DbCommonSpec,
+	enableClusterMongoDBRoles bool,
+	conn om.Connection,
+	mongodbResourceNsName types.NamespacedName,
+	previousRoles []string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	roles, err := r.getRoles(ctx, db, enableClusterMongoDBRoles, mongodbResourceNsName)
 	if err != nil {
 		return workflow.Failed(err)
@@ -267,7 +292,12 @@ func mergeRoles(deployed []mdbv1.MongoDBRole, current []mdbv1.MongoDBRole, previ
 // It will also add the referenced resources to the resource watcher, so that they are watched for changes.
 // The referenced resources are expected to be of kind ClusterMongoDBRole.
 // This implementation is prepared for a future namespaced variant of ClusterMongoDBRole.
-func (r *ReconcileCommonController) getRoleRefs(ctx context.Context, roleRefs []mdbv1.MongoDBRoleRef, mongodbResourceNsName types.NamespacedName, mdbVersion string) ([]mdbv1.MongoDBRole, error) {
+func (r *ReconcileCommonController) getRoleRefs(
+	ctx context.Context,
+	roleRefs []mdbv1.MongoDBRoleRef,
+	mongodbResourceNsName types.NamespacedName,
+	mdbVersion string,
+) ([]mdbv1.MongoDBRole, error) {
 	roles := make([]mdbv1.MongoDBRole, len(roleRefs))
 
 	for idx, ref := range roleRefs {
@@ -280,7 +310,10 @@ func (r *ReconcileCommonController) getRoleRefs(ctx context.Context, roleRefs []
 			err := r.client.Get(ctx, types.NamespacedName{Name: ref.Name}, customRole)
 			if err != nil {
 				if apiErrors.IsNotFound(err) {
-					return nil, xerrors.Errorf("ClusterMongoDBRole '%s' not found. If the resource was deleted, the role is still present in MongoDB. To correctly remove a role from MongoDB, please remove the reference from spec.security.roleRefs.", ref.Name)
+					return nil, xerrors.Errorf(
+						"ClusterMongoDBRole '%s' not found. If the resource was deleted, the role is still present in MongoDB. To correctly remove a role from MongoDB, please remove the reference from spec.security.roleRefs.",
+						ref.Name,
+					)
 				}
 				return nil, xerrors.Errorf("Failed to retrieve ClusterMongoDBRole '%s': %w", ref.Name, err)
 			}
@@ -304,7 +337,13 @@ func (r *ReconcileCommonController) getRoleRefs(ctx context.Context, roleRefs []
 
 // updateStatus updates the status for the CR using patch operation. Note, that the resource status is mutated and
 // it's important to pass resource by pointer to all methods which invoke current 'updateStatus'.
-func (r *ReconcileCommonController) updateStatus(ctx context.Context, reconciledResource v1.CustomResourceReadWriter, st workflow.Status, log *zap.SugaredLogger, statusOptions ...status.Option) (reconcile.Result, error) {
+func (r *ReconcileCommonController) updateStatus(
+	ctx context.Context,
+	reconciledResource v1.CustomResourceReadWriter,
+	st workflow.Status,
+	log *zap.SugaredLogger,
+	statusOptions ...status.Option,
+) (reconcile.Result, error) {
 	return commoncontroller.UpdateStatus(ctx, r.client, reconciledResource, st, log, statusOptions...)
 }
 
@@ -321,7 +360,12 @@ type WatcherResource interface {
 // Note: everything is watched under the same namespace as the objectKey
 // in case getSecretNames func is nil, we will default to common mechanism to get the secret names
 // TODO: unify the watcher setup with the secret creation/mounting code in database creation
-func (r *ReconcileCommonController) SetupCommonWatchers(watcherResource WatcherResource, getTLSSecretNames func() []string, getInternalAuthSecretNames func() []string, resourceNameForSecret string) {
+func (r *ReconcileCommonController) SetupCommonWatchers(
+	watcherResource WatcherResource,
+	getTLSSecretNames func() []string,
+	getInternalAuthSecretNames func() []string,
+	resourceNameForSecret string,
+) {
 	// We remove all watched resources
 	objectToReconcile := watcherResource.ObjectKey()
 	r.resourceWatcher.RemoveDependentWatchedResources(objectToReconcile)
@@ -366,13 +410,23 @@ func (r *ReconcileCommonController) SetupCommonWatchers(watcherResource WatcherR
 }
 
 // GetResource populates the provided runtime.Object with some additional error handling
-func (r *ReconcileCommonController) GetResource(ctx context.Context, request reconcile.Request, resource v1.CustomResourceReadWriter, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *ReconcileCommonController) GetResource(
+	ctx context.Context,
+	request reconcile.Request,
+	resource v1.CustomResourceReadWriter,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	return commoncontroller.GetResource(ctx, r.client, request, resource, log)
 }
 
 // prepareResourceForReconciliation finds the object being reconciled. Returns the reconcile result and any error that
 // occurred.
-func (r *ReconcileCommonController) prepareResourceForReconciliation(ctx context.Context, request reconcile.Request, resource v1.CustomResourceReadWriter, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *ReconcileCommonController) prepareResourceForReconciliation(
+	ctx context.Context,
+	request reconcile.Request,
+	resource v1.CustomResourceReadWriter,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	if result, err := r.GetResource(ctx, request, resource, log); err != nil {
 		return result, err
 	}
@@ -409,15 +463,29 @@ func checkIfHasExcessProcesses(conn om.Connection, resourceName string, log *zap
 		log.Warnw("could not remove externally managed tag from Ops Manager group", "error", err)
 	}
 
-	return workflow.Pending("cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)")
+	return workflow.Pending(
+		"cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)",
+	)
 }
 
 // validateInternalClusterCertsAndCheckTLSType verifies that all the x509 internal cluster certs exist and return whether they are built following the kubernetes.io/tls secret type (tls.crt/tls.key entries).
 // TODO: this is almost the same as certs.EnsureSSLCertsForStatefulSet, we should centralize the functionality
-func (r *ReconcileCommonController) validateInternalClusterCertsAndCheckTLSType(ctx context.Context, configurator certs.X509CertConfigurator, opts certs.Options, log *zap.SugaredLogger) error {
+func (r *ReconcileCommonController) validateInternalClusterCertsAndCheckTLSType(
+	ctx context.Context,
+	configurator certs.X509CertConfigurator,
+	opts certs.Options,
+	log *zap.SugaredLogger,
+) error {
 	secretName := opts.InternalClusterSecretName
 
-	err := certs.VerifyAndEnsureCertificatesForStatefulSet(ctx, configurator.GetSecretReadClient(), configurator.GetSecretWriteClient(), secretName, opts, log)
+	err := certs.VerifyAndEnsureCertificatesForStatefulSet(
+		ctx,
+		configurator.GetSecretReadClient(),
+		configurator.GetSecretWriteClient(),
+		secretName,
+		opts,
+		log,
+	)
 	if err != nil {
 		return xerrors.Errorf("the secret object '%s' does not contain all the certificates needed: %w", secretName, err)
 	}
@@ -432,8 +500,25 @@ func (r *ReconcileCommonController) validateInternalClusterCertsAndCheckTLSType(
 }
 
 // ensureBackupConfigurationAndUpdateStatus configures backup in Ops Manager based on the MongoDB resources spec
-func (r *ReconcileCommonController) ensureBackupConfigurationAndUpdateStatus(ctx context.Context, conn om.Connection, mdb backup.ConfigReaderUpdater, secretsReader secrets.SecretClient, log *zap.SugaredLogger, backupEnableDelay time.Duration) workflow.Status {
-	statusOpt, opts := backup.EnsureBackupConfigurationInOpsManager(ctx, mdb, secretsReader, conn.GroupID(), conn, conn, conn, log, backupEnableDelay)
+func (r *ReconcileCommonController) ensureBackupConfigurationAndUpdateStatus(
+	ctx context.Context,
+	conn om.Connection,
+	mdb backup.ConfigReaderUpdater,
+	secretsReader secrets.SecretClient,
+	log *zap.SugaredLogger,
+	backupEnableDelay time.Duration,
+) workflow.Status {
+	statusOpt, opts := backup.EnsureBackupConfigurationInOpsManager(
+		ctx,
+		mdb,
+		secretsReader,
+		conn.GroupID(),
+		conn,
+		conn,
+		conn,
+		log,
+		backupEnableDelay,
+	)
 	if len(opts) > 0 {
 		if _, err := r.updateStatus(ctx, mdb, statusOpt, log, opts...); err != nil {
 			return workflow.Failed(err)
@@ -464,14 +549,23 @@ func ensureSupportedOpsManagerVersion(conn om.Connection) workflow.Status {
 			return workflow.Failed(xerrors.Errorf("Failed when trying to parse Ops Manager version"))
 		}
 		if omVersion.LT(semver.MustParse(oldestSupportedOpsManagerVersion)) {
-			return workflow.Unsupported("This MongoDB ReplicaSet is managed by Ops Manager version %s, which is not supported by this version of the operator. Please upgrade it to a version >=%s", omVersion, oldestSupportedOpsManagerVersion)
+			return workflow.Unsupported(
+				"This MongoDB ReplicaSet is managed by Ops Manager version %s, which is not supported by this version of the operator. Please upgrade it to a version >=%s",
+				omVersion,
+				oldestSupportedOpsManagerVersion,
+			)
 		}
 	}
 	return workflow.OK()
 }
 
 // scaleStatefulSet sets the number of replicas for a StatefulSet and returns a reference of the updated resource.
-func (r *ReconcileCommonController) scaleStatefulSet(ctx context.Context, namespace, name string, replicas int32, client kubernetesClient.Client) (appsv1.StatefulSet, error) {
+func (r *ReconcileCommonController) scaleStatefulSet(
+	ctx context.Context,
+	namespace, name string,
+	replicas int32,
+	client kubernetesClient.Client,
+) (appsv1.StatefulSet, error) {
 	if set, err := client.GetStatefulSet(ctx, kube.ObjectKey(namespace, name)); err != nil {
 		return set, err
 	} else {
@@ -489,7 +583,9 @@ func validateScram(mdb *mdbv1.MongoDB, ac *om.AutomationConfig) workflow.Status 
 
 	scram256IsAlreadyEnabled := stringutil.Contains(ac.Auth.DeploymentAuthMechanisms, string(authentication.ScramSha256))
 	attemptingToDowngradeMongoDBVersion := ac.Deployment.MinimumMajorVersion() >= 4 && specVersion.Major < 4
-	isDowngradingFromScramSha256ToScramSha1 := attemptingToDowngradeMongoDBVersion && stringutil.Contains(mdb.Spec.Security.Authentication.GetModes(), "SCRAM") && scram256IsAlreadyEnabled
+	isDowngradingFromScramSha256ToScramSha1 := attemptingToDowngradeMongoDBVersion &&
+		stringutil.Contains(mdb.Spec.Security.Authentication.GetModes(), "SCRAM") &&
+		scram256IsAlreadyEnabled
 
 	if isDowngradingFromScramSha256ToScramSha1 {
 		return workflow.Invalid("Unable to downgrade to SCRAM-SHA-1 when SCRAM-SHA-256 has been enabled")
@@ -522,7 +618,15 @@ func getSubjectFromCertificate(cert string) (string, error) {
 // enables/disables authentication. If the authentication can't be fully configured, a boolean value indicating that
 // an additional reconciliation needs to be queued up to fully make the authentication changes is returned.
 // Note: updateOmAuthentication needs to be called before reconciling other auth related settings.
-func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, conn om.Connection, processNames []string, ar authentication.AuthResource, agentCertPath, caFilepath, clusterFilePath string, isRecovering bool, log *zap.SugaredLogger) (status workflow.Status, multiStageReconciliation bool) {
+func (r *ReconcileCommonController) updateOmAuthentication(
+	ctx context.Context,
+	conn om.Connection,
+	processNames []string,
+	ar authentication.AuthResource,
+	agentCertPath, caFilepath, clusterFilePath string,
+	isRecovering bool,
+	log *zap.SugaredLogger,
+) (status workflow.Status, multiStageReconciliation bool) {
 	// don't touch authentication settings if resource has not been configured with them
 	if ar.GetSecurity() == nil || ar.GetSecurity().Authentication == nil {
 		return workflow.OK(), false
@@ -572,7 +676,12 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 		databaseSecretPath = r.VaultClient.DatabaseSecretPath()
 	}
 	if ar.IsLDAPEnabled() {
-		bindUserPassword, err := r.ReadSecretKey(ctx, kube.ObjectKey(ar.GetNamespace(), ar.GetSecurity().Authentication.Ldap.BindQuerySecretRef.Name), databaseSecretPath, "password")
+		bindUserPassword, err := r.ReadSecretKey(
+			ctx,
+			kube.ObjectKey(ar.GetNamespace(), ar.GetSecurity().Authentication.Ldap.BindQuerySecretRef.Name),
+			databaseSecretPath,
+			"password",
+		)
 		if err != nil {
 			return workflow.Failed(xerrors.Errorf("error reading bind user password: %w", err)), false
 		}
@@ -616,7 +725,12 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 		}
 		if ar.GetSecurity().ShouldUseLDAP(ac.Auth.AutoAuthMechanism) {
 			secretRef := ar.GetSecurity().Authentication.Agents.AutomationPasswordSecretRef
-			autoConfigPassword, err := r.ReadSecretKey(ctx, kube.ObjectKey(ar.GetNamespace(), secretRef.Name), databaseSecretPath, secretRef.Key)
+			autoConfigPassword, err := r.ReadSecretKey(
+				ctx,
+				kube.ObjectKey(ar.GetNamespace(), secretRef.Name),
+				databaseSecretPath,
+				secretRef.Key,
+			)
 			if err != nil {
 				return workflow.Failed(xerrors.Errorf("error reading automation agent password: %w", err)), false
 			}
@@ -657,7 +771,13 @@ func (r *ReconcileCommonController) updateOmAuthentication(ctx context.Context, 
 
 // configureAgentSubjects returns a new authentication.Options which has configured the Subject lines for the automation agent.
 // The Ops Manager user names for these agents will be configured based on the contents of the secret.
-func (r *ReconcileCommonController) configureAgentSubjects(ctx context.Context, namespace string, secretKeySelector corev1.SecretKeySelector, authOpts authentication.Options, log *zap.SugaredLogger) (authentication.Options, error) {
+func (r *ReconcileCommonController) configureAgentSubjects(
+	ctx context.Context,
+	namespace string,
+	secretKeySelector corev1.SecretKeySelector,
+	authOpts authentication.Options,
+	log *zap.SugaredLogger,
+) (authentication.Options, error) {
 	userOpts, err := r.readAgentSubjectsFromSecret(ctx, namespace, secretKeySelector, log)
 	if err != nil {
 		return authentication.Options{}, xerrors.Errorf("error reading agent subjects from secret: %w", err)
@@ -666,7 +786,12 @@ func (r *ReconcileCommonController) configureAgentSubjects(ctx context.Context, 
 	return authOpts, nil
 }
 
-func (r *ReconcileCommonController) readAgentSubjectsFromSecret(ctx context.Context, namespace string, secretKeySelector corev1.SecretKeySelector, log *zap.SugaredLogger) (authentication.UserOptions, error) {
+func (r *ReconcileCommonController) readAgentSubjectsFromSecret(
+	ctx context.Context,
+	namespace string,
+	secretKeySelector corev1.SecretKeySelector,
+	log *zap.SugaredLogger,
+) (authentication.UserOptions, error) {
 	userOpts := authentication.UserOptions{}
 
 	var databaseSecretPath string
@@ -695,7 +820,13 @@ func (r *ReconcileCommonController) readAgentSubjectsFromSecret(ctx context.Cont
 	}, nil
 }
 
-func (r *ReconcileCommonController) clearProjectAuthenticationSettings(ctx context.Context, conn om.Connection, mdb *mdbv1.MongoDB, processNames []string, log *zap.SugaredLogger) error {
+func (r *ReconcileCommonController) clearProjectAuthenticationSettings(
+	ctx context.Context,
+	conn om.Connection,
+	mdb *mdbv1.MongoDB,
+	processNames []string,
+	log *zap.SugaredLogger,
+) error {
 	agentCertSecretName := mdb.Spec.GetSecurity().AgentClientCertificateSecretName(mdb.Name)
 	agentCertSecretSelector := corev1.SecretKeySelector{
 		LocalObjectReference: corev1.LocalObjectReference{Name: agentCertSecretName},
@@ -717,7 +848,12 @@ func (r *ReconcileCommonController) clearProjectAuthenticationSettings(ctx conte
 }
 
 // ensureX509SecretAndCheckTLSType checks if the secrets containing the certificates are present and whether the certificate are of kubernetes.io/tls type.
-func (r *ReconcileCommonController) ensureX509SecretAndCheckTLSType(ctx context.Context, configurator certs.X509CertConfigurator, currentAuthMechanism string, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileCommonController) ensureX509SecretAndCheckTLSType(
+	ctx context.Context,
+	configurator certs.X509CertConfigurator,
+	currentAuthMechanism string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	security := configurator.GetDbCommonSpec().GetSecurity()
 	authSpec := security.Authentication
 	if authSpec == nil || !security.Authentication.Enabled {
@@ -729,7 +865,13 @@ func (r *ReconcileCommonController) ensureX509SecretAndCheckTLSType(ctx context.
 			return workflow.Failed(xerrors.Errorf("Authentication mode for project is x509 but this MDB resource is not TLS enabled"))
 		}
 		agentSecretName := security.AgentClientCertificateSecretName(configurator.GetName())
-		err := certs.VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx, configurator.GetSecretReadClient(), configurator.GetSecretWriteClient(), kube.ObjectKey(configurator.GetNamespace(), agentSecretName), log)
+		err := certs.VerifyAndEnsureClientCertificatesForAgentsAndTLSType(
+			ctx,
+			configurator.GetSecretReadClient(),
+			configurator.GetSecretWriteClient(),
+			kube.ObjectKey(configurator.GetNamespace(), agentSecretName),
+			log,
+		)
 		if err != nil {
 			return workflow.Failed(err)
 		}
@@ -752,7 +894,13 @@ func (r *ReconcileCommonController) ensureX509SecretAndCheckTLSType(ctx context.
 }
 
 // setupInternalClusterAuthIfItHasChanged enables internal cluster auth if possible in case the path has changed and did exist before.
-func (r *ReconcileCommonController) setupInternalClusterAuthIfItHasChanged(conn om.Connection, names []string, clusterAuth string, filePath string, isRecovering bool) error {
+func (r *ReconcileCommonController) setupInternalClusterAuthIfItHasChanged(
+	conn om.Connection,
+	names []string,
+	clusterAuth string,
+	filePath string,
+	isRecovering bool,
+) error {
 	if filePath == "" {
 		return nil
 	}
@@ -766,7 +914,12 @@ func (r *ReconcileCommonController) setupInternalClusterAuthIfItHasChanged(conn 
 // getAgentVersion resolves the agent version to use. When customAgentURL is set,
 // the version is extracted from the URL filename, overriding the Ops Manager API,
 // mapping file, and Cloud Manager paths.
-func (r *ReconcileCommonController) getAgentVersion(conn om.Connection, omVersion string, isAppDB bool, log *zap.SugaredLogger) (string, error) {
+func (r *ReconcileCommonController) getAgentVersion(
+	conn om.Connection,
+	omVersion string,
+	isAppDB bool,
+	log *zap.SugaredLogger,
+) (string, error) {
 	// When a custom agent URL is set, derive the version from the URL filename.
 	// This overrides all other version resolution (Ops Manager API, mapping, Cloud Manager).
 	if r.customAgentURL != "" {
@@ -800,7 +953,13 @@ func agentVersionFromURL(url string) string {
 }
 
 // deleteClusterResources removes all resources that are associated with the given resource owner in a given cluster.
-func (r *ReconcileCommonController) deleteClusterResources(ctx context.Context, client kubernetesClient.Client, clusterName string, resourceOwner v1.ObjectOwner, log *zap.SugaredLogger) error {
+func (r *ReconcileCommonController) deleteClusterResources(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	clusterName string,
+	resourceOwner v1.ObjectOwner,
+	log *zap.SugaredLogger,
+) error {
 	errs := deleteOwnedClusterResources(ctx, client, clusterName, resourceOwner, log)
 
 	r.resourceWatcher.RemoveDependentWatchedResources(resourceOwner.ObjectKey())
@@ -809,7 +968,13 @@ func (r *ReconcileCommonController) deleteClusterResources(ctx context.Context, 
 }
 
 // deleteOwnedClusterResources removes the label-owned resources of the given resource owner in a given cluster.
-func deleteOwnedClusterResources(ctx context.Context, client kubernetesClient.Client, clusterName string, resourceOwner v1.ObjectOwner, log *zap.SugaredLogger) error {
+func deleteOwnedClusterResources(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	clusterName string,
+	resourceOwner v1.ObjectOwner,
+	log *zap.SugaredLogger,
+) error {
 	objectKey := resourceOwner.ObjectKey()
 
 	// cleanup resources in the namespace as the MongoDB with the corresponding label.
@@ -848,7 +1013,12 @@ func deleteOwnedClusterResources(ctx context.Context, client kubernetesClient.Cl
 
 // agentCertHashAndPath returns a hash of an agent certificate along with file path
 // to the said certificate. File path also contains the hash.
-func (r *ReconcileCommonController) agentCertHashAndPath(ctx context.Context, log *zap.SugaredLogger, namespace, agentCertSecretName string, appdbSecretPath string) (string, string) {
+func (r *ReconcileCommonController) agentCertHashAndPath(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	namespace, agentCertSecretName string,
+	appdbSecretPath string,
+) (string, string) {
 	agentCertHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, namespace, agentCertSecretName, appdbSecretPath, log)
 	agentCertPath := ""
 	if agentCertHash != "" {
@@ -871,7 +1041,16 @@ func isPrometheusSupported(conn om.Connection) bool {
 }
 
 // UpdatePrometheus configures Prometheus on the Deployment for this resource.
-func UpdatePrometheus(ctx context.Context, d *om.Deployment, conn om.Connection, prometheus *v1.Prometheus, sClient secrets.SecretClient, namespace string, certName string, log *zap.SugaredLogger) error {
+func UpdatePrometheus(
+	ctx context.Context,
+	d *om.Deployment,
+	conn om.Connection,
+	prometheus *v1.Prometheus,
+	sClient secrets.SecretClient,
+	namespace string,
+	certName string,
+	log *zap.SugaredLogger,
+) error {
 	if prometheus == nil {
 		return nil
 	}
@@ -921,7 +1100,8 @@ func UpdatePrometheus(ctx context.Context, d *om.Deployment, conn om.Connection,
 // during this reconciliation. This function may return a different value on the next reconciliation
 // if the state of Ops Manager has been changed.
 func canConfigureAuthentication(ac *om.AutomationConfig, authenticationModes []string, log *zap.SugaredLogger) bool {
-	attemptingToEnableX509 := !stringutil.Contains(ac.Auth.DeploymentAuthMechanisms, util.AutomationConfigX509Option) && stringutil.Contains(authenticationModes, util.X509)
+	attemptingToEnableX509 := !stringutil.Contains(ac.Auth.DeploymentAuthMechanisms, util.AutomationConfigX509Option) &&
+		stringutil.Contains(authenticationModes, util.X509)
 	canEnableX509InOpsManager := ac.Deployment.AllProcessesAreTLSEnabled() || ac.Deployment.NumberOfProcesses() == 0
 
 	log.Debugw("canConfigureAuthentication",
@@ -962,7 +1142,13 @@ func getVolumeFromStatefulSet(sts appsv1.StatefulSet, name string) (corev1.Volum
 }
 
 // wasTLSSecretMounted checks whether TLS was previously enabled by looking at the state of the volumeMounts of the pod.
-func wasTLSSecretMounted(ctx context.Context, secretGetter secret.Getter, currentSts appsv1.StatefulSet, mdb mdbv1.MongoDB, log *zap.SugaredLogger) bool {
+func wasTLSSecretMounted(
+	ctx context.Context,
+	secretGetter secret.Getter,
+	currentSts appsv1.StatefulSet,
+	mdb mdbv1.MongoDB,
+	log *zap.SugaredLogger,
+) bool {
 	tlsVolume, err := getVolumeFromStatefulSet(currentSts, util.SecretVolumeName)
 	if err != nil {
 		return false
@@ -989,7 +1175,13 @@ func wasTLSSecretMounted(ctx context.Context, secretGetter secret.Getter, curren
 }
 
 // wasCAConfigMapMounted checks whether the CA ConfigMap  by looking at the state of the volumeMounts of the pod.
-func wasCAConfigMapMounted(ctx context.Context, configMapGetter configmap.Getter, currentSts appsv1.StatefulSet, mdb mdbv1.MongoDB, log *zap.SugaredLogger) bool {
+func wasCAConfigMapMounted(
+	ctx context.Context,
+	configMapGetter configmap.Getter,
+	currentSts appsv1.StatefulSet,
+	mdb mdbv1.MongoDB,
+	log *zap.SugaredLogger,
+) bool {
 	caVolume, err := getVolumeFromStatefulSet(currentSts, util.ConfigMapVolumeCAMountPath)
 	if err != nil {
 		return false
@@ -1019,7 +1211,15 @@ func wasCAConfigMapMounted(ctx context.Context, configMapGetter configmap.Getter
 // needs to be updated first. In the case of unmounting certs, for instance, the certs should be not
 // required anymore before we unmount them, or the automation-agent and readiness probe will never
 // reach goal state.
-func publishAutomationConfigFirst(ctx context.Context, getter kubernetesClient.Client, mdb mdbv1.MongoDB, lastSpec *mdbv1.MongoDbSpec, configFunc func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions, defaultArchitecture architectures.DefaultArchitecture, log *zap.SugaredLogger) bool {
+func publishAutomationConfigFirst(
+	ctx context.Context,
+	getter kubernetesClient.Client,
+	mdb mdbv1.MongoDB,
+	lastSpec *mdbv1.MongoDbSpec,
+	configFunc func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions,
+	defaultArchitecture architectures.DefaultArchitecture,
+	log *zap.SugaredLogger,
+) bool {
 	opts := configFunc(mdb)
 
 	namespacedName := kube.ObjectKey(mdb.Namespace, opts.GetStatefulSetName())
@@ -1054,7 +1254,8 @@ func publishAutomationConfigFirst(ctx context.Context, getter kubernetesClient.C
 		return true
 	}
 
-	if mdb.Spec.Security.GetAgentMechanism(opts.CurrentAgentAuthMode) != util.X509 && statefulset.VolumeMountWithNameExists(volumeMounts, util.AgentSecretName) {
+	if mdb.Spec.Security.GetAgentMechanism(opts.CurrentAgentAuthMode) != util.X509 &&
+		statefulset.VolumeMountWithNameExists(volumeMounts, util.AgentSecretName) {
 		log.Debug(automationConfigFirstMsg("project.AuthMode", "empty"))
 		return true
 	}
@@ -1100,7 +1301,18 @@ type PrometheusConfiguration struct {
 	prometheusCertHash string
 }
 
-func ReconcileReplicaSetAC(ctx context.Context, d om.Deployment, spec mdbv1.DbCommonSpec, lastMongodConfig map[string]interface{}, resourceName string, rs om.ReplicaSetWithProcesses, caFilePath string, internalClusterPath string, pc *PrometheusConfiguration, log *zap.SugaredLogger) error {
+func ReconcileReplicaSetAC(
+	ctx context.Context,
+	d om.Deployment,
+	spec mdbv1.DbCommonSpec,
+	lastMongodConfig map[string]interface{},
+	resourceName string,
+	rs om.ReplicaSetWithProcesses,
+	caFilePath string,
+	internalClusterPath string,
+	pc *PrometheusConfiguration,
+	log *zap.SugaredLogger,
+) error {
 	// it is not possible to disable internal cluster authentication once enabled
 	if d.ExistingProcessesHaveInternalClusterAuthentication(rs.Processes) && spec.Security.GetInternalClusterAuthenticationMode() == "" {
 		return xerrors.Errorf("cannot disable x509 internal cluster authentication")
@@ -1108,13 +1320,19 @@ func ReconcileReplicaSetAC(ctx context.Context, d om.Deployment, spec mdbv1.DbCo
 
 	excessProcesses := d.GetNumberOfExcessProcesses(resourceName)
 	if excessProcesses > 0 {
-		return xerrors.Errorf("cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)")
+		return xerrors.Errorf(
+			"cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)",
+		)
 	}
 
 	d.MergeReplicaSet(rs, spec.GetAdditionalMongodConfig().ToMap(), lastMongodConfig, log)
 	d.ConfigureMonitoringAndBackup(log, spec.GetSecurity().IsTLSEnabled(), caFilePath)
 	d.ConfigureTLS(spec.GetSecurity(), caFilePath)
-	d.ConfigureInternalClusterAuthentication(rs.GetProcessNames(), spec.GetSecurity().GetInternalClusterAuthenticationMode(), internalClusterPath)
+	d.ConfigureInternalClusterAuthentication(
+		rs.GetProcessNames(),
+		spec.GetSecurity().GetInternalClusterAuthenticationMode(),
+		internalClusterPath,
+	)
 
 	// if we don't set up a prometheus connection, then we don't want to set up prometheus for instance because we do not support it yet.
 	if pc != nil {

--- a/controllers/operator/common_controller_test.go
+++ b/controllers/operator/common_controller_test.go
@@ -88,11 +88,30 @@ func TestPrepareOpsManagerConnection_TagNamespace(t *testing.T) {
 		ctx := context.Background()
 		kubeClient, omConnectionFactory := mock.NewDefaultFakeClient()
 		controller := NewReconcileCommonController(ctx, kubeClient)
-		projectConfig, err := project.ReadProjectConfig(ctx, controller.client, kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName), "mdb-name")
+		projectConfig, err := project.ReadProjectConfig(
+			ctx,
+			controller.client,
+			kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName),
+			"mdb-name",
+		)
 		require.NoError(t, err)
-		credsConfig, err := project.ReadCredentials(ctx, controller.SecretClient, kube.ObjectKey(mock.TestNamespace, mock.TestCredentialsSecretName), &zap.SugaredLogger{})
+		credsConfig, err := project.ReadCredentials(
+			ctx,
+			controller.SecretClient,
+			kube.ObjectKey(mock.TestNamespace, mock.TestCredentialsSecretName),
+			&zap.SugaredLogger{},
+		)
 		require.NoError(t, err)
-		conn, _, err := connection.PrepareOpsManagerConnection(ctx, controller.SecretClient, projectConfig, credsConfig, omConnectionFactory.GetConnectionFunc, mock.TestNamespace, tagNamespace, zap.S())
+		conn, _, err := connection.PrepareOpsManagerConnection(
+			ctx,
+			controller.SecretClient,
+			projectConfig,
+			credsConfig,
+			omConnectionFactory.GetConnectionFunc,
+			mock.TestNamespace,
+			tagNamespace,
+			zap.S(),
+		)
 		require.NoError(t, err)
 		return conn.(*om.MockedOmConnection)
 	}
@@ -123,7 +142,9 @@ func TestPrepareOmConnection_FindExistingGroup(t *testing.T) {
 	omConnectionFactory.SetPostCreateHook(func(c om.Connection) {
 		// Important: the organization for the group has a different name ("foo") then group (om.TestGroupName).
 		// So it won't work for cases when the group "was created before" by Operator
-		c.(*om.MockedOmConnection).OrganizationsWithGroups = map[*om.Organization][]*om.Project{{ID: om.TestOrgID, Name: "foo"}: {{Name: om.TestGroupName, ID: "existing-group-id", OrgID: om.TestOrgID}}}
+		c.(*om.MockedOmConnection).OrganizationsWithGroups = map[*om.Organization][]*om.Project{
+			{ID: om.TestOrgID, Name: "foo"}: {{Name: om.TestGroupName, ID: "existing-group-id", OrgID: om.TestOrgID}},
+		}
 	})
 
 	controller := NewReconcileCommonController(ctx, kubeClient)
@@ -133,7 +154,12 @@ func TestPrepareOmConnection_FindExistingGroup(t *testing.T) {
 	assert.Len(t, mockOm.OrganizationsWithGroups, 1)
 
 	mockOm.CheckOrderOfOperations(t, reflect.ValueOf(mockOm.ReadOrganization), reflect.ValueOf(mockOm.ReadProjectsInOrganizationByName))
-	mockOm.CheckOperationsDidntHappen(t, reflect.ValueOf(mockOm.ReadOrganizations), reflect.ValueOf(mockOm.CreateProject), reflect.ValueOf(mockOm.ReadProjectsInOrganization))
+	mockOm.CheckOperationsDidntHappen(
+		t,
+		reflect.ValueOf(mockOm.ReadOrganizations),
+		reflect.ValueOf(mockOm.CreateProject),
+		reflect.ValueOf(mockOm.ReadProjectsInOrganization),
+	)
 }
 
 // TestPrepareOmConnection_DuplicatedGroups verifies that if there are groups with the same name but in different organization
@@ -149,7 +175,9 @@ func TestPrepareOmConnection_DuplicatedGroups(t *testing.T) {
 	omConnectionFactory.SetPostCreateHook(func(c om.Connection) {
 		// Important: the organization for the group has a different name ("foo") then group (om.TestGroupName).
 		// So it won't work for cases when the group "was created before" by Operator
-		c.(*om.MockedOmConnection).OrganizationsWithGroups = map[*om.Organization][]*om.Project{{ID: om.TestOrgID, Name: "foo"}: {{Name: om.TestGroupName, ID: "existing-group-id", OrgID: om.TestOrgID}}}
+		c.(*om.MockedOmConnection).OrganizationsWithGroups = map[*om.Organization][]*om.Project{
+			{ID: om.TestOrgID, Name: "foo"}: {{Name: om.TestGroupName, ID: "existing-group-id", OrgID: om.TestOrgID}},
+		}
 	})
 
 	// The only difference from TestPrepareOmConnection_FindExistingGroup above is that the config map contains only project name
@@ -273,22 +301,42 @@ func TestUpdateStatus_Patched(t *testing.T) {
 
 func TestReadSubjectFromJustCertificate(t *testing.T) {
 	ctx := context.Background()
-	assertSubjectFromFileSucceeds(ctx, t, "CN=mms-automation-agent,OU=MongoDB Kubernetes Operator,O=mms-automation-agent,L=NY,ST=NY,C=US", "testdata/certificates/just_certificate")
+	assertSubjectFromFileSucceeds(
+		ctx,
+		t,
+		"CN=mms-automation-agent,OU=MongoDB Kubernetes Operator,O=mms-automation-agent,L=NY,ST=NY,C=US",
+		"testdata/certificates/just_certificate",
+	)
 }
 
 func TestReadSubjectFromCertificateThenKey(t *testing.T) {
 	ctx := context.Background()
-	assertSubjectFromFileSucceeds(ctx, t, "CN=mms-automation-agent,OU=MongoDB Kubernetes Operator,O=mms-automation-agent,L=NY,ST=NY,C=US", "testdata/certificates/certificate_then_key")
+	assertSubjectFromFileSucceeds(
+		ctx,
+		t,
+		"CN=mms-automation-agent,OU=MongoDB Kubernetes Operator,O=mms-automation-agent,L=NY,ST=NY,C=US",
+		"testdata/certificates/certificate_then_key",
+	)
 }
 
 func TestReadSubjectFromKeyThenCertificate(t *testing.T) {
 	ctx := context.Background()
-	assertSubjectFromFileSucceeds(ctx, t, "CN=mms-automation-agent,OU=MongoDB Kubernetes Operator,O=mms-automation-agent,L=NY,ST=NY,C=US", "testdata/certificates/key_then_certificate")
+	assertSubjectFromFileSucceeds(
+		ctx,
+		t,
+		"CN=mms-automation-agent,OU=MongoDB Kubernetes Operator,O=mms-automation-agent,L=NY,ST=NY,C=US",
+		"testdata/certificates/key_then_certificate",
+	)
 }
 
 func TestReadSubjectFromCertInStrictlyRFC2253(t *testing.T) {
 	ctx := context.Background()
-	assertSubjectFromFileSucceeds(ctx, t, "CN=mms-agent-cert,O=MongoDB-agent,OU=TSE,L=New Delhi,ST=New Delhi,C=IN", "testdata/certificates/cert_rfc2253")
+	assertSubjectFromFileSucceeds(
+		ctx,
+		t,
+		"CN=mms-agent-cert,O=MongoDB-agent,OU=TSE,L=New Delhi,ST=New Delhi,C=IN",
+		"testdata/certificates/cert_rfc2253",
+	)
 }
 
 func TestReadSubjectNoCertificate(t *testing.T) {
@@ -738,12 +786,24 @@ func TestSecretWatcherWithAllResources(t *testing.T) {
 	agentCert := rs.GetSecurity().AgentClientCertificateSecretName(rs.Name)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, caName)}:                        {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}:              {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, memberCert)}:                       {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, internalAuthCert)}:                 {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, agentCert)}:                        {kube.ObjectKey(mock.TestNamespace, rs.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, caName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, memberCert)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, internalAuthCert)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, agentCert)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
 	}
 
 	assert.Equal(t, expected, controller.resourceWatcher.GetWatchedResources())
@@ -762,10 +822,18 @@ func TestSecretWatcherWithSelfProvidedTLSSecretNames(t *testing.T) {
 	}, nil, rs.Name)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, caName)}:                        {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}:              {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, "a-secret")}:                       {kube.ObjectKey(mock.TestNamespace, rs.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, caName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, "a-secret")}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
 	}
 
 	assert.Equal(t, expected, controller.resourceWatcher.GetWatchedResources())
@@ -852,13 +920,37 @@ func assertSubjectFromFile(t *testing.T, expectedSubject, filePath string, passe
 	assert.Equal(t, expectedSubject, subject)
 }
 
-func prepareConnection(ctx context.Context, controller *ReconcileCommonController, omConnectionFunc om.ConnectionFactory, t *testing.T) (*om.MockedOmConnection, *env.PodEnvVars) {
-	projectConfig, err := project.ReadProjectConfig(ctx, controller.client, kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName), "mdb-name")
+func prepareConnection(
+	ctx context.Context,
+	controller *ReconcileCommonController,
+	omConnectionFunc om.ConnectionFactory,
+	t *testing.T,
+) (*om.MockedOmConnection, *env.PodEnvVars) {
+	projectConfig, err := project.ReadProjectConfig(
+		ctx,
+		controller.client,
+		kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName),
+		"mdb-name",
+	)
 	assert.NoError(t, err)
-	credsConfig, err := project.ReadCredentials(ctx, controller.SecretClient, kube.ObjectKey(mock.TestNamespace, mock.TestCredentialsSecretName), &zap.SugaredLogger{})
+	credsConfig, err := project.ReadCredentials(
+		ctx,
+		controller.SecretClient,
+		kube.ObjectKey(mock.TestNamespace, mock.TestCredentialsSecretName),
+		&zap.SugaredLogger{},
+	)
 	assert.NoError(t, err)
 
-	conn, _, e := connection.PrepareOpsManagerConnection(ctx, controller.SecretClient, projectConfig, credsConfig, omConnectionFunc, mock.TestNamespace, true, zap.S())
+	conn, _, e := connection.PrepareOpsManagerConnection(
+		ctx,
+		controller.SecretClient,
+		projectConfig,
+		credsConfig,
+		omConnectionFunc,
+		mock.TestNamespace,
+		true,
+		zap.S(),
+	)
 	mockOm := conn.(*om.MockedOmConnection)
 	assert.NoError(t, e)
 	return mockOm, newPodVars(conn, projectConfig, mdbv1.Warn)
@@ -881,7 +973,13 @@ func testConnectionSpec() mdbv1.ConnectionSpec {
 	}
 }
 
-func checkReconcileSuccessful(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, object *mdbv1.MongoDB, client client.Client) {
+func checkReconcileSuccessful(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	object *mdbv1.MongoDB,
+	client client.Client,
+) {
 	err := client.Update(ctx, object)
 	require.NoError(t, err)
 
@@ -920,7 +1018,13 @@ func checkReconcileSuccessful(ctx context.Context, t *testing.T, reconciler reco
 	require.NoError(t, client.Get(ctx, kube.ObjectKeyFromApiObject(object), object))
 }
 
-func checkOMReconciliationSuccessful(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, om *omv1.MongoDBOpsManager, client client.Client) {
+func checkOMReconciliationSuccessful(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	om *omv1.MongoDBOpsManager,
+	client client.Client,
+) {
 	res, err := reconciler.Reconcile(ctx, requestFromObject(om))
 	expected, _ := workflow.Pending("doesn't matter").Requeue().ReconcileResult()
 	assert.Equal(t, expected, res)
@@ -934,7 +1038,13 @@ func checkOMReconciliationSuccessful(ctx context.Context, t *testing.T, reconcil
 	require.NoError(t, client.Get(ctx, kube.ObjectKeyFromApiObject(om), om))
 }
 
-func checkOMReconciliationInvalid(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, om *omv1.MongoDBOpsManager, client client.Client) {
+func checkOMReconciliationInvalid(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	om *omv1.MongoDBOpsManager,
+	client client.Client,
+) {
 	res, err := reconciler.Reconcile(ctx, requestFromObject(om))
 	expected, _ := workflow.Pending("doesn't matter").Requeue().ReconcileResult()
 	assert.Equal(t, expected, res)
@@ -954,7 +1064,15 @@ func checkOMReconciliationPending(ctx context.Context, t *testing.T, reconciler 
 	assert.True(t, res.RequeueAfter > 0)
 }
 
-func checkReconcileFailed(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, object *mdbv1.MongoDB, expectedRetry bool, expectedErrorMessage string, client client.Client) {
+func checkReconcileFailed(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	object *mdbv1.MongoDB,
+	expectedRetry bool,
+	expectedErrorMessage string,
+	client client.Client,
+) {
 	failedResult := reconcile.Result{}
 	if expectedRetry {
 		failedResult.RequeueAfter = 10 * time.Second
@@ -969,7 +1087,15 @@ func checkReconcileFailed(ctx context.Context, t *testing.T, reconciler reconcil
 	assert.Contains(t, object.Status.Message, expectedErrorMessage)
 }
 
-func checkReconcilePending(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, object *mdbv1.MongoDB, expectedErrorMessage string, client client.Client, requeueAfter time.Duration) {
+func checkReconcilePending(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	object *mdbv1.MongoDB,
+	expectedErrorMessage string,
+	client client.Client,
+	requeueAfter time.Duration,
+) {
 	failedResult := reconcile.Result{RequeueAfter: requeueAfter * time.Second}
 	result, e := reconciler.Reconcile(ctx, requestFromObject(object))
 	assert.Nil(t, e, "When pending, error should be nil")
@@ -999,7 +1125,12 @@ type testReconciliationResources struct {
 
 // agentVersionMappingTest is a helper function to verify that the version mapping mechanism works correctly in controllers
 // in case retrieving the version fails, the user should have the possibility to override the image in the pod specs
-func agentVersionMappingTest(ctx context.Context, t *testing.T, defaultResource testReconciliationResources, overridenResource testReconciliationResources) {
+func agentVersionMappingTest(
+	ctx context.Context,
+	t *testing.T,
+	defaultResource testReconciliationResources,
+	overridenResource testReconciliationResources,
+) {
 	nonExistingPath := "/foo/bar/foo"
 
 	t.Run("Static architecture, version retrieving fails, image is overriden, reconciliation should succeed", func(t *testing.T) {
@@ -1026,7 +1157,13 @@ func agentVersionMappingTest(ctx context.Context, t *testing.T, defaultResource 
 	})
 }
 
-func testConcurrentReconciles(ctx context.Context, t *testing.T, client client.Client, reconciler reconcile.Reconciler, objects ...client.Object) {
+func testConcurrentReconciles(
+	ctx context.Context,
+	t *testing.T,
+	client client.Client,
+	reconciler reconcile.Reconciler,
+	objects ...client.Object,
+) {
 	for _, object := range objects {
 		err := mock.CreateOrUpdate(ctx, client, object)
 		require.NoError(t, err)

--- a/controllers/operator/connection/opsmanager_connection.go
+++ b/controllers/operator/connection/opsmanager_connection.go
@@ -22,7 +22,16 @@ import (
 // tagNamespace controls whether the calling controller's namespace is added as a tag on the OM project.
 // Pass false for controllers where multiple namespaces share one project (e.g. MongoDBUser), because
 // Ops Manager enforces a hard limit of 10 tags per project and each namespace would otherwise consume one slot.
-func PrepareOpsManagerConnection(ctx context.Context, client secrets.SecretClient, projectConfig mdbv1.ProjectConfig, credentials mdbv1.Credentials, connectionFunc om.ConnectionFactory, namespace string, tagNamespace bool, log *zap.SugaredLogger) (om.Connection, string, error) {
+func PrepareOpsManagerConnection(
+	ctx context.Context,
+	client secrets.SecretClient,
+	projectConfig mdbv1.ProjectConfig,
+	credentials mdbv1.Credentials,
+	connectionFunc om.ConnectionFactory,
+	namespace string,
+	tagNamespace bool,
+	log *zap.SugaredLogger,
+) (om.Connection, string, error) {
 	omProject, conn, err := project.ReadOrCreateProject(projectConfig, credentials, connectionFunc, log)
 	if err != nil {
 		return nil, "", xerrors.Errorf("error reading or creating project in Ops Manager: %w", err)
@@ -88,7 +97,14 @@ func EnsureTagAdded(conn om.Connection, project *om.Project, tag string, log *za
 // With this we Pre-seed the target project's Automation Config from the prior project
 // before any pod mutation, so agents switching to the new GROUP_ID find the
 // same topology and auth.key already in place.
-func EnsureTargetAutomationConfigSeeded(targetConn om.Connection, sourceProjectID string, projectConfig mdbv1.ProjectConfig, credentials mdbv1.Credentials, connectionFunc om.ConnectionFactory, log *zap.SugaredLogger) error {
+func EnsureTargetAutomationConfigSeeded(
+	targetConn om.Connection,
+	sourceProjectID string,
+	projectConfig mdbv1.ProjectConfig,
+	credentials mdbv1.Credentials,
+	connectionFunc om.ConnectionFactory,
+	log *zap.SugaredLogger,
+) error {
 	if sourceProjectID == "" || sourceProjectID == targetConn.GroupID() {
 		return nil
 	}

--- a/controllers/operator/construct/appdb_agent_command.go
+++ b/controllers/operator/construct/appdb_agent_command.go
@@ -57,7 +57,13 @@ fi
 // AutomationAgentCommand returns the full command array for the automation agent container.
 // withAgentAPIKeyExport selects the preamble that exports AGENT_API_KEY from the mounted
 // agent-api-key secret, which the agent uses to register with Ops Manager for monitoring.
-func AutomationAgentCommand(withStatic bool, withAgentAPIKeyExport bool, logLevel v1.LogLevel, logFile string, maxLogFileDurationHours int) []string {
+func AutomationAgentCommand(
+	withStatic bool,
+	withAgentAPIKeyExport bool,
+	logLevel v1.LogLevel,
+	logFile string,
+	maxLogFileDurationHours int,
+) []string {
 	// This is somewhat undocumented at https://www.mongodb.com/docs/ops-manager/current/reference/mongodb-agent-settings/
 	// Not setting the -logFile option make the mongodb-agent log to stdout. Setting -logFile /dev/stdout will result in
 	// an error by the agent trying to open /dev/stdout-verbose and still trying to do log rotation.
@@ -77,7 +83,14 @@ func AutomationAgentCommand(withStatic bool, withAgentAPIKeyExport bool, logLeve
 		downloadSnippet = downloadCustomAgentIfSet()
 	}
 
-	return []string{"/bin/bash", "-c", GetMongodbUserCommand(withStatic, withAgentAPIKeyExport) + downloadSnippet + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions}
+	return []string{
+		"/bin/bash",
+		"-c",
+		GetMongodbUserCommand(
+			withStatic,
+			withAgentAPIKeyExport,
+		) + downloadSnippet + BaseAgentCommand() + " -cluster=" + appdbClusterFilePath + appdbAutomationAgentOptions + agentLogOptions,
+	}
 }
 
 // GetMongodbUserCommand returns the bash preamble for the automation agent. When

--- a/controllers/operator/construct/appdb_construction.go
+++ b/controllers/operator/construct/appdb_construction.go
@@ -97,7 +97,11 @@ func appDbLabels(opsManager *om.MongoDBOpsManager, memberClusterNum int) statefu
 }
 
 // appDbPodSpec return the podtemplatespec modification required for the AppDB statefulset.
-func appDbPodSpec(initContainerImage string, om om.MongoDBOpsManager, defaultArchitecture architectures.DefaultArchitecture) podtemplatespec.Modification {
+func appDbPodSpec(
+	initContainerImage string,
+	om om.MongoDBOpsManager,
+	defaultArchitecture architectures.DefaultArchitecture,
+) podtemplatespec.Modification {
 	// The following sets almost the exact same values for the containers
 	// But with the addition of a default memory request for the mongod one
 	appdbPodSpec := NewDefaultPodSpecWrapper(*om.Spec.AppDB.PodSpec)
@@ -121,7 +125,12 @@ func appDbPodSpec(initContainerImage string, om om.MongoDBOpsManager, defaultArc
 		// volumes of different containers.
 		initUpdateFunc = func(templateSpec *corev1.PodTemplateSpec) {
 			templateSpec.Spec.InitContainers = []corev1.Container{}
-			podtemplatespec.WithInitContainer(InitAppDbContainerName, buildAppDBInitContainer(initContainerImage, []corev1.VolumeMount{scriptsVolumeMount, hooksVolumeMount}))(templateSpec)
+			podtemplatespec.WithInitContainer(
+				InitAppDbContainerName,
+				buildAppDBInitContainer(initContainerImage, []corev1.VolumeMount{scriptsVolumeMount, hooksVolumeMount}),
+			)(
+				templateSpec,
+			)
 		}
 	}
 
@@ -154,7 +163,11 @@ cp /probes/version-upgrade-hook /hooks/version-upgrade
 
 // getTLSVolumesAndVolumeMounts returns the slices of volumes and volume-mounts
 // that the AppDB STS needs for TLS resources.
-func getTLSVolumesAndVolumeMounts(appDb om.AppDBSpec, podVars *env.PodEnvVars, log *zap.SugaredLogger) ([]corev1.Volume, []corev1.VolumeMount) {
+func getTLSVolumesAndVolumeMounts(
+	appDb om.AppDBSpec,
+	podVars *env.PodEnvVars,
+	log *zap.SugaredLogger,
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	if log == nil {
 		log = zap.S()
 	}
@@ -267,7 +280,11 @@ func vaultModification(appDB om.AppDBSpec, podVars *env.PodEnvVars, opts AppDBSt
 
 		if appDB.Prometheus != nil && appDB.Prometheus.TLSSecretRef.Name != "" && opts.PrometheusTLSCertHash != "" {
 			appDBSecretsToInject.PrometheusTLSCertHash = opts.PrometheusTLSCertHash
-			appDBSecretsToInject.PrometheusTLSPath = fmt.Sprintf("%s%s", appDB.Prometheus.TLSSecretRef.Name, certs.OperatorGeneratedCertSuffix)
+			appDBSecretsToInject.PrometheusTLSPath = fmt.Sprintf(
+				"%s%s",
+				appDB.Prometheus.TLSSecretRef.Name,
+				certs.OperatorGeneratedCertSuffix,
+			)
 		}
 
 		modification = podtemplatespec.Apply(
@@ -302,8 +319,16 @@ func customPersistenceConfig(om *om.MongoDBOpsManager) statefulset.Modification 
 
 		// We already have, by default, the data volume mount,
 		// here we also create the logs and journal one, as subpath from the same volume
-		logsVolumeMount := statefulset.CreateVolumeMount(om.Spec.AppDB.DataVolumeName(), util.PvcMountPathLogs, statefulset.WithSubPath(om.Spec.AppDB.LogsVolumeName()))
-		journalVolumeMount := statefulset.CreateVolumeMount(om.Spec.AppDB.DataVolumeName(), util.PvcMountPathJournal, statefulset.WithSubPath(util.PvcNameJournal))
+		logsVolumeMount := statefulset.CreateVolumeMount(
+			om.Spec.AppDB.DataVolumeName(),
+			util.PvcMountPathLogs,
+			statefulset.WithSubPath(om.Spec.AppDB.LogsVolumeName()),
+		)
+		journalVolumeMount := statefulset.CreateVolumeMount(
+			om.Spec.AppDB.DataVolumeName(),
+			util.PvcMountPathJournal,
+			statefulset.WithSubPath(util.PvcNameJournal),
+		)
 		volumeMounts := []corev1.VolumeMount{journalVolumeMount, logsVolumeMount}
 		return statefulset.Apply(
 			statefulset.WithVolumeClaim(om.Spec.AppDB.DataVolumeName(), pvcModification),
@@ -362,7 +387,15 @@ func ShouldMountSSLMMSCAConfigMap(podVars *env.PodEnvVars) bool {
 }
 
 // AppDbStatefulSet fully constructs the AppDb StatefulSet that is ready to be sent to the Kubernetes API server.
-func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, opts AppDBStatefulSetOptions, scaler interfaces.MultiClusterReplicaSetScaler, updateStrategyType appsv1.StatefulSetUpdateStrategyType, defaultArchitecture architectures.DefaultArchitecture, log *zap.SugaredLogger) (appsv1.StatefulSet, error) {
+func AppDbStatefulSet(
+	opsManager om.MongoDBOpsManager,
+	podVars *env.PodEnvVars,
+	opts AppDBStatefulSetOptions,
+	scaler interfaces.MultiClusterReplicaSetScaler,
+	updateStrategyType appsv1.StatefulSetUpdateStrategyType,
+	defaultArchitecture architectures.DefaultArchitecture,
+	log *zap.SugaredLogger,
+) (appsv1.StatefulSet, error) {
 	appDb := &opsManager.Spec.AppDB
 
 	var podSpec *corev1.PodTemplateSpec
@@ -376,12 +409,21 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 		originalLen := len(podSpec.Spec.Containers)
 		podSpec.Spec.Containers = removeContainerByName(podSpec.Spec.Containers, monitoringAgentContainerName)
 		if len(podSpec.Spec.Containers) < originalLen {
-			log.Warnf("Removed deprecated container %q from user-supplied podTemplateSpec; monitoring is now handled by the single automation agent", monitoringAgentContainerName)
+			log.Warnf(
+				"Removed deprecated container %q from user-supplied podTemplateSpec; monitoring is now handled by the single automation agent",
+				monitoringAgentContainerName,
+			)
 		}
 	}
 
 	// We copy the Automation Agent command from community and add the agent startup parameters
-	automationAgentCommand := AutomationAgentCommand(architectures.IsRunningStaticArchitecture(opsManager.Annotations, defaultArchitecture), ShouldEnableMonitoring(podVars), opsManager.Spec.AppDB.GetAgentLogLevel(), opsManager.Spec.AppDB.GetAgentLogFile(), opsManager.Spec.AppDB.GetAgentMaxLogFileDurationHours())
+	automationAgentCommand := AutomationAgentCommand(
+		architectures.IsRunningStaticArchitecture(opsManager.Annotations, defaultArchitecture),
+		ShouldEnableMonitoring(podVars),
+		opsManager.Spec.AppDB.GetAgentLogLevel(),
+		opsManager.Spec.AppDB.GetAgentLogFile(),
+		opsManager.Spec.AppDB.GetAgentMaxLogFileDurationHours(),
+	)
 	idx := len(automationAgentCommand) - 1
 	automationAgentCommand[idx] += appDb.AutomationAgent.StartupParameters.ToCommandLineArgs()
 
@@ -393,7 +435,10 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 
 	automationAgentCommand[idx] += overrideLocalHostFlag(appDb, externalDomain)
 
-	acVersionConfigMapVolume := statefulset.CreateVolumeFromConfigMap("automation-config-goal-version", opsManager.Spec.AppDB.AutomationConfigConfigMapName())
+	acVersionConfigMapVolume := statefulset.CreateVolumeFromConfigMap(
+		"automation-config-goal-version",
+		opsManager.Spec.AppDB.AutomationConfigConfigMapName(),
+	)
 	acVersionMount := corev1.VolumeMount{
 		Name:      acVersionConfigMapVolume.Name,
 		ReadOnly:  true,
@@ -409,7 +454,11 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 
 	keyFileNsName := appDb.GetAgentKeyfileSecretNamespacedName()
 	keyFileVolume := statefulset.CreateVolumeFromEmptyDir(keyFileNsName.Name)
-	keyFileVolumeMount := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
+	keyFileVolumeMount := statefulset.CreateVolumeMount(
+		keyFileVolume.Name,
+		"/var/lib/mongodb-mms-automation/authentication",
+		statefulset.WithReadOnly(false),
+	)
 
 	mongodbAgentVolumeMounts := []corev1.VolumeMount{agentHealthStatusVolumeMount, keyFileVolumeMount, tmpVolumeMount}
 
@@ -417,7 +466,11 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 	if appDb.NeedsAutomationConfigVolume() {
 		automationConfigVolume := statefulset.CreateVolumeFromSecret("automation-config", appDb.AutomationConfigSecretName())
 		automationConfigVolumeFunc = podtemplatespec.WithVolume(automationConfigVolume)
-		automationConfigVolumeMount := statefulset.CreateVolumeMount(automationConfigVolume.Name, "/var/lib/automation/config", statefulset.WithReadOnly(true))
+		automationConfigVolumeMount := statefulset.CreateVolumeMount(
+			automationConfigVolume.Name,
+			"/var/lib/automation/config",
+			statefulset.WithReadOnly(true),
+		)
 		mongodbAgentVolumeMounts = append(mongodbAgentVolumeMounts, automationConfigVolumeMount)
 	}
 	mongodVolumeMounts := []corev1.VolumeMount{mongodHealthStatusVolumeMount, keyFileVolumeMount, tmpVolumeMount}
@@ -439,8 +492,14 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 	if withInitContainers {
 		mongodVolumeMounts = append(mongodVolumeMounts, hooksVolumeMount)
 		mongodbAgentVolumeMounts = append(mongodbAgentVolumeMounts, scriptsVolumeMount)
-		upgradeInitContainer = podtemplatespec.WithInitContainer(appdbVersionUpgradeHookName, appdbVersionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount}, ""))
-		readinessInitContainer = podtemplatespec.WithInitContainer(AppDBReadinessProbeContainerName, appdbReadinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount}, ""))
+		upgradeInitContainer = podtemplatespec.WithInitContainer(
+			appdbVersionUpgradeHookName,
+			appdbVersionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount}, ""),
+		)
+		readinessInitContainer = podtemplatespec.WithInitContainer(
+			AppDBReadinessProbeContainerName,
+			appdbReadinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount}, ""),
+		)
 	} else {
 		staticMounts := []corev1.VolumeMount{hooksVolumeMount, scriptsVolumeMount, tmpVolumeMount}
 		withStaticContainerModification = podtemplatespec.WithContainer(util.AgentContainerUtilitiesName, appdbMongodbAgentUtilitiesContainer(staticMounts, opts.InitAppDBImage))
@@ -495,8 +554,19 @@ func AppDbStatefulSet(opsManager om.MongoDBOpsManager, podVars *env.PodEnvVars, 
 				podtemplatespec.WithVolume(tmpVolume),
 				podtemplatespec.WithVolume(keyFileVolume),
 				podtemplatespec.WithVolume(acVersionConfigMapVolume),
-				podtemplatespec.WithContainer(util.AgentContainerName, appdbMongodbAgentContainer(appDb.AutomationConfigSecretName(), mongodbAgentVolumeMounts, opts.AgentImage, automationAgentCommand)),
-				podtemplatespec.WithContainer(util.MongodbContainerName, appdbMongodbContainer(opts.MongodbImage, mongodVolumeMounts, appDb.GetMongodConfiguration(), !withInitContainers)),
+				podtemplatespec.WithContainer(
+					util.AgentContainerName,
+					appdbMongodbAgentContainer(
+						appDb.AutomationConfigSecretName(),
+						mongodbAgentVolumeMounts,
+						opts.AgentImage,
+						automationAgentCommand,
+					),
+				),
+				podtemplatespec.WithContainer(
+					util.MongodbContainerName,
+					appdbMongodbContainer(opts.MongodbImage, mongodVolumeMounts, appDb.GetMongodConfiguration(), !withInitContainers),
+				),
 				withStaticContainerModification,
 				upgradeInitContainer,
 				readinessInitContainer,

--- a/controllers/operator/construct/appdb_construction_test.go
+++ b/controllers/operator/construct/appdb_construction_test.go
@@ -33,8 +33,15 @@ func TestAppDBAgentFlags(t *testing.T) {
 	}
 	om := omv1.NewOpsManagerBuilderDefault().Build()
 	om.Spec.AppDB.AutomationAgent.StartupParameters = agentStartupParameters
-	sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
-		AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil), appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+	sts, err := AppDbStatefulSet(
+		*om,
+		&env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{},
+		scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil),
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		nil,
+	)
 	assert.NoError(t, err)
 
 	command := sts.Spec.Template.Spec.Containers[0].Command
@@ -79,13 +86,27 @@ func TestAppDBMultiClusterPerClusterStatefulSetOverride(t *testing.T) {
 		SetAppDBClusterSpecList(clusterSpecList).
 		Build()
 
-	stsA, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
-		AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "cluster-a", 0, nil), appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+	stsA, err := AppDbStatefulSet(
+		*om,
+		&env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{},
+		scalers.GetAppDBScaler(om, "cluster-a", 0, nil),
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		nil,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, hostAliasesA, stsA.Spec.Template.Spec.HostAliases)
 
-	stsB, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
-		AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "cluster-b", 1, nil), appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+	stsB, err := AppDbStatefulSet(
+		*om,
+		&env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{},
+		scalers.GetAppDBScaler(om, "cluster-b", 1, nil),
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		nil,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, hostAliasesB, stsB.Spec.Template.Spec.HostAliases)
 
@@ -105,7 +126,15 @@ func TestAppDbStatefulSet_SingleAgentContainer(t *testing.T) {
 	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
 	podVars := &env.PodEnvVars{ProjectID: "proj-123", AgentAPIKey: "key"}
 
-	sts, err := AppDbStatefulSet(*om, podVars, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	sts, err := AppDbStatefulSet(
+		*om,
+		podVars,
+		AppDBStatefulSetOptions{},
+		scaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	require.NoError(t, err)
 
 	containerNames := make([]string, 0)
@@ -120,7 +149,15 @@ func TestAppDbStatefulSet_SingleAgentContainer_MonitoringDisabled(t *testing.T) 
 	om := omv1.NewOpsManagerBuilderDefault().Build()
 	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
 
-	sts, err := AppDbStatefulSet(*om, nil, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	sts, err := AppDbStatefulSet(
+		*om,
+		nil,
+		AppDBStatefulSetOptions{},
+		scaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	require.NoError(t, err)
 
 	for _, c := range sts.Spec.Template.Spec.Containers {
@@ -134,7 +171,15 @@ func TestAppDbStatefulSet_MonitoringCredentialsAsCLIFlags(t *testing.T) {
 	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
 	podVars := &env.PodEnvVars{ProjectID: "proj-123", AgentAPIKey: "key"}
 
-	sts, err := AppDbStatefulSet(*om, podVars, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	sts, err := AppDbStatefulSet(
+		*om,
+		podVars,
+		AppDBStatefulSetOptions{},
+		scaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	require.NoError(t, err)
 
 	agent := findContainerByName(t, sts.Spec.Template.Spec.Containers, util.AgentContainerName)
@@ -154,7 +199,15 @@ func TestAppDbStatefulSet_NoMonitoringCredentialsWhenDisabled(t *testing.T) {
 	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
 
 	// nil podVars => ShouldEnableMonitoring returns false
-	sts, err := AppDbStatefulSet(*om, nil, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	sts, err := AppDbStatefulSet(
+		*om,
+		nil,
+		AppDBStatefulSetOptions{},
+		scaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	require.NoError(t, err)
 
 	agent := findContainerByName(t, sts.Spec.Template.Spec.Containers, util.AgentContainerName)
@@ -208,7 +261,15 @@ func TestAppDbStatefulSet_UserTemplateMonitoringContainerStripped(t *testing.T) 
 	}
 
 	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
-	sts, err := AppDbStatefulSet(*om, nil, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, zap.S())
+	sts, err := AppDbStatefulSet(
+		*om,
+		nil,
+		AppDBStatefulSetOptions{},
+		scaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		zap.S(),
+	)
 	require.NoError(t, err)
 
 	for _, c := range sts.Spec.Template.Spec.Containers {
@@ -232,20 +293,38 @@ func TestAppDbStatefulSet_MultiClusterIdentity(t *testing.T) {
 			SetAppDBClusterSpecList(clusterSpecList).
 			Build()
 
-		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
-			AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "cluster-a", 0, nil), appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+		sts, err := AppDbStatefulSet(
+			*om,
+			&env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{},
+			scalers.GetAppDBScaler(om, "cluster-a", 0, nil),
+			appsv1.OnDeleteStatefulSetStrategyType,
+			architectures.NonStatic,
+			nil,
+		)
 		assert.NoError(t, err)
 		assert.Empty(t, sts.OwnerReferences,
 			"StatefulSet in a remote member cluster must not carry an ownerReference pointing to the MongoDBOpsManager CR")
-		assert.Equal(t, om.Name, sts.Annotations[handler.MongoDBMultiResourceAnnotation],
-			"StatefulSet must carry MongoDBMultiResourceAnnotation so watch predicates and the OM connection factory can map it back to its parent CR")
+		assert.Equal(
+			t,
+			om.Name,
+			sts.Annotations[handler.MongoDBMultiResourceAnnotation],
+			"StatefulSet must carry MongoDBMultiResourceAnnotation so watch predicates and the OM connection factory can map it back to its parent CR",
+		)
 	})
 
 	t.Run("single-cluster mode: ownerReference set, no multi-cluster annotation", func(t *testing.T) {
 		om := omv1.NewOpsManagerBuilderDefault().Build()
 
-		sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
-			AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil), appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+		sts, err := AppDbStatefulSet(
+			*om,
+			&env.PodEnvVars{ProjectID: "abcd"},
+			AppDBStatefulSetOptions{},
+			scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil),
+			appsv1.OnDeleteStatefulSetStrategyType,
+			architectures.NonStatic,
+			nil,
+		)
 		assert.NoError(t, err)
 		assert.Len(t, sts.OwnerReferences, 1,
 			"StatefulSet in single-cluster mode must carry an ownerReference so Kubernetes GC can clean it up")
@@ -280,8 +359,15 @@ func TestResourceRequirements(t *testing.T) {
 		},
 	}
 
-	sts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"},
-		AppDBStatefulSetOptions{}, scalers.GetAppDBScaler(om, "central", 0, nil), appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+	sts, err := AppDbStatefulSet(
+		*om,
+		&env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{},
+		scalers.GetAppDBScaler(om, "central", 0, nil),
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		nil,
+	)
 	assert.NoError(t, err)
 
 	for _, c := range sts.Spec.Template.Spec.Containers {

--- a/controllers/operator/construct/appdb_statefulset.go
+++ b/controllers/operator/construct/appdb_statefulset.go
@@ -27,7 +27,12 @@ const (
 	appdbAutomationConfigEnv = "AUTOMATION_CONFIG_MAP"
 )
 
-func appdbMongodbAgentContainer(automationConfigSecretName string, volumeMounts []corev1.VolumeMount, agentImage string, command []string) container.Modification {
+func appdbMongodbAgentContainer(
+	automationConfigSecretName string,
+	volumeMounts []corev1.VolumeMount,
+	agentImage string,
+	command []string,
+) container.Modification {
 	_, containerSecurityContext := podtemplatespec.WithDefaultSecurityContextsModifications()
 	return container.Apply(
 		container.WithName(util.AgentContainerName),
@@ -72,7 +77,9 @@ func appdbMongodbAgentUtilitiesContainer(volumeMounts []corev1.VolumeMount, init
 		container.WithImagePullPolicy(corev1.PullAlways),
 		container.WithResourceRequirements(resourcerequirements.Defaults()),
 		container.WithVolumeMounts(volumeMounts),
-		container.WithCommand([]string{"bash", "-c", "touch /tmp/agent-utilities-holder_marker && tail -F -n0 /tmp/agent-utilities-holder_marker"}),
+		container.WithCommand(
+			[]string{"bash", "-c", "touch /tmp/agent-utilities-holder_marker && tail -F -n0 /tmp/agent-utilities-holder_marker"},
+		),
 		container.WithArgs([]string{""}),
 		containerSecurityContext,
 	)
@@ -211,7 +218,12 @@ echo "Starting mongod..."
 `, signalHandling, filePath, appdbKeyfileFilePath, mongodExec)
 }
 
-func appdbMongodbContainer(mongodbImage string, volumeMounts []corev1.VolumeMount, additionalMongoDBConfig v1.MongodConfiguration, isStatic bool) container.Modification {
+func appdbMongodbContainer(
+	mongodbImage string,
+	volumeMounts []corev1.VolumeMount,
+	additionalMongoDBConfig v1.MongodConfiguration,
+	isStatic bool,
+) container.Modification {
 	filePath := additionalMongoDBConfig.GetDBDataDir() + "/" + appdbAutomationMongodConfFileName
 	mongoDbCommand := appdbBuildMongodbCommand(filePath, isStatic)
 

--- a/controllers/operator/construct/backup_construction.go
+++ b/controllers/operator/construct/backup_construction.go
@@ -35,7 +35,14 @@ const (
 )
 
 // BackupDaemonStatefulSet fully constructs the Backup StatefulSet.
-func BackupDaemonStatefulSet(ctx context.Context, centralClusterSecretClient secrets.SecretClient, opsManager *omv1.MongoDBOpsManager, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger, additionalOpts ...func(*OpsManagerStatefulSetOptions)) (appsv1.StatefulSet, error) {
+func BackupDaemonStatefulSet(
+	ctx context.Context,
+	centralClusterSecretClient secrets.SecretClient,
+	opsManager *omv1.MongoDBOpsManager,
+	memberCluster multicluster.MemberCluster,
+	log *zap.SugaredLogger,
+	additionalOpts ...func(*OpsManagerStatefulSetOptions),
+) (appsv1.StatefulSet, error) {
 	opts := backupOptions(memberCluster, additionalOpts...)(opsManager)
 
 	if err := opts.updateHTTPSCertSecret(ctx, centralClusterSecretClient, memberCluster, opsManager.OwnerReferenceForMemberCluster(), log); err != nil {
@@ -48,7 +55,12 @@ func BackupDaemonStatefulSet(ctx context.Context, centralClusterSecretClient sec
 		// if the secret is specified, we must have a queryable.pem entry.
 		_, err := secret.ReadKey(ctx, memberCluster.SecretClient, "queryable.pem", kube.ObjectKey(opsManager.Namespace, secretName))
 		if err != nil {
-			return appsv1.StatefulSet{}, xerrors.Errorf("error reading queryable.pem key from secret %s/%s: %w", opsManager.Namespace, secretName, err)
+			return appsv1.StatefulSet{}, xerrors.Errorf(
+				"error reading queryable.pem key from secret %s/%s: %w",
+				opsManager.Namespace,
+				secretName,
+				err,
+			)
 		}
 	}
 
@@ -67,7 +79,10 @@ func BackupDaemonStatefulSet(ctx context.Context, centralClusterSecretClient sec
 }
 
 // backupOptions returns a function which returns the OpsManagerStatefulSetOptions to create the BackupDaemon StatefulSet.
-func backupOptions(memberCluster multicluster.MemberCluster, additionalOpts ...func(opts *OpsManagerStatefulSetOptions)) func(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
+func backupOptions(
+	memberCluster multicluster.MemberCluster,
+	additionalOpts ...func(opts *OpsManagerStatefulSetOptions),
+) func(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 	return func(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 		opts := getSharedOpsManagerOptions(opsManager)
 

--- a/controllers/operator/construct/backup_construction_test.go
+++ b/controllers/operator/construct/backup_construction_test.go
@@ -23,7 +23,13 @@ func TestBuildBackupDaemonStatefulSet(t *testing.T) {
 		VaultClient: &vault.VaultClient{},
 		KubeClient:  client,
 	}
-	sts, err := BackupDaemonStatefulSet(ctx, secretsClient, omv1.NewOpsManagerBuilderDefault().SetName("test-om").Build(), multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient), zap.S())
+	sts, err := BackupDaemonStatefulSet(
+		ctx,
+		secretsClient,
+		omv1.NewOpsManagerBuilderDefault().SetName("test-om").Build(),
+		multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient),
+		zap.S(),
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, "test-om-backup-daemon", sts.Name)
 	assert.Equal(t, util.BackupDaemonContainerName, sts.Spec.Template.Spec.Containers[0].Name)
@@ -37,7 +43,13 @@ func TestBackupPodTemplate_TerminationTimeout(t *testing.T) {
 		VaultClient: &vault.VaultClient{},
 		KubeClient:  client,
 	}
-	set, err := BackupDaemonStatefulSet(ctx, secretsClient, omv1.NewOpsManagerBuilderDefault().SetName("test-om").Build(), multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient), zap.S())
+	set, err := BackupDaemonStatefulSet(
+		ctx,
+		secretsClient,
+		omv1.NewOpsManagerBuilderDefault().SetName("test-om").Build(),
+		multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient),
+		zap.S(),
+	)
 	assert.NoError(t, err)
 	podSpecTemplate := set.Spec.Template
 	assert.Equal(t, int64(4200), *podSpecTemplate.Spec.TerminationGracePeriodSeconds)
@@ -50,7 +62,12 @@ func TestBuildBackupDaemonContainer(t *testing.T) {
 		VaultClient: &vault.VaultClient{},
 		KubeClient:  client,
 	}
-	sts, err := BackupDaemonStatefulSet(ctx, secretsClient, omv1.NewOpsManagerBuilderDefault().SetVersion("4.2.0").Build(), multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient), zap.S(),
+	sts, err := BackupDaemonStatefulSet(
+		ctx,
+		secretsClient,
+		omv1.NewOpsManagerBuilderDefault().SetVersion("4.2.0").Build(),
+		multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient),
+		zap.S(),
 		WithOpsManagerImage("quay.io/mongodb/mongodb-enterprise-ops-manager:4.2.0"),
 	)
 	assert.NoError(t, err)
@@ -80,7 +97,13 @@ func TestMultipleBackupDaemons(t *testing.T) {
 		VaultClient: &vault.VaultClient{},
 		KubeClient:  client,
 	}
-	sts, err := BackupDaemonStatefulSet(ctx, secretsClient, omv1.NewOpsManagerBuilderDefault().SetVersion("4.2.0").SetBackupMembers(3).Build(), multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient), zap.S())
+	sts, err := BackupDaemonStatefulSet(
+		ctx,
+		secretsClient,
+		omv1.NewOpsManagerBuilderDefault().SetVersion("4.2.0").SetBackupMembers(3).Build(),
+		multicluster.GetLegacyCentralMemberCluster(1, 0, client, secretsClient),
+		zap.S(),
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, int(*sts.Spec.Replicas))
 }

--- a/controllers/operator/construct/construction_test.go
+++ b/controllers/operator/construct/construction_test.go
@@ -172,7 +172,15 @@ func TestBuildAppDbStatefulSetDefault(t *testing.T) {
 	t.Setenv(util.OpsManagerMonitorAppDB, "false")
 	om := omv1.NewOpsManagerBuilderDefault().Build()
 	scaler := scalers.GetAppDBScaler(om, multicluster.LegacyCentralClusterName, 0, nil)
-	appDbSts, err := AppDbStatefulSet(*om, &env.PodEnvVars{ProjectID: "abcd"}, AppDBStatefulSetOptions{}, scaler, appsv1.OnDeleteStatefulSetStrategyType, architectures.NonStatic, nil)
+	appDbSts, err := AppDbStatefulSet(
+		*om,
+		&env.PodEnvVars{ProjectID: "abcd"},
+		AppDBStatefulSetOptions{},
+		scaler,
+		appsv1.OnDeleteStatefulSetStrategyType,
+		architectures.NonStatic,
+		nil,
+	)
 	assert.NoError(t, err)
 	podSpecTemplate := appDbSts.Spec.Template.Spec
 	assert.Len(t, podSpecTemplate.InitContainers, 1)
@@ -210,7 +218,11 @@ func TestBasePodSpec_Affinity(t *testing.T) {
 // TestBasePodSpec_AntiAffinityDefaultTopology checks that the default topology key is created if the topology key is
 // not specified
 func TestBasePodSpec_AntiAffinityDefaultTopology(t *testing.T) {
-	sts := DatabaseStatefulSet(*mdbv1.NewStandaloneBuilder().SetName("my-standalone").Build(), StandaloneOptions(GetPodEnvOptions()), zap.S())
+	sts := DatabaseStatefulSet(
+		*mdbv1.NewStandaloneBuilder().SetName("my-standalone").Build(),
+		StandaloneOptions(GetPodEnvOptions()),
+		zap.S(),
+	)
 
 	spec := sts.Spec.Template.Spec
 	term := spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
@@ -309,13 +321,23 @@ func TestPodSpec_Requirements(t *testing.T) {
 		SetMemoryLimit("1012M").
 		Build()
 
-	sts := DatabaseStatefulSet(*mdbv1.NewReplicaSetBuilder().SetPodSpec(&podSpec.MongoDbPodSpec).Build(), ReplicaSetOptions(GetPodEnvOptions()), zap.S())
+	sts := DatabaseStatefulSet(
+		*mdbv1.NewReplicaSetBuilder().SetPodSpec(&podSpec.MongoDbPodSpec).Build(),
+		ReplicaSetOptions(GetPodEnvOptions()),
+		zap.S(),
+	)
 
 	podSpecTemplate := sts.Spec.Template
 	container := podSpecTemplate.Spec.Containers[0]
 
-	expectedLimits := corev1.ResourceList{corev1.ResourceCPU: ParseQuantityOrZero("0.3"), corev1.ResourceMemory: ParseQuantityOrZero("1012M")}
-	expectedRequests := corev1.ResourceList{corev1.ResourceCPU: ParseQuantityOrZero("0.1"), corev1.ResourceMemory: ParseQuantityOrZero("512M")}
+	expectedLimits := corev1.ResourceList{
+		corev1.ResourceCPU:    ParseQuantityOrZero("0.3"),
+		corev1.ResourceMemory: ParseQuantityOrZero("1012M"),
+	}
+	expectedRequests := corev1.ResourceList{
+		corev1.ResourceCPU:    ParseQuantityOrZero("0.1"),
+		corev1.ResourceMemory: ParseQuantityOrZero("512M"),
+	}
 	assert.Equal(t, expectedLimits, container.Resources.Limits)
 	assert.Equal(t, expectedRequests, container.Resources.Requests)
 }

--- a/controllers/operator/construct/database_construction.go
+++ b/controllers/operator/construct/database_construction.go
@@ -281,7 +281,12 @@ func (c shardedOptionCfg) hasExternalDomain() bool {
 }
 
 // ShardOptions returns a set of options which will configure single Shard StatefulSet
-func ShardOptions(shardNum int, shardSpec *mdbv1.ShardedClusterComponentSpec, memberClusterName string, additionalOpts ...func(options *DatabaseStatefulSetOptions)) func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
+func ShardOptions(
+	shardNum int,
+	shardSpec *mdbv1.ShardedClusterComponentSpec,
+	memberClusterName string,
+	additionalOpts ...func(options *DatabaseStatefulSetOptions),
+) func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
 	return func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
 		cfg := shardedOptionCfg{
 			mdb:               mdb,
@@ -298,7 +303,11 @@ func ShardOptions(shardNum int, shardSpec *mdbv1.ShardedClusterComponentSpec, me
 }
 
 // ConfigServerOptions returns a set of options which will configure a Config Server StatefulSet
-func ConfigServerOptions(configSrvSpec *mdbv1.ShardedClusterComponentSpec, memberClusterName string, additionalOpts ...func(options *DatabaseStatefulSetOptions)) func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
+func ConfigServerOptions(
+	configSrvSpec *mdbv1.ShardedClusterComponentSpec,
+	memberClusterName string,
+	additionalOpts ...func(options *DatabaseStatefulSetOptions),
+) func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
 	return func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
 		cfg := shardedOptionCfg{
 			mdb:               mdb,
@@ -315,7 +324,11 @@ func ConfigServerOptions(configSrvSpec *mdbv1.ShardedClusterComponentSpec, membe
 }
 
 // MongosOptions returns a set of options which will configure a Mongos StatefulSet
-func MongosOptions(mongosSpec *mdbv1.ShardedClusterComponentSpec, memberClusterName string, additionalOpts ...func(options *DatabaseStatefulSetOptions)) func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
+func MongosOptions(
+	mongosSpec *mdbv1.ShardedClusterComponentSpec,
+	memberClusterName string,
+	additionalOpts ...func(options *DatabaseStatefulSetOptions),
+) func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
 	return func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions {
 		cfg := shardedOptionCfg{
 			mdb:               mdb,
@@ -337,7 +350,11 @@ func MongosOptions(mongosSpec *mdbv1.ShardedClusterComponentSpec, memberClusterN
 	}
 }
 
-func DatabaseStatefulSet(mdb mdbv1.MongoDB, stsOptFunc func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions, log *zap.SugaredLogger) appsv1.StatefulSet {
+func DatabaseStatefulSet(
+	mdb mdbv1.MongoDB,
+	stsOptFunc func(mdb mdbv1.MongoDB) DatabaseStatefulSetOptions,
+	log *zap.SugaredLogger,
+) appsv1.StatefulSet {
 	stsOptions := stsOptFunc(mdb)
 	dbSts := DatabaseStatefulSetHelper(&mdb, &stsOptions, log)
 
@@ -360,7 +377,11 @@ func DatabaseStatefulSet(mdb mdbv1.MongoDB, stsOptFunc func(mdb mdbv1.MongoDB) D
 	return dbSts
 }
 
-func DatabaseStatefulSetHelper(mdb databaseStatefulSetSource, stsOpts *DatabaseStatefulSetOptions, log *zap.SugaredLogger) appsv1.StatefulSet {
+func DatabaseStatefulSetHelper(
+	mdb databaseStatefulSetSource,
+	stsOpts *DatabaseStatefulSetOptions,
+	log *zap.SugaredLogger,
+) appsv1.StatefulSet {
 	allSources := getAllMongoDBVolumeSources(mdb, *stsOpts, log)
 
 	var extraEnvs []corev1.EnvVar
@@ -416,7 +437,12 @@ func buildVaultDatabaseSecretsToInject(mdb databaseStatefulSetSource, opts Datab
 }
 
 // buildDatabaseStatefulSetConfigurationFunction returns the function that will modify the StatefulSet
-func buildDatabaseStatefulSetConfigurationFunction(mdb databaseStatefulSetSource, podTemplateSpecFunc podtemplatespec.Modification, opts DatabaseStatefulSetOptions, log *zap.SugaredLogger) statefulset.Modification {
+func buildDatabaseStatefulSetConfigurationFunction(
+	mdb databaseStatefulSetSource,
+	podTemplateSpecFunc podtemplatespec.Modification,
+	opts DatabaseStatefulSetOptions,
+	log *zap.SugaredLogger,
+) statefulset.Modification {
 	podLabels := map[string]string{
 		appLabelKey:             opts.ServiceName,
 		util.OperatorLabelName:  util.OperatorLabelValue,
@@ -478,7 +504,10 @@ func buildDatabaseStatefulSetConfigurationFunction(mdb databaseStatefulSetSource
 	podTemplateAnnotationFunc := podtemplatespec.NOOP()
 
 	if vault.IsVaultSecretBackend() {
-		podTemplateAnnotationFunc = podtemplatespec.Apply(podTemplateAnnotationFunc, podtemplatespec.WithAnnotations(secretsToInject.DatabaseAnnotations(mdb.GetNamespace())))
+		podTemplateAnnotationFunc = podtemplatespec.Apply(
+			podTemplateAnnotationFunc,
+			podtemplatespec.WithAnnotations(secretsToInject.DatabaseAnnotations(mdb.GetNamespace())),
+		)
 	}
 
 	stsName := opts.GetStatefulSetName()
@@ -535,7 +564,10 @@ func buildDatabaseStatefulSetConfigurationFunction(mdb databaseStatefulSetSource
 		podtemplatespec.WithAffinity(podAffinity, PodAntiAffinityLabelKey, 100),
 		podtemplatespec.WithTerminationGracePeriodSeconds(util.DefaultPodTerminationPeriodSeconds),
 		podtemplatespec.WithPodLabels(podLabels),
-		podtemplatespec.WithContainerByIndex(0, sharedDatabaseContainerFunc(databaseImage, *opts.PodSpec, volumeMounts, configureContainerSecurityContext, opts.ServicePort)),
+		podtemplatespec.WithContainerByIndex(
+			0,
+			sharedDatabaseContainerFunc(databaseImage, *opts.PodSpec, volumeMounts, configureContainerSecurityContext, opts.ServicePort),
+		),
 		volumesFunc,
 		configurePodSpecSecurityContext,
 		configureImagePullSecrets,
@@ -560,7 +592,9 @@ func buildDatabaseStatefulSetConfigurationFunction(mdb databaseStatefulSetSource
 	)
 }
 
-func buildPersistentVolumeClaimsFuncs(opts DatabaseStatefulSetOptions) (map[string]persistentvolumeclaim.Modification, []corev1.VolumeMount) {
+func buildPersistentVolumeClaimsFuncs(
+	opts DatabaseStatefulSetOptions,
+) (map[string]persistentvolumeclaim.Modification, []corev1.VolumeMount) {
 	var claims map[string]persistentvolumeclaim.Modification
 	var mounts []corev1.VolumeMount
 
@@ -585,7 +619,13 @@ func buildPersistentVolumeClaimsFuncs(opts DatabaseStatefulSetOptions) (map[stri
 	return claims, mounts
 }
 
-func sharedDatabaseContainerFunc(databaseImage string, podSpecWrapper mdbv1.PodSpecWrapper, volumeMounts []corev1.VolumeMount, configureContainerSecurityContext container.Modification, port int32) container.Modification {
+func sharedDatabaseContainerFunc(
+	databaseImage string,
+	podSpecWrapper mdbv1.PodSpecWrapper,
+	volumeMounts []corev1.VolumeMount,
+	configureContainerSecurityContext container.Modification,
+	port int32,
+) container.Modification {
 	return container.Apply(
 		container.WithResourceRequirements(buildRequirementsFromPodSpec(podSpecWrapper)),
 		container.WithPorts([]corev1.ContainerPort{{ContainerPort: port}}),
@@ -637,7 +677,11 @@ func getTLSPrometheusVolumeAndVolumeMount(prom *v1.Prometheus) ([]corev1.Volume,
 
 // getAllMongoDBVolumeSources returns a slice of  MongoDBVolumeSource. These are used to determine which volumes
 // and volume mounts should be added to the StatefulSet.
-func getAllMongoDBVolumeSources(mdb databaseStatefulSetSource, databaseOpts DatabaseStatefulSetOptions, log *zap.SugaredLogger) []MongoDBVolumeSource {
+func getAllMongoDBVolumeSources(
+	mdb databaseStatefulSetSource,
+	databaseOpts DatabaseStatefulSetOptions,
+	log *zap.SugaredLogger,
+) []MongoDBVolumeSource {
 	caVolume := &caVolumeSource{
 		opts:   databaseOpts,
 		logger: log,
@@ -656,7 +700,11 @@ func getAllMongoDBVolumeSources(mdb databaseStatefulSetSource, databaseOpts Data
 }
 
 // getVolumesAndVolumeMounts returns all volumes and mounts required for the StatefulSet.
-func getVolumesAndVolumeMounts(mdb databaseStatefulSetSource, databaseOpts DatabaseStatefulSetOptions, agentCertsSecretName, internalClusterAuthSecretName string) ([]corev1.Volume, []corev1.VolumeMount) {
+func getVolumesAndVolumeMounts(
+	mdb databaseStatefulSetSource,
+	databaseOpts DatabaseStatefulSetOptions,
+	agentCertsSecretName, internalClusterAuthSecretName string,
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	var volumesToAdd []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
 
@@ -665,7 +713,8 @@ func getVolumesAndVolumeMounts(mdb databaseStatefulSetSource, databaseOpts Datab
 	volumesToAdd = append(volumesToAdd, prometheusVolumes...)
 	volumeMounts = append(volumeMounts, prometheusVolumeMounts...)
 
-	if !vault.IsVaultSecretBackend() && mdb.GetSecurity().ShouldUseX509(databaseOpts.CurrentAgentAuthMode) || mdb.GetSecurity().ShouldUseClientCertificates() {
+	if !vault.IsVaultSecretBackend() && mdb.GetSecurity().ShouldUseX509(databaseOpts.CurrentAgentAuthMode) ||
+		mdb.GetSecurity().ShouldUseClientCertificates() {
 		agentSecretVolume := statefulset.CreateVolumeFromSecret(util.AgentSecretName, agentCertsSecretName)
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			MountPath: util.AgentCertMountPath,
@@ -687,7 +736,10 @@ func getVolumesAndVolumeMounts(mdb databaseStatefulSetSource, databaseOpts Datab
 	}
 
 	if !vault.IsVaultSecretBackend() {
-		volumesToAdd = append(volumesToAdd, statefulset.CreateVolumeFromSecret(AgentAPIKeyVolumeName, agents.ApiKeySecretName(databaseOpts.PodVars.ProjectID)))
+		volumesToAdd = append(
+			volumesToAdd,
+			statefulset.CreateVolumeFromSecret(AgentAPIKeyVolumeName, agents.ApiKeySecretName(databaseOpts.PodVars.ProjectID)),
+		)
 		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(AgentAPIKeyVolumeName, AgentAPIKeySecretPath))
 	}
 
@@ -749,12 +801,17 @@ func buildStaticArchitecturePodTemplateSpec(opts DatabaseStatefulSetOptions, mdb
 		container.WithArgs([]string{""}),
 		container.WithImage(opts.InitDatabaseImage),
 		container.WithEnvs(databaseEnvVars(opts)...),
-		container.WithCommand([]string{"bash", "-c", "touch /tmp/agent-utilities-holder_marker && tail -F -n0 /tmp/agent-utilities-holder_marker"}),
+		container.WithCommand(
+			[]string{"bash", "-c", "touch /tmp/agent-utilities-holder_marker && tail -F -n0 /tmp/agent-utilities-holder_marker"},
+		),
 		configureContainerSecurityContext,
 	)}
 
 	if opts.HostNameOverrideConfigmapName != "" {
-		volumes = append(volumes, statefulset.CreateVolumeFromConfigMap(opts.HostNameOverrideConfigmapName, opts.HostNameOverrideConfigmapName))
+		volumes = append(
+			volumes,
+			statefulset.CreateVolumeFromConfigMap(opts.HostNameOverrideConfigmapName, opts.HostNameOverrideConfigmapName),
+		)
 		hostnameOverrideModification := container.WithVolumeMounts([]corev1.VolumeMount{
 			{
 				Name:      opts.HostNameOverrideConfigmapName,
@@ -779,7 +836,10 @@ func buildStaticArchitecturePodTemplateSpec(opts DatabaseStatefulSetOptions, mdb
 }
 
 // buildNonStaticArchitecturePodTemplateSpec constructs the podTemplateSpec for non-static architecture
-func buildNonStaticArchitecturePodTemplateSpec(opts DatabaseStatefulSetOptions, mdb databaseStatefulSetSource) podtemplatespec.Modification {
+func buildNonStaticArchitecturePodTemplateSpec(
+	opts DatabaseStatefulSetOptions,
+	mdb databaseStatefulSetSource,
+) podtemplatespec.Modification {
 	// scripts volume is shared by the init container and the AppDB, so the startup
 	// script can be copied over
 	scriptsVolume := statefulset.CreateVolumeFromEmptyDir("database-scripts")
@@ -805,7 +865,10 @@ func buildNonStaticArchitecturePodTemplateSpec(opts DatabaseStatefulSetOptions, 
 	)}
 
 	if opts.HostNameOverrideConfigmapName != "" {
-		volumes = append(volumes, statefulset.CreateVolumeFromConfigMap(opts.HostNameOverrideConfigmapName, opts.HostNameOverrideConfigmapName))
+		volumes = append(
+			volumes,
+			statefulset.CreateVolumeFromConfigMap(opts.HostNameOverrideConfigmapName, opts.HostNameOverrideConfigmapName),
+		)
 		hostnameOverrideModification := container.WithVolumeMounts([]corev1.VolumeMount{
 			{
 				Name:      opts.HostNameOverrideConfigmapName,
@@ -922,7 +985,10 @@ func logConfigurationToEnvVars(parameters mdbv1.StartupParameters, additionalMon
 
 	// the following are hardcoded log files where we don't support changing the names
 	envVars = append(envVars, corev1.EnvVar{Name: LogFileMongoDBEnv, Value: path.Join(util.PvcMountPathLogs, "mongodb.log")})
-	envVars = append(envVars, corev1.EnvVar{Name: LogFileAgentMonitoringEnv, Value: path.Join(util.PvcMountPathLogs, "monitoring-agent.log")})
+	envVars = append(
+		envVars,
+		corev1.EnvVar{Name: LogFileAgentMonitoringEnv, Value: path.Join(util.PvcMountPathLogs, "monitoring-agent.log")},
+	)
 	envVars = append(envVars, corev1.EnvVar{Name: LogFileAgentBackupEnv, Value: path.Join(util.PvcMountPathLogs, "backup-agent.log")})
 
 	return envVars
@@ -1092,12 +1158,24 @@ func newDefaultPodSpec() mdbv1.MongoDbPodSpec {
 }
 
 // GetNonPersistentMongoDBVolumeMounts returns two arrays of non-persistent, empty volumes and corresponding mounts for the database container.
-func GetNonPersistentMongoDBVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount) {
+func GetNonPersistentMongoDBVolumeMounts(
+	volumes []corev1.Volume,
+	volumeMounts []corev1.VolumeMount,
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumes = append(volumes, statefulset.CreateVolumeFromEmptyDir(util.PvcNameData))
 
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathData, statefulset.WithSubPath(util.PvcNameData)))
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathJournal, statefulset.WithSubPath(util.PvcNameJournal)))
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathLogs, statefulset.WithSubPath(util.PvcNameLogs)))
+	volumeMounts = append(
+		volumeMounts,
+		statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathData, statefulset.WithSubPath(util.PvcNameData)),
+	)
+	volumeMounts = append(
+		volumeMounts,
+		statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathJournal, statefulset.WithSubPath(util.PvcNameJournal)),
+	)
+	volumeMounts = append(
+		volumeMounts,
+		statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathLogs, statefulset.WithSubPath(util.PvcNameLogs)),
+	)
 
 	return volumes, volumeMounts
 }
@@ -1108,12 +1186,21 @@ func GetNonPersistentAgentVolumeMounts(volumes []corev1.Volume, volumeMounts []c
 
 	// The agent reads and writes into its own directory. It also contains a subdirectory called downloads.
 	// This one is published by the Dockerfile
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvMms, util.PvcMmsMountPath, statefulset.WithSubPath(util.PvcMms)))
+	volumeMounts = append(
+		volumeMounts,
+		statefulset.CreateVolumeMount(util.PvMms, util.PvcMmsMountPath, statefulset.WithSubPath(util.PvcMms)),
+	)
 
 	// Runtime data for MMS
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvMms, util.PvcMmsHomeMountPath, statefulset.WithSubPath(util.PvcMmsHome)))
+	volumeMounts = append(
+		volumeMounts,
+		statefulset.CreateVolumeMount(util.PvMms, util.PvcMmsHomeMountPath, statefulset.WithSubPath(util.PvcMmsHome)),
+	)
 
-	volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.PvMms, util.PvcMountPathTmp, statefulset.WithSubPath(util.PvcNameTmp)))
+	volumeMounts = append(
+		volumeMounts,
+		statefulset.CreateVolumeMount(util.PvMms, util.PvcMountPathTmp, statefulset.WithSubPath(util.PvcNameTmp)),
+	)
 
 	return volumes, volumeMounts
 }

--- a/controllers/operator/construct/database_construction_test.go
+++ b/controllers/operator/construct/database_construction_test.go
@@ -53,7 +53,10 @@ func Test_buildDatabaseInitContainer(t *testing.T) {
 	assert.Equal(t, expectedContainer, container)
 }
 
-func createShardSpecAndDefaultCluster(client kubernetesClient.Client, sc *mdbv1.MongoDB) (*mdbv1.ShardedClusterComponentSpec, multicluster.MemberCluster) {
+func createShardSpecAndDefaultCluster(
+	client kubernetesClient.Client,
+	sc *mdbv1.MongoDB,
+) (*mdbv1.ShardedClusterComponentSpec, multicluster.MemberCluster) {
 	shardSpec := sc.Spec.ShardSpec.DeepCopy()
 	shardSpec.ClusterSpecList = mdbv1.ClusterSpecList{
 		{
@@ -62,7 +65,12 @@ func createShardSpecAndDefaultCluster(client kubernetesClient.Client, sc *mdbv1.
 		},
 	}
 
-	return shardSpec, multicluster.GetLegacyCentralMemberCluster(sc.Spec.MongodsPerShardCount, 0, client, secrets.SecretClient{KubeClient: client})
+	return shardSpec, multicluster.GetLegacyCentralMemberCluster(
+		sc.Spec.MongodsPerShardCount,
+		0,
+		client,
+		secrets.SecretClient{KubeClient: client},
+	)
 }
 
 func createConfigSrvSpec(sc *mdbv1.MongoDB) *mdbv1.ShardedClusterComponentSpec {
@@ -123,7 +131,11 @@ func TestStatefulsetCreationPanicsIfEnvVariablesAreNotSetStatic(t *testing.T) {
 			DatabaseStatefulSet(*sc, ShardOptions(0, shardSpec, memberCluster.Name, WithDefaultArchitecture(architectures.Static)), zap.S())
 		})
 		assert.Panics(t, func() {
-			DatabaseStatefulSet(*sc, ConfigServerOptions(configServerSpec, memberCluster.Name, WithDefaultArchitecture(architectures.Static)), zap.S())
+			DatabaseStatefulSet(
+				*sc,
+				ConfigServerOptions(configServerSpec, memberCluster.Name, WithDefaultArchitecture(architectures.Static)),
+				zap.S(),
+			)
 		})
 		assert.Panics(t, func() {
 			DatabaseStatefulSet(*sc, MongosOptions(mongosSpec, memberCluster.Name, WithDefaultArchitecture(architectures.Static)), zap.S())
@@ -233,13 +245,28 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 	assert.Len(t, envVars, 6)
 
 	logFileAutomationAgentEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "log.file")}
-	logFileAutomationAgentVerboseEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "log-verbose.file")}
-	logFileAutomationAgentDefaultEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")}
-	logFileAutomationAgentVerboseDefaultEnvVar := corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")}
+	logFileAutomationAgentVerboseEnvVar := corev1.EnvVar{
+		Name:  LogFileAutomationAgentVerboseEnv,
+		Value: path.Join(util.PvcMountPathLogs, "log-verbose.file"),
+	}
+	logFileAutomationAgentDefaultEnvVar := corev1.EnvVar{
+		Name:  LogFileAutomationAgentEnv,
+		Value: path.Join(util.PvcMountPathLogs, "automation-agent.log"),
+	}
+	logFileAutomationAgentVerboseDefaultEnvVar := corev1.EnvVar{
+		Name:  LogFileAutomationAgentVerboseEnv,
+		Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log"),
+	}
 	logFileMongoDBAuditEnvVar := corev1.EnvVar{Name: LogFileMongoDBAuditEnv, Value: path.Join(util.PvcMountPathLogs, "audit.log")}
-	logFileMongoDBAuditDefaultEnvVar := corev1.EnvVar{Name: LogFileMongoDBAuditEnv, Value: path.Join(util.PvcMountPathLogs, "mongodb-audit.log")}
+	logFileMongoDBAuditDefaultEnvVar := corev1.EnvVar{
+		Name:  LogFileMongoDBAuditEnv,
+		Value: path.Join(util.PvcMountPathLogs, "mongodb-audit.log"),
+	}
 	logFileMongoDBEnvVar := corev1.EnvVar{Name: LogFileMongoDBEnv, Value: path.Join(util.PvcMountPathLogs, "mongodb.log")}
-	logFileAgentMonitoringEnvVar := corev1.EnvVar{Name: LogFileAgentMonitoringEnv, Value: path.Join(util.PvcMountPathLogs, "monitoring-agent.log")}
+	logFileAgentMonitoringEnvVar := corev1.EnvVar{
+		Name:  LogFileAgentMonitoringEnv,
+		Value: path.Join(util.PvcMountPathLogs, "monitoring-agent.log"),
+	}
 	logFileAgentBackupEnvVar := corev1.EnvVar{Name: LogFileAgentBackupEnv, Value: path.Join(util.PvcMountPathLogs, "backup-agent.log")}
 
 	numberOfLogFilesInEnvVars := 6
@@ -278,7 +305,10 @@ func TestLogConfigurationToEnvVars(t *testing.T) {
 	})
 
 	t.Run("all log files are default", func(t *testing.T) {
-		envVars = logConfigurationToEnvVars(map[string]string{"other": "value"}, mdbv1.NewEmptyAdditionalMongodConfig().AddOption("other", "value"))
+		envVars = logConfigurationToEnvVars(
+			map[string]string{"other": "value"},
+			mdbv1.NewEmptyAdditionalMongodConfig().AddOption("other", "value"),
+		)
 		assert.Len(t, envVars, numberOfLogFilesInEnvVars)
 		assert.Contains(t, envVars, logFileAutomationAgentDefaultEnvVar)
 		assert.Contains(t, envVars, logFileAutomationAgentVerboseDefaultEnvVar)
@@ -309,14 +339,30 @@ func TestGetAutomationLogEnvVars(t *testing.T) {
 
 	t.Run("empty automation log file is falling back to default names", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{"logFile": ""})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")})
+		assert.Contains(
+			t,
+			envVars,
+			corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")},
+		)
+		assert.Contains(
+			t,
+			envVars,
+			corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")},
+		)
 	})
 
 	t.Run("not set logFile cause falling back to default names", func(t *testing.T) {
 		envVars := getAutomationLogEnvVars(map[string]string{})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")})
-		assert.Contains(t, envVars, corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")})
+		assert.Contains(
+			t,
+			envVars,
+			corev1.EnvVar{Name: LogFileAutomationAgentEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent.log")},
+		)
+		assert.Contains(
+			t,
+			envVars,
+			corev1.EnvVar{Name: LogFileAutomationAgentVerboseEnv, Value: path.Join(util.PvcMountPathLogs, "automation-agent-verbose.log")},
+		)
 	})
 }
 
@@ -361,7 +407,11 @@ func TestDatabaseStatefulSet_StaticContainersEnvVars(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mdb := mdbv1.NewReplicaSetBuilder().SetAnnotations(tt.annotations).Build()
-			sts := DatabaseStatefulSet(*mdb, ReplicaSetOptions(GetPodEnvOptions(), WithDefaultArchitecture(architectures.DefaultArchitecture(tt.defaultArchitecture))), zap.S())
+			sts := DatabaseStatefulSet(
+				*mdb,
+				ReplicaSetOptions(GetPodEnvOptions(), WithDefaultArchitecture(architectures.DefaultArchitecture(tt.defaultArchitecture))),
+				zap.S(),
+			)
 
 			agentContainerIdx := slices.IndexFunc(sts.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
 				return container.Name == util.AgentContainerName

--- a/controllers/operator/construct/jvm_test.go
+++ b/controllers/operator/construct/jvm_test.go
@@ -27,7 +27,14 @@ func TestBuildJvmEnvVar(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, buildJvmEnvVar(tt.args.customParams, tt.args.containerMemParams), "buildJvmEnvVar(%v, %v)", tt.args.customParams, tt.args.containerMemParams)
+			assert.Equalf(
+				t,
+				tt.want,
+				buildJvmEnvVar(tt.args.customParams, tt.args.containerMemParams),
+				"buildJvmEnvVar(%v, %v)",
+				tt.args.customParams,
+				tt.args.containerMemParams,
+			)
 		})
 	}
 }

--- a/controllers/operator/construct/multicluster/multicluster_replicaset.go
+++ b/controllers/operator/construct/multicluster/multicluster_replicaset.go
@@ -13,7 +13,9 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/merge"
 )
 
-func MultiClusterReplicaSetOptions(additionalOpts ...func(options *construct.DatabaseStatefulSetOptions)) func(mdbm mdbmultiv1.MongoDBMultiCluster) construct.DatabaseStatefulSetOptions {
+func MultiClusterReplicaSetOptions(
+	additionalOpts ...func(options *construct.DatabaseStatefulSetOptions),
+) func(mdbm mdbmultiv1.MongoDBMultiCluster) construct.DatabaseStatefulSetOptions {
 	return func(mdbm mdbmultiv1.MongoDBMultiCluster) construct.DatabaseStatefulSetOptions {
 		stsSpec := appsv1.StatefulSetSpec{}
 		if mdbm.Spec.StatefulSetConfiguration != nil {
@@ -77,7 +79,10 @@ func PodLabel(mdbmName string) map[string]string {
 	}
 }
 
-func MultiClusterStatefulSet(mdbm mdbmultiv1.MongoDBMultiCluster, stsOptFunc func(mdbm mdbmultiv1.MongoDBMultiCluster) construct.DatabaseStatefulSetOptions) appsv1.StatefulSet {
+func MultiClusterStatefulSet(
+	mdbm mdbmultiv1.MongoDBMultiCluster,
+	stsOptFunc func(mdbm mdbmultiv1.MongoDBMultiCluster) construct.DatabaseStatefulSetOptions,
+) appsv1.StatefulSet {
 	stsOptions := stsOptFunc(mdbm)
 	dbSts := construct.DatabaseStatefulSetHelper(&mdbm, &stsOptions, nil)
 

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -117,7 +117,12 @@ func WithReplicas(replicas int) func(opts *OpsManagerStatefulSetOptions) {
 	}
 }
 
-func WithKmipConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, client kubernetesClient.Client, log *zap.SugaredLogger) func(opts *OpsManagerStatefulSetOptions) {
+func WithKmipConfig(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	client kubernetesClient.Client,
+	log *zap.SugaredLogger,
+) func(opts *OpsManagerStatefulSetOptions) {
 	return func(opts *OpsManagerStatefulSetOptions) {
 		if !opsManager.Spec.IsKmipEnabled() {
 			return
@@ -146,7 +151,11 @@ func WithKmipConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, cli
 				}
 
 				clientCertificatePasswordSecret := &corev1.Secret{}
-				err := client.Get(ctx, kube.ObjectKey(m.GetNamespace(), c.ClientCertificatePasswordSecretName(m.GetName())), clientCertificatePasswordSecret)
+				err := client.Get(
+					ctx,
+					kube.ObjectKey(m.GetNamespace(), c.ClientCertificatePasswordSecretName(m.GetName())),
+					clientCertificatePasswordSecret,
+				)
 				if !apiErrors.IsNotFound(err) {
 					log.Warnf("failed to fetch the %s Secret from Kubernetes: %v", c.ClientCertificateSecretName(m.GetName()), err)
 				} else if err == nil {
@@ -184,7 +193,13 @@ func WithOMDefaultArchitecture(defaultArchitecture architectures.DefaultArchitec
 }
 
 // updateHTTPSCertSecret updates the fields for the OpsManager HTTPS certificate in case the provided secret is of type kubernetes.io/tls.
-func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(ctx context.Context, centralClusterSecretClient secrets.SecretClient, memberCluster multicluster.MemberCluster, ownerReferences []metav1.OwnerReference, log *zap.SugaredLogger) error {
+func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(
+	ctx context.Context,
+	centralClusterSecretClient secrets.SecretClient,
+	memberCluster multicluster.MemberCluster,
+	ownerReferences []metav1.OwnerReference,
+	log *zap.SugaredLogger,
+) error {
 	// Return immediately if no Certificate is provided
 	if opts.HTTPSCertSecretName == "" {
 		return nil
@@ -197,7 +212,9 @@ func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(ctx context.Cont
 
 	if vault.IsVaultSecretBackend() {
 		opsManagerSecretPath = centralClusterSecretClient.VaultClient.OpsManagerSecretPath()
-		secretData, err = centralClusterSecretClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", opsManagerSecretPath, opts.Namespace, opts.HTTPSCertSecretName))
+		secretData, err = centralClusterSecretClient.VaultClient.ReadSecretBytes(
+			fmt.Sprintf("%s/%s/%s", opsManagerSecretPath, opts.Namespace, opts.HTTPSCertSecretName),
+		)
 		if err != nil {
 			return err
 		}
@@ -222,10 +239,25 @@ func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(ctx context.Cont
 		return err
 	}
 
-	certHash := enterprisepem.ReadHashFromSecret(ctx, centralClusterSecretClient, opts.Namespace, opts.HTTPSCertSecretName, opsManagerSecretPath, log)
+	certHash := enterprisepem.ReadHashFromSecret(
+		ctx,
+		centralClusterSecretClient,
+		opts.Namespace,
+		opts.HTTPSCertSecretName,
+		opsManagerSecretPath,
+		log,
+	)
 
 	// The operator concatenates the two fields of the secret into a PEM secret
-	err = certs.CreateOrUpdatePEMSecretWithPreviousCert(ctx, memberCluster.SecretClient, kube.ObjectKey(opts.Namespace, opts.HTTPSCertSecretName), certHash, data, ownerReferences, certs.OpsManager)
+	err = certs.CreateOrUpdatePEMSecretWithPreviousCert(
+		ctx,
+		memberCluster.SecretClient,
+		kube.ObjectKey(opts.Namespace, opts.HTTPSCertSecretName),
+		certHash,
+		data,
+		ownerReferences,
+		certs.OpsManager,
+	)
 	if err != nil {
 		return err
 	}
@@ -238,7 +270,14 @@ func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(ctx context.Cont
 
 // OpsManagerStatefulSet is the base method for building StatefulSet shared by Ops Manager and Backup Daemon.
 // Shouldn't be called by end users directly
-func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secrets.SecretClient, opsManager *omv1.MongoDBOpsManager, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger, additionalOpts ...func(*OpsManagerStatefulSetOptions)) (appsv1.StatefulSet, error) {
+func OpsManagerStatefulSet(
+	ctx context.Context,
+	centralClusterSecretClient secrets.SecretClient,
+	opsManager *omv1.MongoDBOpsManager,
+	memberCluster multicluster.MemberCluster,
+	log *zap.SugaredLogger,
+	additionalOpts ...func(*OpsManagerStatefulSetOptions),
+) (appsv1.StatefulSet, error) {
 	opts := opsManagerOptions(memberCluster, additionalOpts...)(opsManager)
 
 	opts.Annotations = opsManager.Annotations
@@ -253,7 +292,12 @@ func OpsManagerStatefulSet(ctx context.Context, centralClusterSecretClient secre
 		// if the secret is specified, we must have a queryable.pem entry.
 		_, err := secret.ReadKey(ctx, centralClusterSecretClient, "queryable.pem", kube.ObjectKey(opsManager.Namespace, secretName))
 		if err != nil {
-			return appsv1.StatefulSet{}, xerrors.Errorf("error reading queryable.pem key from secret %s/%s: %w", opsManager.Namespace, secretName, err)
+			return appsv1.StatefulSet{}, xerrors.Errorf(
+				"error reading queryable.pem key from secret %s/%s: %w",
+				opsManager.Namespace,
+				secretName,
+				err,
+			)
 		}
 	}
 
@@ -292,7 +336,10 @@ func getSharedOpsManagerOptions(opsManager *omv1.MongoDBOpsManager) OpsManagerSt
 }
 
 // opsManagerOptions returns a function which returns the OpsManagerStatefulSetOptions to create the OpsManager StatefulSet
-func opsManagerOptions(memberCluster multicluster.MemberCluster, additionalOpts ...func(opts *OpsManagerStatefulSetOptions)) func(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
+func opsManagerOptions(
+	memberCluster multicluster.MemberCluster,
+	additionalOpts ...func(opts *OpsManagerStatefulSetOptions),
+) func(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 	return func(opsManager *omv1.MongoDBOpsManager) OpsManagerStatefulSetOptions {
 		var stsSpec *appsv1.StatefulSetSpec = nil
 		if opsManager.Spec.StatefulSetConfiguration != nil {
@@ -499,16 +546,26 @@ func backupAndOpsManagerSharedConfiguration(opts OpsManagerStatefulSetOptions) s
 	)
 }
 
-func appendKmipVolumes(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, opts OpsManagerStatefulSetOptions) ([]corev1.Volume, []corev1.VolumeMount) {
+func appendKmipVolumes(
+	volumes []corev1.Volume,
+	volumeMounts []corev1.VolumeMount,
+	opts OpsManagerStatefulSetOptions,
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	if opts.kmip != nil {
 		volumes = append(volumes, statefulset.CreateVolumeFromConfigMap(util.KMIPServerCAName, opts.kmip.ServerConfiguration.CA))
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.KMIPServerCAName, util.KMIPServerCAHome, statefulset.WithReadOnly(true)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(util.KMIPServerCAName, util.KMIPServerCAHome, statefulset.WithReadOnly(true)),
+		)
 
 		for _, cc := range opts.kmip.ClientConfigurations {
 			clientSecretName := util.KMIPClientSecretNamePrefix + cc.ClientCertificateSecretName
 			clientSecretPath := util.KMIPClientSecretsHome + "/" + cc.ClientCertificateSecretName
 			volumes = append(volumes, statefulset.CreateVolumeFromSecret(clientSecretName, cc.ClientCertificateSecretName))
-			volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(clientSecretName, clientSecretPath, statefulset.WithReadOnly(true)))
+			volumeMounts = append(
+				volumeMounts,
+				statefulset.CreateVolumeMount(clientSecretName, clientSecretPath, statefulset.WithReadOnly(true)),
+			)
 		}
 	}
 	return volumes, volumeMounts
@@ -686,40 +743,105 @@ func hasVolumeMount(opts OpsManagerStatefulSetOptions, mountPath string) bool {
 	return false
 }
 
-func getNonPersistentOpsManagerVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, opts OpsManagerStatefulSetOptions) ([]corev1.Volume, []corev1.VolumeMount) {
+func getNonPersistentOpsManagerVolumeMounts(
+	volumes []corev1.Volume,
+	volumeMounts []corev1.VolumeMount,
+	opts OpsManagerStatefulSetOptions,
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumes = append(volumes, statefulset.CreateVolumeFromEmptyDir(util.OpsManagerPvcNameData))
 
 	// Mount default emptyDir paths only if user hasn't provided custom overrides.
 	// This allows users to use their own PVCs for any of these paths.
 	if !hasVolumeMount(opts, util.PvcMountPathTmp) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.PvcMountPathTmp, statefulset.WithSubPath(util.PvcNameTmp)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.PvcMountPathTmp, statefulset.WithSubPath(util.PvcNameTmp)),
+		)
 	}
 	if !hasVolumeMount(opts, util.OpsManagerPvcMountPathTmp) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.OpsManagerPvcMountPathTmp, statefulset.WithSubPath(util.OpsManagerPvcNameTmp)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcNameData,
+				util.OpsManagerPvcMountPathTmp,
+				statefulset.WithSubPath(util.OpsManagerPvcNameTmp),
+			),
+		)
 	}
 	if !hasVolumeMount(opts, util.OpsManagerPvcMountPathLogs) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.OpsManagerPvcMountPathLogs, statefulset.WithSubPath(util.OpsManagerPvcNameLogs)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcNameData,
+				util.OpsManagerPvcMountPathLogs,
+				statefulset.WithSubPath(util.OpsManagerPvcNameLogs),
+			),
+		)
 	}
 	if !hasVolumeMount(opts, util.OpsManagerPvcMountPathEtc) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.OpsManagerPvcMountPathEtc, statefulset.WithSubPath(util.OpsManagerPvcNameEtc)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcNameData,
+				util.OpsManagerPvcMountPathEtc,
+				statefulset.WithSubPath(util.OpsManagerPvcNameEtc),
+			),
+		)
 	}
 
 	if opts.LoggingConfiguration != nil && opts.LoggingConfiguration.LogBackRef != nil {
-		volumes = append(volumes, statefulset.CreateVolumeFromConfigMap(util.OpsManagerPvcLogBackNameVolume, opts.LoggingConfiguration.LogBackRef.Name))
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcLogBackNameVolume, util.OpsManagerPvcLogbackMountPath, statefulset.WithSubPath(util.OpsManagerPvcLogbackSubPath)))
+		volumes = append(
+			volumes,
+			statefulset.CreateVolumeFromConfigMap(util.OpsManagerPvcLogBackNameVolume, opts.LoggingConfiguration.LogBackRef.Name),
+		)
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcLogBackNameVolume,
+				util.OpsManagerPvcLogbackMountPath,
+				statefulset.WithSubPath(util.OpsManagerPvcLogbackSubPath),
+			),
+		)
 	}
 
 	if opts.LoggingConfiguration != nil && opts.LoggingConfiguration.LogBackAccessRef != nil {
-		volumes = append(volumes, statefulset.CreateVolumeFromConfigMap(util.OpsManagerPvcLogBackAccessNameVolume, opts.LoggingConfiguration.LogBackAccessRef.Name))
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcLogBackAccessNameVolume, util.OpsManagerPvcLogbackAccessMountPath, statefulset.WithSubPath(util.OpsManagerPvcLogbackAccessSubPath)))
+		volumes = append(
+			volumes,
+			statefulset.CreateVolumeFromConfigMap(
+				util.OpsManagerPvcLogBackAccessNameVolume,
+				opts.LoggingConfiguration.LogBackAccessRef.Name,
+			),
+		)
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcLogBackAccessNameVolume,
+				util.OpsManagerPvcLogbackAccessMountPath,
+				statefulset.WithSubPath(util.OpsManagerPvcLogbackAccessSubPath),
+			),
+		)
 	}
 
 	if !hasVolumeMount(opts, util.OpsManagerPvcMountDownloads) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.OpsManagerPvcMountDownloads, statefulset.WithSubPath(util.OpsManagerPvcNameDownloads)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcNameData,
+				util.OpsManagerPvcMountDownloads,
+				statefulset.WithSubPath(util.OpsManagerPvcNameDownloads),
+			),
+		)
 	}
 
 	if !hasVolumeMount(opts, util.OpsManagerPvcMountPathConf) {
-		volumeMounts = append(volumeMounts, statefulset.CreateVolumeMount(util.OpsManagerPvcNameData, util.OpsManagerPvcMountPathConf, statefulset.WithSubPath(util.OpsManagerPvcNameConf)))
+		volumeMounts = append(
+			volumeMounts,
+			statefulset.CreateVolumeMount(
+				util.OpsManagerPvcNameData,
+				util.OpsManagerPvcMountPathConf,
+				statefulset.WithSubPath(util.OpsManagerPvcNameConf),
+			),
+		)
 	}
 
 	return volumes, volumeMounts

--- a/controllers/operator/construct/opsmanager_construction_test.go
+++ b/controllers/operator/construct/opsmanager_construction_test.go
@@ -96,14 +96,24 @@ func TestBuildJvmParamsEnvVars_FromCustomContainerResource(t *testing.T) {
 	assert.Equal(t, "-DFakeOptionEnabled", envVarsNoLimitsOrReqs[0].Value)
 }
 
-func createOpsManagerStatefulset(ctx context.Context, om *omv1.MongoDBOpsManager, additionalOpts ...func(*OpsManagerStatefulSetOptions)) (appsv1.StatefulSet, error) {
+func createOpsManagerStatefulset(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	additionalOpts ...func(*OpsManagerStatefulSetOptions),
+) (appsv1.StatefulSet, error) {
 	client, _ := mock.NewDefaultFakeClient()
 	secretsClient := secrets.SecretClient{
 		VaultClient: &vault.VaultClient{},
 		KubeClient:  client,
 	}
 
-	omSts, err := OpsManagerStatefulSet(ctx, secretsClient, om, multicluster.GetLegacyCentralMemberCluster(om.Spec.Replicas, 0, client, secretsClient), zap.S(), additionalOpts...)
+	omSts, err := OpsManagerStatefulSet(
+		ctx,
+		secretsClient,
+		om,
+		multicluster.GetLegacyCentralMemberCluster(om.Spec.Replicas, 0, client, secretsClient),
+		zap.S(),
+		additionalOpts...)
 	return omSts, err
 }
 
@@ -159,7 +169,13 @@ func TestBuildJvmParamsEnvVars_FromDefaultPodSpec(t *testing.T) {
 		KubeClient:  client,
 	}
 
-	omSts, err := OpsManagerStatefulSet(ctx, secretsClient, om, multicluster.GetLegacyCentralMemberCluster(om.Spec.Replicas, 0, client, secretsClient), zap.S())
+	omSts, err := OpsManagerStatefulSet(
+		ctx,
+		secretsClient,
+		om,
+		multicluster.GetLegacyCentralMemberCluster(om.Spec.Replicas, 0, client, secretsClient),
+		zap.S(),
+	)
 	assert.NoError(t, err)
 	template := omSts.Spec.Template
 

--- a/controllers/operator/construct/pvc.go
+++ b/controllers/operator/construct/pvc.go
@@ -12,7 +12,12 @@ import (
 // PvcFunc convenience function to build a PersistentVolumeClaim. It accepts two config parameters - the one specified by
 // the customers and the default one configured by the Operator. Putting the default one to the signature ensures the
 // calling code doesn't forget to think about default values in case the user hasn't provided values.
-func PvcFunc(name string, config *v1.PersistenceConfig, defaultConfig v1.PersistenceConfig, labels map[string]string) persistentvolumeclaim.Modification {
+func PvcFunc(
+	name string,
+	config *v1.PersistenceConfig,
+	defaultConfig v1.PersistenceConfig,
+	labels map[string]string,
+) persistentvolumeclaim.Modification {
 	selectorFunc := persistentvolumeclaim.NOOP()
 	storageClassNameFunc := persistentvolumeclaim.NOOP()
 	if config != nil {
@@ -33,7 +38,11 @@ func PvcFunc(name string, config *v1.PersistenceConfig, defaultConfig v1.Persist
 	)
 }
 
-func createClaimsAndMountsMultiModeFunc(persistence *v1.Persistence, defaultConfig v1.MultiplePersistenceConfig, labels map[string]string) (map[string]persistentvolumeclaim.Modification, []corev1.VolumeMount) {
+func createClaimsAndMountsMultiModeFunc(
+	persistence *v1.Persistence,
+	defaultConfig v1.MultiplePersistenceConfig,
+	labels map[string]string,
+) (map[string]persistentvolumeclaim.Modification, []corev1.VolumeMount) {
 	mounts := []corev1.VolumeMount{
 		statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathData),
 		statefulset.CreateVolumeMount(util.PvcNameJournal, util.PvcMountPathJournal),
@@ -46,7 +55,10 @@ func createClaimsAndMountsMultiModeFunc(persistence *v1.Persistence, defaultConf
 	}, mounts
 }
 
-func createClaimsAndMountsSingleModeFunc(config *v1.PersistenceConfig, opts DatabaseStatefulSetOptions) (map[string]persistentvolumeclaim.Modification, []corev1.VolumeMount) {
+func createClaimsAndMountsSingleModeFunc(
+	config *v1.PersistenceConfig,
+	opts DatabaseStatefulSetOptions,
+) (map[string]persistentvolumeclaim.Modification, []corev1.VolumeMount) {
 	mounts := []corev1.VolumeMount{
 		statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathData, statefulset.WithSubPath(util.PvcNameData)),
 		statefulset.CreateVolumeMount(util.PvcNameData, util.PvcMountPathJournal, statefulset.WithSubPath(util.PvcNameJournal)),

--- a/controllers/operator/construct/scalers/appdb_scaler.go
+++ b/controllers/operator/construct/scalers/appdb_scaler.go
@@ -6,9 +6,20 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/multicluster"
 )
 
-func GetAppDBScaler(opsManager *om.MongoDBOpsManager, memberClusterName string, memberClusterNum int, prevMembers []multicluster.MemberCluster) interfaces.MultiClusterReplicaSetScaler {
+func GetAppDBScaler(
+	opsManager *om.MongoDBOpsManager,
+	memberClusterName string,
+	memberClusterNum int,
+	prevMembers []multicluster.MemberCluster,
+) interfaces.MultiClusterReplicaSetScaler {
 	if opsManager.Spec.AppDB.IsMultiCluster() {
-		return NewMultiClusterReplicaSetScaler("AppDB", opsManager.Spec.AppDB.ClusterSpecList, memberClusterName, memberClusterNum, prevMembers)
+		return NewMultiClusterReplicaSetScaler(
+			"AppDB",
+			opsManager.Spec.AppDB.ClusterSpecList,
+			memberClusterName,
+			memberClusterNum,
+			prevMembers,
+		)
 	} else {
 		return NewAppDBSingleClusterScaler(opsManager)
 	}

--- a/controllers/operator/construct/scalers/replicaset_scaler.go
+++ b/controllers/operator/construct/scalers/replicaset_scaler.go
@@ -17,7 +17,13 @@ type MultiClusterReplicaSetScaler struct {
 	scalerDescription string
 }
 
-func NewMultiClusterReplicaSetScaler(scalerDescription string, clusterSpecList mdbv1.ClusterSpecList, memberClusterName string, memberClusterNum int, prevMembers []multicluster.MemberCluster) *MultiClusterReplicaSetScaler {
+func NewMultiClusterReplicaSetScaler(
+	scalerDescription string,
+	clusterSpecList mdbv1.ClusterSpecList,
+	memberClusterName string,
+	memberClusterNum int,
+	prevMembers []multicluster.MemberCluster,
+) *MultiClusterReplicaSetScaler {
 	return &MultiClusterReplicaSetScaler{
 		scalerDescription: scalerDescription,
 		clusterSpecList:   clusterSpecList,
@@ -146,7 +152,17 @@ func (s *MultiClusterReplicaSetScaler) ScalerDescription() string {
 }
 
 func (s *MultiClusterReplicaSetScaler) String() string {
-	return fmt.Sprintf("{MultiClusterReplicaSetScaler (%s): still scaling: %t (finishing this reconcile: %t), clusterName=%s, clusterIdx=%d, current/target replicas:%d/%d, "+
-		"replicas this reconciliation: %d, scaling first time: %t}", s.scalerDescription, s.CurrentReplicas() != s.TargetReplicas(), scale.ReplicasThisReconciliation(s) == s.TargetReplicas(), s.memberClusterName, s.memberClusterNum,
-		s.CurrentReplicas(), s.TargetReplicas(), scale.ReplicasThisReconciliation(s), s.ScalingFirstTime())
+	return fmt.Sprintf(
+		"{MultiClusterReplicaSetScaler (%s): still scaling: %t (finishing this reconcile: %t), clusterName=%s, clusterIdx=%d, current/target replicas:%d/%d, "+
+			"replicas this reconciliation: %d, scaling first time: %t}",
+		s.scalerDescription,
+		s.CurrentReplicas() != s.TargetReplicas(),
+		scale.ReplicasThisReconciliation(s) == s.TargetReplicas(),
+		s.memberClusterName,
+		s.memberClusterNum,
+		s.CurrentReplicas(),
+		s.TargetReplicas(),
+		scale.ReplicasThisReconciliation(s),
+		s.ScalingFirstTime(),
+	)
 }

--- a/controllers/operator/controlledfeature/controlled_feature.go
+++ b/controllers/operator/controlledfeature/controlled_feature.go
@@ -76,7 +76,12 @@ type Getter interface {
 
 // EnsureFeatureControls updates the controlled feature based on the provided MongoDB
 // resource if the version of Ops Manager supports it
-func EnsureFeatureControls(mdb mdbv1.MongoDB, updater Updater, omVersion versionutil.OpsManagerVersion, log *zap.SugaredLogger) workflow.Status {
+func EnsureFeatureControls(
+	mdb mdbv1.MongoDB,
+	updater Updater,
+	omVersion versionutil.OpsManagerVersion,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !ShouldUseFeatureControls(omVersion) {
 		log.Debugf("Ops Manager version is %s, which does not support Feature Controls API", omVersion)
 		return workflow.OK()

--- a/controllers/operator/controlledfeature/feature_by_mdb_test.go
+++ b/controllers/operator/controlledfeature/feature_by_mdb_test.go
@@ -53,7 +53,12 @@ func TestBuildFeatureControlsByMdb_MongodbParams(t *testing.T) {
 				{
 					PolicyType: DisableMongodConfig,
 					// The options have been deduplicated and contain the list of all options for each sharded cluster member
-					DisabledParams: []string{"storage.indexBuildRetry", "storage.journal.enabled", "systemLog.traceAllExceptions", "systemLog.verbosity"},
+					DisabledParams: []string{
+						"storage.indexBuildRetry",
+						"storage.journal.enabled",
+						"systemLog.traceAllExceptions",
+						"systemLog.verbosity",
+					},
 				},
 				{PolicyType: DisableMongodVersion},
 			},

--- a/controllers/operator/create/create.go
+++ b/controllers/operator/create/create.go
@@ -47,7 +47,14 @@ var (
 
 // DatabaseInKubernetes creates (updates if it exists) the StatefulSet with its Services.
 // It returns any errors coming from Kubernetes API.
-func DatabaseInKubernetes(ctx context.Context, client kubernetesClient.Client, mdb mdbv1.MongoDB, sts appsv1.StatefulSet, config func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func DatabaseInKubernetes(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	mdb mdbv1.MongoDB,
+	sts appsv1.StatefulSet,
+	config func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, error) {
 	opts := config(mdb)
 	set, err := enterprisests.CreateOrUpdateStatefulset(ctx, client, mdb.Namespace, log, &sts)
 	if err != nil {
@@ -60,7 +67,14 @@ func DatabaseInKubernetes(ctx context.Context, client kubernetesClient.Client, m
 	}
 
 	namespacedName := kube.ObjectKey(mdb.Namespace, set.Spec.ServiceName)
-	internalService := BuildService(namespacedName, &mdb, &set.Spec.ServiceName, nil, opts.ServicePort, omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP})
+	internalService := BuildService(
+		namespacedName,
+		&mdb,
+		&set.Spec.ServiceName,
+		nil,
+		opts.ServicePort,
+		omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP},
+	)
 	internalService.OwnerReferences = mdb.OwnerReferenceForMemberCluster()
 
 	// Adds Prometheus Port if Prometheus has been enabled.
@@ -93,7 +107,12 @@ func DatabaseInKubernetes(ctx context.Context, client kubernetesClient.Client, m
 // HandlePVCResize handles the state machine of a PVC resize.
 // Note: it modifies the desiredSTS.annotation to trigger a rolling restart later
 // We leverage workflowStatus.WithAdditionalOptions(...) to merge/update/add to existing mdb.status.pvc
-func HandlePVCResize(ctx context.Context, memberClient kubernetesClient.Client, desiredSts *appsv1.StatefulSet, log *zap.SugaredLogger) workflow.Status {
+func HandlePVCResize(
+	ctx context.Context,
+	memberClient kubernetesClient.Client,
+	desiredSts *appsv1.StatefulSet,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	existingStatefulSet, stsErr := memberClient.GetStatefulSet(ctx, kube.ObjectKey(desiredSts.Namespace, desiredSts.Name))
 	if stsErr != nil {
 		// if we are here it means its first reconciling, we can skip the whole pvc state machine
@@ -111,7 +130,9 @@ func HandlePVCResize(ctx context.Context, memberClient kubernetesClient.Client, 
 	for _, pvcResize := range pvcResizes {
 		if pvcResize.resizeIndicator == 1 {
 			log.Debug("Can't update the stateful set, as we cannot decrease the pvc size")
-			return workflow.Failed(xerrors.Errorf("can't update pvc and statefulset to a smaller storage, from: %s - to:%s", pvcResize.from, pvcResize.to))
+			return workflow.Failed(
+				xerrors.Errorf("can't update pvc and statefulset to a smaller storage, from: %s - to:%s", pvcResize.from, pvcResize.to),
+			)
 		}
 		if pvcResize.resizeIndicator == -1 {
 			log.Infof("Detected PVC size expansion; for pvc %s, from: %s to: %s", pvcResize.pvcName, pvcResize.from, pvcResize.to)
@@ -142,7 +163,8 @@ func HandlePVCResize(ctx context.Context, memberClient kubernetesClient.Client, 
 			log.Info("Deleting StatefulSet and orphan pods")
 			// Cascade delete the StatefulSet
 			deletePolicy := metav1.DeletePropagationOrphan
-			if err := memberClient.Delete(ctx, desiredSts, client.PropagationPolicy(deletePolicy)); err != nil && !apiErrors.IsNotFound(err) {
+			if err := memberClient.Delete(ctx, desiredSts, client.PropagationPolicy(deletePolicy)); err != nil &&
+				!apiErrors.IsNotFound(err) {
 				return workflow.Failed(xerrors.Errorf("error deleting sts, err: %s", err))
 			}
 
@@ -154,7 +176,8 @@ func HandlePVCResize(ctx context.Context, memberClient kubernetesClient.Client, 
 					"Restarting the reconcile").WithAdditionalOptions(status.NewPVCsStatusOption(&status.PVC{Phase: pvc.PhasePVCResize, StatefulsetName: desiredSts.Name}))
 			}
 			log.Info("Statefulset have been orphaned")
-			return workflow.OK().WithAdditionalOptions(status.NewPVCsStatusOption(&status.PVC{Phase: pvc.PhaseSTSOrphaned, StatefulsetName: desiredSts.Name}))
+			return workflow.OK().
+				WithAdditionalOptions(status.NewPVCsStatusOption(&status.PVC{Phase: pvc.PhaseSTSOrphaned, StatefulsetName: desiredSts.Name}))
 		} else {
 			log.Info("PVCs are still resizing, waiting until it has finished")
 			return workflow.Pending("PVC resizes has not finished; current state of sts: %s: %s", desiredSts.Name, pvc.PhasePVCResize).WithAdditionalOptions(status.NewPVCsStatusOption(&status.PVC{Phase: pvc.PhasePVCResize, StatefulsetName: desiredSts.Name}))
@@ -164,7 +187,13 @@ func HandlePVCResize(ctx context.Context, memberClient kubernetesClient.Client, 
 	return workflow.OK()
 }
 
-func checkStatefulsetIsDeleted(ctx context.Context, memberClient kubernetesClient.Client, desiredSts *appsv1.StatefulSet, sleepDuration time.Duration, log *zap.SugaredLogger) bool {
+func checkStatefulsetIsDeleted(
+	ctx context.Context,
+	memberClient kubernetesClient.Client,
+	desiredSts *appsv1.StatefulSet,
+	sleepDuration time.Duration,
+	log *zap.SugaredLogger,
+) bool {
 	// After deleting the statefulset it can take seconds to be reflected in kubernetes.
 	// In case it is still not reflected
 	deletedIsStatefulset := false
@@ -190,7 +219,9 @@ func hasFinishedResizing(ctx context.Context, memberClient kubernetesClient.Clie
 	finishedResizing := true
 	for _, currentPVC := range pvcList.Items {
 		if template, index := getMatchingPVCTemplateFromSTS(desiredSts, &currentPVC); template != nil {
-			if currentPVC.Status.Capacity.Storage().Cmp(*desiredSts.Spec.VolumeClaimTemplates[index].Spec.Resources.Requests.Storage()) != 0 {
+			if currentPVC.Status.Capacity.Storage().
+				Cmp(*desiredSts.Spec.VolumeClaimTemplates[index].Spec.Resources.Requests.Storage()) !=
+				0 {
 				finishedResizing = false
 			}
 		}
@@ -199,7 +230,12 @@ func hasFinishedResizing(ctx context.Context, memberClient kubernetesClient.Clie
 }
 
 // resizePVCsStorage takes the sts we want to create and update all matching pvc with the new storage
-func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, statefulSetToCreate *appsv1.StatefulSet, log *zap.SugaredLogger) error {
+func resizePVCsStorage(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	statefulSetToCreate *appsv1.StatefulSet,
+	log *zap.SugaredLogger,
+) error {
 	// this is to ensure that requests to a potentially not allowed resource is not blocking the operator until the end
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
@@ -213,7 +249,13 @@ func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, 
 		if template, _ := getMatchingPVCTemplateFromSTS(statefulSetToCreate, &existingPVC); template != nil {
 			currentSize := existingPVC.Spec.Resources.Requests[corev1.ResourceStorage]
 			targetSize := *template.Spec.Resources.Requests.Storage()
-			log.Infof("Resizing PVC %s/%s from %s to %s", existingPVC.GetNamespace(), existingPVC.GetName(), currentSize.String(), targetSize.String())
+			log.Infof(
+				"Resizing PVC %s/%s from %s to %s",
+				existingPVC.GetNamespace(),
+				existingPVC.GetName(),
+				currentSize.String(),
+				targetSize.String(),
+			)
 			existingPVC.Spec.Resources.Requests[corev1.ResourceStorage] = targetSize
 			if err := kubeClient.Update(ctx, &existingPVC); err != nil {
 				return err
@@ -223,7 +265,10 @@ func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, 
 	return nil
 }
 
-func getMatchingPVCTemplateFromSTS(statefulSet *appsv1.StatefulSet, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, int) {
+func getMatchingPVCTemplateFromSTS(
+	statefulSet *appsv1.StatefulSet,
+	pvc *corev1.PersistentVolumeClaim,
+) (*corev1.PersistentVolumeClaim, int) {
 	for i, claimTemplate := range statefulSet.Spec.VolumeClaimTemplates {
 		expectedPrefix := fmt.Sprintf("%s-%s", claimTemplate.Name, statefulSet.Name)
 
@@ -238,12 +283,28 @@ func getMatchingPVCTemplateFromSTS(statefulSet *appsv1.StatefulSet, pvc *corev1.
 
 // createExternalServices creates the external services.
 // For sharded clusters: services are only created for mongos.
-func createExternalServices(ctx context.Context, client kubernetesClient.Client, mdb mdbv1.MongoDB, opts construct.DatabaseStatefulSetOptions, namespacedName client.ObjectKey, set *appsv1.StatefulSet, podNum int, log *zap.SugaredLogger) error {
+func createExternalServices(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	mdb mdbv1.MongoDB,
+	opts construct.DatabaseStatefulSetOptions,
+	namespacedName client.ObjectKey,
+	set *appsv1.StatefulSet,
+	podNum int,
+	log *zap.SugaredLogger,
+) error {
 	if mdb.IsShardedCluster() && !opts.IsMongos() {
 		return nil
 	}
 	// TODO: we should not use OpsManager specific type `omv1.MongoDBOpsManagerServiceDefinition`
-	externalService := BuildService(namespacedName, &mdb, &set.Spec.ServiceName, ptr.To(dns.GetPodName(set.Name, podNum)), opts.ServicePort, omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeLoadBalancer})
+	externalService := BuildService(
+		namespacedName,
+		&mdb,
+		&set.Spec.ServiceName,
+		ptr.To(dns.GetPodName(set.Name, podNum)),
+		opts.ServicePort,
+		omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeLoadBalancer},
+	)
 	externalService.OwnerReferences = mdb.OwnerReferenceForMemberCluster()
 
 	if mdb.Spec.DbCommonSpec.GetExternalDomain() != nil {
@@ -254,15 +315,33 @@ func createExternalServices(ctx context.Context, client kubernetesClient.Client,
 		// external domain (e.g. for multi-cluster no-mesh), then we need to define backup port.
 		// In the agent process, we pass -ephemeralPortOffset 1 argument to define, that backup port should be a standard port+1.
 		backupPort := GetNonEphemeralBackupPort(opts.ServicePort)
-		externalService.Spec.Ports = append(externalService.Spec.Ports, corev1.ServicePort{Port: backupPort, TargetPort: intstr.FromInt32(backupPort), Name: "backup"})
+		externalService.Spec.Ports = append(
+			externalService.Spec.Ports,
+			corev1.ServicePort{Port: backupPort, TargetPort: intstr.FromInt32(backupPort), Name: "backup"},
+		)
 	}
 
 	if mdb.Spec.ExternalAccessConfiguration.ExternalService.SpecWrapper != nil {
-		externalService.Spec = merge.ServiceSpec(externalService.Spec, mdb.Spec.ExternalAccessConfiguration.ExternalService.SpecWrapper.Spec)
+		externalService.Spec = merge.ServiceSpec(
+			externalService.Spec,
+			mdb.Spec.ExternalAccessConfiguration.ExternalService.SpecWrapper.Spec,
+		)
 	}
-	externalService.Annotations = merge.StringToStringMap(externalService.Annotations, mdb.Spec.ExternalAccessConfiguration.ExternalService.Annotations)
+	externalService.Annotations = merge.StringToStringMap(
+		externalService.Annotations,
+		mdb.Spec.ExternalAccessConfiguration.ExternalService.Annotations,
+	)
 
-	placeholderReplacer := GetSingleClusterMongoDBPlaceholderReplacer(mdb.Name, set.Name, mdb.Namespace, mdb.ServiceName(), mdb.Spec.GetExternalDomain(), mdb.Spec.GetClusterDomain(), podNum, mdb.GetResourceType())
+	placeholderReplacer := GetSingleClusterMongoDBPlaceholderReplacer(
+		mdb.Name,
+		set.Name,
+		mdb.Namespace,
+		mdb.ServiceName(),
+		mdb.Spec.GetExternalDomain(),
+		mdb.Spec.GetClusterDomain(),
+		podNum,
+		mdb.GetResourceType(),
+	)
 	if processedAnnotations, replacedFlag, err := placeholderReplacer.ProcessMap(externalService.Annotations); err != nil {
 		return xerrors.Errorf("failed to process annotations in service %s: %w", externalService.Name, err)
 	} else if replacedFlag {
@@ -292,7 +371,16 @@ const (
 	PlaceholderClusterIndex        = "clusterIndex"
 )
 
-func GetSingleClusterMongoDBPlaceholderReplacer(resourceName string, statefulSetName string, namespace string, serviceName string, externalDomain *string, clusterDomain string, podIdx int, resourceType mdbv1.ResourceType) *placeholders.Replacer {
+func GetSingleClusterMongoDBPlaceholderReplacer(
+	resourceName string,
+	statefulSetName string,
+	namespace string,
+	serviceName string,
+	externalDomain *string,
+	clusterDomain string,
+	podIdx int,
+	resourceType mdbv1.ResourceType,
+) *placeholders.Replacer {
 	podName := dns.GetPodName(statefulSetName, podIdx)
 	placeholderValues := map[string]string{
 		PlaceholderPodIndex:            fmt.Sprintf("%d", podIdx),
@@ -320,7 +408,16 @@ func GetSingleClusterMongoDBPlaceholderReplacer(resourceName string, statefulSet
 	return placeholders.New(placeholderValues)
 }
 
-func GetMultiClusterMongoDBPlaceholderReplacer(name string, stsName string, namespace string, clusterName string, clusterNum int, externalDomain *string, clusterDomain string, podIdx int) *placeholders.Replacer {
+func GetMultiClusterMongoDBPlaceholderReplacer(
+	name string,
+	stsName string,
+	namespace string,
+	clusterName string,
+	clusterNum int,
+	externalDomain *string,
+	clusterDomain string,
+	podIdx int,
+) *placeholders.Replacer {
 	podName := dns.GetMultiPodName(stsName, clusterNum, podIdx)
 	serviceDomain := dns.GetServiceDomain(namespace, clusterDomain, externalDomain)
 	placeholderValues := map[string]string{
@@ -331,14 +428,28 @@ func GetMultiClusterMongoDBPlaceholderReplacer(name string, stsName string, name
 		PlaceholderStatefulSetName:     dns.GetMultiStatefulSetName(stsName, clusterNum),
 		PlaceholderExternalServiceName: dns.GetMultiExternalServiceName(stsName, clusterNum, podIdx),
 		PlaceholderMongodProcessDomain: serviceDomain,
-		PlaceholderMongodProcessFQDN:   dns.GetMultiClusterPodServiceFQDN(stsName, namespace, clusterNum, externalDomain, podIdx, clusterDomain),
-		PlaceholderClusterName:         clusterName,
-		PlaceholderClusterIndex:        fmt.Sprintf("%d", clusterNum),
+		PlaceholderMongodProcessFQDN: dns.GetMultiClusterPodServiceFQDN(
+			stsName,
+			namespace,
+			clusterNum,
+			externalDomain,
+			podIdx,
+			clusterDomain,
+		),
+		PlaceholderClusterName:  clusterName,
+		PlaceholderClusterIndex: fmt.Sprintf("%d", clusterNum),
 	}
 
 	if strings.HasSuffix(stsName, "mongos") {
 		placeholderValues[PlaceholderMongosProcessDomain] = serviceDomain
-		placeholderValues[PlaceholderMongosProcessFQDN] = dns.GetMultiClusterPodServiceFQDN(stsName, namespace, clusterNum, externalDomain, podIdx, clusterDomain)
+		placeholderValues[PlaceholderMongosProcessFQDN] = dns.GetMultiClusterPodServiceFQDN(
+			stsName,
+			namespace,
+			clusterNum,
+			externalDomain,
+			podIdx,
+			clusterDomain,
+		)
 		if externalDomain != nil {
 			placeholderValues[PlaceholderMongosProcessDomain] = *externalDomain
 		}
@@ -354,14 +465,28 @@ func GetMultiClusterMongoDBPlaceholderReplacer(name string, stsName string, name
 }
 
 // AppDBInKubernetes creates or updates the StatefulSet and Service required for the AppDB.
-func AppDBInKubernetes(ctx context.Context, client kubernetesClient.Client, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet, serviceSelectorLabel string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func AppDBInKubernetes(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	opsManager *omv1.MongoDBOpsManager,
+	sts appsv1.StatefulSet,
+	serviceSelectorLabel string,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, error) {
 	set, err := enterprisests.CreateOrUpdateStatefulset(ctx, client, opsManager.Namespace, log, &sts)
 	if err != nil {
 		return nil, err
 	}
 
 	namespacedName := kube.ObjectKey(opsManager.Namespace, set.Spec.ServiceName)
-	internalService := BuildService(namespacedName, opsManager, ptr.To(serviceSelectorLabel), nil, opsManager.Spec.AppDB.AdditionalMongodConfig.GetPortOrDefault(), omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP})
+	internalService := BuildService(
+		namespacedName,
+		opsManager,
+		ptr.To(serviceSelectorLabel),
+		nil,
+		opsManager.Spec.AppDB.AdditionalMongodConfig.GetPortOrDefault(),
+		omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP},
+	)
 	internalService.OwnerReferences = opsManager.AppDBOwnerReferenceForMemberCluster()
 
 	// Adds Prometheus Port if Prometheus has been enabled.
@@ -383,7 +508,13 @@ func (s StatefulSetIsRecreating) Error() string {
 }
 
 // BackupDaemonInKubernetes creates or updates the StatefulSet and Services required.
-func BackupDaemonInKubernetes(ctx context.Context, client kubernetesClient.Client, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func BackupDaemonInKubernetes(
+	ctx context.Context,
+	client kubernetesClient.Client,
+	opsManager *omv1.MongoDBOpsManager,
+	sts appsv1.StatefulSet,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, error) {
 	set, err := enterprisests.CreateOrUpdateStatefulset(ctx, client, opsManager.Namespace, log, &sts)
 	if err != nil {
 		// Check if it is a k8s error or a custom one
@@ -401,7 +532,14 @@ func BackupDaemonInKubernetes(ctx context.Context, client kubernetesClient.Clien
 		return nil, StatefulSetIsRecreating{"deleted the old backup stateful set and creating a new one in next reconciliation"}
 	}
 	namespacedName := kube.ObjectKey(opsManager.Namespace, set.Spec.ServiceName)
-	internalService := BuildService(namespacedName, opsManager, &set.Spec.ServiceName, nil, construct.BackupDaemonServicePort, omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP})
+	internalService := BuildService(
+		namespacedName,
+		opsManager,
+		&set.Spec.ServiceName,
+		nil,
+		construct.BackupDaemonServicePort,
+		omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP},
+	)
 	internalService.OwnerReferences = opsManager.OwnerReferenceForMemberCluster()
 	internalService.Spec.PublishNotReadyAddresses = false
 
@@ -410,7 +548,13 @@ func BackupDaemonInKubernetes(ctx context.Context, client kubernetesClient.Clien
 
 // OpsManagerInKubernetes creates all the required Kubernetes resources for Ops Manager.
 // It creates the StatefulSet and all required services.
-func OpsManagerInKubernetes(ctx context.Context, memberCluster multicluster.MemberCluster, opsManager *omv1.MongoDBOpsManager, sts appsv1.StatefulSet, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func OpsManagerInKubernetes(
+	ctx context.Context,
+	memberCluster multicluster.MemberCluster,
+	opsManager *omv1.MongoDBOpsManager,
+	sts appsv1.StatefulSet,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, error) {
 	set, err := enterprisests.CreateOrUpdateStatefulset(ctx, memberCluster.Client, opsManager.Namespace, log, &sts)
 	if err != nil {
 		return nil, err
@@ -500,7 +644,14 @@ func addQueryableBackupPortToService(opsManager *omv1.MongoDBOpsManager, service
 //
 // When appLabel is specified, then the selector is targeting all pods (round-robin service). Usable for e.g. OpsManager service.
 // When podLabel is specified, then the selector is targeting only a single pod. Used for external services or multi-cluster services.
-func BuildService(namespacedName types.NamespacedName, owner v1.ObjectOwner, appLabel *string, podLabel *string, port int32, mongoServiceDefinition omv1.MongoDBOpsManagerServiceDefinition) corev1.Service {
+func BuildService(
+	namespacedName types.NamespacedName,
+	owner v1.ObjectOwner,
+	appLabel *string,
+	podLabel *string,
+	port int32,
+	mongoServiceDefinition omv1.MongoDBOpsManagerServiceDefinition,
+) corev1.Service {
 	svcLabels := owner.GetOwnerLabels()
 
 	selectorLabels := map[string]string{
@@ -591,7 +742,10 @@ type pvcResize struct {
 //	 1: toCreateVolumeClaims < desiredVolumeClaims → decrease storage
 //	-1: toCreateVolumeClaims > desiredVolumeClaims → increase storage
 //	 0: toCreateVolumeClaims = desiredVolumeClaims → storage stays same
-func resourceStorageHasChanged(existingVolumeClaims []corev1.PersistentVolumeClaim, desiredVolumeClaims []corev1.PersistentVolumeClaim) []pvcResize {
+func resourceStorageHasChanged(
+	existingVolumeClaims []corev1.PersistentVolumeClaim,
+	desiredVolumeClaims []corev1.PersistentVolumeClaim,
+) []pvcResize {
 	existingClaimByName := map[string]*corev1.PersistentVolumeClaim{}
 	var pvcResizes []pvcResize
 

--- a/controllers/operator/create/create_test.go
+++ b/controllers/operator/create/create_test.go
@@ -40,11 +40,18 @@ func init() {
 
 func TestBuildService(t *testing.T) {
 	mdb := mdbv1.NewReplicaSetBuilder().Build()
-	svc := BuildService(kube.ObjectKey(mock.TestNamespace, "my-svc"), mdb, ptr.To("label"), nil, 2000, omv1.MongoDBOpsManagerServiceDefinition{
-		Type:           corev1.ServiceTypeClusterIP,
-		Port:           2000,
-		LoadBalancerIP: "loadbalancerip",
-	})
+	svc := BuildService(
+		kube.ObjectKey(mock.TestNamespace, "my-svc"),
+		mdb,
+		ptr.To("label"),
+		nil,
+		2000,
+		omv1.MongoDBOpsManagerServiceDefinition{
+			Type:           corev1.ServiceTypeClusterIP,
+			Port:           2000,
+			LoadBalancerIP: "loadbalancerip",
+		},
+	)
 
 	// BuildService does not set OwnerReferences; callers are responsible for setting them
 	// explicitly (single-cluster) or leaving them nil (multi-cluster).
@@ -59,11 +66,18 @@ func TestBuildService(t *testing.T) {
 	assert.True(t, svc.Spec.PublishNotReadyAddresses)
 
 	// test podName label not nil
-	svc = BuildService(kube.ObjectKey(mock.TestNamespace, "my-svc"), mdb, nil, ptr.To("podName"), 2000, omv1.MongoDBOpsManagerServiceDefinition{
-		Type:           corev1.ServiceTypeClusterIP,
-		Port:           2000,
-		LoadBalancerIP: "loadbalancerip",
-	})
+	svc = BuildService(
+		kube.ObjectKey(mock.TestNamespace, "my-svc"),
+		mdb,
+		nil,
+		ptr.To("podName"),
+		2000,
+		omv1.MongoDBOpsManagerServiceDefinition{
+			Type:           corev1.ServiceTypeClusterIP,
+			Port:           2000,
+			LoadBalancerIP: "loadbalancerip",
+		},
+	)
 
 	assert.Empty(t, svc.OwnerReferences)
 	assert.Equal(t, mock.TestNamespace, svc.Namespace)
@@ -107,7 +121,12 @@ func TestOpsManagerInKubernetes_InternalConnectivityOverride(t *testing.T) {
 	svc, err := fakeClient.GetService(ctx, kube.ObjectKey(testOm.Namespace, testOm.SvcName()))
 	assert.NoError(t, err, "Internal service exists")
 
-	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeClusterIP, "The operator creates a ClusterIP service if explicitly requested to do so.")
+	assert.Equal(
+		t,
+		svc.Spec.Type,
+		corev1.ServiceTypeClusterIP,
+		"The operator creates a ClusterIP service if explicitly requested to do so.",
+	)
 	assert.Equal(t, svc.Spec.ClusterIP, "0.0.12.0", "The operator configures the requested ClusterIP for the service")
 
 	assert.Len(t, svc.Spec.Ports, 2, "Backup port should have been added to existing internal service")
@@ -595,7 +614,12 @@ func TestDatabaseInKubernetes_ExternalServicesWithExternalDomainHaveAdditionalBa
 	service2.Name = "mdb-1-svc-external"
 	expectedServices := []corev1.Service{service1, service2}
 
-	testDatabaseInKubernetesExternalServices(ctx, t, mdbv1.ExternalAccessConfiguration{ExternalDomain: ptr.To("example.com")}, expectedServices)
+	testDatabaseInKubernetesExternalServices(
+		ctx,
+		t,
+		mdbv1.ExternalAccessConfiguration{ExternalDomain: ptr.To("example.com")},
+		expectedServices,
+	)
 }
 
 func TestDatabaseInKubernetes_ExternalServicesWithServiceSpecOverrides(t *testing.T) {
@@ -794,7 +818,12 @@ func TestDatabaseInKubernetes_ExternalServicesWithPlaceholders_WithExternalDomai
 	testDatabaseInKubernetesExternalServices(ctx, t, externalAccessConfiguration, []corev1.Service{service1, service2})
 }
 
-func testDatabaseInKubernetesExternalServices(ctx context.Context, t *testing.T, externalAccessConfiguration mdbv1.ExternalAccessConfiguration, expectedServices []corev1.Service) {
+func testDatabaseInKubernetesExternalServices(
+	ctx context.Context,
+	t *testing.T,
+	externalAccessConfiguration mdbv1.ExternalAccessConfiguration,
+	expectedServices []corev1.Service,
+) {
 	log := zap.S()
 	fakeClient, _ := mock.NewDefaultFakeClient()
 	mdb := mdbv1.NewReplicaSetBuilder().
@@ -870,7 +899,10 @@ func TestDatabaseInKubernetesExternalServicesSharded(t *testing.T) {
 	require.Errorf(t, err, "expected no shard service")
 }
 
-func createShardSpecAndDefaultCluster(client kubernetesClient.Client, sc *mdbv1.MongoDB) (*mdbv1.ShardedClusterComponentSpec, multicluster.MemberCluster) {
+func createShardSpecAndDefaultCluster(
+	client kubernetesClient.Client,
+	sc *mdbv1.MongoDB,
+) (*mdbv1.ShardedClusterComponentSpec, multicluster.MemberCluster) {
 	shardSpec := sc.Spec.ShardSpec.DeepCopy()
 	shardSpec.ClusterSpecList = mdbv1.ClusterSpecList{
 		{
@@ -880,7 +912,12 @@ func createShardSpecAndDefaultCluster(client kubernetesClient.Client, sc *mdbv1.
 		},
 	}
 
-	return shardSpec, multicluster.GetLegacyCentralMemberCluster(sc.Spec.MongodsPerShardCount, 0, client, secrets.SecretClient{KubeClient: client})
+	return shardSpec, multicluster.GetLegacyCentralMemberCluster(
+		sc.Spec.MongodsPerShardCount,
+		0,
+		client,
+		secrets.SecretClient{KubeClient: client},
+	)
 }
 
 func createMongosSpec(sc *mdbv1.MongoDB) *mdbv1.ShardedClusterComponentSpec {
@@ -905,8 +942,19 @@ func createShardSts(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDB, log *
 
 func createMongosSts(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDB, log *zap.SugaredLogger, kubeClient kubernetesClient.Client) {
 	mongosSpec := createMongosSpec(mdb)
-	sts := construct.DatabaseStatefulSet(*mdb, construct.MongosOptions(mongosSpec, multicluster.LegacyCentralClusterName, construct.GetPodEnvOptions()), log)
-	mutatedSts, err := DatabaseInKubernetes(ctx, kubeClient, *mdb, sts, construct.MongosOptions(mongosSpec, multicluster.LegacyCentralClusterName), log)
+	sts := construct.DatabaseStatefulSet(
+		*mdb,
+		construct.MongosOptions(mongosSpec, multicluster.LegacyCentralClusterName, construct.GetPodEnvOptions()),
+		log,
+	)
+	mutatedSts, err := DatabaseInKubernetes(
+		ctx,
+		kubeClient,
+		*mdb,
+		sts,
+		construct.MongosOptions(mongosSpec, multicluster.LegacyCentralClusterName),
+		log,
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, mutatedSts)
 }
@@ -1039,7 +1087,12 @@ func createStatefulSet(name, namespace, size1, size2, size3 string) *appsv1.Stat
 	}
 }
 
-func createPVCFromTemplate(pvcTemplate corev1.PersistentVolumeClaim, stsName string, namespace string, ordinal int32) *corev1.PersistentVolumeClaim {
+func createPVCFromTemplate(
+	pvcTemplate corev1.PersistentVolumeClaim,
+	stsName string,
+	namespace string,
+	ordinal int32,
+) *corev1.PersistentVolumeClaim {
 	pvcName := fmt.Sprintf("%s-%s-%d", pvcTemplate.Name, stsName, ordinal)
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1147,7 +1200,14 @@ func TestResourceStorageHasChanged(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, resourceStorageHasChanged(tt.args.existingPVC, tt.args.toCreatePVC), "resourceStorageHasChanged(%v, %v)", tt.args.existingPVC, tt.args.toCreatePVC)
+			assert.Equalf(
+				t,
+				tt.want,
+				resourceStorageHasChanged(tt.args.existingPVC, tt.args.toCreatePVC),
+				"resourceStorageHasChanged(%v, %v)",
+				tt.args.existingPVC,
+				tt.args.toCreatePVC,
+			)
 		})
 	}
 }

--- a/controllers/operator/envoy_config_builder_test.go
+++ b/controllers/operator/envoy_config_builder_test.go
@@ -152,8 +152,20 @@ func TestBuildCDSJSON_SingleShard_WithTLS(t *testing.T) {
 
 func TestBuildCDSJSON_MultipleShards(t *testing.T) {
 	routes := []envoyRoute{
-		{Name: "mdb-sh-0", NameSafe: "mdb_sh_0", SNIHostname: "s0.ns.svc.cluster.local", UpstreamHosts: []string{"m0.ns.svc.cluster.local"}, UpstreamPort: 27028},
-		{Name: "mdb-sh-1", NameSafe: "mdb_sh_1", SNIHostname: "s1.ns.svc.cluster.local", UpstreamHosts: []string{"m1.ns.svc.cluster.local"}, UpstreamPort: 27028},
+		{
+			Name:          "mdb-sh-0",
+			NameSafe:      "mdb_sh_0",
+			SNIHostname:   "s0.ns.svc.cluster.local",
+			UpstreamHosts: []string{"m0.ns.svc.cluster.local"},
+			UpstreamPort:  27028,
+		},
+		{
+			Name:          "mdb-sh-1",
+			NameSafe:      "mdb_sh_1",
+			SNIHostname:   "s1.ns.svc.cluster.local",
+			UpstreamHosts: []string{"m1.ns.svc.cluster.local"},
+			UpstreamPort:  27028,
+		},
 	}
 	result, err := buildCDSJSON(routes, false, testCAKeyName())
 	require.NoError(t, err)
@@ -221,9 +233,27 @@ func TestBuildLDSJSON_SingleShard_WithTLS(t *testing.T) {
 
 func TestBuildLDSJSON_MultipleShards_WithTLS(t *testing.T) {
 	routes := []envoyRoute{
-		{Name: "mdb-sh-0", NameSafe: "mdb_sh_0", SNIHostname: "shard0.ns.svc.cluster.local", UpstreamHosts: []string{"mongot0.ns.svc.cluster.local"}, UpstreamPort: 27028},
-		{Name: "mdb-sh-1", NameSafe: "mdb_sh_1", SNIHostname: "shard1.ns.svc.cluster.local", UpstreamHosts: []string{"mongot1.ns.svc.cluster.local"}, UpstreamPort: 27028},
-		{Name: "mdb-sh-2", NameSafe: "mdb_sh_2", SNIHostname: "shard2.ns.svc.cluster.local", UpstreamHosts: []string{"mongot2.ns.svc.cluster.local"}, UpstreamPort: 27028},
+		{
+			Name:          "mdb-sh-0",
+			NameSafe:      "mdb_sh_0",
+			SNIHostname:   "shard0.ns.svc.cluster.local",
+			UpstreamHosts: []string{"mongot0.ns.svc.cluster.local"},
+			UpstreamPort:  27028,
+		},
+		{
+			Name:          "mdb-sh-1",
+			NameSafe:      "mdb_sh_1",
+			SNIHostname:   "shard1.ns.svc.cluster.local",
+			UpstreamHosts: []string{"mongot1.ns.svc.cluster.local"},
+			UpstreamPort:  27028,
+		},
+		{
+			Name:          "mdb-sh-2",
+			NameSafe:      "mdb_sh_2",
+			SNIHostname:   "shard2.ns.svc.cluster.local",
+			UpstreamHosts: []string{"mongot2.ns.svc.cluster.local"},
+			UpstreamPort:  27028,
+		},
 	}
 
 	result, err := buildLDSJSON(routes, true, testCAKeyName(), nil)
@@ -374,8 +404,16 @@ func TestBuildCluster_UsesTypedExtensionProtocolOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify deprecated fields are NOT set
-	assert.Nil(t, cluster.Http2ProtocolOptions, "deprecated Http2ProtocolOptions should not be set on Cluster")           //nolint:staticcheck
-	assert.Nil(t, cluster.CommonHttpProtocolOptions, "deprecated CommonHttpProtocolOptions should not be set on Cluster") //nolint:staticcheck
+	assert.Nil(
+		t,
+		cluster.Http2ProtocolOptions,
+		"deprecated Http2ProtocolOptions should not be set on Cluster",
+	) //nolint:staticcheck
+	assert.Nil(
+		t,
+		cluster.CommonHttpProtocolOptions,
+		"deprecated CommonHttpProtocolOptions should not be set on Cluster",
+	) //nolint:staticcheck
 
 	// Verify TypedExtensionProtocolOptions is set
 	require.Contains(t, cluster.TypedExtensionProtocolOptions, "envoy.extensions.upstreams.http.v3.HttpProtocolOptions")

--- a/controllers/operator/inspect/statefulset_inspector.go
+++ b/controllers/operator/inspect/statefulset_inspector.go
@@ -30,8 +30,15 @@ func (s StatefulSetState) GetResourcesNotReadyStatus() []status.ResourceNotReady
 	if s.IsReady() {
 		return []status.ResourceNotReady{}
 	}
-	zap.S().Debugf("StatefulSet %s (wanted: %d, ready: %d, updated: %d, generation: %d, observedGeneration: %d, expectedGeneration: %d)", s.statefulSetKey.Name, s.wanted, s.ready, s.updated, s.generation, s.observedGeneration, s.expectedGeneration)
-	msg := fmt.Sprintf("Not all the Pods are ready (wanted: %d, updated: %d, ready: %d, current: %d)", s.wanted, s.updated, s.ready, s.current)
+	zap.S().
+		Debugf("StatefulSet %s (wanted: %d, ready: %d, updated: %d, generation: %d, observedGeneration: %d, expectedGeneration: %d)", s.statefulSetKey.Name, s.wanted, s.ready, s.updated, s.generation, s.observedGeneration, s.expectedGeneration)
+	msg := fmt.Sprintf(
+		"Not all the Pods are ready (wanted: %d, updated: %d, ready: %d, current: %d)",
+		s.wanted,
+		s.updated,
+		s.ready,
+		s.current,
+	)
 	return []status.ResourceNotReady{{
 		Kind:    status.StatefulsetKind,
 		Name:    s.statefulSetKey.Name,

--- a/controllers/operator/mock/mockedkubeclient.go
+++ b/controllers/operator/mock/mockedkubeclient.go
@@ -56,13 +56,19 @@ func NewDefaultFakeClient(objects ...client.Object) (kubernetesClient.Client, *o
 }
 
 // NewDefaultFakeClientWithOMConnectionFactory is the same as NewDefaultFakeClient, but you can pass omConnectionFactory from outside.
-func NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory *om.CachedOMConnectionFactory, objects ...client.Object) kubernetesClient.Client {
+func NewDefaultFakeClientWithOMConnectionFactory(
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	objects ...client.Object,
+) kubernetesClient.Client {
 	return NewEmptyFakeClientWithInterceptor(omConnectionFactory, append(objects, GetDefaultResources()...)...)
 }
 
 // NewEmptyFakeClientWithInterceptor initializes empty fake kube client with interceptor for automatically marking statefulsets as ready.
 // It doesn't add any default resources, but adds passed objects if any.
-func NewEmptyFakeClientWithInterceptor(omConnectionFactory *om.CachedOMConnectionFactory, objects ...client.Object) kubernetesClient.Client {
+func NewEmptyFakeClientWithInterceptor(
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	objects ...client.Object,
+) kubernetesClient.Client {
 	fakeClientBuilder := NewEmptyFakeClientBuilder()
 	if len(objects) > 0 {
 		fakeClientBuilder.WithObjects(objects...)
@@ -106,20 +112,35 @@ func NewEmptyFakeClientBuilder() *fake.ClientBuilder {
 		return nil
 	}
 
-	builder.WithStatusSubresource(&mdbv1.MongoDB{}, &mdbmulti.MongoDBMultiCluster{}, &omv1.MongoDBOpsManager{}, &user.MongoDBUser{}, &searchv1.MongoDBSearch{}, &mdbcv1.MongoDBCommunity{}, &rolev1.ClusterMongoDBRole{}, &vaiv1.VoyageAI{})
+	builder.WithStatusSubresource(
+		&mdbv1.MongoDB{},
+		&mdbmulti.MongoDBMultiCluster{},
+		&omv1.MongoDBOpsManager{},
+		&user.MongoDBUser{},
+		&searchv1.MongoDBSearch{},
+		&mdbcv1.MongoDBCommunity{},
+		&rolev1.ClusterMongoDBRole{},
+		&vaiv1.VoyageAI{},
+	)
 
 	ot := testing.NewObjectTracker(s, scheme.Codecs.UniversalDecoder())
-	return builder.WithScheme(s).WithObjectTracker(ot).WithIndex(&searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, func(obj client.Object) []string {
-		mdbSearch := obj.(*searchv1.MongoDBSearch)
-		resourceRef := mdbSearch.GetMongoDBResourceRef()
-		if resourceRef == nil {
-			return []string{}
-		}
-		return []string{resourceRef.Namespace + "/" + resourceRef.Name}
-	})
+	return builder.WithScheme(s).
+		WithObjectTracker(ot).
+		WithIndex(&searchv1.MongoDBSearch{}, searchv1.MongoDBSearchIndexFieldName, func(obj client.Object) []string {
+			mdbSearch := obj.(*searchv1.MongoDBSearch)
+			resourceRef := mdbSearch.GetMongoDBResourceRef()
+			if resourceRef == nil {
+				return []string{}
+			}
+			return []string{resourceRef.Namespace + "/" + resourceRef.Name}
+		})
 }
 
-func GetFakeClientInterceptorGetFunc(omConnectionFactory *om.CachedOMConnectionFactory, markStsAsReady bool, addOMHosts bool) func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func GetFakeClientInterceptorGetFunc(
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	markStsAsReady bool,
+	addOMHosts bool,
+) func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	return func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 		if err := c.Get(ctx, key, obj, opts...); err != nil {
 			return err
@@ -252,7 +273,14 @@ func markStatefulSetsReady(set *appsv1.StatefulSet, addOMHosts bool, omConn om.C
 			hostnames := mockedOMConnection.Hostnames
 			if hostnames == nil {
 				if val, ok := set.Annotations[handler.MongoDBMultiResourceAnnotation]; ok {
-					hostnames = dns.GetMultiClusterProcessHostnames(val, set.Namespace, multicluster.MustGetClusterNumFromMultiStsName(set.Name), int(*set.Spec.Replicas), "cluster.local", nil)
+					hostnames = dns.GetMultiClusterProcessHostnames(
+						val,
+						set.Namespace,
+						multicluster.MustGetClusterNumFromMultiStsName(set.Name),
+						int(*set.Spec.Replicas),
+						"cluster.local",
+						nil,
+					)
 				} else {
 					// We also "register" automation agents.
 					// So far we don't support custom cluster name

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -92,7 +92,17 @@ type ReconcileMongoDbMultiReplicaSet struct {
 
 var _ reconcile.Reconciler = &ReconcileMongoDbMultiReplicaSet{}
 
-func newMultiClusterReplicaSetReconciler(ctx context.Context, kubeClient client.Client, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, omFunc om.ConnectionFactory, memberClustersMap map[string]client.Client) *ReconcileMongoDbMultiReplicaSet {
+func newMultiClusterReplicaSetReconciler(
+	ctx context.Context,
+	kubeClient client.Client,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	omFunc om.ConnectionFactory,
+	memberClustersMap map[string]client.Client,
+) *ReconcileMongoDbMultiReplicaSet {
 	clientsMap := make(map[string]kubernetesClient.Client)
 	secretClientsMap := make(map[string]secrets.SecretClient)
 
@@ -141,7 +151,13 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 	}
 
 	if !architectures.IsRunningStaticArchitecture(mrs.Annotations, r.defaultArchitecture) {
-		agents.UpgradeAllIfNeeded(ctx, agents.ClientSecret{Client: r.client, SecretClient: r.SecretClient}, r.omConnectionFactory, GetWatchedNamespace(), true)
+		agents.UpgradeAllIfNeeded(
+			ctx,
+			agents.ClientSecret{Client: r.client, SecretClient: r.SecretClient},
+			r.omConnectionFactory,
+			GetWatchedNamespace(),
+			true,
+		)
 	}
 
 	if err := mrs.ProcessValidationsOnReconcile(nil); err != nil {
@@ -153,7 +169,16 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 		return r.updateStatus(ctx, &mrs, workflow.Failed(xerrors.Errorf("Error reading project config and credentials: %w", err)), log)
 	}
 
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, mrs.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		mrs.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, &mrs, workflow.Failed(xerrors.Errorf("error establishing connection to Ops Manager: %w", err)), log)
 	}
@@ -166,7 +191,10 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 		return r.updateStatus(ctx, &mrs, workflow.Failed(err), log)
 	}
 	if len(failedClusterNames) > 0 && !multicluster.ShouldPerformFailover() {
-		log.Warnf("Reconciling with degraded clusters; the following will be skipped this cycle: %+v (automated failover disabled)", failedClusterNames)
+		log.Warnf(
+			"Reconciling with degraded clusters; the following will be skipped this cycle: %+v (automated failover disabled)",
+			failedClusterNames,
+		)
 	}
 
 	r.SetupCommonWatchers(&mrs, nil, nil, mrs.Name)
@@ -181,7 +209,14 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 		internalClusterCertSecretName := mrs.Spec.GetSecurity().InternalClusterAuthSecretName(mrs.Name)
 		// TODO: check if it makes sense to define funcs reading hash in the common controller. See agentCertHashAndPath for a reference.
 		tlsCertHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, mrs.Namespace, certSecretName, "", log)
-		internalClusterCertHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, mrs.Namespace, internalClusterCertSecretName, "", log)
+		internalClusterCertHash := enterprisepem.ReadHashFromSecret(
+			ctx,
+			r.SecretClient,
+			mrs.Namespace,
+			internalClusterCertSecretName,
+			"",
+			log,
+		)
 
 		if internalClusterCertHash != "" {
 			internalClusterCertPath = fmt.Sprintf("%s%s", util.InternalClusterAuthMountPath, internalClusterCertHash)
@@ -199,7 +234,13 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 	// configuration and a subsequent attempt to overwrite it later, the operator would be stuck in Pending phase.
 	// See CLOUDP-189433 and CLOUDP-229222 for more details.
 	if recovery.ShouldTriggerRecovery(mrs.Status.Phase != mdbstatus.PhaseRunning, mrs.Status.LastTransition) {
-		log.Warnf("Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s", mrs.Namespace, mrs.Name, mrs.Status.Phase, mrs.Status.LastTransition)
+		log.Warnf(
+			"Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s",
+			mrs.Namespace,
+			mrs.Name,
+			mrs.Status.Phase,
+			mrs.Status.LastTransition,
+		)
 		automationConfigError := r.updateOmDeploymentRs(ctx, conn, mrs, agentCertPath, tlsCertPath, internalClusterCertPath, true, log)
 		reconcileStatus := r.reconcileMemberResources(ctx, &mrs, log, conn, projectConfig, agentCertHash)
 		if !reconcileStatus.IsOK() {
@@ -248,7 +289,12 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 
 	needToRequeue := !clusterSpecListsEqual(actualSpecList, desiredSpecList)
 	if needToRequeue {
-		return r.updateStatus(ctx, &mrs, workflow.Pending("MongoDBMultiCluster deployment is not yet ready, requeuing reconciliation."), log)
+		return r.updateStatus(
+			ctx,
+			&mrs,
+			workflow.Pending("MongoDBMultiCluster deployment is not yet ready, requeuing reconciliation."),
+			log,
+		)
 	}
 
 	log.Infow("Finished reconciliation for MultiReplicaSet", "Spec", mrs.Spec, "Status", mrs.Status)
@@ -257,7 +303,11 @@ func (r *ReconcileMongoDbMultiReplicaSet) Reconcile(ctx context.Context, request
 
 // publishAutomationConfigFirstMultiCluster returns a boolean indicating whether Ops Manager
 // needs to be updated before the StatefulSets are created for this resource.
-func (r *ReconcileMongoDbMultiReplicaSet) publishAutomationConfigFirstMultiCluster(ctx context.Context, mrs *mdbmultiv1.MongoDBMultiCluster, log *zap.SugaredLogger) (bool, error) {
+func (r *ReconcileMongoDbMultiReplicaSet) publishAutomationConfigFirstMultiCluster(
+	ctx context.Context,
+	mrs *mdbmultiv1.MongoDBMultiCluster,
+	log *zap.SugaredLogger,
+) (bool, error) {
 	if architectures.IsRunningStaticArchitecture(mrs.Annotations, r.defaultArchitecture) {
 		if mrs.IsInChangeVersion() {
 			return true, nil
@@ -332,7 +382,10 @@ func isScalingDown(mrs *mdbmultiv1.MongoDBMultiCluster) (bool, error) {
 	return false, nil
 }
 
-func (r *ReconcileMongoDbMultiReplicaSet) firstStatefulSet(ctx context.Context, mrs *mdbmultiv1.MongoDBMultiCluster) (appsv1.StatefulSet, error) {
+func (r *ReconcileMongoDbMultiReplicaSet) firstStatefulSet(
+	ctx context.Context,
+	mrs *mdbmultiv1.MongoDBMultiCluster,
+) (appsv1.StatefulSet, error) {
 	// We want to get an existing statefulset, so we should fetch the client from "mrs.Spec.ClusterSpecList.ClusterSpecs"
 	// instead of mrs.GetClusterSpecItems(), since the later returns the effective clusterspecs, which might return
 	// clusters which have been removed and do not have a running statefulset.
@@ -367,7 +420,14 @@ func (r *ReconcileMongoDbMultiReplicaSet) firstStatefulSet(ctx context.Context, 
 // reconcileMemberResources handles the synchronization of kubernetes resources, which can be statefulsets, services etc.
 // All the resources required in the k8s cluster (as opposed to the automation config) for creating the replicaset
 // should be reconciled in this method.
-func (r *ReconcileMongoDbMultiReplicaSet) reconcileMemberResources(ctx context.Context, mrs *mdbmultiv1.MongoDBMultiCluster, log *zap.SugaredLogger, conn om.Connection, projectConfig mdb.ProjectConfig, agentCertHash string) workflow.Status {
+func (r *ReconcileMongoDbMultiReplicaSet) reconcileMemberResources(
+	ctx context.Context,
+	mrs *mdbmultiv1.MongoDBMultiCluster,
+	log *zap.SugaredLogger,
+	conn om.Connection,
+	projectConfig mdb.ProjectConfig,
+	agentCertHash string,
+) workflow.Status {
 	err := r.reconcileServices(ctx, log, mrs)
 	if err != nil {
 		return workflow.Failed(err)
@@ -400,7 +460,14 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileMemberResources(ctx context.C
 	return r.reconcileStatefulSets(ctx, mrs, log, conn, projectConfig, agentCertHash)
 }
 
-func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(ctx context.Context, mrs *mdbmultiv1.MongoDBMultiCluster, log *zap.SugaredLogger, conn om.Connection, projectConfig mdb.ProjectConfig, agentCertHash string) workflow.Status {
+func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(
+	ctx context.Context,
+	mrs *mdbmultiv1.MongoDBMultiCluster,
+	log *zap.SugaredLogger,
+	conn om.Connection,
+	projectConfig mdb.ProjectConfig,
+	agentCertHash string,
+) workflow.Status {
 	clusterSpecList, err := mrs.GetClusterSpecItems()
 	if err != nil {
 		return workflow.Failed(xerrors.Errorf("failed to read cluster spec list: %w", err))
@@ -494,8 +561,20 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(ctx context.Cont
 
 		// get cert hash of tls secret if it exists
 		certHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, mrs.Namespace, mrsConfig.CertSecretName, "", log)
-		internalCertHash := enterprisepem.ReadHashFromSecret(ctx, r.SecretClient, mrs.Namespace, mrsConfig.InternalClusterSecretName, "", log)
-		log.Debugf("Creating StatefulSet %s with %d replicas in cluster: %s", mrs.MultiStatefulsetName(clusterNum), replicasThisReconciliation, item.ClusterName)
+		internalCertHash := enterprisepem.ReadHashFromSecret(
+			ctx,
+			r.SecretClient,
+			mrs.Namespace,
+			mrsConfig.InternalClusterSecretName,
+			"",
+			log,
+		)
+		log.Debugf(
+			"Creating StatefulSet %s with %d replicas in cluster: %s",
+			mrs.MultiStatefulsetName(clusterNum),
+			replicasThisReconciliation,
+			item.ClusterName,
+		)
 
 		stsOverride := appsv1.StatefulSetSpec{}
 		if item.StatefulSetConfiguration != nil {
@@ -525,8 +604,12 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(ctx context.Cont
 			InternalClusterHash(internalCertHash),
 			WithLabels(mrs.GetOwnerLabels()),
 			WithAdditionalMongodConfig(mrs.Spec.GetAdditionalMongodConfig()),
-			WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
-			WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
+			WithInitDatabaseNonStaticImage(
+				images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion),
+			),
+			WithDatabaseNonStaticImage(
+				images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion),
+			),
 			WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, automationAgentVersion)),
 			WithCustomAgentURL(r.customAgentURL),
 
@@ -587,7 +670,12 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileStatefulSets(ctx context.Cont
 
 // updateStatusFromInnerMethod ensures to only update the status if it has been updated.
 // Since spec.Mapping is just a cache, it would be replaced; therefore, we need to cache it
-func (r *ReconcileMongoDbMultiReplicaSet) updateStatusFromInnerMethod(ctx context.Context, mrs *mdbmultiv1.MongoDBMultiCluster, log *zap.SugaredLogger, workflowStatus workflow.Status) error {
+func (r *ReconcileMongoDbMultiReplicaSet) updateStatusFromInnerMethod(
+	ctx context.Context,
+	mrs *mdbmultiv1.MongoDBMultiCluster,
+	log *zap.SugaredLogger,
+	workflowStatus workflow.Status,
+) error {
 	// if there are no pvc changes, then we don't need to update the status
 	if !workflow.ContainsPVCOption(workflowStatus.StatusOptions()) {
 		return nil
@@ -644,7 +732,11 @@ func getMembersForClusterSpecItemThisReconciliation(mrs *mdbmultiv1.MongoDBMulti
 }
 
 // saveLastAchievedSpec updates the MongoDBMultiCluster resource with the spec that was just achieved.
-func (r *ReconcileMongoDbMultiReplicaSet) saveLastAchievedSpec(ctx context.Context, mrs mdbmultiv1.MongoDBMultiCluster, rsMemberIds map[string]map[string]int) error {
+func (r *ReconcileMongoDbMultiReplicaSet) saveLastAchievedSpec(
+	ctx context.Context,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+	rsMemberIds map[string]map[string]int,
+) error {
 	clusterSpecs, err := mrs.GetClusterSpecItems()
 	if err != nil {
 		return err
@@ -685,7 +777,12 @@ func (r *ReconcileMongoDbMultiReplicaSet) saveLastAchievedSpec(ctx context.Conte
 	}
 
 	// Set annotation and state for previously configured roles
-	roleAnnotation, _, err := r.getRoleAnnotation(ctx, mrs.Spec.DbCommonSpec, r.enableClusterMongoDBRoles, kube.ObjectKeyFromApiObject(&mrs))
+	roleAnnotation, _, err := r.getRoleAnnotation(
+		ctx,
+		mrs.Spec.DbCommonSpec,
+		r.enableClusterMongoDBRoles,
+		kube.ObjectKeyFromApiObject(&mrs),
+	)
 	if err != nil {
 		return err
 	}
@@ -698,7 +795,14 @@ func (r *ReconcileMongoDbMultiReplicaSet) saveLastAchievedSpec(ctx context.Conte
 
 // updateOmDeploymentRs performs OM registration operation for the replicaset. So the changes will be finally propagated
 // to automation agents in containers
-func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Context, conn om.Connection, mrs mdbmultiv1.MongoDBMultiCluster, agentCertPath, tlsCertPath, internalClusterCertPath string, isRecovering bool, log *zap.SugaredLogger) error {
+func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(
+	ctx context.Context,
+	conn om.Connection,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+	agentCertPath, tlsCertPath, internalClusterCertPath string,
+	isRecovering bool,
+	log *zap.SugaredLogger,
+) error {
 	reachableHostnames := make([]string, 0)
 
 	clusterSpecList, err := mrs.GetClusterSpecItems()
@@ -712,13 +816,24 @@ func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Conte
 		log.Errorf("failed retrieving list of failed clusters: %s", err.Error())
 	}
 	for _, spec := range clusterSpecList {
-		hostnamesToAdd := dns.GetMultiClusterProcessHostnames(mrs.Name, mrs.Namespace, mrs.ClusterNum(spec.ClusterName), spec.Members, mrs.Spec.GetClusterDomain(), mrs.Spec.GetExternalDomainForMemberCluster(spec.ClusterName))
+		hostnamesToAdd := dns.GetMultiClusterProcessHostnames(
+			mrs.Name,
+			mrs.Namespace,
+			mrs.ClusterNum(spec.ClusterName),
+			spec.Members,
+			mrs.Spec.GetClusterDomain(),
+			mrs.Spec.GetExternalDomainForMemberCluster(spec.ClusterName),
+		)
 		if stringutil.Contains(failedClusterNames, spec.ClusterName) {
 			log.Debugf("Skipping hostnames %+v as they are part of the failed cluster %s ", hostnamesToAdd, spec.ClusterName)
 			continue
 		}
 		if mrs.GetClusterSpecByName(spec.ClusterName) == nil {
-			log.Debugf("Skipping hostnames %+v as they are part of a cluster not known by the operator %s ", hostnamesToAdd, spec.ClusterName)
+			log.Debugf(
+				"Skipping hostnames %+v as they are part of a cluster not known by the operator %s ",
+				hostnamesToAdd,
+				spec.ClusterName,
+			)
 			continue
 		}
 		reachableHostnames = append(reachableHostnames, hostnamesToAdd...)
@@ -746,19 +861,45 @@ func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Conte
 	}
 	log.Debugf("Existing process Ids: %+v", processIds)
 
-	processes, err := process.CreateMongodProcessesWithLimitMulti(r.imageUrls[util.MongodbImageEnv], r.forceEnterprise, mrs, tlsCertPath, r.defaultArchitecture)
+	processes, err := process.CreateMongodProcessesWithLimitMulti(
+		r.imageUrls[util.MongodbImageEnv],
+		r.forceEnterprise,
+		mrs,
+		tlsCertPath,
+		r.defaultArchitecture,
+	)
 	if err != nil && !isRecovering {
 		return err
 	}
 
 	if len(processes) != len(mrs.Spec.GetMemberOptions()) {
-		log.Warnf("the number of member options is different than the number of mongod processes to be created: %d processes - %d replica set member options", len(processes), len(mrs.Spec.GetMemberOptions()))
+		log.Warnf(
+			"the number of member options is different than the number of mongod processes to be created: %d processes - %d replica set member options",
+			len(processes),
+			len(mrs.Spec.GetMemberOptions()),
+		)
 	}
-	rs := om.NewMultiClusterReplicaSetWithProcesses(om.NewReplicaSet(mrs.Name, mrs.Spec.Version), processes, mrs.Spec.GetMemberOptions(), processIds, mrs.Spec.Connectivity)
+	rs := om.NewMultiClusterReplicaSetWithProcesses(
+		om.NewReplicaSet(mrs.Name, mrs.Spec.Version),
+		processes,
+		mrs.Spec.GetMemberOptions(),
+		processIds,
+		mrs.Spec.Connectivity,
+	)
 
 	caFilePath := fmt.Sprintf("%s/ca-pem", util.TLSCaMountPath)
 
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, rs.GetProcessNames(), &mrs, agentCertPath, caFilePath, internalClusterCertPath, isRecovering, log)
+	status, additionalReconciliationRequired := r.updateOmAuthentication(
+		ctx,
+		conn,
+		rs.GetProcessNames(),
+		&mrs,
+		agentCertPath,
+		caFilePath,
+		internalClusterCertPath,
+		isRecovering,
+		log,
+	)
 	if !status.IsOK() && !isRecovering {
 		return xerrors.Errorf("failed to enable Authentication for MongoDB Multi Replicaset")
 	}
@@ -767,7 +908,18 @@ func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Conte
 
 	err = conn.ReadUpdateDeployment(
 		func(d om.Deployment) error {
-			return ReconcileReplicaSetAC(ctx, d, mrs.Spec.DbCommonSpec, lastMongodbConfig, mrs.Name, rs, caFilePath, internalClusterCertPath, nil, log)
+			return ReconcileReplicaSetAC(
+				ctx,
+				d,
+				mrs.Spec.DbCommonSpec,
+				lastMongodbConfig,
+				mrs.Name,
+				rs,
+				caFilePath,
+				internalClusterCertPath,
+				nil,
+				log,
+			)
 		},
 		log,
 	)
@@ -913,7 +1065,11 @@ func getService(mrs *mdbmultiv1.MongoDBMultiCluster, clusterName string, podNum 
 
 // reconcileServices makes sure that we have a service object corresponding to each statefulset pod
 // in the member clusters
-func (r *ReconcileMongoDbMultiReplicaSet) reconcileServices(ctx context.Context, log *zap.SugaredLogger, mrs *mdbmultiv1.MongoDBMultiCluster) error {
+func (r *ReconcileMongoDbMultiReplicaSet) reconcileServices(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	mrs *mdbmultiv1.MongoDBMultiCluster,
+) error {
 	clusterSpecList, err := mrs.GetClusterSpecItems()
 	if err != nil {
 		return err
@@ -949,7 +1105,14 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileServices(ctx context.Context,
 		// ensure Headless service
 		headlessServiceName := mrs.MultiHeadlessServiceName(mrs.ClusterNum(e.ClusterName))
 		nameSpacedName := kube.ObjectKey(mrs.Namespace, headlessServiceName)
-		headlessService := create.BuildService(nameSpacedName, mrs, ptr.To(headlessServiceName), nil, mrs.Spec.AdditionalMongodConfig.GetPortOrDefault(), omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP})
+		headlessService := create.BuildService(
+			nameSpacedName,
+			mrs,
+			ptr.To(headlessServiceName),
+			nil,
+			mrs.Spec.AdditionalMongodConfig.GetPortOrDefault(),
+			omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP},
+		)
 		headlessService.OwnerReferences = nil
 		if err := ensureHeadlessService(ctx, client, headlessService, e.ClusterName); err != nil {
 			return err
@@ -995,15 +1158,36 @@ func ensureSRVService(ctx context.Context, client service.GetUpdateCreator, svc 
 // so there is no point in creating pod services.
 // But when external domains are not used, then mongod process hostnames use pod service FQDN, and
 // at the same time user might want to expose externally using external services.
-func ensureServices(ctx context.Context, client service.GetUpdateCreator, clientClusterName string, m *mdbmultiv1.MongoDBMultiCluster, clusterSpecItem mdb.ClusterSpecItem, log *zap.SugaredLogger) error {
+func ensureServices(
+	ctx context.Context,
+	client service.GetUpdateCreator,
+	clientClusterName string,
+	m *mdbmultiv1.MongoDBMultiCluster,
+	clusterSpecItem mdb.ClusterSpecItem,
+	log *zap.SugaredLogger,
+) error {
 	for podNum := 0; podNum < clusterSpecItem.Members; podNum++ {
 		var svc corev1.Service
 		if m.Spec.GetExternalAccessConfigurationForMemberCluster(clusterSpecItem.ClusterName) != nil {
 			svc = getExternalService(m, clusterSpecItem.ClusterName, podNum)
 			externalDomain := m.Spec.GetExternalDomainForMemberCluster(clusterSpecItem.ClusterName)
-			placeholderReplacer := create.GetMultiClusterMongoDBPlaceholderReplacer(m.Name, m.Name, m.Namespace, clusterSpecItem.ClusterName, m.ClusterNum(clusterSpecItem.ClusterName), externalDomain, m.Spec.ClusterDomain, podNum)
+			placeholderReplacer := create.GetMultiClusterMongoDBPlaceholderReplacer(
+				m.Name,
+				m.Name,
+				m.Namespace,
+				clusterSpecItem.ClusterName,
+				m.ClusterNum(clusterSpecItem.ClusterName),
+				externalDomain,
+				m.Spec.ClusterDomain,
+				podNum,
+			)
 			if processedAnnotations, replacedFlag, err := placeholderReplacer.ProcessMap(svc.Annotations); err != nil {
-				return xerrors.Errorf("failed to process annotations in external service %s in cluster %s: %w", svc.Name, clientClusterName, err)
+				return xerrors.Errorf(
+					"failed to process annotations in external service %s in cluster %s: %w",
+					svc.Name,
+					clientClusterName,
+					err,
+				)
 			} else if replacedFlag {
 				log.Debugf("Replaced placeholders in annotations in external service %s in cluster: %s. Annotations before: %+v, annotations after: %+v", svc.Name, clientClusterName, svc.Annotations, processedAnnotations)
 				svc.Annotations = processedAnnotations
@@ -1041,7 +1225,14 @@ func getHostnameOverrideConfigMap(mrs mdbmultiv1.MongoDBMultiCluster, clusterNum
 	externalDomain := mrs.Spec.GetExternalDomainForMemberCluster(clusterName)
 	for podNum := 0; podNum < members; podNum++ {
 		key := dns.GetMultiPodName(mrs.Name, clusterNum, podNum)
-		data[key] = dns.GetMultiClusterPodServiceFQDN(mrs.Name, mrs.Namespace, clusterNum, externalDomain, podNum, mrs.Spec.GetClusterDomain())
+		data[key] = dns.GetMultiClusterPodServiceFQDN(
+			mrs.Name,
+			mrs.Namespace,
+			clusterNum,
+			externalDomain,
+			podNum,
+			mrs.Spec.GetClusterDomain(),
+		)
 	}
 
 	cm := corev1.ConfigMap{
@@ -1055,7 +1246,11 @@ func getHostnameOverrideConfigMap(mrs mdbmultiv1.MongoDBMultiCluster, clusterNum
 	return cm
 }
 
-func (r *ReconcileMongoDbMultiReplicaSet) reconcileHostnameOverrideConfigMap(ctx context.Context, log *zap.SugaredLogger, mrs mdbmultiv1.MongoDBMultiCluster) error {
+func (r *ReconcileMongoDbMultiReplicaSet) reconcileHostnameOverrideConfigMap(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+) error {
 	clusterSpecList, err := mrs.GetClusterSpecItems()
 	if err != nil {
 		return err
@@ -1088,7 +1283,12 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileHostnameOverrideConfigMap(ctx
 	return nil
 }
 
-func (r *ReconcileMongoDbMultiReplicaSet) reconcileOMCAConfigMap(ctx context.Context, log *zap.SugaredLogger, mrs mdbmultiv1.MongoDBMultiCluster, configMapName string) error {
+func (r *ReconcileMongoDbMultiReplicaSet) reconcileOMCAConfigMap(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+	configMapName string,
+) error {
 	clusterSpecList, err := mrs.GetClusterSpecItems()
 	if err != nil {
 		return err
@@ -1120,10 +1320,37 @@ func (r *ReconcileMongoDbMultiReplicaSet) reconcileOMCAConfigMap(ctx context.Con
 
 // AddMultiReplicaSetController creates a new MongoDbMultiReplicaset Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, requiredHealthyStreak int, memberClustersMap map[string]cluster.Cluster) error {
+func AddMultiReplicaSetController(
+	ctx context.Context,
+	mgr manager.Manager,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	requiredHealthyStreak int,
+	memberClustersMap map[string]cluster.Cluster,
+) error {
 	// Create a new controller
-	reconciler := newMultiClusterReplicaSetReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, om.NewOpsManagerConnection, multicluster.ClustersMapToClientMap(memberClustersMap))
-	c, err := controller.New(util.MongoDbMultiClusterController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	reconciler := newMultiClusterReplicaSetReconciler(
+		ctx,
+		mgr.GetClient(),
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		forceEnterprise,
+		enableClusterMongoDBRoles,
+		agentDebug,
+		agentDebugImage,
+		defaultArchitecture,
+		om.NewOpsManagerConnection,
+		multicluster.ClustersMapToClientMap(memberClustersMap),
+	)
+	c, err := controller.New(
+		util.MongoDbMultiClusterController,
+		mgr,
+		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)},
+	) // nolint:forbidigo
 	if err != nil {
 		return err
 	}
@@ -1170,7 +1397,14 @@ func AddMultiReplicaSetController(ctx context.Context, mgr manager.Manager, imag
 	}
 
 	for clusterName, memberCluster := range memberClustersMap {
-		err = c.Watch(source.Kind[client.Object](memberCluster.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
+		err = c.Watch(
+			source.Kind[client.Object](
+				memberCluster.GetCache(),
+				&appsv1.StatefulSet{},
+				&khandler.EnqueueRequestForOwnerMultiCluster{},
+				watch.PredicatesForMultiStatefulSet(),
+			),
+		)
 		if err != nil {
 			return xerrors.Errorf("failed to set StatefulSet watch on member cluster %s: %w", clusterName, err)
 		}
@@ -1212,14 +1446,27 @@ func (r *ReconcileMongoDbMultiReplicaSet) OnDelete(ctx context.Context, obj runt
 }
 
 // cleanOpsManagerState removes the project configuration (processes, auth settings etc.) from the corresponding OM project.
-func (r *ReconcileMongoDbMultiReplicaSet) cleanOpsManagerState(ctx context.Context, mrs mdbmultiv1.MongoDBMultiCluster, log *zap.SugaredLogger) error {
+func (r *ReconcileMongoDbMultiReplicaSet) cleanOpsManagerState(
+	ctx context.Context,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+	log *zap.SugaredLogger,
+) error {
 	projectConfig, credsConfig, err := project.ReadConfigAndCredentials(ctx, r.client, r.SecretClient, &mrs, log)
 	if err != nil {
 		return err
 	}
 
 	log.Infow("Removing replica set from Ops Manager", "config", mrs.Spec)
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, mrs.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		mrs.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return err
 	}
@@ -1255,7 +1502,10 @@ func (r *ReconcileMongoDbMultiReplicaSet) cleanOpsManagerState(ctx context.Conte
 		log.Infow("Stop monitoring removed hosts in Ops Manager", "removedHosts", hostsToRemove)
 		if err := host.StopMonitoring(conn, hostsToRemove, log); err != nil {
 			// StopMonitoring may fail with 401 if hosts are already removed or auth is misconfigured.
-			errs = multierror.Append(errs, xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err))
+			errs = multierror.Append(
+				errs,
+				xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err),
+			)
 		}
 	}
 
@@ -1278,7 +1528,11 @@ func (r *ReconcileMongoDbMultiReplicaSet) cleanOpsManagerState(ctx context.Conte
 }
 
 // deleteManagedResources deletes resources across all member clusters that are owned by this MongoDBMultiCluster resource.
-func (r *ReconcileMongoDbMultiReplicaSet) deleteManagedResources(ctx context.Context, mrs mdbmultiv1.MongoDBMultiCluster, log *zap.SugaredLogger) error {
+func (r *ReconcileMongoDbMultiReplicaSet) deleteManagedResources(
+	ctx context.Context,
+	mrs mdbmultiv1.MongoDBMultiCluster,
+	log *zap.SugaredLogger,
+) error {
 	var errs error
 	if err := r.cleanOpsManagerState(ctx, mrs, log); err != nil {
 		errs = multierror.Append(errs, err)

--- a/controllers/operator/mongodbmultireplicaset_controller_test.go
+++ b/controllers/operator/mongodbmultireplicaset_controller_test.go
@@ -52,7 +52,14 @@ func init() {
 
 var clusters = []string{"api1.kube.com", "api2.kube.com", "api3.kube.com"}
 
-func checkMultiReconcileSuccessful(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, m *mdbmulti.MongoDBMultiCluster, client client.Client, shouldRequeue bool) {
+func checkMultiReconcileSuccessful(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	m *mdbmulti.MongoDBMultiCluster,
+	client client.Client,
+	shouldRequeue bool,
+) {
 	err := client.Update(ctx, m)
 	assert.NoError(t, err)
 
@@ -109,7 +116,14 @@ func TestMultiReplicaSetClusterReconcileContainerImages(t *testing.T) {
 
 	ctx := context.Background()
 	mrs := mdbmulti.DefaultMultiReplicaSetBuilder().SetClusterSpecList(clusters).SetVersion("8.0.0").Build()
-	reconciler, kubeClient, memberClients, _ := defaultMultiReplicaSetReconciler(ctx, imageUrlsMock, "2.0.0", "1.0.0", mrs, architectures.NonStatic)
+	reconciler, kubeClient, memberClients, _ := defaultMultiReplicaSetReconciler(
+		ctx,
+		imageUrlsMock,
+		"2.0.0",
+		"1.0.0",
+		mrs,
+		architectures.NonStatic,
+	)
 
 	checkMultiReconcileSuccessful(ctx, t, reconciler, mrs, kubeClient, false)
 
@@ -126,8 +140,16 @@ func TestMultiReplicaSetClusterReconcileContainerImages(t *testing.T) {
 			require.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 
-			assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE", sts.Spec.Template.Spec.InitContainers[0].Image)
-			assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-database:@sha256:MONGODB_DATABASE", sts.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE",
+				sts.Spec.Template.Spec.InitContainers[0].Image,
+			)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-kubernetes-database:@sha256:MONGODB_DATABASE",
+				sts.Spec.Template.Spec.Containers[0].Image,
+			)
 		})
 	}
 }
@@ -143,7 +165,14 @@ func TestMultiReplicaSetClusterReconcileContainerImagesWithStaticArchitecture(t 
 
 	ctx := context.Background()
 	mrs := mdbmulti.DefaultMultiReplicaSetBuilder().SetClusterSpecList(clusters).SetVersion("8.0.0").Build()
-	reconciler, kubeClient, memberClients, omConnectionFactory := defaultMultiReplicaSetReconciler(ctx, imageUrlsMock, "", "", mrs, architectures.Static)
+	reconciler, kubeClient, memberClients, omConnectionFactory := defaultMultiReplicaSetReconciler(
+		ctx,
+		imageUrlsMock,
+		"",
+		"",
+		mrs,
+		architectures.Static,
+	)
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
 		connection.(*om.MockedOmConnection).SetAgentVersion("12.0.30.7791-1", "")
 	})
@@ -208,7 +237,9 @@ func TestReconcilePVCResizeMultiCluster(t *testing.T) {
 		createdConfigPVCs := getPVCsMulti(t, ctx, mrs, clusterMap)
 
 		newSize := "2Gi"
-		configuration.SpecWrapper.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests = map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: resource.MustParse(newSize)}
+		configuration.SpecWrapper.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests = map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceStorage: resource.MustParse(newSize),
+		}
 		mrs.Spec.StatefulSetConfiguration = &configuration
 		err := c.Update(ctx, mrs)
 		assert.NoError(t, err)
@@ -301,7 +332,12 @@ type pvcClient struct {
 	client                 client.Client
 }
 
-func getPVCsMulti(t *testing.T, ctx context.Context, mrs *mdbmulti.MongoDBMultiCluster, memberClusterMap map[string]client.Client) []pvcClient {
+func getPVCsMulti(
+	t *testing.T,
+	ctx context.Context,
+	mrs *mdbmulti.MongoDBMultiCluster,
+	memberClusterMap map[string]client.Client,
+) []pvcClient {
 	var createdConfigPVCs []pvcClient
 	for _, item := range mrs.Spec.ClusterSpecList {
 		c := memberClusterMap[item.ClusterName]
@@ -321,7 +357,14 @@ func testNoResizeMulti(t *testing.T, c kubernetesClient.Client, ctx context.Cont
 	assert.Nil(t, m.Status.PVCs)
 }
 
-func testMDBStatusMulti(t *testing.T, c kubernetesClient.Client, ctx context.Context, mrs *mdbmulti.MongoDBMultiCluster, expectedMDBPhase status.Phase, expectedPVCS status.PVCS) {
+func testMDBStatusMulti(
+	t *testing.T,
+	c kubernetesClient.Client,
+	ctx context.Context,
+	mrs *mdbmulti.MongoDBMultiCluster,
+	expectedMDBPhase status.Phase,
+	expectedPVCS status.PVCS,
+) {
 	m := mdbmulti.MongoDBMultiCluster{}
 	err := c.Get(ctx, kube.ObjectKey(mrs.Namespace, mrs.Name), &m)
 	require.NoError(t, err)
@@ -348,8 +391,12 @@ func TestMultiClusterConfigMapAndSecretWatched(t *testing.T) {
 	checkMultiReconcileSuccessful(ctx, t, reconciler, mrs, client, false)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, mrs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, mrs.Spec.Credentials)}:             {kube.ObjectKey(mock.TestNamespace, mrs.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, mrs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, mrs.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, mrs.Name),
+		},
 	}
 
 	assert.Equal(t, reconciler.resourceWatcher.GetWatchedResources(), expected)
@@ -576,7 +623,14 @@ func TestResourceDeletion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			mrs := tc.create()
-			reconciler, client, memberClients, omConnectionFactory := defaultMultiReplicaSetReconciler(ctx, nil, "", "", mrs, architectures.NonStatic)
+			reconciler, client, memberClients, omConnectionFactory := defaultMultiReplicaSetReconciler(
+				ctx,
+				nil,
+				"",
+				"",
+				mrs,
+				architectures.NonStatic,
+			)
 			checkMultiReconcileSuccessful(ctx, t, reconciler, mrs, client, false)
 
 			t.Run("Resources are created", func(t *testing.T) {
@@ -790,7 +844,20 @@ func TestMultiReplicaSetRace(t *testing.T) {
 
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory().WithResourceToProjectMapping(resourceToProjectMapping)
 	memberClusterMap := getFakeMultiClusterMapWithConfiguredInterceptor(clusters, omConnectionFactory, true, true)
-	reconciler := newMultiClusterReplicaSetReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc, memberClusterMap)
+	reconciler := newMultiClusterReplicaSetReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+		memberClusterMap,
+	)
 
 	testConcurrentReconciles(ctx, t, fakeClient, reconciler, rs1, rs2, rs3)
 }
@@ -842,7 +909,14 @@ func TestScaling(t *testing.T) {
 		mrs.Spec.ClusterSpecList[0].StatefulSetConfiguration = stsWrapper
 		mrs.Spec.ClusterSpecList[1].Members = 1
 		mrs.Spec.ClusterSpecList[2].Members = 1
-		reconciler, client, memberClusters, omConnectionFactory := defaultMultiReplicaSetReconciler(ctx, nil, "", "", mrs, architectures.NonStatic)
+		reconciler, client, memberClusters, omConnectionFactory := defaultMultiReplicaSetReconciler(
+			ctx,
+			nil,
+			"",
+			"",
+			mrs,
+			architectures.NonStatic,
+		)
 
 		checkMultiReconcileSuccessful(ctx, t, reconciler, mrs, client, false)
 		statefulSets := readStatefulSets(ctx, mrs, memberClusters)
@@ -888,7 +962,14 @@ func TestScaling(t *testing.T) {
 		mrs.Spec.ClusterSpecList[0].Members = 3
 		mrs.Spec.ClusterSpecList[1].Members = 2
 		mrs.Spec.ClusterSpecList[2].Members = 3
-		reconciler, client, memberClusters, omConnectionFactory := defaultMultiReplicaSetReconciler(ctx, nil, "", "", mrs, architectures.NonStatic)
+		reconciler, client, memberClusters, omConnectionFactory := defaultMultiReplicaSetReconciler(
+			ctx,
+			nil,
+			"",
+			"",
+			mrs,
+			architectures.NonStatic,
+		)
 
 		checkMultiReconcileSuccessful(ctx, t, reconciler, mrs, client, false)
 		statefulSets := readStatefulSets(ctx, mrs, memberClusters)
@@ -1411,7 +1492,14 @@ func TestMultiReplicaSet_AgentVersionMapping(t *testing.T) {
 
 	t.Run("Static architecture, version retrieving fails, image is overriden, reconciliation should succeeds", func(t *testing.T) {
 		t.Setenv(agentVersionManagement.MappingFilePathEnv, nonExistingPath)
-		overridenReconciler, overridenClient, _, _ := defaultMultiReplicaSetReconciler(ctx, nil, "", "", overridenResource, architectures.Static)
+		overridenReconciler, overridenClient, _, _ := defaultMultiReplicaSetReconciler(
+			ctx,
+			nil,
+			"",
+			"",
+			overridenResource,
+			architectures.Static,
+		)
 		checkMultiReconcileSuccessful(ctx, t, overridenReconciler, overridenResource, overridenClient, false)
 	})
 
@@ -1501,7 +1589,13 @@ func assertClusterpresent(t *testing.T, m map[string]int, specs mdb.ClusterSpecL
 	assert.Equal(t, arr, tmp)
 }
 
-func assertStatefulSetReplicas(ctx context.Context, t *testing.T, mrs *mdbmulti.MongoDBMultiCluster, memberClusters map[string]client.Client, expectedReplicas ...int) {
+func assertStatefulSetReplicas(
+	ctx context.Context,
+	t *testing.T,
+	mrs *mdbmulti.MongoDBMultiCluster,
+	memberClusters map[string]client.Client,
+	expectedReplicas ...int,
+) {
 	statefulSets := readStatefulSets(ctx, mrs, memberClusters)
 
 	for i := range expectedReplicas {
@@ -1511,7 +1605,11 @@ func assertStatefulSetReplicas(ctx context.Context, t *testing.T, mrs *mdbmulti.
 	}
 }
 
-func readStatefulSets(ctx context.Context, mrs *mdbmulti.MongoDBMultiCluster, memberClusters map[string]client.Client) map[string]appsv1.StatefulSet {
+func readStatefulSets(
+	ctx context.Context,
+	mrs *mdbmulti.MongoDBMultiCluster,
+	memberClusters map[string]client.Client,
+) map[string]appsv1.StatefulSet {
 	allStatefulSets := map[string]appsv1.StatefulSet{}
 	clusterSpecList, err := mrs.GetClusterSpecItems()
 	if err != nil {
@@ -1547,8 +1645,21 @@ func specsAreEqual(spec1, spec2 mdbmulti.MongoDBMultiSpec) (bool, error) {
 	return bytes.Equal(spec1Bytes, spec2Bytes), nil
 }
 
-func defaultMultiReplicaSetReconciler(ctx context.Context, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, m *mdbmulti.MongoDBMultiCluster, arch architectures.DefaultArchitecture) (*ReconcileMongoDbMultiReplicaSet, kubernetesClient.Client, map[string]client.Client, *om.CachedOMConnectionFactory) {
-	multiReplicaSetController, client, clusterMap, omConnectionFactory := multiReplicaSetReconciler(ctx, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, m, arch)
+func defaultMultiReplicaSetReconciler(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	m *mdbmulti.MongoDBMultiCluster,
+	arch architectures.DefaultArchitecture,
+) (*ReconcileMongoDbMultiReplicaSet, kubernetesClient.Client, map[string]client.Client, *om.CachedOMConnectionFactory) {
+	multiReplicaSetController, client, clusterMap, omConnectionFactory := multiReplicaSetReconciler(
+		ctx,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		m,
+		arch,
+	)
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
 		connection.(*om.MockedOmConnection).Hostnames = calculateHostNamesForExternalDomains(m)
 	})
@@ -1576,10 +1687,29 @@ func calculateHostNamesForExternalDomains(m *mdbmulti.MongoDBMultiCluster) []str
 	return expectedHostnames
 }
 
-func multiReplicaSetReconciler(ctx context.Context, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, m *mdbmulti.MongoDBMultiCluster, arch architectures.DefaultArchitecture) (*ReconcileMongoDbMultiReplicaSet, kubernetesClient.Client, map[string]client.Client, *om.CachedOMConnectionFactory) {
+func multiReplicaSetReconciler(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	m *mdbmulti.MongoDBMultiCluster,
+	arch architectures.DefaultArchitecture,
+) (*ReconcileMongoDbMultiReplicaSet, kubernetesClient.Client, map[string]client.Client, *om.CachedOMConnectionFactory) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(m)
 	memberClusterMap := getFakeMultiClusterMap(omConnectionFactory)
-	return newMultiClusterReplicaSetReconciler(ctx, kubeClient, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, false, false, false, "", arch, omConnectionFactory.GetConnectionFunc, memberClusterMap), kubeClient, memberClusterMap, omConnectionFactory
+	return newMultiClusterReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		false,
+		false,
+		false,
+		"",
+		arch,
+		omConnectionFactory.GetConnectionFunc,
+		memberClusterMap,
+	), kubeClient, memberClusterMap, omConnectionFactory
 }
 
 func getFakeMultiClusterMap(omConnectionFactory *om.CachedOMConnectionFactory) map[string]client.Client {
@@ -1593,11 +1723,19 @@ func getFakeMultiClusterMapWithClusters(clusters []string, omConnectionFactory *
 // getAppDBFakeMultiClusterMapWithClusters is used for appdb multi cluster tests
 // In AppDB we manually add the hosts in OM by calling the /hosts endpoint.
 // Here we set `addOMHosts` to false so that we can test what hostnames the operator adds.
-func getAppDBFakeMultiClusterMapWithClusters(clusters []string, omConnectionFactory *om.CachedOMConnectionFactory) map[string]client.Client {
+func getAppDBFakeMultiClusterMapWithClusters(
+	clusters []string,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+) map[string]client.Client {
 	return getFakeMultiClusterMapWithConfiguredInterceptor(clusters, omConnectionFactory, true, false)
 }
 
-func getFakeMultiClusterMapWithConfiguredInterceptor(clusters []string, omConnectionFactory *om.CachedOMConnectionFactory, markStsAsReady bool, addOMHosts bool) map[string]client.Client {
+func getFakeMultiClusterMapWithConfiguredInterceptor(
+	clusters []string,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	markStsAsReady bool,
+	addOMHosts bool,
+) map[string]client.Client {
 	clientMap := make(map[string]client.Client)
 
 	for _, e := range clusters {

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -103,7 +103,17 @@ type OpsManagerReconciler struct {
 
 var _ reconcile.Reconciler = &OpsManagerReconciler{}
 
-func NewOpsManagerReconciler(ctx context.Context, kubeClient client.Client, memberClustersMap map[string]client.Client, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string, defaultArchitecture architectures.DefaultArchitecture, omFunc om.ConnectionFactory, initializer api.Initializer, adminProvider api.AdminProvider) *OpsManagerReconciler {
+func NewOpsManagerReconciler(
+	ctx context.Context,
+	kubeClient client.Client,
+	memberClustersMap map[string]client.Client,
+	imageUrls images.ImageUrls,
+	initDatabaseVersion, initOpsManagerImageVersion string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	omFunc om.ConnectionFactory,
+	initializer api.Initializer,
+	adminProvider api.AdminProvider,
+) *OpsManagerReconciler {
 	return &OpsManagerReconciler{
 		ReconcileCommonController:  NewReconcileCommonController(ctx, kubeClient),
 		omConnectionFactory:        omFunc,
@@ -137,13 +147,26 @@ type OpsManagerReconcilerHelper struct {
 	deploymentState *OMDeploymentState
 }
 
-func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) (*OpsManagerReconcilerHelper, error) {
+func NewOpsManagerReconcilerHelper(
+	ctx context.Context,
+	opsManagerReconciler *OpsManagerReconciler,
+	opsManager *omv1.MongoDBOpsManager,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+) (*OpsManagerReconcilerHelper, error) {
 	reconcilerHelper := OpsManagerReconcilerHelper{
 		opsManager: opsManager,
 	}
 
 	if !opsManager.Spec.IsMultiCluster() {
-		reconcilerHelper.memberClusters = []multicluster.MemberCluster{multicluster.GetLegacyCentralMemberCluster(opsManager.Spec.Replicas, 0, opsManagerReconciler.client, opsManagerReconciler.SecretClient)}
+		reconcilerHelper.memberClusters = []multicluster.MemberCluster{
+			multicluster.GetLegacyCentralMemberCluster(
+				opsManager.Spec.Replicas,
+				0,
+				opsManagerReconciler.client,
+				opsManagerReconciler.SecretClient,
+			),
+		}
 		return &reconcilerHelper, nil
 	}
 
@@ -197,7 +220,14 @@ func NewOpsManagerReconcilerHelper(ctx context.Context, opsManagerReconciler *Op
 	return &reconcilerHelper, nil
 }
 
-func (r *OpsManagerReconcilerHelper) initializeStateStore(ctx context.Context, reconciler *OpsManagerReconciler, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger, clusterNamesFromClusterSpecList []string) error {
+func (r *OpsManagerReconcilerHelper) initializeStateStore(
+	ctx context.Context,
+	reconciler *OpsManagerReconciler,
+	opsManager *omv1.MongoDBOpsManager,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+	clusterNamesFromClusterSpecList []string,
+) error {
 	r.deploymentState = NewOMDeploymentState()
 
 	r.stateStore = NewStateStore[OMDeploymentState](opsManager, kube.BaseOwnerReference(opsManager), reconciler.client)
@@ -227,7 +257,10 @@ func (r *OpsManagerReconcilerHelper) initializeStateStore(ctx context.Context, r
 		r.deploymentState = state
 	}
 
-	r.deploymentState.ClusterMapping = multicluster.AssignIndexesForMemberClusterNames(r.deploymentState.ClusterMapping, clusterNamesFromClusterSpecList)
+	r.deploymentState.ClusterMapping = multicluster.AssignIndexesForMemberClusterNames(
+		r.deploymentState.ClusterMapping,
+		clusterNamesFromClusterSpecList,
+	)
 
 	if err := r.saveOMState(ctx, opsManager, reconciler.client, log); err != nil {
 		return err
@@ -236,7 +269,12 @@ func (r *OpsManagerReconcilerHelper) initializeStateStore(ctx context.Context, r
 	return nil
 }
 
-func (r *OpsManagerReconcilerHelper) saveOMState(ctx context.Context, spec *omv1.MongoDBOpsManager, client kubernetesClient.Client, log *zap.SugaredLogger) error {
+func (r *OpsManagerReconcilerHelper) saveOMState(
+	ctx context.Context,
+	spec *omv1.MongoDBOpsManager,
+	client kubernetesClient.Client,
+	log *zap.SugaredLogger,
+) error {
 	if err := r.stateStore.WriteState(ctx, r.deploymentState, log); err != nil {
 		return err
 	}
@@ -247,7 +285,12 @@ func (r *OpsManagerReconcilerHelper) saveOMState(ctx context.Context, spec *omv1
 }
 
 // writeLegacyStateConfigMap converts the DeploymentState to the legacy Config Map and write it to the cluster
-func (r *OpsManagerReconcilerHelper) writeLegacyStateConfigMap(ctx context.Context, spec *omv1.MongoDBOpsManager, client kubernetesClient.Client, log *zap.SugaredLogger) error {
+func (r *OpsManagerReconcilerHelper) writeLegacyStateConfigMap(
+	ctx context.Context,
+	spec *omv1.MongoDBOpsManager,
+	client kubernetesClient.Client,
+	log *zap.SugaredLogger,
+) error {
 	// ClusterMapping ConfigMap
 	mappingConfigMapData := map[string]string{}
 	for k, v := range r.deploymentState.ClusterMapping {
@@ -293,8 +336,14 @@ type backupDaemonFQDN struct {
 func (r *OpsManagerReconcilerHelper) BackupDaemonHeadlessFQDNs() []backupDaemonFQDN {
 	var fqdns []backupDaemonFQDN
 	for _, memberCluster := range r.GetMemberClusters() {
-		clusterHostnames, _ := dns.GetDNSNames(r.BackupDaemonStatefulSetNameForMemberCluster(memberCluster), r.BackupDaemonHeadlessServiceNameForMemberCluster(memberCluster),
-			r.opsManager.Namespace, r.opsManager.Spec.GetClusterDomain(), r.BackupDaemonMembersForMemberCluster(memberCluster), nil)
+		clusterHostnames, _ := dns.GetDNSNames(
+			r.BackupDaemonStatefulSetNameForMemberCluster(memberCluster),
+			r.BackupDaemonHeadlessServiceNameForMemberCluster(memberCluster),
+			r.opsManager.Namespace,
+			r.opsManager.Spec.GetClusterDomain(),
+			r.BackupDaemonMembersForMemberCluster(memberCluster),
+			nil,
+		)
 		for _, hostname := range clusterHostnames {
 			fqdns = append(fqdns, backupDaemonFQDN{hostname: hostname, memberClusterName: memberCluster.Name})
 		}
@@ -354,8 +403,14 @@ func (r *OpsManagerReconcilerHelper) BackupDaemonHeadlessServiceNameForMemberClu
 
 func (r *OpsManagerReconcilerHelper) BackupDaemonPodServiceNameForMemberCluster(memberCluster multicluster.MemberCluster) []string {
 	if memberCluster.Legacy {
-		hostnames, _ := dns.GetDNSNames(r.BackupDaemonStatefulSetNameForMemberCluster(memberCluster), r.BackupDaemonHeadlessServiceNameForMemberCluster(memberCluster),
-			r.opsManager.Namespace, r.opsManager.Spec.GetClusterDomain(), r.BackupDaemonMembersForMemberCluster(memberCluster), nil)
+		hostnames, _ := dns.GetDNSNames(
+			r.BackupDaemonStatefulSetNameForMemberCluster(memberCluster),
+			r.BackupDaemonHeadlessServiceNameForMemberCluster(memberCluster),
+			r.opsManager.Namespace,
+			r.opsManager.Spec.GetClusterDomain(),
+			r.BackupDaemonMembersForMemberCluster(memberCluster),
+			nil,
+		)
 		return hostnames
 	}
 
@@ -367,7 +422,11 @@ func (r *OpsManagerReconcilerHelper) BackupDaemonPodServiceNameForMemberCluster(
 	return hostnames
 }
 
-func (r *OpsManagerReconcilerHelper) migrateToNewDeploymentState(ctx context.Context, om *omv1.MongoDBOpsManager, centralClient kubernetesClient.Client) error {
+func (r *OpsManagerReconcilerHelper) migrateToNewDeploymentState(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	centralClient kubernetesClient.Client,
+) error {
 	legacyMemberClusterMapping, err := getLegacyMemberClusterMapping(ctx, om.Namespace, om.ClusterMappingConfigMapName(), centralClient)
 	if apiErrors.IsNotFound(err) || !om.Spec.IsMultiCluster() {
 		legacyMemberClusterMapping = map[string]int{}
@@ -407,10 +466,26 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	// just log the error and put in the "Unsupported" state
 	semverVersion, err := versionutil.StringToSemverVersion(opsManager.Spec.Version)
 	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Invalid("%s is not a valid version", opsManager.Spec.Version), log, opsManagerExtraStatusParams)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Invalid("%s is not a valid version", opsManager.Spec.Version),
+			log,
+			opsManagerExtraStatusParams,
+		)
 	}
 	if semverVersion.LT(r.oldestSupportedVersion) {
-		return r.updateStatus(ctx, opsManager, workflow.Unsupported("Ops Manager Version %s is not supported by this version of the operator. Please upgrade to a version >=%s", opsManager.Spec.Version, oldestSupportedOpsManagerVersion), log, opsManagerExtraStatusParams)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Unsupported(
+				"Ops Manager Version %s is not supported by this version of the operator. Please upgrade to a version >=%s",
+				opsManager.Spec.Version,
+				oldestSupportedOpsManagerVersion,
+			),
+			log,
+			opsManagerExtraStatusParams,
+		)
 	}
 
 	if part, err := opsManager.ProcessValidationsOnReconcile(); err != nil {
@@ -418,7 +493,13 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	if err := ensureSharedGlobalResources(ctx, r.client, opsManager); err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error ensuring shared global resources %w", err)), log, opsManagerExtraStatusParams)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Error ensuring shared global resources %w", err)),
+			log,
+			opsManagerExtraStatusParams,
+		)
 	}
 
 	// 1. Reconcile AppDB
@@ -433,14 +514,24 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	// We need to remove the watches on the top of the reconcile since we might add resources with the same key below.
 	if opsManager.IsTLSEnabled() {
-		r.resourceWatcher.RegisterWatchedTLSResources(opsManager.ObjectKey(), opsManager.Spec.GetOpsManagerCA(), []string{opsManager.TLSCertificateSecretName()})
+		r.resourceWatcher.RegisterWatchedTLSResources(
+			opsManager.ObjectKey(),
+			opsManager.Spec.GetOpsManagerCA(),
+			[]string{opsManager.TLSCertificateSecretName()},
+		)
 	}
 	// register backup
 	r.watchMongoDBResourcesReferencedByBackup(ctx, opsManager, log)
 
 	appDbReconciler, err := r.createNewAppDBReconciler(ctx, opsManager, log)
 	if err != nil {
-		return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", err)), log, opsManagerExtraStatusParams)
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			workflow.Failed(xerrors.Errorf("Error initializing AppDB reconciler: %w", err)),
+			log,
+			opsManagerExtraStatusParams,
+		)
 	}
 
 	result, err := appDbReconciler.ReconcileAppDB(ctx, opsManager)
@@ -460,7 +551,13 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	for _, memberCluster := range opsManagerReconcilerHelper.getHealthyMemberClusters() {
 		if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, opsManager, appDBConnectionString, memberCluster, log); err != nil {
-			return r.updateStatus(ctx, opsManager, workflow.Failed(xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)), log, opsManagerExtraStatusParams)
+			return r.updateStatus(
+				ctx,
+				opsManager,
+				workflow.Failed(xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)),
+				log,
+				opsManagerExtraStatusParams,
+			)
 		}
 	}
 
@@ -468,9 +565,24 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	opsManagerImage := images.ContainerImage(r.imageUrls, util.OpsManagerImageUrl, opsManager.Spec.Version)
 
 	// 2. Reconcile Ops Manager
-	status, omAdmin := r.reconcileOpsManager(ctx, opsManagerReconcilerHelper, opsManager, appDBConnectionString, initOpsManagerImage, opsManagerImage, log)
+	status, omAdmin := r.reconcileOpsManager(
+		ctx,
+		opsManagerReconcilerHelper,
+		opsManager,
+		appDBConnectionString,
+		initOpsManagerImage,
+		opsManagerImage,
+		log,
+	)
 	if !status.IsOK() {
-		return r.updateStatus(ctx, opsManager, status, log, opsManagerExtraStatusParams, mdbstatus.NewBaseUrlOption(opsManager.CentralURL()))
+		return r.updateStatus(
+			ctx,
+			opsManager,
+			status,
+			log,
+			opsManagerExtraStatusParams,
+			mdbstatus.NewBaseUrlOption(opsManager.CentralURL()),
+		)
 	}
 
 	// the AppDB still needs to configure monitoring, now that Ops Manager has been created
@@ -516,7 +628,11 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 }
 
 // ensureSharedGlobalResources ensures that resources that are shared across watched namespaces (e.g. secrets) are in sync
-func ensureSharedGlobalResources(ctx context.Context, secretGetUpdaterCreator secret.GetUpdateCreator, opsManager *omv1.MongoDBOpsManager) error {
+func ensureSharedGlobalResources(
+	ctx context.Context,
+	secretGetUpdaterCreator secret.GetUpdateCreator,
+	opsManager *omv1.MongoDBOpsManager,
+) error {
 	operatorNamespace := env.ReadOrPanic(util.CurrentNamespace) // nolint:forbidigo
 	if operatorNamespace == opsManager.Namespace {
 		// nothing to sync, OM runs in the same namespace as the operator
@@ -544,7 +660,11 @@ func ensureSharedGlobalResources(ctx context.Context, secretGetUpdaterCreator se
 }
 
 // createOrUpdateSecretIfNotFound creates the given secret if it does not exist.
-func createOrUpdateSecretIfNotFound(ctx context.Context, secretGetUpdaterCreator secret.GetUpdateCreator, desiredSecret corev1.Secret) error {
+func createOrUpdateSecretIfNotFound(
+	ctx context.Context,
+	secretGetUpdaterCreator secret.GetUpdateCreator,
+	desiredSecret corev1.Secret,
+) error {
 	_, err := secretGetUpdaterCreator.GetSecret(ctx, kube.ObjectKey(desiredSecret.Namespace, desiredSecret.Name))
 	if err != nil {
 		if secret.SecretNotExist(err) {
@@ -555,7 +675,13 @@ func createOrUpdateSecretIfNotFound(ctx context.Context, secretGetUpdaterCreator
 	return nil
 }
 
-func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, appDBConnectionString, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (workflow.Status, api.OpsManagerAdmin) {
+func (r *OpsManagerReconciler) reconcileOpsManager(
+	ctx context.Context,
+	reconcilerHelper *OpsManagerReconcilerHelper,
+	opsManager *omv1.MongoDBOpsManager,
+	appDBConnectionString, initOpsManagerImage, opsManagerImage string,
+	log *zap.SugaredLogger,
+) (workflow.Status, api.OpsManagerAdmin) {
 	var genKeySecretMap map[string][]byte
 	var err error
 	if genKeySecretMap, err = r.ensureGenKeyInOperatorCluster(ctx, opsManager, log); err != nil {
@@ -589,13 +715,29 @@ func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcil
 	// Prepare Ops Manager StatefulSets in parallel in all member clusters
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
-		mutatedSts, err := r.createOpsManagerStatefulsetInMemberCluster(ctx, reconcilerHelper, appDBConnectionString, memberCluster, initOpsManagerImage, opsManagerImage, log)
+		mutatedSts, err := r.createOpsManagerStatefulsetInMemberCluster(
+			ctx,
+			reconcilerHelper,
+			appDBConnectionString,
+			memberCluster,
+			initOpsManagerImage,
+			opsManagerImage,
+			log,
+		)
 		if err != nil {
-			return workflow.Failed(xerrors.Errorf("error creating Ops Manager statefulset in member cluster %s: %w", memberCluster.Name, err)), nil
+			return workflow.Failed(
+				xerrors.Errorf("error creating Ops Manager statefulset in member cluster %s: %w", memberCluster.Name, err),
+			), nil
 		}
 
 		expectedGeneration := mutatedSts.GetGeneration()
-		statefulsetStatus := statefulset.GetStatefulSetStatus(ctx, opsManager.Namespace, reconcilerHelper.OpsManagerStatefulSetNameForMemberCluster(memberCluster), expectedGeneration, memberCluster.Client)
+		statefulsetStatus := statefulset.GetStatefulSetStatus(
+			ctx,
+			opsManager.Namespace,
+			reconcilerHelper.OpsManagerStatefulSetNameForMemberCluster(memberCluster),
+			expectedGeneration,
+			memberCluster.Client,
+		)
 		workflowStatus = workflowStatus.Merge(statefulsetStatus)
 	}
 
@@ -633,7 +775,13 @@ func (r *OpsManagerReconciler) reconcileOpsManager(ctx context.Context, reconcil
 
 // triggerOmChangedEventIfNeeded triggers upgrade process for all the MongoDB agents in the system if the major/minor version upgrade
 // happened for Ops Manager
-func triggerOmChangedEventIfNeeded(ctx context.Context, opsManager *omv1.MongoDBOpsManager, c kubernetesClient.Client, defaultArchitecture architectures.DefaultArchitecture, log *zap.SugaredLogger) error {
+func triggerOmChangedEventIfNeeded(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	c kubernetesClient.Client,
+	defaultArchitecture architectures.DefaultArchitecture,
+	log *zap.SugaredLogger,
+) error {
 	if opsManager.Spec.Version == opsManager.Status.OpsManagerStatus.Version || opsManager.Status.OpsManagerStatus.Version == "" {
 		return nil
 	}
@@ -646,7 +794,11 @@ func triggerOmChangedEventIfNeeded(ctx context.Context, opsManager *omv1.MongoDB
 		return xerrors.Errorf("failed to parse Ops Manager status version %s: %w", opsManager.Status.OpsManagerStatus.Version, err)
 	}
 	if newVersion.Major != oldVersion.Major || newVersion.Minor != oldVersion.Minor {
-		log.Infof("Ops Manager version has upgraded from %s to %s - scheduling the upgrade for all the Agents in the system", oldVersion, newVersion)
+		log.Infof(
+			"Ops Manager version has upgraded from %s to %s - scheduling the upgrade for all the Agents in the system",
+			oldVersion,
+			newVersion,
+		)
 		if architectures.IsRunningStaticArchitecture(opsManager.Annotations, defaultArchitecture) {
 			mdbList := &mdbv1.MongoDBList{}
 			err := c.List(ctx, mdbList)
@@ -686,7 +838,9 @@ func (r *OpsManagerReconciler) stopBackupDaemonIfNeeded(ctx context.Context, rec
 	}
 
 	for _, memberCluster := range reconcileHelper.getHealthyMemberClusters() {
-		if _, err := r.scaleStatefulSet(ctx, opsManager.Namespace, reconcileHelper.BackupDaemonStatefulSetNameForMemberCluster(memberCluster), 0, memberCluster.Client); client.IgnoreNotFound(err) != nil {
+		if _, err := r.scaleStatefulSet(ctx, opsManager.Namespace, reconcileHelper.BackupDaemonStatefulSetNameForMemberCluster(memberCluster), 0, memberCluster.Client); client.IgnoreNotFound(
+			err,
+		) != nil {
 			return err
 		}
 
@@ -707,7 +861,14 @@ func (r *OpsManagerReconciler) stopBackupDaemonIfNeeded(ctx context.Context, rec
 	return nil
 }
 
-func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConnectionString, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) reconcileBackupDaemon(
+	ctx context.Context,
+	reconcilerHelper *OpsManagerReconcilerHelper,
+	opsManager *omv1.MongoDBOpsManager,
+	omAdmin api.OpsManagerAdmin,
+	appDBConnectionString, initOpsManagerImage, opsManagerImage string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	backupStatusPartOption := mdbstatus.NewOMPartOption(mdbstatus.Backup)
 
 	// If backup is not enabled, we check whether it is still configured in OM to update the status.
@@ -735,7 +896,15 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range reconcilerHelper.getHealthyMemberClusters() {
 		// Prepare Backup Daemon StatefulSet (create and wait)
-		mutatedSts, err := r.createBackupDaemonStatefulset(ctx, reconcilerHelper, appDBConnectionString, memberCluster, initOpsManagerImage, opsManagerImage, log)
+		mutatedSts, err := r.createBackupDaemonStatefulset(
+			ctx,
+			reconcilerHelper,
+			appDBConnectionString,
+			memberCluster,
+			initOpsManagerImage,
+			opsManagerImage,
+			log,
+		)
 		if err != nil {
 			// Check if it is a k8s error or a custom one
 			var statefulSetIsRecreatingError create.StatefulSetIsRecreating
@@ -743,11 +912,19 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 				return workflow.Pending("%s", statefulSetIsRecreatingError.Error()).Requeue()
 			}
 
-			return workflow.Failed(xerrors.Errorf("error creating Backup Daemon statefulset in member cluster %s: %w", memberCluster.Name, err))
+			return workflow.Failed(
+				xerrors.Errorf("error creating Backup Daemon statefulset in member cluster %s: %w", memberCluster.Name, err),
+			)
 		}
 
 		expectedGeneration := mutatedSts.GetGeneration()
-		stsStatus := statefulset.GetStatefulSetStatus(ctx, opsManager.Namespace, reconcilerHelper.BackupDaemonStatefulSetNameForMemberCluster(memberCluster), expectedGeneration, memberCluster.Client)
+		stsStatus := statefulset.GetStatefulSetStatus(
+			ctx,
+			opsManager.Namespace,
+			reconcilerHelper.BackupDaemonStatefulSetNameForMemberCluster(memberCluster),
+			expectedGeneration,
+			memberCluster.Client,
+		)
 		workflowStatus = workflowStatus.Merge(stsStatus)
 	}
 
@@ -770,26 +947,50 @@ func (r *OpsManagerReconciler) reconcileBackupDaemon(ctx context.Context, reconc
 }
 
 // readOpsManagerResource reads Ops Manager Custom resource into pointer provided
-func (r *OpsManagerReconciler) readOpsManagerResource(ctx context.Context, request reconcile.Request, ref *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *OpsManagerReconciler) readOpsManagerResource(
+	ctx context.Context,
+	request reconcile.Request,
+	ref *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	if result, err := r.GetResource(ctx, request, ref, log); err != nil {
 		return result, err
 	}
 	// Reset warnings so that they are not stale, will populate accurate warnings in reconciliation
-	ref.SetWarnings([]mdbstatus.Warning{}, mdbstatus.NewOMPartOption(mdbstatus.OpsManager), mdbstatus.NewOMPartOption(mdbstatus.AppDb), mdbstatus.NewOMPartOption(mdbstatus.Backup))
+	ref.SetWarnings(
+		[]mdbstatus.Warning{},
+		mdbstatus.NewOMPartOption(mdbstatus.OpsManager),
+		mdbstatus.NewOMPartOption(mdbstatus.AppDb),
+		mdbstatus.NewOMPartOption(mdbstatus.Backup),
+	)
 	return reconcile.Result{}, nil
 }
 
 // ensureAppDBConnectionString ensures that the AppDB Connection String exists in a secret.
-func (r *OpsManagerReconciler) ensureAppDBConnectionStringInMemberCluster(ctx context.Context, opsManager *omv1.MongoDBOpsManager, computedConnectionString string, memberCluster multicluster.MemberCluster, log *zap.SugaredLogger) error {
+func (r *OpsManagerReconciler) ensureAppDBConnectionStringInMemberCluster(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	computedConnectionString string,
+	memberCluster multicluster.MemberCluster,
+	log *zap.SugaredLogger,
+) error {
 	var opsManagerSecretPath string
 	if r.VaultClient != nil {
 		opsManagerSecretPath = r.VaultClient.OpsManagerSecretPath()
 	}
 
-	_, err := memberCluster.SecretClient.ReadSecret(ctx, kube.ObjectKey(opsManager.Namespace, opsManager.AppDBMongoConnectionStringSecretName()), opsManagerSecretPath)
+	_, err := memberCluster.SecretClient.ReadSecret(
+		ctx,
+		kube.ObjectKey(opsManager.Namespace, opsManager.AppDBMongoConnectionStringSecretName()),
+		opsManagerSecretPath,
+	)
 	if err != nil {
 		if secret.SecretNotExist(err) {
-			log.Debugf("AppDB connection string secret was not found in cluster %s, creating %s now", memberCluster.Name, kube.ObjectKey(opsManager.Namespace, opsManager.AppDBMongoConnectionStringSecretName()))
+			log.Debugf(
+				"AppDB connection string secret was not found in cluster %s, creating %s now",
+				memberCluster.Name,
+				kube.ObjectKey(opsManager.Namespace, opsManager.AppDBMongoConnectionStringSecretName()),
+			)
 			// assume the secret was not found, need to create it
 
 			connectionStringSecret := secret.Builder().
@@ -811,7 +1012,10 @@ func (r *OpsManagerReconciler) ensureAppDBConnectionStringInMemberCluster(ctx co
 		SetName(opsManager.AppDBMongoConnectionStringSecretName()).
 		SetNamespace(opsManager.Namespace).
 		SetStringMapToData(connectionStringSecretData).Build()
-	log.Debugf("Connection string secret already exists, updating %s", kube.ObjectKey(opsManager.Namespace, opsManager.AppDBMongoConnectionStringSecretName()))
+	log.Debugf(
+		"Connection string secret already exists, updating %s",
+		kube.ObjectKey(opsManager.Namespace, opsManager.AppDBMongoConnectionStringSecretName()),
+	)
 	return memberCluster.SecretClient.PutSecret(ctx, connectionStringSecret, opsManagerSecretPath)
 }
 
@@ -821,7 +1025,14 @@ func hashConnectionString(connectionString string) string {
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hashBytes[:])
 }
 
-func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConnectionString string, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(
+	ctx context.Context,
+	reconcilerHelper *OpsManagerReconcilerHelper,
+	appDBConnectionString string,
+	memberCluster multicluster.MemberCluster,
+	initOpsManagerImage, opsManagerImage string,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, error) {
 	opsManager := reconcilerHelper.opsManager
 
 	r.ensureConfiguration(reconcilerHelper, log)
@@ -855,9 +1066,31 @@ func (r *OpsManagerReconciler) createOpsManagerStatefulsetInMemberCluster(ctx co
 	return create.OpsManagerInKubernetes(ctx, memberCluster, opsManager, sts, log)
 }
 
-func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClustersMap map[string]cluster.Cluster, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string, defaultArchitecture architectures.DefaultArchitecture) error {
-	reconciler := NewOpsManagerReconciler(ctx, mgr.GetClient(), multicluster.ClustersMapToClientMap(memberClustersMap), imageUrls, initDatabaseVersion, initOpsManagerImageVersion, defaultArchitecture, om.NewOpsManagerConnection, &api.DefaultInitializer{}, api.NewOmAdmin)
-	c, err := controller.New(util.MongoDbOpsManagerController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+func AddOpsManagerController(
+	ctx context.Context,
+	mgr manager.Manager,
+	memberClustersMap map[string]cluster.Cluster,
+	imageUrls images.ImageUrls,
+	initDatabaseVersion, initOpsManagerImageVersion string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) error {
+	reconciler := NewOpsManagerReconciler(
+		ctx,
+		mgr.GetClient(),
+		multicluster.ClustersMapToClientMap(memberClustersMap),
+		imageUrls,
+		initDatabaseVersion,
+		initOpsManagerImageVersion,
+		defaultArchitecture,
+		om.NewOpsManagerConnection,
+		&api.DefaultInitializer{},
+		api.NewOmAdmin,
+	)
+	c, err := controller.New(
+		util.MongoDbOpsManagerController,
+		mgr,
+		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)},
+	) // nolint:forbidigo
 	if err != nil {
 		return err
 	}
@@ -899,7 +1132,14 @@ func AddOpsManagerController(ctx context.Context, mgr manager.Manager, memberClu
 		}
 	}
 	for clusterName, memberCluster := range memberClustersMap {
-		err = c.Watch(source.Kind[client.Object](memberCluster.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
+		err = c.Watch(
+			source.Kind[client.Object](
+				memberCluster.GetCache(),
+				&appsv1.StatefulSet{},
+				&khandler.EnqueueRequestForOwnerMultiCluster{},
+				watch.PredicatesForMultiStatefulSet(),
+			),
+		)
 		if err != nil {
 			return xerrors.Errorf("failed to set AppDB StatefulSet watch on member cluster %s: %w", clusterName, err)
 		}
@@ -944,7 +1184,14 @@ func (r *OpsManagerReconciler) ensureConfiguration(reconcilerHelper *OpsManagerR
 // Note, that the idea of creating two statefulsets for Ops Manager and Backup Daemon in parallel hasn't worked out
 // as the daemon in this case just hangs silently (in practice it's ok to start it in ~1 min after start of OM though
 // we will just start them sequentially)
-func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context, reconcilerHelper *OpsManagerReconcilerHelper, appDBConnectionString string, memberCluster multicluster.MemberCluster, initOpsManagerImage, opsManagerImage string, log *zap.SugaredLogger) (*appsv1.StatefulSet, error) {
+func (r *OpsManagerReconciler) createBackupDaemonStatefulset(
+	ctx context.Context,
+	reconcilerHelper *OpsManagerReconcilerHelper,
+	appDBConnectionString string,
+	memberCluster multicluster.MemberCluster,
+	initOpsManagerImage, opsManagerImage string,
+	log *zap.SugaredLogger,
+) (*appsv1.StatefulSet, error) {
 	if err := r.ensureAppDBConnectionStringInMemberCluster(ctx, reconcilerHelper.opsManager, appDBConnectionString, memberCluster, log); err != nil {
 		return nil, xerrors.Errorf("error ensuring AppDB connection string in cluster %s: %w", memberCluster.Name, err)
 	}
@@ -979,7 +1226,11 @@ func (r *OpsManagerReconciler) createBackupDaemonStatefulset(ctx context.Context
 	return mutatedSts, nil
 }
 
-func (r *OpsManagerReconciler) watchMongoDBResourcesReferencedByKmip(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
+func (r *OpsManagerReconciler) watchMongoDBResourcesReferencedByKmip(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) {
 	if !opsManager.Spec.IsKmipEnabled() {
 		return
 	}
@@ -1025,7 +1276,11 @@ func (r *OpsManagerReconciler) watchCaReferencedByKmip(opsManager *omv1.MongoDBO
 		kube.ObjectKeyFromApiObject(opsManager))
 }
 
-func (r *OpsManagerReconciler) watchMongoDBResourcesReferencedByBackup(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) {
+func (r *OpsManagerReconciler) watchMongoDBResourcesReferencedByBackup(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) {
 	if !opsManager.Spec.Backup.Enabled {
 		return
 	}
@@ -1080,7 +1335,11 @@ func setConfigProperty(opsManager *omv1.MongoDBOpsManager, key, value string, lo
 	}
 }
 
-func (r *OpsManagerReconciler) ensureGenKeyInOperatorCluster(ctx context.Context, om *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (map[string][]byte, error) {
+func (r *OpsManagerReconciler) ensureGenKeyInOperatorCluster(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (map[string][]byte, error) {
 	objectKey := kube.ObjectKey(om.Namespace, om.Name+"-gen-key")
 	var opsManagerSecretPath string
 	if r.VaultClient != nil {
@@ -1118,7 +1377,11 @@ func (r *OpsManagerReconciler) ensureGenKeyInOperatorCluster(ctx context.Context
 	return nil, xerrors.Errorf("error reading secret %v: %w", objectKey, err)
 }
 
-func (r *OpsManagerReconciler) replicateGenKeyInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, secretMap map[string][]byte) error {
+func (r *OpsManagerReconciler) replicateGenKeyInMemberClusters(
+	ctx context.Context,
+	reconcileHelper *OpsManagerReconcilerHelper,
+	secretMap map[string][]byte,
+) error {
 	if !reconcileHelper.opsManager.Spec.IsMultiCluster() {
 		return nil
 	}
@@ -1144,7 +1407,10 @@ func (r *OpsManagerReconciler) replicateGenKeyInMemberClusters(ctx context.Conte
 	return nil
 }
 
-func (r *OpsManagerReconciler) replicateQueryableBackupTLSSecretInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
+func (r *OpsManagerReconciler) replicateQueryableBackupTLSSecretInMemberClusters(
+	ctx context.Context,
+	reconcileHelper *OpsManagerReconcilerHelper,
+) error {
 	if !reconcileHelper.opsManager.Spec.IsMultiCluster() {
 		return nil
 	}
@@ -1152,10 +1418,20 @@ func (r *OpsManagerReconciler) replicateQueryableBackupTLSSecretInMemberClusters
 	if reconcileHelper.opsManager.Spec.Backup == nil || reconcileHelper.opsManager.Spec.Backup.QueryableBackupSecretRef.Name == "" {
 		return nil
 	}
-	return r.replicateSecretInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.Backup.QueryableBackupSecretRef.Name)
+	return r.replicateSecretInMemberClusters(
+		ctx,
+		reconcileHelper,
+		reconcileHelper.opsManager.Namespace,
+		reconcileHelper.opsManager.Spec.Backup.QueryableBackupSecretRef.Name,
+	)
 }
 
-func (r *OpsManagerReconciler) replicateSecretInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, namespace string, secretName string) error {
+func (r *OpsManagerReconciler) replicateSecretInMemberClusters(
+	ctx context.Context,
+	reconcileHelper *OpsManagerReconcilerHelper,
+	namespace string,
+	secretName string,
+) error {
 	objectKey := kube.ObjectKey(namespace, secretName)
 	var opsManagerSecretPath string
 	if r.VaultClient != nil {
@@ -1187,7 +1463,12 @@ func (r *OpsManagerReconciler) replicateTLSCAInMemberClusters(ctx context.Contex
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetOpsManagerCA())
+	return r.replicateConfigMapInMemberClusters(
+		ctx,
+		reconcileHelper,
+		reconcileHelper.opsManager.Namespace,
+		reconcileHelper.opsManager.Spec.GetOpsManagerCA(),
+	)
 }
 
 func (r *OpsManagerReconciler) replicateLogBackInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1228,7 +1509,12 @@ func (r *OpsManagerReconciler) replicateAppDBTLSCAInMemberClusters(ctx context.C
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.GetAppDbCA())
+	return r.replicateConfigMapInMemberClusters(
+		ctx,
+		reconcileHelper,
+		reconcileHelper.opsManager.Namespace,
+		reconcileHelper.opsManager.Spec.GetAppDbCA(),
+	)
 }
 
 func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper) error {
@@ -1236,10 +1522,20 @@ func (r *OpsManagerReconciler) replicateKMIPCAInMemberClusters(ctx context.Conte
 		return nil
 	}
 
-	return r.replicateConfigMapInMemberClusters(ctx, reconcileHelper, reconcileHelper.opsManager.Namespace, reconcileHelper.opsManager.Spec.Backup.Encryption.Kmip.Server.CA)
+	return r.replicateConfigMapInMemberClusters(
+		ctx,
+		reconcileHelper,
+		reconcileHelper.opsManager.Namespace,
+		reconcileHelper.opsManager.Spec.Backup.Encryption.Kmip.Server.CA,
+	)
 }
 
-func (r *OpsManagerReconciler) replicateConfigMapInMemberClusters(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, namespace string, configMapName string) error {
+func (r *OpsManagerReconciler) replicateConfigMapInMemberClusters(
+	ctx context.Context,
+	reconcileHelper *OpsManagerReconcilerHelper,
+	namespace string,
+	configMapName string,
+) error {
 	if !reconcileHelper.opsManager.Spec.IsMultiCluster() || configMapName == "" {
 		return nil
 	}
@@ -1266,7 +1562,10 @@ func (r *OpsManagerReconciler) replicateConfigMapInMemberClusters(ctx context.Co
 	return nil
 }
 
-func (r *OpsManagerReconciler) getOpsManagerAPIKeySecretName(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (string, workflow.Status) {
+func (r *OpsManagerReconciler) getOpsManagerAPIKeySecretName(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+) (string, workflow.Status) {
 	var operatorVaultSecretPath string
 	if r.VaultClient != nil {
 		operatorVaultSecretPath = r.VaultClient.OperatorSecretPath()
@@ -1292,7 +1591,12 @@ func detailedAPIErrorMsg(adminKeySecretName types.NamespacedName) string {
 // asking the user to fix this manually.
 // Theoretically, the Operator could remove the appdb StatefulSet (as the OM must be empty without any user data) and
 // allow the db to get recreated, but this is a quite radical operation.
-func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, centralURL string, log *zap.SugaredLogger) (workflow.Status, api.OpsManagerAdmin) {
+func (r *OpsManagerReconciler) prepareOpsManager(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	centralURL string,
+	log *zap.SugaredLogger,
+) (workflow.Status, api.OpsManagerAdmin) {
 	// We won't support cross-namespace secrets until CLOUDP-46636 is resolved
 	adminObjectKey := kube.ObjectKey(opsManager.Namespace, opsManager.Spec.AdminSecret)
 
@@ -1306,7 +1610,9 @@ func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager
 
 	if secret.SecretNotExist(err) {
 		// This requires user actions - let's wait a bit longer than 10 seconds
-		return workflow.Failed(xerrors.Errorf("the secret %s doesn't exist - you need to create it to finish Ops Manager initialization", adminObjectKey)).WithRetry(60), nil
+		return workflow.Failed(xerrors.Errorf("the secret %s doesn't exist - you need to create it to finish Ops Manager initialization", adminObjectKey)).
+				WithRetry(60),
+			nil
 	} else if err != nil {
 		return workflow.Failed(err), nil
 	}
@@ -1388,7 +1694,9 @@ func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager
 	}
 	if found, msg := util.DoAndRetry(readAdminKeySecretFunc, log, 10, 5); !found {
 		return workflow.Failed(xerrors.Errorf("admin API key secret for Ops Manager doesn't exist - was it removed accidentally? %s. The error: %s",
-			detailedAPIErrorMsg(adminKeySecretName), msg)).WithRetry(30), nil
+				detailedAPIErrorMsg(adminKeySecretName), msg)).
+				WithRetry(30),
+			nil
 	}
 
 	// Ops Manager api key Secret has the same structure as the MongoDB credentials secret
@@ -1407,7 +1715,14 @@ func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager
 }
 
 // prepareBackupInOpsManager makes the changes to backup admin configuration based on the Ops Manager spec
-func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, reconcileHelper *OpsManagerReconcilerHelper, opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) prepareBackupInOpsManager(
+	ctx context.Context,
+	reconcileHelper *OpsManagerReconcilerHelper,
+	opsManager *omv1.MongoDBOpsManager,
+	omAdmin api.OpsManagerAdmin,
+	appDBConnectionString string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1419,7 +1734,11 @@ func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, re
 		if apierror.NewNonNil(err).ErrorBackupDaemonConfigIsNotFound() {
 			log.Infow("Backup Daemon is not configured, enabling it", "hostname", fqdn.hostname, "headDB", util.PvcMountPathHeadDb)
 
-			err = omAdmin.CreateDaemonConfig(fqdn.hostname, util.PvcMountPathHeadDb, opsManager.GetMemberClusterBackupAssignmentLabels(fqdn.memberClusterName))
+			err = omAdmin.CreateDaemonConfig(
+				fqdn.hostname,
+				util.PvcMountPathHeadDb,
+				opsManager.GetMemberClusterBackupAssignmentLabels(fqdn.memberClusterName),
+			)
 			if apierror.NewNonNil(err).ErrorBackupDaemonConfigIsNotFound() {
 				// Unfortunately by this time backup daemon may not have been started yet, and we don't have proper
 				// mechanism to ensure this using readiness probe, so we just retry
@@ -1458,8 +1777,12 @@ func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, re
 
 	// 6. FileSystem store configs
 	status = status.Merge(r.ensureFileSystemStoreConfigurationInOpsManager(opsManager, omAdmin))
-	if len(opsManager.Spec.Backup.S3Configs) == 0 && len(opsManager.Spec.Backup.BlockStoreConfigs) == 0 && len(opsManager.Spec.Backup.FileSystemStoreConfigs) == 0 {
-		return status.Merge(workflow.Invalid("Either S3 or Blockstore or FileSystem Snapshot configuration is required for backup").WithTargetPhase(mdbstatus.PhasePending))
+	if len(opsManager.Spec.Backup.S3Configs) == 0 && len(opsManager.Spec.Backup.BlockStoreConfigs) == 0 &&
+		len(opsManager.Spec.Backup.FileSystemStoreConfigs) == 0 {
+		return status.Merge(
+			workflow.Invalid("Either S3 or Blockstore or FileSystem Snapshot configuration is required for backup").
+				WithTargetPhase(mdbstatus.PhasePending),
+		)
 	}
 
 	return status
@@ -1469,7 +1792,12 @@ func (r *OpsManagerReconciler) prepareBackupInOpsManager(ctx context.Context, re
 // and removes the non-existing ones. Note that there's no update operation as so far the Operator manages only one field
 // 'path'. This will allow users to make any additional changes to the file system stores using Ops Manager UI and the
 // Operator won't override them
-func (r *OpsManagerReconciler) ensureOplogStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.OplogStoreAdmin, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureOplogStoresInOpsManager(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	omAdmin api.OplogStoreAdmin,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1529,7 +1857,13 @@ func (r *OpsManagerReconciler) ensureOplogStoresInOpsManager(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, s3OplogAdmin api.S3OplogStoreAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	s3OplogAdmin api.S3OplogStoreAdmin,
+	appDBConnectionString string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1593,7 +1927,12 @@ func (r *OpsManagerReconciler) ensureS3OplogStoresInOpsManager(ctx context.Conte
 // and removes the non-existing ones. Note that there's no update operation as so far the Operator manages only one field
 // 'path'. This will allow users to make any additional changes to the file system stores using Ops Manager UI and the
 // Operator won't override them
-func (r *OpsManagerReconciler) ensureBlockStoresInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.BlockStoreAdmin, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureBlockStoresInOpsManager(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	omAdmin api.BlockStoreAdmin,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1648,7 +1987,13 @@ func (r *OpsManagerReconciler) ensureBlockStoresInOpsManager(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(ctx context.Context, opsManager *omv1.MongoDBOpsManager, omAdmin api.S3StoreBlockStoreAdmin, appDBConnectionString string, log *zap.SugaredLogger) workflow.Status {
+func (r *OpsManagerReconciler) ensureS3ConfigurationInOpsManager(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	omAdmin api.S3StoreBlockStoreAdmin,
+	appDBConnectionString string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if !opsManager.Spec.Backup.Enabled {
 		return workflow.OK()
 	}
@@ -1734,7 +2079,10 @@ func (r *OpsManagerReconciler) readS3Credentials(ctx context.Context, s3SecretNa
 
 // ensureFileSystemStoreConfigurationInOpsManage makes sure that the FileSystem snapshot stores specified in the
 // MongoDB CR are configured correctly in OpsManager.
-func (r *OpsManagerReconciler) ensureFileSystemStoreConfigurationInOpsManager(opsManager *omv1.MongoDBOpsManager, omAdmin api.OpsManagerAdmin) workflow.Status {
+func (r *OpsManagerReconciler) ensureFileSystemStoreConfigurationInOpsManager(
+	opsManager *omv1.MongoDBOpsManager,
+	omAdmin api.OpsManagerAdmin,
+) workflow.Status {
 	opsManagerFSStoreConfigs, err := omAdmin.ReadFileSystemStoreConfigs()
 	if err != nil {
 		return workflow.Failed(xerrors.New(err.Error()))
@@ -1766,7 +2114,13 @@ func shouldUseAppDb(config omv1.S3Config) bool {
 }
 
 // buildAppDbOMS3Config creates a backup.S3Config which is configured to use The AppDb.
-func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConnectionString string) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildAppDbOMS3Config(
+	ctx context.Context,
+	om *omv1.MongoDBOpsManager,
+	config omv1.S3Config,
+	isOpLog bool,
+	appDBConnectionString string,
+) (backup.S3Config, workflow.Status) {
 	var s3Creds *backup.S3Credentials
 
 	if !config.IRSAEnabled {
@@ -1792,7 +2146,12 @@ func (r *OpsManagerReconciler) buildAppDbOMS3Config(ctx context.Context, om *omv
 
 // buildMongoDbOMS3Config creates a backup.S3Config which is configured to use a referenced
 // MongoDB resource.
-func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildMongoDbOMS3Config(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	config omv1.S3Config,
+	isOpLog bool,
+) (backup.S3Config, workflow.Status) {
 	mongodb, status := r.getMongoDbForS3Config(ctx, opsManager, config)
 	if !status.IsOK() {
 		return backup.S3Config{}, status
@@ -1834,7 +2193,11 @@ func (r *OpsManagerReconciler) buildMongoDbOMS3Config(ctx context.Context, opsMa
 
 // readCustomCAFilePathsAndContents returns the filepath and contents of the custom CA which is used to configure
 // the S3Store.
-func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(ctx context.Context, opsManager *omv1.MongoDBOpsManager, isOpLog bool) ([]backup.S3CustomCertificate, error) {
+func (r *OpsManagerReconciler) readCustomCAFilePathsAndContents(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	isOpLog bool,
+) ([]backup.S3CustomCertificate, error) {
 	var customCertificates []backup.S3CustomCertificate
 	var err error
 
@@ -1884,7 +2247,13 @@ func getCAs(ctx context.Context, s3Config []omv1.S3Config, ns string, client sec
 
 // buildOMS3Config builds the OM API S3 config from the Operator OM CR configuration. This involves some logic to
 // get the mongo URI, which points to either the external resource or to the AppDB
-func (r *OpsManagerReconciler) buildOMS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config, isOpLog bool, appDBConnectionString string) (backup.S3Config, workflow.Status) {
+func (r *OpsManagerReconciler) buildOMS3Config(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	config omv1.S3Config,
+	isOpLog bool,
+	appDBConnectionString string,
+) (backup.S3Config, workflow.Status) {
 	if shouldUseAppDb(config) {
 		return r.buildAppDbOMS3Config(ctx, opsManager, config, isOpLog, appDBConnectionString)
 	}
@@ -1892,7 +2261,11 @@ func (r *OpsManagerReconciler) buildOMS3Config(ctx context.Context, opsManager *
 }
 
 // getMongoDbForS3Config returns the referenced MongoDB resource which should be used when configuring the backup config.
-func (r *OpsManagerReconciler) getMongoDbForS3Config(ctx context.Context, opsManager *omv1.MongoDBOpsManager, config omv1.S3Config) (S3ConfigGetter, workflow.Status) {
+func (r *OpsManagerReconciler) getMongoDbForS3Config(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	config omv1.S3Config,
+) (S3ConfigGetter, workflow.Status) {
 	mongodb, mongodbMulti := &mdbv1.MongoDB{}, &mdbmulti.MongoDBMultiCluster{}
 	mongodbObjectKey := config.MongodbResourceObjectKey(opsManager)
 
@@ -1921,7 +2294,12 @@ func (r *OpsManagerReconciler) getMongoDbForS3Config(ctx context.Context, opsMan
 // getS3MongoDbUserNameAndPassword returns userName and password if MongoDB resource has scram-sha enabled.
 // Note, that we don't worry if the 'mongodbUserRef' is specified but SCRAM-SHA is not enabled - we just ignore the
 // user.
-func (r *OpsManagerReconciler) getS3MongoDbUserNameAndPassword(ctx context.Context, modes []string, namespace string, config omv1.S3Config) (string, string, workflow.Status) {
+func (r *OpsManagerReconciler) getS3MongoDbUserNameAndPassword(
+	ctx context.Context,
+	modes []string,
+	namespace string,
+	config omv1.S3Config,
+) (string, string, workflow.Status) {
 	if !stringutil.Contains(modes, util.SCRAM) {
 		return "", "", workflow.OK()
 	}
@@ -1944,7 +2322,11 @@ func (r *OpsManagerReconciler) getS3MongoDbUserNameAndPassword(ctx context.Conte
 
 // buildOMDatastoreConfig builds the OM API datastore config based on the Kubernetes OM resource one.
 // To do this it may need to read the Mongodb User and its password to build mongodb url correctly
-func (r *OpsManagerReconciler) buildOMDatastoreConfig(ctx context.Context, opsManager *omv1.MongoDBOpsManager, operatorConfig omv1.DataStoreConfig) (backup.DataStoreConfig, workflow.Status) {
+func (r *OpsManagerReconciler) buildOMDatastoreConfig(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	operatorConfig omv1.DataStoreConfig,
+) (backup.DataStoreConfig, workflow.Status) {
 	mongodb := &mdbv1.MongoDB{}
 	mongodbObjectKey := operatorConfig.MongodbResourceObjectKey(opsManager.Namespace)
 
@@ -1971,15 +2353,22 @@ func (r *OpsManagerReconciler) buildOMDatastoreConfig(ctx context.Context, opsMa
 		mongodbUserObjectKey := operatorConfig.MongodbUserObjectKey(opsManager.Namespace)
 		err := r.client.Get(ctx, mongodbUserObjectKey, mongodbUser)
 		if secret.SecretNotExist(err) {
-			return backup.DataStoreConfig{}, workflow.Pending("The MongoDBUser object %s doesn't exist", operatorConfig.MongodbResourceObjectKey(opsManager.Namespace))
+			return backup.DataStoreConfig{}, workflow.Pending(
+				"The MongoDBUser object %s doesn't exist",
+				operatorConfig.MongodbResourceObjectKey(opsManager.Namespace),
+			)
 		}
 		if err != nil {
-			return backup.DataStoreConfig{}, workflow.Failed(xerrors.Errorf("Failed to fetch the user %s: %w", operatorConfig.MongodbResourceObjectKey(opsManager.Namespace), err))
+			return backup.DataStoreConfig{}, workflow.Failed(
+				xerrors.Errorf("Failed to fetch the user %s: %w", operatorConfig.MongodbResourceObjectKey(opsManager.Namespace), err),
+			)
 		}
 		userName = mongodbUser.Spec.Username
 		password, err = mongodbUser.GetPassword(ctx, r.SecretClient)
 		if err != nil {
-			return backup.DataStoreConfig{}, workflow.Failed(xerrors.Errorf("Failed to read password for the user %s: %w", mongodbUserObjectKey, err))
+			return backup.DataStoreConfig{}, workflow.Failed(
+				xerrors.Errorf("Failed to read password for the user %s: %w", mongodbUserObjectKey, err),
+			)
 		}
 	}
 
@@ -2065,8 +2454,22 @@ func (r *OpsManagerReconciler) OnDelete(ctx context.Context, obj interface{}, lo
 	log.Info("Cleaned up Ops Manager related resources.")
 }
 
-func (r *OpsManagerReconciler) createNewAppDBReconciler(ctx context.Context, opsManager *omv1.MongoDBOpsManager, log *zap.SugaredLogger) (*ReconcileAppDbReplicaSet, error) {
-	return NewAppDBReplicaSetReconciler(ctx, r.imageUrls, r.initDatabaseVersion, opsManager, r.ReconcileCommonController, r.omConnectionFactory, r.memberClustersMap, r.defaultArchitecture, log)
+func (r *OpsManagerReconciler) createNewAppDBReconciler(
+	ctx context.Context,
+	opsManager *omv1.MongoDBOpsManager,
+	log *zap.SugaredLogger,
+) (*ReconcileAppDbReplicaSet, error) {
+	return NewAppDBReplicaSetReconciler(
+		ctx,
+		r.imageUrls,
+		r.initDatabaseVersion,
+		opsManager,
+		r.ReconcileCommonController,
+		r.omConnectionFactory,
+		r.memberClustersMap,
+		r.defaultArchitecture,
+		log,
+	)
 }
 
 // getAnnotationsForOpsManagerResource returns all the annotations that should be applied to the resource

--- a/controllers/operator/mongodbopsmanager_controller_multi_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_multi_test.go
@@ -71,7 +71,14 @@ type omMemberClusterChecks struct {
 	om           *omv1.MongoDBOpsManager
 }
 
-func newOMMemberClusterChecks(ctx context.Context, t *testing.T, opsManager *omv1.MongoDBOpsManager, clusterName string, kubeClient client.Client, clusterIndex int) *omMemberClusterChecks {
+func newOMMemberClusterChecks(
+	ctx context.Context,
+	t *testing.T,
+	opsManager *omv1.MongoDBOpsManager,
+	clusterName string,
+	kubeClient client.Client,
+	clusterIndex int,
+) *omMemberClusterChecks {
 	result := omMemberClusterChecks{
 		ctx:          ctx,
 		t:            t,
@@ -263,7 +270,17 @@ func TestOpsManagerMultiCluster(t *testing.T) {
 	opsManager.Spec.Security.CertificatesSecretsPrefix = "om-prefix"
 	appDB := opsManager.Spec.AppDB
 
-	reconciler, omClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", opsManager, memberClusterMap, omConnectionFactory, architectures.NonStatic)
+	reconciler, omClient, _ := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		opsManager,
+		memberClusterMap,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 
 	// prepare TLS certificates and CA in central cluster
 
@@ -372,7 +389,17 @@ func TestOpsManagerMultiClusterWithKMIP(t *testing.T) {
 
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
 	memberClusterMap := getFakeMultiClusterMapWithClusters(clusters, omConnectionFactory)
-	reconciler, client, _ := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, memberClusterMap, omConnectionFactory, architectures.NonStatic)
+	reconciler, client, _ := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		testOm,
+		memberClusterMap,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 	addKMIPTestResources(ctx, client, testOm, mdbName, clientCertificatePrefix)
 	configureBackupResources(ctx, client, testOm)
 
@@ -396,7 +423,10 @@ func TestOpsManagerMultiClusterWithKMIP(t *testing.T) {
 		ReadOnly:  true,
 	}
 	expectedCAVolume := statefulset.CreateVolumeFromConfigMap(util.KMIPServerCAName, kmipCAConfigMapName)
-	expectedClientCertVolume := statefulset.CreateVolumeFromSecret(util.KMIPClientSecretNamePrefix+expectedClientCertificateSecretName, expectedClientCertificateSecretName)
+	expectedClientCertVolume := statefulset.CreateVolumeFromSecret(
+		util.KMIPClientSecretNamePrefix+expectedClientCertificateSecretName,
+		expectedClientCertificateSecretName,
+	)
 
 	for clusterIdx, clusterSpecItem := range clusterSpecItems {
 		memberClusterClient := memberClusterMap[clusterSpecItem.ClusterName]
@@ -476,7 +506,17 @@ func TestOpsManagerMultiClusterUnreachableNoPanic(t *testing.T) {
 	opsManager.Spec.Security.CertificatesSecretsPrefix = "om-prefix"
 	appDB := opsManager.Spec.AppDB
 
-	reconciler, omClient, _ := defaultTestOmReconciler(ctx, t, nil, "", "", opsManager, memberClusterMap, omConnectionFactory, architectures.NonStatic)
+	reconciler, omClient, _ := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		opsManager,
+		memberClusterMap,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 
 	// prepare TLS certificates and CA in central cluster
 

--- a/controllers/operator/mongodbopsmanager_controller_test.go
+++ b/controllers/operator/mongodbopsmanager_controller_test.go
@@ -280,9 +280,20 @@ func TestOpsManagerReconciler_OnDeleteClusterResourceCleanup(t *testing.T) {
 			})
 			kubeClient := kubernetesClient.NewClient(fakeClientBuilder.Build())
 
-			reconciler := NewOpsManagerReconciler(ctx, kubeClient, memberClustersMap, images.ImageUrls{}, "", "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc, &MockedInitializer{expectedOmURL: testOm.CentralURL(), t: t}, func(baseUrl string, user string, publicApiKey string, ca *string) api.OpsManagerAdmin {
-				return api.NewMockedAdminProvider(baseUrl, user, publicApiKey, true).(*api.MockedOmAdmin)
-			})
+			reconciler := NewOpsManagerReconciler(
+				ctx,
+				kubeClient,
+				memberClustersMap,
+				images.ImageUrls{},
+				"",
+				"",
+				architectures.NonStatic,
+				omConnectionFactory.GetConnectionFunc,
+				&MockedInitializer{expectedOmURL: testOm.CentralURL(), t: t},
+				func(baseUrl string, user string, publicApiKey string, ca *string) api.OpsManagerAdmin {
+					return api.NewMockedAdminProvider(baseUrl, user, publicApiKey, true).(*api.MockedOmAdmin)
+				},
+			)
 
 			reconciler.OnDelete(ctx, testOm, zap.S())
 
@@ -299,7 +310,17 @@ func TestOpsManagerReconciler_prepareOpsManager(t *testing.T) {
 	ctx := context.Background()
 	testOm := DefaultOpsManagerBuilder().Build()
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, client, initializer := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	reconciler, client, initializer := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		testOm,
+		nil,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 
 	reconcileStatus, _ := reconciler.prepareOpsManager(ctx, testOm, testOm.CentralURL(), zap.S())
 
@@ -375,7 +396,17 @@ func TestOpsManagerReconciler_prepareOpsManagerTwoCalls(t *testing.T) {
 	ctx := context.Background()
 	testOm := DefaultOpsManagerBuilder().Build()
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, client, initializer := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	reconciler, client, initializer := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		testOm,
+		nil,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 
 	reconciler.prepareOpsManager(ctx, testOm, testOm.CentralURL(), zap.S())
 
@@ -410,7 +441,17 @@ func TestOpsManagerReconciler_prepareOpsManagerDuplicatedUser(t *testing.T) {
 	ctx := context.Background()
 	testOm := DefaultOpsManagerBuilder().Build()
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, client, initializer := defaultTestOmReconciler(ctx, t, nil, "", "", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	reconciler, client, initializer := defaultTestOmReconciler(
+		ctx,
+		t,
+		nil,
+		"",
+		"",
+		testOm,
+		nil,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 
 	reconciler.prepareOpsManager(ctx, testOm, testOm.CentralURL(), zap.S())
 
@@ -533,7 +574,12 @@ func TestOpsManagerPodTemplateSpec_IsAnnotatedWithHash(t *testing.T) {
 
 	checkOMReconciliationSuccessful(ctx, t, reconciler, testOm, reconciler.client)
 
-	connectionString, err := secret.ReadKey(ctx, reconciler.client, util.AppDbConnectionStringKey, kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()))
+	connectionString, err := secret.ReadKey(
+		ctx,
+		reconciler.client,
+		util.AppDbConnectionStringKey,
+		kube.ObjectKey(testOm.Namespace, testOm.AppDBMongoConnectionStringSecretName()),
+	)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, connectionString)
 
@@ -546,8 +592,12 @@ func TestOpsManagerPodTemplateSpec_IsAnnotatedWithHash(t *testing.T) {
 	assert.Contains(t, podTemplate.Annotations, "connectionStringHash")
 	assert.Equal(t, podTemplate.Annotations["connectionStringHash"], hashConnectionString(buildMongoConnectionUrl(testOm, "password", nil)))
 	testOm.Spec.AppDB.Members = 5
-	assert.NotEqual(t, podTemplate.Annotations["connectionStringHash"], hashConnectionString(buildMongoConnectionUrl(testOm, "password", nil)),
-		"Changing the number of members should result in a different Connection String and different hash")
+	assert.NotEqual(
+		t,
+		podTemplate.Annotations["connectionStringHash"],
+		hashConnectionString(buildMongoConnectionUrl(testOm, "password", nil)),
+		"Changing the number of members should result in a different Connection String and different hash",
+	)
 	testOm.Spec.AppDB.Members = 3
 	testOm.Spec.AppDB.Version = "4.2.0"
 	assert.Equal(t, podTemplate.Annotations["connectionStringHash"], hashConnectionString(buildMongoConnectionUrl(testOm, "password", nil)),
@@ -580,7 +630,17 @@ func TestOpsManagerReconcileContainerImages(t *testing.T) {
 		Build()
 
 	omConnectionFactory := om.NewDefaultCachedOMConnectionFactory()
-	reconciler, client, _ := defaultTestOmReconciler(ctx, t, imageUrlsMock, "3.4.5", "1.2.3", testOm, nil, omConnectionFactory, architectures.NonStatic)
+	reconciler, client, _ := defaultTestOmReconciler(
+		ctx,
+		t,
+		imageUrlsMock,
+		"3.4.5",
+		"1.2.3",
+		testOm,
+		nil,
+		omConnectionFactory,
+		architectures.NonStatic,
+	)
 	configureBackupResources(ctx, client, testOm)
 
 	checkOMReconciliationSuccessful(ctx, t, reconciler, testOm, reconciler.client)
@@ -597,8 +657,16 @@ func TestOpsManagerReconcileContainerImages(t *testing.T) {
 			require.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 
-			assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:@sha256:MONGODB_INIT_OPS_MANAGER", sts.Spec.Template.Spec.InitContainers[0].Image)
-			assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-ops-manager:@sha256:MONGODB_OPS_MANAGER", sts.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-kubernetes-init-ops-manager:@sha256:MONGODB_INIT_OPS_MANAGER",
+				sts.Spec.Template.Spec.InitContainers[0].Image,
+			)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-enterprise-ops-manager:@sha256:MONGODB_OPS_MANAGER",
+				sts.Spec.Template.Spec.Containers[0].Image,
+			)
 		})
 	}
 
@@ -609,9 +677,17 @@ func TestOpsManagerReconcileContainerImages(t *testing.T) {
 	require.Len(t, appDBSts.Spec.Template.Spec.InitContainers, 1)
 	require.Len(t, appDBSts.Spec.Template.Spec.Containers, 2)
 
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:INIT_DATABASE_SHA", appDBSts.Spec.Template.Spec.InitContainers[0].Image)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:INIT_DATABASE_SHA",
+		appDBSts.Spec.Template.Spec.InitContainers[0].Image,
+	)
 	assert.Equal(t, "quay.io/mongodb/mongodb-agent@sha256:AGENT_SHA", appDBSts.Spec.Template.Spec.Containers[0].Image)
-	assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:MONGODB_SHA", appDBSts.Spec.Template.Spec.Containers[1].Image)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:MONGODB_SHA",
+		appDBSts.Spec.Template.Spec.Containers[1].Image,
+	)
 }
 
 func TestOpsManagerReconcileContainerImagesWithStaticArchitecture(t *testing.T) {
@@ -653,7 +729,11 @@ func TestOpsManagerReconcileContainerImagesWithStaticArchitecture(t *testing.T) 
 			assert.Len(t, sts.Spec.Template.Spec.InitContainers, 0)
 			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 
-			assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-ops-manager:@sha256:MONGODB_OPS_MANAGER", sts.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-enterprise-ops-manager:@sha256:MONGODB_OPS_MANAGER",
+				sts.Spec.Template.Spec.Containers[0].Image,
+			)
 		})
 	}
 
@@ -663,7 +743,11 @@ func TestOpsManagerReconcileContainerImagesWithStaticArchitecture(t *testing.T) 
 
 	require.Len(t, appDBSts.Spec.Template.Spec.InitContainers, 0)
 	require.Len(t, appDBSts.Spec.Template.Spec.Containers, 3)
-	assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:MONGODB_SHA", appDBSts.Spec.Template.Spec.Containers[1].Image)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:MONGODB_SHA",
+		appDBSts.Spec.Template.Spec.Containers[1].Image,
+	)
 }
 
 func TestOpsManagerConnectionString_IsPassedAsSecretRef(t *testing.T) {
@@ -756,7 +840,10 @@ func TestOpsManagerWithKMIP(t *testing.T) {
 
 	expectedCAVolume := statefulset.CreateVolumeFromConfigMap(util.KMIPServerCAName, kmipCAConfigMapName)
 	assert.Contains(t, volumes, expectedCAVolume)
-	expectedClientCertVolume := statefulset.CreateVolumeFromSecret(util.KMIPClientSecretNamePrefix+expectedClientCertificateSecretName, expectedClientCertificateSecretName)
+	expectedClientCertVolume := statefulset.CreateVolumeFromSecret(
+		util.KMIPClientSecretNamePrefix+expectedClientCertificateSecretName,
+		expectedClientCertificateSecretName,
+	)
 	assert.Contains(t, volumes, expectedClientCertVolume)
 }
 
@@ -776,8 +863,15 @@ func TestOpsManagerBackupDaemonHostName(t *testing.T) {
 	assert.Equal(t, []string{"test-om-backup-daemon-0.test-om-backup-daemon-svc.my-namespace.svc.some.domain"},
 		DefaultOpsManagerBuilder().SetClusterDomain("some.domain").Build().BackupDaemonFQDNs())
 
-	assert.Equal(t, []string{"test-om-backup-daemon-0.test-om-backup-daemon-svc.my-namespace.svc.cluster.local", "test-om-backup-daemon-1.test-om-backup-daemon-svc.my-namespace.svc.cluster.local", "test-om-backup-daemon-2.test-om-backup-daemon-svc.my-namespace.svc.cluster.local"},
-		DefaultOpsManagerBuilder().SetBackupMembers(3).Build().BackupDaemonFQDNs())
+	assert.Equal(
+		t,
+		[]string{
+			"test-om-backup-daemon-0.test-om-backup-daemon-svc.my-namespace.svc.cluster.local",
+			"test-om-backup-daemon-1.test-om-backup-daemon-svc.my-namespace.svc.cluster.local",
+			"test-om-backup-daemon-2.test-om-backup-daemon-svc.my-namespace.svc.cluster.local",
+		},
+		DefaultOpsManagerBuilder().SetBackupMembers(3).Build().BackupDaemonFQDNs(),
+	)
 }
 
 func TestOpsManagerBackupAssignmentLabels(t *testing.T) {
@@ -876,22 +970,58 @@ func TestTriggerOmChangedEventIfNeeded(t *testing.T) {
 	ctx := context.Background()
 	t.Run("Om changed event got triggered, major version update", func(t *testing.T) {
 		nextScheduledTime := agents.NextScheduledUpgradeTime()
-		assert.NoError(t, triggerOmChangedEventIfNeeded(ctx, omv1.NewOpsManagerBuilder().SetVersion("5.2.13").SetOMStatusVersion("4.2.13").Build(), nil, architectures.NonStatic, zap.S()))
+		assert.NoError(
+			t,
+			triggerOmChangedEventIfNeeded(
+				ctx,
+				omv1.NewOpsManagerBuilder().SetVersion("5.2.13").SetOMStatusVersion("4.2.13").Build(),
+				nil,
+				architectures.NonStatic,
+				zap.S(),
+			),
+		)
 		assert.NotEqual(t, nextScheduledTime, agents.NextScheduledUpgradeTime())
 	})
 	t.Run("Om changed event got triggered, minor version update", func(t *testing.T) {
 		nextScheduledTime := agents.NextScheduledUpgradeTime()
-		assert.NoError(t, triggerOmChangedEventIfNeeded(ctx, omv1.NewOpsManagerBuilder().SetVersion("4.4.0").SetOMStatusVersion("4.2.13").Build(), nil, architectures.NonStatic, zap.S()))
+		assert.NoError(
+			t,
+			triggerOmChangedEventIfNeeded(
+				ctx,
+				omv1.NewOpsManagerBuilder().SetVersion("4.4.0").SetOMStatusVersion("4.2.13").Build(),
+				nil,
+				architectures.NonStatic,
+				zap.S(),
+			),
+		)
 		assert.NotEqual(t, nextScheduledTime, agents.NextScheduledUpgradeTime())
 	})
 	t.Run("Om changed event got triggered, minor version update, candidate version", func(t *testing.T) {
 		nextScheduledTime := agents.NextScheduledUpgradeTime()
-		assert.NoError(t, triggerOmChangedEventIfNeeded(ctx, omv1.NewOpsManagerBuilder().SetVersion("4.4.0-rc2").SetOMStatusVersion("4.2.13").Build(), nil, architectures.NonStatic, zap.S()))
+		assert.NoError(
+			t,
+			triggerOmChangedEventIfNeeded(
+				ctx,
+				omv1.NewOpsManagerBuilder().SetVersion("4.4.0-rc2").SetOMStatusVersion("4.2.13").Build(),
+				nil,
+				architectures.NonStatic,
+				zap.S(),
+			),
+		)
 		assert.NotEqual(t, nextScheduledTime, agents.NextScheduledUpgradeTime())
 	})
 	t.Run("Om changed event not triggered, patch version update", func(t *testing.T) {
 		nextScheduledTime := agents.NextScheduledUpgradeTime()
-		assert.NoError(t, triggerOmChangedEventIfNeeded(ctx, omv1.NewOpsManagerBuilder().SetVersion("4.4.10").SetOMStatusVersion("4.4.0").Build(), nil, architectures.NonStatic, zap.S()))
+		assert.NoError(
+			t,
+			triggerOmChangedEventIfNeeded(
+				ctx,
+				omv1.NewOpsManagerBuilder().SetVersion("4.4.10").SetOMStatusVersion("4.4.0").Build(),
+				nil,
+				architectures.NonStatic,
+				zap.S(),
+			),
+		)
 		assert.Equal(t, nextScheduledTime, agents.NextScheduledUpgradeTime())
 	})
 }
@@ -974,13 +1104,16 @@ func TestOpsManagerRace(t *testing.T) {
 	ctx := context.Background()
 	opsManager1 := DefaultOpsManagerBuilder().SetName("om1").
 		AddOplogStoreConfig("oplog-store-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).
-		AddBlockStoreConfig("block-store-config-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).Build()
+		AddBlockStoreConfig("block-store-config-1", "my-user", types.NamespacedName{Name: "config-1-mdb", Namespace: mock.TestNamespace}).
+		Build()
 	opsManager2 := DefaultOpsManagerBuilder().SetName("om2").
 		AddOplogStoreConfig("oplog-store-2", "my-user", types.NamespacedName{Name: "config-2-mdb", Namespace: mock.TestNamespace}).
-		AddBlockStoreConfig("block-store-config-2", "my-user", types.NamespacedName{Name: "config-2-mdb", Namespace: mock.TestNamespace}).Build()
+		AddBlockStoreConfig("block-store-config-2", "my-user", types.NamespacedName{Name: "config-2-mdb", Namespace: mock.TestNamespace}).
+		Build()
 	opsManager3 := DefaultOpsManagerBuilder().SetName("om3").
 		AddOplogStoreConfig("oplog-store-3", "my-user", types.NamespacedName{Name: "config-3-mdb", Namespace: mock.TestNamespace}).
-		AddBlockStoreConfig("block-store-config-3", "my-user", types.NamespacedName{Name: "config-3-mdb", Namespace: mock.TestNamespace}).Build()
+		AddBlockStoreConfig("block-store-config-3", "my-user", types.NamespacedName{Name: "config-3-mdb", Namespace: mock.TestNamespace}).
+		Build()
 
 	resourceToProjectMapping := map[string]string{
 		"om1": opsManager1.Spec.AppDB.GetName(),
@@ -1014,9 +1147,20 @@ func TestOpsManagerRace(t *testing.T) {
 
 	initializer := &MockedInitializer{expectedOmURL: opsManager1.CentralURL(), t: t, skipChecks: true}
 
-	reconciler := NewOpsManagerReconciler(ctx, kubeClient, nil, nil, "fake-initDatabaseVersion", "fake-initOpsManagerImageVersion", architectures.NonStatic, omConnectionFactory.GetConnectionFunc, initializer, func(baseUrl string, user string, publicApiKey string, ca *string) api.OpsManagerAdmin {
-		return api.NewMockedAdminProvider(baseUrl, user, publicApiKey, false).(*api.MockedOmAdmin)
-	})
+	reconciler := NewOpsManagerReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		nil,
+		"fake-initDatabaseVersion",
+		"fake-initOpsManagerImageVersion",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+		initializer,
+		func(baseUrl string, user string, publicApiKey string, ca *string) api.OpsManagerAdmin {
+			return api.NewMockedAdminProvider(baseUrl, user, publicApiKey, false).(*api.MockedOmAdmin)
+		},
+	)
 
 	assert.NoError(t, reconciler.client.CreateSecret(ctx, s))
 
@@ -1136,7 +1280,12 @@ func TestDependentResources_AreRemoved_WhenBackupIsDisabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("All MongoDB resource should be watched.", func(t *testing.T) {
-		assert.Len(t, reconciler.resourceWatcher.GetWatchedResourcesOfType(watch.MongoDB, testOm.Namespace), 6, "All non S3 configs should have a corresponding MongoDB resource and should be watched.")
+		assert.Len(
+			t,
+			reconciler.resourceWatcher.GetWatchedResourcesOfType(watch.MongoDB, testOm.Namespace),
+			6,
+			"All non S3 configs should have a corresponding MongoDB resource and should be watched.",
+		)
 	})
 
 	t.Run("Removing backup configs causes the resource no longer be watched", func(t *testing.T) {
@@ -1168,7 +1317,12 @@ func TestDependentResources_AreRemoved_WhenBackupIsDisabled(t *testing.T) {
 
 		res, err = reconciler.Reconcile(ctx, requestFromObject(testOm))
 		assert.NoError(t, err)
-		assert.Len(t, reconciler.resourceWatcher.GetWatchedResourcesOfType(watch.MongoDB, testOm.Namespace), 0, "Backup has been disabled, none of the resources should be watched anymore.")
+		assert.Len(
+			t,
+			reconciler.resourceWatcher.GetWatchedResourcesOfType(watch.MongoDB, testOm.Namespace),
+			0,
+			"Backup has been disabled, none of the resources should be watched anymore.",
+		)
 	})
 }
 
@@ -1257,7 +1411,16 @@ func configureBackupResources(ctx context.Context, m kubernetesClient.Client, te
 	}
 }
 
-func defaultTestOmReconciler(ctx context.Context, t *testing.T, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string, opsManager *omv1.MongoDBOpsManager, globalMemberClustersMap map[string]client.Client, omConnectionFactory *om.CachedOMConnectionFactory, arch architectures.DefaultArchitecture) (*OpsManagerReconciler, kubernetesClient.Client, *MockedInitializer) {
+func defaultTestOmReconciler(
+	ctx context.Context,
+	t *testing.T,
+	imageUrls images.ImageUrls,
+	initDatabaseVersion, initOpsManagerImageVersion string,
+	opsManager *omv1.MongoDBOpsManager,
+	globalMemberClustersMap map[string]client.Client,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	arch architectures.DefaultArchitecture,
+) (*OpsManagerReconciler, kubernetesClient.Client, *MockedInitializer) {
 	kubeClient := mock.NewEmptyFakeClientWithInterceptor(omConnectionFactory, opsManager.DeepCopy())
 
 	// create an admin user secret
@@ -1273,12 +1436,23 @@ func defaultTestOmReconciler(ctx context.Context, t *testing.T, imageUrls images
 
 	initializer := &MockedInitializer{expectedOmURL: opsManager.CentralURL(), t: t}
 
-	reconciler := NewOpsManagerReconciler(ctx, kubeClient, globalMemberClustersMap, imageUrls, initDatabaseVersion, initOpsManagerImageVersion, arch, omConnectionFactory.GetConnectionFunc, initializer, func(baseUrl string, user string, publicApiKey string, ca *string) api.OpsManagerAdmin {
-		if api.CurrMockedAdmin == nil {
-			api.CurrMockedAdmin = api.NewMockedAdminProvider(baseUrl, user, publicApiKey, true).(*api.MockedOmAdmin)
-		}
-		return api.CurrMockedAdmin
-	})
+	reconciler := NewOpsManagerReconciler(
+		ctx,
+		kubeClient,
+		globalMemberClustersMap,
+		imageUrls,
+		initDatabaseVersion,
+		initOpsManagerImageVersion,
+		arch,
+		omConnectionFactory.GetConnectionFunc,
+		initializer,
+		func(baseUrl string, user string, publicApiKey string, ca *string) api.OpsManagerAdmin {
+			if api.CurrMockedAdmin == nil {
+				api.CurrMockedAdmin = api.NewMockedAdminProvider(baseUrl, user, publicApiKey, true).(*api.MockedOmAdmin)
+			}
+			return api.CurrMockedAdmin
+		},
+	)
 
 	assert.NoError(t, reconciler.client.CreateSecret(ctx, s))
 	return reconciler, kubeClient, initializer
@@ -1336,7 +1510,12 @@ func (o *MockedInitializer) TryCreateUser(omUrl string, _ string, user api.User,
 	}, nil
 }
 
-func addKMIPTestResources(ctx context.Context, client client.Client, om *omv1.MongoDBOpsManager, mdbName, clientCertificatePrefixName string) {
+func addKMIPTestResources(
+	ctx context.Context,
+	client client.Client,
+	om *omv1.MongoDBOpsManager,
+	mdbName, clientCertificatePrefixName string,
+) {
 	mdb := mdbv1.NewReplicaSetBuilder().SetBackup(mdbv1.Backup{
 		Mode: "enabled",
 		Encryption: &mdbv1.Encryption{

--- a/controllers/operator/mongodbopsmanager_event_handler.go
+++ b/controllers/operator/mongodbopsmanager_event_handler.go
@@ -24,7 +24,11 @@ type MongoDBOpsManagerEventHandler struct {
 }
 
 // Delete implements EventHandler and it is called when the CR is removed
-func (eh *MongoDBOpsManagerEventHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (eh *MongoDBOpsManagerEventHandler) Delete(
+	ctx context.Context,
+	e event.TypedDeleteEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	objectKey := kube.ObjectKey(e.Object.GetNamespace(), e.Object.GetName())
 	logger := zap.S().With("resource", objectKey)
 

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -174,7 +174,11 @@ func (r *ReplicaSetReconcilerHelper) initialize(ctx context.Context) error {
 // updateStatus is a pass-through method that calls the reconciler updateStatus.
 // In the future (multi-cluster epic), this will be enhanced to write deployment state to ConfigMap after every status
 // update (similar to sharded cluster pattern), but for now it just delegates to maintain the same architecture.
-func (r *ReplicaSetReconcilerHelper) updateStatus(ctx context.Context, status workflow.Status, statusOptions ...mdbstatus.Option) (reconcile.Result, error) {
+func (r *ReplicaSetReconcilerHelper) updateStatus(
+	ctx context.Context,
+	status workflow.Status,
+	statusOptions ...mdbstatus.Option,
+) (reconcile.Result, error) {
 	return r.reconciler.updateStatus(ctx, r.resource, status, r.log, statusOptions...)
 }
 
@@ -188,11 +192,25 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 
 	// === 1. Initial Checks and setup
 	if !architectures.IsRunningStaticArchitecture(rs.Annotations, reconciler.defaultArchitecture) {
-		agents.UpgradeAllIfNeeded(ctx, agents.ClientSecret{Client: reconciler.client, SecretClient: reconciler.SecretClient}, reconciler.omConnectionFactory, GetWatchedNamespace(), false)
+		agents.UpgradeAllIfNeeded(
+			ctx,
+			agents.ClientSecret{Client: reconciler.client, SecretClient: reconciler.SecretClient},
+			reconciler.omConnectionFactory,
+			GetWatchedNamespace(),
+			false,
+		)
 	}
 
 	log.Info("-> ReplicaSet.Reconcile")
-	log.Infow("ReplicaSet.Spec", "spec", rs.Spec, "desiredReplicas", scale.ReplicasThisReconciliation(rs), "isScaling", scale.IsStillScaling(rs))
+	log.Infow(
+		"ReplicaSet.Spec",
+		"spec",
+		rs.Spec,
+		"desiredReplicas",
+		scale.ReplicasThisReconciliation(rs),
+		"isScaling",
+		scale.IsStillScaling(rs),
+	)
 	log.Infow("ReplicaSet.Status", "status", rs.Status)
 
 	if err := rs.ProcessValidationsOnReconcile(nil); err != nil {
@@ -204,7 +222,16 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 		return r.updateStatus(ctx, workflow.Failed(err))
 	}
 
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, reconciler.SecretClient, projectConfig, credsConfig, reconciler.omConnectionFactory, rs.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		reconciler.SecretClient,
+		projectConfig,
+		credsConfig,
+		reconciler.omConnectionFactory,
+		rs.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, workflow.Failed(xerrors.Errorf("failed to prepare Ops Manager connection: %w", err)))
 	}
@@ -253,8 +280,22 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 	if reconciler.VaultClient != nil {
 		databaseSecretPath = reconciler.VaultClient.DatabaseSecretPath()
 	}
-	tlsCertHash := enterprisepem.ReadHashFromSecret(ctx, reconciler.SecretClient, rs.Namespace, rsCertsConfig.CertSecretName, databaseSecretPath, log)
-	internalClusterCertHash := enterprisepem.ReadHashFromSecret(ctx, reconciler.SecretClient, rs.Namespace, rsCertsConfig.InternalClusterSecretName, databaseSecretPath, log)
+	tlsCertHash := enterprisepem.ReadHashFromSecret(
+		ctx,
+		reconciler.SecretClient,
+		rs.Namespace,
+		rsCertsConfig.CertSecretName,
+		databaseSecretPath,
+		log,
+	)
+	internalClusterCertHash := enterprisepem.ReadHashFromSecret(
+		ctx,
+		reconciler.SecretClient,
+		rs.Namespace,
+		rsCertsConfig.InternalClusterSecretName,
+		databaseSecretPath,
+		log,
+	)
 
 	tlsCertPath := ""
 	internalClusterCertPath := ""
@@ -268,7 +309,14 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 	agentCertSecretName := rs.GetSecurity().AgentClientCertificateSecretName(rs.Name)
 	agentCertHash, agentCertPath := reconciler.agentCertHashAndPath(ctx, log, rs.Namespace, agentCertSecretName, databaseSecretPath)
 
-	prometheusCertHash, err := certs.EnsureTLSCertsForPrometheus(ctx, reconciler.SecretClient, rs.GetNamespace(), rs.GetPrometheus(), certs.Database, log)
+	prometheusCertHash, err := certs.EnsureTLSCertsForPrometheus(
+		ctx,
+		reconciler.SecretClient,
+		rs.GetNamespace(),
+		rs.GetPrometheus(),
+		certs.Database,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, workflow.Failed(xerrors.Errorf("could not generate certificates for Prometheus: %w", err)))
 	}
@@ -298,8 +346,15 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 	// configuration and a subsequent attempt to overwrite it later, the operator would be stuck in Pending phase.
 	// See CLOUDP-189433 and CLOUDP-229222 for more details.
 	if recovery.ShouldTriggerRecovery(rs.Status.Phase != mdbstatus.PhaseRunning, rs.Status.LastTransition) {
-		log.Warnf("Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s", rs.Namespace, rs.Name, rs.Status.Phase, rs.Status.LastTransition)
-		automationConfigStatus := r.updateOmDeploymentRs(ctx, conn, r.deploymentState.LastReconcileMemberCount, tlsCertPath, internalClusterCertPath, deploymentOpts, shouldMirrorKeyfileForMongot, true).OnErrorPrepend("failed to create/update (Ops Manager reconciliation phase):")
+		log.Warnf(
+			"Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s",
+			rs.Namespace,
+			rs.Name,
+			rs.Status.Phase,
+			rs.Status.LastTransition,
+		)
+		automationConfigStatus := r.updateOmDeploymentRs(ctx, conn, r.deploymentState.LastReconcileMemberCount, tlsCertPath, internalClusterCertPath, deploymentOpts, shouldMirrorKeyfileForMongot, true).
+			OnErrorPrepend("failed to create/update (Ops Manager reconciliation phase):")
 		reconcileStatus := r.reconcileMemberResources(ctx, conn, projectConfig, deploymentOpts, r.deploymentState.LastConfiguredRoles)
 		if !reconcileStatus.IsOK() {
 			log.Errorf("Recovery failed because of reconcile errors, %v", reconcileStatus)
@@ -310,10 +365,19 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 	}
 
 	// 5. Actual reconciliation execution, Ops Manager and kubernetes resources update
-	publishAutomationConfigFirst := publishAutomationConfigFirst(ctx, reconciler.client, *rs, r.deploymentState.LastAchievedSpec, r.buildStatefulSetOptions(ctx, conn, projectConfig, deploymentOpts), reconciler.defaultArchitecture, log)
+	publishAutomationConfigFirst := publishAutomationConfigFirst(
+		ctx,
+		reconciler.client,
+		*rs,
+		r.deploymentState.LastAchievedSpec,
+		r.buildStatefulSetOptions(ctx, conn, projectConfig, deploymentOpts),
+		reconciler.defaultArchitecture,
+		log,
+	)
 	status := workflow.RunInGivenOrder(publishAutomationConfigFirst,
 		func() workflow.Status {
-			return r.updateOmDeploymentRs(ctx, conn, r.deploymentState.LastReconcileMemberCount, tlsCertPath, internalClusterCertPath, deploymentOpts, shouldMirrorKeyfileForMongot, false).OnErrorPrepend("failed to create/update (Ops Manager reconciliation phase):")
+			return r.updateOmDeploymentRs(ctx, conn, r.deploymentState.LastReconcileMemberCount, tlsCertPath, internalClusterCertPath, deploymentOpts, shouldMirrorKeyfileForMongot, false).
+				OnErrorPrepend("failed to create/update (Ops Manager reconciliation phase):")
 		},
 		func() workflow.Status {
 			return r.reconcileMemberResources(ctx, conn, projectConfig, deploymentOpts, r.deploymentState.LastConfiguredRoles)
@@ -325,7 +389,16 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 
 	// === 6. Final steps
 	if scale.IsStillScaling(rs) {
-		return r.updateStatus(ctx, workflow.Pending("Continuing scaling operation for ReplicaSet %s, desiredMembers=%d, currentMembers=%d", rs.ObjectKey(), rs.DesiredReplicas(), scale.ReplicasThisReconciliation(rs)), mdbstatus.MembersOption(rs))
+		return r.updateStatus(
+			ctx,
+			workflow.Pending(
+				"Continuing scaling operation for ReplicaSet %s, desiredMembers=%d, currentMembers=%d",
+				rs.ObjectKey(),
+				rs.DesiredReplicas(),
+				scale.ReplicasThisReconciliation(rs),
+			),
+			mdbstatus.MembersOption(rs),
+		)
 	}
 
 	// Get lastspec, vault annotations when needed and write them to the resource.
@@ -341,7 +414,12 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 		annotationsToAdd[k] = val
 	}
 
-	roleAnnotation, _, err := r.reconciler.getRoleAnnotation(ctx, r.resource.Spec.DbCommonSpec, r.reconciler.enableClusterMongoDBRoles, kube.ObjectKeyFromApiObject(r.resource))
+	roleAnnotation, _, err := r.reconciler.getRoleAnnotation(
+		ctx,
+		r.resource.Spec.DbCommonSpec,
+		r.reconciler.enableClusterMongoDBRoles,
+		kube.ObjectKeyFromApiObject(r.resource),
+	)
 	if err != nil {
 		return r.updateStatus(ctx, workflow.Failed(err))
 	}
@@ -354,10 +432,26 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 	}
 
 	log.Infof("Finished reconciliation for MongoDbReplicaSet! %s", completionMessage(conn.BaseURL(), conn.GroupID()))
-	return r.updateStatus(ctx, workflow.OK(), mdbstatus.NewBaseUrlOption(deployment.Link(conn.BaseURL(), conn.GroupID())), mdbstatus.NewProjectIdOption(conn.GroupID()), mdbstatus.MembersOption(rs), mdbstatus.NewPVCsStatusOptionEmptyStatus())
+	return r.updateStatus(
+		ctx,
+		workflow.OK(),
+		mdbstatus.NewBaseUrlOption(deployment.Link(conn.BaseURL(), conn.GroupID())),
+		mdbstatus.NewProjectIdOption(conn.GroupID()),
+		mdbstatus.MembersOption(rs),
+		mdbstatus.NewPVCsStatusOptionEmptyStatus(),
+	)
 }
 
-func newReplicaSetReconciler(ctx context.Context, kubeClient client.Client, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, omFunc om.ConnectionFactory) *ReconcileMongoDbReplicaSet {
+func newReplicaSetReconciler(
+	ctx context.Context,
+	kubeClient client.Client,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	omFunc om.ConnectionFactory,
+) *ReconcileMongoDbReplicaSet {
 	return &ReconcileMongoDbReplicaSet{
 		ReconcileCommonController: NewReconcileCommonController(ctx, kubeClient),
 		omConnectionFactory:       omFunc,
@@ -424,7 +518,14 @@ func getHostnameOverrideConfigMapForReplicaset(mdb *mdbv1.MongoDB) corev1.Config
 	data := make(map[string]string)
 
 	if mdb.Spec.DbCommonSpec.GetExternalDomain() != nil {
-		hostnames, names := dns.GetDNSNames(mdb.Name, "", mdb.GetObjectMeta().GetNamespace(), mdb.Spec.GetClusterDomain(), mdb.Spec.Members, mdb.Spec.DbCommonSpec.GetExternalDomain())
+		hostnames, names := dns.GetDNSNames(
+			mdb.Name,
+			"",
+			mdb.GetObjectMeta().GetNamespace(),
+			mdb.Spec.GetClusterDomain(),
+			mdb.Spec.Members,
+			mdb.Spec.DbCommonSpec.GetExternalDomain(),
+		)
 		for i := range hostnames {
 			data[names[i]] = hostnames[i]
 		}
@@ -440,7 +541,11 @@ func getHostnameOverrideConfigMapForReplicaset(mdb *mdbv1.MongoDB) corev1.Config
 	return cm
 }
 
-func (r *ReplicaSetReconcilerHelper) reconcileHostnameOverrideConfigMap(ctx context.Context, log *zap.SugaredLogger, getUpdateCreator configmap.GetUpdateCreator) error {
+func (r *ReplicaSetReconcilerHelper) reconcileHostnameOverrideConfigMap(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	getUpdateCreator configmap.GetUpdateCreator,
+) error {
 	if r.resource.Spec.DbCommonSpec.GetExternalDomain() == nil {
 		return nil
 	}
@@ -458,7 +563,13 @@ func (r *ReplicaSetReconcilerHelper) reconcileHostnameOverrideConfigMap(ctx cont
 // reconcileMemberResources handles the synchronization of kubernetes resources, which can be statefulsets, services etc.
 // All the resources required in the k8s cluster (as opposed to the automation config) for creating the replicaset
 // should be reconciled in this method.
-func (r *ReplicaSetReconcilerHelper) reconcileMemberResources(ctx context.Context, conn om.Connection, projectConfig mdbv1.ProjectConfig, deploymentOptions deploymentOptionsRS, lastConfiguredRoles []string) workflow.Status {
+func (r *ReplicaSetReconcilerHelper) reconcileMemberResources(
+	ctx context.Context,
+	conn om.Connection,
+	projectConfig mdbv1.ProjectConfig,
+	deploymentOptions deploymentOptionsRS,
+	lastConfiguredRoles []string,
+) workflow.Status {
 	rs := r.resource
 	reconciler := r.reconciler
 	log := r.log
@@ -476,7 +587,12 @@ func (r *ReplicaSetReconcilerHelper) reconcileMemberResources(ctx context.Contex
 	return r.reconcileStatefulSet(ctx, conn, projectConfig, deploymentOptions)
 }
 
-func (r *ReplicaSetReconcilerHelper) reconcileStatefulSet(ctx context.Context, conn om.Connection, projectConfig mdbv1.ProjectConfig, deploymentOptions deploymentOptionsRS) workflow.Status {
+func (r *ReplicaSetReconcilerHelper) reconcileStatefulSet(
+	ctx context.Context,
+	conn om.Connection,
+	projectConfig mdbv1.ProjectConfig,
+	deploymentOptions deploymentOptionsRS,
+) workflow.Status {
 	rs := r.resource
 	reconciler := r.reconciler
 	log := r.log
@@ -487,7 +603,14 @@ func (r *ReplicaSetReconcilerHelper) reconcileStatefulSet(ctx context.Context, c
 		return status
 	}
 
-	status = certs.EnsureSSLCertsForStatefulSet(ctx, reconciler.SecretClient, reconciler.SecretClient, *rs.Spec.Security, certs.ReplicaSetConfig(*rs), log)
+	status = certs.EnsureSSLCertsForStatefulSet(
+		ctx,
+		reconciler.SecretClient,
+		reconciler.SecretClient,
+		*rs.Spec.Security,
+		certs.ReplicaSetConfig(*rs),
+		log,
+	)
 	if !status.IsOK() {
 		return status
 	}
@@ -532,7 +655,12 @@ func (r *ReplicaSetReconcilerHelper) handlePVCResize(ctx context.Context, sts *a
 }
 
 // buildStatefulSetOptions creates the options needed for constructing the StatefulSet
-func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(ctx context.Context, conn om.Connection, projectConfig mdbv1.ProjectConfig, deploymentOptions deploymentOptionsRS) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
+func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(
+	ctx context.Context,
+	conn om.Connection,
+	projectConfig mdbv1.ProjectConfig,
+	deploymentOptions deploymentOptionsRS,
+) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
 	rs := r.resource
 	reconciler := r.reconciler
 	log := r.log
@@ -546,8 +674,22 @@ func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(ctx context.Context
 		databaseSecretPath = reconciler.VaultClient.DatabaseSecretPath()
 	}
 
-	tlsCertHash := enterprisepem.ReadHashFromSecret(ctx, reconciler.SecretClient, rs.Namespace, rsCertsConfig.CertSecretName, databaseSecretPath, log)
-	internalClusterCertHash := enterprisepem.ReadHashFromSecret(ctx, reconciler.SecretClient, rs.Namespace, rsCertsConfig.InternalClusterSecretName, databaseSecretPath, log)
+	tlsCertHash := enterprisepem.ReadHashFromSecret(
+		ctx,
+		reconciler.SecretClient,
+		rs.Namespace,
+		rsCertsConfig.CertSecretName,
+		databaseSecretPath,
+		log,
+	)
+	internalClusterCertHash := enterprisepem.ReadHashFromSecret(
+		ctx,
+		reconciler.SecretClient,
+		rs.Namespace,
+		rsCertsConfig.InternalClusterSecretName,
+		databaseSecretPath,
+		log,
+	)
 
 	rsConfig := construct.ReplicaSetOptions(
 		PodEnvVars(newPodVars(conn, projectConfig, rs.Spec.LogLevel)),
@@ -559,11 +701,17 @@ func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(ctx context.Context
 		WithVaultConfig(vaultConfig),
 		WithLabels(rs.Labels),
 		WithAdditionalMongodConfig(rs.Spec.GetAdditionalMongodConfig()),
-		WithInitDatabaseNonStaticImage(images.ContainerImage(reconciler.imageUrls, util.InitDatabaseImageUrlEnv, reconciler.initDatabaseNonStaticImageVersion)),
-		WithDatabaseNonStaticImage(images.ContainerImage(reconciler.imageUrls, util.NonStaticDatabaseEnterpriseImage, reconciler.databaseNonStaticImageVersion)),
+		WithInitDatabaseNonStaticImage(
+			images.ContainerImage(reconciler.imageUrls, util.InitDatabaseImageUrlEnv, reconciler.initDatabaseNonStaticImageVersion),
+		),
+		WithDatabaseNonStaticImage(
+			images.ContainerImage(reconciler.imageUrls, util.NonStaticDatabaseEnterpriseImage, reconciler.databaseNonStaticImageVersion),
+		),
 		WithAgentImage(images.ContainerImage(reconciler.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
 		WithCustomAgentURL(reconciler.customAgentURL),
-		WithMongodbImage(images.GetOfficialImage(reconciler.imageUrls, rs.Spec.Version, rs.GetAnnotations(), reconciler.defaultArchitecture)),
+		WithMongodbImage(
+			images.GetOfficialImage(reconciler.imageUrls, rs.Spec.Version, rs.GetAnnotations(), reconciler.defaultArchitecture),
+		),
 		WithAgentDebug(reconciler.agentDebug),
 		WithAgentDebugImage(reconciler.agentDebugImage),
 		WithDefaultArchitecture(reconciler.defaultArchitecture),
@@ -574,10 +722,34 @@ func (r *ReplicaSetReconcilerHelper) buildStatefulSetOptions(ctx context.Context
 
 // AddReplicaSetController creates a new MongoDbReplicaset Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture) error {
+func AddReplicaSetController(
+	ctx context.Context,
+	mgr manager.Manager,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) error {
 	// Create a new controller
-	reconciler := newReplicaSetReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, om.NewOpsManagerConnection)
-	c, err := controller.New(util.MongoDbReplicaSetController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		mgr.GetClient(),
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		forceEnterprise,
+		enableClusterMongoDBRoles,
+		agentDebug,
+		agentDebugImage,
+		defaultArchitecture,
+		om.NewOpsManagerConnection,
+	)
+	c, err := controller.New(
+		util.MongoDbReplicaSetController,
+		mgr,
+		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)},
+	) // nolint:forbidigo
 	if err != nil {
 		return err
 	}
@@ -590,7 +762,13 @@ func AddReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls
 		return err
 	}
 
-	err = c.Watch(source.Channel(OmUpdateChannel, &handler.EnqueueRequestForObject{}, source.WithPredicates[client.Object, reconcile.Request](watch.PredicatesForMongoDB(mdbv1.ReplicaSet))))
+	err = c.Watch(
+		source.Channel(
+			OmUpdateChannel,
+			&handler.EnqueueRequestForObject{},
+			source.WithPredicates[client.Object, reconcile.Request](watch.PredicatesForMongoDB(mdbv1.ReplicaSet)),
+		),
+	)
 	if err != nil {
 		return xerrors.Errorf("not able to setup OmUpdateChannel to listent to update events from OM: %s", err)
 	}
@@ -666,7 +844,15 @@ func AddReplicaSetController(ctx context.Context, mgr manager.Manager, imageUrls
 
 // updateOmDeploymentRs performs OM registration operation for the replicaset. So the changes will be finally propagated
 // to automation agents in containers
-func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, conn om.Connection, membersNumberBefore int, tlsCertPath, internalClusterCertPath string, deploymentOptions deploymentOptionsRS, shouldMirrorKeyfileForMongot bool, isRecovering bool) workflow.Status {
+func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(
+	ctx context.Context,
+	conn om.Connection,
+	membersNumberBefore int,
+	tlsCertPath, internalClusterCertPath string,
+	deploymentOptions deploymentOptionsRS,
+	shouldMirrorKeyfileForMongot bool,
+	isRecovering bool,
+) workflow.Status {
 	rs := r.resource
 	log := r.log
 	reconciler := r.reconciler
@@ -682,10 +868,28 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 
 	caFilePath := fmt.Sprintf("%s/ca-pem", util.TLSCaMountPath)
 
-	replicaSet := replicaset.BuildFromMongoDBWithReplicas(reconciler.imageUrls[util.MongodbImageEnv], reconciler.forceEnterprise, rs, replicasTarget, rs.CalculateFeatureCompatibilityVersion(), tlsCertPath, reconciler.defaultArchitecture)
+	replicaSet := replicaset.BuildFromMongoDBWithReplicas(
+		reconciler.imageUrls[util.MongodbImageEnv],
+		reconciler.forceEnterprise,
+		rs,
+		replicasTarget,
+		rs.CalculateFeatureCompatibilityVersion(),
+		tlsCertPath,
+		reconciler.defaultArchitecture,
+	)
 	processNames := replicaSet.GetProcessNames()
 
-	status, additionalReconciliationRequired := reconciler.updateOmAuthentication(ctx, conn, processNames, rs, deploymentOptions.agentCertPath, caFilePath, internalClusterCertPath, isRecovering, log)
+	status, additionalReconciliationRequired := reconciler.updateOmAuthentication(
+		ctx,
+		conn,
+		processNames,
+		rs,
+		deploymentOptions.agentCertPath,
+		caFilePath,
+		internalClusterCertPath,
+		isRecovering,
+		log,
+	)
 	if !status.IsOK() && !isRecovering {
 		return status
 	}
@@ -710,7 +914,18 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 					return err
 				}
 			}
-			return ReconcileReplicaSetAC(ctx, d, rs.Spec.DbCommonSpec, lastRsConfig.ToMap(), rs.Name, replicaSet, caFilePath, internalClusterCertPath, &prometheusConfiguration, log)
+			return ReconcileReplicaSetAC(
+				ctx,
+				d,
+				rs.Spec.DbCommonSpec,
+				lastRsConfig.ToMap(),
+				rs.Name,
+				replicaSet,
+				caFilePath,
+				internalClusterCertPath,
+				&prometheusConfiguration,
+				log,
+			)
 		},
 		log,
 	)
@@ -739,7 +954,8 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 		return workflow.Failed(err)
 	}
 
-	if status := reconciler.ensureBackupConfigurationAndUpdateStatus(ctx, conn, rs, reconciler.SecretClient, log, 0); !status.IsOK() && !isRecovering {
+	if status := reconciler.ensureBackupConfigurationAndUpdateStatus(ctx, conn, rs, reconciler.SecretClient, log, 0); !status.IsOK() &&
+		!isRecovering {
 		return status
 	}
 
@@ -766,7 +982,16 @@ func (r *ReplicaSetReconcilerHelper) cleanOpsManagerState(ctx context.Context, r
 	}
 
 	log.Infow("Removing replica set from Ops Manager", "config", rs.Spec)
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.reconciler.SecretClient, projectConfig, credsConfig, r.reconciler.omConnectionFactory, rs.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.reconciler.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.reconciler.omConnectionFactory,
+		rs.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return err
 	}
@@ -805,12 +1030,22 @@ func (r *ReplicaSetReconcilerHelper) cleanOpsManagerState(ctx context.Context, r
 
 	// During deletion, calculate the maximum number of hosts that could possibly exist to ensure complete cleanup.
 	// Reading from Status here is appropriate since this is outside the reconciliation loop.
-	hostsToRemove, _ := dns.GetDNSNames(rs.Name, rs.ServiceName(), rs.Namespace, rs.Spec.GetClusterDomain(), util.MaxInt(rs.Status.Members, rs.Spec.Members), rs.Spec.GetExternalDomain())
+	hostsToRemove, _ := dns.GetDNSNames(
+		rs.Name,
+		rs.ServiceName(),
+		rs.Namespace,
+		rs.Spec.GetClusterDomain(),
+		util.MaxInt(rs.Status.Members, rs.Spec.Members),
+		rs.Spec.GetExternalDomain(),
+	)
 	log.Infow("Stop monitoring removed hosts in Ops Manager", "removedHosts", hostsToRemove)
 
 	if err := host.StopMonitoring(conn, hostsToRemove, log); err != nil {
 		// StopMonitoring may fail with 401 if hosts are already removed or auth is misconfigured.
-		errs = multierror.Append(errs, xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err))
+		errs = multierror.Append(
+			errs,
+			xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err),
+		)
 	}
 
 	if err := r.reconciler.clearProjectAuthenticationSettings(ctx, conn, rs, processNames, log); err != nil {
@@ -840,7 +1075,14 @@ func (r *ReconcileMongoDbReplicaSet) OnDelete(ctx context.Context, obj runtime.O
 }
 
 func getAllHostsForReplicas(rs *mdbv1.MongoDB, membersCount int) []string {
-	hostnames, _ := dns.GetDNSNames(rs.Name, rs.ServiceName(), rs.Namespace, rs.Spec.GetClusterDomain(), membersCount, rs.Spec.DbCommonSpec.GetExternalDomain())
+	hostnames, _ := dns.GetDNSNames(
+		rs.Name,
+		rs.ServiceName(),
+		rs.Namespace,
+		rs.Spec.GetClusterDomain(),
+		membersCount,
+		rs.Spec.DbCommonSpec.GetExternalDomain(),
+	)
 	return hostnames
 }
 
@@ -876,7 +1118,9 @@ func (r *ReplicaSetReconcilerHelper) mirrorKeyfileIntoSecretForMongot(ctx contex
 	log := r.log
 
 	keyfileContents := maputil.ReadMapValueAsString(d, "auth", "key")
-	keyfileSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", rs.Name, searchcontroller.MongotKeyfileFilename), Namespace: rs.Namespace}}
+	keyfileSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", rs.Name, searchcontroller.MongotKeyfileFilename), Namespace: rs.Namespace},
+	}
 
 	log.Infof("Mirroring the replicaset %s's keyfile into the secret %s", rs.ObjectKey(), kube.ObjectKeyFromApiObject(keyfileSecret))
 
@@ -899,7 +1143,12 @@ func (r *ReplicaSetReconcilerHelper) lookupCorrespondingSearchResource(ctx conte
 	if err := reconciler.client.List(ctx, searchList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(searchv1.MongoDBSearchIndexFieldName, rs.GetNamespace()+"/"+rs.GetName()),
 	}); err != nil {
-		return nil, xerrors.Errorf("Failed to list MongoDBSearch resources referred in the MongoDB resource %s/%s. err : %v", rs.Namespace, rs.Name, err)
+		return nil, xerrors.Errorf(
+			"Failed to list MongoDBSearch resources referred in the MongoDB resource %s/%s. err : %v",
+			rs.Namespace,
+			rs.Name,
+			err,
+		)
 	}
 
 	if len(searchList.Items) == 0 {

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -97,7 +97,19 @@ func TestReplicaSetRace(t *testing.T) {
 			Get: mock.GetFakeClientInterceptorGetFunc(omConnectionFactory, true, true),
 		}).Build()
 
-	reconciler := newReplicaSetReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	testConcurrentReconciles(ctx, t, fakeClient, reconciler, rs, rs2, rs3)
 }
@@ -124,7 +136,11 @@ func TestReplicaSetClusterReconcileContainerImages(t *testing.T) {
 	require.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 	require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE", sts.Spec.Template.Spec.InitContainers[0].Image)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE",
+		sts.Spec.Template.Spec.InitContainers[0].Image,
+	)
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-database:@sha256:MONGODB_DATABASE", sts.Spec.Template.Spec.Containers[0].Image)
 }
 
@@ -279,7 +295,11 @@ func TestExposedExternallyReplicaSet(t *testing.T) {
 	assert.Error(t, err)
 
 	for podNum := 0; podNum < 3; podNum++ {
-		err := client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%d-svc-external", rs.Name, podNum), Namespace: rs.Namespace}, externalService)
+		err := client.Get(
+			ctx,
+			types.NamespacedName{Name: fmt.Sprintf("%s-%d-svc-external", rs.Name, podNum), Namespace: rs.Namespace},
+			externalService,
+		)
 		assert.NoError(t, err)
 
 		assert.NoError(t, err)
@@ -310,7 +330,14 @@ func TestExposedExternallyReplicaSetExternalDomainInHostnames(t *testing.T) {
 	testExposedExternallyReplicaSetExternalDomainInHostnames(ctx, t, replicaSetName, memberCount, externalDomain, expectedHostnames)
 }
 
-func testExposedExternallyReplicaSetExternalDomainInHostnames(ctx context.Context, t *testing.T, replicaSetName string, memberCount int, externalDomain string, expectedHostnames []string) {
+func testExposedExternallyReplicaSetExternalDomainInHostnames(
+	ctx context.Context,
+	t *testing.T,
+	replicaSetName string,
+	memberCount int,
+	externalDomain string,
+	expectedHostnames []string,
+) {
 	rs := DefaultReplicaSetBuilder().SetName(replicaSetName).SetMembers(memberCount).ExposedExternally(nil, nil, &externalDomain).Build()
 	reconciler, client, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", rs, architectures.NonStatic)
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
@@ -354,7 +381,11 @@ func TestExposedExternallyReplicaSetWithNodePort(t *testing.T) {
 
 	// then
 	for podNum := 0; podNum < 3; podNum++ {
-		err := client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%d-svc-external", rs.Name, podNum), Namespace: rs.Namespace}, externalService)
+		err := client.Get(
+			ctx,
+			types.NamespacedName{Name: fmt.Sprintf("%s-%d-svc-external", rs.Name, podNum), Namespace: rs.Namespace},
+			externalService,
+		)
 		assert.NoError(t, err)
 
 		assert.NoError(t, err)
@@ -379,7 +410,15 @@ func TestCreateReplicaSet_TLS(t *testing.T) {
 	for _, v := range processes {
 		assert.NotNil(t, v.TLSConfig())
 		assert.Len(t, v.TLSConfig(), 2)
-		assert.Equal(t, fmt.Sprintf("%s/%s", util.TLSCertMountPath, pem.ReadHashFromSecret(ctx, reconciler.SecretClient, rs.Namespace, fmt.Sprintf("%s-cert", rs.Name), "", zap.S())), v.TLSConfig()["certificateKeyFile"])
+		assert.Equal(
+			t,
+			fmt.Sprintf(
+				"%s/%s",
+				util.TLSCertMountPath,
+				pem.ReadHashFromSecret(ctx, reconciler.SecretClient, rs.Namespace, fmt.Sprintf("%s-cert", rs.Name), "", zap.S()),
+			),
+			v.TLSConfig()["certificateKeyFile"],
+		)
 		assert.Equal(t, "requireTLS", v.TLSConfig()["mode"])
 	}
 
@@ -545,7 +584,12 @@ func TestReplicaSetCustomPodSpecTemplateStatic(t *testing.T) {
 	podSpecTemplate := statefulSet.Spec.Template.Spec
 	assert.Len(t, podSpecTemplate.Containers, 4, "Should have 4 containers now")
 	assert.Equal(t, util.AgentContainerName, podSpecTemplate.Containers[0].Name, "Agent container should be first alphabetically")
-	assert.Equal(t, "my-custom-container", podSpecTemplate.Containers[len(podSpecTemplate.Containers)-1].Name, "Custom container should be last")
+	assert.Equal(
+		t,
+		"my-custom-container",
+		podSpecTemplate.Containers[len(podSpecTemplate.Containers)-1].Name,
+		"Custom container should be last",
+	)
 }
 
 func TestFeatureControlPolicyAndTagAddedWithNewerOpsManager(t *testing.T) {
@@ -554,7 +598,19 @@ func TestFeatureControlPolicyAndTagAddedWithNewerOpsManager(t *testing.T) {
 
 	omConnectionFactory := om.NewCachedOMConnectionFactory(omConnectionFactoryFuncSettingVersion())
 	fakeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
-	reconciler := newReplicaSetReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, rs, fakeClient)
 
@@ -578,7 +634,19 @@ func TestFeatureControlPolicyNoAuthNewerOpsManager(t *testing.T) {
 
 	omConnectionFactory := om.NewCachedOMConnectionFactory(omConnectionFactoryFuncSettingVersion())
 	fakeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
-	reconciler := newReplicaSetReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newReplicaSetReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, rs, fakeClient)
 
@@ -611,13 +679,29 @@ func TestScalingScalesOneMemberAtATime_WhenScalingDown(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, time.Duration(10000000000), res.RequeueAfter, "Scaling from 5 -> 4 should enqueue another reconciliation")
 
-	assertCorrectNumberOfMembersAndProcesses(ctx, t, 4, rs, client, omConnectionFactory.GetConnection(), "We should have updated the status with the intermediate value of 4")
+	assertCorrectNumberOfMembersAndProcesses(
+		ctx,
+		t,
+		4,
+		rs,
+		client,
+		omConnectionFactory.GetConnection(),
+		"We should have updated the status with the intermediate value of 4",
+	)
 
 	res, err = reconciler.Reconcile(ctx, requestFromObject(rs))
 	assert.NoError(t, err)
 	assert.Equal(t, util.TWENTY_FOUR_HOURS, res.RequeueAfter, "Once we reach the target value, we should not scale anymore")
 
-	assertCorrectNumberOfMembersAndProcesses(ctx, t, 3, rs, client, omConnectionFactory.GetConnection(), "The members should now be set to the final desired value")
+	assertCorrectNumberOfMembersAndProcesses(
+		ctx,
+		t,
+		3,
+		rs,
+		client,
+		omConnectionFactory.GetConnection(),
+		"The members should now be set to the final desired value",
+	)
 }
 
 func TestScalingScalesOneMemberAtATime_WhenScalingUp(t *testing.T) {
@@ -638,12 +722,28 @@ func TestScalingScalesOneMemberAtATime_WhenScalingUp(t *testing.T) {
 
 	assert.Equal(t, time.Duration(10000000000), res.RequeueAfter, "Scaling from 1 -> 3 should enqueue another reconciliation")
 
-	assertCorrectNumberOfMembersAndProcesses(ctx, t, 2, rs, client, omConnectionFactory.GetConnection(), "We should have updated the status with the intermediate value of 2")
+	assertCorrectNumberOfMembersAndProcesses(
+		ctx,
+		t,
+		2,
+		rs,
+		client,
+		omConnectionFactory.GetConnection(),
+		"We should have updated the status with the intermediate value of 2",
+	)
 
 	res, err = reconciler.Reconcile(ctx, requestFromObject(rs))
 	assert.NoError(t, err)
 
-	assertCorrectNumberOfMembersAndProcesses(ctx, t, 3, rs, client, omConnectionFactory.GetConnection(), "Once we reach the target value, we should not scale anymore")
+	assertCorrectNumberOfMembersAndProcesses(
+		ctx,
+		t,
+		3,
+		rs,
+		client,
+		omConnectionFactory.GetConnection(),
+		"Once we reach the target value, we should not scale anymore",
+	)
 }
 
 func TestReplicaSetPortIsConfigurable_WithAdditionalMongoConfig(t *testing.T) {
@@ -675,8 +775,12 @@ func TestReplicaSet_ConfigMapAndSecretWatched(t *testing.T) {
 	checkReconcileSuccessful(ctx, t, reconciler, rs, client)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}:              {kube.ObjectKey(mock.TestNamespace, rs.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
 	}
 
 	assert.Equal(t, reconciler.resourceWatcher.GetWatchedResources(), expected)
@@ -694,10 +798,18 @@ func TestTLSResourcesAreWatchedAndUnwatched(t *testing.T) {
 	checkReconcileSuccessful(ctx, t, reconciler, rs, client)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}:              {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, "custom-ca")}:                   {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.GetName()+"-cert")}:             {kube.ObjectKey(mock.TestNamespace, rs.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, "custom-ca")}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.GetName()+"-cert")}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
 	}
 
 	assert.Equal(t, reconciler.resourceWatcher.GetWatchedResources(), expected)
@@ -706,8 +818,12 @@ func TestTLSResourcesAreWatchedAndUnwatched(t *testing.T) {
 	checkReconcileSuccessful(ctx, t, reconciler, rs, client)
 
 	expected = map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, rs.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}:              {kube.ObjectKey(mock.TestNamespace, rs.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, rs.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, rs.Name),
+		},
 	}
 
 	assert.Equal(t, reconciler.resourceWatcher.GetWatchedResources(), expected)
@@ -852,7 +968,11 @@ func TestHandlePVCResize(t *testing.T) {
 				Name:      "data-pvc-example-sts-0",
 				Namespace: "default",
 			},
-			Spec: corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: resource.MustParse("1Gi")}}},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
 			Status: corev1.PersistentVolumeClaimStatus{
 				Capacity: corev1.ResourceList{
 					corev1.ResourceStorage: resource.MustParse("1Gi"),
@@ -1090,7 +1210,15 @@ func TestReplicasetRoleAnnotationIsSet(t *testing.T) {
 	assert.Len(t, roles, 0)
 }
 
-func testPVCFinishedResizing(t *testing.T, ctx context.Context, memberClient kubernetesClient.Client, p *corev1.PersistentVolumeClaim, reconciledResource *mdbv1.MongoDB, statefulSet *appsv1.StatefulSet, logger *zap.SugaredLogger) {
+func testPVCFinishedResizing(
+	t *testing.T,
+	ctx context.Context,
+	memberClient kubernetesClient.Client,
+	p *corev1.PersistentVolumeClaim,
+	reconciledResource *mdbv1.MongoDB,
+	statefulSet *appsv1.StatefulSet,
+	logger *zap.SugaredLogger,
+) {
 	// Simulate that the PVC has finished resizing
 	setPVCWithUpdatedResource(ctx, t, memberClient, p)
 
@@ -1115,7 +1243,14 @@ func testPVCFinishedResizing(t *testing.T, ctx context.Context, memberClient kub
 	}
 }
 
-func testPVCStillResizing(t *testing.T, ctx context.Context, memberClient kubernetesClient.Client, reconciledResource *mdbv1.MongoDB, statefulSet *appsv1.StatefulSet, logger *zap.SugaredLogger) {
+func testPVCStillResizing(
+	t *testing.T,
+	ctx context.Context,
+	memberClient kubernetesClient.Client,
+	reconciledResource *mdbv1.MongoDB,
+	statefulSet *appsv1.StatefulSet,
+	logger *zap.SugaredLogger,
+) {
 	// Simulate that the PVC is still resizing by not updating the Capacity in the PVC status
 
 	// Call the HandlePVCResize function
@@ -1130,7 +1265,14 @@ func testPVCStillResizing(t *testing.T, ctx context.Context, memberClient kubern
 	reconciledResource.UpdateStatus(status.PhasePending, status.NewPVCsStatusOption(getPVCOption(st)))
 }
 
-func testPVCResizeStarted(t *testing.T, ctx context.Context, memberClient kubernetesClient.Client, reconciledResource *mdbv1.MongoDB, statefulSet *appsv1.StatefulSet, logger *zap.SugaredLogger) {
+func testPVCResizeStarted(
+	t *testing.T,
+	ctx context.Context,
+	memberClient kubernetesClient.Client,
+	reconciledResource *mdbv1.MongoDB,
+	statefulSet *appsv1.StatefulSet,
+	logger *zap.SugaredLogger,
+) {
 	// Update the StatefulSet to request more storage
 	statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("2Gi")
 
@@ -1145,7 +1287,13 @@ func testPVCResizeStarted(t *testing.T, ctx context.Context, memberClient kubern
 	reconciledResource.UpdateStatus(status.PhasePending, st.StatusOptions()...)
 }
 
-func testPhaseNoActionRequired(t *testing.T, ctx context.Context, memberClient kubernetesClient.Client, statefulSet *appsv1.StatefulSet, logger *zap.SugaredLogger) {
+func testPhaseNoActionRequired(
+	t *testing.T,
+	ctx context.Context,
+	memberClient kubernetesClient.Client,
+	statefulSet *appsv1.StatefulSet,
+	logger *zap.SugaredLogger,
+) {
 	st := create.HandlePVCResize(ctx, memberClient, statefulSet, logger)
 	// Verify the function returns Pending
 	assert.Equal(t, status.PhaseRunning, st.Phase())
@@ -1165,7 +1313,13 @@ func setPVCWithUpdatedResource(ctx context.Context, t *testing.T, c client.Clien
 	assert.NoError(t, err)
 }
 
-func setupClients(t *testing.T, ctx context.Context, p *corev1.PersistentVolumeClaim, statefulSet *appsv1.StatefulSet, reconciledResource *mdbv1.MongoDB) (kubernetesClient.Client, *kubernetesClient.Client) {
+func setupClients(
+	t *testing.T,
+	ctx context.Context,
+	p *corev1.PersistentVolumeClaim,
+	statefulSet *appsv1.StatefulSet,
+	reconciledResource *mdbv1.MongoDB,
+) (kubernetesClient.Client, *kubernetesClient.Client) {
 	memberClient, _ := mock.NewDefaultFakeClient(reconciledResource)
 
 	err := memberClient.Create(ctx, p)
@@ -1187,7 +1341,15 @@ func getPVCOption(st workflow.Status) *status.PVC {
 
 // assertCorrectNumberOfMembersAndProcesses ensures that both the mongodb resource and the Ops Manager deployment
 // have the correct number of processes/replicas at each stage of the scaling operation
-func assertCorrectNumberOfMembersAndProcesses(ctx context.Context, t *testing.T, expected int, mdb *mdbv1.MongoDB, client client.Client, omConnection om.Connection, msg string) {
+func assertCorrectNumberOfMembersAndProcesses(
+	ctx context.Context,
+	t *testing.T,
+	expected int,
+	mdb *mdbv1.MongoDB,
+	client client.Client,
+	omConnection om.Connection,
+	msg string,
+) {
 	err := client.Get(ctx, mdb.ObjectKey(), mdb)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, mdb.Status.Members, msg)
@@ -1196,12 +1358,30 @@ func assertCorrectNumberOfMembersAndProcesses(ctx context.Context, t *testing.T,
 	assert.Len(t, dep.ProcessesCopy(), expected)
 }
 
-func defaultReplicaSetReconciler(ctx context.Context, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, rs *mdbv1.MongoDB, arch architectures.DefaultArchitecture) (*ReconcileMongoDbReplicaSet, kubernetesClient.Client, *om.CachedOMConnectionFactory) {
+func defaultReplicaSetReconciler(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	rs *mdbv1.MongoDB,
+	arch architectures.DefaultArchitecture,
+) (*ReconcileMongoDbReplicaSet, kubernetesClient.Client, *om.CachedOMConnectionFactory) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(rs)
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
 		connection.(*om.MockedOmConnection).Hostnames = calculateReplicaSetExternalHostnames(rs)
 	})
-	return newReplicaSetReconciler(ctx, kubeClient, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, false, false, false, "", arch, omConnectionFactory.GetConnectionFunc), kubeClient, omConnectionFactory
+	return newReplicaSetReconciler(
+		ctx,
+		kubeClient,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		false,
+		false,
+		false,
+		"",
+		arch,
+		omConnectionFactory.GetConnectionFunc,
+	), kubeClient, omConnectionFactory
 }
 
 func calculateReplicaSetExternalHostnames(rs *mdbv1.MongoDB) []string {
@@ -1399,7 +1579,11 @@ func (b *ReplicaSetBuilder) SetOpsManagerConfigMapName(opsManagerConfigMapName s
 	return b
 }
 
-func (b *ReplicaSetBuilder) ExposedExternally(specOverride *corev1.ServiceSpec, annotationsOverride map[string]string, externalDomain *string) *ReplicaSetBuilder {
+func (b *ReplicaSetBuilder) ExposedExternally(
+	specOverride *corev1.ServiceSpec,
+	annotationsOverride map[string]string,
+	externalDomain *string,
+) *ReplicaSetBuilder {
 	b.Spec.ExternalAccessConfiguration = &mdbv1.ExternalAccessConfiguration{}
 	b.Spec.ExternalAccessConfiguration.ExternalDomain = externalDomain
 	if specOverride != nil {
@@ -1610,18 +1794,26 @@ func TestPublishAutomationConfigFirst(t *testing.T) {
 				Build()
 			kubeClient := kubernetesClient.NewClient(fakeClient)
 
-			result := publishAutomationConfigFirst(ctx, kubeClient, tc.mdb, tc.lastSpec, func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
-				return construct.DatabaseStatefulSetOptions{
-					Name:                 mdb.Name,
-					Replicas:             mdb.Spec.Members,
-					CurrentAgentAuthMode: tc.currentAgentAuthMode,
-					PodVars: &env.PodEnvVars{
-						SSLProjectConfig: env.SSLProjectConfig{
-							SSLMMSCAConfigMap: tc.sslMMSCAConfigMap,
+			result := publishAutomationConfigFirst(
+				ctx,
+				kubeClient,
+				tc.mdb,
+				tc.lastSpec,
+				func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
+					return construct.DatabaseStatefulSetOptions{
+						Name:                 mdb.Name,
+						Replicas:             mdb.Spec.Members,
+						CurrentAgentAuthMode: tc.currentAgentAuthMode,
+						PodVars: &env.PodEnvVars{
+							SSLProjectConfig: env.SSLProjectConfig{
+								SSLMMSCAConfigMap: tc.sslMMSCAConfigMap,
+							},
 						},
-					},
-				}
-			}, architectures.NonStatic, zap.S())
+					}
+				},
+				architectures.NonStatic,
+				zap.S(),
+			)
 
 			assert.Equal(t, tc.expectedPublishACFirst, result)
 		})

--- a/controllers/operator/mongodbresource_event_handler.go
+++ b/controllers/operator/mongodbresource_event_handler.go
@@ -29,7 +29,11 @@ type ResourceEventHandler struct {
 	deleter Deleter
 }
 
-func (h *ResourceEventHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (h *ResourceEventHandler) Delete(
+	ctx context.Context,
+	e event.TypedDeleteEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	objectKey := kube.ObjectKey(e.Object.GetNamespace(), e.Object.GetName())
 	logger := zap.S().With("resource", objectKey)
 

--- a/controllers/operator/mongodbsearch_controller.go
+++ b/controllers/operator/mongodbsearch_controller.go
@@ -107,7 +107,10 @@ func newPrepareSearch(operatorClusterName string) prepareSearchFuncs {
 		},
 		shouldSkipCluster: func(search *searchv1.MongoDBSearch, log *zap.SugaredLogger) bool {
 			if !search.LocalizeToCluster(operatorClusterName) {
-				log.Infof("spec.clusters does not list this operator's cluster %q; skipping (another operator owns this CR)", operatorClusterName)
+				log.Infof(
+					"spec.clusters does not list this operator's cluster %q; skipping (another operator owns this CR)",
+					operatorClusterName,
+				)
 				return true
 			}
 			return false
@@ -203,19 +206,35 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 
 	searchSource, err := r.getSourceMongoDBForSearch(ctx, r.kubeClient, mdbSearch, log)
 	if err != nil {
-		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("Waiting for MongoDB source: %s", err)), log)
+		return commoncontroller.UpdateStatus(
+			ctx,
+			r.kubeClient,
+			mdbSearch,
+			workflow.Failed(xerrors.Errorf("Waiting for MongoDB source: %s", err)),
+			log,
+		)
 	}
 
 	if mdbSearch.IsWireprotoEnabled() {
 		log.Info("Enabling the mongot wireproto server as required by annotation")
 		// the keyfile secret is necessary for wireproto authentication
-		r.watch.AddWatchedResourceIfNotAdded(searchSource.KeyfileSecretName(), mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
+		r.watch.AddWatchedResourceIfNotAdded(
+			searchSource.KeyfileSecretName(),
+			mdbSearch.Namespace,
+			watch.Secret,
+			mdbSearch.NamespacedName(),
+		)
 	}
 
 	r.registerTLSResourceWatches(mdbSearch, searchSource)
 
 	if mdbSearch.Spec.AutoEmbedding != nil {
-		r.watch.AddWatchedResourceIfNotAdded(mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name, mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
+		r.watch.AddWatchedResourceIfNotAdded(
+			mdbSearch.Spec.AutoEmbedding.EmbeddingModelAPIKeySecret.Name,
+			mdbSearch.Namespace,
+			watch.Secret,
+			mdbSearch.NamespacedName(),
+		)
 	}
 
 	// Watch the dedicated keyFilePassword secrets so correcting a wrong password (without a cert/key
@@ -239,9 +258,21 @@ func (r *MongoDBSearchReconciler) Reconcile(ctx context.Context, request reconci
 		// A concurrent writer bumped the ConfigMap between read and update; retry
 		// instead of marking the CR Failed over a transient race.
 		if apierrors.IsConflict(err) {
-			return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Pending("Search state was modified concurrently, re-queuing").Requeue(), log)
+			return commoncontroller.UpdateStatus(
+				ctx,
+				r.kubeClient,
+				mdbSearch,
+				workflow.Pending("Search state was modified concurrently, re-queuing").Requeue(),
+				log,
+			)
 		}
-		return commoncontroller.UpdateStatus(ctx, r.kubeClient, mdbSearch, workflow.Failed(xerrors.Errorf("failed to read or repair search state: %w", err)), log)
+		return commoncontroller.UpdateStatus(
+			ctx,
+			r.kubeClient,
+			mdbSearch,
+			workflow.Failed(xerrors.Errorf("failed to read or repair search state: %w", err)),
+			log,
+		)
 	}
 
 	reconcileHelper := searchcontroller.NewMongoDBSearchReconcileHelper(
@@ -290,7 +321,12 @@ func (r *MongoDBSearchReconciler) surfaceMissingSecrets(
 	}
 }
 
-func (r *MongoDBSearchReconciler) getSourceMongoDBForSearch(ctx context.Context, kubeClient client.Client, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
+func (r *MongoDBSearchReconciler) getSourceMongoDBForSearch(
+	ctx context.Context,
+	kubeClient client.Client,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) (searchcontroller.SearchSourceDBResource, error) {
 	return getSearchSource(ctx, kubeClient, r.watch, search, log)
 }
 
@@ -319,7 +355,12 @@ func (r *MongoDBSearchReconciler) OnDelete(ctx context.Context, obj runtime.Obje
 			errs = errors.Join(errs, err)
 		}
 		if errs != nil {
-			log.Warnf("Failed to clean up resources of deleted MongoDBSearch %s on cluster %q: %v", search.NamespacedName(), clusterName, errs)
+			log.Warnf(
+				"Failed to clean up resources of deleted MongoDBSearch %s on cluster %q: %v",
+				search.NamespacedName(),
+				clusterName,
+				errs,
+			)
 		}
 	}
 
@@ -331,12 +372,54 @@ func (r *MongoDBSearchReconciler) OnDelete(ctx context.Context, obj runtime.Obje
 // resources. The state ConfigMap is deliberately absent: it lives on the
 // central cluster only, and a hub whose own cluster is member-registered would
 // otherwise delete the live central state — see deleteLocalSearchResources.
-func deleteMemberSearchResources(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, clusterName string, log *zap.SugaredLogger) error {
+func deleteMemberSearchResources(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName string,
+	log *zap.SugaredLogger,
+) error {
 	errs := errors.Join(
-		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "StatefulSet", searchMongotComponent, &appsv1.StatefulSetList{}, log),
-		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "headless Service", searchMongotComponent, &corev1.ServiceList{}, log),
-		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "proxy Service", searchProxyComponent, &corev1.ServiceList{}, log),
-		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "ConfigMap", searchMongotComponent, &corev1.ConfigMapList{}, log),
+		searchcontroller.DeleteAllOwnedResources(
+			ctx,
+			c,
+			search,
+			clusterName,
+			"StatefulSet",
+			searchMongotComponent,
+			&appsv1.StatefulSetList{},
+			log,
+		),
+		searchcontroller.DeleteAllOwnedResources(
+			ctx,
+			c,
+			search,
+			clusterName,
+			"headless Service",
+			searchMongotComponent,
+			&corev1.ServiceList{},
+			log,
+		),
+		searchcontroller.DeleteAllOwnedResources(
+			ctx,
+			c,
+			search,
+			clusterName,
+			"proxy Service",
+			searchProxyComponent,
+			&corev1.ServiceList{},
+			log,
+		),
+		searchcontroller.DeleteAllOwnedResources(
+			ctx,
+			c,
+			search,
+			clusterName,
+			"ConfigMap",
+			searchMongotComponent,
+			&corev1.ConfigMapList{},
+			log,
+		),
 		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "Secret", searchMongotComponent, &corev1.SecretList{}, log),
 	)
 	for _, s := range []struct{ kind, name string }{
@@ -352,7 +435,13 @@ func deleteMemberSearchResources(ctx context.Context, c kubernetesClient.Client,
 
 // deleteLocalSearchResources additionally deletes the central state ConfigMap:
 // it runs only when THIS operator's own cluster was removed from spec.clusters.
-func deleteLocalSearchResources(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, clusterName string, log *zap.SugaredLogger) error {
+func deleteLocalSearchResources(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName string,
+	log *zap.SugaredLogger,
+) error {
 	stateCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      searchcontroller.SearchStateCMName(search),
@@ -363,10 +452,34 @@ func deleteLocalSearchResources(ctx context.Context, c kubernetesClient.Client, 
 	return errors.Join(deleteMemberSearchResources(ctx, c, search, clusterName, log), stateErr)
 }
 
-func deleteEnvoySearchResources(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, clusterName string, log *zap.SugaredLogger) error {
+func deleteEnvoySearchResources(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName string,
+	log *zap.SugaredLogger,
+) error {
 	return errors.Join(
-		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "Deployment", searchProxyComponent, &appsv1.DeploymentList{}, log),
-		searchcontroller.DeleteAllOwnedResources(ctx, c, search, clusterName, "ConfigMap", searchProxyComponent, &corev1.ConfigMapList{}, log),
+		searchcontroller.DeleteAllOwnedResources(
+			ctx,
+			c,
+			search,
+			clusterName,
+			"Deployment",
+			searchProxyComponent,
+			&appsv1.DeploymentList{},
+			log,
+		),
+		searchcontroller.DeleteAllOwnedResources(
+			ctx,
+			c,
+			search,
+			clusterName,
+			"ConfigMap",
+			searchProxyComponent,
+			&corev1.ConfigMapList{},
+			log,
+		),
 	)
 }
 
@@ -486,7 +599,10 @@ func memberMongoDBSearchResourceWatches(r *MongoDBSearchReconciler) []mongoDBSea
 	}
 }
 
-func (r *MongoDBSearchReconciler) registerTLSResourceWatches(mdbSearch *searchv1.MongoDBSearch, searchSource searchcontroller.SearchSourceDBResource) {
+func (r *MongoDBSearchReconciler) registerTLSResourceWatches(
+	mdbSearch *searchv1.MongoDBSearch,
+	searchSource searchcontroller.SearchSourceDBResource,
+) {
 	if tlsSourceConfig := searchSource.TLSConfig(); tlsSourceConfig != nil {
 		for wType, resources := range tlsSourceConfig.ResourcesToWatch {
 			for _, resource := range resources {
@@ -501,7 +617,12 @@ func (r *MongoDBSearchReconciler) registerTLSResourceWatches(mdbSearch *searchv1
 		for _, cluster := range mdbSearch.Spec.Clusters {
 			for _, shardName := range shardedSource.GetShardNames() {
 				sourceSecretNsName := mdbSearch.TLSSecretForClusterShard(cluster.ResolveIndex(), shardName)
-				r.watch.AddWatchedResourceIfNotAdded(sourceSecretNsName.Name, sourceSecretNsName.Namespace, watch.Secret, mdbSearch.NamespacedName())
+				r.watch.AddWatchedResourceIfNotAdded(
+					sourceSecretNsName.Name,
+					sourceSecretNsName.Namespace,
+					watch.Secret,
+					mdbSearch.NamespacedName(),
+				)
 			}
 		}
 		return
@@ -516,7 +637,13 @@ func (r *MongoDBSearchReconciler) registerTLSResourceWatches(mdbSearch *searchv1
 
 // getSearchSource resolves the source database for a MongoDBSearch resource.
 // Shared by both the main search controller and the Envoy controller.
-func getSearchSource(ctx context.Context, kubeClient client.Client, watcher *watch.ResourceWatcher, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (searchcontroller.SearchSourceDBResource, error) {
+func getSearchSource(
+	ctx context.Context,
+	kubeClient client.Client,
+	watcher *watch.ResourceWatcher,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) (searchcontroller.SearchSourceDBResource, error) {
 	if search.IsExternalMongoDBSource() {
 		externalSpec := search.Spec.Source.ExternalMongoDBSource
 		if search.IsExternalSourceSharded() {

--- a/controllers/operator/mongodbsearch_controller_test.go
+++ b/controllers/operator/mongodbsearch_controller_test.go
@@ -122,7 +122,10 @@ func newSearchReconciler(
 func buildExpectedMongotConfig(search *searchv1.MongoDBSearch, mdbc *mdbcv1.MongoDBCommunity) mongot.Config {
 	var hostAndPorts []string
 	for i := range mdbc.Spec.Members {
-		hostAndPorts = append(hostAndPorts, fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", mdbc.Name, i, mdbc.Name+"-svc", search.Namespace, 27017))
+		hostAndPorts = append(
+			hostAndPorts,
+			fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", mdbc.Name, i, mdbc.Name+"-svc", search.Namespace, 27017),
+		)
 	}
 
 	logLevel := "INFO"
@@ -246,9 +249,19 @@ func TestMongoDBSearchOnDelete_SweepsOwnedResourcesAndDependentWatches(t *testin
 	}
 	newFixture := func(prefix string) clusterFixture {
 		return clusterFixture{
-			ownedSts: &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: prefix + "-owned-sts", Namespace: searchKey.Namespace, Labels: maps.Clone(ownerLabels)}},
-			ownedDep: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: prefix + "-owned-deployment", Namespace: searchKey.Namespace, Labels: maps.Clone(ownerLabels)}},
-			foreign:  &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: prefix + "-foreign", Namespace: searchKey.Namespace, Labels: foreignLabels}},
+			ownedSts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix + "-owned-sts", Namespace: searchKey.Namespace, Labels: maps.Clone(ownerLabels)},
+			},
+			ownedDep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      prefix + "-owned-deployment",
+					Namespace: searchKey.Namespace,
+					Labels:    maps.Clone(ownerLabels),
+				},
+			},
+			foreign: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix + "-foreign", Namespace: searchKey.Namespace, Labels: foreignLabels},
+			},
 		}
 	}
 	deleteErr := fmt.Errorf("injected StatefulSet sweep failure")
@@ -270,7 +283,12 @@ func TestMongoDBSearchOnDelete_SweepsOwnedResourcesAndDependentWatches(t *testin
 	memberA := newClusterClient(fixtureA, failStsSweep)
 	memberB := newClusterClient(fixtureB, interceptor.Funcs{})
 	centralClient := newClusterClient(centralFixture, interceptor.Funcs{})
-	reconciler := newMongoDBSearchReconciler(centralClient, searchcontroller.OperatorSearchConfig{}, map[string]client.Client{"member-a": memberA, "member-b": memberB}, "")
+	reconciler := newMongoDBSearchReconciler(
+		centralClient,
+		searchcontroller.OperatorSearchConfig{},
+		map[string]client.Client{"member-a": memberA, "member-b": memberB},
+		"",
+	)
 	otherSearchKey := types.NamespacedName{Name: "other-search", Namespace: mock.TestNamespace}
 	sharedSecret := types.NamespacedName{Name: "shared-secret", Namespace: mock.TestNamespace}
 	reconciler.watch.AddWatchedResourceIfNotAdded(sharedSecret.Name, sharedSecret.Namespace, watch.Secret, searchKey)
@@ -285,7 +303,11 @@ func TestMongoDBSearchOnDelete_SweepsOwnedResourcesAndDependentWatches(t *testin
 	for watchedObj, dependents := range reconciler.watch.GetWatchedResources() {
 		assert.NotContains(t, dependents, searchKey, "deleted search must be removed from watcher key %s", watchedObj)
 	}
-	assert.Contains(t, reconciler.watch.GetWatchedResources()[watch.Object{ResourceType: watch.Secret, Resource: sharedSecret}], otherSearchKey)
+	assert.Contains(
+		t,
+		reconciler.watch.GetWatchedResources()[watch.Object{ResourceType: watch.Secret, Resource: sharedSecret}],
+		otherSearchKey,
+	)
 
 	assert.Positive(t, logs.FilterMessageSnippet(deleteErr.Error()).Len(), "expected a warning mentioning the injected sweep failure")
 	// The failed StatefulSet sweep on member-a blocks neither the other kinds nor member-b.
@@ -864,7 +886,12 @@ func newSearchReconcilerWithMembers(
 		}
 	}
 	centralClient := builder.Build()
-	return newMongoDBSearchReconciler(centralClient, searchcontroller.OperatorSearchConfig{}, memberClients, operatorClusterName), centralClient
+	return newMongoDBSearchReconciler(
+		centralClient,
+		searchcontroller.OperatorSearchConfig{},
+		memberClients,
+		operatorClusterName,
+	), centralClient
 }
 
 // driveSearchReconcileToRunning loops Reconcile up to maxPasses, seeding LoadBalancer
@@ -912,7 +939,14 @@ func assertSearchOwnerLabels(t *testing.T, search *searchv1.MongoDBSearch, sameC
 	for _, obj := range objs {
 		labels := obj.GetLabels()
 		assert.Equal(t, search.Name, labels[khandler.MongoDBSearchOwnerNameLabel], "owner-name label on %T %s", obj, obj.GetName())
-		assert.Equal(t, search.Namespace, labels[khandler.MongoDBSearchOwnerNamespaceLabel], "owner-namespace label on %T %s", obj, obj.GetName())
+		assert.Equal(
+			t,
+			search.Namespace,
+			labels[khandler.MongoDBSearchOwnerNamespaceLabel],
+			"owner-namespace label on %T %s",
+			obj,
+			obj.GetName(),
+		)
 		if sameCluster {
 			require.Len(t, obj.GetOwnerReferences(), 1, "same-cluster resource %T %s must retain the GC backstop", obj, obj.GetName())
 			assert.Equal(t, search.UID, obj.GetOwnerReferences()[0].UID)
@@ -926,11 +960,15 @@ func newOperatorPerClusterMongoDBSearch(name, namespace string) *searchv1.MongoD
 	clusters := []searchv1.ClusterSpec{
 		{
 			Name: "cluster-a", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"},
+			},
 		},
 		{
 			Name: "cluster-b", Index: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"},
+			},
 		},
 	}
 	return &searchv1.MongoDBSearch{
@@ -1012,14 +1050,70 @@ func TestReconcile_OperatorPerCluster_RemovedClusterCleansLocalResources(t *test
 	reconciler, c := newSearchReconcilerWithMembers(t, nil, nil, "cluster-c", search)
 	legacyAuthLabels := khandler.SearchOwnershipLabels(search, "", "")
 	managed := []client.Object{
-		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "removed-mongot", Namespace: search.Namespace, UID: "removed-sts", Labels: khandler.SearchOwnershipLabels(search, "", searchMongotComponent)}},
-		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "removed-headless", Namespace: search.Namespace, UID: "removed-headless", Labels: khandler.SearchOwnershipLabels(search, "", searchMongotComponent)}},
-		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "removed-proxy", Namespace: search.Namespace, UID: "removed-proxy", Labels: khandler.SearchOwnershipLabels(search, "", searchProxyComponent)}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "removed-config", Namespace: search.Namespace, UID: "removed-config", Labels: khandler.SearchOwnershipLabels(search, "", searchMongotComponent)}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: searchcontroller.SearchStateCMName(search), Namespace: search.Namespace, UID: "removed-state", Labels: khandler.SearchOwnershipLabels(search, "", "")}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.X509OperatorManagedSecret().Name, Namespace: search.Namespace, UID: "legacy-x509", Labels: maps.Clone(legacyAuthLabels)}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.ScramClientCertOperatorManagedSecret().Name, Namespace: search.Namespace, UID: "legacy-scram", Labels: maps.Clone(legacyAuthLabels)}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "removed-secret", Namespace: search.Namespace, UID: "removed-secret", Labels: khandler.SearchOwnershipLabels(search, "", searchMongotComponent)}},
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "removed-mongot",
+				Namespace: search.Namespace,
+				UID:       "removed-sts",
+				Labels:    khandler.SearchOwnershipLabels(search, "", searchMongotComponent),
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "removed-headless",
+				Namespace: search.Namespace,
+				UID:       "removed-headless",
+				Labels:    khandler.SearchOwnershipLabels(search, "", searchMongotComponent),
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "removed-proxy",
+				Namespace: search.Namespace,
+				UID:       "removed-proxy",
+				Labels:    khandler.SearchOwnershipLabels(search, "", searchProxyComponent),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "removed-config",
+				Namespace: search.Namespace,
+				UID:       "removed-config",
+				Labels:    khandler.SearchOwnershipLabels(search, "", searchMongotComponent),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      searchcontroller.SearchStateCMName(search),
+				Namespace: search.Namespace,
+				UID:       "removed-state",
+				Labels:    khandler.SearchOwnershipLabels(search, "", ""),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      search.X509OperatorManagedSecret().Name,
+				Namespace: search.Namespace,
+				UID:       "legacy-x509",
+				Labels:    maps.Clone(legacyAuthLabels),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      search.ScramClientCertOperatorManagedSecret().Name,
+				Namespace: search.Namespace,
+				UID:       "legacy-scram",
+				Labels:    maps.Clone(legacyAuthLabels),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "removed-secret",
+				Namespace: search.Namespace,
+				UID:       "removed-secret",
+				Labels:    khandler.SearchOwnershipLabels(search, "", searchMongotComponent),
+			},
+		},
 	}
 	for _, obj := range managed {
 		require.NoError(t, c.Create(ctx, obj))
@@ -1050,7 +1144,13 @@ func TestReconcile_OperatorPerCluster_RemovedClusterCleansLocalResources(t *test
 	_, err := reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
 	for _, obj := range managed {
-		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(obj), obj), "%T %s must survive an invalid-spec reconcile", obj, obj.GetName())
+		require.NoError(
+			t,
+			c.Get(ctx, client.ObjectKeyFromObject(obj), obj),
+			"%T %s must survive an invalid-spec reconcile",
+			obj,
+			obj.GetName(),
+		)
 	}
 	afterInvalid := &searchv1.MongoDBSearch{}
 	require.NoError(t, c.Get(ctx, req.NamespacedName, afterInvalid))
@@ -1103,8 +1203,22 @@ func TestMongoDBSearchReconcile_HubRemovedClusterCleansManagedMemberResources(t 
 			var memberB client.Client = mock.NewEmptyFakeClientBuilder().Build()
 			labels := khandler.SearchOwnershipLabels(search, "", searchMongotComponent)
 
-			sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: search.StatefulSetNamespacedNameForCluster(1).Name, Namespace: search.Namespace, UID: "removed-sts", Labels: labels}}
-			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.StatefulSetNamespacedNameForCluster(1).Name + "-tls", Namespace: search.Namespace, UID: "removed-secret", Labels: maps.Clone(labels)}}
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.StatefulSetNamespacedNameForCluster(1).Name,
+					Namespace: search.Namespace,
+					UID:       "removed-sts",
+					Labels:    labels,
+				},
+			}
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.StatefulSetNamespacedNameForCluster(1).Name + "-tls",
+					Namespace: search.Namespace,
+					UID:       "removed-secret",
+					Labels:    maps.Clone(labels),
+				},
+			}
 			require.NoError(t, memberB.Create(ctx, sts))
 			require.NoError(t, memberB.Create(ctx, secret))
 			injectedErr := fmt.Errorf("injected member delete failure")
@@ -1137,7 +1251,10 @@ func TestMongoDBSearchReconcile_HubRemovedClusterCleansManagedMemberResources(t 
 			}, "")
 			logs := observeControllerLogs(t)
 
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+			_, err := reconciler.Reconcile(
+				ctx,
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}},
+			)
 			require.NoError(t, err)
 
 			// The removed-member sweep on the hub's own cluster must not touch the
@@ -1152,7 +1269,11 @@ func TestMongoDBSearchReconcile_HubRemovedClusterCleansManagedMemberResources(t 
 			stsErr := memberB.Get(ctx, client.ObjectKeyFromObject(sts), &appsv1.StatefulSet{})
 			if tc.failStsDelete {
 				assert.NoError(t, stsErr, "failed delete leaves the StatefulSet behind for the next reconcile")
-				assert.Positive(t, logs.FilterMessageSnippet(injectedErr.Error()).Len(), "expected a warning mentioning the injected delete failure")
+				assert.Positive(
+					t,
+					logs.FilterMessageSnippet(injectedErr.Error()).Len(),
+					"expected a warning mentioning the injected delete failure",
+				)
 			} else {
 				assert.True(t, apiErrors.IsNotFound(stsErr))
 				assert.Zero(t, logs.FilterMessageSnippet(injectedErr.Error()).Len())
@@ -1172,10 +1293,38 @@ func TestMongoDBSearchReconcile_HubRemovedClusterCleansManagedMemberResources(t 
 		centralClient := mock.NewEmptyFakeClientBuilder().WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
 		labels := khandler.SearchOwnershipLabels(search, "", searchMongotComponent)
 		live := []client.Object{
-			&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: search.StatefulSetNamespacedNameForCluster(0).Name, Namespace: search.Namespace, UID: "live-sts", Labels: maps.Clone(labels)}},
-			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: search.SearchServiceNamespacedNameForCluster(0).Name, Namespace: search.Namespace, UID: "live-svc", Labels: maps.Clone(labels)}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.MongotConfigConfigMapNameForCluster(0).Name, Namespace: search.Namespace, UID: "live-cm", Labels: maps.Clone(labels)}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.Name + "-live-tls", Namespace: search.Namespace, UID: "live-secret", Labels: maps.Clone(labels)}},
+			&appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.StatefulSetNamespacedNameForCluster(0).Name,
+					Namespace: search.Namespace,
+					UID:       "live-sts",
+					Labels:    maps.Clone(labels),
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.SearchServiceNamespacedNameForCluster(0).Name,
+					Namespace: search.Namespace,
+					UID:       "live-svc",
+					Labels:    maps.Clone(labels),
+				},
+			},
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.MongotConfigConfigMapNameForCluster(0).Name,
+					Namespace: search.Namespace,
+					UID:       "live-cm",
+					Labels:    maps.Clone(labels),
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.Name + "-live-tls",
+					Namespace: search.Namespace,
+					UID:       "live-secret",
+					Labels:    maps.Clone(labels),
+				},
+			},
 		}
 		for _, obj := range live {
 			require.NoError(t, centralClient.Create(ctx, obj))
@@ -1184,7 +1333,10 @@ func TestMongoDBSearchReconcile_HubRemovedClusterCleansManagedMemberResources(t 
 			"cluster-hub": centralClient,
 		}, "")
 
-		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}})
+		_, err := reconciler.Reconcile(
+			ctx,
+			reconcile.Request{NamespacedName: types.NamespacedName{Name: search.Name, Namespace: search.Namespace}},
+		)
 		require.NoError(t, err)
 
 		for _, obj := range live {
@@ -1225,11 +1377,21 @@ func newOperatorPerClusterShardedMongoDBSearch(name, namespace string) *searchv1
 	clusters := []searchv1.ClusterSpec{
 		{
 			Name: "cluster-a", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)),
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-a.example.com", RouterHostname: "router.cluster-a.example.com"}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{
+					ExternalHostname: "{shardName}.cluster-a.example.com",
+					RouterHostname:   "router.cluster-a.example.com",
+				},
+			},
 		},
 		{
 			Name: "cluster-b", Index: ptr.To(int32(1)), Replicas: ptr.To(int32(1)),
-			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.cluster-b.example.com", RouterHostname: "router.cluster-b.example.com"}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{
+				Managed: &searchv1.ManagedLBConfig{
+					ExternalHostname: "{shardName}.cluster-b.example.com",
+					RouterHostname:   "router.cluster-b.example.com",
+				},
+			},
 		},
 	}
 	return &searchv1.MongoDBSearch{
@@ -1367,10 +1529,24 @@ func TestReconcile_OperatorPerCluster_ShardedSource_ProjectedReconcilesLocalOnly
 				assert.True(t, apiErrors.IsNotFound(err), "STS %q must NOT exist; err=%v", wrongName, err)
 				cm := &corev1.ConfigMap{}
 				err = c.Get(ctx, search.MongotConfigMapForClusterShard(tc.wrongIdx, shard), cm)
-				assert.True(t, apiErrors.IsNotFound(err), "mongot ConfigMap for shard %s at idx %d must NOT exist; err=%v", shard, tc.wrongIdx, err)
+				assert.True(
+					t,
+					apiErrors.IsNotFound(err),
+					"mongot ConfigMap for shard %s at idx %d must NOT exist; err=%v",
+					shard,
+					tc.wrongIdx,
+					err,
+				)
 				svc := &corev1.Service{}
 				err = c.Get(ctx, search.MongotServiceForClusterShard(tc.wrongIdx, shard), svc)
-				assert.True(t, apiErrors.IsNotFound(err), "headless Service for shard %s at idx %d must NOT exist; err=%v", shard, tc.wrongIdx, err)
+				assert.True(
+					t,
+					apiErrors.IsNotFound(err),
+					"headless Service for shard %s at idx %d must NOT exist; err=%v",
+					shard,
+					tc.wrongIdx,
+					err,
+				)
 			}
 			wrongProxy := &corev1.Service{}
 			err := c.Get(ctx, search.ProxyServiceNamespacedNameForCluster(tc.wrongIdx), wrongProxy)

--- a/controllers/operator/mongodbsearch_metrics_controller.go
+++ b/controllers/operator/mongodbsearch_metrics_controller.go
@@ -110,7 +110,12 @@ type MongoDBSearchMetricsForwarderReconciler struct {
 	prepareSearch prepareSearchFuncs
 }
 
-func newMongoDBSearchMetricsForwarderReconciler(c client.Client, defaultImage string, memberClusterMap map[string]client.Client, operatorClusterName string) *MongoDBSearchMetricsForwarderReconciler {
+func newMongoDBSearchMetricsForwarderReconciler(
+	c client.Client,
+	defaultImage string,
+	memberClusterMap map[string]client.Client,
+	operatorClusterName string,
+) *MongoDBSearchMetricsForwarderReconciler {
 	clientsMap := make(map[string]kubernetesClient.Client, len(memberClusterMap))
 	for k, v := range memberClusterMap {
 		clientsMap[k] = kubernetesClient.NewClient(v)
@@ -185,7 +190,14 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 		fallthrough
 	case searchv1.MetricsForwarderModeEnabled:
 		if !mdbSearch.Spec.Observability.Prometheus.IsEnabled() {
-			return r.updateMetricsForwarderStatus(ctx, mdbSearch, workflow.Invalid("metrics forwarder requires Prometheus; set spec.observability.prometheus.mode: enabled to enable it, or set spec.observability.metricsForwarder.mode: disabled to silence this message"), log)
+			return r.updateMetricsForwarderStatus(
+				ctx,
+				mdbSearch,
+				workflow.Invalid(
+					"metrics forwarder requires Prometheus; set spec.observability.prometheus.mode: enabled to enable it, or set spec.observability.metricsForwarder.mode: disabled to silence this message",
+				),
+				log,
+			)
 		}
 		return r.updateMetricsForwarderStatus(ctx, mdbSearch, r.reconcileCore(ctx, mdbSearch, log), log)
 	case searchv1.MetricsForwarderModeDisabled:
@@ -202,7 +214,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) Reconcile(ctx context.Context,
 // degrades to a spec-only sweep). Failures only warn: the disabled paths must
 // never mark the CR Failed, and the retained topology state entries and Ops
 // Manager hosts drive the retry on the next reconcile.
-func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResourcesFromState(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) {
+func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResourcesFromState(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) {
 	workList := r.buildClusterWorkList(search)
 	if topologyState, err := r.loadTopologyState(ctx, search, log); err != nil {
 		log.Warnf("Sweeping only the current spec clusters; persisted metrics forwarder state is unreadable: %v", err)
@@ -214,12 +230,19 @@ func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResource
 	}
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Context, mdbSearch *searchv1.MongoDBSearch, log *zap.SugaredLogger) workflow.Status {
+func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(
+	ctx context.Context,
+	mdbSearch *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	deleting := !mdbSearch.DeletionTimestamp.IsZero()
 	cleaningRemovedOperator := operatorClusterNotInSearchSpec(mdbSearch, r.operatorClusterName)
 	if !deleting && !cleaningRemovedOperator {
 		if r.defaultImage == "" {
-			return workflow.Invalid("%s environment variable must be set on the operator to use metrics forwarder", util.MetricsForwarderImageEnv)
+			return workflow.Invalid(
+				"%s environment variable must be set on the operator to use metrics forwarder",
+				util.MetricsForwarderImageEnv,
+			)
 		}
 
 		if mdbSearch.Status.Version == "" {
@@ -284,7 +307,12 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 	r.watch.AddWatchedResourceIfNotAdded(fwdCtx.projectConfigMapRef.Name, mdbSearch.Namespace, watch.ConfigMap, mdbSearch.NamespacedName())
 	r.watch.AddWatchedResourceIfNotAdded(fwdCtx.agentApiKeySecret.Name, mdbSearch.Namespace, watch.Secret, mdbSearch.NamespacedName())
 	if projectConfig.SSLMMSCAConfigMap != "" {
-		r.watch.AddWatchedResourceIfNotAdded(projectConfig.SSLMMSCAConfigMap, mdbSearch.Namespace, watch.ConfigMap, mdbSearch.NamespacedName())
+		r.watch.AddWatchedResourceIfNotAdded(
+			projectConfig.SSLMMSCAConfigMap,
+			mdbSearch.Namespace,
+			watch.ConfigMap,
+			mdbSearch.NamespacedName(),
+		)
 	}
 
 	if !cleaningRemovedOperator {
@@ -319,7 +347,8 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		firstFailure = removedErr
 	}
 
-	if cleaningRemovedOperator && removedErr == nil && !removedPending && controllerutil.ContainsFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
+	if cleaningRemovedOperator && removedErr == nil && !removedPending &&
+		controllerutil.ContainsFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer) {
 		currentState, err := r.loadTopologyState(ctx, mdbSearch, log)
 		if err != nil {
 			return workflow.Failed(err)
@@ -327,7 +356,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 		if _, stateExists := currentState.Clusters[r.operatorClusterName]; !stateExists {
 			controllerutil.RemoveFinalizer(mdbSearch, util.SearchMetricsForwarderFinalizer)
 			if err := r.kubeClient.Update(ctx, mdbSearch); err != nil {
-				return workflow.Failed(fmt.Errorf("failed to remove finalizer after cleaning removed cluster %q: %w", r.operatorClusterName, err))
+				return workflow.Failed(
+					fmt.Errorf("failed to remove finalizer after cleaning removed cluster %q: %w", r.operatorClusterName, err),
+				)
 			}
 		}
 	}
@@ -335,7 +366,10 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileCore(ctx context.Cont
 	// When no cluster has a registered client there is nothing to make progress
 	// on, and Pending is the honest signal.
 	if len(workList) > 0 && len(missingClusters) == len(workList) {
-		return workflow.Pending("None of the clusters in spec.clusters is registered with the operator: %s", strings.Join(missingClusters, ", "))
+		return workflow.Pending(
+			"None of the clusters in spec.clusters is registered with the operator: %s",
+			strings.Join(missingClusters, ", "),
+		)
 	}
 
 	for _, w := range workList {
@@ -377,7 +411,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) buildClusterWorkList(search *s
 		}
 		for _, c := range search.Spec.Clusters {
 			if c.Name == r.operatorClusterName {
-				return []clusterWorkItem{newClusterWorkItem(search, c.Name, c.ResolveIndex(), r.kubeClient, r.memberClients, r.operatorClusterName)}
+				return []clusterWorkItem{
+					newClusterWorkItem(search, c.Name, c.ResolveIndex(), r.kubeClient, r.memberClients, r.operatorClusterName),
+				}
 			}
 		}
 		return nil
@@ -397,7 +433,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) buildClusterWorkList(search *s
 // and Ops Manager host ids derive from the CR name and index); the cluster
 // name is display metadata and the client-routing key, and never gates
 // lifecycle decisions.
-func (r *MongoDBSearchMetricsForwarderReconciler) loadTopologyState(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (*searchTopologyState, error) {
+func (r *MongoDBSearchMetricsForwarderReconciler) loadTopologyState(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) (*searchTopologyState, error) {
 	topologyState, err := r.openTopologyStateStore(search).ReadState(ctx)
 	if apierrors.IsNotFound(err) {
 		return &searchTopologyState{Clusters: map[string]clusterTopologyState{}}, nil
@@ -490,7 +530,11 @@ func normalizeTopologyState(search *searchv1.MongoDBSearch, topologyState *searc
 // client; a named entry with no resolvable index is invalid state, and guessing
 // an index could delete another cluster's resources, so its cleanup is skipped
 // with a warning.
-func (r *MongoDBSearchMetricsForwarderReconciler) workForRemovedClusters(search *searchv1.MongoDBSearch, topologyState *searchTopologyState, log *zap.SugaredLogger) []clusterWorkItem {
+func (r *MongoDBSearchMetricsForwarderReconciler) workForRemovedClusters(
+	search *searchv1.MongoDBSearch,
+	topologyState *searchTopologyState,
+	log *zap.SugaredLogger,
+) []clusterWorkItem {
 	liveNameByIndex := specNamesByIndex(search)
 	var work []clusterWorkItem
 	for clusterName, clusterState := range topologyState.Clusters {
@@ -504,7 +548,10 @@ func (r *MongoDBSearchMetricsForwarderReconciler) workForRemovedClusters(search 
 		if r.operatorClusterName != "" && clusterName != "" && clusterName != r.operatorClusterName {
 			continue
 		}
-		work = append(work, newClusterWorkItem(search, clusterName, *clusterState.ClusterIndex, r.kubeClient, r.memberClients, r.operatorClusterName))
+		work = append(
+			work,
+			newClusterWorkItem(search, clusterName, *clusterState.ClusterIndex, r.kubeClient, r.memberClients, r.operatorClusterName),
+		)
 	}
 	sort.Slice(work, func(i, j int) bool { return work[i].ClusterName < work[j].ClusterName })
 	return work
@@ -699,7 +746,10 @@ type forwarderContext struct {
 // forwarder needs. The second return is a pre-resolved Ops Manager group id, empty when it must be
 // looked up later from the agent key. The final return is false for sources that don't support the
 // forwarder (e.g. MongoDBCommunity), in which case the other returns are unset.
-func (r *MongoDBSearchMetricsForwarderReconciler) resolveForwarderContext(mdbSearch *searchv1.MongoDBSearch, searchSource searchcontroller.SearchSourceDBResource) (forwarderContext, string, workflow.Status, bool) {
+func (r *MongoDBSearchMetricsForwarderReconciler) resolveForwarderContext(
+	mdbSearch *searchv1.MongoDBSearch,
+	searchSource searchcontroller.SearchSourceDBResource,
+) (forwarderContext, string, workflow.Status, bool) {
 	// External sources, and any source with an explicit project config, resolve from that config.
 	if mdbSearch.IsExternalMongoDBSource() || mdbSearch.MetricsForwarderHasExplicitProjectConfig() {
 		fwdCtx, status := r.resolveFromExplicitProjectConfig(mdbSearch)
@@ -719,10 +769,14 @@ func (r *MongoDBSearchMetricsForwarderReconciler) resolveForwarderContext(mdbSea
 	}
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) resolveFromExplicitProjectConfig(search *searchv1.MongoDBSearch) (forwarderContext, workflow.Status) {
+func (r *MongoDBSearchMetricsForwarderReconciler) resolveFromExplicitProjectConfig(
+	search *searchv1.MongoDBSearch,
+) (forwarderContext, workflow.Status) {
 	config := search.Spec.Observability.MetricsForwarder
 	if config.OpsManager == nil {
-		return forwarderContext{}, workflow.Invalid(".spec.observability.metricsForwarder.opsManager must be provided for external MongoDB sources")
+		return forwarderContext{}, workflow.Invalid(
+			".spec.observability.metricsForwarder.opsManager must be provided for external MongoDB sources",
+		)
 	}
 
 	return forwarderContext{
@@ -731,7 +785,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) resolveFromExplicitProjectConf
 	}, workflow.OK()
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) resolveFromEnterpriseSource(source *mdbv1.MongoDB) (forwarderContext, string, workflow.Status) {
+func (r *MongoDBSearchMetricsForwarderReconciler) resolveFromEnterpriseSource(
+	source *mdbv1.MongoDB,
+) (forwarderContext, string, workflow.Status) {
 	groupId := source.Status.ProjectId
 	if groupId == "" {
 		return forwarderContext{}, "", workflow.Pending("Waiting for project to be reconciled")
@@ -743,7 +799,12 @@ func (r *MongoDBSearchMetricsForwarderReconciler) resolveFromEnterpriseSource(so
 	}, groupId, workflow.OK()
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) resolveGroupFromAgentKey(ctx context.Context, projectConfig mdbv1.ProjectConfig, agentSecretKey types.NamespacedName, log *zap.SugaredLogger) (string, error) {
+func (r *MongoDBSearchMetricsForwarderReconciler) resolveGroupFromAgentKey(
+	ctx context.Context,
+	projectConfig mdbv1.ProjectConfig,
+	agentSecretKey types.NamespacedName,
+	log *zap.SugaredLogger,
+) (string, error) {
 	agentKey, err := r.readAgentApiKey(ctx, agentSecretKey)
 	if err != nil {
 		return "", err
@@ -774,7 +835,10 @@ func (r *MongoDBSearchMetricsForwarderReconciler) resolveGroupFromAgentKey(ctx c
 }
 
 // readAgentApiKey reads the Ops Manager agent API key from the given secret.
-func (r *MongoDBSearchMetricsForwarderReconciler) readAgentApiKey(ctx context.Context, agentSecretKey types.NamespacedName) (string, error) {
+func (r *MongoDBSearchMetricsForwarderReconciler) readAgentApiKey(
+	ctx context.Context,
+	agentSecretKey types.NamespacedName,
+) (string, error) {
 	secretData, err := r.secretClient.ReadSecret(ctx, agentSecretKey, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to read agent key secret %s: %w", agentSecretKey.Name, err)
@@ -800,7 +864,11 @@ type omAgentRequester interface {
 
 type omHTTPAgentRequester struct{}
 
-func (r omHTTPAgentRequester) RequestWithAgentAuth(projectConfig mdbv1.ProjectConfig, method, path, authHeader string, body any) ([]byte, error) {
+func (r omHTTPAgentRequester) RequestWithAgentAuth(
+	projectConfig mdbv1.ProjectConfig,
+	method, path, authHeader string,
+	body any,
+) ([]byte, error) {
 	respBody, _, err := newOMHTTPClient(projectConfig).RequestWithAgentAuth(method, projectConfig.BaseURL, path, authHeader, body)
 	return respBody, err
 }
@@ -827,7 +895,11 @@ func (r omHTTPAgentRequester) GetOMVersion(projectConfig mdbv1.ProjectConfig) (v
 //   - Unknown version or unparseable semver: Implicit → Unsupported; Explicit → Failed.
 //   - Cloud Manager connection:              Implicit → Unsupported; Explicit → Failed.
 //   - Self-hosted OM version < 8.0.25:      Implicit → Unsupported; Explicit → Failed.
-func (r *MongoDBSearchMetricsForwarderReconciler) checkOMVersionForMetricsEndpoint(mdbSearch *searchv1.MongoDBSearch, projectConfig mdbv1.ProjectConfig, log *zap.SugaredLogger) (bool, workflow.Status) {
+func (r *MongoDBSearchMetricsForwarderReconciler) checkOMVersionForMetricsEndpoint(
+	mdbSearch *searchv1.MongoDBSearch,
+	projectConfig mdbv1.ProjectConfig,
+	log *zap.SugaredLogger,
+) (bool, workflow.Status) {
 	explicit := mdbSearch.MetricsForwarderHasExplicitProjectConfig()
 
 	const disableHint = " Set '.spec.observability.metricsForwarder.mode: disabled' to silence this message"
@@ -874,7 +946,9 @@ func (r *MongoDBSearchMetricsForwarderReconciler) checkOMVersionForMetricsEndpoi
 	const message = "Ops Manager version %s does not support the metrics forwarding endpoint (minimum: %s)." + disableHint
 
 	if explicit {
-		return false, workflow.Failed(fmt.Errorf(message, omVersion, metricsForwarderMinOpsManagerVersion)) //nolint:staticcheck // ST1005: "Ops Manager" is a proper product name
+		return false, workflow.Failed(
+			fmt.Errorf(message, omVersion, metricsForwarderMinOpsManagerVersion),
+		) //nolint:staticcheck // ST1005: "Ops Manager" is a proper product name
 	}
 	return false, workflow.Unsupported(message, omVersion, metricsForwarderMinOpsManagerVersion)
 }
@@ -949,7 +1023,12 @@ func desiredClusterTopology(search *searchv1.MongoDBSearch, shardNames []string,
 		for _, shardName := range shardNames {
 			c, err := search.ResolveSizingForClusterShard(w.ClusterName, shardName)
 			if err != nil {
-				return clusterTopologyState{}, fmt.Errorf("failed to resolve sizing for cluster %q shard %q: %w", w.ClusterName, shardName, err)
+				return clusterTopologyState{}, fmt.Errorf(
+					"failed to resolve sizing for cluster %q shard %q: %w",
+					w.ClusterName,
+					shardName,
+					err,
+				)
 			}
 			current.ShardReplicas[shardName] = c.ReplicasOrDefault()
 		}
@@ -1070,7 +1149,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) reconcileTopologyState(
 
 // mongotPodIsTerminating reports whether the named pod in the given cluster exists and is actively
 // being deleted (DeletionTimestamp is set).
-func (r *MongoDBSearchMetricsForwarderReconciler) mongotPodIsTerminating(ctx context.Context, namespace, podName string, c kubernetesClient.Client) (bool, error) {
+func (r *MongoDBSearchMetricsForwarderReconciler) mongotPodIsTerminating(
+	ctx context.Context,
+	namespace, podName string,
+	c kubernetesClient.Client,
+) (bool, error) {
 	pod := &corev1.Pod{}
 	if err := c.Get(ctx, kube.ObjectKey(namespace, podName), pod); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1139,7 +1222,15 @@ type deleteHostsResponse struct {
 // mongodb.opsmanager.host.id resource attribute the metrics forwarder assigns during OTLP ingestion.
 // Deletion is scoped to the project's groupID via agent authentication; ids belonging to other
 // projects or already-deleted hosts are reported NOT_FOUND and treated as success.
-func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedMongotPods(ctx context.Context, search *searchv1.MongoDBSearch, podNames []string, groupID string, projectConfig mdbv1.ProjectConfig, agentSecretName string, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedMongotPods(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	podNames []string,
+	groupID string,
+	projectConfig mdbv1.ProjectConfig,
+	agentSecretName string,
+	log *zap.SugaredLogger,
+) error {
 	if len(podNames) == 0 {
 		return nil
 	}
@@ -1193,12 +1284,20 @@ func (r *MongoDBSearchMetricsForwarderReconciler) cleanupRemovedMongotPods(ctx c
 // sha1(groupID + "-" + namespace + "-" + podName). The groupID is folded in so the id is globally
 // unique across all projects.
 func mongotHostID(groupID, namespace, podName string) string {
-	sum := sha1.Sum([]byte(fmt.Sprintf("%s-%s-%s", groupID, namespace, podName))) //nolint //Used to derive a stable host identifier, not for security.
+	sum := sha1.Sum(
+		[]byte(fmt.Sprintf("%s-%s-%s", groupID, namespace, podName)),
+	) //nolint //Used to derive a stable host identifier, not for security.
 	return hex.EncodeToString(sum[:])
 }
 
 // ensureMetricsForwarderConfigMap creates or updates the metrics forwarder ConfigMap for one cluster.
-func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, configYAML []byte, w clusterWorkItem, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderConfigMap(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	configYAML []byte,
+	w clusterWorkItem,
+	log *zap.SugaredLogger,
+) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      search.MetricsForwarderConfigMapNameForCluster(w.ClusterIndex),
@@ -1220,7 +1319,14 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderConfigMa
 }
 
 // ensureMetricsForwarderDeployment creates or updates the metrics forwarder Deployment for one cluster.
-func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployment(ctx context.Context, search *searchv1.MongoDBSearch, configYAML []byte, groupID, agentKeySecretName, caConfigMapName string, w clusterWorkItem, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployment(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	configYAML []byte,
+	groupID, agentKeySecretName, caConfigMapName string,
+	w clusterWorkItem,
+	log *zap.SugaredLogger,
+) error {
 	configHash := fmt.Sprintf("%x", sha256.Sum256(configYAML))
 	labels := metricsForwarderLabelsForCluster(search, w.ClusterIndex)
 	podLabels := metricsForwarderPodLabelsForCluster(search, w.ClusterIndex)
@@ -1250,7 +1356,15 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployme
 						metricsForwarderConfigHashAnnotation: configHash,
 					},
 				},
-				Spec: buildMetricsForwarderPodSpec(search, agentKeySecretName, caConfigMapName, w.ClusterIndex, r.defaultImage, resources, managedSecurityContext),
+				Spec: buildMetricsForwarderPodSpec(
+					search,
+					agentKeySecretName,
+					caConfigMapName,
+					w.ClusterIndex,
+					r.defaultImage,
+					resources,
+					managedSecurityContext,
+				),
 			},
 		}
 
@@ -1272,7 +1386,14 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureMetricsForwarderDeployme
 	return nil
 }
 
-func buildMetricsForwarderPodSpec(search *searchv1.MongoDBSearch, agentKeySecretName, caConfigMapName string, clusterIndex int, image string, resources corev1.ResourceRequirements, managedSecurityContext bool) corev1.PodSpec {
+func buildMetricsForwarderPodSpec(
+	search *searchv1.MongoDBSearch,
+	agentKeySecretName, caConfigMapName string,
+	clusterIndex int,
+	image string,
+	resources corev1.ResourceRequirements,
+	managedSecurityContext bool,
+) corev1.PodSpec {
 	volumes := []corev1.Volume{
 		{
 			Name: "metrics-forwarder-config",
@@ -1387,19 +1508,32 @@ func metricsForwarderLabels(search *searchv1.MongoDBSearch) map[string]string {
 }
 
 // updateMetricsForwarderStatus patches the metricsForwarder sub-status.
-func (r *MongoDBSearchMetricsForwarderReconciler) updateMetricsForwarderStatus(ctx context.Context, search *searchv1.MongoDBSearch, st workflow.Status, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *MongoDBSearchMetricsForwarderReconciler) updateMetricsForwarderStatus(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	st workflow.Status,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	partOption := searchv1.NewSearchPartOption(searchv1.SearchPartMetricsForwarder)
 	return commoncontroller.UpdateStatus(ctx, r.kubeClient, search, st, log, partOption)
 }
 
 // clearMetricsForwarderStatus removes the metricsForwarder substatus.
-func (r *MongoDBSearchMetricsForwarderReconciler) clearMetricsForwarderStatus(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *MongoDBSearchMetricsForwarderReconciler) clearMetricsForwarderStatus(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	search.Status.MetricsForwarder = nil
 	partOption := searchv1.NewSearchPartOption(searchv1.SearchPartMetricsForwarder)
 	return commoncontroller.UpdateStatus(ctx, r.kubeClient, search, workflow.OK(), log, partOption)
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) ensureFinalizer(ctx context.Context, search *searchv1.MongoDBSearch, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) ensureFinalizer(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	log *zap.SugaredLogger,
+) error {
 	if finalizerAdded := controllerutil.AddFinalizer(search, util.SearchMetricsForwarderFinalizer); finalizerAdded {
 		log.Info("Adding finalizer to the MongoDBSearch resource")
 		if err := r.kubeClient.Update(ctx, search); err != nil {
@@ -1409,7 +1543,16 @@ func (r *MongoDBSearchMetricsForwarderReconciler) ensureFinalizer(ctx context.Co
 	return nil
 }
 
-func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context.Context, search *searchv1.MongoDBSearch, shardNames []string, groupID string, projectConfig mdbv1.ProjectConfig, agentSecretName string, workList []clusterWorkItem, log *zap.SugaredLogger) workflow.Status {
+func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	shardNames []string,
+	groupID string,
+	projectConfig mdbv1.ProjectConfig,
+	agentSecretName string,
+	workList []clusterWorkItem,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	log.Info("Performing pre deletion cleanup before deleting MongoDBSearch metrics forwarder")
 
 	topologyState, err := r.loadTopologyState(ctx, search, log)
@@ -1441,7 +1584,11 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 		}
 		if found {
 			anyDepFound = true
-			log.Infof("Deleting metrics forwarder Deployment %s (cluster=%q) before deregistering Ops Manager hosts", search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex), w.ClusterName)
+			log.Infof(
+				"Deleting metrics forwarder Deployment %s (cluster=%q) before deregistering Ops Manager hosts",
+				search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex),
+				w.ClusterName,
+			)
 		}
 	}
 	if anyDepFound {
@@ -1480,7 +1627,12 @@ func (r *MongoDBSearchMetricsForwarderReconciler) preDeletionCleanup(ctx context
 // (Client==nil) are skipped. Only objects still carrying this Search identity's
 // forwarder labels are deleted; customer objects and other identities are never
 // touched.
-func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResources(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	workList []clusterWorkItem,
+	log *zap.SugaredLogger,
+) error {
 	var deleteErr error
 	for _, w := range workList {
 		if w.Client == nil {
@@ -1496,7 +1648,16 @@ func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResource
 			{"agent-key Secret", &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: search.MetricsForwarderAgentKeySecretNameForCluster(w.ClusterIndex), Namespace: search.Namespace}}},
 			{"CA ConfigMap", &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.MetricsForwarderCACertConfigMapNameForCluster(w.ClusterIndex), Namespace: search.Namespace}}},
 		} {
-			_, err := searchcontroller.DeleteOwnedResource(ctx, w.Client, search, w.ClusterName, singleton.kind, metricsForwarderLabelName, singleton.obj, log)
+			_, err := searchcontroller.DeleteOwnedResource(
+				ctx,
+				w.Client,
+				search,
+				w.ClusterName,
+				singleton.kind,
+				metricsForwarderLabelName,
+				singleton.obj,
+				log,
+			)
 			deleteErr = errors.Join(deleteErr, err)
 		}
 	}
@@ -1507,8 +1668,15 @@ func (r *MongoDBSearchMetricsForwarderReconciler) deleteMetricsForwarderResource
 // Foreground propagation so found keeps reporting true until its pods are fully
 // gone — Ops Manager host deregistration must not run while a collector still
 // pushes.
-func deleteForwarderDeployment(ctx context.Context, search *searchv1.MongoDBSearch, w clusterWorkItem, log *zap.SugaredLogger) (bool, error) {
-	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex), Namespace: search.Namespace}}
+func deleteForwarderDeployment(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	w clusterWorkItem,
+	log *zap.SugaredLogger,
+) (bool, error) {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: search.MetricsForwarderDeploymentNameForCluster(w.ClusterIndex), Namespace: search.Namespace},
+	}
 	return searchcontroller.DeleteOwnedResource(ctx, w.Client, search, w.ClusterName, "Deployment", metricsForwarderLabelName, dep, log,
 		client.PropagationPolicy(metav1.DeletePropagationForeground))
 }
@@ -1538,7 +1706,13 @@ func memberMongoDBSearchMetricsForwarderResourceWatches(r *MongoDBSearchMetricsF
 }
 
 // AddMongoDBSearchMetricsForwarderController registers the metrics forwarder controller with the manager.
-func AddMongoDBSearchMetricsForwarderController(ctx context.Context, mgr manager.Manager, defaultImage string, memberClusterObjectsMap map[string]runtimeCluster.Cluster, operatorClusterName string) error {
+func AddMongoDBSearchMetricsForwarderController(
+	ctx context.Context,
+	mgr manager.Manager,
+	defaultImage string,
+	memberClusterObjectsMap map[string]runtimeCluster.Cluster,
+	operatorClusterName string,
+) error {
 	r := newMongoDBSearchMetricsForwarderReconciler(
 		mgr.GetClient(),
 		defaultImage,

--- a/controllers/operator/mongodbsearch_metrics_controller_test.go
+++ b/controllers/operator/mongodbsearch_metrics_controller_test.go
@@ -107,7 +107,10 @@ func newTestProjectConfigMap(name, namespace, baseURL string) *corev1.ConfigMap 
 }
 
 // newMetricsForwarderReconciler creates the reconciler with a fake client populated with the given objects.
-func newMetricsForwarderReconciler(defaultImage string, objects ...client.Object) (*MongoDBSearchMetricsForwarderReconciler, client.Client) {
+func newMetricsForwarderReconciler(
+	defaultImage string,
+	objects ...client.Object,
+) (*MongoDBSearchMetricsForwarderReconciler, client.Client) {
 	builder := mock.NewEmptyFakeClientBuilder()
 	if len(objects) > 0 {
 		builder.WithObjects(objects...)
@@ -134,7 +137,11 @@ type stubOMAgentRequester struct {
 	getOMVersionFn func(projectConfig mdbv1.ProjectConfig) (versionutil.OpsManagerVersion, error)
 }
 
-func (s stubOMAgentRequester) RequestWithAgentAuth(projectConfig mdbv1.ProjectConfig, method, path, authHeader string, body any) ([]byte, error) {
+func (s stubOMAgentRequester) RequestWithAgentAuth(
+	projectConfig mdbv1.ProjectConfig,
+	method, path, authHeader string,
+	body any,
+) ([]byte, error) {
 	return s.fn(projectConfig, method, path, authHeader, body)
 }
 
@@ -263,8 +270,11 @@ func TestReconcileCore_LegacyTopologyStateEntryCleanedAfterMoveToNamedClusters(t
 			},
 			initialState: clusterTopologyState{ClusterIndex: ptr.To(0)},
 			verify: func(t *testing.T, fakeClient client.Client, search *searchv1.MongoDBSearch, legacyDeployment *appsv1.Deployment, deletedHostIDs []string) {
-				assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(legacyDeployment), &appsv1.Deployment{})),
-					"legacy central Deployment must be deleted after the move to named clusters")
+				assert.True(
+					t,
+					apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(legacyDeployment), &appsv1.Deployment{})),
+					"legacy central Deployment must be deleted after the move to named clusters",
+				)
 				topologyState := getFullTopologyState(t, fakeClient, search)
 				assert.NotContains(t, topologyState.Clusters, "")
 				// Each named cluster persists its own pinned index, written once.
@@ -310,8 +320,11 @@ func TestReconcileCore_LegacyTopologyStateEntryCleanedAfterMoveToNamedClusters(t
 				"cluster-b": {ClusterIndex: ptr.To(1), Replicas: 1},
 			}},
 			verify: func(t *testing.T, fakeClient client.Client, search *searchv1.MongoDBSearch, oldDeployment *appsv1.Deployment, deletedHostIDs []string) {
-				assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(oldDeployment), &appsv1.Deployment{})),
-					"old-index Deployment must be deleted after the index change")
+				assert.True(
+					t,
+					apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(oldDeployment), &appsv1.Deployment{})),
+					"old-index Deployment must be deleted after the index change",
+				)
 				require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{
 					Name: search.MetricsForwarderDeploymentNameForCluster(7), Namespace: search.Namespace,
 				}, &appsv1.Deployment{}), "new-index Deployment must be created")
@@ -334,7 +347,14 @@ func TestReconcileCore_LegacyTopologyStateEntryCleanedAfterMoveToNamedClusters(t
 				stateJSON, err := json.Marshal(tc.fullState)
 				require.NoError(t, err)
 				stateCM := &corev1.ConfigMap{}
-				require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Name: testSearchName + "-metrics-forwarder-state", Namespace: testNamespace}, stateCM))
+				require.NoError(
+					t,
+					fakeClient.Get(
+						t.Context(),
+						types.NamespacedName{Name: testSearchName + "-metrics-forwarder-state", Namespace: testNamespace},
+						stateCM,
+					),
+				)
 				stateCM.Data[stateKey] = string(stateJSON)
 				require.NoError(t, fakeClient.Update(t.Context(), stateCM))
 			}
@@ -485,7 +505,12 @@ func TestMetricsForwarderResources_WorkListAndOwnerLocality(t *testing.T) {
 	}{
 		{name: "local legacy single cluster"},
 		{name: "hub member cluster", clusters: []searchv1.ClusterSpec{{Name: "member-a", Index: ptr.To(int32(0))}}, crossCluster: true},
-		{name: "operator-per-cluster entry keeps pinned index and stays local", clusters: []searchv1.ClusterSpec{{Name: "cluster-b", Index: ptr.To(int32(7))}}, operatorClusterName: "cluster-b", wantIdx: 7},
+		{
+			name:                "operator-per-cluster entry keeps pinned index and stays local",
+			clusters:            []searchv1.ClusterSpec{{Name: "cluster-b", Index: ptr.To(int32(7))}},
+			operatorClusterName: "cluster-b",
+			wantIdx:             7,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -507,7 +532,19 @@ func TestMetricsForwarderResources_WorkListAndOwnerLocality(t *testing.T) {
 			assert.Equal(t, tc.wantIdx, work.ClusterIndex)
 
 			require.NoError(t, r.ensureMetricsForwarderConfigMap(t.Context(), search, []byte("receivers: {}"), work, zap.S()))
-			require.NoError(t, r.ensureMetricsForwarderDeployment(t.Context(), search, []byte("receivers: {}"), testGroupID, "agent-key-secret", "", work, zap.S()))
+			require.NoError(
+				t,
+				r.ensureMetricsForwarderDeployment(
+					t.Context(),
+					search,
+					[]byte("receivers: {}"),
+					testGroupID,
+					"agent-key-secret",
+					"",
+					work,
+					zap.S(),
+				),
+			)
 			require.NoError(t, r.replicateForwarderDependencies(t.Context(), search, sourceSecret.Name, sourceCA.Name, work, zap.S()))
 
 			for name, obj := range map[types.NamespacedName]client.Object{
@@ -838,8 +875,19 @@ func TestReconcile_EnterpriseSource_CreatesDeploymentAndConfigMap(t *testing.T) 
 		wantStateKey        string
 	}{
 		{name: "legacy single cluster"},
-		{name: "hub member cluster", clusters: []searchv1.ClusterSpec{{Name: "member-a", Index: ptr.To(int32(0))}}, crossCluster: true, wantStateKey: "member-a"},
-		{name: "operator-per-cluster", clusters: []searchv1.ClusterSpec{{Name: "cluster-b", Index: ptr.To(int32(7))}}, operatorClusterName: "cluster-b", wantIdx: 7, wantStateKey: "cluster-b"},
+		{
+			name:         "hub member cluster",
+			clusters:     []searchv1.ClusterSpec{{Name: "member-a", Index: ptr.To(int32(0))}},
+			crossCluster: true,
+			wantStateKey: "member-a",
+		},
+		{
+			name:                "operator-per-cluster",
+			clusters:            []searchv1.ClusterSpec{{Name: "cluster-b", Index: ptr.To(int32(7))}},
+			operatorClusterName: "cluster-b",
+			wantIdx:             7,
+			wantStateKey:        "cluster-b",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -876,7 +924,12 @@ func TestReconcile_EnterpriseSource_CreatesDeploymentAndConfigMap(t *testing.T) 
 					Namespace: testNamespace,
 					Name:      search.MetricsForwarderDeploymentNameForCluster(tc.wantIdx),
 				}, &appsv1.Deployment{})
-				assert.True(t, apierrors.IsNotFound(err), "member cluster's Deployment must never fall back to the central cluster, got err=%v", err)
+				assert.True(
+					t,
+					apierrors.IsNotFound(err),
+					"member cluster's Deployment must never fall back to the central cluster, got err=%v",
+					err,
+				)
 			} else {
 				assert.NotEmpty(t, dep.GetOwnerReferences(), "local resources carry the CR owner ref")
 			}
@@ -928,7 +981,16 @@ func TestReconcile_DisabledMode_DeletesResources(t *testing.T) {
 		Labels:    map[string]string{"app": "foreign"},
 	}}
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace), stateCM, existingDep, foreignDep)
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+		stateCM,
+		existingDep,
+		foreignDep,
+	)
 	fakeClientWithWatch, ok := fakeClient.(client.WithWatch)
 	require.True(t, ok)
 	var propagationPolicy *metav1.DeletionPropagation
@@ -1050,7 +1112,10 @@ func TestReconcile_CommunitySource_FinalizerLifecycle(t *testing.T) {
 				search.Finalizers = []string{util.SearchMetricsForwarderFinalizer}
 			}
 			if tc.persistedHosts {
-				objects = append(objects, newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0), Replicas: 1}))
+				objects = append(
+					objects,
+					newTestTopologyStateConfigMap(t, search, clusterTopologyState{ClusterIndex: ptr.To(0), Replicas: 1}),
+				)
 			}
 			r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, objects...)
 			if tc.deleteSearch {
@@ -1114,7 +1179,13 @@ func TestReconcile_DeletionFinalizerLifecycle(t *testing.T) {
 	}{
 		{name: "no Deployment deregisters hosts and removes the finalizer", image: testDefaultImage, disabledMode: true, stateReplicas: 2},
 		{name: "running Deployment drains before hosts are deregistered", image: testDefaultImage, existingDep: true, stateReplicas: 1},
-		{name: "Ops Manager failure retains the finalizer for retry", image: testDefaultImage, omError: true, stateReplicas: 1, wantRetained: true},
+		{
+			name:          "Ops Manager failure retains the finalizer for retry",
+			image:         testDefaultImage,
+			omError:       true,
+			stateReplicas: 1,
+			wantRetained:  true,
+		},
 		{name: "invalid spec and missing image never block deletion cleanup", invalidSpec: true},
 	}
 	for _, tc := range tests {
@@ -1187,10 +1258,20 @@ func TestReconcile_DeletionFinalizerLifecycle(t *testing.T) {
 				assert.Empty(t, deletedHostIDs, "expected no host deregistration while Deployment still exists")
 				require.NotNil(t, propagationPolicy)
 				assert.Equal(t, metav1.DeletePropagationForeground, *propagationPolicy)
-				assert.True(t, apierrors.IsNotFound(fakeClient.Get(context.Background(), client.ObjectKeyFromObject(existingDep), &appsv1.Deployment{})))
+				assert.True(
+					t,
+					apierrors.IsNotFound(
+						fakeClient.Get(context.Background(), client.ObjectKeyFromObject(existingDep), &appsv1.Deployment{}),
+					),
+				)
 				midDeleteSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 				require.NotNil(t, midDeleteSearch.DeletionTimestamp)
-				assert.Contains(t, midDeleteSearch.Finalizers, util.SearchMetricsForwarderFinalizer, "finalizer must remain until host cleanup finishes")
+				assert.Contains(
+					t,
+					midDeleteSearch.Finalizers,
+					util.SearchMetricsForwarderFinalizer,
+					"finalizer must remain until host cleanup finishes",
+				)
 
 				// Phase 2: the Deployment is gone → hosts deregistered, finalizer removed.
 				result = reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
@@ -1205,12 +1286,20 @@ func TestReconcile_DeletionFinalizerLifecycle(t *testing.T) {
 			}
 			assert.ElementsMatch(t, wantHosts, deletedHostIDs)
 
-			err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testSearchName}, &searchv1.MongoDBSearch{})
+			err := fakeClient.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: testNamespace, Name: testSearchName},
+				&searchv1.MongoDBSearch{},
+			)
 			if tc.wantRetained {
 				assert.True(t, result.RequeueAfter > 0)
 				require.NoError(t, err)
-				assert.Contains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer,
-					"finalizer must stay until host cleanup succeeds")
+				assert.Contains(
+					t,
+					getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers,
+					util.SearchMetricsForwarderFinalizer,
+					"finalizer must stay until host cleanup succeeds",
+				)
 			} else {
 				assert.True(t, apierrors.IsNotFound(err), "expected MongoDBSearch to be deleted after finalizer removal, got err=%v", err)
 			}
@@ -1253,10 +1342,21 @@ func TestReconcile_MissingClusterClientSurfacesPending(t *testing.T) {
 
 		require.True(t, st.IsOK(), "status: %s", searchcontroller.MessageFromStatus(st))
 		// The registered cluster got its Deployment on its member cluster...
-		require.NoError(t, memberA.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, &appsv1.Deployment{}))
+		require.NoError(
+			t,
+			memberA.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+				&appsv1.Deployment{},
+			),
+		)
 		// ...and the missing cluster never fell back to the central client.
 		for _, idx := range []int{0, 1} {
-			err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(idx)}, &appsv1.Deployment{})
+			err := fakeClient.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(idx)},
+				&appsv1.Deployment{},
+			)
 			assert.True(t, apierrors.IsNotFound(err), "no Deployment expected on the central cluster at index %d, got err=%v", idx, err)
 		}
 	})
@@ -1419,31 +1519,55 @@ func TestReconcile_RemovedPerClusterOperatorCleansPersistedTopology(t *testing.T
 			if tc.failDepDelete {
 				// Kubernetes-side cleanup failures are warnings: the persisted state
 				// entry and finalizer survive so the next reconcile retries.
-				assert.Positive(t, logs.FilterMessageSnippet(injectedDepDeleteErr.Error()).Len(), "expected a warning containing %q", injectedDepDeleteErr.Error())
+				assert.Positive(
+					t,
+					logs.FilterMessageSnippet(injectedDepDeleteErr.Error()).Len(),
+					"expected a warning containing %q",
+					injectedDepDeleteErr.Error(),
+				)
 				require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(removedClusterDep), &appsv1.Deployment{}),
 					"removed cluster's Deployment must survive a warned cleanup failure")
 				assert.Contains(t, getFullTopologyState(t, fakeClient, search).Clusters, "cluster-b")
-				assert.Contains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
+				assert.Contains(
+					t,
+					getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers,
+					util.SearchMetricsForwarderFinalizer,
+				)
 				return
 			}
 			assert.True(t, result.RequeueAfter > 0)
 			result = reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
-			assert.True(t, apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(removedClusterDep), &appsv1.Deployment{})))
+			assert.True(
+				t,
+				apierrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKeyFromObject(removedClusterDep), &appsv1.Deployment{})),
+			)
 			if tc.failFinalizerRemoval {
 				assert.True(t, result.RequeueAfter > 0)
-				assert.Contains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer,
-					"finalizer must survive a failed removal update and be retried")
+				assert.Contains(
+					t,
+					getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers,
+					util.SearchMetricsForwarderFinalizer,
+					"finalizer must survive a failed removal update and be retried",
+				)
 				reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 				assert.NotContains(t, getFullTopologyState(t, fakeClient, search).Clusters, "cluster-b")
-				assert.NotContains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
+				assert.NotContains(
+					t,
+					getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers,
+					util.SearchMetricsForwarderFinalizer,
+				)
 				return
 			}
 			if tc.omError {
 				// A live CR with a real Ops Manager failure must fail and retry:
 				// finalizer and persisted state entry survive for the next attempt.
 				assert.True(t, result.RequeueAfter > 0)
-				assert.Contains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
+				assert.Contains(
+					t,
+					getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers,
+					util.SearchMetricsForwarderFinalizer,
+				)
 				assert.Contains(t, getFullTopologyState(t, fakeClient, search).Clusters, "cluster-b")
 				return
 			}
@@ -1455,7 +1579,11 @@ func TestReconcile_RemovedPerClusterOperatorCleansPersistedTopology(t *testing.T
 				return
 			}
 			require.NoError(t, err)
-			assert.NotContains(t, getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers, util.SearchMetricsForwarderFinalizer)
+			assert.NotContains(
+				t,
+				getMongoDBSearch(t, fakeClient, testNamespace, testSearchName).Finalizers,
+				util.SearchMetricsForwarderFinalizer,
+			)
 
 			result = reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 			assert.Equal(t, util.TWENTY_FOUR_HOURS, result.RequeueAfter)
@@ -1519,7 +1647,13 @@ func TestReconcile_EnterpriseSource_NoProjectID_Pending(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
@@ -1535,7 +1669,13 @@ func TestReconcile_NoStatusVersion_Pending(t *testing.T) {
 	search.Status.Version = ""
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
@@ -1703,7 +1843,13 @@ func TestReconcile_AutoMode_InternalEnterprise_EnabledByDefault(t *testing.T) {
 	// No explicit metrics forwarder config - auto mode by default
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
 	// Should create the Deployment since auto mode with enterprise source enables it
@@ -1724,7 +1870,13 @@ func TestReconcile_ConfigMapHash_TriggersRollout(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
 	// Get the config hash annotation
@@ -1783,7 +1935,14 @@ func TestReconcile_WithCACert(t *testing.T) {
 		Data:       map[string]string{util.CaCertMMS: "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"},
 	}
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, caCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		caCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
 	// Verify Deployment has the CA volume
@@ -2124,7 +2283,13 @@ func TestMetricsForwarder_OMVersionTooOld_ImplicitConnection(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: "8.0.0"})
 
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
@@ -2136,7 +2301,11 @@ func TestMetricsForwarder_OMVersionTooOld_ImplicitConnection(t *testing.T) {
 
 	// No Deployment must exist.
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created for unsupported OM version")
 }
 
@@ -2160,7 +2329,11 @@ func TestMetricsForwarder_OMVersionTooOld_ExplicitConnection(t *testing.T) {
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, metricsForwarderMinOpsManagerVersion)
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created for unsupported OM version")
 }
 
@@ -2190,7 +2363,13 @@ func TestMetricsForwarder_CloudManager_ImplicitConnection(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: "v20240101"})
 
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
@@ -2201,7 +2380,11 @@ func TestMetricsForwarder_CloudManager_ImplicitConnection(t *testing.T) {
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Cloud Manager")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created when OM is Cloud Manager")
 }
 
@@ -2226,7 +2409,11 @@ func TestMetricsForwarder_CloudManager_ExplicitConnection(t *testing.T) {
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Cloud Manager")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created for Cloud Manager explicit connection")
 }
 
@@ -2239,12 +2426,22 @@ func TestMetricsForwarder_OMVersionSupported(t *testing.T) {
 
 	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, agentKeySecret)
 	// Default stub already returns 8.0.25; being explicit here for clarity.
-	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: metricsForwarderMinOpsManagerVersion})
+	r.omRequester = newStubOMAgentRequesterWithVersion(
+		testGroupID,
+		versionutil.OpsManagerVersion{VersionString: metricsForwarderMinOpsManagerVersion},
+	)
 
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
 
 	dep := &appsv1.Deployment{}
-	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep))
+	require.NoError(
+		t,
+		fakeClient.Get(
+			context.Background(),
+			types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+			dep,
+		),
+	)
 
 	updatedSearch := getMongoDBSearch(t, fakeClient, testNamespace, testSearchName)
 	require.NotNil(t, updatedSearch.Status.MetricsForwarder)
@@ -2258,7 +2455,13 @@ func TestMetricsForwarder_OMVersionFetchError_Pending(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	stub := newStubOMAgentRequester(testGroupID)
 	stub.getOMVersionFn = func(_ mdbv1.ProjectConfig) (versionutil.OpsManagerVersion, error) {
 		return versionutil.OpsManagerVersion{}, fmt.Errorf("connection refused")
@@ -2273,7 +2476,11 @@ func TestMetricsForwarder_OMVersionFetchError_Pending(t *testing.T) {
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Checking Ops Manager version compatibility")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created while OM version check is pending")
 }
 
@@ -2284,7 +2491,13 @@ func TestMetricsForwarder_OMVersionUnknown_Unsupported(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: ""})
 
 	reconcileMetricsForwarder(t, r, testNamespace, testSearchName)
@@ -2295,7 +2508,11 @@ func TestMetricsForwarder_OMVersionUnknown_Unsupported(t *testing.T) {
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Could not determine Ops Manager version")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created when OM version is unknown")
 }
 
@@ -2306,7 +2523,13 @@ func TestMetricsForwarder_OMVersionSemverParseError_Unsupported(t *testing.T) {
 	search := newTestMongoDBSearch(testSearchName, testNamespace, testMDBName)
 	projectCM := newTestProjectConfigMap(testProjectCMName, testNamespace, testOMBaseURL)
 
-	r, fakeClient := newMetricsForwarderReconciler(testDefaultImage, mdb, search, projectCM, newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace))
+	r, fakeClient := newMetricsForwarderReconciler(
+		testDefaultImage,
+		mdb,
+		search,
+		projectCM,
+		newTestAgentKeySecret(testGroupID+"-group-secret", testNamespace),
+	)
 	// "a.b.c" has three dot-segments so OpsManagerVersion.Semver() attempts semver.Make("a.b.c"),
 	// which fails because the components are non-numeric.
 	r.omRequester = newStubOMAgentRequesterWithVersion(testGroupID, versionutil.OpsManagerVersion{VersionString: "a.b.c"})
@@ -2319,7 +2542,11 @@ func TestMetricsForwarder_OMVersionSemverParseError_Unsupported(t *testing.T) {
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Could not determine Ops Manager version")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created when OM version cannot be parsed")
 }
 
@@ -2343,7 +2570,11 @@ func TestMetricsForwarder_OMVersionUnknown_ExplicitConnection_Failed(t *testing.
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Could not determine Ops Manager version")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created when OM version is unknown")
 }
 
@@ -2367,7 +2598,11 @@ func TestMetricsForwarder_OMVersionSemverParseError_ExplicitConnection_Failed(t 
 	assert.Contains(t, updatedSearch.Status.MetricsForwarder.Message, "Could not determine Ops Manager version")
 
 	dep := &appsv1.Deployment{}
-	err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)}, dep)
+	err := fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: testNamespace, Name: search.MetricsForwarderDeploymentNameForCluster(0)},
+		dep,
+	)
 	assert.True(t, apierrors.IsNotFound(err), "deployment should not be created when OM version cannot be parsed")
 }
 
@@ -2408,11 +2643,26 @@ func TestReconcileCore_StateWriteFailurePreventsDeploymentCreation(t *testing.T)
 // callReconcileTopologyState invokes reconcileTopologyState directly against the
 // single-cluster (clusterName=="", clusterIndex=0) work item, bypassing the full
 // Reconcile path so each test targets one state-machine transition.
-func callReconcileTopologyState(t *testing.T, r *MongoDBSearchMetricsForwarderReconciler, search *searchv1.MongoDBSearch, shardNames []string, agentSecretName string) (bool, error) {
+func callReconcileTopologyState(
+	t *testing.T,
+	r *MongoDBSearchMetricsForwarderReconciler,
+	search *searchv1.MongoDBSearch,
+	shardNames []string,
+	agentSecretName string,
+) (bool, error) {
 	t.Helper()
 	projectConfig := mdbv1.ProjectConfig{BaseURL: testOMBaseURL}
 	w := clusterWorkItem{ClusterName: "", ClusterIndex: 0, Client: r.kubeClient}
-	return r.reconcileTopologyState(context.Background(), search, shardNames, testGroupID, projectConfig, agentSecretName, w, zap.NewNop().Sugar())
+	return r.reconcileTopologyState(
+		context.Background(),
+		search,
+		shardNames,
+		testGroupID,
+		projectConfig,
+		agentSecretName,
+		w,
+		zap.NewNop().Sugar(),
+	)
 }
 
 // newTestMongoDBSearchWithReplicas creates a MongoDBSearch with an explicit replica count on the

--- a/controllers/operator/mongodbsearchenvoy_controller.go
+++ b/controllers/operator/mongodbsearchenvoy_controller.go
@@ -89,7 +89,12 @@ type MongoDBSearchEnvoyReconciler struct {
 	prepareSearch prepareSearchFuncs
 }
 
-func newMongoDBSearchEnvoyReconciler(c client.Client, defaultEnvoyImage string, memberClustersMap map[string]client.Client, operatorClusterName string) *MongoDBSearchEnvoyReconciler {
+func newMongoDBSearchEnvoyReconciler(
+	c client.Client,
+	defaultEnvoyImage string,
+	memberClustersMap map[string]client.Client,
+	operatorClusterName string,
+) *MongoDBSearchEnvoyReconciler {
 	clientsMap := make(map[string]kubernetesClient.Client, len(memberClustersMap))
 	for k, v := range memberClustersMap {
 		clientsMap[k] = kubernetesClient.NewClient(v)
@@ -213,7 +218,15 @@ func (r *MongoDBSearchEnvoyReconciler) Reconcile(ctx context.Context, request re
 	// When no cluster has a registered client there is nothing to make progress
 	// on, and Pending is the honest signal.
 	if len(workList) > 0 && len(missingClusters) == len(workList) {
-		return r.updateLBStatus(ctx, mdbSearch, workflow.Pending("None of the clusters in spec.clusters is registered with the operator: %s", strings.Join(missingClusters, ", ")), log)
+		return r.updateLBStatus(
+			ctx,
+			mdbSearch,
+			workflow.Pending(
+				"None of the clusters in spec.clusters is registered with the operator: %s",
+				strings.Join(missingClusters, ", "),
+			),
+			log,
+		)
 	}
 
 	if reconcileErrs != nil {
@@ -258,7 +271,14 @@ func (r *MongoDBSearchEnvoyReconciler) buildClusterWorkList(search *searchv1.Mon
 // registered member client. A missing member client leaves Client nil: callers
 // report the cluster as not registered and never fall back to the central
 // client.
-func newClusterWorkItem(search *searchv1.MongoDBSearch, clusterName string, clusterIndex int, central kubernetesClient.Client, members map[string]kubernetesClient.Client, operatorClusterName string) clusterWorkItem {
+func newClusterWorkItem(
+	search *searchv1.MongoDBSearch,
+	clusterName string,
+	clusterIndex int,
+	central kubernetesClient.Client,
+	members map[string]kubernetesClient.Client,
+	operatorClusterName string,
+) clusterWorkItem {
 	work := clusterWorkItem{
 		ClusterName:  clusterName,
 		ClusterIndex: clusterIndex,
@@ -326,7 +346,12 @@ func (r *MongoDBSearchEnvoyReconciler) reconcileForCluster(
 
 // updateLBStatus patches the loadBalancer sub-status on the MongoDBSearch CR
 // and returns the reconcile result derived from the workflow status.
-func (r *MongoDBSearchEnvoyReconciler) updateLBStatus(ctx context.Context, search *searchv1.MongoDBSearch, st workflow.Status, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *MongoDBSearchEnvoyReconciler) updateLBStatus(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	st workflow.Status,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	partOption := searchv1.NewSearchPartOption(searchv1.SearchPartLoadBalancer)
 	return commoncontroller.UpdateStatus(ctx, r.kubeClient, search, st, log, partOption)
 }
@@ -352,18 +377,45 @@ func (r *MongoDBSearchEnvoyReconciler) clearLBStatus(ctx context.Context, search
 // LB transition. Deletes go through the shared owned-resource check: a same-name
 // object not owned by this MongoDBSearch is skipped rather than an error, so LB
 // teardown cannot requeue forever on a collision it can never resolve.
-func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(ctx context.Context, search *searchv1.MongoDBSearch, workList []clusterWorkItem, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) deleteEnvoyResources(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	workList []clusterWorkItem,
+	log *zap.SugaredLogger,
+) error {
 	var errs error
 	for _, w := range workList {
 		if w.Client == nil {
 			log.Warnf("cluster %q: no Kubernetes client registered for Envoy cleanup; skipping", w.ClusterName)
 			continue
 		}
-		deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(w.ClusterIndex), Namespace: search.Namespace}}
-		_, err := searchcontroller.DeleteOwnedResource(ctx, w.Client, search, w.ClusterName, "Envoy Deployment", searchProxyComponent, deployment, log)
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(w.ClusterIndex), Namespace: search.Namespace},
+		}
+		_, err := searchcontroller.DeleteOwnedResource(
+			ctx,
+			w.Client,
+			search,
+			w.ClusterName,
+			"Envoy Deployment",
+			searchProxyComponent,
+			deployment,
+			log,
+		)
 		errs = errors.Join(errs, err)
-		configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(w.ClusterIndex), Namespace: search.Namespace}}
-		_, err = searchcontroller.DeleteOwnedResource(ctx, w.Client, search, w.ClusterName, "Envoy ConfigMap", searchProxyComponent, configMap, log)
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(w.ClusterIndex), Namespace: search.Namespace},
+		}
+		_, err = searchcontroller.DeleteOwnedResource(
+			ctx,
+			w.Client,
+			search,
+			w.ClusterName,
+			"Envoy ConfigMap",
+			searchProxyComponent,
+			configMap,
+			log,
+		)
 		errs = errors.Join(errs, err)
 	}
 	return errs
@@ -384,7 +436,13 @@ func caKeyNameFromTLSConfig(tlsCfg *searchcontroller.TLSSourceConfig) string {
 // routingReadyMongotGroups is the state-CM switch; a shard not listed is pending and
 // its per-shard filter chain is redirected to the cluster-level cluster with the
 // routed_from_another_shard header.
-func buildShardRoutes(search *searchv1.MongoDBSearch, shardNames []string, clusterIndex int, clusterName string, routingReadyMongotGroups []string) []envoyRoute {
+func buildShardRoutes(
+	search *searchv1.MongoDBSearch,
+	shardNames []string,
+	clusterIndex int,
+	clusterName string,
+	routingReadyMongotGroups []string,
+) []envoyRoute {
 	// +1 for the cluster-level route appended at the end.
 	routes := make([]envoyRoute, 0, len(shardNames)+1)
 	namespace := search.Namespace
@@ -462,7 +520,13 @@ func buildShardRoutes(search *searchv1.MongoDBSearch, shardNames []string, clust
 // clusterName "" is the single-cluster path, but clusterIndex is still the CRD-pinned
 // index (a single-entry CR pinned non-zero must not reconcile at 0). routingReadyMongotGroups
 // gives a not-yet-listed mongot group fallback routing via the routed_from_another_shard header.
-func buildRoutesForCluster(search *searchv1.MongoDBSearch, source searchcontroller.SearchSourceDBResource, clusterIndex int, clusterName string, routingReadyMongotGroups []string) []envoyRoute {
+func buildRoutesForCluster(
+	search *searchv1.MongoDBSearch,
+	source searchcontroller.SearchSourceDBResource,
+	clusterIndex int,
+	clusterName string,
+	routingReadyMongotGroups []string,
+) []envoyRoute {
 	if shardedSource, ok := source.(searchcontroller.SearchSourceShardedDeployment); ok {
 		return buildShardRoutes(search, shardedSource.GetShardNames(), clusterIndex, clusterName, routingReadyMongotGroups)
 	}
@@ -496,7 +560,13 @@ func buildReplicaSetRouteForCluster(search *searchv1.MongoDBSearch, clusterIndex
 // ensureConfigMap creates or updates the Envoy ConfigMap with three files:
 // bootstrap.json (static), cds.json (dynamic clusters), and lds.json (dynamic listener).
 // Kubernetes ConfigMap updates are atomic (symlink swap), so all files update together.
-func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON, cdsJSON, ldsJSON string, w clusterWorkItem, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureConfigMap(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	bootstrapJSON, cdsJSON, ldsJSON string,
+	w clusterWorkItem,
+	log *zap.SugaredLogger,
+) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      search.LoadBalancerConfigMapNameForCluster(w.ClusterIndex),
@@ -536,7 +606,15 @@ func envoyConfigHash(configJSON string) (string, error) {
 // ensureDeployment creates or updates the Envoy Deployment.
 // The config hash is computed from bootstrapJSON only — CDS/LDS changes are
 // hot-reloaded by Envoy via filesystem xDS and do not require a pod restart.
-func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, search *searchv1.MongoDBSearch, bootstrapJSON string, w clusterWorkItem, managedLB *searchv1.ManagedLBConfig, tlsCfg *searchcontroller.TLSSourceConfig, log *zap.SugaredLogger) error {
+func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(
+	ctx context.Context,
+	search *searchv1.MongoDBSearch,
+	bootstrapJSON string,
+	w clusterWorkItem,
+	managedLB *searchv1.ManagedLBConfig,
+	tlsCfg *searchcontroller.TLSSourceConfig,
+	log *zap.SugaredLogger,
+) error {
 	configHash, err := envoyConfigHash(bootstrapJSON)
 	if err != nil {
 		return err
@@ -606,7 +684,15 @@ func (r *MongoDBSearchEnvoyReconciler) ensureDeployment(ctx context.Context, sea
 // clusterIndex selects the per-cluster ConfigMap volume name. Without this,
 // MC pods mount a ConfigMap that does not exist in the member cluster and
 // Envoy never starts.
-func buildEnvoyPodSpec(search *searchv1.MongoDBSearch, clusterIndex int, tlsCfg *searchcontroller.TLSSourceConfig, tlsEnabled bool, image string, resources corev1.ResourceRequirements, managedSecurityContext bool) corev1.PodSpec {
+func buildEnvoyPodSpec(
+	search *searchv1.MongoDBSearch,
+	clusterIndex int,
+	tlsCfg *searchcontroller.TLSSourceConfig,
+	tlsEnabled bool,
+	image string,
+	resources corev1.ResourceRequirements,
+	managedSecurityContext bool,
+) corev1.PodSpec {
 	volumes := []corev1.Volume{
 		{
 			Name: "envoy-config",
@@ -836,11 +922,22 @@ func envoyPodLabelsForCluster(search *searchv1.MongoDBSearch, clusterIndex int) 
 //
 // For each member cluster we register watches on Envoy Deployment + ConfigMap
 // using the label-based mapper (cross-cluster owner refs do not GC).
-func AddMongoDBSearchEnvoyController(ctx context.Context, mgr manager.Manager, defaultEnvoyImage string, memberClusterObjectsMap map[string]runtimeCluster.Cluster, operatorClusterName string) error {
+func AddMongoDBSearchEnvoyController(
+	ctx context.Context,
+	mgr manager.Manager,
+	defaultEnvoyImage string,
+	memberClusterObjectsMap map[string]runtimeCluster.Cluster,
+	operatorClusterName string,
+) error {
 	// NOTE: The field index for MongoDBSearchIndexFieldName is already registered
 	// by AddMongoDBSearchController. Do not register it again here.
 
-	r := newMongoDBSearchEnvoyReconciler(mgr.GetClient(), defaultEnvoyImage, multicluster.ClustersMapToClientMap(memberClusterObjectsMap), operatorClusterName)
+	r := newMongoDBSearchEnvoyReconciler(
+		mgr.GetClient(),
+		defaultEnvoyImage,
+		multicluster.ClustersMapToClientMap(memberClusterObjectsMap),
+		operatorClusterName,
+	)
 
 	c, err := controller.New("mongodbsearchenvoy", mgr, controller.Options{
 		Reconciler:              r,

--- a/controllers/operator/mongodbsearchenvoy_controller_test.go
+++ b/controllers/operator/mongodbsearchenvoy_controller_test.go
@@ -986,7 +986,18 @@ func TestEnsureConfigMap_WritesToCorrectMemberCluster(t *testing.T) {
 
 	search := &searchv1.MongoDBSearch{ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"}}
 	// cluster "a" is at index 0 in the mapping.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName), zap.S()))
+	require.NoError(
+		t,
+		r.ensureConfigMap(
+			context.Background(),
+			search,
+			`{"bootstrap":1}`,
+			`{"cds":1}`,
+			`{"lds":1}`,
+			newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName),
+			zap.S(),
+		),
+	)
 
 	// Member A has the ConfigMap named with index 0.
 	cmA := &corev1.ConfigMap{}
@@ -1019,7 +1030,18 @@ func TestEnsureConfigMap_MultiCluster_NoOwnerRef(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "abc"},
 	}
 	// cluster "a" is at index 0.
-	require.NoError(t, r.ensureConfigMap(context.Background(), search, `{"bootstrap":1}`, `{"cds":1}`, `{"lds":1}`, newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName), zap.S()))
+	require.NoError(
+		t,
+		r.ensureConfigMap(
+			context.Background(),
+			search,
+			`{"bootstrap":1}`,
+			`{"cds":1}`,
+			`{"lds":1}`,
+			newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName),
+			zap.S(),
+		),
+	)
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, memberA.Get(context.Background(),
@@ -1096,10 +1118,14 @@ func TestReconcileForCluster_UnknownClusterPending(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid"},
 		Spec: searchv1.MongoDBSearchSpec{
-			Source: &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
 			Clusters: []searchv1.ClusterSpec{{
-				Name:         "missing-cluster",
-				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-missing-cluster.example.com"}},
+				Name: "missing-cluster",
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-missing-cluster.example.com"},
+				},
 			}},
 		},
 	}
@@ -1172,7 +1198,16 @@ func TestReconcileForCluster_RendersInMemberCluster(t *testing.T) {
 	}
 
 	// cluster "a" is at index 0 in the mapping.
-	st := r.reconcileForCluster(context.Background(), search, nil, false, nil, newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName), nil, zap.S())
+	st := r.reconcileForCluster(
+		context.Background(),
+		search,
+		nil,
+		false,
+		nil,
+		newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName),
+		nil,
+		zap.S(),
+	)
 	require.True(t, st.IsOK(), "expected OK, got %s: %s", st.Phase(), searchcontroller.MessageFromStatus(st))
 
 	// Member cluster has Deployment + ConfigMap; central does not.
@@ -1223,13 +1258,29 @@ func TestEnsureDeployment_Replicas(t *testing.T) {
 	} {
 		search.Spec.Clusters[0].LoadBalancer.Managed.Replicas = tc.lbReplicas
 		// cluster "a" is at index 0.
-		require.NoError(t, r.ensureDeployment(context.Background(), search, `{"x":1}`, newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName), search.GetManagedLBForCluster("a"), nil, zap.S()))
+		require.NoError(
+			t,
+			r.ensureDeployment(
+				context.Background(),
+				search,
+				`{"x":1}`,
+				newClusterWorkItem(search, "a", 0, r.kubeClient, r.memberClients, r.operatorClusterName),
+				search.GetManagedLBForCluster("a"),
+				nil,
+				zap.S(),
+			),
+		)
 
 		dep := &appsv1.Deployment{}
 		require.NoError(t, memberA.Get(context.Background(),
 			types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}, dep))
 		require.NotNil(t, dep.Spec.Replicas)
-		assert.Equal(t, tc.expectedDeplReplicas, *dep.Spec.Replicas, "envoy replicas must be set to the same value configured in search resource")
+		assert.Equal(
+			t,
+			tc.expectedDeplReplicas,
+			*dep.Spec.Replicas,
+			"envoy replicas must be set to the same value configured in search resource",
+		)
 		assert.Empty(t, dep.OwnerReferences)
 
 		memberA.Delete(context.Background(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
@@ -1632,8 +1683,16 @@ func TestDeleteEnvoyResources(t *testing.T) {
 				assert.Positive(t, logs.FilterMessageSnippet(tc.wantWarn).Len(), "expected a warning containing %q", tc.wantWarn)
 			}
 			for _, o := range tc.objs {
-				depErr := clients[o.cluster].Get(ctx, types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(o.index), Namespace: "ns"}, &appsv1.Deployment{})
-				cmErr := clients[o.cluster].Get(ctx, types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(o.index), Namespace: "ns"}, &corev1.ConfigMap{})
+				depErr := clients[o.cluster].Get(
+					ctx,
+					types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(o.index), Namespace: "ns"},
+					&appsv1.Deployment{},
+				)
+				cmErr := clients[o.cluster].Get(
+					ctx,
+					types.NamespacedName{Name: search.LoadBalancerConfigMapNameForCluster(o.index), Namespace: "ns"},
+					&corev1.ConfigMap{},
+				)
 				if o.wantKept {
 					assert.NoError(t, depErr)
 					assert.NoError(t, cmErr)
@@ -1662,8 +1721,22 @@ func TestEnvoyReconcile_HubRemovedClusterCleansManagedMemberResources(t *testing
 			memberA := fake.NewClientBuilder().WithScheme(scheme).Build()
 			var memberB client.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
 			labels := khandler.SearchOwnershipLabels(search, "", searchProxyComponent)
-			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerDeploymentNameForCluster(1), Namespace: search.Namespace, UID: "removed-deployment", Labels: labels}}
-			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: search.LoadBalancerConfigMapNameForCluster(1), Namespace: search.Namespace, UID: "removed-config", Labels: maps.Clone(labels)}}
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.LoadBalancerDeploymentNameForCluster(1),
+					Namespace: search.Namespace,
+					UID:       "removed-deployment",
+					Labels:    labels,
+				},
+			}
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      search.LoadBalancerConfigMapNameForCluster(1),
+					Namespace: search.Namespace,
+					UID:       "removed-config",
+					Labels:    maps.Clone(labels),
+				},
+			}
 			require.NoError(t, memberB.Create(ctx, deployment))
 			require.NoError(t, memberB.Create(ctx, configMap))
 			injectedErr := fmt.Errorf("injected envoy delete failure")
@@ -1678,7 +1751,11 @@ func TestEnvoyReconcile_HubRemovedClusterCleansManagedMemberResources(t *testing
 				})
 			}
 
-			central := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&searchv1.MongoDBSearch{}).WithObjects(search).Build()
+			central := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&searchv1.MongoDBSearch{}).
+				WithObjects(search).
+				Build()
 			r := newMongoDBSearchEnvoyReconciler(central, "envoy:latest", map[string]client.Client{
 				"cluster-a": memberA,
 				"cluster-b": memberB,
@@ -1712,7 +1789,11 @@ func TestEnvoyReconcile_HubRemovedClusterCleansManagedMemberResources(t *testing
 			depErr := memberB.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})
 			if tc.failDepDelete {
 				assert.NoError(t, depErr, "failed delete leaves the Deployment behind for the next reconcile")
-				assert.Positive(t, logs.FilterMessageSnippet(injectedErr.Error()).Len(), "expected a warning mentioning the injected delete failure")
+				assert.Positive(
+					t,
+					logs.FilterMessageSnippet(injectedErr.Error()).Len(),
+					"expected a warning mentioning the injected delete failure",
+				)
 			} else {
 				assert.True(t, apierrors.IsNotFound(depErr))
 				assert.Zero(t, logs.FilterMessageSnippet(injectedErr.Error()).Len())
@@ -1784,9 +1865,14 @@ func TestReconcile_RoutingReadyFromState_DrivesFallbackRoutes(t *testing.T) {
 				},
 			},
 			Clusters: []searchv1.ClusterSpec{{
-				Name:         "cluster-a",
-				Index:        ptr.To(int32(0)),
-				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-{shardName}.example.com", RouterHostname: "mongot-router.example.com"}},
+				Name:  "cluster-a",
+				Index: ptr.To(int32(0)),
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{
+						ExternalHostname: "mongot-{shardName}.example.com",
+						RouterHostname:   "mongot-router.example.com",
+					},
+				},
 			}},
 		},
 	}
@@ -1841,9 +1927,13 @@ func newMCEnvoySearch(name, namespace, uid string, clusters ...searchv1.ClusterS
 
 func newOperatorPerClusterEnvoySearch(name, namespace string, clusterBIndex int32) *searchv1.MongoDBSearch {
 	clusterA := pinnedCluster("cluster-a", 0)
-	clusterA.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"}}
+	clusterA.LoadBalancer = &searchv1.LoadBalancerConfig{
+		Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-a.example.com"},
+	}
 	clusterB := pinnedCluster("cluster-b", clusterBIndex)
-	clusterB.LoadBalancer = &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"}}
+	clusterB.LoadBalancer = &searchv1.LoadBalancerConfig{
+		Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-cluster-b.example.com"},
+	}
 	return &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},
 		Spec: searchv1.MongoDBSearchSpec{
@@ -1879,8 +1969,10 @@ func TestBuildReplicaSetRouteForCluster_ResolvedIndexNotArrayPos(t *testing.T) {
 	// SNI is the cluster's literal LB hostname; the resolved index (7), not the array
 	// position (0), must drive the per-cluster mongot Service name in UpstreamHosts.
 	clusters := []searchv1.ClusterSpec{{
-		Name:         "eu-west-k8s",
-		LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-eu-west-k8s.apps.example.com"}},
+		Name: "eu-west-k8s",
+		LoadBalancer: &searchv1.LoadBalancerConfig{
+			Managed: &searchv1.ManagedLBConfig{ExternalHostname: "mongot-eu-west-k8s.apps.example.com"},
+		},
 	}}
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "test-ns"},
@@ -1985,7 +2077,9 @@ func TestEnvoyReconcile_LBCleanup_DeletesAtPinnedIndex(t *testing.T) {
 	search := &searchv1.MongoDBSearch{
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns", UID: "search-uid", Generation: 1},
 		Spec: searchv1.MongoDBSearchSpec{
-			Source:   &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}}},
+			Source: &searchv1.MongoDBSource{
+				ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{HostAndPorts: []string{"mongo-0:27017"}},
+			},
 			Clusters: []searchv1.ClusterSpec{{Name: "cluster-a", Index: ptr.To(int32(3))}},
 		},
 		// LB previously managed → status present; spec no longer managed → cleanup branch.
@@ -2192,8 +2286,10 @@ func TestReconcileForCluster_OperatorPerCluster_ShardedSource_RendersToProvidedC
 		ObjectMeta: metav1.ObjectMeta{Name: "mdb-search", Namespace: "ns"},
 		Spec: searchv1.MongoDBSearchSpec{
 			Clusters: []searchv1.ClusterSpec{{
-				Name:         "kind-e2e-cluster-1",
-				LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.kind-e2e-cluster-1.example.com"}},
+				Name: "kind-e2e-cluster-1",
+				LoadBalancer: &searchv1.LoadBalancerConfig{
+					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.kind-e2e-cluster-1.example.com"},
+				},
 			}},
 		},
 	}
@@ -2201,7 +2297,16 @@ func TestReconcileForCluster_OperatorPerCluster_ShardedSource_RendersToProvidedC
 
 	// Drive reconcileForCluster directly with the projected cluster name and
 	// r.kubeClient — the operator-per-cluster with unified CR path that buildClusterWorkList wires.
-	st := r.reconcileForCluster(context.Background(), search, source, false, nil, clusterWorkItem{ClusterName: "kind-e2e-cluster-1", ClusterIndex: 0, Client: r.kubeClient}, nil, zap.S())
+	st := r.reconcileForCluster(
+		context.Background(),
+		search,
+		source,
+		false,
+		nil,
+		clusterWorkItem{ClusterName: "kind-e2e-cluster-1", ClusterIndex: 0, Client: r.kubeClient},
+		nil,
+		zap.S(),
+	)
 	require.True(t, st.IsOK(), "operator-per-cluster with unified CR sharded reconcile should succeed, got %s: %s",
 		st.Phase(), searchcontroller.MessageFromStatus(st))
 
@@ -2322,7 +2427,18 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 	depName := types.NamespacedName{Name: search.LoadBalancerDeploymentNameForCluster(0), Namespace: "ns"}
 
 	// First apply: operator creates the Deployment with its config-hash annotation.
-	require.NoError(t, r.ensureDeployment(ctx, search, `{"bootstrap":1}`, newClusterWorkItem(search, "", 0, r.kubeClient, r.memberClients, r.operatorClusterName), managedLB, nil, zap.S()))
+	require.NoError(
+		t,
+		r.ensureDeployment(
+			ctx,
+			search,
+			`{"bootstrap":1}`,
+			newClusterWorkItem(search, "", 0, r.kubeClient, r.memberClients, r.operatorClusterName),
+			managedLB,
+			nil,
+			zap.S(),
+		),
+	)
 
 	dep := &appsv1.Deployment{}
 	require.NoError(t, central.Get(ctx, depName, dep))
@@ -2334,7 +2450,18 @@ func TestEnsureDeployment_PreservesRolloutRestartAnnotation(t *testing.T) {
 	require.NoError(t, central.Update(ctx, dep))
 
 	// Re-apply (as any reconcile triggered during the rollout would).
-	require.NoError(t, r.ensureDeployment(ctx, search, `{"bootstrap":1}`, newClusterWorkItem(search, "", 0, r.kubeClient, r.memberClients, r.operatorClusterName), managedLB, nil, zap.S()))
+	require.NoError(
+		t,
+		r.ensureDeployment(
+			ctx,
+			search,
+			`{"bootstrap":1}`,
+			newClusterWorkItem(search, "", 0, r.kubeClient, r.memberClients, r.operatorClusterName),
+			managedLB,
+			nil,
+			zap.S(),
+		),
+	)
 
 	require.NoError(t, central.Get(ctx, depName, dep))
 	assert.Equal(t, "2026-07-14T13:53:28Z", dep.Spec.Template.Annotations[restartedAtKey],

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -92,7 +92,18 @@ type ReconcileMongoDbShardedCluster struct {
 	defaultArchitecture architectures.DefaultArchitecture
 }
 
-func newShardedClusterReconciler(ctx context.Context, kubeClient client.Client, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClusterMap map[string]client.Client, omFunc om.ConnectionFactory, backupEnableDelay time.Duration) *ReconcileMongoDbShardedCluster {
+func newShardedClusterReconciler(
+	ctx context.Context,
+	kubeClient client.Client,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	memberClusterMap map[string]client.Client,
+	omFunc om.ConnectionFactory,
+	backupEnableDelay time.Duration,
+) *ReconcileMongoDbShardedCluster {
 	return &ReconcileMongoDbShardedCluster{
 		ReconcileCommonController: NewReconcileCommonController(ctx, kubeClient),
 		omConnectionFactory:       omFunc,
@@ -142,7 +153,10 @@ func NewShardedClusterDeploymentState() *ShardedClusterDeploymentState {
 	}
 }
 
-func (r *ShardedClusterReconcileHelper) initializeMemberClusters(globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger) error {
+func (r *ShardedClusterReconcileHelper) initializeMemberClusters(
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+) error {
 	mongoDB := r.sc
 	shardsMap := r.desiredShardsConfiguration
 	configSrvSpecList := r.desiredConfigServerConfiguration.ClusterSpecList
@@ -170,7 +184,10 @@ func (r *ShardedClusterReconcileHelper) initializeMemberClusters(globalMemberClu
 		}
 		slices.Sort(allReferencedClusterNames)
 
-		r.deploymentState.ClusterMapping = multicluster.AssignIndexesForMemberClusterNames(r.deploymentState.ClusterMapping, allReferencedClusterNames)
+		r.deploymentState.ClusterMapping = multicluster.AssignIndexesForMemberClusterNames(
+			r.deploymentState.ClusterMapping,
+			allReferencedClusterNames,
+		)
 
 		configSrvGetLastAppliedMembersFunc := func(memberClusterName string) int {
 			if count, ok := r.deploymentState.Status.SizeStatusInClusters.ConfigServerMongodsInClusters[memberClusterName]; ok {
@@ -179,7 +196,14 @@ func (r *ShardedClusterReconcileHelper) initializeMemberClusters(globalMemberClu
 				return 0
 			}
 		}
-		r.configSrvMemberClusters = createMemberClusterListFromClusterSpecList(configSrvSpecList, globalMemberClustersMap, log, r.deploymentState.ClusterMapping, configSrvGetLastAppliedMembersFunc, false)
+		r.configSrvMemberClusters = createMemberClusterListFromClusterSpecList(
+			configSrvSpecList,
+			globalMemberClustersMap,
+			log,
+			r.deploymentState.ClusterMapping,
+			configSrvGetLastAppliedMembersFunc,
+			false,
+		)
 
 		mongosGetLastAppliedMembersFunc := func(memberClusterName string) int {
 			if count, ok := r.deploymentState.Status.SizeStatusInClusters.MongosCountInClusters[memberClusterName]; ok {
@@ -188,8 +212,21 @@ func (r *ShardedClusterReconcileHelper) initializeMemberClusters(globalMemberClu
 				return 0
 			}
 		}
-		r.mongosMemberClusters = createMemberClusterListFromClusterSpecList(mongosClusterSpecList, globalMemberClustersMap, log, r.deploymentState.ClusterMapping, mongosGetLastAppliedMembersFunc, false)
-		r.shardsMemberClustersMap, r.allShardsMemberClusters = r.createShardsMemberClusterLists(shardsMap, globalMemberClustersMap, log, r.deploymentState, false)
+		r.mongosMemberClusters = createMemberClusterListFromClusterSpecList(
+			mongosClusterSpecList,
+			globalMemberClustersMap,
+			log,
+			r.deploymentState.ClusterMapping,
+			mongosGetLastAppliedMembersFunc,
+			false,
+		)
+		r.shardsMemberClustersMap, r.allShardsMemberClusters = r.createShardsMemberClusterLists(
+			shardsMap,
+			globalMemberClustersMap,
+			log,
+			r.deploymentState,
+			false,
+		)
 	} else {
 		r.shardsMemberClustersMap, r.allShardsMemberClusters = r.createShardsMemberClusterLists(shardsMap, globalMemberClustersMap, log, r.deploymentState, true)
 
@@ -213,16 +250,46 @@ func (r *ShardedClusterReconcileHelper) initializeMemberClusters(globalMemberClu
 
 	r.allMemberClusters = r.createAllMemberClustersList()
 
-	log.Debugf("Initialized shards member cluster list: %+v", util.Transform(r.allShardsMemberClusters, func(m multicluster.MemberCluster) string {
-		// TODO Replicas is not relevant when iterating over allShardsMemberClusters; construct full list by iterating over shardsMemberClustersMap
-		return fmt.Sprintf("{Name: %s, Index: %d, Replicas: %d, Active: %t, Healthy: %t}", m.Name, m.Index, m.Replicas, m.Active, m.Healthy)
-	}))
-	log.Debugf("Initialized mongos member cluster list: %+v", util.Transform(r.mongosMemberClusters, func(m multicluster.MemberCluster) string {
-		return fmt.Sprintf("{Name: %s, Index: %d, Replicas: %d, Active: %t, Healthy: %t}", m.Name, m.Index, m.Replicas, m.Active, m.Healthy)
-	}))
-	log.Debugf("Initialized config servers member cluster list: %+v", util.Transform(r.configSrvMemberClusters, func(m multicluster.MemberCluster) string {
-		return fmt.Sprintf("{Name: %s, Index: %d, Replicas: %d, Active: %t, Healthy: %t}", m.Name, m.Index, m.Replicas, m.Active, m.Healthy)
-	}))
+	log.Debugf(
+		"Initialized shards member cluster list: %+v",
+		util.Transform(r.allShardsMemberClusters, func(m multicluster.MemberCluster) string {
+			// TODO Replicas is not relevant when iterating over allShardsMemberClusters; construct full list by iterating over shardsMemberClustersMap
+			return fmt.Sprintf(
+				"{Name: %s, Index: %d, Replicas: %d, Active: %t, Healthy: %t}",
+				m.Name,
+				m.Index,
+				m.Replicas,
+				m.Active,
+				m.Healthy,
+			)
+		}),
+	)
+	log.Debugf(
+		"Initialized mongos member cluster list: %+v",
+		util.Transform(r.mongosMemberClusters, func(m multicluster.MemberCluster) string {
+			return fmt.Sprintf(
+				"{Name: %s, Index: %d, Replicas: %d, Active: %t, Healthy: %t}",
+				m.Name,
+				m.Index,
+				m.Replicas,
+				m.Active,
+				m.Healthy,
+			)
+		}),
+	)
+	log.Debugf(
+		"Initialized config servers member cluster list: %+v",
+		util.Transform(r.configSrvMemberClusters, func(m multicluster.MemberCluster) string {
+			return fmt.Sprintf(
+				"{Name: %s, Index: %d, Replicas: %d, Active: %t, Healthy: %t}",
+				m.Name,
+				m.Index,
+				m.Replicas,
+				m.Active,
+				m.Healthy,
+			)
+		}),
+	)
 	return nil
 }
 
@@ -249,7 +316,13 @@ func (r *ShardedClusterReconcileHelper) createAllMemberClustersList() []multiclu
 
 // createShardsMemberClusterLists creates a list of member clusters from the current desired shards configuration.
 // legacyMemberCluster parameter is used to indicate the member cluster should be marked as Legacy for reusing this function also in single-cluster mode.
-func (r *ShardedClusterReconcileHelper) createShardsMemberClusterLists(shardsMap map[int]*mdbv1.ShardedClusterComponentSpec, globalMemberClustersMap map[string]client.Client, log *zap.SugaredLogger, deploymentState *ShardedClusterDeploymentState, legacyMemberCluster bool) (map[int][]multicluster.MemberCluster, []multicluster.MemberCluster) {
+func (r *ShardedClusterReconcileHelper) createShardsMemberClusterLists(
+	shardsMap map[int]*mdbv1.ShardedClusterComponentSpec,
+	globalMemberClustersMap map[string]client.Client,
+	log *zap.SugaredLogger,
+	deploymentState *ShardedClusterDeploymentState,
+	legacyMemberCluster bool,
+) (map[int][]multicluster.MemberCluster, []multicluster.MemberCluster) {
 	shardMemberClustersMap := map[int][]multicluster.MemberCluster{}
 	var allShardsMemberClusters []multicluster.MemberCluster
 	alreadyAdded := map[string]struct{}{}
@@ -280,7 +353,14 @@ func (r *ShardedClusterReconcileHelper) createShardsMemberClusterLists(shardsMap
 			return 0
 		}
 		// we use here shardSpec.ClusterSpecList directly as it's already a "processed" one from shardMap
-		shardMemberClustersMap[shardIdx] = createMemberClusterListFromClusterSpecList(shardSpec.ClusterSpecList, globalMemberClustersMap, log, deploymentState.ClusterMapping, shardGetLastAppliedMembersFunc, legacyMemberCluster)
+		shardMemberClustersMap[shardIdx] = createMemberClusterListFromClusterSpecList(
+			shardSpec.ClusterSpecList,
+			globalMemberClustersMap,
+			log,
+			deploymentState.ClusterMapping,
+			shardGetLastAppliedMembersFunc,
+			legacyMemberCluster,
+		)
 
 		for _, shardMemberCluster := range shardMemberClustersMap[shardIdx] {
 			if _, ok := alreadyAdded[shardMemberCluster.Name]; !ok {
@@ -325,7 +405,11 @@ func (r *ShardedClusterReconcileHelper) prepareDesiredShardsConfiguration() map[
 		topLevelPersistenceOverride, topLevelPodSpecOverride := getShardTopLevelOverrides(spec, shardIdx)
 
 		shardComponentSpec := *spec.ShardSpec.DeepCopy()
-		shardComponentSpec.ClusterSpecList = processClusterSpecList(shardComponentSpec.ClusterSpecList, topLevelPodSpecOverride, topLevelPersistenceOverride)
+		shardComponentSpec.ClusterSpecList = processClusterSpecList(
+			shardComponentSpec.ClusterSpecList,
+			topLevelPodSpecOverride,
+			topLevelPersistenceOverride,
+		)
 		shardComponentSpecs[shardIdx] = &shardComponentSpec
 	}
 
@@ -336,7 +420,13 @@ func (r *ShardedClusterReconcileHelper) prepareDesiredShardsConfiguration() map[
 		// here we copy the whole element and overwrite at the end of every iteration
 		defaultShardConfiguration := shardComponentSpecs[shardIndex].DeepCopy()
 		topLevelPersistenceOverride, topLevelPodSpecOverride := getShardTopLevelOverrides(spec, shardIndex)
-		shardComponentSpecs[shardIndex] = processShardOverride(spec, shardOverride, defaultShardConfiguration, topLevelPodSpecOverride, topLevelPersistenceOverride)
+		shardComponentSpecs[shardIndex] = processShardOverride(
+			spec,
+			shardOverride,
+			defaultShardConfiguration,
+			topLevelPodSpecOverride,
+			topLevelPersistenceOverride,
+		)
 	}
 	return shardComponentSpecs
 }
@@ -361,7 +451,12 @@ func getShardTopLevelOverrides(spec *mdbv1.MongoDbSpec, shardIdx int) (*v1.Persi
 	return topLevelPersistenceOverride, topLevelPodSpecOverride
 }
 
-func mergeOverrideClusterSpecList(shardOverride mdbv1.ShardOverride, defaultShardConfiguration *mdbv1.ShardedClusterComponentSpec, topLevelPodSpecOverride *corev1.PodTemplateSpec, topLevelPersistenceOverride *v1.Persistence) *mdbv1.ShardedClusterComponentSpec {
+func mergeOverrideClusterSpecList(
+	shardOverride mdbv1.ShardOverride,
+	defaultShardConfiguration *mdbv1.ShardedClusterComponentSpec,
+	topLevelPodSpecOverride *corev1.PodTemplateSpec,
+	topLevelPersistenceOverride *v1.Persistence,
+) *mdbv1.ShardedClusterComponentSpec {
 	finalShardConfiguration := defaultShardConfiguration.DeepCopy()
 	// We override here all elements of ClusterSpecList, but statefulset overrides if provided here
 	// will be merged on top of previous sts overrides.
@@ -378,7 +473,10 @@ func mergeOverrideClusterSpecList(shardOverride mdbv1.ShardOverride, defaultShar
 			}
 			// We only need to perform a merge if there is a top level override, otherwise we keep an empty sts configuration
 			if topLevelPodSpecOverride != nil {
-				shardOverrideClusterSpecItem.StatefulSetConfiguration.SpecWrapper.Spec.Template = merge.PodTemplateSpecs(*topLevelPodSpecOverride, shardOverrideClusterSpecItem.StatefulSetConfiguration.SpecWrapper.Spec.Template)
+				shardOverrideClusterSpecItem.StatefulSetConfiguration.SpecWrapper.Spec.Template = merge.PodTemplateSpecs(
+					*topLevelPodSpecOverride,
+					shardOverrideClusterSpecItem.StatefulSetConfiguration.SpecWrapper.Spec.Template,
+				)
 			}
 			if (shardOverrideClusterSpecItem.PodSpec == nil || shardOverrideClusterSpecItem.PodSpec.Persistence == nil) &&
 				topLevelPersistenceOverride != nil {
@@ -459,7 +557,13 @@ func expandShardOverrides(initialOverrides []mdbv1.ShardOverride) []mdbv1.ShardO
 	return expandedShardOverrides
 }
 
-func processShardOverride(spec *mdbv1.MongoDbSpec, shardOverride mdbv1.ShardOverride, defaultShardConfiguration *mdbv1.ShardedClusterComponentSpec, topLevelPodSpecOverride *corev1.PodTemplateSpec, topLevelPersistenceOverride *v1.Persistence) *mdbv1.ShardedClusterComponentSpec {
+func processShardOverride(
+	spec *mdbv1.MongoDbSpec,
+	shardOverride mdbv1.ShardOverride,
+	defaultShardConfiguration *mdbv1.ShardedClusterComponentSpec,
+	topLevelPodSpecOverride *corev1.PodTemplateSpec,
+	topLevelPersistenceOverride *v1.Persistence,
+) *mdbv1.ShardedClusterComponentSpec {
 	if shardOverride.Agent != nil {
 		defaultShardConfiguration.Agent = *shardOverride.Agent
 	}
@@ -490,7 +594,10 @@ func processShardOverride(spec *mdbv1.MongoDbSpec, shardOverride mdbv1.ShardOver
 			if defaultShardConfiguration.ClusterSpecList[idx].StatefulSetConfiguration == nil {
 				defaultShardConfiguration.ClusterSpecList[idx].StatefulSetConfiguration = &v1.StatefulSetConfiguration{}
 			}
-			defaultShardConfiguration.ClusterSpecList[idx].StatefulSetConfiguration.SpecWrapper.Spec = merge.StatefulSetSpecs(defaultShardConfiguration.ClusterSpecList[idx].StatefulSetConfiguration.SpecWrapper.Spec, shardOverride.StatefulSetConfiguration.SpecWrapper.Spec)
+			defaultShardConfiguration.ClusterSpecList[idx].StatefulSetConfiguration.SpecWrapper.Spec = merge.StatefulSetSpecs(
+				defaultShardConfiguration.ClusterSpecList[idx].StatefulSetConfiguration.SpecWrapper.Spec,
+				shardOverride.StatefulSetConfiguration.SpecWrapper.Spec,
+			)
 		}
 	}
 
@@ -529,7 +636,11 @@ func (r *ShardedClusterReconcileHelper) prepareDesiredMongosConfiguration() *mdb
 
 	topLevelPodSpecOverride, topLevelPersistenceOverride := extractOverridesFromPodSpec(spec.MongosPodSpec)
 	mongosComponentSpec := spec.MongosSpec.DeepCopy()
-	mongosComponentSpec.ClusterSpecList = processClusterSpecList(mongosComponentSpec.ClusterSpecList, topLevelPodSpecOverride, topLevelPersistenceOverride)
+	mongosComponentSpec.ClusterSpecList = processClusterSpecList(
+		mongosComponentSpec.ClusterSpecList,
+		topLevelPodSpecOverride,
+		topLevelPersistenceOverride,
+	)
 
 	return mongosComponentSpec
 }
@@ -541,7 +652,11 @@ func (r *ShardedClusterReconcileHelper) prepareDesiredConfigServerConfiguration(
 
 	topLevelPodSpecOverride, topLevelPersistenceOverride := extractOverridesFromPodSpec(spec.ConfigSrvPodSpec)
 	configSrvComponentSpec := spec.ConfigSrvSpec.DeepCopy()
-	configSrvComponentSpec.ClusterSpecList = processClusterSpecList(configSrvComponentSpec.ClusterSpecList, topLevelPodSpecOverride, topLevelPersistenceOverride)
+	configSrvComponentSpec.ClusterSpecList = processClusterSpecList(
+		configSrvComponentSpec.ClusterSpecList,
+		topLevelPodSpecOverride,
+		topLevelPersistenceOverride,
+	)
 
 	return configSrvComponentSpec
 }
@@ -562,7 +677,10 @@ func processClusterSpecList(
 			if clusterSpecList[i].StatefulSetConfiguration == nil {
 				clusterSpecList[i].StatefulSetConfiguration = &v1.StatefulSetConfiguration{}
 			}
-			clusterSpecList[i].StatefulSetConfiguration.SpecWrapper.Spec.Template = merge.PodTemplateSpecs(*topLevelPodSpecOverride.DeepCopy(), clusterSpecList[i].StatefulSetConfiguration.SpecWrapper.Spec.Template)
+			clusterSpecList[i].StatefulSetConfiguration.SpecWrapper.Spec.Template = merge.PodTemplateSpecs(
+				*topLevelPodSpecOverride.DeepCopy(),
+				clusterSpecList[i].StatefulSetConfiguration.SpecWrapper.Spec.Template,
+			)
 		}
 		if clusterSpecList[i].PodSpec == nil {
 			clusterSpecList[i].PodSpec = &mdbv1.MongoDbPodSpec{}
@@ -661,8 +779,24 @@ func NewShardedClusterReconcilerHelper(
 	log *zap.SugaredLogger,
 	backupEnableDelay time.Duration,
 ) (*ShardedClusterReconcileHelper, error) {
-	return newShardedClusterReconcilerHelper(ctx, reconciler, imageUrls, initDatabaseNonStaticImageVersion,
-		databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, sc, globalMemberClustersMap, omConnectionFactory, log, false, backupEnableDelay)
+	return newShardedClusterReconcilerHelper(
+		ctx,
+		reconciler,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		forceEnterprise,
+		enableClusterMongoDBRoles,
+		agentDebug,
+		agentDebugImage,
+		defaultArchitecture,
+		sc,
+		globalMemberClustersMap,
+		omConnectionFactory,
+		log,
+		false,
+		backupEnableDelay,
+	)
 }
 
 func newShardedClusterReconcilerHelper(
@@ -775,7 +909,12 @@ func blockScalingBothWays(desiredReplicasScalers []interfaces.MultiClusterReplic
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) initializeStateStore(ctx context.Context, reconciler *ReconcileCommonController, sc *mdbv1.MongoDB, log *zap.SugaredLogger) error {
+func (r *ShardedClusterReconcileHelper) initializeStateStore(
+	ctx context.Context,
+	reconciler *ReconcileCommonController,
+	sc *mdbv1.MongoDB,
+	log *zap.SugaredLogger,
+) error {
 	r.deploymentState = NewShardedClusterDeploymentState()
 
 	r.stateStore = NewStateStore[ShardedClusterDeploymentState](sc, kube.BaseOwnerReference(sc), reconciler.client)
@@ -834,7 +973,23 @@ func (r *ReconcileMongoDbShardedCluster) Reconcile(ctx context.Context, request 
 		return reconcileResult, err
 	}
 
-	reconcilerHelper, err := NewShardedClusterReconcilerHelper(ctx, r.ReconcileCommonController, r.imageUrls, r.initDatabaseNonStaticImageVersion, r.databaseNonStaticImageVersion, r.forceEnterprise, r.enableClusterMongoDBRoles, r.agentDebug, r.agentDebugImage, r.defaultArchitecture, sc, r.memberClustersMap, r.omConnectionFactory, log, r.backupEnableDelay)
+	reconcilerHelper, err := NewShardedClusterReconcilerHelper(
+		ctx,
+		r.ReconcileCommonController,
+		r.imageUrls,
+		r.initDatabaseNonStaticImageVersion,
+		r.databaseNonStaticImageVersion,
+		r.forceEnterprise,
+		r.enableClusterMongoDBRoles,
+		r.agentDebug,
+		r.agentDebugImage,
+		r.defaultArchitecture,
+		sc,
+		r.memberClustersMap,
+		r.omConnectionFactory,
+		log,
+		r.backupEnableDelay,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, sc, workflow.Failed(xerrors.Errorf("Failed to initialize sharded cluster reconciler: %w", err)), log)
 	}
@@ -843,7 +998,23 @@ func (r *ReconcileMongoDbShardedCluster) Reconcile(ctx context.Context, request 
 
 // OnDelete tries to complete a Deletion reconciliation event
 func (r *ReconcileMongoDbShardedCluster) OnDelete(ctx context.Context, obj runtime.Object, log *zap.SugaredLogger) error {
-	reconcilerHelper, err := NewShardedClusterReconcilerHelper(ctx, r.ReconcileCommonController, r.imageUrls, r.initDatabaseNonStaticImageVersion, r.databaseNonStaticImageVersion, r.forceEnterprise, r.enableClusterMongoDBRoles, r.agentDebug, r.agentDebugImage, r.defaultArchitecture, obj.(*mdbv1.MongoDB), r.memberClustersMap, r.omConnectionFactory, log, r.backupEnableDelay)
+	reconcilerHelper, err := NewShardedClusterReconcilerHelper(
+		ctx,
+		r.ReconcileCommonController,
+		r.imageUrls,
+		r.initDatabaseNonStaticImageVersion,
+		r.databaseNonStaticImageVersion,
+		r.forceEnterprise,
+		r.enableClusterMongoDBRoles,
+		r.agentDebug,
+		r.agentDebugImage,
+		r.defaultArchitecture,
+		obj.(*mdbv1.MongoDB),
+		r.memberClustersMap,
+		r.omConnectionFactory,
+		log,
+		r.backupEnableDelay,
+	)
 	if err != nil {
 		return err
 	}
@@ -859,7 +1030,13 @@ func (r *ShardedClusterReconcileHelper) Reconcile(ctx context.Context, log *zap.
 	log.Info("-> ShardedCluster.Reconcile")
 	log.Infow("ShardedCluster.Spec", "spec", sc.Spec)
 	log.Infow("ShardedCluster.Status", "status", r.deploymentState.Status)
-	log.Infow("ShardedCluster.deploymentState", "sizeStatus", r.deploymentState.Status.MongodbShardedClusterSizeConfig, "sizeStatusInClusters", r.deploymentState.Status.SizeStatusInClusters)
+	log.Infow(
+		"ShardedCluster.deploymentState",
+		"sizeStatus",
+		r.deploymentState.Status.MongodbShardedClusterSizeConfig,
+		"sizeStatusInClusters",
+		r.deploymentState.Status.SizeStatusInClusters,
+	)
 
 	r.logAllScalers(log)
 
@@ -887,15 +1064,36 @@ func (r *ShardedClusterReconcileHelper) Reconcile(ctx context.Context, log *zap.
 	}
 
 	if !architectures.IsRunningStaticArchitecture(sc.Annotations, r.defaultArchitecture) {
-		agents.UpgradeAllIfNeeded(ctx, agents.ClientSecret{Client: r.commonController.client, SecretClient: r.commonController.SecretClient}, r.omConnectionFactory, GetWatchedNamespace(), false)
+		agents.UpgradeAllIfNeeded(
+			ctx,
+			agents.ClientSecret{Client: r.commonController.client, SecretClient: r.commonController.SecretClient},
+			r.omConnectionFactory,
+			GetWatchedNamespace(),
+			false,
+		)
 	}
 
-	projectConfig, credsConfig, err := project.ReadConfigAndCredentials(ctx, r.commonController.client, r.commonController.SecretClient, sc, log)
+	projectConfig, credsConfig, err := project.ReadConfigAndCredentials(
+		ctx,
+		r.commonController.client,
+		r.commonController.SecretClient,
+		sc,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, sc, workflow.Failed(err), log)
 	}
 
-	conn, agentAPIKey, err := connection.PrepareOpsManagerConnection(ctx, r.commonController.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, sc.Namespace, true, log)
+	conn, agentAPIKey, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.commonController.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		sc.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, sc, workflow.Failed(err), log)
 	}
@@ -949,12 +1147,20 @@ func (r *ShardedClusterReconcileHelper) Reconcile(ctx context.Context, log *zap.
 	// Saving the inremented sizes into the deployment state and requeuing will make ReplicasThisReconciliation to report again +1 and will perform another scaling one by one.
 	// Returning false here means, we've finished scaling. In this case the sizes will be updated as the last step of the reconcile when reporting Running state.
 	if r.shouldContinueScalingOneByOne() {
-		return r.updateStatus(ctx, sc, workflow.Pending("Continuing scaling operation for ShardedCluster %s mongodsPerShardCount ... %+v, mongosCount %+v, configServerCount %+v",
-			sc.ObjectKey(),
-			sizeStatus.MongodsPerShardCount,
-			sizeStatus.MongosCount,
-			sizeStatus.ConfigServerCount,
-		), log, mdbstatus.ShardedClusterSizeConfigOption{SizeConfig: sizeStatus}, mdbstatus.ShardedClusterSizeStatusInClustersOption{SizeConfigInClusters: sizeStatusInClusters})
+		return r.updateStatus(
+			ctx,
+			sc,
+			workflow.Pending(
+				"Continuing scaling operation for ShardedCluster %s mongodsPerShardCount ... %+v, mongosCount %+v, configServerCount %+v",
+				sc.ObjectKey(),
+				sizeStatus.MongodsPerShardCount,
+				sizeStatus.MongosCount,
+				sizeStatus.ConfigServerCount,
+			),
+			log,
+			mdbstatus.ShardedClusterSizeConfigOption{SizeConfig: sizeStatus},
+			mdbstatus.ShardedClusterSizeStatusInClustersOption{SizeConfigInClusters: sizeStatusInClusters},
+		)
 	}
 
 	// Only remove any stateful sets if we are scaling down.
@@ -985,7 +1191,12 @@ func (r *ShardedClusterReconcileHelper) Reconcile(ctx context.Context, log *zap.
 	}
 
 	// Set annotation and state for previously configured roles
-	_, roleStrings, err := r.commonController.getRoleAnnotation(ctx, r.sc.Spec.DbCommonSpec, r.enableClusterMongoDBRoles, kube.ObjectKeyFromApiObject(r.sc))
+	_, roleStrings, err := r.commonController.getRoleAnnotation(
+		ctx,
+		r.sc.Spec.DbCommonSpec,
+		r.enableClusterMongoDBRoles,
+		kube.ObjectKeyFromApiObject(r.sc),
+	)
 	if err != nil {
 		return r.updateStatus(ctx, sc, workflow.Failed(err), log)
 	}
@@ -1072,7 +1283,12 @@ func (r *ShardedClusterReconcileHelper) applySearchParametersForShards(ctx conte
 			shardConfig.AdditionalMongodConfig = mdbv1.NewEmptyAdditionalMongodConfig()
 		}
 
-		searchMongodConfig := searchcontroller.GetMongodConfigParametersForShard(search, shardName, sc.Spec.GetClusterDomain(), searchClusterIndex)
+		searchMongodConfig := searchcontroller.GetMongodConfigParametersForShard(
+			search,
+			shardName,
+			sc.Spec.GetClusterDomain(),
+			searchClusterIndex,
+		)
 		shardConfig.AdditionalMongodConfig.AddOption("setParameter", searchMongodConfig["setParameter"])
 
 		log.Debugf("Applied search config for shard %s: mongotHost=%v", shardName, searchMongodConfig["setParameter"])
@@ -1086,7 +1302,13 @@ func (r *ShardedClusterReconcileHelper) applySearchParametersForShards(ctx conte
 
 	// clusterName="": operator-managed sharded source is single-cluster only at MVP.
 	// Q1-MC sharded would need per-cluster mongos config (gated on ShardOverrides API redesign).
-	searchMongosConfig := searchcontroller.GetMongosConfigParametersForSharded(search, searchClusterIndex, "", shardNames, sc.Spec.GetClusterDomain())
+	searchMongosConfig := searchcontroller.GetMongosConfigParametersForSharded(
+		search,
+		searchClusterIndex,
+		"",
+		shardNames,
+		sc.Spec.GetClusterDomain(),
+	)
 	r.desiredMongosConfiguration.AdditionalMongodConfig.AddOption("setParameter", searchMongosConfig["setParameter"])
 
 	log.Infof("Applied search config for mongos: mongotHost=%v", searchMongosConfig["setParameter"])
@@ -1125,7 +1347,13 @@ func (r *ShardedClusterReconcileHelper) lookupCorrespondingSearchResource(ctx co
 	return search, nil
 }
 
-func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(ctx context.Context, obj interface{}, conn om.Connection, projectConfig mdbv1.ProjectConfig, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(
+	ctx context.Context,
+	obj interface{},
+	conn om.Connection,
+	projectConfig mdbv1.ProjectConfig,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	log.Info("ShardedCluster.doShardedClusterProcessing")
 	sc := obj.(*mdbv1.MongoDB)
 
@@ -1162,7 +1390,14 @@ func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(ctx context.C
 		return workflowStatus
 	}
 
-	prometheusCertHash, err := certs.EnsureTLSCertsForPrometheus(ctx, r.commonController.SecretClient, sc.GetNamespace(), sc.GetPrometheus(), certs.Database, log)
+	prometheusCertHash, err := certs.EnsureTLSCertsForPrometheus(
+		ctx,
+		r.commonController.SecretClient,
+		sc.GetNamespace(),
+		sc.GetPrometheus(),
+		certs.Database,
+		log,
+	)
 	if err != nil {
 		return workflow.Failed(xerrors.Errorf("Could not generate certificates for Prometheus: %w", err))
 	}
@@ -1222,8 +1457,15 @@ func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(ctx context.C
 	// configuration and a subsequent attempt to overwrite it later, the operator would be stuck in Pending phase.
 	// See CLOUDP-189433 and CLOUDP-229222 for more details.
 	if recovery.ShouldTriggerRecovery(r.deploymentState.Status.Phase != mdbstatus.PhaseRunning, r.deploymentState.Status.LastTransition) {
-		log.Warnf("Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s", sc.Namespace, sc.Name, r.deploymentState.Status.Phase, r.deploymentState.Status.LastTransition)
-		automationConfigStatus := r.updateOmDeploymentShardedCluster(ctx, conn, sc, opts, true, log).OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
+		log.Warnf(
+			"Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s",
+			sc.Namespace,
+			sc.Name,
+			r.deploymentState.Status.Phase,
+			r.deploymentState.Status.LastTransition,
+		)
+		automationConfigStatus := r.updateOmDeploymentShardedCluster(ctx, conn, sc, opts, true, log).
+			OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
 		deploymentStatus := r.createKubernetesResources(ctx, sc, opts, log)
 		if !deploymentStatus.IsOK() {
 			log.Errorf("Recovery failed because of deployment errors, %v", deploymentStatus)
@@ -1233,13 +1475,25 @@ func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(ctx context.C
 		}
 	}
 
-	workflowStatus = workflow.RunInGivenOrder(anyStatefulSetNeedsToPublishStateToOM(ctx, *sc, r.commonController.client, r.deploymentState.LastAchievedSpec, allConfigs, r.defaultArchitecture, log),
+	workflowStatus = workflow.RunInGivenOrder(
+		anyStatefulSetNeedsToPublishStateToOM(
+			ctx,
+			*sc,
+			r.commonController.client,
+			r.deploymentState.LastAchievedSpec,
+			allConfigs,
+			r.defaultArchitecture,
+			log,
+		),
 		func() workflow.Status {
-			return r.updateOmDeploymentShardedCluster(ctx, conn, sc, opts, false, log).OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
+			return r.updateOmDeploymentShardedCluster(ctx, conn, sc, opts, false, log).
+				OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
 		},
 		func() workflow.Status {
-			return r.createKubernetesResources(ctx, sc, opts, log).OnErrorPrepend("Failed to create/update (Kubernetes reconciliation phase):")
-		})
+			return r.createKubernetesResources(ctx, sc, opts, log).
+				OnErrorPrepend("Failed to create/update (Kubernetes reconciliation phase):")
+		},
+	)
 
 	if !workflowStatus.IsOK() {
 		return workflowStatus
@@ -1248,14 +1502,19 @@ func (r *ShardedClusterReconcileHelper) doShardedClusterProcessing(ctx context.C
 }
 
 // prepareX509CertConfigurator returns x509 configurator for the specified memberCluster.
-func (r *ShardedClusterReconcileHelper) prepareX509CertConfigurator(memberCluster multicluster.MemberCluster) certs.ShardedSetX509CertConfigurator {
+func (r *ShardedClusterReconcileHelper) prepareX509CertConfigurator(
+	memberCluster multicluster.MemberCluster,
+) certs.ShardedSetX509CertConfigurator {
 	var opts []certs.Options
 
 	// we don't have inverted mapping of memberCluster -> shard/configSrv/mongos configuration, so we need to find the specified member cluster first
 	for shardIdx := range r.desiredShardsConfiguration {
 		for _, shardMemberCluster := range r.shardsMemberClustersMap[shardIdx] {
 			if shardMemberCluster.Name == memberCluster.Name {
-				opts = append(opts, certs.ShardConfig(*r.sc, shardIdx, r.sc.Spec.GetExternalDomain(), r.GetShardScaler(shardIdx, shardMemberCluster)))
+				opts = append(
+					opts,
+					certs.ShardConfig(*r.sc, shardIdx, r.sc.Spec.GetExternalDomain(), r.GetShardScaler(shardIdx, shardMemberCluster)),
+				)
 			}
 		}
 	}
@@ -1325,7 +1584,9 @@ func getCertTypeForAllShardedClusterCertificates(certTypes map[string]bool) (cor
 	curTypeIsTLS := valueSlice[0]
 	for i := 1; i < len(valueSlice); i++ {
 		if valueSlice[i] != curTypeIsTLS {
-			return corev1.SecretTypeOpaque, xerrors.Errorf("TLS Certificates for Sharded cluster must all be of the same type - either kubernetes.io/tls or secrets containing a concatenated pem file")
+			return corev1.SecretTypeOpaque, xerrors.Errorf(
+				"TLS Certificates for Sharded cluster must all be of the same type - either kubernetes.io/tls or secrets containing a concatenated pem file",
+			)
 		}
 	}
 	if curTypeIsTLS {
@@ -1336,7 +1597,15 @@ func getCertTypeForAllShardedClusterCertificates(certTypes map[string]bool) (cor
 
 // anyStatefulSetNeedsToPublishStateToOM checks to see if any stateful set
 // of the given sharded cluster needs to publish state to Ops Manager before updating Kubernetes resources
-func anyStatefulSetNeedsToPublishStateToOM(ctx context.Context, sc mdbv1.MongoDB, kubeClient kubernetesClient.Client, lastSpec *mdbv1.MongoDbSpec, configs []func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions, defaultArchitecture architectures.DefaultArchitecture, log *zap.SugaredLogger) bool {
+func anyStatefulSetNeedsToPublishStateToOM(
+	ctx context.Context,
+	sc mdbv1.MongoDB,
+	kubeClient kubernetesClient.Client,
+	lastSpec *mdbv1.MongoDbSpec,
+	configs []func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions,
+	defaultArchitecture architectures.DefaultArchitecture,
+	log *zap.SugaredLogger,
+) bool {
 	for _, cf := range configs {
 		if publishAutomationConfigFirst(ctx, kubeClient, sc, lastSpec, cf, defaultArchitecture, log) {
 			return true
@@ -1347,7 +1616,12 @@ func anyStatefulSetNeedsToPublishStateToOM(ctx context.Context, sc mdbv1.MongoDB
 
 // getAllConfigs returns a list of all the configuration functions associated with the Sharded Cluster.
 // This includes the Mongos, the Config Server and all Shards
-func (r *ShardedClusterReconcileHelper) getAllConfigs(ctx context.Context, sc mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger) []func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
+func (r *ShardedClusterReconcileHelper) getAllConfigs(
+	ctx context.Context,
+	sc mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+) []func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
 	allConfigs := make([]func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions, 0)
 	for shardIdx := range r.desiredShardsConfiguration {
 		for _, memberCluster := range getHealthyMemberClusters(r.shardsMemberClustersMap[shardIdx]) {
@@ -1393,7 +1667,11 @@ func (r *ShardedClusterReconcileHelper) removeUnusedStatefulsets(ctx context.Con
 	}
 }
 
-func (r *ShardedClusterReconcileHelper) ensureSSLCertificates(ctx context.Context, s *mdbv1.MongoDB, log *zap.SugaredLogger) (workflow.Status, map[string]bool) {
+func (r *ShardedClusterReconcileHelper) ensureSSLCertificates(
+	ctx context.Context,
+	s *mdbv1.MongoDB,
+	log *zap.SugaredLogger,
+) (workflow.Status, map[string]bool) {
 	tlsConfig := s.Spec.GetTLSConfig()
 
 	certSecretTypes := map[string]bool{}
@@ -1408,14 +1686,28 @@ func (r *ShardedClusterReconcileHelper) ensureSSLCertificates(ctx context.Contex
 	var workflowStatus workflow.Status = workflow.OK()
 	for _, memberCluster := range getHealthyMemberClusters(r.mongosMemberClusters) {
 		mongosCert := certs.MongosConfig(*s, r.sc.Spec.GetExternalDomain(), r.GetMongosScaler(memberCluster))
-		tStatus := certs.EnsureSSLCertsForStatefulSet(ctx, r.commonController.SecretClient, memberCluster.SecretClient, *s.Spec.Security, mongosCert, log)
+		tStatus := certs.EnsureSSLCertsForStatefulSet(
+			ctx,
+			r.commonController.SecretClient,
+			memberCluster.SecretClient,
+			*s.Spec.Security,
+			mongosCert,
+			log,
+		)
 		certSecretTypes[mongosCert.CertSecretName] = true
 		workflowStatus = workflowStatus.Merge(tStatus)
 	}
 
 	for _, memberCluster := range getHealthyMemberClusters(r.configSrvMemberClusters) {
 		configSrvCert := certs.ConfigSrvConfig(*s, r.sc.Spec.DbCommonSpec.GetExternalDomain(), r.GetConfigSrvScaler(memberCluster))
-		tStatus := certs.EnsureSSLCertsForStatefulSet(ctx, r.commonController.SecretClient, memberCluster.SecretClient, *s.Spec.Security, configSrvCert, log)
+		tStatus := certs.EnsureSSLCertsForStatefulSet(
+			ctx,
+			r.commonController.SecretClient,
+			memberCluster.SecretClient,
+			*s.Spec.Security,
+			configSrvCert,
+			log,
+		)
 		certSecretTypes[configSrvCert.CertSecretName] = true
 		workflowStatus = workflowStatus.Merge(tStatus)
 	}
@@ -1423,7 +1715,14 @@ func (r *ShardedClusterReconcileHelper) ensureSSLCertificates(ctx context.Contex
 	for i := 0; i < s.Spec.ShardCount; i++ {
 		for _, memberCluster := range getHealthyMemberClusters(r.shardsMemberClustersMap[i]) {
 			shardCert := certs.ShardConfig(*s, i, r.sc.Spec.DbCommonSpec.GetExternalDomain(), r.GetShardScaler(i, memberCluster))
-			tStatus := certs.EnsureSSLCertsForStatefulSet(ctx, r.commonController.SecretClient, memberCluster.SecretClient, *s.Spec.Security, shardCert, log)
+			tStatus := certs.EnsureSSLCertsForStatefulSet(
+				ctx,
+				r.commonController.SecretClient,
+				memberCluster.SecretClient,
+				*s.Spec.Security,
+				shardCert,
+				log,
+			)
 			certSecretTypes[shardCert.CertSecretName] = true
 			workflowStatus = workflowStatus.Merge(tStatus)
 		}
@@ -1436,7 +1735,12 @@ func (r *ShardedClusterReconcileHelper) ensureSSLCertificates(ctx context.Contex
 // This function returns errorStatus if any errors occurred or pendingStatus if the statefulsets are not
 // ready yet
 // Note, that it doesn't remove any existing shards - this will be done later
-func (r *ShardedClusterReconcileHelper) createKubernetesResources(ctx context.Context, s *mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) createKubernetesResources(
+	ctx context.Context,
+	s *mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if r.sc.Spec.IsMultiCluster() {
 		// for multi-cluster deployment we should create pod-services first, as doing it after is a bit too late
 		// statefulset creation loops and waits for sts to become ready, and it's easier for the replica set to be ready if
@@ -1451,7 +1755,8 @@ func (r *ShardedClusterReconcileHelper) createKubernetesResources(ctx context.Co
 	// In static containers, the operator controls the order of up and downgrades.
 	// For sharded clusters, we need to reverse the order of downgrades vs. upgrades.
 	// See more here: https://www.mongodb.com/docs/manual/release-notes/6.0-downgrade-sharded-cluster/
-	if lastSpec != nil && architectures.IsRunningStaticArchitecture(s.Annotations, r.defaultArchitecture) && versionutil.IsDowngrade(lastSpec.Version, s.Spec.Version) {
+	if lastSpec != nil && architectures.IsRunningStaticArchitecture(s.Annotations, r.defaultArchitecture) &&
+		versionutil.IsDowngrade(lastSpec.Version, s.Spec.Version) {
 		if mongosStatus := r.createOrUpdateMongos(ctx, s, opts, log); !mongosStatus.IsOK() {
 			return mongosStatus
 		}
@@ -1480,7 +1785,12 @@ func (r *ShardedClusterReconcileHelper) createKubernetesResources(ctx context.Co
 	return workflow.OK()
 }
 
-func (r *ShardedClusterReconcileHelper) createOrUpdateMongos(ctx context.Context, s *mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) createOrUpdateMongos(
+	ctx context.Context,
+	s *mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	// it doesn't matter for which cluster we get scaler here as we need it only
 	// for ScalingFirstTime, which is iterating over all member clusters internally anyway
 	mongosScalingFirstTime := r.GetMongosScaler(r.mongosMemberClusters[0]).ScalingFirstTime()
@@ -1517,7 +1827,12 @@ func (r *ShardedClusterReconcileHelper) createOrUpdateMongos(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *ShardedClusterReconcileHelper) createOrUpdateShards(ctx context.Context, s *mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) createOrUpdateShards(
+	ctx context.Context,
+	s *mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	shardsNames := make([]string, s.Spec.ShardCount)
 	for shardIdx := 0; shardIdx < s.Spec.ShardCount; shardIdx++ {
 		// it doesn't matter for which cluster we get scaler as we need it only for ScalingFirstTime which is iterating over all member clusters internally anyway
@@ -1570,7 +1885,12 @@ func (r *ShardedClusterReconcileHelper) createOrUpdateShards(ctx context.Context
 	return workflow.OK()
 }
 
-func (r *ShardedClusterReconcileHelper) createOrUpdateConfigServers(ctx context.Context, s *mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) createOrUpdateConfigServers(
+	ctx context.Context,
+	s *mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	// it doesn't matter for which cluster we get scaler here as we need it only
 	// for ScalingFirstTime, which is iterating over all member clusters internally anyway
 	configSrvScalingFirstTime := r.GetConfigSrvScaler(r.configSrvMemberClusters[0]).ScalingFirstTime()
@@ -1611,7 +1931,12 @@ func (r *ShardedClusterReconcileHelper) createOrUpdateConfigServers(ctx context.
 	return workflow.OK()
 }
 
-func (r *ShardedClusterReconcileHelper) handlePVCResize(ctx context.Context, memberCluster multicluster.MemberCluster, sts *appsv1.StatefulSet, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) handlePVCResize(
+	ctx context.Context,
+	memberCluster multicluster.MemberCluster,
+	sts *appsv1.StatefulSet,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	workflowStatus := create.HandlePVCResize(ctx, memberCluster.Client, sts, log)
 	if !workflowStatus.IsOK() {
 		return workflowStatus
@@ -1638,7 +1963,9 @@ func isShardOverridden(shardName string, shardOverrides []mdbv1.ShardOverride) b
 // What is important to note it the scalers used here and usage of scale.ReplicasThisReconciliation makes the sizes returned consistent throughout a single reconcile execution and
 // with the guarantee that only one node can be added at a time to any replicaset.
 // That means we use the scale.ReplicasThisReconciliation function with scalers in other parts of the reconciler logic (e.g. for creating sts and processes for AC, here for status).
-func (r *ShardedClusterReconcileHelper) calculateSizeStatus(s *mdbv1.MongoDB) (*mdbstatus.MongodbShardedSizeStatusInClusters, *mdbstatus.MongodbShardedClusterSizeConfig) {
+func (r *ShardedClusterReconcileHelper) calculateSizeStatus(
+	s *mdbv1.MongoDB,
+) (*mdbstatus.MongodbShardedSizeStatusInClusters, *mdbstatus.MongodbShardedClusterSizeConfig) {
 	sizeStatusInClusters := r.deploymentState.Status.SizeStatusInClusters.DeepCopy()
 	sizeStatus := r.deploymentState.Status.MongodbShardedClusterSizeConfig.DeepCopy()
 
@@ -1725,12 +2052,27 @@ func (r *ShardedClusterReconcileHelper) OnDelete(ctx context.Context, obj runtim
 }
 
 func (r *ShardedClusterReconcileHelper) cleanOpsManagerState(ctx context.Context, sc *mdbv1.MongoDB, log *zap.SugaredLogger) error {
-	projectConfig, credsConfig, err := project.ReadConfigAndCredentials(ctx, r.commonController.client, r.commonController.SecretClient, sc, log)
+	projectConfig, credsConfig, err := project.ReadConfigAndCredentials(
+		ctx,
+		r.commonController.client,
+		r.commonController.SecretClient,
+		sc,
+		log,
+	)
 	if err != nil {
 		return err
 	}
 
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.commonController.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, sc.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.commonController.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		sc.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return err
 	}
@@ -1770,7 +2112,10 @@ func (r *ShardedClusterReconcileHelper) cleanOpsManagerState(ctx context.Context
 
 	if err := host.StopMonitoring(conn, hostsToRemove, log); err != nil {
 		// StopMonitoring may fail with 401 if hosts are already removed or auth is misconfigured.
-		errs = multierror.Append(errs, xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err))
+		errs = multierror.Append(
+			errs,
+			xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err),
+		)
 	}
 
 	if err := r.commonController.clearProjectAuthenticationSettings(ctx, conn, sc, processNames, log); err != nil {
@@ -1793,14 +2138,47 @@ func (r *ShardedClusterReconcileHelper) cleanOpsManagerState(ctx context.Context
 
 func logDiffOfProcessNames(acProcesses []string, healthyProcesses []string, log *zap.SugaredLogger) {
 	if len(acProcesses) != len(healthyProcesses) {
-		log.Debugw("process count mismatch between AC and healthy processes", "acCount", len(acProcesses), "healthyCount", len(healthyProcesses))
+		log.Debugw(
+			"process count mismatch between AC and healthy processes",
+			"acCount",
+			len(acProcesses),
+			"healthyCount",
+			len(healthyProcesses),
+		)
 	}
 }
 
-func AddShardedClusterController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClustersMap map[string]cluster.Cluster, backupEnableDelay time.Duration) error {
+func AddShardedClusterController(
+	ctx context.Context,
+	mgr manager.Manager,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	memberClustersMap map[string]cluster.Cluster,
+	backupEnableDelay time.Duration,
+) error {
 	// Create a new controller
-	reconciler := newShardedClusterReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, multicluster.ClustersMapToClientMap(memberClustersMap), om.NewOpsManagerConnection, backupEnableDelay)
-	options := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)} // nolint:forbidigo
+	reconciler := newShardedClusterReconciler(
+		ctx,
+		mgr.GetClient(),
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		forceEnterprise,
+		enableClusterMongoDBRoles,
+		agentDebug,
+		agentDebugImage,
+		defaultArchitecture,
+		multicluster.ClustersMapToClientMap(memberClustersMap),
+		om.NewOpsManagerConnection,
+		backupEnableDelay,
+	)
+	options := controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1),
+	} // nolint:forbidigo
 	c, err := controller.New(util.MongoDbShardedClusterController, mgr, options)
 	if err != nil {
 		return err
@@ -1808,12 +2186,20 @@ func AddShardedClusterController(ctx context.Context, mgr manager.Manager, image
 
 	// watch for changes to sharded cluster MongoDB resources
 	eventHandler := ResourceEventHandler{deleter: reconciler}
-	err = c.Watch(source.Kind[client.Object](mgr.GetCache(), &mdbv1.MongoDB{}, &eventHandler, watch.PredicatesForMongoDB(mdbv1.ShardedCluster)))
+	err = c.Watch(
+		source.Kind[client.Object](mgr.GetCache(), &mdbv1.MongoDB{}, &eventHandler, watch.PredicatesForMongoDB(mdbv1.ShardedCluster)),
+	)
 	if err != nil {
 		return err
 	}
 
-	err = c.Watch(source.Channel(OmUpdateChannel, &handler.EnqueueRequestForObject{}, source.WithPredicates[client.Object, reconcile.Request](watch.PredicatesForMongoDB(mdbv1.ShardedCluster))))
+	err = c.Watch(
+		source.Channel(
+			OmUpdateChannel,
+			&handler.EnqueueRequestForObject{},
+			source.WithPredicates[client.Object, reconcile.Request](watch.PredicatesForMongoDB(mdbv1.ShardedCluster)),
+		),
+	)
 	if err != nil {
 		return xerrors.Errorf("not able to setup OmUpdateChannel to listent to update events from OM: %s", err)
 	}
@@ -1874,7 +2260,14 @@ func AddShardedClusterController(ctx context.Context, mgr manager.Manager, image
 	}
 
 	for clusterName, memberCluster := range memberClustersMap {
-		err = c.Watch(source.Kind[client.Object](memberCluster.GetCache(), &appsv1.StatefulSet{}, &khandler.EnqueueRequestForOwnerMultiCluster{}, watch.PredicatesForMultiStatefulSet()))
+		err = c.Watch(
+			source.Kind[client.Object](
+				memberCluster.GetCache(),
+				&appsv1.StatefulSet{},
+				&khandler.EnqueueRequestForOwnerMultiCluster{},
+				watch.PredicatesForMultiStatefulSet(),
+			),
+		)
 		if err != nil {
 			return xerrors.Errorf("failed to set StatefulSet watch on member cluster %s: %w", clusterName, err)
 		}
@@ -1899,19 +2292,37 @@ func (r *ShardedClusterReconcileHelper) getConfigSrvHostnames(memberCluster mult
 		externalDomain = r.sc.Spec.DbCommonSpec.GetExternalDomain()
 	}
 	if !memberCluster.Legacy {
-		return dns.GetMultiClusterProcessHostnamesAndPodNames(r.sc.ConfigRsName(), r.sc.Namespace, memberCluster.Index, replicas, r.sc.Spec.GetClusterDomain(), externalDomain)
+		return dns.GetMultiClusterProcessHostnamesAndPodNames(
+			r.sc.ConfigRsName(),
+			r.sc.Namespace,
+			memberCluster.Index,
+			replicas,
+			r.sc.Spec.GetClusterDomain(),
+			externalDomain,
+		)
 	} else {
 		return dns.GetDNSNames(r.GetConfigSrvStsName(memberCluster), r.sc.ConfigSrvServiceName(), r.sc.Namespace, r.sc.Spec.GetClusterDomain(), replicas, externalDomain)
 	}
 }
 
-func (r *ShardedClusterReconcileHelper) getShardHostnames(shardIdx int, memberCluster multicluster.MemberCluster, replicas int) ([]string, []string) {
+func (r *ShardedClusterReconcileHelper) getShardHostnames(
+	shardIdx int,
+	memberCluster multicluster.MemberCluster,
+	replicas int,
+) ([]string, []string) {
 	externalDomain := r.sc.Spec.ShardSpec.ClusterSpecList.GetExternalDomainForMemberCluster(memberCluster.Name)
 	if externalDomain == nil && r.sc.Spec.IsMultiCluster() {
 		externalDomain = r.sc.Spec.DbCommonSpec.GetExternalDomain()
 	}
 	if !memberCluster.Legacy {
-		return dns.GetMultiClusterProcessHostnamesAndPodNames(r.sc.ShardRsName(shardIdx), r.sc.Namespace, memberCluster.Index, replicas, r.sc.Spec.GetClusterDomain(), externalDomain)
+		return dns.GetMultiClusterProcessHostnamesAndPodNames(
+			r.sc.ShardRsName(shardIdx),
+			r.sc.Namespace,
+			memberCluster.Index,
+			replicas,
+			r.sc.Spec.GetClusterDomain(),
+			externalDomain,
+		)
 	} else {
 		return dns.GetDNSNames(r.GetShardStsName(shardIdx, memberCluster), r.sc.ShardServiceName(), r.sc.Namespace, r.sc.Spec.GetClusterDomain(), replicas, externalDomain)
 	}
@@ -1923,7 +2334,14 @@ func (r *ShardedClusterReconcileHelper) getMongosHostnames(memberCluster multicl
 		externalDomain = r.sc.Spec.DbCommonSpec.GetExternalDomain()
 	}
 	if !memberCluster.Legacy {
-		return dns.GetMultiClusterProcessHostnamesAndPodNames(r.sc.MongosRsName(), r.sc.Namespace, memberCluster.Index, replicas, r.sc.Spec.GetClusterDomain(), externalDomain)
+		return dns.GetMultiClusterProcessHostnamesAndPodNames(
+			r.sc.MongosRsName(),
+			r.sc.Namespace,
+			memberCluster.Index,
+			replicas,
+			r.sc.Spec.GetClusterDomain(),
+			externalDomain,
+		)
 	} else {
 		// In Single Cluster Mode, only Mongos are exposed to the outside consumption. As such, they need to use proper
 		// External Domain.
@@ -1953,7 +2371,14 @@ type deploymentOptions struct {
 // phase 2: remove the "junk" replica sets and their processes, wait for agents to reach the goal.
 // The logic is designed to be idempotent: if the reconciliation is retried the controller will never skip the phase 1
 // until the agents have performed draining
-func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(ctx context.Context, conn om.Connection, sc *mdbv1.MongoDB, opts deploymentOptions, isRecovering bool, log *zap.SugaredLogger) workflow.Status {
+func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(
+	ctx context.Context,
+	conn om.Connection,
+	sc *mdbv1.MongoDB,
+	opts deploymentOptions,
+	isRecovering bool,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	err := r.waitForAgentsToRegister(sc, conn, log)
 	if err != nil {
 		if !isRecovering {
@@ -2010,7 +2435,9 @@ func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(ctx con
 		logDiffOfProcessNames(processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "shardsRemoving"))
 		if err = om.WaitForReadyState(conn, healthyProcessesToWaitForReadyState, isRecovering, log); err != nil {
 			if !isRecovering {
-				return workflow.Failed(xerrors.Errorf("automation agents haven't reached READY state while cleaning replica set and processes: %w", err))
+				return workflow.Failed(
+					xerrors.Errorf("automation agents haven't reached READY state while cleaning replica set and processes: %w", err),
+				)
 			}
 			logWarnIgnoredDueToRecovery(log, err)
 		}
@@ -2037,7 +2464,14 @@ func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(ctx con
 	return workflow.OK()
 }
 
-func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, conn om.Connection, sc *mdbv1.MongoDB, opts *deploymentOptions, isRecovering bool, log *zap.SugaredLogger) ([]string, bool, workflow.Status) {
+func (r *ShardedClusterReconcileHelper) publishDeployment(
+	ctx context.Context,
+	conn om.Connection,
+	sc *mdbv1.MongoDB,
+	opts *deploymentOptions,
+	isRecovering bool,
+	log *zap.SugaredLogger,
+) ([]string, bool, workflow.Status) {
 	// Mongos
 	var mongosProcesses []om.Process
 	// We take here the first cluster arbitrarily because the options are used for irrelevant stuff below, same for
@@ -2077,10 +2511,19 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 	for shardIdx := 0; shardIdx < r.sc.Spec.ShardCount; shardIdx++ {
 		shardOptionsFunc := r.getShardOptions(ctx, *sc, shardIdx, *opts, log, r.shardsMemberClustersMap[shardIdx][0])
 		shardOptions := shardOptionsFunc(*r.sc)
-		shardInternalClusterPaths = append(shardInternalClusterPaths, fmt.Sprintf("%s/%s", util.InternalClusterAuthMountPath, shardOptions.InternalClusterHash))
+		shardInternalClusterPaths = append(
+			shardInternalClusterPaths,
+			fmt.Sprintf("%s/%s", util.InternalClusterAuthMountPath, shardOptions.InternalClusterHash),
+		)
 		shardMemberCertPath := fmt.Sprintf("%s/%s", util.TLSCertMountPath, shardOptions.CertificateHash)
 		desiredShardProcesses, desiredShardMemberOptions := r.createDesiredShardProcessesAndMemberOptions(shardIdx, shardMemberCertPath)
-		shards[shardIdx], _ = buildReplicaSetFromProcesses(r.sc.ShardRsName(shardIdx), desiredShardProcesses, sc, desiredShardMemberOptions, existingDeployment)
+		shards[shardIdx], _ = buildReplicaSetFromProcesses(
+			r.sc.ShardRsName(shardIdx),
+			desiredShardProcesses,
+			sc,
+			desiredShardMemberOptions,
+			existingDeployment,
+		)
 	}
 
 	// updateOmAuthentication normally takes care of the certfile rotation code, but since sharded-cluster is special pertaining multiple clusterfiles, we code this part here for now.
@@ -2096,7 +2539,17 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 
 	logDiffOfProcessNames(opts.processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "updateOmAuthentication"))
 
-	workflowStatus, additionalReconciliationRequired := r.commonController.updateOmAuthentication(ctx, conn, healthyProcessesToWaitForReadyState, sc, opts.agentCertPath, opts.caFilePath, "", isRecovering, log)
+	workflowStatus, additionalReconciliationRequired := r.commonController.updateOmAuthentication(
+		ctx,
+		conn,
+		healthyProcessesToWaitForReadyState,
+		sc,
+		opts.agentCertPath,
+		opts.caFilePath,
+		"",
+		isRecovering,
+		log,
+	)
 	if !workflowStatus.IsOK() {
 		if !isRecovering {
 			return nil, false, workflowStatus
@@ -2110,15 +2563,21 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 		func(d om.Deployment) error {
 			allProcesses := getAllProcesses(shards, configRs, mongosProcesses)
 			// it is not possible to disable internal cluster authentication once enabled
-			if sc.Spec.Security.GetInternalClusterAuthenticationMode() == "" && d.ExistingProcessesHaveInternalClusterAuthentication(allProcesses) {
+			if sc.Spec.Security.GetInternalClusterAuthenticationMode() == "" &&
+				d.ExistingProcessesHaveInternalClusterAuthentication(allProcesses) {
 				return xerrors.Errorf("cannot disable x509 internal cluster authentication")
 			}
 			numberOfOtherMembers := d.GetNumberOfExcessProcesses(sc.Name)
 			if numberOfOtherMembers > 0 {
-				return xerrors.Errorf("cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)")
+				return xerrors.Errorf(
+					"cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)",
+				)
 			}
 
-			lastConfigServerConf, err := mdbv1.GetLastAdditionalMongodConfigByType(r.deploymentState.LastAchievedSpec, mdbv1.ConfigServerConfig)
+			lastConfigServerConf, err := mdbv1.GetLastAdditionalMongodConfigByType(
+				r.deploymentState.LastAchievedSpec,
+				mdbv1.ConfigServerConfig,
+			)
 			if err != nil {
 				return err
 			}
@@ -2157,7 +2616,16 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 			setupInternalClusterAuth(d, sc.Name, sc.GetSecurity().GetInternalClusterAuthenticationMode(),
 				configSrvInternalClusterPath, mongosInternalClusterPath, shardInternalClusterPaths)
 
-			_ = UpdatePrometheus(ctx, &d, conn, sc.GetPrometheus(), r.commonController.SecretClient, sc.GetNamespace(), opts.prometheusCertHash, log)
+			_ = UpdatePrometheus(
+				ctx,
+				&d,
+				conn,
+				sc.GetPrometheus(),
+				r.commonController.SecretClient,
+				sc.GetNamespace(),
+				opts.prometheusCertHash,
+				log,
+			)
 
 			finalProcesses = d.GetProcessNames(om.ShardedCluster{}, sc.Name)
 
@@ -2192,17 +2660,55 @@ func logWarnIgnoredDueToRecovery(log *zap.SugaredLogger, err any) {
 	log.Warnf("ignoring error due to automatic recovery process: %v", err)
 }
 
-func setInternalAuthClusterFileIfItHasChanged(d om.Deployment, internalAuthMode string, name string, configInternalClusterPath string, mongosInternalClusterPath string, shardsInternalClusterPath []string, isRecovering bool) {
-	d.SetInternalClusterFilePathOnlyIfItThePathHasChanged(d.GetShardedClusterConfigProcessNames(name), configInternalClusterPath, internalAuthMode, isRecovering)
-	d.SetInternalClusterFilePathOnlyIfItThePathHasChanged(d.GetShardedClusterMongosProcessNames(name), mongosInternalClusterPath, internalAuthMode, isRecovering)
+func setInternalAuthClusterFileIfItHasChanged(
+	d om.Deployment,
+	internalAuthMode string,
+	name string,
+	configInternalClusterPath string,
+	mongosInternalClusterPath string,
+	shardsInternalClusterPath []string,
+	isRecovering bool,
+) {
+	d.SetInternalClusterFilePathOnlyIfItThePathHasChanged(
+		d.GetShardedClusterConfigProcessNames(name),
+		configInternalClusterPath,
+		internalAuthMode,
+		isRecovering,
+	)
+	d.SetInternalClusterFilePathOnlyIfItThePathHasChanged(
+		d.GetShardedClusterMongosProcessNames(name),
+		mongosInternalClusterPath,
+		internalAuthMode,
+		isRecovering,
+	)
 	for i, path := range shardsInternalClusterPath {
-		d.SetInternalClusterFilePathOnlyIfItThePathHasChanged(d.GetShardedClusterShardProcessNames(name, i), path, internalAuthMode, isRecovering)
+		d.SetInternalClusterFilePathOnlyIfItThePathHasChanged(
+			d.GetShardedClusterShardProcessNames(name, i),
+			path,
+			internalAuthMode,
+			isRecovering,
+		)
 	}
 }
 
-func setupInternalClusterAuth(d om.Deployment, name string, internalClusterAuthMode string, configInternalClusterPath string, mongosInternalClusterPath string, shardsInternalClusterPath []string) {
-	d.ConfigureInternalClusterAuthentication(d.GetShardedClusterConfigProcessNames(name), internalClusterAuthMode, configInternalClusterPath)
-	d.ConfigureInternalClusterAuthentication(d.GetShardedClusterMongosProcessNames(name), internalClusterAuthMode, mongosInternalClusterPath)
+func setupInternalClusterAuth(
+	d om.Deployment,
+	name string,
+	internalClusterAuthMode string,
+	configInternalClusterPath string,
+	mongosInternalClusterPath string,
+	shardsInternalClusterPath []string,
+) {
+	d.ConfigureInternalClusterAuthentication(
+		d.GetShardedClusterConfigProcessNames(name),
+		internalClusterAuthMode,
+		configInternalClusterPath,
+	)
+	d.ConfigureInternalClusterAuthentication(
+		d.GetShardedClusterMongosProcessNames(name),
+		internalClusterAuthMode,
+		mongosInternalClusterPath,
+	)
 
 	for i, path := range shardsInternalClusterPath {
 		d.ConfigureInternalClusterAuthentication(d.GetShardedClusterShardProcessNames(name, i), internalClusterAuthMode, path)
@@ -2242,7 +2748,11 @@ func (r *ShardedClusterReconcileHelper) waitForAgentsToRegister(sc *mdbv1.MongoD
 	for shardIdx := 0; shardIdx < sc.Spec.ShardCount; shardIdx++ {
 		var shardHostnames []string
 		for _, memberCluster := range getHealthyMemberClusters(r.shardsMemberClustersMap[shardIdx]) {
-			hostnames, _ := r.getShardHostnames(shardIdx, memberCluster, scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)))
+			hostnames, _ := r.getShardHostnames(
+				shardIdx,
+				memberCluster,
+				scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)),
+			)
 			shardHostnames = append(shardHostnames, hostnames...)
 		}
 		if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(conn, shardHostnames, log.With("hostnamesOf", "shard", "shardIdx", shardIdx)); err != nil {
@@ -2345,13 +2855,26 @@ func (r *ShardedClusterReconcileHelper) createDesiredMongosProcesses(certificate
 	return processes
 }
 
-func (r *ShardedClusterReconcileHelper) createDesiredConfigSrvProcessesAndMemberOptions(certificateFilePath string) ([]om.Process, []automationconfig.MemberOptions) {
+func (r *ShardedClusterReconcileHelper) createDesiredConfigSrvProcessesAndMemberOptions(
+	certificateFilePath string,
+) ([]om.Process, []automationconfig.MemberOptions) {
 	var processes []om.Process
 	var memberOptions []automationconfig.MemberOptions
 	for _, memberCluster := range r.configSrvMemberClusters {
 		hostnames, podNames := r.getConfigSrvHostnames(memberCluster, scale.ReplicasThisReconciliation(r.GetConfigSrvScaler(memberCluster)))
 		for i := range hostnames {
-			process := om.NewMongodProcess(podNames[i], hostnames[i], r.imageUrls[util.MongodbImageEnv], r.forceEnterprise, r.sc.Spec.ConfigSrvSpec.GetAdditionalMongodConfig(), r.sc.GetSpec(), certificateFilePath, r.sc.Annotations, r.sc.CalculateFeatureCompatibilityVersion(), r.defaultArchitecture)
+			process := om.NewMongodProcess(
+				podNames[i],
+				hostnames[i],
+				r.imageUrls[util.MongodbImageEnv],
+				r.forceEnterprise,
+				r.sc.Spec.ConfigSrvSpec.GetAdditionalMongodConfig(),
+				r.sc.GetSpec(),
+				certificateFilePath,
+				r.sc.Annotations,
+				r.sc.CalculateFeatureCompatibilityVersion(),
+				r.defaultArchitecture,
+			)
 			processes = append(processes, process)
 		}
 
@@ -2362,13 +2885,31 @@ func (r *ShardedClusterReconcileHelper) createDesiredConfigSrvProcessesAndMember
 	return processes, memberOptions
 }
 
-func (r *ShardedClusterReconcileHelper) createDesiredShardProcessesAndMemberOptions(shardIdx int, certificateFilePath string) ([]om.Process, []automationconfig.MemberOptions) {
+func (r *ShardedClusterReconcileHelper) createDesiredShardProcessesAndMemberOptions(
+	shardIdx int,
+	certificateFilePath string,
+) ([]om.Process, []automationconfig.MemberOptions) {
 	var processes []om.Process
 	var memberOptions []automationconfig.MemberOptions
 	for _, memberCluster := range r.shardsMemberClustersMap[shardIdx] {
-		hostnames, podNames := r.getShardHostnames(shardIdx, memberCluster, scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)))
+		hostnames, podNames := r.getShardHostnames(
+			shardIdx,
+			memberCluster,
+			scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)),
+		)
 		for i := range hostnames {
-			process := om.NewMongodProcess(podNames[i], hostnames[i], r.imageUrls[util.MongodbImageEnv], r.forceEnterprise, r.desiredShardsConfiguration[shardIdx].GetAdditionalMongodConfig(), r.sc.GetSpec(), certificateFilePath, r.sc.Annotations, r.sc.CalculateFeatureCompatibilityVersion(), r.defaultArchitecture)
+			process := om.NewMongodProcess(
+				podNames[i],
+				hostnames[i],
+				r.imageUrls[util.MongodbImageEnv],
+				r.forceEnterprise,
+				r.desiredShardsConfiguration[shardIdx].GetAdditionalMongodConfig(),
+				r.sc.GetSpec(),
+				certificateFilePath,
+				r.sc.Annotations,
+				r.sc.CalculateFeatureCompatibilityVersion(),
+				r.defaultArchitecture,
+			)
 			processes = append(processes, process)
 		}
 		specMemberOptions := r.desiredShardsConfiguration[shardIdx].GetClusterSpecItem(memberCluster.Name).MemberConfig
@@ -2378,20 +2919,69 @@ func (r *ShardedClusterReconcileHelper) createDesiredShardProcessesAndMemberOpti
 	return processes, memberOptions
 }
 
-func createConfigSrvProcesses(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, mdb *mdbv1.MongoDB, certificateFilePath string, defaultArchitecture architectures.DefaultArchitecture) []om.Process {
-	return createMongodProcessForShardedCluster(mongoDBImage, forceEnterprise, set, mdb.Spec.ConfigSrvSpec.GetAdditionalMongodConfig(), mdb, certificateFilePath, defaultArchitecture)
+func createConfigSrvProcesses(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	mdb *mdbv1.MongoDB,
+	certificateFilePath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) []om.Process {
+	return createMongodProcessForShardedCluster(
+		mongoDBImage,
+		forceEnterprise,
+		set,
+		mdb.Spec.ConfigSrvSpec.GetAdditionalMongodConfig(),
+		mdb,
+		certificateFilePath,
+		defaultArchitecture,
+	)
 }
 
-func createShardProcesses(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, mdb *mdbv1.MongoDB, certificateFilePath string, defaultArchitecture architectures.DefaultArchitecture) []om.Process {
-	return createMongodProcessForShardedCluster(mongoDBImage, forceEnterprise, set, mdb.Spec.ShardSpec.GetAdditionalMongodConfig(), mdb, certificateFilePath, defaultArchitecture)
+func createShardProcesses(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	mdb *mdbv1.MongoDB,
+	certificateFilePath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) []om.Process {
+	return createMongodProcessForShardedCluster(
+		mongoDBImage,
+		forceEnterprise,
+		set,
+		mdb.Spec.ShardSpec.GetAdditionalMongodConfig(),
+		mdb,
+		certificateFilePath,
+		defaultArchitecture,
+	)
 }
 
-func createMongodProcessForShardedCluster(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, additionalMongodConfig *mdbv1.AdditionalMongodConfig, mdb *mdbv1.MongoDB, certificateFilePath string, defaultArchitecture architectures.DefaultArchitecture) []om.Process {
+func createMongodProcessForShardedCluster(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	additionalMongodConfig *mdbv1.AdditionalMongodConfig,
+	mdb *mdbv1.MongoDB,
+	certificateFilePath string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) []om.Process {
 	hostnames, names := dns.GetDnsForStatefulSet(set, mdb.Spec.GetClusterDomain(), nil)
 	processes := make([]om.Process, len(hostnames))
 
 	for idx, hostname := range hostnames {
-		processes[idx] = om.NewMongodProcess(names[idx], hostname, mongoDBImage, forceEnterprise, additionalMongodConfig, &mdb.Spec, certificateFilePath, mdb.Annotations, mdb.CalculateFeatureCompatibilityVersion(), defaultArchitecture)
+		processes[idx] = om.NewMongodProcess(
+			names[idx],
+			hostname,
+			mongoDBImage,
+			forceEnterprise,
+			additionalMongodConfig,
+			&mdb.Spec,
+			certificateFilePath,
+			mdb.Annotations,
+			mdb.CalculateFeatureCompatibilityVersion(),
+			defaultArchitecture,
+		)
 	}
 
 	return processes
@@ -2399,7 +2989,13 @@ func createMongodProcessForShardedCluster(mongoDBImage string, forceEnterprise b
 
 // buildReplicaSetFromProcesses creates the 'ReplicaSetWithProcesses' with specified processes. This is of use only
 // for sharded cluster (config server, shards)
-func buildReplicaSetFromProcesses(name string, members []om.Process, mdb *mdbv1.MongoDB, memberOptions []automationconfig.MemberOptions, deployment om.Deployment) (om.ReplicaSetWithProcesses, error) {
+func buildReplicaSetFromProcesses(
+	name string,
+	members []om.Process,
+	mdb *mdbv1.MongoDB,
+	memberOptions []automationconfig.MemberOptions,
+	deployment om.Deployment,
+) (om.ReplicaSetWithProcesses, error) {
 	replicaSet := om.NewReplicaSet(name, mdb.Spec.GetMongoDBVersion())
 
 	existingProcessIds := getReplicaSetProcessIdsFromReplicaSets(replicaSet.Name(), deployment)
@@ -2418,7 +3014,13 @@ func buildReplicaSetFromProcesses(name string, members []om.Process, mdb *mdbv1.
 }
 
 // getConfigServerOptions returns the Options needed to build the StatefulSet for the config server.
-func (r *ShardedClusterReconcileHelper) getConfigServerOptions(ctx context.Context, sc mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger, memberCluster multicluster.MemberCluster) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
+func (r *ShardedClusterReconcileHelper) getConfigServerOptions(
+	ctx context.Context,
+	sc mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+	memberCluster multicluster.MemberCluster,
+) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
 	certSecretName := sc.GetSecurity().MemberCertificateSecretName(sc.ConfigRsName())
 	internalClusterSecretName := sc.GetSecurity().InternalClusterAuthSecretName(sc.ConfigRsName())
 
@@ -2435,16 +3037,31 @@ func (r *ShardedClusterReconcileHelper) getConfigServerOptions(ctx context.Conte
 		ServiceName(r.GetConfigSrvServiceName(memberCluster)),
 		PodEnvVars(opts.podEnvVars),
 		CurrentAgentAuthMechanism(opts.currentAgentAuthMode),
-		CertificateHash(enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, certSecretName, databaseSecretPath, log)),
+		CertificateHash(
+			enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, certSecretName, databaseSecretPath, log),
+		),
 		AgentCertHash(opts.agentCertHash),
-		InternalClusterHash(enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, internalClusterSecretName, databaseSecretPath, log)),
+		InternalClusterHash(
+			enterprisepem.ReadHashFromSecret(
+				ctx,
+				r.commonController.SecretClient,
+				sc.Namespace,
+				internalClusterSecretName,
+				databaseSecretPath,
+				log,
+			),
+		),
 		PrometheusTLSCertHash(opts.prometheusCertHash),
 		WithVaultConfig(vaultConfig),
 		WithAdditionalMongodConfig(r.desiredConfigServerConfiguration.GetAdditionalMongodConfig()),
 		WithDefaultConfigSrvStorageSize(),
 		WithStsLabels(r.statefulsetLabels()),
-		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
-		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
+		WithInitDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion),
+		),
+		WithDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion),
+		),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
 		WithCustomAgentURL(r.commonController.customAgentURL),
 
@@ -2460,7 +3077,13 @@ func (r *ShardedClusterReconcileHelper) getConfigServerOptions(ctx context.Conte
 }
 
 // getMongosOptions returns the Options needed to build the StatefulSet for the mongos.
-func (r *ShardedClusterReconcileHelper) getMongosOptions(ctx context.Context, sc mdbv1.MongoDB, opts deploymentOptions, log *zap.SugaredLogger, memberCluster multicluster.MemberCluster) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
+func (r *ShardedClusterReconcileHelper) getMongosOptions(
+	ctx context.Context,
+	sc mdbv1.MongoDB,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+	memberCluster multicluster.MemberCluster,
+) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
 	certSecretName := sc.GetSecurity().MemberCertificateSecretName(sc.MongosRsName())
 	internalClusterSecretName := sc.GetSecurity().InternalClusterAuthSecretName(sc.MongosRsName())
 
@@ -2474,15 +3097,37 @@ func (r *ShardedClusterReconcileHelper) getMongosOptions(ctx context.Context, sc
 		StatefulSetNameOverride(r.GetMongosStsName(memberCluster)),
 		PodEnvVars(opts.podEnvVars),
 		CurrentAgentAuthMechanism(opts.currentAgentAuthMode),
-		CertificateHash(enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, certSecretName, vaultConfig.DatabaseSecretPath, log)),
+		CertificateHash(
+			enterprisepem.ReadHashFromSecret(
+				ctx,
+				r.commonController.SecretClient,
+				sc.Namespace,
+				certSecretName,
+				vaultConfig.DatabaseSecretPath,
+				log,
+			),
+		),
 		AgentCertHash(opts.agentCertHash),
-		InternalClusterHash(enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, internalClusterSecretName, vaultConfig.DatabaseSecretPath, log)),
+		InternalClusterHash(
+			enterprisepem.ReadHashFromSecret(
+				ctx,
+				r.commonController.SecretClient,
+				sc.Namespace,
+				internalClusterSecretName,
+				vaultConfig.DatabaseSecretPath,
+				log,
+			),
+		),
 		PrometheusTLSCertHash(opts.prometheusCertHash),
 		WithVaultConfig(vaultConfig),
 		WithAdditionalMongodConfig(r.desiredMongosConfiguration.GetAdditionalMongodConfig()),
 		WithStsLabels(r.statefulsetLabels()),
-		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
-		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
+		WithInitDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion),
+		),
+		WithDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion),
+		),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
 		WithCustomAgentURL(r.commonController.customAgentURL),
 
@@ -2498,7 +3143,14 @@ func (r *ShardedClusterReconcileHelper) getMongosOptions(ctx context.Context, sc
 }
 
 // getShardOptions returns the Options needed to build the StatefulSet for a given shard.
-func (r *ShardedClusterReconcileHelper) getShardOptions(ctx context.Context, sc mdbv1.MongoDB, shardNum int, opts deploymentOptions, log *zap.SugaredLogger, memberCluster multicluster.MemberCluster) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
+func (r *ShardedClusterReconcileHelper) getShardOptions(
+	ctx context.Context,
+	sc mdbv1.MongoDB,
+	shardNum int,
+	opts deploymentOptions,
+	log *zap.SugaredLogger,
+	memberCluster multicluster.MemberCluster,
+) func(mdb mdbv1.MongoDB) construct.DatabaseStatefulSetOptions {
 	certSecretName := sc.GetSecurity().MemberCertificateSecretName(sc.ShardRsName(shardNum))
 	internalClusterSecretName := sc.GetSecurity().InternalClusterAuthSecretName(sc.ShardRsName(shardNum))
 
@@ -2514,15 +3166,30 @@ func (r *ShardedClusterReconcileHelper) getShardOptions(ctx context.Context, sc 
 		StatefulSetNameOverride(r.GetShardStsName(shardNum, memberCluster)),
 		PodEnvVars(opts.podEnvVars),
 		CurrentAgentAuthMechanism(opts.currentAgentAuthMode),
-		CertificateHash(enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, certSecretName, databaseSecretPath, log)),
+		CertificateHash(
+			enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, certSecretName, databaseSecretPath, log),
+		),
 		AgentCertHash(opts.agentCertHash),
-		InternalClusterHash(enterprisepem.ReadHashFromSecret(ctx, r.commonController.SecretClient, sc.Namespace, internalClusterSecretName, databaseSecretPath, log)),
+		InternalClusterHash(
+			enterprisepem.ReadHashFromSecret(
+				ctx,
+				r.commonController.SecretClient,
+				sc.Namespace,
+				internalClusterSecretName,
+				databaseSecretPath,
+				log,
+			),
+		),
 		PrometheusTLSCertHash(opts.prometheusCertHash),
 		WithVaultConfig(vaultConfig),
 		WithAdditionalMongodConfig(r.desiredShardsConfiguration[shardNum].GetAdditionalMongodConfig()),
 		WithStsLabels(r.statefulsetLabels()),
-		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
-		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
+		WithInitDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion),
+		),
+		WithDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion),
+		),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, r.automationAgentVersion)),
 		WithCustomAgentURL(r.commonController.customAgentURL),
 
@@ -2570,7 +3237,13 @@ func (r *ShardedClusterReconcileHelper) migrateToNewDeploymentState(sc *mdbv1.Mo
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) updateStatus(ctx context.Context, resource *mdbv1.MongoDB, status workflow.Status, log *zap.SugaredLogger, statusOptions ...mdbstatus.Option) (reconcile.Result, error) {
+func (r *ShardedClusterReconcileHelper) updateStatus(
+	ctx context.Context,
+	resource *mdbv1.MongoDB,
+	status workflow.Status,
+	log *zap.SugaredLogger,
+	statusOptions ...mdbstatus.Option,
+) (reconcile.Result, error) {
 	if result, err := r.commonController.updateStatus(ctx, resource, status, log, statusOptions...); err != nil {
 		return result, err
 	} else {
@@ -2608,16 +3281,39 @@ func (r *ShardedClusterReconcileHelper) GetMongosStsName(memberCluster multiclus
 	}
 }
 
-func (r *ShardedClusterReconcileHelper) GetConfigSrvScaler(memberCluster multicluster.MemberCluster) interfaces.MultiClusterReplicaSetScaler {
-	return scalers.NewMultiClusterReplicaSetScaler("configSrv", r.desiredConfigServerConfiguration.ClusterSpecList, memberCluster.Name, memberCluster.Index, r.configSrvMemberClusters)
+func (r *ShardedClusterReconcileHelper) GetConfigSrvScaler(
+	memberCluster multicluster.MemberCluster,
+) interfaces.MultiClusterReplicaSetScaler {
+	return scalers.NewMultiClusterReplicaSetScaler(
+		"configSrv",
+		r.desiredConfigServerConfiguration.ClusterSpecList,
+		memberCluster.Name,
+		memberCluster.Index,
+		r.configSrvMemberClusters,
+	)
 }
 
 func (r *ShardedClusterReconcileHelper) GetMongosScaler(memberCluster multicluster.MemberCluster) interfaces.MultiClusterReplicaSetScaler {
-	return scalers.NewMultiClusterReplicaSetScaler("mongos", r.desiredMongosConfiguration.ClusterSpecList, memberCluster.Name, memberCluster.Index, r.mongosMemberClusters)
+	return scalers.NewMultiClusterReplicaSetScaler(
+		"mongos",
+		r.desiredMongosConfiguration.ClusterSpecList,
+		memberCluster.Name,
+		memberCluster.Index,
+		r.mongosMemberClusters,
+	)
 }
 
-func (r *ShardedClusterReconcileHelper) GetShardScaler(shardIdx int, memberCluster multicluster.MemberCluster) interfaces.MultiClusterReplicaSetScaler {
-	return scalers.NewMultiClusterReplicaSetScaler(fmt.Sprintf("shard idx %d", shardIdx), r.desiredShardsConfiguration[shardIdx].ClusterSpecList, memberCluster.Name, memberCluster.Index, r.shardsMemberClustersMap[shardIdx])
+func (r *ShardedClusterReconcileHelper) GetShardScaler(
+	shardIdx int,
+	memberCluster multicluster.MemberCluster,
+) interfaces.MultiClusterReplicaSetScaler {
+	return scalers.NewMultiClusterReplicaSetScaler(
+		fmt.Sprintf("shard idx %d", shardIdx),
+		r.desiredShardsConfiguration[shardIdx].ClusterSpecList,
+		memberCluster.Name,
+		memberCluster.Index,
+		r.shardsMemberClustersMap[shardIdx],
+	)
 }
 
 func (r *ShardedClusterReconcileHelper) getAllScalers() []interfaces.MultiClusterReplicaSetScaler {
@@ -2648,7 +3344,12 @@ func (r *ShardedClusterReconcileHelper) GetConfigSrvServiceName(memberCluster mu
 	}
 }
 
-func (r *ShardedClusterReconcileHelper) replicateAgentKeySecret(ctx context.Context, conn om.Connection, agentKey string, log *zap.SugaredLogger) error {
+func (r *ShardedClusterReconcileHelper) replicateAgentKeySecret(
+	ctx context.Context,
+	conn om.Connection,
+	agentKey string,
+	log *zap.SugaredLogger,
+) error {
 	for _, memberCluster := range getHealthyMemberClusters(r.allMemberClusters) {
 		var databaseSecretPath string
 		if memberCluster.SecretClient.VaultClient != nil {
@@ -2680,7 +3381,10 @@ func (r *ShardedClusterReconcileHelper) createHostnameOverrideConfigMapData() ma
 
 	for _, memberCluster := range r.mongosMemberClusters {
 		mongosScaler := r.GetMongosScaler(memberCluster)
-		mongosHostnames, mongosPodNames := r.getMongosHostnames(memberCluster, max(mongosScaler.CurrentReplicas(), mongosScaler.DesiredReplicas()))
+		mongosHostnames, mongosPodNames := r.getMongosHostnames(
+			memberCluster,
+			max(mongosScaler.CurrentReplicas(), mongosScaler.DesiredReplicas()),
+		)
 		for i := range mongosPodNames {
 			data[mongosPodNames[i]] = mongosHostnames[i]
 		}
@@ -2688,7 +3392,10 @@ func (r *ShardedClusterReconcileHelper) createHostnameOverrideConfigMapData() ma
 
 	for _, memberCluster := range r.configSrvMemberClusters {
 		configSrvScaler := r.GetConfigSrvScaler(memberCluster)
-		configSrvHostnames, configSrvPodNames := r.getConfigSrvHostnames(memberCluster, max(configSrvScaler.CurrentReplicas(), configSrvScaler.DesiredReplicas()))
+		configSrvHostnames, configSrvPodNames := r.getConfigSrvHostnames(
+			memberCluster,
+			max(configSrvScaler.CurrentReplicas(), configSrvScaler.DesiredReplicas()),
+		)
 		for i := range configSrvPodNames {
 			data[configSrvPodNames[i]] = configSrvHostnames[i]
 		}
@@ -2697,7 +3404,11 @@ func (r *ShardedClusterReconcileHelper) createHostnameOverrideConfigMapData() ma
 	for shardIdx := 0; shardIdx < max(r.sc.Spec.ShardCount, r.deploymentState.Status.ShardCount); shardIdx++ {
 		for _, memberCluster := range r.shardsMemberClustersMap[shardIdx] {
 			shardScaler := r.GetShardScaler(shardIdx, memberCluster)
-			shardHostnames, shardPodNames := r.getShardHostnames(shardIdx, memberCluster, max(shardScaler.CurrentReplicas(), shardScaler.DesiredReplicas()))
+			shardHostnames, shardPodNames := r.getShardHostnames(
+				shardIdx,
+				memberCluster,
+				max(shardScaler.CurrentReplicas(), shardScaler.DesiredReplicas()),
+			)
 			for i := range shardPodNames {
 				data[shardPodNames[i]] = shardHostnames[i]
 			}
@@ -2718,7 +3429,13 @@ func (r *ShardedClusterReconcileHelper) reconcileHostnameOverrideConfigMap(ctx c
 	for _, memberCluster := range getHealthyMemberClusters(r.allMemberClusters) {
 		err := configmap.CreateOrUpdate(ctx, memberCluster.Client, cm)
 		if err != nil && !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("failed to create configmap: %s/%s in cluster: %s, err: %w", r.sc.Namespace, cm.Name, memberCluster.Name, err)
+			return xerrors.Errorf(
+				"failed to create configmap: %s/%s in cluster: %s, err: %w",
+				r.sc.Namespace,
+				cm.Name,
+				memberCluster.Name,
+				err,
+			)
 		}
 		log.Debugf("Successfully ensured configmap: %s/%s in cluster: %s", r.sc.Namespace, cm.Name, memberCluster.Name)
 	}
@@ -2759,7 +3476,12 @@ func (r *ShardedClusterReconcileHelper) reconcileServices(ctx context.Context, l
 				log.Debugf("creating duplicated services for %s in cluster: %s", svc.Name, memberCluster.Name)
 				err := service.CreateOrUpdateService(ctx, memberCluster.Client, *svc)
 				if err != nil {
-					return xerrors.Errorf("failed to create (duplicate) pod service %s in cluster: %s, err: %w", svc.Name, memberCluster.Name, err)
+					return xerrors.Errorf(
+						"failed to create (duplicate) pod service %s in cluster: %s, err: %w",
+						svc.Name,
+						memberCluster.Name,
+						err,
+					)
 				}
 			}
 		}
@@ -2768,12 +3490,19 @@ func (r *ShardedClusterReconcileHelper) reconcileServices(ctx context.Context, l
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) reconcileConfigServerServices(ctx context.Context, log *zap.SugaredLogger, memberCluster multicluster.MemberCluster, allServices []*corev1.Service) error {
+func (r *ShardedClusterReconcileHelper) reconcileConfigServerServices(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	memberCluster multicluster.MemberCluster,
+	allServices []*corev1.Service,
+) error {
 	portOrDefault := r.desiredConfigServerConfiguration.AdditionalMongodConfig.GetPortOrDefault()
 	scaler := r.GetConfigSrvScaler(memberCluster)
 
 	for podNum := 0; podNum < scaler.DesiredReplicas(); podNum++ {
-		configServerExternalAccess := r.desiredConfigServerConfiguration.ClusterSpecList.GetExternalAccessConfigurationForMemberCluster(memberCluster.Name)
+		configServerExternalAccess := r.desiredConfigServerConfiguration.ClusterSpecList.GetExternalAccessConfigurationForMemberCluster(
+			memberCluster.Name,
+		)
 		if configServerExternalAccess == nil {
 			configServerExternalAccess = r.sc.Spec.ExternalAccessConfiguration
 		}
@@ -2786,7 +3515,12 @@ func (r *ShardedClusterReconcileHelper) reconcileConfigServerServices(ctx contex
 				podNum,
 				portOrDefault)
 			if err != nil {
-				return xerrors.Errorf("failed to build an external service %s in cluster: %s, err: %w", dns.GetMultiExternalServiceName(r.sc.ConfigSrvServiceName(), memberCluster.Index, podNum), memberCluster.Name, err)
+				return xerrors.Errorf(
+					"failed to build an external service %s in cluster: %s, err: %w",
+					dns.GetMultiExternalServiceName(r.sc.ConfigSrvServiceName(), memberCluster.Index, podNum),
+					memberCluster.Name,
+					err,
+				)
 			}
 			if err = service.CreateOrUpdateService(ctx, memberCluster.Client, svc); err != nil && !errors.IsAlreadyExists(err) {
 				return xerrors.Errorf("failed to create external service %s in cluster: %s, err: %w", svc.Name, memberCluster.Name, err)
@@ -2808,8 +3542,16 @@ func (r *ShardedClusterReconcileHelper) reconcileConfigServerServices(ctx contex
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) reconcileShardServices(ctx context.Context, log *zap.SugaredLogger, shardIdx int, memberCluster multicluster.MemberCluster, allServices []*corev1.Service) error {
-	shardsExternalAccess := r.desiredShardsConfiguration[shardIdx].ClusterSpecList.GetExternalAccessConfigurationForMemberCluster(memberCluster.Name)
+func (r *ShardedClusterReconcileHelper) reconcileShardServices(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	shardIdx int,
+	memberCluster multicluster.MemberCluster,
+	allServices []*corev1.Service,
+) error {
+	shardsExternalAccess := r.desiredShardsConfiguration[shardIdx].ClusterSpecList.GetExternalAccessConfigurationForMemberCluster(
+		memberCluster.Name,
+	)
 	if shardsExternalAccess == nil {
 		shardsExternalAccess = r.sc.Spec.ExternalAccessConfiguration
 	}
@@ -2827,7 +3569,12 @@ func (r *ShardedClusterReconcileHelper) reconcileShardServices(ctx context.Conte
 				podNum,
 				portOrDefault)
 			if err != nil {
-				return xerrors.Errorf("failed to build an external service %s in cluster: %s, err: %w", dns.GetMultiExternalServiceName(r.sc.ShardRsName(shardIdx), memberCluster.Index, podNum), memberCluster.Name, err)
+				return xerrors.Errorf(
+					"failed to build an external service %s in cluster: %s, err: %w",
+					dns.GetMultiExternalServiceName(r.sc.ShardRsName(shardIdx), memberCluster.Index, podNum),
+					memberCluster.Name,
+					err,
+				)
 			}
 			if err = service.CreateOrUpdateService(ctx, memberCluster.Client, svc); err != nil && !errors.IsAlreadyExists(err) {
 				return xerrors.Errorf("failed to create external service %s in cluster: %s, err: %w", svc.Name, memberCluster.Name, err)
@@ -2851,11 +3598,18 @@ func (r *ShardedClusterReconcileHelper) reconcileShardServices(ctx context.Conte
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) reconcileMongosServices(ctx context.Context, log *zap.SugaredLogger, memberCluster multicluster.MemberCluster, allServices []*corev1.Service) error {
+func (r *ShardedClusterReconcileHelper) reconcileMongosServices(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	memberCluster multicluster.MemberCluster,
+	allServices []*corev1.Service,
+) error {
 	scaler := r.GetMongosScaler(memberCluster)
 	portOrDefault := r.desiredMongosConfiguration.AdditionalMongodConfig.GetPortOrDefault()
 	for podNum := 0; podNum < scaler.DesiredReplicas(); podNum++ {
-		mongosExternalAccess := r.desiredMongosConfiguration.ClusterSpecList.GetExternalAccessConfigurationForMemberCluster(memberCluster.Name)
+		mongosExternalAccess := r.desiredMongosConfiguration.ClusterSpecList.GetExternalAccessConfigurationForMemberCluster(
+			memberCluster.Name,
+		)
 		if mongosExternalAccess == nil {
 			mongosExternalAccess = r.sc.Spec.ExternalAccessConfiguration
 		}
@@ -2868,7 +3622,12 @@ func (r *ShardedClusterReconcileHelper) reconcileMongosServices(ctx context.Cont
 				podNum,
 				portOrDefault)
 			if err != nil {
-				return xerrors.Errorf("failed to build an external service %s in cluster: %s, err: %w", dns.GetMultiExternalServiceName(r.sc.MongosRsName(), memberCluster.Index, podNum), memberCluster.Name, err)
+				return xerrors.Errorf(
+					"failed to build an external service %s in cluster: %s, err: %w",
+					dns.GetMultiExternalServiceName(r.sc.MongosRsName(), memberCluster.Index, podNum),
+					memberCluster.Name,
+					err,
+				)
 			}
 			if err = service.CreateOrUpdateService(ctx, memberCluster.Client, svc); err != nil && !errors.IsAlreadyExists(err) {
 				return xerrors.Errorf("failed to create external service %s in cluster: %s, err: %w", svc.Name, memberCluster.Name, err)
@@ -2892,7 +3651,12 @@ func (r *ShardedClusterReconcileHelper) reconcileMongosServices(ctx context.Cont
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) createHeadlessServiceForStatefulSet(ctx context.Context, stsName string, port int32, memberCluster multicluster.MemberCluster) error {
+func (r *ShardedClusterReconcileHelper) createHeadlessServiceForStatefulSet(
+	ctx context.Context,
+	stsName string,
+	port int32,
+	memberCluster multicluster.MemberCluster,
+) error {
 	// If the cluster is legacy (single cluster), we don't create headless services
 	if memberCluster.Legacy {
 		return nil
@@ -2900,7 +3664,14 @@ func (r *ShardedClusterReconcileHelper) createHeadlessServiceForStatefulSet(ctx 
 
 	headlessServiceName := dns.GetMultiHeadlessServiceName(stsName, memberCluster.Index)
 	nameSpacedName := kube.ObjectKey(r.sc.Namespace, headlessServiceName)
-	headlessService := create.BuildService(nameSpacedName, r.sc, ptr.To(headlessServiceName), nil, port, omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP})
+	headlessService := create.BuildService(
+		nameSpacedName,
+		r.sc,
+		ptr.To(headlessServiceName),
+		nil,
+		port,
+		omv1.MongoDBOpsManagerServiceDefinition{Type: corev1.ServiceTypeClusterIP},
+	)
 	headlessService.OwnerReferences = r.sc.OwnerReferenceForMemberCluster()
 
 	if err := service.CreateOrUpdateService(ctx, memberCluster.Client, headlessService); err != nil && !errors.IsAlreadyExists(err) {
@@ -2909,7 +3680,13 @@ func (r *ShardedClusterReconcileHelper) createHeadlessServiceForStatefulSet(ctx 
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) getPodExternalService(memberCluster multicluster.MemberCluster, statefulSetName string, externalAccessConfiguration *mdbv1.ExternalAccessConfiguration, podNum int, port int32) (corev1.Service, error) {
+func (r *ShardedClusterReconcileHelper) getPodExternalService(
+	memberCluster multicluster.MemberCluster,
+	statefulSetName string,
+	externalAccessConfiguration *mdbv1.ExternalAccessConfiguration,
+	podNum int,
+	port int32,
+) (corev1.Service, error) {
 	svc := r.getPodService(statefulSetName, memberCluster, podNum, port)
 	svc.Name = dns.GetMultiExternalServiceName(statefulSetName, memberCluster.Index, podNum)
 	svc.Spec.Type = corev1.ServiceTypeLoadBalancer
@@ -2922,9 +3699,23 @@ func (r *ShardedClusterReconcileHelper) getPodExternalService(memberCluster mult
 		svc.Annotations = merge.StringToStringMap(svc.Annotations, externalAccessConfiguration.ExternalService.Annotations)
 	}
 
-	placeholderReplacer := create.GetMultiClusterMongoDBPlaceholderReplacer(r.sc.Name, statefulSetName, r.sc.Namespace, memberCluster.Name, memberCluster.Index, externalAccessConfiguration.ExternalDomain, r.sc.Spec.ClusterDomain, podNum)
+	placeholderReplacer := create.GetMultiClusterMongoDBPlaceholderReplacer(
+		r.sc.Name,
+		statefulSetName,
+		r.sc.Namespace,
+		memberCluster.Name,
+		memberCluster.Index,
+		externalAccessConfiguration.ExternalDomain,
+		r.sc.Spec.ClusterDomain,
+		podNum,
+	)
 	if processedAnnotations, replacedFlag, err := placeholderReplacer.ProcessMap(svc.Annotations); err != nil {
-		return corev1.Service{}, xerrors.Errorf("failed to process annotations in external service %s in cluster %s: %w", svc.Name, memberCluster.Name, err)
+		return corev1.Service{}, xerrors.Errorf(
+			"failed to process annotations in external service %s in cluster %s: %w",
+			svc.Name,
+			memberCluster.Name,
+			err,
+		)
 	} else if replacedFlag {
 		svc.Annotations = processedAnnotations
 	}
@@ -2952,7 +3743,11 @@ func (r *ShardedClusterReconcileHelper) replicateTLSCAConfigMap(ctx context.Cont
 			Build()
 		err = configmap.CreateOrUpdate(ctx, memberCluster.Client, memberCAConfigMap)
 		if err != nil && !errors.IsAlreadyExists(err) {
-			return xerrors.Errorf("failed to replicate CA ConfigMap from the operator cluster to cluster %s, err: %w", memberCluster.Name, err)
+			return xerrors.Errorf(
+				"failed to replicate CA ConfigMap from the operator cluster to cluster %s, err: %w",
+				memberCluster.Name,
+				err,
+			)
 		}
 		log.Debugf("Successfully ensured configmap: %s/%s in cluster: %s", r.sc.Namespace, caConfigMapName, memberCluster.Name)
 	}
@@ -2960,7 +3755,11 @@ func (r *ShardedClusterReconcileHelper) replicateTLSCAConfigMap(ctx context.Cont
 	return nil
 }
 
-func (r *ShardedClusterReconcileHelper) replicateSSLMMSCAConfigMap(ctx context.Context, projectConfig mdbv1.ProjectConfig, log *zap.SugaredLogger) error {
+func (r *ShardedClusterReconcileHelper) replicateSSLMMSCAConfigMap(
+	ctx context.Context,
+	projectConfig mdbv1.ProjectConfig,
+	log *zap.SugaredLogger,
+) error {
 	if !r.sc.Spec.IsMultiCluster() || projectConfig.SSLMMSCAConfigMap == "" {
 		return nil
 	}
@@ -2981,7 +3780,12 @@ func (r *ShardedClusterReconcileHelper) replicateSSLMMSCAConfigMap(ctx context.C
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return xerrors.Errorf("failed to sync SSLMMSCAConfigMap to cluster: %s, err: %w", memberCluster.Name, err)
 		}
-		log.Debugf("Successfully ensured configmap: %s/%s in cluster: %s", r.sc.Namespace, projectConfig.SSLMMSCAConfigMap, memberCluster.Name)
+		log.Debugf(
+			"Successfully ensured configmap: %s/%s in cluster: %s",
+			r.sc.Namespace,
+			projectConfig.SSLMMSCAConfigMap,
+			memberCluster.Name,
+		)
 	}
 
 	return nil
@@ -3024,7 +3828,12 @@ func (r *ShardedClusterReconcileHelper) shouldContinueScalingOneByOne() bool {
 	return false
 }
 
-func (r *ShardedClusterReconcileHelper) getPodService(stsName string, memberCluster multicluster.MemberCluster, podNum int, port int32) corev1.Service {
+func (r *ShardedClusterReconcileHelper) getPodService(
+	stsName string,
+	memberCluster multicluster.MemberCluster,
+	podNum int,
+	port int32,
+) corev1.Service {
 	svcLabels := map[string]string{
 		appsv1.StatefulSetPodNameLabel: dns.GetMultiPodName(stsName, memberCluster.Index, podNum),
 	}
@@ -3118,7 +3927,10 @@ func (r *ShardedClusterReconcileHelper) getHealthyMongosProcesses() ([]string, [
 	var processNames []string
 	var hostnames []string
 	for _, memberCluster := range getHealthyMemberClusters(r.mongosMemberClusters) {
-		clusterHostnames, clusterProcessNames := r.getMongosHostnames(memberCluster, scale.ReplicasThisReconciliation(r.GetMongosScaler(memberCluster)))
+		clusterHostnames, clusterProcessNames := r.getMongosHostnames(
+			memberCluster,
+			scale.ReplicasThisReconciliation(r.GetMongosScaler(memberCluster)),
+		)
 		hostnames = append(hostnames, clusterHostnames...)
 		processNames = append(processNames, clusterProcessNames...)
 	}
@@ -3129,7 +3941,10 @@ func (r *ShardedClusterReconcileHelper) getHealthyConfigSrvProcesses() ([]string
 	var processNames []string
 	var hostnames []string
 	for _, memberCluster := range getHealthyMemberClusters(r.configSrvMemberClusters) {
-		clusterHostnames, clusterProcessNames := r.getConfigSrvHostnames(memberCluster, scale.ReplicasThisReconciliation(r.GetConfigSrvScaler(memberCluster)))
+		clusterHostnames, clusterProcessNames := r.getConfigSrvHostnames(
+			memberCluster,
+			scale.ReplicasThisReconciliation(r.GetConfigSrvScaler(memberCluster)),
+		)
 		hostnames = append(hostnames, clusterHostnames...)
 		processNames = append(processNames, clusterProcessNames...)
 	}
@@ -3141,7 +3956,11 @@ func (r *ShardedClusterReconcileHelper) getHealthyShardsProcesses() ([]string, [
 	var hostnames []string
 	for shardIdx := 0; shardIdx < r.sc.Spec.ShardCount; shardIdx++ {
 		for _, memberCluster := range getHealthyMemberClusters(r.shardsMemberClustersMap[shardIdx]) {
-			clusterHostnames, clusterProcessNames := r.getShardHostnames(shardIdx, memberCluster, scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)))
+			clusterHostnames, clusterProcessNames := r.getShardHostnames(
+				shardIdx,
+				memberCluster,
+				scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)),
+			)
 			hostnames = append(hostnames, clusterHostnames...)
 			processNames = append(processNames, clusterProcessNames...)
 		}
@@ -3153,20 +3972,30 @@ func (r *ShardedClusterReconcileHelper) blockNonEmptyClusterSpecItemRemoval() er
 	for shardIdx, shardClusters := range r.shardsMemberClustersMap {
 		for _, shardCluster := range shardClusters {
 			if !r.desiredShardsConfiguration[shardIdx].ClusterSpecItemExists(shardCluster.Name) && shardCluster.Replicas > 0 {
-				return xerrors.Errorf("Cannot remove shard member cluster %s with non-zero members count in shard %d. Please scale down members to zero first", shardCluster.Name, shardIdx)
+				return xerrors.Errorf(
+					"Cannot remove shard member cluster %s with non-zero members count in shard %d. Please scale down members to zero first",
+					shardCluster.Name,
+					shardIdx,
+				)
 			}
 		}
 	}
 
 	for _, configSrvCluster := range r.configSrvMemberClusters {
 		if !r.desiredConfigServerConfiguration.ClusterSpecItemExists(configSrvCluster.Name) && configSrvCluster.Replicas > 0 {
-			return xerrors.Errorf("Cannot remove configSrv member cluster %s with non-zero members count. Please scale down members to zero first", configSrvCluster.Name)
+			return xerrors.Errorf(
+				"Cannot remove configSrv member cluster %s with non-zero members count. Please scale down members to zero first",
+				configSrvCluster.Name,
+			)
 		}
 	}
 
 	for _, mongosCluster := range r.mongosMemberClusters {
 		if !r.desiredMongosConfiguration.ClusterSpecItemExists(mongosCluster.Name) && mongosCluster.Replicas > 0 {
-			return xerrors.Errorf("Cannot remove mongos member cluster %s with non-zero members count. Please scale down members to zero first", mongosCluster.Name)
+			return xerrors.Errorf(
+				"Cannot remove mongos member cluster %s with non-zero members count. Please scale down members to zero first",
+				mongosCluster.Name,
+			)
 		}
 	}
 
@@ -3180,7 +4009,12 @@ func (r *ShardedClusterReconcileHelper) blockNonEmptyClusterSpecItemRemoval() er
 //   - There are healthy mongos process not in goal state (their automation config version is lesser than the goal version).
 //   - The agent plan of those mongos processes contains 'RollingChangeArgs'.
 //   - All other healthy processes other than mongos are in goal state.
-func checkForMongosDeadlock(clusterState agents.MongoDBClusterStateInOM, mongosReplicaSetName string, isScaling bool, log *zap.SugaredLogger) (isDeadlocked bool, deadlockedMongos []agents.ProcessState) {
+func checkForMongosDeadlock(
+	clusterState agents.MongoDBClusterStateInOM,
+	mongosReplicaSetName string,
+	isScaling bool,
+	log *zap.SugaredLogger,
+) (isDeadlocked bool, deadlockedMongos []agents.ProcessState) {
 	if !isScaling {
 		log.Debugf("Skipping mongos deadlock check as there is no scaling in progress")
 		return false, nil
@@ -3195,13 +4029,19 @@ func checkForMongosDeadlock(clusterState agents.MongoDBClusterStateInOM, mongosR
 		return false, nil
 	}
 
-	allHealthyProcessesNotInGoalState := slices.DeleteFunc(clusterState.GetProcessesNotInGoalState(), func(processState agents.ProcessState) bool {
-		return processState.IsStale()
-	})
+	allHealthyProcessesNotInGoalState := slices.DeleteFunc(
+		clusterState.GetProcessesNotInGoalState(),
+		func(processState agents.ProcessState) bool {
+			return processState.IsStale()
+		},
+	)
 
-	allHealthyMongosNotInGoalState := slices.DeleteFunc(slices.Clone(allHealthyProcessesNotInGoalState), func(processState agents.ProcessState) bool {
-		return !strings.HasPrefix(processState.ProcessName, mongosReplicaSetName)
-	})
+	allHealthyMongosNotInGoalState := slices.DeleteFunc(
+		slices.Clone(allHealthyProcessesNotInGoalState),
+		func(processState agents.ProcessState) bool {
+			return !strings.HasPrefix(processState.ProcessName, mongosReplicaSetName)
+		},
+	)
 
 	if len(allHealthyMongosNotInGoalState) == 0 {
 		log.Debugf("Mongos deadlock check reported negative. All healthy mongos processes are in goal state in the cluster")
@@ -3209,7 +4049,10 @@ func checkForMongosDeadlock(clusterState agents.MongoDBClusterStateInOM, mongosR
 	}
 
 	if len(allHealthyProcessesNotInGoalState) > len(allHealthyMongosNotInGoalState) {
-		log.Debugf("Mongos deadlock check reported negative. There are other healthy processes not in goal state that are not mongos; allHealthyProcessesNotInGoalState=%+v", allHealthyProcessesNotInGoalState)
+		log.Debugf(
+			"Mongos deadlock check reported negative. There are other healthy processes not in goal state that are not mongos; allHealthyProcessesNotInGoalState=%+v",
+			allHealthyProcessesNotInGoalState,
+		)
 		return false, nil
 	}
 
@@ -3226,10 +4069,14 @@ func checkForMongosDeadlock(clusterState agents.MongoDBClusterStateInOM, mongosR
 		staleHostnames := util.Transform(staleProcesses, func(obj agents.ProcessState) string {
 			return obj.Hostname
 		})
-		log.Warnf("Detected mongos %+v performing RollingChangeArgs operation while there are processes in the cluster that are considered down. "+
-			"Skipping waiting for those mongos processes in order to allow the operator to perform scaling. "+
-			"Please verify the list of stale (down/unhealthy) processes and change MongoDB resource to remove them from the cluster. "+
-			"The operator will not perform removal of those procesess automatically. Hostnames of stale processes: %+v", allDeadlockedMongos, staleHostnames)
+		log.Warnf(
+			"Detected mongos %+v performing RollingChangeArgs operation while there are processes in the cluster that are considered down. "+
+				"Skipping waiting for those mongos processes in order to allow the operator to perform scaling. "+
+				"Please verify the list of stale (down/unhealthy) processes and change MongoDB resource to remove them from the cluster. "+
+				"The operator will not perform removal of those procesess automatically. Hostnames of stale processes: %+v",
+			allDeadlockedMongos,
+			staleHostnames,
+		)
 
 		return true, allDeadlockedMongos
 	}

--- a/controllers/operator/mongodbshardedcluster_controller_multi_test.go
+++ b/controllers/operator/mongodbshardedcluster_controller_multi_test.go
@@ -44,9 +44,46 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
 )
 
-func newShardedClusterReconcilerForMultiCluster(ctx context.Context, forceEnterprise bool, sc *mdbv1.MongoDB, globalMemberClustersMap map[string]client.Client, kubeClient kubernetesClient.Client, omConnectionFactory *om.CachedOMConnectionFactory) (*ReconcileMongoDbShardedCluster, *ShardedClusterReconcileHelper, error) {
-	r := newShardedClusterReconciler(ctx, kubeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, globalMemberClustersMap, omConnectionFactory.GetConnectionFunc, testBackupEnableDelay)
-	reconcileHelper, err := NewShardedClusterReconcilerHelper(ctx, r.ReconcileCommonController, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", forceEnterprise, false, false, "", architectures.NonStatic, sc, globalMemberClustersMap, omConnectionFactory.GetConnectionFunc, zap.S(), testBackupEnableDelay)
+func newShardedClusterReconcilerForMultiCluster(
+	ctx context.Context,
+	forceEnterprise bool,
+	sc *mdbv1.MongoDB,
+	globalMemberClustersMap map[string]client.Client,
+	kubeClient kubernetesClient.Client,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+) (*ReconcileMongoDbShardedCluster, *ShardedClusterReconcileHelper, error) {
+	r := newShardedClusterReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		globalMemberClustersMap,
+		omConnectionFactory.GetConnectionFunc,
+		testBackupEnableDelay,
+	)
+	reconcileHelper, err := NewShardedClusterReconcilerHelper(
+		ctx,
+		r.ReconcileCommonController,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		forceEnterprise,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		sc,
+		globalMemberClustersMap,
+		omConnectionFactory.GetConnectionFunc,
+		zap.S(),
+		testBackupEnableDelay,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -687,33 +724,78 @@ func TestReconcileCreateMultiClusterShardedClusterWithExternalDomain(t *testing.
 	kubeClient := kubernetesClient.NewClient(fakeClient)
 	memberClusterMap := getFakeMultiClusterMapWithConfiguredInterceptor(memberClusters.ClusterNames, omConnectionFactory, true, true)
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	require.NoError(t, err)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
-		allHostnames, _ := generateAllHosts(sc, memberClusters.MongosDistribution, clusterMapping, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.ExampleExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			memberClusters.MongosDistribution,
+			clusterMapping,
+			memberClusters.ConfigServerDistribution,
+			memberClusters.ShardDistribution,
+			test.ClusterLocalDomains,
+			test.ExampleExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	})
 
 	require.NoError(t, err)
 	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
-	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(sc, clusterMapping, memberClusters.MongosDistribution, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.ExampleExternalClusterDomains)
+	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(
+		sc,
+		clusterMapping,
+		memberClusters.MongosDistribution,
+		memberClusters.ConfigServerDistribution,
+		memberClusters.ShardDistribution,
+		test.ClusterLocalDomains,
+		test.ExampleExternalClusterDomains,
+	)
 
 	for clusterIdx, clusterSpecItem := range sc.Spec.ShardSpec.ClusterSpecList {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, sc.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			sc.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 		configSrvStsName := fmt.Sprintf("%s-config-%d", sc.Name, clusterIdx)
 		configMembers := memberClusters.ConfigServerDistribution[clusterSpecItem.ClusterName]
 		memberClusterChecks.checkExternalServices(ctx, configSrvStsName, configMembers)
 		memberClusterChecks.checkInternalServices(ctx, configSrvStsName)
 		memberClusterChecks.checkPerPodServicesDontExist(ctx, configSrvStsName, configMembers)
-		memberClusterChecks.checkServiceAnnotations(ctx, configSrvStsName, configMembers, sc, clusterSpecItem.ClusterName, clusterIdx, test.ExampleExternalClusterDomains.ConfigServerExternalDomain)
+		memberClusterChecks.checkServiceAnnotations(
+			ctx,
+			configSrvStsName,
+			configMembers,
+			sc,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			test.ExampleExternalClusterDomains.ConfigServerExternalDomain,
+		)
 
 		mongosStsName := fmt.Sprintf("%s-mongos-%d", sc.Name, clusterIdx)
 		mongosMembers := memberClusters.MongosDistribution[clusterSpecItem.ClusterName]
 		memberClusterChecks.checkExternalServices(ctx, mongosStsName, mongosMembers)
 		memberClusterChecks.checkInternalServices(ctx, mongosStsName)
 		memberClusterChecks.checkPerPodServicesDontExist(ctx, mongosStsName, mongosMembers)
-		memberClusterChecks.checkServiceAnnotations(ctx, mongosStsName, mongosMembers, sc, clusterSpecItem.ClusterName, clusterIdx, test.ExampleExternalClusterDomains.MongosExternalDomain)
+		memberClusterChecks.checkServiceAnnotations(
+			ctx,
+			mongosStsName,
+			mongosMembers,
+			sc,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			test.ExampleExternalClusterDomains.MongosExternalDomain,
+		)
 
 		for shardIdx := 0; shardIdx < memberClusters.ShardCount(); shardIdx++ {
 			shardStsName := fmt.Sprintf("%s-%d-%d", sc.Name, shardIdx, clusterIdx)
@@ -721,8 +803,20 @@ func TestReconcileCreateMultiClusterShardedClusterWithExternalDomain(t *testing.
 			memberClusterChecks.checkExternalServices(ctx, shardStsName, shardMembers)
 			memberClusterChecks.checkInternalServices(ctx, shardStsName)
 			memberClusterChecks.checkPerPodServicesDontExist(ctx, shardStsName, shardMembers)
-			memberClusterChecks.checkServiceAnnotations(ctx, shardStsName, shardMembers, sc, clusterSpecItem.ClusterName, clusterIdx, test.ExampleExternalClusterDomains.ShardsExternalDomain)
-			memberClusterChecks.checkHostnameOverrideConfigMap(ctx, fmt.Sprintf("%s-hostname-override", sc.Name), expectedHostnameOverrideMap)
+			memberClusterChecks.checkServiceAnnotations(
+				ctx,
+				shardStsName,
+				shardMembers,
+				sc,
+				clusterSpecItem.ClusterName,
+				clusterIdx,
+				test.ExampleExternalClusterDomains.ShardsExternalDomain,
+			)
+			memberClusterChecks.checkHostnameOverrideConfigMap(
+				ctx,
+				fmt.Sprintf("%s-hostname-override", sc.Name),
+				expectedHostnameOverrideMap,
+			)
 		}
 	}
 }
@@ -758,19 +852,48 @@ func TestReconcileCreateMultiClusterShardedClusterWithExternalAccessAndOnlyTopLe
 	kubeClient := kubernetesClient.NewClient(fakeClient)
 	memberClusterMap := getFakeMultiClusterMapWithConfiguredInterceptor(memberClusters.ClusterNames, omConnectionFactory, true, true)
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
-		allHostnames, _ := generateAllHosts(sc, memberClusters.MongosDistribution, clusterMapping, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.SingleExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			memberClusters.MongosDistribution,
+			clusterMapping,
+			memberClusters.ConfigServerDistribution,
+			memberClusters.ShardDistribution,
+			test.ClusterLocalDomains,
+			test.SingleExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	})
 
 	require.NoError(t, err)
 	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
-	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(sc, clusterMapping, memberClusters.MongosDistribution, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.SingleExternalClusterDomains)
+	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(
+		sc,
+		clusterMapping,
+		memberClusters.MongosDistribution,
+		memberClusters.ConfigServerDistribution,
+		memberClusters.ShardDistribution,
+		test.ClusterLocalDomains,
+		test.SingleExternalClusterDomains,
+	)
 
 	for clusterIdx, clusterSpecItem := range sc.Spec.ShardSpec.ClusterSpecList {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, sc.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			sc.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 		configSrvStsName := fmt.Sprintf("%s-config-%d", sc.Name, clusterIdx)
 		configMembers := memberClusters.ConfigServerDistribution[clusterSpecItem.ClusterName]
 		memberClusterChecks.checkExternalServices(ctx, configSrvStsName, configMembers)
@@ -825,19 +948,48 @@ func TestReconcileCreateMultiClusterShardedClusterWithExternalAccessAndNoExterna
 	kubeClient := kubernetesClient.NewClient(fakeClient)
 	memberClusterMap := getFakeMultiClusterMapWithConfiguredInterceptor(memberClusters.ClusterNames, omConnectionFactory, true, true)
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
-		allHostnames, _ := generateAllHosts(sc, memberClusters.MongosDistribution, clusterMapping, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			memberClusters.MongosDistribution,
+			clusterMapping,
+			memberClusters.ConfigServerDistribution,
+			memberClusters.ShardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	})
 
 	require.NoError(t, err)
 	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
-	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(sc, clusterMapping, memberClusters.MongosDistribution, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(
+		sc,
+		clusterMapping,
+		memberClusters.MongosDistribution,
+		memberClusters.ConfigServerDistribution,
+		memberClusters.ShardDistribution,
+		test.ClusterLocalDomains,
+		test.NoneExternalClusterDomains,
+	)
 
 	for clusterIdx, clusterSpecItem := range sc.Spec.ShardSpec.ClusterSpecList {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, sc.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			sc.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 		configSrvStsName := fmt.Sprintf("%s-config-%d", sc.Name, clusterIdx)
 		configMembers := memberClusters.ConfigServerDistribution[clusterSpecItem.ClusterName]
 		memberClusterChecks.checkInternalServices(ctx, configSrvStsName)
@@ -850,7 +1002,15 @@ func TestReconcileCreateMultiClusterShardedClusterWithExternalAccessAndNoExterna
 		memberClusterChecks.checkInternalServices(ctx, mongosStsName)
 		// Without external domain, we need per-pod mongos services
 		memberClusterChecks.checkPerPodServices(ctx, mongosStsName, mongosMembers)
-		memberClusterChecks.checkServiceAnnotations(ctx, mongosStsName, mongosMembers, sc, clusterSpecItem.ClusterName, clusterIdx, test.ExampleAccessWithNoExternalDomain.MongosExternalDomain)
+		memberClusterChecks.checkServiceAnnotations(
+			ctx,
+			mongosStsName,
+			mongosMembers,
+			sc,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			test.ExampleAccessWithNoExternalDomain.MongosExternalDomain,
+		)
 
 		for shardIdx := 0; shardIdx < memberClusters.ShardCount(); shardIdx++ {
 			shardStsName := fmt.Sprintf("%s-%d-%d", sc.Name, shardIdx, clusterIdx)
@@ -892,10 +1052,25 @@ func TestReconcileCreateMultiClusterShardedCluster(t *testing.T) {
 	kubeClient := kubernetesClient.NewClient(fakeClient)
 	memberClusterMap := getFakeMultiClusterMapWithConfiguredInterceptor(memberClusters.ClusterNames, omConnectionFactory, true, true)
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
-		allHostnames, _ := generateAllHosts(sc, memberClusters.MongosDistribution, clusterMapping, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			memberClusters.MongosDistribution,
+			clusterMapping,
+			memberClusters.ConfigServerDistribution,
+			memberClusters.ShardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	})
 
@@ -903,15 +1078,33 @@ func TestReconcileCreateMultiClusterShardedCluster(t *testing.T) {
 	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
 	checkCorrectShardDistributionInStatus(t, sc)
 
-	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(sc, clusterMapping, memberClusters.MongosDistribution, memberClusters.ConfigServerDistribution, memberClusters.ShardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(
+		sc,
+		clusterMapping,
+		memberClusters.MongosDistribution,
+		memberClusters.ConfigServerDistribution,
+		memberClusters.ShardDistribution,
+		test.ClusterLocalDomains,
+		test.NoneExternalClusterDomains,
+	)
 
 	for clusterIdx, clusterSpecItem := range sc.Spec.ShardSpec.ClusterSpecList {
-		memberClusterChecks := newClusterChecks(t, clusterSpecItem.ClusterName, clusterIdx, sc.Namespace, memberClusterMap[clusterSpecItem.ClusterName])
+		memberClusterChecks := newClusterChecks(
+			t,
+			clusterSpecItem.ClusterName,
+			clusterIdx,
+			sc.Namespace,
+			memberClusterMap[clusterSpecItem.ClusterName],
+		)
 		for shardIdx := 0; shardIdx < memberClusters.ShardCount(); shardIdx++ {
 			shardStsName := fmt.Sprintf("%s-%d-%d", sc.Name, shardIdx, clusterIdx)
 			memberClusterChecks.checkStatefulSet(ctx, shardStsName, memberClusters.ShardDistribution[shardIdx][clusterSpecItem.ClusterName])
 			memberClusterChecks.checkInternalServices(ctx, shardStsName)
-			memberClusterChecks.checkPerPodServices(ctx, shardStsName, memberClusters.ShardDistribution[shardIdx][clusterSpecItem.ClusterName])
+			memberClusterChecks.checkPerPodServices(
+				ctx,
+				shardStsName,
+				memberClusters.ShardDistribution[shardIdx][clusterSpecItem.ClusterName],
+			)
 		}
 
 		// Config servers statefulsets should have the names mongoName-config-0, mongoName-config-1
@@ -931,9 +1124,25 @@ func TestReconcileCreateMultiClusterShardedCluster(t *testing.T) {
 	}
 }
 
-func createExpectedHostnameOverrideMap(sc *mdbv1.MongoDB, clusterMapping map[string]int, mongosDistribution map[string]int, configSrvDistribution map[string]int, shardDistribution []map[string]int, clusterDomains test.ClusterDomains, externalClusterDomains test.ClusterDomains) map[string]string {
+func createExpectedHostnameOverrideMap(
+	sc *mdbv1.MongoDB,
+	clusterMapping map[string]int,
+	mongosDistribution map[string]int,
+	configSrvDistribution map[string]int,
+	shardDistribution []map[string]int,
+	clusterDomains test.ClusterDomains,
+	externalClusterDomains test.ClusterDomains,
+) map[string]string {
 	expectedHostnameOverrideMap := map[string]string{}
-	allHostnames, allPodNames := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, clusterDomains, externalClusterDomains)
+	allHostnames, allPodNames := generateAllHosts(
+		sc,
+		mongosDistribution,
+		clusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+		clusterDomains,
+		externalClusterDomains,
+	)
 	for i := range allPodNames {
 		expectedHostnameOverrideMap[allPodNames[i]] = allHostnames[i]
 	}
@@ -988,7 +1197,10 @@ func (r *MultiClusterShardedClusterConfigList) GenerateAllHosts(sc *mdbv1.MongoD
 
 		for shardIdx := 0; shardIdx < len(clusterSpec.ShardsMembersArray); shardIdx++ {
 			for podIdx := 0; podIdx < clusterSpec.ShardsMembersArray[shardIdx]; podIdx++ {
-				allHosts = append(allHosts, getMultiClusterFQDN(sc.ShardRsName(shardIdx), sc.Namespace, clusterIdx, podIdx, "cluster.local", ""))
+				allHosts = append(
+					allHosts,
+					getMultiClusterFQDN(sc.ShardRsName(shardIdx), sc.Namespace, clusterIdx, podIdx, "cluster.local", ""),
+				)
 				allPodNames = append(allPodNames, getPodName(sc.ShardRsName(shardIdx), clusterIdx, podIdx))
 			}
 		}
@@ -1013,10 +1225,18 @@ func TestReconcileMultiClusterShardedClusterCertsAndSecretsReplication(t *testin
 	}
 	shardClusterSpecList := test.CreateClusterSpecList(memberClusterNames, shardDistribution[0])
 
-	mongosDistribution := map[string]int{expectedClusterConfigList[1].Name: 1, expectedClusterConfigList[2].Name: 3, expectedClusterConfigList[3].Name: 2}
+	mongosDistribution := map[string]int{
+		expectedClusterConfigList[1].Name: 1,
+		expectedClusterConfigList[2].Name: 3,
+		expectedClusterConfigList[3].Name: 2,
+	}
 	mongosAndConfigSrvClusterSpecList := test.CreateClusterSpecList(memberClusterNames, mongosDistribution)
 
-	configSrvDistribution := map[string]int{expectedClusterConfigList[0].Name: 2, expectedClusterConfigList[1].Name: 1, expectedClusterConfigList[3].Name: 3}
+	configSrvDistribution := map[string]int{
+		expectedClusterConfigList[0].Name: 2,
+		expectedClusterConfigList[1].Name: 1,
+		expectedClusterConfigList[3].Name: 3,
+	}
 	configSrvDistributionClusterSpecList := test.CreateClusterSpecList(memberClusterNames, configSrvDistribution)
 
 	certificatesSecretsPrefix := "some-prefix"
@@ -1090,10 +1310,25 @@ func TestReconcileMultiClusterShardedClusterCertsAndSecretsReplication(t *testin
 	memberClusterMap := getFakeMultiClusterMapWithConfiguredInterceptor(memberClusterNames, omConnectionFactory, true, false)
 
 	ctx := context.Background()
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
-		allHostnames, _ := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			mongosDistribution,
+			clusterMapping,
+			configSrvDistribution,
+			shardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	})
 
@@ -1125,15 +1360,21 @@ func createSecretsForShards(resourceName string, shardCount int, certificatesSec
 		shardData["tls.crt"], shardData["tls.key"] = createMockCertAndKeyBytes()
 
 		shardSecrets = append(shardSecrets, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-%d-cert", certificatesSecretsPrefix, resourceName, i), Namespace: mock.TestNamespace},
-			Data:       shardData,
-			Type:       corev1.SecretTypeTLS,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s-%d-cert", certificatesSecretsPrefix, resourceName, i),
+				Namespace: mock.TestNamespace,
+			},
+			Data: shardData,
+			Type: corev1.SecretTypeTLS,
 		})
 
 		shardSecrets = append(shardSecrets, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-%d-%s", certificatesSecretsPrefix, resourceName, i, util.ClusterFileName), Namespace: mock.TestNamespace},
-			Data:       shardData,
-			Type:       corev1.SecretTypeTLS,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s-%d-%s", certificatesSecretsPrefix, resourceName, i, util.ClusterFileName),
+				Namespace: mock.TestNamespace,
+			},
+			Data: shardData,
+			Type: corev1.SecretTypeTLS,
 		})
 	}
 	return shardSecrets
@@ -1152,9 +1393,12 @@ func createMongosSecrets(resourceName string, certificatesSecretsPrefix string) 
 	}
 
 	mongosClusterFileSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-mongos-%s", certificatesSecretsPrefix, resourceName, util.ClusterFileName), Namespace: mock.TestNamespace},
-		Data:       mongosData,
-		Type:       corev1.SecretTypeTLS,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-mongos-%s", certificatesSecretsPrefix, resourceName, util.ClusterFileName),
+			Namespace: mock.TestNamespace,
+		},
+		Data: mongosData,
+		Type: corev1.SecretTypeTLS,
 	}
 
 	return []client.Object{mongosSecret, mongosClusterFileSecret}
@@ -1165,15 +1409,21 @@ func createConfigSrvSecrets(resourceName string, certificatesSecretsPrefix strin
 	configData["tls.crt"], configData["tls.key"] = createMockCertAndKeyBytes()
 
 	configSrvSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-config-cert", certificatesSecretsPrefix, resourceName), Namespace: mock.TestNamespace},
-		Data:       configData,
-		Type:       corev1.SecretTypeTLS,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-config-cert", certificatesSecretsPrefix, resourceName),
+			Namespace: mock.TestNamespace,
+		},
+		Data: configData,
+		Type: corev1.SecretTypeTLS,
 	}
 
 	configSrvClusterSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-config-%s", certificatesSecretsPrefix, resourceName, util.ClusterFileName), Namespace: mock.TestNamespace},
-		Data:       configData,
-		Type:       corev1.SecretTypeTLS,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-config-%s", certificatesSecretsPrefix, resourceName, util.ClusterFileName),
+			Namespace: mock.TestNamespace,
+		},
+		Data: configData,
+		Type: corev1.SecretTypeTLS,
 	}
 
 	return []client.Object{configSrvSecret, configSrvClusterSecret}
@@ -1186,7 +1436,10 @@ func createAgentCertsSecret(resourceName string, certificatesSecretsPrefix strin
 		cert.Subject.Province = []string{"New York"}
 		cert.Subject.Country = []string{"US"}
 	}
-	cert, key := createMockCertAndKeyBytes(subjectModifier, func(cert *x509.Certificate) { cert.Subject.CommonName = util.AutomationAgentName })
+	cert, key := createMockCertAndKeyBytes(
+		subjectModifier,
+		func(cert *x509.Certificate) { cert.Subject.CommonName = util.AutomationAgentName },
+	)
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1261,12 +1514,27 @@ func TestReconcileForComplexMultiClusterYaml(t *testing.T) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(sc)
 	memberClusterMap := getFakeMultiClusterMapWithClusters(memberClusterNames, omConnectionFactory)
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	require.NoError(t, err)
 
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
-		hosts, _ := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		hosts, _ := generateAllHosts(
+			sc,
+			mongosDistribution,
+			clusterMapping,
+			configSrvDistribution,
+			shardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(hosts)
 	})
 
@@ -1278,7 +1546,9 @@ func TestReconcileForComplexMultiClusterYaml(t *testing.T) {
 	require.NoError(t, err)
 	automationConfig, err := omConnectionFactory.GetConnection().ReadAutomationConfig()
 	require.NoError(t, err)
-	normalizedActualReplicaSets, err := normalizeObjectToInterfaceMap(map[string]any{"replicaSets": automationConfig.Deployment.GetReplicaSets()})
+	normalizedActualReplicaSets, err := normalizeObjectToInterfaceMap(
+		map[string]any{"replicaSets": automationConfig.Deployment.GetReplicaSets()},
+	)
 	require.NoError(t, err)
 	if !assert.Equal(t, normalizedExpectedReplicaSets, normalizedActualReplicaSets) {
 		visualDiff, err := getVisualJsonDiff(normalizedExpectedReplicaSets, normalizedActualReplicaSets)
@@ -1288,7 +1558,13 @@ func TestReconcileForComplexMultiClusterYaml(t *testing.T) {
 
 	for shardIdx := 0; shardIdx < sc.Spec.ShardCount; shardIdx++ {
 		for clusterName, expectedMembersCount := range shardDistribution[shardIdx] {
-			memberClusterChecks := newClusterChecks(t, clusterName, clusterMapping[clusterName], sc.Namespace, memberClusterMap[clusterName])
+			memberClusterChecks := newClusterChecks(
+				t,
+				clusterName,
+				clusterMapping[clusterName],
+				sc.Namespace,
+				memberClusterMap[clusterName],
+			)
 			if expectedMembersCount > 0 {
 				memberClusterChecks.checkStatefulSet(ctx, sc.MultiShardRsName(clusterMapping[clusterName], shardIdx), expectedMembersCount)
 			} else {
@@ -1311,26 +1587,63 @@ func TestReconcileForComplexMultiClusterYaml(t *testing.T) {
 		memberClusterChecks.checkStatefulSet(ctx, sc.MultiConfigRsName(clusterMapping[clusterName]), expectedMembersCount)
 	}
 
-	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(sc, clusterMapping, mongosDistribution, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+	expectedHostnameOverrideMap := createExpectedHostnameOverrideMap(
+		sc,
+		clusterMapping,
+		mongosDistribution,
+		configSrvDistribution,
+		shardDistribution,
+		test.ClusterLocalDomains,
+		test.NoneExternalClusterDomains,
+	)
 	for _, clusterName := range memberClusterNames {
 		memberClusterChecks := newClusterChecks(t, clusterName, clusterMapping[clusterName], sc.Namespace, memberClusterMap[clusterName])
 		memberClusterChecks.checkHostnameOverrideConfigMap(ctx, fmt.Sprintf("%s-hostname-override", sc.Name), expectedHostnameOverrideMap)
 	}
 }
 
-func generateAllHosts(sc *mdbv1.MongoDB, mongosDistribution map[string]int, clusterMapping map[string]int, configSrvDistribution map[string]int, shardDistribution []map[string]int, clusterDomain test.ClusterDomains, externalClusterDomain test.ClusterDomains) ([]string, []string) {
+func generateAllHosts(
+	sc *mdbv1.MongoDB,
+	mongosDistribution map[string]int,
+	clusterMapping map[string]int,
+	configSrvDistribution map[string]int,
+	shardDistribution []map[string]int,
+	clusterDomain test.ClusterDomains,
+	externalClusterDomain test.ClusterDomains,
+) ([]string, []string) {
 	var allHosts []string
 	var allPodNames []string
-	podNames, hosts := generateHostsWithDistribution(sc.MongosRsName(), sc.Namespace, mongosDistribution, clusterMapping, clusterDomain.MongosExternalDomain, externalClusterDomain.MongosExternalDomain)
+	podNames, hosts := generateHostsWithDistribution(
+		sc.MongosRsName(),
+		sc.Namespace,
+		mongosDistribution,
+		clusterMapping,
+		clusterDomain.MongosExternalDomain,
+		externalClusterDomain.MongosExternalDomain,
+	)
 	allHosts = append(allHosts, hosts...)
 	allPodNames = append(allPodNames, podNames...)
 
-	podNames, hosts = generateHostsWithDistribution(sc.ConfigRsName(), sc.Namespace, configSrvDistribution, clusterMapping, clusterDomain.ConfigServerExternalDomain, externalClusterDomain.ConfigServerExternalDomain)
+	podNames, hosts = generateHostsWithDistribution(
+		sc.ConfigRsName(),
+		sc.Namespace,
+		configSrvDistribution,
+		clusterMapping,
+		clusterDomain.ConfigServerExternalDomain,
+		externalClusterDomain.ConfigServerExternalDomain,
+	)
 	allHosts = append(allHosts, hosts...)
 	allPodNames = append(allPodNames, podNames...)
 
 	for shardIdx := 0; shardIdx < sc.Spec.ShardCount; shardIdx++ {
-		podNames, hosts = generateHostsWithDistribution(sc.ShardRsName(shardIdx), sc.Namespace, shardDistribution[shardIdx], clusterMapping, clusterDomain.ShardsExternalDomain, externalClusterDomain.ShardsExternalDomain)
+		podNames, hosts = generateHostsWithDistribution(
+			sc.ShardRsName(shardIdx),
+			sc.Namespace,
+			shardDistribution[shardIdx],
+			clusterMapping,
+			clusterDomain.ShardsExternalDomain,
+			externalClusterDomain.ShardsExternalDomain,
+		)
 		allHosts = append(allHosts, hosts...)
 		allPodNames = append(allPodNames, podNames...)
 	}
@@ -1397,7 +1710,12 @@ func TestMigrateToNewDeploymentState(t *testing.T) {
 
 // Without genericity and type hinting, when unmarshalling the file in a struct, fields that should be omitted when empty
 // are not, and the actual/expected configurations are not compared correctly
-func testDesiredConfigurationFromYAML[T *mdbv1.ShardedClusterComponentSpec | map[int]*mdbv1.ShardedClusterComponentSpec](t *testing.T, mongoDBResourceFile string, expectedConfigurationFile string, shardedComponentType string) {
+func testDesiredConfigurationFromYAML[T *mdbv1.ShardedClusterComponentSpec | map[int]*mdbv1.ShardedClusterComponentSpec](
+	t *testing.T,
+	mongoDBResourceFile string,
+	expectedConfigurationFile string,
+	shardedComponentType string,
+) {
 	ctx := context.Background()
 	sc, err := loadMongoDBResource(mongoDBResourceFile)
 	require.NoError(t, err)
@@ -1406,7 +1724,14 @@ func testDesiredConfigurationFromYAML[T *mdbv1.ShardedClusterComponentSpec | map
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(sc)
 	memberClusterMap := getFakeMultiClusterMapWithClusters(memberClusterNames, omConnectionFactory)
 
-	_, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	_, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	require.NoError(t, err)
 
 	var actual interface{}
@@ -1453,30 +1778,60 @@ func testDesiredConfigurationFromYAML[T *mdbv1.ShardedClusterComponentSpec | map
 
 // Multi-Cluster
 func TestShardMapForComplexMultiClusterYaml(t *testing.T) {
-	testDesiredConfigurationFromYAML[map[int]*mdbv1.ShardedClusterComponentSpec](t, "testdata/mdb-sharded-multi-cluster-complex.yaml", "testdata/mdb-sharded-multi-cluster-complex-expected-shardmap.yaml", "shard")
+	testDesiredConfigurationFromYAML[map[int]*mdbv1.ShardedClusterComponentSpec](
+		t,
+		"testdata/mdb-sharded-multi-cluster-complex.yaml",
+		"testdata/mdb-sharded-multi-cluster-complex-expected-shardmap.yaml",
+		"shard",
+	)
 }
 
 // Config servers and Mongos share a lot of logic, and have the same settings in CRDs, the two below tests use the same files, and are almost identical
 func TestConfigServerdExpectedConfigFromMultiClusterYaml(t *testing.T) {
-	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](t, "testdata/mdb-sharded-multi-cluster-configsrv-mongos.yaml", "testdata/mdb-sharded-multi-cluster-configsrv-mongos-expected-config.yaml", "config")
+	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](
+		t,
+		"testdata/mdb-sharded-multi-cluster-configsrv-mongos.yaml",
+		"testdata/mdb-sharded-multi-cluster-configsrv-mongos-expected-config.yaml",
+		"config",
+	)
 }
 
 func TestMongosExpectedConfigFromMultiClusterYaml(t *testing.T) {
-	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](t, "testdata/mdb-sharded-multi-cluster-configsrv-mongos.yaml", "testdata/mdb-sharded-multi-cluster-configsrv-mongos-expected-config.yaml", "mongos")
+	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](
+		t,
+		"testdata/mdb-sharded-multi-cluster-configsrv-mongos.yaml",
+		"testdata/mdb-sharded-multi-cluster-configsrv-mongos-expected-config.yaml",
+		"mongos",
+	)
 }
 
 // Single-Cluster
 func TestShardMapForSingleClusterWithOverridesYaml(t *testing.T) {
-	testDesiredConfigurationFromYAML[map[int]*mdbv1.ShardedClusterComponentSpec](t, "testdata/mdb-sharded-single-with-overrides.yaml", "testdata/mdb-sharded-single-with-overrides-expected-shardmap.yaml", "shard")
+	testDesiredConfigurationFromYAML[map[int]*mdbv1.ShardedClusterComponentSpec](
+		t,
+		"testdata/mdb-sharded-single-with-overrides.yaml",
+		"testdata/mdb-sharded-single-with-overrides-expected-shardmap.yaml",
+		"shard",
+	)
 }
 
 // Config servers and Mongos share a lot of logic, and have the same settings in CRDs, the two below tests use the same files, and are almost identical
 func TestConfigServerdExpectedConfigFromSingleClusterYaml(t *testing.T) {
-	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](t, "testdata/mdb-sharded-single-cluster-configsrv-mongos.yaml", "testdata/mdb-sharded-single-cluster-configsrv-mongos-expected-config.yaml", "config")
+	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](
+		t,
+		"testdata/mdb-sharded-single-cluster-configsrv-mongos.yaml",
+		"testdata/mdb-sharded-single-cluster-configsrv-mongos-expected-config.yaml",
+		"config",
+	)
 }
 
 func TestMongosExpectedConfigFromSingleClusterYaml(t *testing.T) {
-	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](t, "testdata/mdb-sharded-single-cluster-configsrv-mongos.yaml", "testdata/mdb-sharded-single-cluster-configsrv-mongos-expected-config.yaml", "mongos")
+	testDesiredConfigurationFromYAML[*mdbv1.ShardedClusterComponentSpec](
+		t,
+		"testdata/mdb-sharded-single-cluster-configsrv-mongos.yaml",
+		"testdata/mdb-sharded-single-cluster-configsrv-mongos-expected-config.yaml",
+		"mongos",
+	)
 }
 
 func TestMultiClusterShardedSetRace(t *testing.T) {
@@ -1504,9 +1859,27 @@ func TestMultiClusterShardedSetRace(t *testing.T) {
 	configSrvDistribution := map[string]int{cluster1: 2, cluster2: 1}
 	configSrvDistributionClusterSpecList := test.CreateClusterSpecList(memberClusterNames, configSrvDistribution)
 
-	sc, cfgMap, projectName := buildShardedClusterWithCustomProjectName("mc-sharded", shardCount, shardClusterSpecList, mongosAndConfigSrvClusterSpecList, configSrvDistributionClusterSpecList)
-	sc1, cfgMap1, projectName1 := buildShardedClusterWithCustomProjectName("mc-sharded-1", shardCount, shardClusterSpecList, mongosAndConfigSrvClusterSpecList, configSrvDistributionClusterSpecList)
-	sc2, cfgMap2, projectName2 := buildShardedClusterWithCustomProjectName("mc-sharded-2", shardCount, shardClusterSpecList, mongosAndConfigSrvClusterSpecList, configSrvDistributionClusterSpecList)
+	sc, cfgMap, projectName := buildShardedClusterWithCustomProjectName(
+		"mc-sharded",
+		shardCount,
+		shardClusterSpecList,
+		mongosAndConfigSrvClusterSpecList,
+		configSrvDistributionClusterSpecList,
+	)
+	sc1, cfgMap1, projectName1 := buildShardedClusterWithCustomProjectName(
+		"mc-sharded-1",
+		shardCount,
+		shardClusterSpecList,
+		mongosAndConfigSrvClusterSpecList,
+		configSrvDistributionClusterSpecList,
+	)
+	sc2, cfgMap2, projectName2 := buildShardedClusterWithCustomProjectName(
+		"mc-sharded-2",
+		shardCount,
+		shardClusterSpecList,
+		mongosAndConfigSrvClusterSpecList,
+		configSrvDistributionClusterSpecList,
+	)
 
 	resourceToProjectMapping := map[string]string{
 		"mc-sharded":   projectName,
@@ -1525,7 +1898,21 @@ func TestMultiClusterShardedSetRace(t *testing.T) {
 	globalMemberClustersMap := getFakeMultiClusterMapWithConfiguredInterceptor(memberClusterNames, omConnectionFactory, true, false)
 
 	ctx := context.Background()
-	reconciler := newShardedClusterReconciler(ctx, kubeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, globalMemberClustersMap, omConnectionFactory.GetConnectionFunc, testBackupEnableDelay)
+	reconciler := newShardedClusterReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		globalMemberClustersMap,
+		omConnectionFactory.GetConnectionFunc,
+		testBackupEnableDelay,
+	)
 
 	allHostnames := generateHostsForCluster(ctx, reconciler, false, sc, mongosDistribution, configSrvDistribution, shardDistribution)
 	allHostnames1 := generateHostsForCluster(ctx, reconciler, false, sc1, mongosDistribution, configSrvDistribution, shardDistribution)
@@ -1674,7 +2061,15 @@ func TestMultiClusterShardedMongosDeadlock(t *testing.T) {
 	require.NoError(t, err)
 
 	addAllHostsWithDistribution := func(connection om.Connection, mongosDistribution map[string]int, clusterMapping map[string]int, configSrvDistribution map[string]int, shardDistribution []map[string]int) {
-		allHostnames, _ := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			mongosDistribution,
+			clusterMapping,
+			configSrvDistribution,
+			shardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	}
 
@@ -1921,11 +2316,24 @@ func TestMultiClusterShardedMongosDeadlock(t *testing.T) {
 	// TODO: statuses in OM mock
 	// TODO: OM mock: set agent ready depending on a clusterDown parameter ? + set mongos not ready if anything is not ready
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	require.NoError(t, err)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 
-	addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configServerDistribution, shardFullDistribution)
+	addAllHostsWithDistribution(
+		omConnectionFactory.GetConnection(),
+		mongosDistribution,
+		clusterMapping,
+		configServerDistribution,
+		shardFullDistribution,
+	)
 
 	err = kubeClient.Get(ctx, mock.ObjectKeyFromApiObject(sc), sc)
 	require.NoError(t, err)
@@ -2222,13 +2630,28 @@ func MultiClusterShardedScalingWithOverridesTestCase(t *testing.T, tc MultiClust
 	require.NoError(t, err)
 
 	addAllHostsWithDistribution := func(connection om.Connection, mongosDistribution map[string]int, clusterMapping map[string]int, configSrvDistribution map[string]int, shardDistribution []map[string]int) {
-		allHostnames, _ := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			mongosDistribution,
+			clusterMapping,
+			configSrvDistribution,
+			shardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	}
 
 	for _, scalingStep := range tc.scalingSteps {
 		t.Run(scalingStep.name, func(t *testing.T) {
-			reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+			reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+				ctx,
+				false,
+				sc,
+				memberClusterMap,
+				kubeClient,
+				omConnectionFactory,
+			)
 			require.NoError(t, err)
 			clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 
@@ -2242,7 +2665,13 @@ func MultiClusterShardedScalingWithOverridesTestCase(t *testing.T, tc MultiClust
 			// to generate the shard distribution.
 			// We pass the *expected* distribution as a parameter, ensuring that all hosts expected to be registered
 			// by the end of the full reconciliation process are added to OM.
-			addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configSrvDistribution, scalingStep.expectedShardDistribution)
+			addAllHostsWithDistribution(
+				omConnectionFactory.GetConnection(),
+				mongosDistribution,
+				clusterMapping,
+				configSrvDistribution,
+				scalingStep.expectedShardDistribution,
+			)
 
 			err = kubeClient.Update(ctx, sc)
 			require.NoError(t, err)
@@ -2571,11 +3000,26 @@ func TestMultiClusterShardedScaling(t *testing.T) {
 		memberClusterClients = append(memberClusterClients, c)
 	}
 
-	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err := newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	require.NoError(t, err)
 	clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 	addAllHostsWithDistribution := func(connection om.Connection, mongosDistribution map[string]int, clusterMapping map[string]int, configSrvDistribution map[string]int, shardDistribution []map[string]int) {
-		allHostnames, _ := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHosts(
+			sc,
+			mongosDistribution,
+			clusterMapping,
+			configSrvDistribution,
+			shardDistribution,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	}
 
@@ -2584,7 +3028,13 @@ func TestMultiClusterShardedScaling(t *testing.T) {
 	_, err = reconciler.Reconcile(ctx, requestFromObject(sc))
 	require.NoError(t, err)
 	require.NoError(t, mock.MarkAllStatefulSetsAsReady(ctx, sc.Namespace, memberClusterClients...))
-	addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution)
+	addAllHostsWithDistribution(
+		omConnectionFactory.GetConnection(),
+		mongosDistribution,
+		clusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+	)
 	reconcileUntilSuccessful(ctx, t, reconciler, sc, kubeClient, memberClusterClients, nil, false)
 
 	// Ensure that reconciliation generated the correct deployment state
@@ -2607,7 +3057,13 @@ func TestMultiClusterShardedScaling(t *testing.T) {
 	// add two config servers
 	// configSrvDistribution := map[string]int{cluster3: 1}
 	configSrvDistribution = map[string]int{cluster1: 2, cluster3: 1}
-	addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution)
+	addAllHostsWithDistribution(
+		omConnectionFactory.GetConnection(),
+		mongosDistribution,
+		clusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+	)
 
 	err = kubeClient.Get(ctx, mock.ObjectKeyFromApiObject(sc), sc)
 	require.NoError(t, err)
@@ -2617,10 +3073,23 @@ func TestMultiClusterShardedScaling(t *testing.T) {
 	err = kubeClient.Update(ctx, sc)
 	require.NoError(t, err)
 
-	reconciler, reconcilerHelper, err = newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err = newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	require.NoError(t, err)
 	clusterMapping = reconcilerHelper.deploymentState.ClusterMapping
-	addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution)
+	addAllHostsWithDistribution(
+		omConnectionFactory.GetConnection(),
+		mongosDistribution,
+		clusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+	)
 
 	require.NoError(t, err)
 	reconcileUntilSuccessful(ctx, t, reconciler, sc, kubeClient, memberClusterClients, nil, false)
@@ -2634,7 +3103,13 @@ func TestMultiClusterShardedScaling(t *testing.T) {
 	}
 
 	mongosDistribution = map[string]int{cluster1: 0, cluster2: 1, cluster3: 1}
-	addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution)
+	addAllHostsWithDistribution(
+		omConnectionFactory.GetConnection(),
+		mongosDistribution,
+		clusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+	)
 
 	err = kubeClient.Get(ctx, mock.ObjectKeyFromApiObject(sc), sc)
 	require.NoError(t, err)
@@ -2644,17 +3119,39 @@ func TestMultiClusterShardedScaling(t *testing.T) {
 	err = kubeClient.Update(ctx, sc)
 	require.NoError(t, err)
 
-	reconciler, reconcilerHelper, err = newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+	reconciler, reconcilerHelper, err = newShardedClusterReconcilerForMultiCluster(
+		ctx,
+		false,
+		sc,
+		memberClusterMap,
+		kubeClient,
+		omConnectionFactory,
+	)
 	require.NoError(t, err)
 	clusterMapping = reconcilerHelper.deploymentState.ClusterMapping
-	addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution)
+	addAllHostsWithDistribution(
+		omConnectionFactory.GetConnection(),
+		mongosDistribution,
+		clusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+	)
 
 	require.NoError(t, err)
 	reconcileUntilSuccessful(ctx, t, reconciler, sc, kubeClient, memberClusterClients, nil, false)
 	checkCorrectShardDistributionInStatus(t, sc)
 }
 
-func reconcileUntilSuccessful(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, object *mdbv1.MongoDB, operatorClient client.Client, memberClusterClients []client.Client, expectedReconciles *int, ignoreFailures bool) {
+func reconcileUntilSuccessful(
+	ctx context.Context,
+	t *testing.T,
+	reconciler reconcile.Reconciler,
+	object *mdbv1.MongoDB,
+	operatorClient client.Client,
+	memberClusterClients []client.Client,
+	expectedReconciles *int,
+	ignoreFailures bool,
+) {
 	maxReconcileCount := 20
 	actualReconciles := 0
 
@@ -2685,13 +3182,51 @@ func reconcileUntilSuccessful(ctx context.Context, t *testing.T, reconciler reco
 	}
 }
 
-func generateHostsForCluster(ctx context.Context, reconciler *ReconcileMongoDbShardedCluster, forceEnterprise bool, sc *mdbv1.MongoDB, mongosDistribution map[string]int, configSrvDistribution map[string]int, shardDistribution []map[string]int) []string {
-	reconcileHelper, _ := NewShardedClusterReconcilerHelper(ctx, reconciler.ReconcileCommonController, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", forceEnterprise, false, false, "", architectures.NonStatic, sc, reconciler.memberClustersMap, reconciler.omConnectionFactory, zap.S(), testBackupEnableDelay)
-	allHostnames, _ := generateAllHosts(sc, mongosDistribution, reconcileHelper.deploymentState.ClusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+func generateHostsForCluster(
+	ctx context.Context,
+	reconciler *ReconcileMongoDbShardedCluster,
+	forceEnterprise bool,
+	sc *mdbv1.MongoDB,
+	mongosDistribution map[string]int,
+	configSrvDistribution map[string]int,
+	shardDistribution []map[string]int,
+) []string {
+	reconcileHelper, _ := NewShardedClusterReconcilerHelper(
+		ctx,
+		reconciler.ReconcileCommonController,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		forceEnterprise,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		sc,
+		reconciler.memberClustersMap,
+		reconciler.omConnectionFactory,
+		zap.S(),
+		testBackupEnableDelay,
+	)
+	allHostnames, _ := generateAllHosts(
+		sc,
+		mongosDistribution,
+		reconcileHelper.deploymentState.ClusterMapping,
+		configSrvDistribution,
+		shardDistribution,
+		test.ClusterLocalDomains,
+		test.NoneExternalClusterDomains,
+	)
 	return allHostnames
 }
 
-func buildShardedClusterWithCustomProjectName(mcShardedClusterName string, shardCount int, shardClusterSpecList mdbv1.ClusterSpecList, mongosAndConfigSrvClusterSpecList mdbv1.ClusterSpecList, configSrvDistributionClusterSpecList mdbv1.ClusterSpecList) (*mdbv1.MongoDB, *corev1.ConfigMap, string) {
+func buildShardedClusterWithCustomProjectName(
+	mcShardedClusterName string,
+	shardCount int,
+	shardClusterSpecList mdbv1.ClusterSpecList,
+	mongosAndConfigSrvClusterSpecList mdbv1.ClusterSpecList,
+	configSrvDistributionClusterSpecList mdbv1.ClusterSpecList,
+) (*mdbv1.MongoDB, *corev1.ConfigMap, string) {
 	configMapName := mock.TestProjectConfigMapName + "-" + mcShardedClusterName
 	projectName := om.TestGroupName + "-" + mcShardedClusterName
 
@@ -2748,7 +3283,10 @@ func checkCorrectShardDistributionInStatus(t *testing.T, sc *mdbv1.MongoDB) {
 				// we need to initialize it only when there are any shard overrides because we receive nil from status)
 				expectedShardOverridesInClusters = map[string]map[string]int{}
 			}
-			expectedShardOverridesInClusters[shardName] = util.TransformToMap(shardOverride.ClusterSpecList, clusterSpecItemOverrideToClusterNameMembers)
+			expectedShardOverridesInClusters[shardName] = util.TransformToMap(
+				shardOverride.ClusterSpecList,
+				clusterSpecItemOverrideToClusterNameMembers,
+			)
 		}
 	}
 
@@ -3649,7 +4187,14 @@ func TestMultiClusterShardedServiceCreation_WithExternalName(t *testing.T) {
 
 			kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(sc)
 			memberClusterMap := getFakeMultiClusterMapWithClusters(memberClusters, omConnectionFactory)
-			reconciler, reconcileHelper, err := newShardedClusterReconcilerForMultiCluster(ctx, false, sc, memberClusterMap, kubeClient, omConnectionFactory)
+			reconciler, reconcileHelper, err := newShardedClusterReconcilerForMultiCluster(
+				ctx,
+				false,
+				sc,
+				memberClusterMap,
+				kubeClient,
+				omConnectionFactory,
+			)
 			require.NoError(t, err)
 
 			mongosDistribution := clusterSpecListToDistribution(tc.mongosClusterSpecList)
@@ -3669,7 +4214,15 @@ func TestMultiClusterShardedServiceCreation_WithExternalName(t *testing.T) {
 					externalDomains.SingleClusterDomain = tc.externalDomains.SingleClusterDomain
 				}
 
-				allHostnames, _ := generateAllHosts(sc, mongosDistribution, clusterMapping, configSrvDistribution, shardDistribution, test.ClusterLocalDomains, externalDomains)
+				allHostnames, _ := generateAllHosts(
+					sc,
+					mongosDistribution,
+					clusterMapping,
+					configSrvDistribution,
+					shardDistribution,
+					test.ClusterLocalDomains,
+					externalDomains,
+				)
 				connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 			})
 
@@ -3691,7 +4244,12 @@ func TestMultiClusterShardedServiceCreation_WithExternalName(t *testing.T) {
 					err = c.Get(ctx, objectKey, &service)
 					require.NoError(t, err)
 
-					assert.Equal(t, expectedService, service, fmt.Sprintf("expected service %s for cluster %s is different", objectKey, clusterName))
+					assert.Equal(
+						t,
+						expectedService,
+						service,
+						fmt.Sprintf("expected service %s for cluster %s is different", objectKey, clusterName),
+					)
 				}
 			}
 		})
@@ -3720,12 +4278,29 @@ func sumSlice[T constraints.Integer](s []T) int {
 	return result
 }
 
-func generateHostsWithDistribution(stsName string, namespace string, distribution map[string]int, clusterIndexMapping map[string]int, clusterDomain string, externalClusterDomain string) ([]string, []string) {
+func generateHostsWithDistribution(
+	stsName string,
+	namespace string,
+	distribution map[string]int,
+	clusterIndexMapping map[string]int,
+	clusterDomain string,
+	externalClusterDomain string,
+) ([]string, []string) {
 	var hosts []string
 	var podNames []string
 	for memberClusterName, memberCount := range distribution {
 		for podIdx := range memberCount {
-			hosts = append(hosts, getMultiClusterFQDN(stsName, namespace, clusterIndexMapping[memberClusterName], podIdx, clusterDomain, externalClusterDomain))
+			hosts = append(
+				hosts,
+				getMultiClusterFQDN(
+					stsName,
+					namespace,
+					clusterIndexMapping[memberClusterName],
+					podIdx,
+					clusterDomain,
+					externalClusterDomain,
+				),
+			)
 			podNames = append(podNames, getPodName(stsName, clusterIndexMapping[memberClusterName], podIdx))
 		}
 	}
@@ -3737,7 +4312,14 @@ func getPodName(stsName string, clusterIdx int, podIdx int) string {
 	return fmt.Sprintf("%s-%d-%d", stsName, clusterIdx, podIdx)
 }
 
-func getMultiClusterFQDN(stsName string, namespace string, clusterIdx int, podIdx int, clusterDomain string, externalClusterDomain string) string {
+func getMultiClusterFQDN(
+	stsName string,
+	namespace string,
+	clusterIdx int,
+	podIdx int,
+	clusterDomain string,
+	externalClusterDomain string,
+) string {
 	if len(externalClusterDomain) != 0 {
 		return fmt.Sprintf("%s.%s", getPodName(stsName, clusterIdx, podIdx), externalClusterDomain)
 	}

--- a/controllers/operator/mongodbshardedcluster_controller_test.go
+++ b/controllers/operator/mongodbshardedcluster_controller_test.go
@@ -79,7 +79,16 @@ func TestReconcileCreateShardedCluster(t *testing.T) {
 	ctx := context.Background()
 	sc := test.DefaultClusterBuilder().Build()
 
-	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	c := kubeClient
 	require.NoError(t, err)
 
@@ -125,17 +134,49 @@ func TestReconcileCreateSingleClusterShardedClusterWithExternalDomainSimplest(t 
 		Build()
 
 	kubeClient := kubernetesClient.NewClient(fakeClient)
-	reconciler, _, _ := newShardedClusterReconcilerFromResource(ctx, nil, "", "", sc, nil, kubeClient, omConnectionFactory, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, _ := newShardedClusterReconcilerFromResource(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		kubeClient,
+		omConnectionFactory,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
 		var allHostnames []string
 		// Note that only Mongos uses external domains. The other components use domains internal to the cluster.
-		mongosHostNames, _ := dns.GetDNSNames(sc.MongosRsName(), sc.ServiceName(), sc.Namespace, "", sc.Spec.MongosCount, &test.ExampleExternalClusterDomains.SingleClusterDomain)
+		mongosHostNames, _ := dns.GetDNSNames(
+			sc.MongosRsName(),
+			sc.ServiceName(),
+			sc.Namespace,
+			"",
+			sc.Spec.MongosCount,
+			&test.ExampleExternalClusterDomains.SingleClusterDomain,
+		)
 		allHostnames = append(allHostnames, mongosHostNames...)
-		configServersHostNames, _ := dns.GetDNSNames(sc.ConfigRsName(), sc.ConfigSrvServiceName(), sc.Namespace, "", sc.Spec.ConfigServerCount, &test.NoneExternalClusterDomains.ConfigServerExternalDomain)
+		configServersHostNames, _ := dns.GetDNSNames(
+			sc.ConfigRsName(),
+			sc.ConfigSrvServiceName(),
+			sc.Namespace,
+			"",
+			sc.Spec.ConfigServerCount,
+			&test.NoneExternalClusterDomains.ConfigServerExternalDomain,
+		)
 		allHostnames = append(allHostnames, configServersHostNames...)
 		for shardIdx := range sc.Spec.ShardCount {
-			shardHostNames, _ := dns.GetDNSNames(sc.ShardRsName(shardIdx), sc.ShardServiceName(), sc.Namespace, "", sc.Spec.MongodsPerShardCount, &test.NoneExternalClusterDomains.ShardsExternalDomain)
+			shardHostNames, _ := dns.GetDNSNames(
+				sc.ShardRsName(shardIdx),
+				sc.ShardServiceName(),
+				sc.Namespace,
+				"",
+				sc.Spec.MongodsPerShardCount,
+				&test.NoneExternalClusterDomains.ShardsExternalDomain,
+			)
 			allHostnames = append(allHostnames, shardHostNames...)
 		}
 
@@ -151,7 +192,15 @@ func TestReconcileCreateSingleClusterShardedClusterWithExternalDomainSimplest(t 
 	mongosStatefulSetName := fmt.Sprintf("%s-mongos", sc.Name)
 	memberClusterChecks.checkExternalServices(ctx, mongosStatefulSetName, sc.Spec.MongosCount)
 	memberClusterChecks.checkPerPodServicesDontExist(ctx, mongosStatefulSetName, sc.Spec.MongosCount)
-	memberClusterChecks.checkServiceAnnotations(ctx, mongosStatefulSetName, sc.Spec.MongosCount, sc, multicluster.LegacyCentralClusterName, 0, test.ExampleExternalClusterDomains.SingleClusterDomain)
+	memberClusterChecks.checkServiceAnnotations(
+		ctx,
+		mongosStatefulSetName,
+		sc.Spec.MongosCount,
+		sc,
+		multicluster.LegacyCentralClusterName,
+		0,
+		test.ExampleExternalClusterDomains.SingleClusterDomain,
+	)
 
 	configServerStatefulSetName := fmt.Sprintf("%s-config", sc.Name)
 	memberClusterChecks.checkExternalServicesDontExist(ctx, configServerStatefulSetName, sc.Spec.ConfigServerCount)
@@ -200,7 +249,21 @@ func TestShardedClusterRace(t *testing.T) {
 		WithObjects(mock.GetDefaultResources()...).
 		Build()
 
-	reconciler := newShardedClusterReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, nil, omConnectionFactory.GetConnectionFunc, testBackupEnableDelay)
+	reconciler := newShardedClusterReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		nil,
+		omConnectionFactory.GetConnectionFunc,
+		testBackupEnableDelay,
+	)
 
 	testConcurrentReconciles(ctx, t, fakeClient, reconciler, sc1, sc2, sc3)
 }
@@ -223,7 +286,16 @@ func TestReconcileCreateShardedCluster_ScaleDown(t *testing.T) {
 	ctx := context.Background()
 	// First creation
 	sc := test.DefaultClusterBuilder().SetShardCountSpec(4).SetShardCountStatus(4).Build()
-	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	checkReconcileSuccessful(ctx, t, reconciler, sc, clusterClient)
@@ -264,7 +336,16 @@ func TestShardedClusterReconcileContainerImages(t *testing.T) {
 	ctx := context.Background()
 	sc := test.DefaultClusterBuilder().SetVersion("8.0.0").SetShardCountSpec(1).Build()
 
-	reconciler, _, kubeClient, _, err := defaultShardedClusterReconciler(ctx, imageUrlsMock, "2.0.0", "1.0.0", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, kubeClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		imageUrlsMock,
+		"2.0.0",
+		"1.0.0",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
@@ -282,8 +363,16 @@ func TestShardedClusterReconcileContainerImages(t *testing.T) {
 			require.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 
-			assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE", sts.Spec.Template.Spec.InitContainers[0].Image)
-			assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-database:@sha256:MONGODB_DATABASE", sts.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE",
+				sts.Spec.Template.Spec.InitContainers[0].Image,
+			)
+			assert.Equal(
+				t,
+				"quay.io/mongodb/mongodb-kubernetes-database:@sha256:MONGODB_DATABASE",
+				sts.Spec.Template.Spec.Containers[0].Image,
+			)
 		})
 	}
 }
@@ -300,7 +389,16 @@ func TestShardedClusterReconcileContainerImagesWithStaticArchitecture(t *testing
 		databaseRelatedImageEnv: "quay.io/mongodb/mongodb-enterprise-server:@sha256:MONGODB_DATABASE",
 	}
 
-	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, imageUrlsMock, "", "", sc, nil, testBackupEnableDelay, architectures.Static)
+	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		imageUrlsMock,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.Static,
+	)
 	require.NoError(t, err)
 
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
@@ -341,7 +439,16 @@ func TestReconcilePVCResizeShardedCluster(t *testing.T) {
 		sc.Spec.Persistent = util.BooleanRef(true)
 		sc.Spec.ConfigSrvPodSpec.Persistence = &persistence
 		sc.Spec.ShardPodSpec.Persistence = &persistence
-		reconciler, _, c, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+		reconciler, _, c, _, err := defaultShardedClusterReconciler(
+			ctx,
+			nil,
+			"",
+			"",
+			sc,
+			nil,
+			testBackupEnableDelay,
+			architectures.NonStatic,
+		)
 		assert.NoError(t, err)
 
 		// first, we create the shardedCluster with sts and pvc,
@@ -367,7 +474,14 @@ func TestReconcilePVCResizeShardedCluster(t *testing.T) {
 		assert.NoError(t, e)
 
 		// its only one sts in the pvc status, since we haven't started the next one yet
-		testMDBStatus(t, c, ctx, sc, status.PhasePending, status.PVCS{{Phase: pvc.PhasePVCResize, StatefulsetName: test.SCBuilderDefaultName + "-config"}})
+		testMDBStatus(
+			t,
+			c,
+			ctx,
+			sc,
+			status.PhasePending,
+			status.PVCS{{Phase: pvc.PhasePVCResize, StatefulsetName: test.SCBuilderDefaultName + "-config"}},
+		)
 
 		testPVCSizeHasIncreased(t, c, ctx, newSize, test.SCBuilderDefaultName+"-config")
 
@@ -375,7 +489,14 @@ func TestReconcilePVCResizeShardedCluster(t *testing.T) {
 		_, e = reconciler.Reconcile(ctx, requestFromObject(sc))
 		assert.NoError(t, e)
 
-		testMDBStatus(t, c, ctx, sc, status.PhasePending, status.PVCS{{Phase: pvc.PhasePVCResize, StatefulsetName: test.SCBuilderDefaultName + "-config"}})
+		testMDBStatus(
+			t,
+			c,
+			ctx,
+			sc,
+			status.PhasePending,
+			status.PVCS{{Phase: pvc.PhasePVCResize, StatefulsetName: test.SCBuilderDefaultName + "-config"}},
+		)
 
 		for _, claim := range createdConfigPVCs {
 			setPVCWithUpdatedResource(ctx, t, c, &claim)
@@ -435,7 +556,14 @@ func testStatefulsetHasAnnotationAndCorrectSize(t *testing.T, c client.Client, c
 	assert.Len(t, sts.Spec.VolumeClaimTemplates, 1)
 }
 
-func testMDBStatus(t *testing.T, c kubernetesClient.Client, ctx context.Context, sc *mdbv1.MongoDB, expectedMDBPhase status.Phase, expectedPVCS status.PVCS) {
+func testMDBStatus(
+	t *testing.T,
+	c kubernetesClient.Client,
+	ctx context.Context,
+	sc *mdbv1.MongoDB,
+	expectedMDBPhase status.Phase,
+	expectedPVCS status.PVCS,
+) {
 	mdb := mdbv1.MongoDB{}
 	err := c.Get(ctx, kube.ObjectKey(sc.Namespace, sc.Name), &mdb)
 	assert.NoError(t, err)
@@ -443,7 +571,12 @@ func testMDBStatus(t *testing.T, c kubernetesClient.Client, ctx context.Context,
 	require.Equal(t, expectedPVCS, mdb.Status.PVCs)
 }
 
-func getPVCs(t *testing.T, c kubernetesClient.Client, ctx context.Context, sc *mdbv1.MongoDB) ([]corev1.PersistentVolumeClaim, []corev1.PersistentVolumeClaim, []corev1.PersistentVolumeClaim) {
+func getPVCs(
+	t *testing.T,
+	c kubernetesClient.Client,
+	ctx context.Context,
+	sc *mdbv1.MongoDB,
+) ([]corev1.PersistentVolumeClaim, []corev1.PersistentVolumeClaim, []corev1.PersistentVolumeClaim) {
 	sts, err := c.GetStatefulSet(ctx, kube.ObjectKey(sc.Namespace, sc.Name+"-config"))
 	assert.NoError(t, err)
 	createdConfigPVCs := createPVCs(t, sts, c)
@@ -503,7 +636,16 @@ func TestAddDeleteShardedCluster(t *testing.T) {
 	// First we need to create a sharded cluster
 	sc := test.DefaultClusterBuilder().Build()
 
-	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
 		connection.(*om.MockedOmConnection).AgentsDelayCount = 1
 	})
@@ -534,7 +676,11 @@ func TestConstructConfigSrv(t *testing.T) {
 	sc := test.DefaultClusterBuilder().Build()
 	configSrvSpec := createConfigSrvSpec(sc)
 	assert.NotPanics(t, func() {
-		construct.DatabaseStatefulSet(*sc, construct.ConfigServerOptions(configSrvSpec, multicluster.LegacyCentralClusterName, construct.GetPodEnvOptions()), zap.S())
+		construct.DatabaseStatefulSet(
+			*sc,
+			construct.ConfigServerOptions(configSrvSpec, multicluster.LegacyCentralClusterName, construct.GetPodEnvOptions()),
+			zap.S(),
+		)
 	})
 }
 
@@ -563,10 +709,23 @@ func TestUpdateOmDeploymentShardedCluster_HostsRemovedFromMonitoring(t *testing.
 		SetConfigServerCountSpec(3).
 		Build()
 
-	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(om.NewMockedOmConnection(createDeploymentFromShardedCluster(t, sc)))
+	omConnectionFactory := om.NewCachedOMConnectionFactoryWithInitializedConnection(
+		om.NewMockedOmConnection(createDeploymentFromShardedCluster(t, sc)),
+	)
 	kubeClient, _ := mock.NewDefaultFakeClient(sc)
 	assert.NoError(t, createMockStateConfigMap(kubeClient, mock.TestNamespace, sc.Name, initialState))
-	_, reconcileHelper, err := newShardedClusterReconcilerFromResource(ctx, nil, "", "", scScaledDown, nil, kubeClient, omConnectionFactory, testBackupEnableDelay, architectures.NonStatic)
+	_, reconcileHelper, err := newShardedClusterReconcilerFromResource(
+		ctx,
+		nil,
+		"",
+		"",
+		scScaledDown,
+		nil,
+		kubeClient,
+		omConnectionFactory,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	assert.NoError(t, err)
 
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
@@ -587,7 +746,18 @@ func TestUpdateOmDeploymentShardedCluster_HostsRemovedFromMonitoring(t *testing.
 	}, nil)
 
 	mockOm := omConnectionFactory.GetConnection().(*om.MockedOmConnection)
-	assert.Equal(t, workflow.OK(), reconcileHelper.updateOmDeploymentShardedCluster(ctx, mockOm, scScaledDown, deploymentOptions{podEnvVars: &env.PodEnvVars{ProjectID: "abcd"}}, false, zap.S()))
+	assert.Equal(
+		t,
+		workflow.OK(),
+		reconcileHelper.updateOmDeploymentShardedCluster(
+			ctx,
+			mockOm,
+			scScaledDown,
+			deploymentOptions{podEnvVars: &env.PodEnvVars{ProjectID: "abcd"}},
+			false,
+			zap.S(),
+		),
+	)
 
 	mockOm.CheckOrderOfOperations(t, reflect.ValueOf(mockOm.ReadUpdateDeployment), reflect.ValueOf(mockOm.RemoveHost))
 
@@ -607,8 +777,16 @@ func TestPodAntiaffinity_MongodsInsideShardAreSpread(t *testing.T) {
 
 	kubeClient, _ := mock.NewDefaultFakeClient(sc)
 	shardSpec, memberCluster := createShardSpecAndDefaultCluster(kubeClient, sc)
-	firstShardSet := construct.DatabaseStatefulSet(*sc, construct.ShardOptions(0, shardSpec, memberCluster.Name, construct.GetPodEnvOptions()), zap.S())
-	secondShardSet := construct.DatabaseStatefulSet(*sc, construct.ShardOptions(1, shardSpec, memberCluster.Name, construct.GetPodEnvOptions()), zap.S())
+	firstShardSet := construct.DatabaseStatefulSet(
+		*sc,
+		construct.ShardOptions(0, shardSpec, memberCluster.Name, construct.GetPodEnvOptions()),
+		zap.S(),
+	)
+	secondShardSet := construct.DatabaseStatefulSet(
+		*sc,
+		construct.ShardOptions(1, shardSpec, memberCluster.Name, construct.GetPodEnvOptions()),
+		zap.S(),
+	)
 
 	assert.Equal(t, sc.ShardRsName(0), firstShardSet.Spec.Selector.MatchLabels[construct.PodAntiAffinityLabelKey])
 	assert.Equal(t, sc.ShardRsName(1), secondShardSet.Spec.Selector.MatchLabels[construct.PodAntiAffinityLabelKey])
@@ -620,7 +798,10 @@ func TestPodAntiaffinity_MongodsInsideShardAreSpread(t *testing.T) {
 	assert.Equal(t, secondShartPodAffinityTerm.LabelSelector.MatchLabels[construct.PodAntiAffinityLabelKey], sc.ShardRsName(1))
 }
 
-func createShardSpecAndDefaultCluster(client kubernetesClient.Client, sc *mdbv1.MongoDB) (*mdbv1.ShardedClusterComponentSpec, multicluster.MemberCluster) {
+func createShardSpecAndDefaultCluster(
+	client kubernetesClient.Client,
+	sc *mdbv1.MongoDB,
+) (*mdbv1.ShardedClusterComponentSpec, multicluster.MemberCluster) {
 	shardSpec := sc.Spec.ShardSpec.DeepCopy()
 	shardSpec.ClusterSpecList = mdbv1.ClusterSpecList{
 		{
@@ -629,7 +810,12 @@ func createShardSpecAndDefaultCluster(client kubernetesClient.Client, sc *mdbv1.
 		},
 	}
 
-	return shardSpec, multicluster.GetLegacyCentralMemberCluster(sc.Spec.MongodsPerShardCount, 0, client, secrets.SecretClient{KubeClient: client})
+	return shardSpec, multicluster.GetLegacyCentralMemberCluster(
+		sc.Spec.MongodsPerShardCount,
+		0,
+		client,
+		secrets.SecretClient{KubeClient: client},
+	)
 }
 
 func createConfigSrvSpec(sc *mdbv1.MongoDB) *mdbv1.ShardedClusterComponentSpec {
@@ -664,7 +850,16 @@ func TestShardedCluster_WithTLSEnabled_AndX509Enabled_Succeeds(t *testing.T) {
 		SetTLSCA("custom-ca").
 		Build()
 
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	addKubernetesTlsResources(ctx, clusterClient, sc)
 
@@ -683,7 +878,16 @@ func TestShardedCluster_NeedToPublishState(t *testing.T) {
 		Build()
 
 	// perform successful reconciliation to populate all the stateful sets in the mocked client
-	reconciler, reconcilerHelper, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, reconcilerHelper, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	addKubernetesTlsResources(ctx, clusterClient, sc)
 	actualResult, err := reconciler.Reconcile(ctx, requestFromObject(sc))
@@ -694,7 +898,18 @@ func TestShardedCluster_NeedToPublishState(t *testing.T) {
 
 	allConfigs := reconcilerHelper.getAllConfigs(ctx, *sc, getEmptyDeploymentOptions(), zap.S())
 
-	assert.False(t, anyStatefulSetNeedsToPublishStateToOM(ctx, *sc, clusterClient, reconcilerHelper.deploymentState.LastAchievedSpec, allConfigs, architectures.NonStatic, zap.S()))
+	assert.False(
+		t,
+		anyStatefulSetNeedsToPublishStateToOM(
+			ctx,
+			*sc,
+			clusterClient,
+			reconcilerHelper.deploymentState.LastAchievedSpec,
+			allConfigs,
+			architectures.NonStatic,
+			zap.S(),
+		),
+	)
 
 	// attempting to set tls to false
 	require.NoError(t, clusterClient.Get(ctx, kube.ObjectKeyFromApiObject(sc), sc))
@@ -706,7 +921,18 @@ func TestShardedCluster_NeedToPublishState(t *testing.T) {
 
 	// Ops Manager state needs to be published first as we want to reach goal state before unmounting certificates
 	allConfigs = reconcilerHelper.getAllConfigs(ctx, *sc, getEmptyDeploymentOptions(), zap.S())
-	assert.True(t, anyStatefulSetNeedsToPublishStateToOM(ctx, *sc, clusterClient, reconcilerHelper.deploymentState.LastAchievedSpec, allConfigs, architectures.NonStatic, zap.S()))
+	assert.True(
+		t,
+		anyStatefulSetNeedsToPublishStateToOM(
+			ctx,
+			*sc,
+			clusterClient,
+			reconcilerHelper.deploymentState.LastAchievedSpec,
+			allConfigs,
+			architectures.NonStatic,
+			zap.S(),
+		),
+	)
 }
 
 func TestShardedCustomPodSpecTemplate(t *testing.T) {
@@ -759,7 +985,16 @@ func TestShardedCustomPodSpecTemplate(t *testing.T) {
 		Spec: configSrvPodSpec,
 	}).Build()
 
-	reconciler, _, kubeClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, kubeClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	addKubernetesTlsResources(ctx, kubeClient, sc)
@@ -781,10 +1016,24 @@ func TestShardedCustomPodSpecTemplate(t *testing.T) {
 	assertPodSpecSts(t, &statefulSetSc1, shardPodSpec.NodeName, shardPodSpec.Hostname, shardPodSpec.RestartPolicy, architectures.NonStatic)
 
 	// assert Pod Spec for Mongos
-	assertPodSpecSts(t, &statefulSetMongoS, mongosPodSpec.NodeName, mongosPodSpec.Hostname, mongosPodSpec.RestartPolicy, architectures.NonStatic)
+	assertPodSpecSts(
+		t,
+		&statefulSetMongoS,
+		mongosPodSpec.NodeName,
+		mongosPodSpec.Hostname,
+		mongosPodSpec.RestartPolicy,
+		architectures.NonStatic,
+	)
 
 	// assert Pod Spec for ConfigServer
-	assertPodSpecSts(t, &statefulSetScConfig, configSrvPodSpec.NodeName, configSrvPodSpec.Hostname, configSrvPodSpec.RestartPolicy, architectures.NonStatic)
+	assertPodSpecSts(
+		t,
+		&statefulSetScConfig,
+		configSrvPodSpec.NodeName,
+		configSrvPodSpec.Hostname,
+		configSrvPodSpec.RestartPolicy,
+		architectures.NonStatic,
+	)
 
 	podSpecTemplateSc0 := statefulSetSc0.Spec.Template.Spec
 	assert.Len(t, podSpecTemplateSc0.Containers, 2, "Should have 3 containers now")
@@ -857,7 +1106,16 @@ func TestShardedCustomPodStaticSpecTemplate(t *testing.T) {
 		Spec: configSrvPodSpec,
 	}).Build()
 
-	reconciler, _, kubeClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.Static)
+	reconciler, _, kubeClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.Static,
+	)
 	require.NoError(t, err)
 
 	addKubernetesTlsResources(ctx, kubeClient, sc)
@@ -879,30 +1137,64 @@ func TestShardedCustomPodStaticSpecTemplate(t *testing.T) {
 	assertPodSpecSts(t, &statefulSetSc1, shardPodSpec.NodeName, shardPodSpec.Hostname, shardPodSpec.RestartPolicy, architectures.Static)
 
 	// assert Pod Spec for Mongos
-	assertPodSpecSts(t, &statefulSetMongoS, mongosPodSpec.NodeName, mongosPodSpec.Hostname, mongosPodSpec.RestartPolicy, architectures.Static)
+	assertPodSpecSts(
+		t,
+		&statefulSetMongoS,
+		mongosPodSpec.NodeName,
+		mongosPodSpec.Hostname,
+		mongosPodSpec.RestartPolicy,
+		architectures.Static,
+	)
 
 	// assert Pod Spec for ConfigServer
-	assertPodSpecSts(t, &statefulSetScConfig, configSrvPodSpec.NodeName, configSrvPodSpec.Hostname, configSrvPodSpec.RestartPolicy, architectures.Static)
+	assertPodSpecSts(
+		t,
+		&statefulSetScConfig,
+		configSrvPodSpec.NodeName,
+		configSrvPodSpec.Hostname,
+		configSrvPodSpec.RestartPolicy,
+		architectures.Static,
+	)
 
 	podSpecTemplateSc0 := statefulSetSc0.Spec.Template.Spec
 	assert.Len(t, podSpecTemplateSc0.Containers, 4, "Should have 4 containers (3 base + 1 custom)")
 	assert.Equal(t, util.AgentContainerName, podSpecTemplateSc0.Containers[0].Name, "Agent container should be first alphabetically")
-	assert.Equal(t, "my-custom-container-sc", podSpecTemplateSc0.Containers[len(podSpecTemplateSc0.Containers)-1].Name, "Custom container should be last")
+	assert.Equal(
+		t,
+		"my-custom-container-sc",
+		podSpecTemplateSc0.Containers[len(podSpecTemplateSc0.Containers)-1].Name,
+		"Custom container should be last",
+	)
 
 	podSpecTemplateSc1 := statefulSetSc1.Spec.Template.Spec
 	assert.Len(t, podSpecTemplateSc1.Containers, 4, "Should have 4 containers (3 base + 1 custom)")
 	assert.Equal(t, util.AgentContainerName, podSpecTemplateSc1.Containers[0].Name, "Agent container should be first alphabetically")
-	assert.Equal(t, "my-custom-container-sc", podSpecTemplateSc1.Containers[len(podSpecTemplateSc1.Containers)-1].Name, "Custom container should be last")
+	assert.Equal(
+		t,
+		"my-custom-container-sc",
+		podSpecTemplateSc1.Containers[len(podSpecTemplateSc1.Containers)-1].Name,
+		"Custom container should be last",
+	)
 
 	podSpecTemplateMongoS := statefulSetMongoS.Spec.Template.Spec
 	assert.Len(t, podSpecTemplateMongoS.Containers, 4, "Should have 4 containers (3 base + 1 custom)")
 	assert.Equal(t, util.AgentContainerName, podSpecTemplateMongoS.Containers[0].Name, "Agent container should be first alphabetically")
-	assert.Equal(t, "my-custom-container-mongos", podSpecTemplateMongoS.Containers[len(podSpecTemplateMongoS.Containers)-1].Name, "Custom container should be last")
+	assert.Equal(
+		t,
+		"my-custom-container-mongos",
+		podSpecTemplateMongoS.Containers[len(podSpecTemplateMongoS.Containers)-1].Name,
+		"Custom container should be last",
+	)
 
 	podSpecTemplateScConfig := statefulSetScConfig.Spec.Template.Spec
 	assert.Len(t, podSpecTemplateScConfig.Containers, 4, "Should have 4 containers (3 base + 1 custom)")
 	assert.Equal(t, util.AgentContainerName, podSpecTemplateScConfig.Containers[0].Name, "Agent container should be first alphabetically")
-	assert.Equal(t, "my-custom-container-config", podSpecTemplateScConfig.Containers[len(podSpecTemplateScConfig.Containers)-1].Name, "Custom container should be last")
+	assert.Equal(
+		t,
+		"my-custom-container-config",
+		podSpecTemplateScConfig.Containers[len(podSpecTemplateScConfig.Containers)-1].Name,
+		"Custom container should be last",
+	)
 }
 
 func TestFeatureControlsNoAuth(t *testing.T) {
@@ -910,7 +1202,21 @@ func TestFeatureControlsNoAuth(t *testing.T) {
 	sc := test.DefaultClusterBuilder().RemoveAuth().Build()
 	omConnectionFactory := om.NewCachedOMConnectionFactory(omConnectionFactoryFuncSettingVersion())
 	fakeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, sc)
-	reconciler := newShardedClusterReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, nil, omConnectionFactory.GetConnectionFunc, testBackupEnableDelay)
+	reconciler := newShardedClusterReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		nil,
+		omConnectionFactory.GetConnectionFunc,
+		testBackupEnableDelay,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, sc, fakeClient)
 
@@ -939,7 +1245,18 @@ func TestScalingShardedCluster_ScalesOneMemberAtATime_WhenScalingUp(t *testing.T
 		Build()
 
 	clusterClient, omConnectionFactory := mock.NewDefaultFakeClient(sc)
-	reconciler, _, err := newShardedClusterReconcilerFromResource(ctx, nil, "", "", sc, nil, clusterClient, omConnectionFactory, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, err := newShardedClusterReconcilerFromResource(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		clusterClient,
+		omConnectionFactory,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	// perform initial reconciliation, so we are not creating a new resource
@@ -1028,7 +1345,16 @@ func TestScalingShardedCluster_ScalesOneMemberAtATime_WhenScalingDown(t *testing
 		SetShardCountStatus(3).
 		Build()
 
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	// perform initial reconciliation so we are not creating a new resource
 	checkReconcileSuccessful(ctx, t, reconciler, sc, clusterClient)
@@ -1097,7 +1423,12 @@ func TestScalingShardedCluster_ScalesOneMemberAtATime_WhenScalingDown(t *testing
 	})
 	t.Run("Final reconciliation", func(t *testing.T) {
 		performReconciliation(false)
-		assert.Equal(t, 1, sc.Status.ShardCount, "Upon finishing reconciliation, the original shard count should be set to the current value")
+		assert.Equal(
+			t,
+			1,
+			sc.Status.ShardCount,
+			"Upon finishing reconciliation, the original shard count should be set to the current value",
+		)
 		assert.Equal(t, 1, sc.Status.MongosCount)
 		assert.Equal(t, 1, sc.Status.ConfigServerCount)
 		assert.Equal(t, int32(3), *getShard(0).Spec.Replicas)
@@ -1111,7 +1442,21 @@ func TestFeatureControlsAuthEnabled(t *testing.T) {
 	sc := test.DefaultClusterBuilder().Build()
 	omConnectionFactory := om.NewCachedOMConnectionFactory(omConnectionFactoryFuncSettingVersion())
 	fakeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, sc)
-	reconciler := newShardedClusterReconciler(ctx, fakeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, nil, omConnectionFactory.GetConnectionFunc, testBackupEnableDelay)
+	reconciler := newShardedClusterReconciler(
+		ctx,
+		fakeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		nil,
+		omConnectionFactory.GetConnectionFunc,
+		testBackupEnableDelay,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, sc, fakeClient)
 
@@ -1146,7 +1491,16 @@ func TestShardedClusterPortsAreConfigurable_WithAdditionalMongoConfig(t *testing
 		SetShardAdditionalConfig(shardConfig).
 		Build()
 
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	checkReconcileSuccessful(ctx, t, reconciler, sc, clusterClient)
@@ -1176,14 +1530,27 @@ func TestShardedCluster_ConfigMapAndSecretWatched(t *testing.T) {
 	ctx := context.Background()
 	sc := test.DefaultClusterBuilder().Build()
 
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	checkReconcileSuccessful(ctx, t, reconciler, sc, clusterClient)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, sc.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, sc.Spec.Credentials)}:              {kube.ObjectKey(mock.TestNamespace, sc.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, sc.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, sc.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, sc.Name),
+		},
 	}
 
 	assert.Equal(t, reconciler.resourceWatcher.GetWatchedResources(), expected)
@@ -1195,7 +1562,16 @@ func TestShardedClusterTLSAndInternalAuthResourcesWatched(t *testing.T) {
 	ctx := context.Background()
 	sc := test.DefaultClusterBuilder().SetShardCountSpec(1).EnableTLS().SetTLSCA("custom-ca").Build()
 	sc.Spec.Security.Authentication.InternalCluster = "x509"
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	addKubernetesTlsResources(ctx, clusterClient, sc)
@@ -1243,7 +1619,16 @@ func TestBackupConfiguration_ShardedCluster(t *testing.T) {
 		}).
 		Build()
 
-	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	omConnectionFactory.SetPostCreateHook(func(c om.Connection) {
 		// 4 because config server + num shards + 1 for entity to represent the sharded cluster itself
@@ -1284,7 +1669,11 @@ func TestBackupConfiguration_ShardedCluster(t *testing.T) {
 		// Re-fetch sc so its ResourceVersion is current after the status patch
 		require.NoError(t, clusterClient.Get(ctx, mock.ObjectKeyFromApiObject(sc), sc))
 		assert.Equal(t, status.PhasePending, sc.Status.Phase, "expected CR to be in Pending phase during backup enable delay")
-		assert.True(t, strings.Contains(sc.Status.Message, backup.BackupEnableDelayPendingMessage), "expected CR message to contain backup enable delay message")
+		assert.True(
+			t,
+			strings.Contains(sc.Status.Message, backup.BackupEnableDelayPendingMessage),
+			"expected CR message to contain backup enable delay message",
+		)
 
 		// Simulate that the backup start delay (60s, the default) has elapsed.
 		// The reconciler overwrites sc.Status from the deployment state configmap before calling
@@ -1357,7 +1746,16 @@ func TestBackupConfiguration_ShardedCluster_DelayStateResetWhenBackupDisabledDur
 		}).
 		Build()
 
-	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	omConnectionFactory.SetPostCreateHook(func(c om.Connection) {
 		clusterIds := []string{"1", "2", "3", "4"}
@@ -1392,7 +1790,12 @@ func TestBackupConfiguration_ShardedCluster_DelayStateResetWhenBackupDisabledDur
 	checkReconcileSuccessful(ctx, t, reconciler, sc, clusterClient)
 
 	require.NoError(t, clusterClient.Get(ctx, mock.ObjectKeyFromApiObject(sc), sc))
-	assert.NotEqual(t, backup.BackupEnableDelayPendingMessage, sc.Status.Message, "expected delay message to be cleared when backup is disabled during delay")
+	assert.NotEqual(
+		t,
+		backup.BackupEnableDelayPendingMessage,
+		sc.Status.Message,
+		"expected delay message to be cleared when backup is disabled during delay",
+	)
 }
 
 func TestBackupConfiguration_ShardedCluster_NegativeDelay(t *testing.T) {
@@ -1405,7 +1808,16 @@ func TestBackupConfiguration_ShardedCluster_NegativeDelay(t *testing.T) {
 		}).
 		Build()
 
-	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testNoBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testNoBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	omConnectionFactory.SetPostCreateHook(func(c om.Connection) {
@@ -1484,7 +1896,16 @@ func TestTlsConfigPrefix_ForShardedCluster(t *testing.T) {
 		}).
 		Build()
 
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 
 	createShardedClusterTLSSecretsFromCustomCerts(ctx, sc, "my-prefix", clusterClient)
@@ -1528,7 +1949,16 @@ func TestShardSpecificPodSpec(t *testing.T) {
 		},
 	}).Build()
 
-	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, clusterClient, _, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	addKubernetesTlsResources(ctx, clusterClient, sc)
 	checkReconcileSuccessful(ctx, t, reconciler, sc, clusterClient)
@@ -1540,7 +1970,14 @@ func TestShardSpecificPodSpec(t *testing.T) {
 	assert.NoError(t, err)
 
 	// shard0 should have the override
-	assertPodSpecSts(t, &statefulSetSc0, shard0PodSpec.NodeName, shard0PodSpec.Hostname, shard0PodSpec.RestartPolicy, architectures.NonStatic)
+	assertPodSpecSts(
+		t,
+		&statefulSetSc0,
+		shard0PodSpec.NodeName,
+		shard0PodSpec.Hostname,
+		shard0PodSpec.RestartPolicy,
+		architectures.NonStatic,
+	)
 
 	// shard1 should have the common one
 	assertPodSpecSts(t, &statefulSetSc1, shardPodSpec.NodeName, shardPodSpec.Hostname, shardPodSpec.RestartPolicy, architectures.NonStatic)
@@ -1570,7 +2007,11 @@ func TestShardedClusterAgentVersionMapping(t *testing.T) {
 	}
 
 	// Override each sts of the sharded cluster
-	overridenResource := test.DefaultClusterBuilder().SetMongosPodSpecTemplate(podTemplate).SetPodConfigSvrSpecTemplate(podTemplate).SetShardPodSpec(podTemplate).Build()
+	overridenResource := test.DefaultClusterBuilder().
+		SetMongosPodSpecTemplate(podTemplate).
+		SetPodConfigSvrSpecTemplate(podTemplate).
+		SetShardPodSpec(podTemplate).
+		Build()
 	overridenResources := testReconciliationResources{
 		Resource:          overridenResource,
 		ReconcilerFactory: reconcilerFactory,
@@ -1579,7 +2020,13 @@ func TestShardedClusterAgentVersionMapping(t *testing.T) {
 	agentVersionMappingTest(ctx, t, defaultResources, overridenResources)
 }
 
-func assertPodSpecSts(t *testing.T, sts *appsv1.StatefulSet, nodeName, hostName string, restartPolicy corev1.RestartPolicy, defaultArchitecture architectures.DefaultArchitecture) {
+func assertPodSpecSts(
+	t *testing.T,
+	sts *appsv1.StatefulSet,
+	nodeName, hostName string,
+	restartPolicy corev1.RestartPolicy,
+	defaultArchitecture architectures.DefaultArchitecture,
+) {
 	podSpecTemplate := sts.Spec.Template.Spec
 	// ensure values were passed to the stateful set
 	assert.Equal(t, nodeName, podSpecTemplate.NodeName)
@@ -1594,12 +2041,29 @@ func assertPodSpecSts(t *testing.T, sts *appsv1.StatefulSet, nodeName, hostName 
 	}
 }
 
-func createMongosProcesses(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, mdb *mdbv1.MongoDB, certificateFilePath string) []om.Process {
+func createMongosProcesses(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	mdb *mdbv1.MongoDB,
+	certificateFilePath string,
+) []om.Process {
 	hostnames, names := dns.GetDnsForStatefulSet(set, mdb.Spec.GetClusterDomain(), nil)
 	processes := make([]om.Process, len(hostnames))
 
 	for idx, hostname := range hostnames {
-		processes[idx] = om.NewMongosProcess(names[idx], hostname, mongoDBImage, forceEnterprise, mdb.Spec.MongosSpec.GetAdditionalMongodConfig(), mdb.GetSpec(), certificateFilePath, mdb.Annotations, mdb.CalculateFeatureCompatibilityVersion(), architectures.NonStatic)
+		processes[idx] = om.NewMongosProcess(
+			names[idx],
+			hostname,
+			mongoDBImage,
+			forceEnterprise,
+			mdb.Spec.MongosSpec.GetAdditionalMongodConfig(),
+			mdb.GetSpec(),
+			certificateFilePath,
+			mdb.Annotations,
+			mdb.CalculateFeatureCompatibilityVersion(),
+			architectures.NonStatic,
+		)
 	}
 
 	return processes
@@ -1618,7 +2082,13 @@ func createDeploymentFromShardedCluster(t *testing.T, updatable v1.CustomResourc
 			construct.GetPodEnvOptions(),
 		)
 		shardSts := construct.DatabaseStatefulSet(*sh, shardOptions, zap.S())
-		shards[i], _ = buildReplicaSetFromProcesses(shardSts.Name, createShardProcesses("fake-mongoDBImage", false, shardSts, sh, "", architectures.NonStatic), sh, sh.Spec.GetMemberOptions(), om.NewDeployment())
+		shards[i], _ = buildReplicaSetFromProcesses(
+			shardSts.Name,
+			createShardProcesses("fake-mongoDBImage", false, shardSts, sh, "", architectures.NonStatic),
+			sh,
+			sh.Spec.GetMemberOptions(),
+			om.NewDeployment(),
+		)
 	}
 
 	desiredMongosConfig := createMongosSpec(sh)
@@ -1639,7 +2109,13 @@ func createDeploymentFromShardedCluster(t *testing.T, updatable v1.CustomResourc
 		construct.GetPodEnvOptions(),
 	)
 	configSvrSts := construct.DatabaseStatefulSet(*sh, configServerOptions, zap.S())
-	configRs, _ := buildReplicaSetFromProcesses(configSvrSts.Name, createConfigSrvProcesses("fake-mongoDBImage", false, configSvrSts, sh, "", architectures.NonStatic), sh, sh.Spec.GetMemberOptions(), om.NewDeployment())
+	configRs, _ := buildReplicaSetFromProcesses(
+		configSvrSts.Name,
+		createConfigSrvProcesses("fake-mongoDBImage", false, configSvrSts, sh, "", architectures.NonStatic),
+		sh,
+		sh.Spec.GetMemberOptions(),
+		om.NewDeployment(),
+	)
 
 	d := om.NewDeployment()
 	_, err := d.MergeShardedCluster(om.DeploymentShardedClusterMergeOptions{
@@ -1654,18 +2130,77 @@ func createDeploymentFromShardedCluster(t *testing.T, updatable v1.CustomResourc
 	return d
 }
 
-func defaultShardedClusterReconciler(ctx context.Context, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, sc *mdbv1.MongoDB, globalMemberClustersMap map[string]client.Client, backupEnableDelay time.Duration, arch architectures.DefaultArchitecture) (*ReconcileMongoDbShardedCluster, *ShardedClusterReconcileHelper, kubernetesClient.Client, *om.CachedOMConnectionFactory, error) {
+func defaultShardedClusterReconciler(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	sc *mdbv1.MongoDB,
+	globalMemberClustersMap map[string]client.Client,
+	backupEnableDelay time.Duration,
+	arch architectures.DefaultArchitecture,
+) (*ReconcileMongoDbShardedCluster, *ShardedClusterReconcileHelper, kubernetesClient.Client, *om.CachedOMConnectionFactory, error) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(sc)
-	r, reconcileHelper, err := newShardedClusterReconcilerFromResource(ctx, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, sc, globalMemberClustersMap, kubeClient, omConnectionFactory, backupEnableDelay, arch)
+	r, reconcileHelper, err := newShardedClusterReconcilerFromResource(
+		ctx,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		sc,
+		globalMemberClustersMap,
+		kubeClient,
+		omConnectionFactory,
+		backupEnableDelay,
+		arch,
+	)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 	return r, reconcileHelper, kubeClient, omConnectionFactory, nil
 }
 
-func newShardedClusterReconcilerFromResource(ctx context.Context, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, sc *mdbv1.MongoDB, globalMemberClustersMap map[string]client.Client, kubeClient kubernetesClient.Client, omConnectionFactory *om.CachedOMConnectionFactory, backupEnableDelay time.Duration, arch architectures.DefaultArchitecture) (*ReconcileMongoDbShardedCluster, *ShardedClusterReconcileHelper, error) {
-	r := newShardedClusterReconciler(ctx, kubeClient, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, false, false, false, "", arch, globalMemberClustersMap, omConnectionFactory.GetConnectionFunc, backupEnableDelay)
-	reconcileHelper, err := NewShardedClusterReconcilerHelper(ctx, r.ReconcileCommonController, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, false, false, false, "", arch, sc, globalMemberClustersMap, omConnectionFactory.GetConnectionFunc, zap.S(), backupEnableDelay)
+func newShardedClusterReconcilerFromResource(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	sc *mdbv1.MongoDB,
+	globalMemberClustersMap map[string]client.Client,
+	kubeClient kubernetesClient.Client,
+	omConnectionFactory *om.CachedOMConnectionFactory,
+	backupEnableDelay time.Duration,
+	arch architectures.DefaultArchitecture,
+) (*ReconcileMongoDbShardedCluster, *ShardedClusterReconcileHelper, error) {
+	r := newShardedClusterReconciler(
+		ctx,
+		kubeClient,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		false,
+		false,
+		false,
+		"",
+		arch,
+		globalMemberClustersMap,
+		omConnectionFactory.GetConnectionFunc,
+		backupEnableDelay,
+	)
+	reconcileHelper, err := NewShardedClusterReconcilerHelper(
+		ctx,
+		r.ReconcileCommonController,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		false,
+		false,
+		false,
+		"",
+		arch,
+		sc,
+		globalMemberClustersMap,
+		omConnectionFactory.GetConnectionFunc,
+		zap.S(),
+		backupEnableDelay,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1734,20 +2269,39 @@ func SingleClusterShardedScalingWithOverridesTestCase(t *testing.T, tc SingleClu
 			memberCount := distribution[multicluster.LegacyCentralClusterName]
 			shardMemberCounts = append(shardMemberCounts, memberCount)
 		}
-		allHostnames, _ := generateAllHostsSingleCluster(sc, mongosCount, configSrvCount, shardMemberCounts, test.ClusterLocalDomains, test.NoneExternalClusterDomains)
+		allHostnames, _ := generateAllHostsSingleCluster(
+			sc,
+			mongosCount,
+			configSrvCount,
+			shardMemberCounts,
+			test.ClusterLocalDomains,
+			test.NoneExternalClusterDomains,
+		)
 		connection.(*om.MockedOmConnection).AddHosts(allHostnames)
 	}
 
 	for _, scalingStep := range tc.scalingSteps {
 		t.Run(scalingStep.name, func(t *testing.T) {
-			reconciler, reconcilerHelper, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+			reconciler, reconcilerHelper, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(
+				ctx,
+				nil,
+				"",
+				"",
+				sc,
+				nil,
+				testBackupEnableDelay,
+				architectures.NonStatic,
+			)
 			_ = omConnectionFactory.GetConnectionFunc(&om.OMContext{GroupName: om.TestGroupName})
 			require.NoError(t, err)
 			clusterMapping := reconcilerHelper.deploymentState.ClusterMapping
 
 			var expectedShardDistribution []map[string]int
 			for _, memberCount := range scalingStep.expectedShardDistribution {
-				expectedShardDistribution = append(expectedShardDistribution, map[string]int{multicluster.LegacyCentralClusterName: memberCount})
+				expectedShardDistribution = append(
+					expectedShardDistribution,
+					map[string]int{multicluster.LegacyCentralClusterName: memberCount},
+				)
 			}
 
 			addAllHostsWithDistribution(omConnectionFactory.GetConnection(), mongosCount, configSrvCount, expectedShardDistribution)
@@ -1762,7 +2316,14 @@ func SingleClusterShardedScalingWithOverridesTestCase(t *testing.T, tc SingleClu
 			reconcileUntilSuccessful(ctx, t, reconciler, sc, kubeClient, []client.Client{kubeClient}, nil, false)
 
 			// Verify scaled deployment
-			checkCorrectShardDistributionInStatefulSets(t, ctx, sc, clusterMapping, map[string]client.Client{multicluster.LegacyCentralClusterName: kubeClient}, expectedShardDistribution)
+			checkCorrectShardDistributionInStatefulSets(
+				t,
+				ctx,
+				sc,
+				clusterMapping,
+				map[string]client.Client{multicluster.LegacyCentralClusterName: kubeClient},
+				expectedShardDistribution,
+			)
 		})
 	}
 }
@@ -1862,7 +2423,16 @@ func TestSharderClusterRoleAnnotationIsSet(t *testing.T) {
 	}
 
 	sc := test.DefaultClusterBuilder().SetRoles([]mdbv1.MongoDBRole{role}).Build()
-	reconciler, _, cl, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	reconciler, _, cl, omConnectionFactory, err := defaultShardedClusterReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		sc,
+		nil,
+		testBackupEnableDelay,
+		architectures.NonStatic,
+	)
 	require.NoError(t, err)
 	checkReconcileSuccessful(ctx, t, reconciler, sc, cl)
 
@@ -1900,7 +2470,13 @@ func TestSharderClusterRoleAnnotationIsSet(t *testing.T) {
 	assert.Len(t, roles, 0)
 }
 
-func generateHostsWithDistributionSingleCluster(stsName string, namespace string, memberCount int, clusterDomain string, externalClusterDomain string) ([]string, []string) {
+func generateHostsWithDistributionSingleCluster(
+	stsName string,
+	namespace string,
+	memberCount int,
+	clusterDomain string,
+	externalClusterDomain string,
+) ([]string, []string) {
 	var hosts []string
 	var podNames []string
 	for podIdx := range memberCount {
@@ -1922,19 +2498,44 @@ func getSingleClusterFQDN(stsName string, namespace string, podIdx int, clusterD
 	return fmt.Sprintf("%s-svc.%s.svc.%s", getPodNameSingleCluster(stsName, podIdx), namespace, clusterDomain)
 }
 
-func generateAllHostsSingleCluster(sc *mdbv1.MongoDB, mongosCount int, configSrvCount int, shardsMemberCounts []int, clusterDomain test.ClusterDomains, externalClusterDomain test.ClusterDomains) ([]string, []string) {
+func generateAllHostsSingleCluster(
+	sc *mdbv1.MongoDB,
+	mongosCount int,
+	configSrvCount int,
+	shardsMemberCounts []int,
+	clusterDomain test.ClusterDomains,
+	externalClusterDomain test.ClusterDomains,
+) ([]string, []string) {
 	var allHosts []string
 	var allPodNames []string
-	podNames, hosts := generateHostsWithDistributionSingleCluster(sc.MongosRsName(), sc.Namespace, mongosCount, clusterDomain.MongosExternalDomain, externalClusterDomain.MongosExternalDomain)
+	podNames, hosts := generateHostsWithDistributionSingleCluster(
+		sc.MongosRsName(),
+		sc.Namespace,
+		mongosCount,
+		clusterDomain.MongosExternalDomain,
+		externalClusterDomain.MongosExternalDomain,
+	)
 	allHosts = append(allHosts, hosts...)
 	allPodNames = append(allPodNames, podNames...)
 
-	podNames, hosts = generateHostsWithDistributionSingleCluster(sc.ConfigRsName(), sc.Namespace, configSrvCount, clusterDomain.ConfigServerExternalDomain, externalClusterDomain.ConfigServerExternalDomain)
+	podNames, hosts = generateHostsWithDistributionSingleCluster(
+		sc.ConfigRsName(),
+		sc.Namespace,
+		configSrvCount,
+		clusterDomain.ConfigServerExternalDomain,
+		externalClusterDomain.ConfigServerExternalDomain,
+	)
 	allHosts = append(allHosts, hosts...)
 	allPodNames = append(allPodNames, podNames...)
 
 	for shardIdx := 0; shardIdx < sc.Spec.ShardCount; shardIdx++ {
-		podNames, hosts = generateHostsWithDistributionSingleCluster(sc.ShardRsName(shardIdx), sc.Namespace, shardsMemberCounts[shardIdx], clusterDomain.ShardsExternalDomain, externalClusterDomain.ShardsExternalDomain)
+		podNames, hosts = generateHostsWithDistributionSingleCluster(
+			sc.ShardRsName(shardIdx),
+			sc.Namespace,
+			shardsMemberCounts[shardIdx],
+			clusterDomain.ShardsExternalDomain,
+			externalClusterDomain.ShardsExternalDomain,
+		)
 		allHosts = append(allHosts, hosts...)
 		allPodNames = append(allPodNames, podNames...)
 	}

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -51,10 +51,34 @@ import (
 
 // AddStandaloneController creates a new MongoDbStandalone Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func AddStandaloneController(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture) error {
+func AddStandaloneController(
+	ctx context.Context,
+	mgr manager.Manager,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) error {
 	// Create a new controller
-	reconciler := newStandaloneReconciler(ctx, mgr.GetClient(), imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, om.NewOpsManagerConnection)
-	c, err := controller.New(util.MongoDbStandaloneController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+	reconciler := newStandaloneReconciler(
+		ctx,
+		mgr.GetClient(),
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		forceEnterprise,
+		enableClusterMongoDBRoles,
+		agentDebug,
+		agentDebugImage,
+		defaultArchitecture,
+		om.NewOpsManagerConnection,
+	)
+	c, err := controller.New(
+		util.MongoDbStandaloneController,
+		mgr,
+		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)},
+	) // nolint:forbidigo
 	if err != nil {
 		return err
 	}
@@ -113,7 +137,18 @@ func AddStandaloneController(ctx context.Context, mgr manager.Manager, imageUrls
 	return nil
 }
 
-func newStandaloneReconciler(ctx context.Context, kubeClient client.Client, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise bool, enableClusterMongoDBRoles bool, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, omFunc om.ConnectionFactory) *ReconcileMongoDbStandalone {
+func newStandaloneReconciler(
+	ctx context.Context,
+	kubeClient client.Client,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise bool,
+	enableClusterMongoDBRoles bool,
+	agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	omFunc om.ConnectionFactory,
+) *ReconcileMongoDbStandalone {
 	return &ReconcileMongoDbStandalone{
 		ReconcileCommonController: NewReconcileCommonController(ctx, kubeClient),
 		omConnectionFactory:       omFunc,
@@ -158,7 +193,13 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 	}
 
 	if !architectures.IsRunningStaticArchitecture(s.Annotations, r.defaultArchitecture) {
-		agents.UpgradeAllIfNeeded(ctx, agents.ClientSecret{Client: r.client, SecretClient: r.SecretClient}, r.omConnectionFactory, GetWatchedNamespace(), false)
+		agents.UpgradeAllIfNeeded(
+			ctx,
+			agents.ClientSecret{Client: r.client, SecretClient: r.SecretClient},
+			r.omConnectionFactory,
+			GetWatchedNamespace(),
+			false,
+		)
 	}
 
 	if err := s.ProcessValidationsOnReconcile(nil); err != nil {
@@ -174,7 +215,16 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 		return r.updateStatus(ctx, s, workflow.Failed(err), log)
 	}
 
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, s.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		s.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, s, workflow.Failed(xerrors.Errorf("Failed to prepare Ops Manager connection: %w", err)), log)
 	}
@@ -262,8 +312,12 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 		PodEnvVars(podVars),
 		WithVaultConfig(vaultConfig),
 		WithAdditionalMongodConfig(s.Spec.GetAdditionalMongodConfig()),
-		WithInitDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion)),
-		WithDatabaseNonStaticImage(images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion)),
+		WithInitDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.InitDatabaseImageUrlEnv, r.initDatabaseNonStaticImageVersion),
+		),
+		WithDatabaseNonStaticImage(
+			images.ContainerImage(r.imageUrls, util.NonStaticDatabaseEnterpriseImage, r.databaseNonStaticImageVersion),
+		),
 		WithAgentImage(images.ContainerImage(r.imageUrls, util.AgentImageUrlEnv, automationAgentVersion)),
 		WithCustomAgentURL(r.customAgentURL),
 
@@ -288,9 +342,11 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 	agentCertSecretName := s.GetSecurity().AgentClientCertificateSecretName(s.Name)
 	_, agentCertPath := r.agentCertHashAndPath(ctx, log, s.Namespace, agentCertSecretName, databaseSecretPath)
 
-	status := workflow.RunInGivenOrder(publishAutomationConfigFirst(ctx, r.client, *s, lastSpec, standaloneOpts, r.defaultArchitecture, log),
+	status := workflow.RunInGivenOrder(
+		publishAutomationConfigFirst(ctx, r.client, *s, lastSpec, standaloneOpts, r.defaultArchitecture, log),
 		func() workflow.Status {
-			return r.updateOmDeployment(ctx, conn, s, sts, false, agentCertPath, log).OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
+			return r.updateOmDeployment(ctx, conn, s, sts, false, agentCertPath, log).
+				OnErrorPrepend("Failed to create/update (Ops Manager reconciliation phase):")
 		},
 		func() workflow.Status {
 			mutatedSts, err := create.DatabaseInKubernetes(ctx, r.client, *s, sts, standaloneOpts, log)
@@ -305,7 +361,8 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 
 			log.Info("Updated StatefulSet for standalone")
 			return workflow.OK()
-		})
+		},
+	)
 
 	if !status.IsOK() {
 		return r.updateStatus(ctx, s, status, log)
@@ -343,26 +400,60 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 	}
 
 	log.Infof("Finished reconciliation for MongoDbStandalone! %s", completionMessage(conn.BaseURL(), conn.GroupID()))
-	return r.updateStatus(ctx, s, status, log, mdbstatus.NewBaseUrlOption(deployment.Link(conn.BaseURL(), conn.GroupID())), mdbstatus.NewProjectIdOption(conn.GroupID()))
+	return r.updateStatus(
+		ctx,
+		s,
+		status,
+		log,
+		mdbstatus.NewBaseUrlOption(deployment.Link(conn.BaseURL(), conn.GroupID())),
+		mdbstatus.NewProjectIdOption(conn.GroupID()),
+	)
 }
 
-func (r *ReconcileMongoDbStandalone) updateOmDeployment(ctx context.Context, conn om.Connection, s *mdbv1.MongoDB, set appsv1.StatefulSet, isRecovering bool, agentCertPath string, log *zap.SugaredLogger) workflow.Status {
+func (r *ReconcileMongoDbStandalone) updateOmDeployment(
+	ctx context.Context,
+	conn om.Connection,
+	s *mdbv1.MongoDB,
+	set appsv1.StatefulSet,
+	isRecovering bool,
+	agentCertPath string,
+	log *zap.SugaredLogger,
+) workflow.Status {
 	if err := agents.WaitForRsAgentsToRegister(set, 0, s.Spec.GetClusterDomain(), conn, log, s); err != nil {
 		return workflow.Failed(err)
 	}
 
 	// TODO standalone PR
-	status, additionalReconciliationRequired := r.updateOmAuthentication(ctx, conn, []string{set.Name}, s, agentCertPath, "", "", isRecovering, log)
+	status, additionalReconciliationRequired := r.updateOmAuthentication(
+		ctx,
+		conn,
+		[]string{set.Name},
+		s,
+		agentCertPath,
+		"",
+		"",
+		isRecovering,
+		log,
+	)
 	if !status.IsOK() {
 		return status
 	}
 
-	standaloneOmObject := createProcess(r.imageUrls[util.MongodbImageEnv], r.forceEnterprise, set, util.DatabaseContainerName, s, r.defaultArchitecture)
+	standaloneOmObject := createProcess(
+		r.imageUrls[util.MongodbImageEnv],
+		r.forceEnterprise,
+		set,
+		util.DatabaseContainerName,
+		s,
+		r.defaultArchitecture,
+	)
 	err := conn.ReadUpdateDeployment(
 		func(d om.Deployment) error {
 			excessProcesses := d.GetNumberOfExcessProcesses(s.Name)
 			if excessProcesses > 0 {
-				return xerrors.Errorf("cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)")
+				return xerrors.Errorf(
+					"cannot have more than 1 MongoDB Cluster per project (see https://docs.mongodb.com/kubernetes-operator/stable/tutorial/migrate-to-single-resource/)",
+				)
 			}
 
 			lastStandaloneConfig, err := s.GetLastAdditionalMongodConfigByType(mdbv1.StandaloneConfig)
@@ -404,7 +495,16 @@ func (r *ReconcileMongoDbStandalone) OnDelete(ctx context.Context, obj runtime.O
 		return err
 	}
 
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, s.Namespace, true, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		s.Namespace,
+		true,
+		log,
+	)
 	if err != nil {
 		return err
 	}
@@ -438,7 +538,10 @@ func (r *ReconcileMongoDbStandalone) OnDelete(ctx context.Context, obj runtime.O
 	log.Infow("Stop monitoring removed hosts", "removedHosts", hostsToRemove)
 	if err := host.StopMonitoring(conn, hostsToRemove, log); err != nil {
 		// StopMonitoring may fail with 401 if hosts are already removed or auth is misconfigured.
-		errs = multierror.Append(errs, xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err))
+		errs = multierror.Append(
+			errs,
+			xerrors.Errorf("failed to stop monitoring for hosts %v. Continuing with cleanup: %w", hostsToRemove, err),
+		)
 	}
 
 	if err := r.clearProjectAuthenticationSettings(ctx, conn, s, processNames, log); err != nil {
@@ -461,8 +564,26 @@ func (r *ReconcileMongoDbStandalone) OnDelete(ctx context.Context, obj runtime.O
 	return errs
 }
 
-func createProcess(mongoDBImage string, forceEnterprise bool, set appsv1.StatefulSet, containerName string, s *mdbv1.MongoDB, defaultArchitecture architectures.DefaultArchitecture) om.Process {
+func createProcess(
+	mongoDBImage string,
+	forceEnterprise bool,
+	set appsv1.StatefulSet,
+	containerName string,
+	s *mdbv1.MongoDB,
+	defaultArchitecture architectures.DefaultArchitecture,
+) om.Process {
 	hostnames, _ := dns.GetDnsForStatefulSet(set, s.Spec.GetClusterDomain(), nil)
-	process := om.NewMongodProcess(s.Name, hostnames[0], mongoDBImage, forceEnterprise, s.Spec.GetAdditionalMongodConfig(), s.GetSpec(), "", s.Annotations, s.CalculateFeatureCompatibilityVersion(), defaultArchitecture)
+	process := om.NewMongodProcess(
+		s.Name,
+		hostnames[0],
+		mongoDBImage,
+		forceEnterprise,
+		s.Spec.GetAdditionalMongodConfig(),
+		s.GetSpec(),
+		"",
+		s.Annotations,
+		s.CalculateFeatureCompatibilityVersion(),
+		defaultArchitecture,
+	)
 	return process
 }

--- a/controllers/operator/mongodbstandalone_controller_test.go
+++ b/controllers/operator/mongodbstandalone_controller_test.go
@@ -36,7 +36,11 @@ import (
 
 func TestCreateOmProcess(t *testing.T) {
 	const mongodbImage = "quay.io/mongodb/mongodb-enterprise-server"
-	sts := construct.DatabaseStatefulSet(*DefaultReplicaSetBuilder().SetName("dublin").Build(), construct.StandaloneOptions(construct.GetPodEnvOptions()), zap.S())
+	sts := construct.DatabaseStatefulSet(
+		*DefaultReplicaSetBuilder().SetName("dublin").Build(),
+		construct.StandaloneOptions(construct.GetPodEnvOptions()),
+		zap.S(),
+	)
 	process := createProcess(mongodbImage, false, sts, util.AgentContainerName, DefaultStandaloneBuilder().Build(), architectures.NonStatic)
 	// Note, that for standalone the name of process is the name of statefulset - not the pod inside it.
 	assert.Equal(t, "dublin", process.Name())
@@ -47,7 +51,11 @@ func TestCreateOmProcess(t *testing.T) {
 func TestCreateOmProcesStatic(t *testing.T) {
 	const mongodbImage = "quay.io/mongodb/mongodb-enterprise-server"
 
-	sts := construct.DatabaseStatefulSet(*DefaultReplicaSetBuilder().SetName("dublin").Build(), construct.StandaloneOptions(construct.GetPodEnvOptions()), zap.S())
+	sts := construct.DatabaseStatefulSet(
+		*DefaultReplicaSetBuilder().SetName("dublin").Build(),
+		construct.StandaloneOptions(construct.GetPodEnvOptions()),
+		zap.S(),
+	)
 	process := createProcess(mongodbImage, false, sts, util.AgentContainerName, DefaultStandaloneBuilder().Build(), architectures.Static)
 	// Note, that for standalone the name of process is the name of statefulset - not the pod inside it.
 	assert.Equal(t, "dublin", process.Name())
@@ -60,7 +68,15 @@ func TestOnAddStandalone(t *testing.T) {
 	st := DefaultStandaloneBuilder().SetVersion("4.1.0").SetService("mysvc").Build()
 	st.Status.FeatureCompatibilityVersion = "4.1"
 
-	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(ctx, nil, "", "", om.NewEmptyMockedOmConnection, st, architectures.NonStatic)
+	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		om.NewEmptyMockedOmConnection,
+		st,
+		architectures.NonStatic,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, st, kubeClient)
 
@@ -98,7 +114,11 @@ func TestStandaloneClusterReconcileContainerImages(t *testing.T) {
 	require.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 	require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE", sts.Spec.Template.Spec.InitContainers[0].Image)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database:@sha256:MONGODB_INIT_DATABASE",
+		sts.Spec.Template.Spec.InitContainers[0].Image,
+	)
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-database:@sha256:MONGODB_DATABASE", sts.Spec.Template.Spec.Containers[0].Image)
 }
 
@@ -113,7 +133,15 @@ func TestStandaloneClusterReconcileContainerImagesWithStaticArchitecture(t *test
 
 	ctx := context.Background()
 	st := DefaultStandaloneBuilder().SetVersion("8.0.0").Build()
-	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(ctx, imageUrlsMock, "", "", om.NewEmptyMockedOmConnection, st, architectures.Static)
+	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(
+		ctx,
+		imageUrlsMock,
+		"",
+		"",
+		om.NewEmptyMockedOmConnection,
+		st,
+		architectures.Static,
+	)
 	omConnectionFactory.SetPostCreateHook(func(connection om.Connection) {
 		connection.(*om.MockedOmConnection).SetAgentVersion("12.0.30.7791-1", "")
 	})
@@ -147,7 +175,19 @@ func TestOnAddStandaloneWithDelay(t *testing.T) {
 		},
 	})
 
-	reconciler := newStandaloneReconciler(ctx, kubeClient, nil, "fake-initDatabaseNonStaticImageVersion", "fake-databaseNonStaticImageVersion", false, false, false, "", architectures.NonStatic, omConnectionFactory.GetConnectionFunc)
+	reconciler := newStandaloneReconciler(
+		ctx,
+		kubeClient,
+		nil,
+		"fake-initDatabaseNonStaticImageVersion",
+		"fake-databaseNonStaticImageVersion",
+		false,
+		false,
+		false,
+		"",
+		architectures.NonStatic,
+		omConnectionFactory.GetConnectionFunc,
+	)
 
 	checkReconcilePending(ctx, t, reconciler, st, "StatefulSet not ready", kubeClient, 3)
 	// this affects Get interceptor func, blocking automatically marking sts as ready
@@ -162,7 +202,15 @@ func TestAddDeleteStandalone(t *testing.T) {
 	// First we need to create a standalone
 	st := DefaultStandaloneBuilder().SetVersion("4.0.0").Build()
 
-	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(ctx, nil, "", "", om.NewEmptyMockedOmConnection, st, architectures.NonStatic)
+	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		om.NewEmptyMockedOmConnection,
+		st,
+		architectures.NonStatic,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, st, kubeClient)
 
@@ -185,7 +233,15 @@ func TestStandaloneAuthenticationOwnedByOpsManager(t *testing.T) {
 	stBuilder.Spec.Security = nil
 	st := stBuilder.Build()
 
-	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(ctx, nil, "", "", omConnectionFactoryFuncSettingVersion(), st, architectures.NonStatic)
+	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		omConnectionFactoryFuncSettingVersion(),
+		st,
+		architectures.NonStatic,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, st, kubeClient)
 
@@ -212,7 +268,15 @@ func TestStandaloneAuthenticationOwnedByOperator(t *testing.T) {
 	ctx := context.Background()
 	st := DefaultStandaloneBuilder().Build()
 
-	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(ctx, nil, "", "", omConnectionFactoryFuncSettingVersion(), st, architectures.NonStatic)
+	reconciler, kubeClient, omConnectionFactory := defaultStandaloneReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		omConnectionFactoryFuncSettingVersion(),
+		st,
+		architectures.NonStatic,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, st, kubeClient)
 
@@ -280,8 +344,12 @@ func TestStandalone_ConfigMapAndSecretWatched(t *testing.T) {
 	checkReconcileSuccessful(ctx, t, reconciler, s, kubeClient)
 
 	expected := map[watch.Object][]types.NamespacedName{
-		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {kube.ObjectKey(mock.TestNamespace, s.Name)},
-		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, s.Spec.Credentials)}:               {kube.ObjectKey(mock.TestNamespace, s.Name)},
+		{ResourceType: watch.ConfigMap, Resource: kube.ObjectKey(mock.TestNamespace, mock.TestProjectConfigMapName)}: {
+			kube.ObjectKey(mock.TestNamespace, s.Name),
+		},
+		{ResourceType: watch.Secret, Resource: kube.ObjectKey(mock.TestNamespace, s.Spec.Credentials)}: {
+			kube.ObjectKey(mock.TestNamespace, s.Name),
+		},
 	}
 
 	actual := reconciler.resourceWatcher.GetWatchedResources()
@@ -331,7 +399,15 @@ func TestStandaloneRoleAnnotationIsSet(t *testing.T) {
 	}
 
 	st := DefaultStandaloneBuilder().SetRoles([]mdbv1.MongoDBRole{role}).Build()
-	reconciler, client, omConnectionFactory := defaultStandaloneReconciler(ctx, nil, "", "", om.NewEmptyMockedOmConnection, st, architectures.NonStatic)
+	reconciler, client, omConnectionFactory := defaultStandaloneReconciler(
+		ctx,
+		nil,
+		"",
+		"",
+		om.NewEmptyMockedOmConnection,
+		st,
+		architectures.NonStatic,
+	)
 
 	checkReconcileSuccessful(ctx, t, reconciler, st, client)
 
@@ -359,10 +435,29 @@ func TestStandaloneRoleAnnotationIsSet(t *testing.T) {
 // defaultStandaloneReconciler is the standalone reconciler used in unit test. It "adds" necessary
 // additional K8s objects (st, connection config map and secrets) necessary for reconciliation,
 // so it's possible to call 'reconcileAppDB()' on it right away
-func defaultStandaloneReconciler(ctx context.Context, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, omConnectionFactoryFunc om.ConnectionFactory, rs *mdbv1.MongoDB, arch architectures.DefaultArchitecture) (*ReconcileMongoDbStandalone, kubernetesClient.Client, *om.CachedOMConnectionFactory) {
+func defaultStandaloneReconciler(
+	ctx context.Context,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	omConnectionFactoryFunc om.ConnectionFactory,
+	rs *mdbv1.MongoDB,
+	arch architectures.DefaultArchitecture,
+) (*ReconcileMongoDbStandalone, kubernetesClient.Client, *om.CachedOMConnectionFactory) {
 	omConnectionFactory := om.NewCachedOMConnectionFactory(omConnectionFactoryFunc)
 	kubeClient := mock.NewDefaultFakeClientWithOMConnectionFactory(omConnectionFactory, rs)
-	return newStandaloneReconciler(ctx, kubeClient, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, false, false, false, "", arch, omConnectionFactory.GetConnectionFunc), kubeClient, omConnectionFactory
+	return newStandaloneReconciler(
+		ctx,
+		kubeClient,
+		imageUrls,
+		initDatabaseNonStaticImageVersion,
+		databaseNonStaticImageVersion,
+		false,
+		false,
+		false,
+		"",
+		arch,
+		omConnectionFactory.GetConnectionFunc,
+	), kubeClient, omConnectionFactory
 }
 
 // TODO remove in favor of '/api/mongodbbuilder.go'
@@ -444,7 +539,18 @@ func createDeploymentFromStandalone(st *mdbv1.MongoDB) om.Deployment {
 	d := om.NewDeployment()
 	sts := construct.DatabaseStatefulSet(*st, construct.StandaloneOptions(construct.GetPodEnvOptions()), zap.S())
 	hostnames, _ := dns.GetDnsForStatefulSet(sts, st.Spec.GetClusterDomain(), nil)
-	process := om.NewMongodProcess(st.Name, hostnames[0], "fake-mongoDBImage", false, st.Spec.AdditionalMongodConfig, st.GetSpec(), "", nil, st.Status.FeatureCompatibilityVersion, architectures.NonStatic)
+	process := om.NewMongodProcess(
+		st.Name,
+		hostnames[0],
+		"fake-mongoDBImage",
+		false,
+		st.Spec.AdditionalMongodConfig,
+		st.GetSpec(),
+		"",
+		nil,
+		st.Status.FeatureCompatibilityVersion,
+		architectures.NonStatic,
+	)
 
 	lastConfig, err := st.GetLastAdditionalMongodConfigByType(mdbv1.StandaloneConfig)
 	if err != nil {

--- a/controllers/operator/mongodbuser_controller.go
+++ b/controllers/operator/mongodbuser_controller.go
@@ -50,7 +50,13 @@ type MongoDBUserReconciler struct {
 	backupEnableDelay             time.Duration
 }
 
-func newMongoDBUserReconciler(ctx context.Context, kubeClient client.Client, omFunc om.ConnectionFactory, memberClustersMap map[string]client.Client, backupEnableDelay time.Duration) *MongoDBUserReconciler {
+func newMongoDBUserReconciler(
+	ctx context.Context,
+	kubeClient client.Client,
+	omFunc om.ConnectionFactory,
+	memberClustersMap map[string]client.Client,
+	backupEnableDelay time.Duration,
+) *MongoDBUserReconciler {
 	clientsMap := make(map[string]kubernetesClient.Client)
 	secretClientsMap := make(map[string]secrets.SecretClient)
 
@@ -70,7 +76,11 @@ func newMongoDBUserReconciler(ctx context.Context, kubeClient client.Client, omF
 	}
 }
 
-func (r *MongoDBUserReconciler) getUser(ctx context.Context, request reconcile.Request, log *zap.SugaredLogger) (*userv1.MongoDBUser, error) {
+func (r *MongoDBUserReconciler) getUser(
+	ctx context.Context,
+	request reconcile.Request,
+	log *zap.SugaredLogger,
+) (*userv1.MongoDBUser, error) {
 	user := &userv1.MongoDBUser{}
 	if _, err := r.GetResource(ctx, request, user, log); err != nil {
 		return nil, err
@@ -111,7 +121,10 @@ func (r *MongoDBUserReconciler) getMongoDB(ctx context.Context, user userv1.Mong
 }
 
 // getMongoDBConnectionBuilder returns an object that can construct a MongoDB Connection String on itself.
-func (r *MongoDBUserReconciler) getMongoDBConnectionBuilder(ctx context.Context, user userv1.MongoDBUser) (connectionstring.ConnectionStringBuilder, error) {
+func (r *MongoDBUserReconciler) getMongoDBConnectionBuilder(
+	ctx context.Context,
+	user userv1.MongoDBUser,
+) (connectionstring.ConnectionStringBuilder, error) {
 	name := getMongoDBObjectKey(user)
 
 	// Try single cluster, sharded single/multi-cluster resource
@@ -181,7 +194,12 @@ func (r *MongoDBUserReconciler) Reconcile(ctx context.Context, request reconcile
 			if controllerutil.ContainsFinalizer(user, util.UserFinalizer) {
 				controllerutil.RemoveFinalizer(user, util.UserFinalizer)
 				if err := r.client.Update(ctx, user); err != nil {
-					return r.updateStatus(ctx, user, workflow.Failed(xerrors.Errorf("Failed to update the user with the removed finalizer: %w", err)), log)
+					return r.updateStatus(
+						ctx,
+						user,
+						workflow.Failed(xerrors.Errorf("Failed to update the user with the removed finalizer: %w", err)),
+						log,
+					)
 				}
 				return r.updateStatus(ctx, user, workflow.Pending("Finalizer will be removed. MongoDB resource not found"), log)
 			}
@@ -205,7 +223,16 @@ func (r *MongoDBUserReconciler) Reconcile(ctx context.Context, request reconcile
 		return r.updateStatus(ctx, user, workflow.Failed(err), log)
 	}
 
-	conn, _, err := connection.PrepareOpsManagerConnection(ctx, r.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, user.Namespace, false, log)
+	conn, _, err := connection.PrepareOpsManagerConnection(
+		ctx,
+		r.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		user.Namespace,
+		false,
+		log,
+	)
 	if err != nil {
 		return r.updateStatus(ctx, user, workflow.Failed(xerrors.Errorf("Failed to prepare Ops Manager connection: %w", err)), log)
 	}
@@ -246,7 +273,16 @@ func (r *MongoDBUserReconciler) delete(ctx context.Context, obj interface{}, log
 		return err
 	}
 
-	_, _, err = connection.PrepareOpsManagerConnection(ctx, r.SecretClient, projectConfig, credsConfig, r.omConnectionFactory, user.Namespace, false, log)
+	_, _, err = connection.PrepareOpsManagerConnection(
+		ctx,
+		r.SecretClient,
+		projectConfig,
+		credsConfig,
+		r.omConnectionFactory,
+		user.Namespace,
+		false,
+		log,
+	)
 	if err != nil {
 		log.Errorf("Failed to prepare Ops Manager connection: %s", err)
 		return err
@@ -285,8 +321,18 @@ func (r *MongoDBUserReconciler) updateConnectionStringSecret(ctx context.Context
 		}
 	}
 
-	mongoAuthUserURI := connectionBuilder.BuildConnectionString(user.Spec.Username, password, connectionstring.SchemeMongoDB, map[string]string{"authSource": user.Spec.Database})
-	mongoAuthUserSRVURI := connectionBuilder.BuildConnectionString(user.Spec.Username, password, connectionstring.SchemeMongoDBSRV, map[string]string{"authSource": user.Spec.Database})
+	mongoAuthUserURI := connectionBuilder.BuildConnectionString(
+		user.Spec.Username,
+		password,
+		connectionstring.SchemeMongoDB,
+		map[string]string{"authSource": user.Spec.Database},
+	)
+	mongoAuthUserSRVURI := connectionBuilder.BuildConnectionString(
+		user.Spec.Username,
+		password,
+		connectionstring.SchemeMongoDBSRV,
+		map[string]string{"authSource": user.Spec.Database},
+	)
 
 	memberClusterSecret := secret.Builder().
 		SetName(secretName).
@@ -311,9 +357,24 @@ func (r *MongoDBUserReconciler) updateConnectionStringSecret(ctx context.Context
 	return secret.CreateOrUpdate(ctx, r.SecretClient, centralClusterSecret)
 }
 
-func AddMongoDBUserController(ctx context.Context, mgr manager.Manager, memberClustersMap map[string]cluster.Cluster, backupEnableDelay time.Duration) error {
-	reconciler := newMongoDBUserReconciler(ctx, mgr.GetClient(), om.NewOpsManagerConnection, multicluster.ClustersMapToClientMap(memberClustersMap), backupEnableDelay)
-	c, err := controller.New(util.MongoDbUserController, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}) // nolint:forbidigo
+func AddMongoDBUserController(
+	ctx context.Context,
+	mgr manager.Manager,
+	memberClustersMap map[string]cluster.Cluster,
+	backupEnableDelay time.Duration,
+) error {
+	reconciler := newMongoDBUserReconciler(
+		ctx,
+		mgr.GetClient(),
+		om.NewOpsManagerConnection,
+		multicluster.ClustersMapToClientMap(memberClustersMap),
+		backupEnableDelay,
+	)
+	c, err := controller.New(
+		util.MongoDbUserController,
+		mgr,
+		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)},
+	) // nolint:forbidigo
 	if err != nil {
 		return err
 	}
@@ -366,7 +427,12 @@ func toOmUser(spec userv1.MongoDBUserSpec, password string, ac *om.AutomationCon
 	return user, nil
 }
 
-func (r *MongoDBUserReconciler) handleScramShaUser(ctx context.Context, user *userv1.MongoDBUser, conn om.Connection, log *zap.SugaredLogger) (res reconcile.Result, e error) {
+func (r *MongoDBUserReconciler) handleScramShaUser(
+	ctx context.Context,
+	user *userv1.MongoDBUser,
+	conn om.Connection,
+	log *zap.SugaredLogger,
+) (res reconcile.Result, e error) {
 	// watch the password secret in order to trigger reconciliation if the
 	// password is updated
 	if user.Spec.PasswordSecretKeyRef.Name != "" {
@@ -431,7 +497,12 @@ func (r *MongoDBUserReconciler) handleScramShaUser(ctx context.Context, user *us
 	return r.updateStatus(ctx, user, workflow.OK(), log, mdbstatus.NewProjectIdOption(conn.GroupID()))
 }
 
-func (r *MongoDBUserReconciler) handleExternalAuthUser(ctx context.Context, user *userv1.MongoDBUser, conn om.Connection, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *MongoDBUserReconciler) handleExternalAuthUser(
+	ctx context.Context,
+	user *userv1.MongoDBUser,
+	conn om.Connection,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	shouldRetry := false
 	updateFunction := func(ac *om.AutomationConfig) error {
 		if !externalAuthMechanismsAvailable(ac.Auth.DeploymentAuthMechanisms) {
@@ -509,7 +580,12 @@ func getAnnotationsForUserResource(user *userv1.MongoDBUser) (map[string]string,
 	return finalAnnotations, nil
 }
 
-func (r *MongoDBUserReconciler) preDeletionCleanup(ctx context.Context, user *userv1.MongoDBUser, conn om.Connection, log *zap.SugaredLogger) (reconcile.Result, error) {
+func (r *MongoDBUserReconciler) preDeletionCleanup(
+	ctx context.Context,
+	user *userv1.MongoDBUser,
+	conn om.Connection,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	log.Info("Performing pre deletion cleanup before deleting MongoDBUser")
 
 	err := conn.ReadUpdateAutomationConfig(func(ac *om.AutomationConfig) error {
@@ -523,7 +599,12 @@ func (r *MongoDBUserReconciler) preDeletionCleanup(ctx context.Context, user *us
 	secretKey := kube.ObjectKey(user.Namespace, user.GetConnectionStringSecretName())
 	for clusterName, c := range r.memberClusterSecretClientsMap {
 		if err := c.DeleteSecret(ctx, secretKey); err != nil && !apiErrors.IsNotFound(err) {
-			return r.updateStatus(ctx, user, workflow.Failed(xerrors.Errorf("Failed to delete connection string secret from member cluster %s: %w", clusterName, err)), log)
+			return r.updateStatus(
+				ctx,
+				user,
+				workflow.Failed(xerrors.Errorf("Failed to delete connection string secret from member cluster %s: %w", clusterName, err)),
+				log,
+			)
 		}
 	}
 
@@ -532,7 +613,12 @@ func (r *MongoDBUserReconciler) preDeletionCleanup(ctx context.Context, user *us
 	}
 
 	if err := r.client.Update(ctx, user); err != nil {
-		return r.updateStatus(ctx, user, workflow.Failed(xerrors.Errorf("Failed to update the user with the removed finalizer: %w", err)), log)
+		return r.updateStatus(
+			ctx,
+			user,
+			workflow.Failed(xerrors.Errorf("Failed to update the user with the removed finalizer: %w", err)),
+			log,
+		)
 	}
 	return r.updateStatus(ctx, user, workflow.OK(), log)
 }

--- a/controllers/operator/mongodbuser_controller_test.go
+++ b/controllers/operator/mongodbuser_controller_test.go
@@ -32,8 +32,14 @@ import (
 )
 
 func TestSettingUserStatus_ToPending_IsFilteredOut(t *testing.T) {
-	userInUpdatedPhase := &userv1.MongoDBUser{ObjectMeta: metav1.ObjectMeta{Name: "mms-user", Namespace: mock.TestNamespace}, Status: userv1.MongoDBUserStatus{Common: status.Common{Phase: status.PhaseUpdated}}}
-	userInPendingPhase := &userv1.MongoDBUser{ObjectMeta: metav1.ObjectMeta{Name: "mms-user", Namespace: mock.TestNamespace}, Status: userv1.MongoDBUserStatus{Common: status.Common{Phase: status.PhasePending}}}
+	userInUpdatedPhase := &userv1.MongoDBUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "mms-user", Namespace: mock.TestNamespace},
+		Status:     userv1.MongoDBUserStatus{Common: status.Common{Phase: status.PhaseUpdated}},
+	}
+	userInPendingPhase := &userv1.MongoDBUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "mms-user", Namespace: mock.TestNamespace},
+		Status:     userv1.MongoDBUserStatus{Common: status.Common{Phase: status.PhasePending}},
+	}
 
 	predicates := watch.PredicatesForUser()
 	updateEvent := event.UpdateEvent{
@@ -135,7 +141,11 @@ func TestNoChange_InAC_After_Same_User_Reconciliation(t *testing.T) {
 
 	acAfterSecondReconcile, _ := omConnectionFactory.GetConnection().ReadAutomationConfig()
 	// verify that the automation cnofig has not been changed because we ran reconciliation second time with the same user
-	assert.True(t, acAfterSecondReconcile.EqualsWithoutDeployment(*originalAC), "Automation config before the second reconciliation and after the second reconciliation should be same")
+	assert.True(
+		t,
+		acAfterSecondReconcile.EqualsWithoutDeployment(*originalAC),
+		"Automation config before the second reconciliation and after the second reconciliation should be same",
+	)
 }
 
 func TestReconciliationSucceed_OnAddingUser_FromADifferentNamespace(t *testing.T) {
@@ -161,7 +171,12 @@ func TestReconciliationSucceed_OnAddingUser_FromADifferentNamespace(t *testing.T
 	expected, _ := workflow.OK().ReconcileResult()
 
 	assert.Nil(t, err, "there should be no error on successful reconciliation")
-	assert.Equal(t, expected, actual, "there should be a successful reconciliation if MongoDBUser and MongoDB resources are in different namespaces")
+	assert.Equal(
+		t,
+		expected,
+		actual,
+		"there should be a successful reconciliation if MongoDBUser and MongoDB resources are in different namespaces",
+	)
 }
 
 func TestReconciliationSucceed_OnAddingUser_WithNoMongoDBNamespaceSpecified(t *testing.T) {
@@ -696,7 +711,14 @@ func TestConnectionStringSecret_NotExplicitlyDeleted_OnUserDeletion(t *testing.T
 // BuildAuthenticationEnabledReplicaSet returns a AutomationConfig after creating a Replica Set with a set of
 // different Authentication values. It should be used to test different combination of authentication modes enabled
 // and agent authentication modes.
-func BuildAuthenticationEnabledReplicaSet(ctx context.Context, t *testing.T, automationConfigOption string, numAgents int, agentAuthMode string, authModes []mdbv1.AuthMode) *om.AutomationConfig {
+func BuildAuthenticationEnabledReplicaSet(
+	ctx context.Context,
+	t *testing.T,
+	automationConfigOption string,
+	numAgents int,
+	agentAuthMode string,
+	authModes []mdbv1.AuthMode,
+) *om.AutomationConfig {
 	user := DefaultMongoDBUserBuilder().SetMongoDBResourceName("my-rs").SetDatabase(authentication.ExternalDB).Build()
 
 	reconciler, client, omConnectionFactory := defaultUserReconciler(ctx, user)
@@ -750,7 +772,13 @@ func createPasswordSecret(ctx context.Context, client client.Client, secretRef u
 	createPasswordSecretInNamespace(ctx, client, secretRef, password, mock.TestNamespace)
 }
 
-func createPasswordSecretInNamespace(ctx context.Context, client client.Client, secretRef userv1.SecretKeyRef, password string, namespace string) {
+func createPasswordSecretInNamespace(
+	ctx context.Context,
+	client client.Client,
+	secretRef userv1.SecretKeyRef,
+	password string,
+	namespace string,
+) {
 	_ = client.Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: secretRef.Name, Namespace: namespace},
 		Data: map[string][]byte{
@@ -767,13 +795,26 @@ func createMongoDBForUserWithAuth(ctx context.Context, client client.Client, use
 
 // defaultUserReconciler is the user reconciler used in unit test. It "adds" necessary
 // additional K8s objects (st, connection config map and secrets) necessary for reconciliation
-func defaultUserReconciler(ctx context.Context, user *userv1.MongoDBUser) (*MongoDBUserReconciler, client.Client, *om.CachedOMConnectionFactory) {
+func defaultUserReconciler(
+	ctx context.Context,
+	user *userv1.MongoDBUser,
+) (*MongoDBUserReconciler, client.Client, *om.CachedOMConnectionFactory) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(user)
 	memberClusterMap := getFakeMultiClusterMap(omConnectionFactory)
-	return newMongoDBUserReconciler(ctx, kubeClient, omConnectionFactory.GetConnectionFunc, memberClusterMap, testBackupEnableDelay), kubeClient, omConnectionFactory
+	return newMongoDBUserReconciler(
+		ctx,
+		kubeClient,
+		omConnectionFactory.GetConnectionFunc,
+		memberClusterMap,
+		testBackupEnableDelay,
+	), kubeClient, omConnectionFactory
 }
 
-func userReconcilerWithAuthMode(ctx context.Context, user *userv1.MongoDBUser, authMode string) (*MongoDBUserReconciler, client.Client, *om.CachedOMConnectionFactory) {
+func userReconcilerWithAuthMode(
+	ctx context.Context,
+	user *userv1.MongoDBUser,
+	authMode string,
+) (*MongoDBUserReconciler, client.Client, *om.CachedOMConnectionFactory) {
 	kubeClient, omConnectionFactory := mock.NewDefaultFakeClient(user)
 	memberClusterMap := getFakeMultiClusterMap(omConnectionFactory)
 	reconciler := newMongoDBUserReconciler(ctx, kubeClient, omConnectionFactory.GetConnectionFunc, memberClusterMap, testBackupEnableDelay)

--- a/controllers/operator/mongodbuser_eventhandler.go
+++ b/controllers/operator/mongodbuser_eventhandler.go
@@ -20,7 +20,11 @@ type MongoDBUserEventHandler struct {
 	}
 }
 
-func (eh *MongoDBUserEventHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (eh *MongoDBUserEventHandler) Delete(
+	ctx context.Context,
+	e event.TypedDeleteEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	zap.S().Infow("Cleaning up MongoDBUser resource", "resource", e.Object)
 	logger := zap.S().With("resource", kube.ObjectKey(e.Object.GetNamespace(), e.Object.GetName()))
 	if err := eh.reconciler.delete(ctx, e.Object, logger); err != nil {

--- a/controllers/operator/pem/secret.go
+++ b/controllers/operator/pem/secret.go
@@ -15,7 +15,12 @@ import (
 
 // ReadHashFromSecret reads the existing Pem from
 // the secret that stores this StatefulSet's Pem collection.
-func ReadHashFromSecret(ctx context.Context, secretClient secrets.SecretClient, namespace, name, basePath string, log *zap.SugaredLogger) string {
+func ReadHashFromSecret(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	namespace, name, basePath string,
+	log *zap.SugaredLogger,
+) string {
 	var secretData map[string]string
 	var err error
 	if vault.IsVaultSecretBackend() {

--- a/controllers/operator/project/credentials.go
+++ b/controllers/operator/project/credentials.go
@@ -14,7 +14,12 @@ import (
 )
 
 // ReadCredentials reads the Secret containing the credentials to authenticate in Ops Manager and creates a matching 'Credentials' object
-func ReadCredentials(ctx context.Context, secretClient secrets.SecretClient, credentialsSecret client.ObjectKey, log *zap.SugaredLogger) (mdbv1.Credentials, error) {
+func ReadCredentials(
+	ctx context.Context,
+	secretClient secrets.SecretClient,
+	credentialsSecret client.ObjectKey,
+	log *zap.SugaredLogger,
+) (mdbv1.Credentials, error) {
 	var operatorSecretPath string
 	if vault.IsVaultSecretBackend() {
 		operatorSecretPath = secretClient.VaultClient.OperatorSecretPath()
@@ -28,11 +33,24 @@ func ReadCredentials(ctx context.Context, secretClient secrets.SecretClient, cre
 	newSecretEntries, publicKey, privateKey := secretContainsPairOfKeys(secret, util.OmPublicApiKey, util.OmPrivateKey)
 
 	if !oldSecretEntries && !newSecretEntries {
-		return mdbv1.Credentials{}, xerrors.Errorf("secret %s does not contain the required entries. It should contain either %s and %s, or %s and %s", credentialsSecret, util.OldOmUser, util.OldOmPublicApiKey, util.OmPublicApiKey, util.OmPrivateKey)
+		return mdbv1.Credentials{}, xerrors.Errorf(
+			"secret %s does not contain the required entries. It should contain either %s and %s, or %s and %s",
+			credentialsSecret,
+			util.OldOmUser,
+			util.OldOmPublicApiKey,
+			util.OmPublicApiKey,
+			util.OmPrivateKey,
+		)
 	}
 
 	if oldSecretEntries {
-		log.Infof("Usage of old entries for the credentials secret (\"%s\" and \"%s\") is deprecated, prefer using \"%s\" and \"%s\"", util.OldOmUser, util.OldOmPublicApiKey, util.OmPublicApiKey, util.OmPrivateKey)
+		log.Infof(
+			"Usage of old entries for the credentials secret (\"%s\" and \"%s\") is deprecated, prefer using \"%s\" and \"%s\"",
+			util.OldOmUser,
+			util.OldOmPublicApiKey,
+			util.OmPublicApiKey,
+			util.OmPrivateKey,
+		)
 		return mdbv1.Credentials{
 			PublicAPIKey:  user,
 			PrivateAPIKey: publicAPIKey,

--- a/controllers/operator/project/project.go
+++ b/controllers/operator/project/project.go
@@ -31,12 +31,28 @@ type Reader interface {
 
 // ReadConfigAndCredentials returns the ProjectConfig and Credentials for a given resource which are
 // used to communicate with Ops Manager.
-func ReadConfigAndCredentials(ctx context.Context, cmGetter configmap.Getter, secretGetter secrets.SecretClient, reader Reader, log *zap.SugaredLogger) (mdbv1.ProjectConfig, mdbv1.Credentials, error) {
-	projectConfig, err := ReadProjectConfig(ctx, cmGetter, kube.ObjectKey(reader.GetProjectConfigMapNamespace(), reader.GetProjectConfigMapName()), reader.GetName())
+func ReadConfigAndCredentials(
+	ctx context.Context,
+	cmGetter configmap.Getter,
+	secretGetter secrets.SecretClient,
+	reader Reader,
+	log *zap.SugaredLogger,
+) (mdbv1.ProjectConfig, mdbv1.Credentials, error) {
+	projectConfig, err := ReadProjectConfig(
+		ctx,
+		cmGetter,
+		kube.ObjectKey(reader.GetProjectConfigMapNamespace(), reader.GetProjectConfigMapName()),
+		reader.GetName(),
+	)
 	if err != nil {
 		return mdbv1.ProjectConfig{}, mdbv1.Credentials{}, xerrors.Errorf("error reading project %w", err)
 	}
-	credsConfig, err := ReadCredentials(ctx, secretGetter, kube.ObjectKey(reader.GetCredentialsSecretNamespace(), reader.GetCredentialsSecretName()), log)
+	credsConfig, err := ReadCredentials(
+		ctx,
+		secretGetter,
+		kube.ObjectKey(reader.GetCredentialsSecretNamespace(), reader.GetCredentialsSecretName()),
+		log,
+	)
 	if err != nil {
 		return mdbv1.ProjectConfig{}, mdbv1.Credentials{}, xerrors.Errorf("error reading Credentials secret: %w", err)
 	}
@@ -57,7 +73,12 @@ duplicated groups/organizations creation. So if for example the standalone and t
 configMap are created in parallel - this function will be invoked sequentially and the second caller will see the group
 created on the first call
 */
-func ReadOrCreateProject(config mdbv1.ProjectConfig, credentials mdbv1.Credentials, connectionFactory om.ConnectionFactory, log *zap.SugaredLogger) (*om.Project, om.Connection, error) {
+func ReadOrCreateProject(
+	config mdbv1.ProjectConfig,
+	credentials mdbv1.Credentials,
+	connectionFactory om.ConnectionFactory,
+	log *zap.SugaredLogger,
+) (*om.Project, om.Connection, error) {
 	projectName := config.ProjectName
 	mutex := om.GetMutex(projectName, config.OrgID)
 	mutex.Lock()
@@ -149,7 +170,12 @@ func findProject(projectName string, organization *om.Organization, conn om.Conn
 // findProjectInsideOrganization looks up a project by name inside an organization and returns the project if it was the only one found by that name.
 // If no project was found, the function returns a nil project to indicate that no such project exists.
 // In all other cases, a non nil error is returned.
-func findProjectInsideOrganization(conn om.Connection, projectName string, organization *om.Organization, log *zap.SugaredLogger) (*om.Project, error) {
+func findProjectInsideOrganization(
+	conn om.Connection,
+	projectName string,
+	organization *om.Organization,
+	log *zap.SugaredLogger,
+) (*om.Project, error) {
 	projects, err := conn.ReadProjectsInOrganizationByName(organization.ID, projectName)
 	if err != nil {
 		if v, ok := err.(*apierror.Error); ok {
@@ -215,7 +241,12 @@ func findOrganizationByName(conn om.Connection, name string, log *zap.SugaredLog
 	return "", nil
 }
 
-func tryCreateProject(organization *om.Organization, projectName, orgId string, conn om.Connection, log *zap.SugaredLogger) (*om.Project, error) {
+func tryCreateProject(
+	organization *om.Organization,
+	projectName, orgId string,
+	conn om.Connection,
+	log *zap.SugaredLogger,
+) (*om.Project, error) {
 	// We can face the following scenario: for the project "foo" with 'orgId=""' the organization "foo" already exists
 	// - so we need to reuse its orgId instead of creating the new Organization with the same name (OM API is quite
 	// poor here - it may create duplicates)

--- a/controllers/operator/project/projectconfig.go
+++ b/controllers/operator/project/projectconfig.go
@@ -32,7 +32,12 @@ func validateProjectConfig(ctx context.Context, cmGetter configmap.Getter, proje
 // ReadProjectConfig returns a "Project" config build from a ConfigMap with a series of attributes
 // like `projectName`, `baseUrl` and a series of attributes related to SSL.
 // If configMap doesn't have a projectName defined - the name of MongoDB resource is used as a name of project
-func ReadProjectConfig(ctx context.Context, cmGetter configmap.Getter, projectConfigMap client.ObjectKey, mdbName string) (mdbv1.ProjectConfig, error) {
+func ReadProjectConfig(
+	ctx context.Context,
+	cmGetter configmap.Getter,
+	projectConfigMap client.ObjectKey,
+	mdbName string,
+) (mdbv1.ProjectConfig, error) {
 	data, err := validateProjectConfig(ctx, cmGetter, projectConfigMap)
 	if err != nil {
 		return mdbv1.ProjectConfig{}, err

--- a/controllers/operator/state_store.go
+++ b/controllers/operator/state_store.go
@@ -122,7 +122,14 @@ func (s *StateStore[S]) getDataValue(key string, obj any) (bool, error) {
 
 func (s *StateStore[S]) setDataValue(key string, value any) error {
 	if jsonBytes, err := json.Marshal(value); err != nil {
-		return xerrors.Errorf("cannot marshal deployment state %s/%s key %s from the value: %v: %w", s.namespace, s.getStateConfigMapName(), key, value, err)
+		return xerrors.Errorf(
+			"cannot marshal deployment state %s/%s key %s from the value: %v: %w",
+			s.namespace,
+			s.getStateConfigMapName(),
+			key,
+			value,
+			err,
+		)
 	} else {
 		s.data[key] = string(jsonBytes)
 	}

--- a/controllers/operator/voyageai_controller.go
+++ b/controllers/operator/voyageai_controller.go
@@ -100,7 +100,13 @@ func (r *VoyageAIReconciler) Reconcile(ctx context.Context, request reconcile.Re
 		secret := &corev1.Secret{}
 		err := r.kubeClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: vai.Namespace}, secret)
 		if apierrors.IsNotFound(err) {
-			return commoncontroller.UpdateStatus(ctx, r.kubeClient, vai, workflow.Pending("TLS certificate secret %q not found", secretName), log)
+			return commoncontroller.UpdateStatus(
+				ctx,
+				r.kubeClient,
+				vai,
+				workflow.Pending("TLS certificate secret %q not found", secretName),
+				log,
+			)
 		} else if err != nil {
 			return commoncontroller.UpdateStatus(ctx, r.kubeClient, vai, workflow.Failed(xerrors.Errorf("failed to get TLS certificate secret %q: %w", secretName, err)), log)
 		}
@@ -108,11 +114,23 @@ func (r *VoyageAIReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 	dep, err := r.ensureDeployment(ctx, vai, log)
 	if err != nil {
-		return commoncontroller.UpdateStatus(ctx, r.kubeClient, vai, workflow.Failed(xerrors.Errorf("failed to ensure Deployment: %w", err)), log)
+		return commoncontroller.UpdateStatus(
+			ctx,
+			r.kubeClient,
+			vai,
+			workflow.Failed(xerrors.Errorf("failed to ensure Deployment: %w", err)),
+			log,
+		)
 	}
 
 	if err := r.ensureService(ctx, vai, log); err != nil {
-		return commoncontroller.UpdateStatus(ctx, r.kubeClient, vai, workflow.Failed(xerrors.Errorf("failed to ensure Service: %w", err)), log)
+		return commoncontroller.UpdateStatus(
+			ctx,
+			r.kubeClient,
+			vai,
+			workflow.Failed(xerrors.Errorf("failed to ensure Service: %w", err)),
+			log,
+		)
 	}
 
 	log.Info("VoyageAI reconciliation complete")
@@ -128,7 +146,11 @@ func (r *VoyageAIReconciler) Reconcile(ctx context.Context, request reconcile.Re
 	return commoncontroller.UpdateStatus(ctx, r.kubeClient, vai, workflow.OK(), log, vaiv1.NewVoyageAIVersionOption(vai.Spec.Version))
 }
 
-func (r *VoyageAIReconciler) ensureDeployment(ctx context.Context, vai *vaiv1.VoyageAI, log *zap.SugaredLogger) (*appsv1.Deployment, error) {
+func (r *VoyageAIReconciler) ensureDeployment(
+	ctx context.Context,
+	vai *vaiv1.VoyageAI,
+	log *zap.SugaredLogger,
+) (*appsv1.Deployment, error) {
 	image := r.voyageAIContainerImage(vai)
 	labels := voyageAILabels(vai)
 	podLabels := voyageAIPodLabels(vai)
@@ -367,17 +389,36 @@ func buildEnvVars(spec *vaiv1.VoyageAISpec, tlsEnabled bool) []corev1.EnvVar {
 
 		if dp.HealthMonitoring != nil {
 			hm := dp.HealthMonitoring
-			envs = append(envs,
+			envs = append(
+				envs,
 				corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__CHECK_INTERVAL", Value: int32ToFloatString(hm.CheckIntervalSeconds)},
-				corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__MAX_CONSECUTIVE_TIMEOUTS", Value: int32ToString(hm.MaxConsecutiveTimeouts)},
-				corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__ACTIVE_CHECK_INTERVAL", Value: int32ToString(hm.ActiveCheckIntervalSeconds)},
-				corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__ACTIVE_CHECK_TIMEOUT", Value: int32ToString(hm.ActiveCheckTimeoutSeconds)},
+				corev1.EnvVar{
+					Name:  "DATA_PARALLEL__HEALTH_MONITORING__MAX_CONSECUTIVE_TIMEOUTS",
+					Value: int32ToString(hm.MaxConsecutiveTimeouts),
+				},
+				corev1.EnvVar{
+					Name:  "DATA_PARALLEL__HEALTH_MONITORING__ACTIVE_CHECK_INTERVAL",
+					Value: int32ToString(hm.ActiveCheckIntervalSeconds),
+				},
+				corev1.EnvVar{
+					Name:  "DATA_PARALLEL__HEALTH_MONITORING__ACTIVE_CHECK_TIMEOUT",
+					Value: int32ToString(hm.ActiveCheckTimeoutSeconds),
+				},
 				corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__MAX_RESTART_ATTEMPTS", Value: int32ToString(hm.MaxRestartAttempts)},
-				corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__RESTART_COOLDOWN", Value: int32ToFloatString(hm.RestartCooldownSeconds)},
+				corev1.EnvVar{
+					Name:  "DATA_PARALLEL__HEALTH_MONITORING__RESTART_COOLDOWN",
+					Value: int32ToFloatString(hm.RestartCooldownSeconds),
+				},
 			)
 
 			if hm.EnableActiveChecks != nil {
-				envs = append(envs, corev1.EnvVar{Name: "DATA_PARALLEL__HEALTH_MONITORING__ENABLE_ACTIVE_CHECKS", Value: strconv.FormatBool(*hm.EnableActiveChecks)})
+				envs = append(
+					envs,
+					corev1.EnvVar{
+						Name:  "DATA_PARALLEL__HEALTH_MONITORING__ENABLE_ACTIVE_CHECKS",
+						Value: strconv.FormatBool(*hm.EnableActiveChecks),
+					},
+				)
 			}
 		}
 	}
@@ -518,7 +559,8 @@ func AddVoyageAIController(ctx context.Context, mgr manager.Manager, imageReposi
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}). // nolint:forbidigo
+		WithOptions(controller.Options{MaxConcurrentReconciles: env.ReadIntOrDefault(util.MaxConcurrentReconcilesEnv, 1)}).
+		// nolint:forbidigo
 		For(&vaiv1.VoyageAI{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapSecretToVoyageAI)).
 		Owns(&appsv1.Deployment{}).

--- a/controllers/operator/voyageai_controller_test.go
+++ b/controllers/operator/voyageai_controller_test.go
@@ -84,7 +84,12 @@ func markDeploymentReady(ctx context.Context, t *testing.T, c client.Client, nam
 	require.NoError(t, c.Status().Update(ctx, dep))
 }
 
-func reconcileVoyageAI(ctx context.Context, t *testing.T, reconciler *VoyageAIReconciler, name, namespace string) (reconcile.Result, error) {
+func reconcileVoyageAI(
+	ctx context.Context,
+	t *testing.T,
+	reconciler *VoyageAIReconciler,
+	name, namespace string,
+) (reconcile.Result, error) {
 	t.Helper()
 	return reconciler.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: name, Namespace: namespace},

--- a/controllers/operator/watch/config_change_handler.go
+++ b/controllers/operator/watch/config_change_handler.go
@@ -48,11 +48,19 @@ type ResourcesHandler struct {
 
 // Note that we implement Create in addition to Update to be able to handle cases when config map or secret is deleted
 // and then created again.
-func (c *ResourcesHandler) Create(ctx context.Context, e event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (c *ResourcesHandler) Create(
+	ctx context.Context,
+	e event.TypedCreateEvent[client.Object],
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	c.doHandle(e.Object.GetNamespace(), e.Object.GetName(), q)
 }
 
-func (c *ResourcesHandler) Update(ctx context.Context, e event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (c *ResourcesHandler) Update(
+	ctx context.Context,
+	e event.TypedUpdateEvent[client.Object],
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	if !shouldHandleUpdate(e) {
 		return
 	}
@@ -84,7 +92,11 @@ func (c *ResourcesHandler) doHandle(namespace, name string, q workqueue.TypedRat
 }
 
 // Seems we don't need to react on config map/secret removal..
-func (c *ResourcesHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (c *ResourcesHandler) Delete(
+	ctx context.Context,
+	e event.TypedDeleteEvent[client.Object],
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	switch e.Object.(type) {
 	case *corev1.ConfigMap:
 		return
@@ -95,7 +107,11 @@ func (c *ResourcesHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[
 	c.doHandle(e.Object.GetNamespace(), e.Object.GetName(), q)
 }
 
-func (c *ResourcesHandler) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (c *ResourcesHandler) Generic(
+	context.Context,
+	event.TypedGenericEvent[client.Object],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 }
 
 // ConfigMapEventHandler is an EventHandler implementation that is used to watch for events on a given ConfigMap and ConfigMapNamespace
@@ -106,10 +122,18 @@ type ConfigMapEventHandler struct {
 	ConfigMapNamespace string
 }
 
-func (m ConfigMapEventHandler) Create(context.Context, event.TypedCreateEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (m ConfigMapEventHandler) Create(
+	context.Context,
+	event.TypedCreateEvent[client.Object],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 }
 
-func (m ConfigMapEventHandler) Update(ctx context.Context, e event.TypedUpdateEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (m ConfigMapEventHandler) Update(
+	ctx context.Context,
+	e event.TypedUpdateEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	if m.isMemberListCM(e.ObjectOld) {
 		switch v := e.ObjectOld.(type) {
 		case *corev1.ConfigMap:
@@ -120,14 +144,26 @@ func (m ConfigMapEventHandler) Update(ctx context.Context, e event.TypedUpdateEv
 	}
 }
 
-func (m ConfigMapEventHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (m ConfigMapEventHandler) Delete(
+	ctx context.Context,
+	e event.TypedDeleteEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	if m.isMemberListCM(e.Object) {
-		errMsg := fmt.Sprintf("%s/%s has been deleted! Note we will need the configmap otherwise the operator will not work", m.ConfigMapNamespace, m.ConfigMapName)
+		errMsg := fmt.Sprintf(
+			"%s/%s has been deleted! Note we will need the configmap otherwise the operator will not work",
+			m.ConfigMapNamespace,
+			m.ConfigMapName,
+		)
 		panic(errMsg)
 	}
 }
 
-func (m ConfigMapEventHandler) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (m ConfigMapEventHandler) Generic(
+	context.Context,
+	event.TypedGenericEvent[client.Object],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 }
 
 func (m ConfigMapEventHandler) isMemberListCM(o client.Object) bool {

--- a/controllers/operator/watch/predicates_test.go
+++ b/controllers/operator/watch/predicates_test.go
@@ -125,7 +125,11 @@ func TestPredicatesForMultiClusterSearchResource(t *testing.T) {
 		{"Create/partial name-only fails", false, func() bool { return p.CreateFunc(event.CreateEvent{Object: partialName}) }},
 		{"Create/partial ns-only fails", false, func() bool { return p.CreateFunc(event.CreateEvent{Object: partialNs}) }},
 		// Update
-		{"Update/both labeled passes", true, func() bool { return p.UpdateFunc(event.UpdateEvent{ObjectOld: labeled, ObjectNew: labeled}) }},
+		{
+			"Update/both labeled passes",
+			true,
+			func() bool { return p.UpdateFunc(event.UpdateEvent{ObjectOld: labeled, ObjectNew: labeled}) },
+		},
 		{"Update/newly labeled passes", true, func() bool { return p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: labeled}) }},
 		{"Update/label removed passes", true, func() bool { return p.UpdateFunc(event.UpdateEvent{ObjectOld: labeled, ObjectNew: plain}) }},
 		{"Update/both plain fails", false, func() bool { return p.UpdateFunc(event.UpdateEvent{ObjectOld: plain, ObjectNew: plain}) }},

--- a/controllers/searchcontroller/community_search_source.go
+++ b/controllers/searchcontroller/community_search_source.go
@@ -32,7 +32,15 @@ func (r *CommunitySearchSource) HostSeeds(shardName string) ([]string, error) {
 	seeds := make([]string, r.Spec.Members)
 	clusterDomain := r.Spec.GetClusterDomain()
 	for i := range seeds {
-		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", r.Name, i, r.ServiceName(), r.Namespace, clusterDomain, r.GetMongodConfiguration().GetDBPort())
+		seeds[i] = fmt.Sprintf(
+			"%s-%d.%s.%s.svc.%s:%d",
+			r.Name,
+			i,
+			r.ServiceName(),
+			r.Namespace,
+			clusterDomain,
+			r.GetMongodConfiguration().GetDBPort(),
+		)
 	}
 	return seeds, nil
 }

--- a/controllers/searchcontroller/enterprise_search_source.go
+++ b/controllers/searchcontroller/enterprise_search_source.go
@@ -29,7 +29,15 @@ func (r EnterpriseResourceSearchSource) HostSeeds(shardName string) ([]string, e
 	seeds := make([]string, r.Spec.Members)
 	clusterDomain := r.Spec.GetClusterDomain()
 	for i := range seeds {
-		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", r.Name, i, r.ServiceName(), r.Namespace, clusterDomain, r.Spec.GetAdditionalMongodConfig().GetPortOrDefault())
+		seeds[i] = fmt.Sprintf(
+			"%s-%d.%s.%s.svc.%s:%d",
+			r.Name,
+			i,
+			r.ServiceName(),
+			r.Namespace,
+			clusterDomain,
+			r.Spec.GetAdditionalMongodConfig().GetPortOrDefault(),
+		)
 	}
 	return seeds, nil
 }

--- a/controllers/searchcontroller/enterprise_search_source_test.go
+++ b/controllers/searchcontroller/enterprise_search_source_test.go
@@ -14,7 +14,13 @@ import (
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
 )
 
-func newEnterpriseSearchSource(version string, topology string, resourceType mdbv1.ResourceType, authModes []string, internalClusterAuth string) EnterpriseResourceSearchSource {
+func newEnterpriseSearchSource(
+	version string,
+	topology string,
+	resourceType mdbv1.ResourceType,
+	authModes []string,
+	internalClusterAuth string,
+) EnterpriseResourceSearchSource {
 	authModesList := make([]mdbv1.AuthMode, len(authModes))
 	for i, mode := range authModes {
 		authModesList[i] = mdbv1.AuthMode(mode)

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper.go
@@ -355,7 +355,9 @@ func (r *MongoDBSearchReconcileHelper) buildShardedWorkList(shardNames []string)
 
 // rsResourceNames returns (sts, headlessSvc, proxySvc, configMap) names for one
 // RS work item. Always indexed; single-cluster is index 0.
-func (r *MongoDBSearchReconcileHelper) rsResourceNames(w clusterWork) (types.NamespacedName, types.NamespacedName, types.NamespacedName, types.NamespacedName) {
+func (r *MongoDBSearchReconcileHelper) rsResourceNames(
+	w clusterWork,
+) (types.NamespacedName, types.NamespacedName, types.NamespacedName, types.NamespacedName) {
 	return r.mdbSearch.StatefulSetNamespacedNameForCluster(w.ClusterIndex),
 		r.mdbSearch.SearchServiceNamespacedNameForCluster(w.ClusterIndex),
 		r.mdbSearch.ProxyServiceNamespacedNameForCluster(w.ClusterIndex),
@@ -533,7 +535,10 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 		log.Warnf("Member cluster %q not registered with the operator; skipping it", clusterName)
 	}
 	if specClusterCount > 0 && len(missingClusters) == specClusterCount {
-		return workflow.Pending("None of the clusters in spec.clusters is registered with the operator: %s", strings.Join(missingClusters, ", "))
+		return workflow.Pending(
+			"None of the clusters in spec.clusters is registered with the operator: %s",
+			strings.Join(missingClusters, ", "),
+		)
 	}
 
 	// Stale-resource cleanup runs only on the post-prerequisite success path
@@ -615,7 +620,10 @@ func (r *MongoDBSearchReconcileHelper) reconcile(ctx context.Context, log *zap.S
 			continue
 		}
 		if res.client == nil {
-			reconcileErrs = multierror.Append(reconcileErrs, xerrors.Errorf("no Kubernetes client registered for cluster %q", res.clusterName))
+			reconcileErrs = multierror.Append(
+				reconcileErrs,
+				xerrors.Errorf("no Kubernetes client registered for cluster %q", res.clusterName),
+			)
 			continue
 		}
 		if err := r.ensureSearchService(ctx, log, res.client, res.svcName, buildClusterLevelProxyService(r.mdbSearch, res)); err != nil {
@@ -729,14 +737,25 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 
 	// Per-unit ingress TLS: each shard may have its own secret, so this cannot
 	// be hoisted out of the loop.
-	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(ctx, unitClient, unit.tlsResource, tlsSecretLabels, unit.ownerReferences)
+	ingressTlsMongotModification, ingressTlsStsModification, err := r.ensureIngressTlsConfig(
+		ctx,
+		unitClient,
+		unit.tlsResource,
+		tlsSecretLabels,
+		unit.ownerReferences,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Per-unit egress TLS (SCRAM CA + optional client cert): uses unitClient so the
 	// operator-managed secret is created on the cluster where mongot pods run.
-	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(ctx, unitClient, tlsSecretLabels, unit.ownerReferences)
+	egressTlsMongotModification, egressTlsStsModification, err := r.ensureEgressTlsConfig(
+		ctx,
+		unitClient,
+		tlsSecretLabels,
+		unit.ownerReferences,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -783,7 +802,17 @@ func (r *MongoDBSearchReconcileHelper) applyReconcileUnit(
 		},
 	))
 
-	stsFunc := CreateSearchStatefulSetFunc(r.mdbSearch, unit.sizing, unit.stsName.Name, r.mdbSearch.Namespace, unit.headlessSvc.Name, unit.configMapName.Name, unit.podLabels, mods.searchImage, mods.usePerPodConfig)
+	stsFunc := CreateSearchStatefulSetFunc(
+		r.mdbSearch,
+		unit.sizing,
+		unit.stsName.Name,
+		r.mdbSearch.Namespace,
+		unit.headlessSvc.Name,
+		unit.configMapName.Name,
+		unit.podLabels,
+		mods.searchImage,
+		mods.usePerPodConfig,
+	)
 	stsOverride := StatefulSetOverrideModification(unit.sizing.StatefulSetConfiguration)
 	mutatedSts, err := r.createOrUpdateStatefulSet(ctx,
 		log,
@@ -867,7 +896,13 @@ func (r *MongoDBSearchReconcileHelper) aggregateReadiness(ctx context.Context, a
 		acc := accFor(res.unit)
 
 		// Per shard mongot StatefulSet readiness — this is what gates the top-level phase (via topStatus).
-		stsStatus := statefulset.GetStatefulSetStatus(ctx, r.mdbSearch.Namespace, res.unit.stsName.Name, res.expectedGeneration, res.unitClient)
+		stsStatus := statefulset.GetStatefulSetStatus(
+			ctx,
+			r.mdbSearch.Namespace,
+			res.unit.stsName.Name,
+			res.expectedGeneration,
+			res.unitClient,
+		)
 		acc.searchPhase = searchv1.WorstOfPhase(acc.searchPhase, stsStatus.Phase())
 		if !stsStatus.IsOK() {
 			if msg := MessageFromStatus(stsStatus); msg != "" {
@@ -935,14 +970,22 @@ func (r *MongoDBSearchReconcileHelper) aggregateReadiness(ctx context.Context, a
 // envoyDeploymentStatus reports the readiness of one cluster's managed Envoy
 // Deployment by reading the Deployment object. Absent/unreadable → Pending, since the
 // envoy controller may not have created it yet.
-func (r *MongoDBSearchReconcileHelper) envoyDeploymentStatus(ctx context.Context, clusterIndex int, unitClient kubernetesClient.Client) workflow.Status {
+func (r *MongoDBSearchReconcileHelper) envoyDeploymentStatus(
+	ctx context.Context,
+	clusterIndex int,
+	unitClient kubernetesClient.Client,
+) workflow.Status {
 	name := r.mdbSearch.LoadBalancerDeploymentNameForCluster(clusterIndex)
 	return r.deploymentReadiness(ctx, unitClient, name, "Load balancer")
 }
 
 // metricsForwarderDeploymentStatus reports the readiness of one cluster's Ops Manager
 // metrics-forwarder Deployment.
-func (r *MongoDBSearchReconcileHelper) metricsForwarderDeploymentStatus(ctx context.Context, clusterIndex int, unitClient kubernetesClient.Client) workflow.Status {
+func (r *MongoDBSearchReconcileHelper) metricsForwarderDeploymentStatus(
+	ctx context.Context,
+	clusterIndex int,
+	unitClient kubernetesClient.Client,
+) workflow.Status {
 	name := r.mdbSearch.MetricsForwarderDeploymentNameForCluster(clusterIndex)
 	return r.deploymentReadiness(ctx, unitClient, name, "Metrics forwarder")
 }
@@ -950,7 +993,11 @@ func (r *MongoDBSearchReconcileHelper) metricsForwarderDeploymentStatus(ctx cont
 // deploymentReadiness reports whether a Deployment has fully rolled out its current spec.
 // A plain ReadyReplicas check is insufficient because during a rolling update ReadyReplicas can equal
 // the desired count while the ready pods still belong to the OLD ReplicaSet.
-func (r *MongoDBSearchReconcileHelper) deploymentReadiness(ctx context.Context, unitClient kubernetesClient.Client, name, kind string) workflow.Status {
+func (r *MongoDBSearchReconcileHelper) deploymentReadiness(
+	ctx context.Context,
+	unitClient kubernetesClient.Client,
+	name, kind string,
+) workflow.Status {
 	dep := &appsv1.Deployment{}
 	if err := unitClient.Get(ctx, kube.ObjectKey(r.mdbSearch.Namespace, name), dep); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -960,10 +1007,22 @@ func (r *MongoDBSearchReconcileHelper) deploymentReadiness(ctx context.Context, 
 	}
 	desired := ptr.Deref(dep.Spec.Replicas, 1)
 	if dep.Status.ObservedGeneration < dep.Generation {
-		return workflow.Pending("%s deployment %s rollout in progress: waiting for generation %d to be observed (observed %d)", kind, name, dep.Generation, dep.Status.ObservedGeneration)
+		return workflow.Pending(
+			"%s deployment %s rollout in progress: waiting for generation %d to be observed (observed %d)",
+			kind,
+			name,
+			dep.Generation,
+			dep.Status.ObservedGeneration,
+		)
 	}
 	if dep.Status.UpdatedReplicas < desired {
-		return workflow.Pending("%s deployment %s rollout in progress: %d/%d updated replicas", kind, name, dep.Status.UpdatedReplicas, desired)
+		return workflow.Pending(
+			"%s deployment %s rollout in progress: %d/%d updated replicas",
+			kind,
+			name,
+			dep.Status.UpdatedReplicas,
+			desired,
+		)
 	}
 	if dep.Status.ReadyReplicas < desired {
 		return workflow.Pending("%s deployment %s not ready: %d/%d replicas ready", kind, name, dep.Status.ReadyReplicas, desired)
@@ -971,7 +1030,12 @@ func (r *MongoDBSearchReconcileHelper) deploymentReadiness(ctx context.Context, 
 	// UpdatedReplicas and ReadyReplicas both reach desired even during a stuck rollout (new-spec pod created but unschedulable
 	// while the old pod stays Ready); only UnavailableReplicas reflects the pending surge pod.
 	if dep.Status.UnavailableReplicas > 0 {
-		return workflow.Pending("%s deployment %s rollout in progress: %d unavailable replica(s)", kind, name, dep.Status.UnavailableReplicas)
+		return workflow.Pending(
+			"%s deployment %s rollout in progress: %d unavailable replica(s)",
+			kind,
+			name,
+			dep.Status.UnavailableReplicas,
+		)
 	}
 	return workflow.OK()
 }
@@ -979,7 +1043,12 @@ func (r *MongoDBSearchReconcileHelper) deploymentReadiness(ctx context.Context, 
 // markRoutingReadyIfThresholdMet flips a shard's routing-ready switch once its
 // mongot STS first meets the routing-readiness threshold. The switch is one-way:
 // a later STS delete/recreate does not put the shard back into fallback routing.
-func (r *MongoDBSearchReconcileHelper) markRoutingReadyIfThresholdMet(ctx context.Context, log *zap.SugaredLogger, unit reconcileUnit, unitClient kubernetesClient.Client) error {
+func (r *MongoDBSearchReconcileHelper) markRoutingReadyIfThresholdMet(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	unit reconcileUnit,
+	unitClient kubernetesClient.Client,
+) error {
 	if unit.shardName == "" || !r.mdbSearch.IsLBModeManaged() || slices.Contains(r.state.RoutingReadyMongotGroups, unit.shardName) {
 		return nil
 	}
@@ -1051,7 +1120,12 @@ func (r *MongoDBSearchReconcileHelper) pruneRoutingReady(ctx context.Context, li
 //
 // It fans out over the central client and every member client; per-kind/per-cluster
 // failures are best-effort — aggregated and retried next reconcile.
-func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Context, log *zap.SugaredLogger, clusters []clusterWork, units []reconcileUnit) error {
+func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	clusters []clusterWork,
+	units []reconcileUnit,
+) error {
 	// Per-kind expected-name sets. They are kept separate (rather than merged) because
 	// shard names can be customer-provided: a stale shard named e.g. "x-svc" would yield
 	// a StatefulSet name that collides with a live shard "x"'s headless Service name, and
@@ -1113,10 +1187,31 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 			continue
 		}
 		c, clusterName := work.Client, work.ClusterName
-		errs = multierror.Append(errs,
+		errs = multierror.Append(
+			errs,
 			deleteOwned(ctx, c, r.mdbSearch, clusterName, "StatefulSet", "", &appsv1.StatefulSetList{}, notExpected(expected.sts), log),
-			deleteOwned(ctx, c, r.mdbSearch, clusterName, "headless Service", mongotComponent, &corev1.ServiceList{}, notExpected(expected.headless), log),
-			deleteOwned(ctx, c, r.mdbSearch, clusterName, "ConfigMap", mongotComponent, &corev1.ConfigMapList{}, notExpected(expected.config), log),
+			deleteOwned(
+				ctx,
+				c,
+				r.mdbSearch,
+				clusterName,
+				"headless Service",
+				mongotComponent,
+				&corev1.ServiceList{},
+				notExpected(expected.headless),
+				log,
+			),
+			deleteOwned(
+				ctx,
+				c,
+				r.mdbSearch,
+				clusterName,
+				"ConfigMap",
+				mongotComponent,
+				&corev1.ConfigMapList{},
+				notExpected(expected.config),
+				log,
+			),
 			// Secrets: sweep only operator-generated name shapes (per-shard ingress
 			// TLS and operator-managed auth Secrets). Customer-provided Secrets —
 			// even ones carrying copied owner labels — never match.
@@ -1126,8 +1221,20 @@ func (r *MongoDBSearchReconcileHelper) cleanupStaleShardResources(ctx context.Co
 			}, log),
 		)
 		if manageProxyServices {
-			errs = multierror.Append(errs,
-				deleteOwned(ctx, c, r.mdbSearch, clusterName, "proxy Service", proxyServiceComponent, &corev1.ServiceList{}, notExpected(expected.proxy), log))
+			errs = multierror.Append(
+				errs,
+				deleteOwned(
+					ctx,
+					c,
+					r.mdbSearch,
+					clusterName,
+					"proxy Service",
+					proxyServiceComponent,
+					&corev1.ServiceList{},
+					notExpected(expected.proxy),
+					log,
+				),
+			)
 		}
 	}
 	return errs.ErrorOrNil()
@@ -1155,7 +1262,10 @@ func isOperatorGeneratedClientAuthSecretName(search *searchv1.MongoDBSearch, nam
 // ensureKeyfileModification returns the keyfile StatefulSet modification if wireproto is enabled.
 // Returns (NOOP, nil, true) if wireproto is disabled.
 // Returns (nil, status, false) if the keyfile is not ready and reconciliation should stop.
-func (r *MongoDBSearchReconcileHelper) ensureKeyfileModification(ctx context.Context, log *zap.SugaredLogger) (statefulset.Modification, workflow.Status, bool) {
+func (r *MongoDBSearchReconcileHelper) ensureKeyfileModification(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+) (statefulset.Modification, workflow.Status, bool) {
 	if !r.mdbSearch.IsWireprotoEnabled() {
 		return statefulset.NOOP(), nil, true
 	}
@@ -1192,13 +1302,21 @@ func (r *MongoDBSearchReconcileHelper) ensureSourceKeyfile(ctx context.Context, 
 // Returns workflow.Pending if any secret is missing (expected to be created).
 // Returns workflow.Failed on other errors.
 // Clusters with no registered client are skipped: the reconcile skips them everywhere.
-func (r *MongoDBSearchReconcileHelper) validatePerShardTLSSecrets(ctx context.Context, log *zap.SugaredLogger, shardNames []string) workflow.Status {
+func (r *MongoDBSearchReconcileHelper) validatePerShardTLSSecrets(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	shardNames []string,
+) workflow.Status {
 	if r.mdbSearch.Spec.Security.TLS == nil {
 		return workflow.OK()
 	}
 
 	if r.mdbSearch.CertificateKeySecretName() {
-		return workflow.Failed(xerrors.New("spec.security.tls.certificateKeySecretRef is not supported for sharded clusters, use spec.security.tls.certsSecretPrefix instead"))
+		return workflow.Failed(
+			xerrors.New(
+				"spec.security.tls.certificateKeySecretRef is not supported for sharded clusters, use spec.security.tls.certsSecretPrefix instead",
+			),
+		)
 	}
 
 	var validationErrs error
@@ -1253,7 +1371,14 @@ func (r *MongoDBSearchReconcileHelper) searchImageAndVersion() (string, string) 
 	return fmt.Sprintf("%s/%s", r.operatorSearchConfig.SearchRepo, r.operatorSearchConfig.SearchName), imageVersion
 }
 
-func (r *MongoDBSearchReconcileHelper) createOrUpdateStatefulSet(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, stsName types.NamespacedName, ownerReferences []metav1.OwnerReference, modifications ...statefulset.Modification) (*appsv1.StatefulSet, error) {
+func (r *MongoDBSearchReconcileHelper) createOrUpdateStatefulSet(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	kubeClient kubernetesClient.Client,
+	stsName types.NamespacedName,
+	ownerReferences []metav1.OwnerReference,
+	modifications ...statefulset.Modification,
+) (*appsv1.StatefulSet, error) {
 	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: stsName.Name, Namespace: stsName.Namespace}}
 	op, err := controllerutil.CreateOrUpdate(ctx, kubeClient, sts, func() error {
 		statefulset.Apply(modifications...)(sts)
@@ -1269,7 +1394,13 @@ func (r *MongoDBSearchReconcileHelper) createOrUpdateStatefulSet(ctx context.Con
 	return sts, nil
 }
 
-func (r *MongoDBSearchReconcileHelper) ensureSearchService(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, svcName types.NamespacedName, desired corev1.Service) error {
+func (r *MongoDBSearchReconcileHelper) ensureSearchService(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	kubeClient kubernetesClient.Client,
+	svcName types.NamespacedName,
+	desired corev1.Service,
+) error {
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName.Name, Namespace: svcName.Namespace}}
 	op, err := controllerutil.CreateOrUpdate(ctx, kubeClient, svc, func() error {
 		resourceVersion := svc.ResourceVersion
@@ -1296,7 +1427,16 @@ func (r *MongoDBSearchReconcileHelper) ensureSearchService(ctx context.Context, 
 // ensureMongotConfig creates or updates the mongot ConfigMap. When
 // auto-embedding is configured, generates leader/follower config files plus
 // pod-name role keys.
-func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, log *zap.SugaredLogger, kubeClient kubernetesClient.Client, cmName types.NamespacedName, stsName, clusterName string, ownerReferences []metav1.OwnerReference, replicas int, modifications ...mongot.Modification) (string, error) {
+func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	kubeClient kubernetesClient.Client,
+	cmName types.NamespacedName,
+	stsName, clusterName string,
+	ownerReferences []metav1.OwnerReference,
+	replicas int,
+	modifications ...mongot.Modification,
+) (string, error) {
 	usePerPodConfig := r.mdbSearch.HasAutoEmbedding()
 
 	mongotConfig := mongot.Config{}
@@ -1306,7 +1446,13 @@ func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, l
 	if err != nil {
 		return "", err
 	}
-	configEntries, keysToRemove, err := buildMongotConfigMapEntries(mongotConfig, perCluster.AdvancedMongotConfigs.ToMap(), usePerPodConfig, stsName, replicas)
+	configEntries, keysToRemove, err := buildMongotConfigMapEntries(
+		mongotConfig,
+		perCluster.AdvancedMongotConfigs.ToMap(),
+		usePerPodConfig,
+		stsName,
+		replicas,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -1357,7 +1503,13 @@ func (r *MongoDBSearchReconcileHelper) ensureMongotConfig(ctx context.Context, l
 //	{stsName}-0:         "leader"
 //	{stsName}-1:         "follower"
 //	{stsName}-N:         "follower"
-func buildMongotConfigMapEntries(config mongot.Config, advancedConfigs map[string]interface{}, usePerPodConfig bool, stsName string, replicas int) (map[string][]byte, []string, error) {
+func buildMongotConfigMapEntries(
+	config mongot.Config,
+	advancedConfigs map[string]interface{},
+	usePerPodConfig bool,
+	stsName string,
+	replicas int,
+) (map[string][]byte, []string, error) {
 	if usePerPodConfig {
 		return buildPerPodConfigEntries(config, advancedConfigs, stsName, replicas)
 	}
@@ -1365,7 +1517,12 @@ func buildMongotConfigMapEntries(config mongot.Config, advancedConfigs map[strin
 }
 
 // buildPerPodConfigEntries creates leader (pod-0) and follower configs with pod-name role keys.
-func buildPerPodConfigEntries(config mongot.Config, advancedConfigs map[string]interface{}, stsName string, replicas int) (map[string][]byte, []string, error) {
+func buildPerPodConfigEntries(
+	config mongot.Config,
+	advancedConfigs map[string]interface{},
+	stsName string,
+	replicas int,
+) (map[string][]byte, []string, error) {
 	leaderData, err := marshalMongotConfig(config, advancedConfigs)
 	if err != nil {
 		return nil, nil, err
@@ -1416,7 +1573,12 @@ func marshalMongotConfig(config mongot.Config, advancedConfigs map[string]interf
 	return yaml.Marshal(merged)
 }
 
-func buildSingleConfigEntry(config mongot.Config, advancedConfigs map[string]interface{}, stsName string, replicas int) (map[string][]byte, []string, error) {
+func buildSingleConfigEntry(
+	config mongot.Config,
+	advancedConfigs map[string]interface{},
+	stsName string,
+	replicas int,
+) (map[string][]byte, []string, error) {
 	data, err := marshalMongotConfig(config, advancedConfigs)
 	if err != nil {
 		return nil, nil, err
@@ -1646,7 +1808,10 @@ func ensureEmbeddingAPIKeySecret(ctx context.Context, client secret.Getter, secr
 
 // ensureEmbeddingConfig returns the mongot config and stateful set modification function based on the values provided in the search CR, it
 // also returns the hash of the secret that has the embedding API keys so that if the keys are changed the search pod is automatically restarted.
-func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(ctx context.Context, log *zap.SugaredLogger) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+) (mongot.Modification, statefulset.Modification, error) {
 	ae := r.mdbSearch.Spec.AutoEmbedding
 	if ae == nil {
 		return mongot.NOOP(), statefulset.NOOP(), nil
@@ -1714,7 +1879,11 @@ func (r *MongoDBSearchReconcileHelper) ensureEmbeddingConfig(ctx context.Context
 	}
 
 	readOnlyByOwnerPermission := int32(400)
-	apiKeyVolume := statefulset.CreateVolumeFromSecret(embeddingKeyVolumeName, ae.EmbeddingModelAPIKeySecret.Name, statefulset.WithSecretDefaultMode(&readOnlyByOwnerPermission))
+	apiKeyVolume := statefulset.CreateVolumeFromSecret(
+		embeddingKeyVolumeName,
+		ae.EmbeddingModelAPIKeySecret.Name,
+		statefulset.WithSecretDefaultMode(&readOnlyByOwnerPermission),
+	)
 	apiKeyVolumeMount := statefulset.CreateVolumeMount(embeddingKeyVolumeName, apiKeysTempVolumeMount, statefulset.WithReadOnly(true))
 
 	stsModification := statefulset.WithPodSpecTemplate(podtemplatespec.Apply(
@@ -1800,7 +1969,13 @@ func setupMongotContainerArgsForAPIKeys() container.Modification {
 // ensureIngressTlsConfig processes TLS configuration for any mongot deployment.
 // For non-sharded deployments, pass r.mdbSearch as the tlsResource.
 // For sharded deployments, pass a perShardTLSResource adapter.
-func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, tlsResource tls.TLSConfigurableResource, labels map[string]string, ownerReferences []metav1.OwnerReference) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	tlsResource tls.TLSConfigurableResource,
+	labels map[string]string,
+	ownerReferences []metav1.OwnerReference,
+) (mongot.Modification, statefulset.Modification, error) {
 	if r.mdbSearch.Spec.Security.TLS == nil {
 		return mongot.NOOP(), removeMongotVolumesAndMounts("tls", "grpc-key-password"), nil
 	}
@@ -1849,7 +2024,10 @@ func (r *MongoDBSearchReconcileHelper) ensureIngressTlsConfig(ctx context.Contex
 
 		volumeMounts = append(volumeMounts, keyPasswordVolumeMount)
 		volumes = append(volumes, podtemplatespec.WithVolume(keyPasswordVolume))
-		containerMods = append(containerMods, prependCommand(sensitiveFilePermissionsWorkaround(GrpcKeyPasswordMountPath, TempGrpcKeyPasswordPath, "0600")))
+		containerMods = append(
+			containerMods,
+			prependCommand(sensitiveFilePermissionsWorkaround(GrpcKeyPasswordMountPath, TempGrpcKeyPasswordPath, "0600")),
+		)
 	}
 
 	containerMods = append(containerMods, container.WithVolumeMounts(volumeMounts))
@@ -1879,7 +2057,12 @@ func (x *x509AuthResource) TLSOperatorSecretNamespacedName() types.NamespacedNam
 
 // ensureX509ClientCertConfig processes x509 client certificate configuration for the sync source in case of mongot to mongod communication.
 // When x509 is configured, it replaces username/password auth with x509 certificate auth.
-func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string, ownerReferences []metav1.OwnerReference) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	labels map[string]string,
+	ownerReferences []metav1.OwnerReference,
+) (mongot.Modification, statefulset.Modification, error) {
 	removeX509Volumes := removeMongotVolumesAndMounts("x509-client-cert", "x509-key-password")
 	if !r.mdbSearch.IsX509Auth() {
 		return mongot.NOOP(), removeX509Volumes, nil
@@ -1952,7 +2135,10 @@ func (r *MongoDBSearchReconcileHelper) ensureX509ClientCertConfig(ctx context.Co
 
 		volumeMounts = append(volumeMounts, keyPasswordVolumeMount)
 		volumes = append(volumes, podtemplatespec.WithVolume(keyPasswordVolume))
-		prependCommands = append(prependCommands, sensitiveFilePermissionsWorkaround(X509KeyPasswordMountPath, TempX509KeyPasswordPath, "0600"))
+		prependCommands = append(
+			prependCommands,
+			sensitiveFilePermissionsWorkaround(X509KeyPasswordMountPath, TempX509KeyPasswordPath, "0600"),
+		)
 	}
 
 	containerModifications := []container.Modification{
@@ -1989,7 +2175,12 @@ func (p *perShardTLSResource) TLSOperatorSecretNamespacedName() types.Namespaced
 	return p.TLSOperatorSecretForClusterShard(p.clusterIndex, p.shardName)
 }
 
-func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context, kubeClient kubernetesClient.Client, labels map[string]string, ownerReferences []metav1.OwnerReference) (mongot.Modification, statefulset.Modification, error) {
+func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	labels map[string]string,
+	ownerReferences []metav1.OwnerReference,
+) (mongot.Modification, statefulset.Modification, error) {
 	removeScramClientVolumes := removeMongotVolumesAndMounts("scram-client-cert", "scram-key-password")
 	tlsSourceConfig := r.db.TLSConfig()
 	if tlsSourceConfig == nil {
@@ -2064,7 +2255,11 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 	if scramCertPath != "" {
 		operatorSecret := r.mdbSearch.ScramClientCertOperatorManagedSecret()
 		scramCertVolume := statefulset.CreateVolumeFromSecret("scram-client-cert", operatorSecret.Name)
-		scramCertVolumeMount := statefulset.CreateVolumeMount("scram-client-cert", ScramClientCertOperatorMountPath, statefulset.WithReadOnly(true))
+		scramCertVolumeMount := statefulset.CreateVolumeMount(
+			"scram-client-cert",
+			ScramClientCertOperatorMountPath,
+			statefulset.WithReadOnly(true),
+		)
 
 		volumeMounts = append(volumeMounts, scramCertVolumeMount)
 		volumes = append(volumes, podtemplatespec.WithVolume(scramCertVolume))
@@ -2076,7 +2271,10 @@ func (r *MongoDBSearchReconcileHelper) ensureEgressTlsConfig(ctx context.Context
 
 			volumeMounts = append(volumeMounts, keyPasswordVolumeMount)
 			volumes = append(volumes, podtemplatespec.WithVolume(keyPasswordVolume))
-			containerMods = append(containerMods, prependCommand(sensitiveFilePermissionsWorkaround(ScramKeyPasswordMountPath, TempScramKeyPasswordPath, "0600")))
+			containerMods = append(
+				containerMods,
+				prependCommand(sensitiveFilePermissionsWorkaround(ScramKeyPasswordMountPath, TempScramKeyPasswordPath, "0600")),
+			)
 		}
 	}
 
@@ -2292,7 +2490,11 @@ func ResolveSingleClusterIndex(search *searchv1.MongoDBSearch) int {
 // clusterIndex must come from ResolveSingleClusterIndex so the endpoint names match the
 // per-cluster resources the search reconciler created.
 func GetMongodConfigParameters(search *searchv1.MongoDBSearch, clusterDomain string, clusterIndex int) map[string]any {
-	return buildSearchSetParameters(mongotHostAndPort(search, clusterDomain, clusterIndex), searchTLSMode(search), !search.IsWireprotoEnabled())
+	return buildSearchSetParameters(
+		mongotHostAndPort(search, clusterDomain, clusterIndex),
+		searchTLSMode(search),
+		!search.IsWireprotoEnabled(),
+	)
 }
 
 // mongotEndpointForShard resolves the per-shard mongot endpoint that the source
@@ -2315,8 +2517,17 @@ func mongotEndpointForShard(search *searchv1.MongoDBSearch, shardName string, cl
 
 // GetMongodConfigParametersForShard returns the mongod configuration parameters for a specific shard
 // in a sharded cluster. clusterIndex must come from ResolveSingleClusterIndex.
-func GetMongodConfigParametersForShard(search *searchv1.MongoDBSearch, shardName string, clusterDomain string, clusterIndex int) map[string]any {
-	return buildSearchSetParameters(mongotEndpointForShard(search, shardName, clusterDomain, clusterIndex), searchTLSMode(search), !search.IsWireprotoEnabled())
+func GetMongodConfigParametersForShard(
+	search *searchv1.MongoDBSearch,
+	shardName string,
+	clusterDomain string,
+	clusterIndex int,
+) map[string]any {
+	return buildSearchSetParameters(
+		mongotEndpointForShard(search, shardName, clusterDomain, clusterIndex),
+		searchTLSMode(search),
+		!search.IsWireprotoEnabled(),
+	)
 }
 
 // GetMongosConfigParametersForSharded picks the mongos→mongot endpoint by topology. No-LB targets the
@@ -2324,7 +2535,13 @@ func GetMongodConfigParametersForShard(search *searchv1.MongoDBSearch, shardName
 // the cluster-level Service would route to the same pod but isn't in SANs.
 // clusterIndex (the spec.clusters[i] pin) is for resource naming only;
 // clusterName resolves the cluster's LB config (empty = first cluster).
-func GetMongosConfigParametersForSharded(search *searchv1.MongoDBSearch, clusterIndex int, clusterName string, shardNames []string, clusterDomain string) map[string]any {
+func GetMongosConfigParametersForSharded(
+	search *searchv1.MongoDBSearch,
+	clusterIndex int,
+	clusterName string,
+	shardNames []string,
+	clusterDomain string,
+) map[string]any {
 	var endpoint string
 	// Three branches: explicit unmanaged LB, no loadBalancer (pre-MVP
 	// single-cluster shape), and managed LB. The TD lists no-LB as RS-only at

--- a/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
+++ b/controllers/searchcontroller/mongodbsearch_reconcile_helper_test.go
@@ -142,7 +142,14 @@ func stsVolumeAndMountNames(sts appsv1.StatefulSet) (map[string]bool, map[string
 	return volumeNames, mountNames
 }
 
-func assertObjectPresence(t *testing.T, c kubernetesClient.Client, nn types.NamespacedName, obj client.Object, wantPresent bool, msg string) {
+func assertObjectPresence(
+	t *testing.T,
+	c kubernetesClient.Client,
+	nn types.NamespacedName,
+	obj client.Object,
+	wantPresent bool,
+	msg string,
+) {
 	t.Helper()
 	err := c.Get(t.Context(), nn, obj)
 	if wantPresent {
@@ -152,7 +159,13 @@ func assertObjectPresence(t *testing.T, c kubernetesClient.Client, nn types.Name
 	}
 }
 
-func reconcileMongoDBSearch(ctx context.Context, fakeClient kubernetesClient.Client, mdbSearch *searchv1.MongoDBSearch, mdbc *mdbcv1.MongoDBCommunity, operatorConfig OperatorSearchConfig) workflow.Status {
+func reconcileMongoDBSearch(
+	ctx context.Context,
+	fakeClient kubernetesClient.Client,
+	mdbSearch *searchv1.MongoDBSearch,
+	mdbc *mdbcv1.MongoDBCommunity,
+	operatorConfig OperatorSearchConfig,
+) workflow.Status {
 	helper := NewMongoDBSearchReconcileHelper(
 		fakeClient,
 		mdbSearch,
@@ -233,7 +246,15 @@ func TestMongoDBSearchReconcileHelper_ValidateSingleMongoDBSearchForSearchSource
 			}
 
 			fakeClient := kubernetesClient.NewClient(clientBuilder.Build())
-			helper := NewMongoDBSearchReconcileHelper(fakeClient, mdbSearch, NewCommunityResourceSearchSource(mdbc), OperatorSearchConfig{}, nil, "", nil)
+			helper := NewMongoDBSearchReconcileHelper(
+				fakeClient,
+				mdbSearch,
+				NewCommunityResourceSearchSource(mdbc),
+				OperatorSearchConfig{},
+				nil,
+				"",
+				nil,
+			)
 			err := helper.ValidateSingleMongoDBSearchForSearchSource(t.Context())
 			if c.expectedError == "" {
 				assert.NoError(t, err)
@@ -287,7 +308,13 @@ func TestGetMongodConfigParameters_TransportAndPorts(t *testing.T) {
 				expectedPort = search.GetMongotWireprotoPort()
 			}
 			// No LB: headless pod-0 FQDN = <sts>-0.<svc>.<ns>.svc.<domain>
-			expectedPrefix := fmt.Sprintf("%s-0.%s.%s.svc.%s", search.Name+"-search-0", search.Name+"-search-0-svc", search.Namespace, clusterDomain)
+			expectedPrefix := fmt.Sprintf(
+				"%s-0.%s.%s.svc.%s",
+				search.Name+"-search-0",
+				search.Name+"-search-0-svc",
+				search.Namespace,
+				clusterDomain,
+			)
 			expectedSuffix := fmt.Sprintf(":%d", expectedPort)
 
 			for _, key := range []string{"mongotHost", "searchIndexManagementHostAndPort"} {
@@ -1170,8 +1197,14 @@ func TestEnsureMongotConfig_PerPodModes(t *testing.T) {
 			name:             "per-pod config mode - 3 replicas with embedding",
 			replicas:         3,
 			hasAutoEmbedding: true,
-			expectedKeys:     []string{MongotConfigLeaderFilename, MongotConfigFollowerFilename, "test-search-search-0", "test-search-search-1", "test-search-search-2"},
-			notExpectedKeys:  []string{MongotConfigFilename},
+			expectedKeys: []string{
+				MongotConfigLeaderFilename,
+				MongotConfigFollowerFilename,
+				"test-search-search-0",
+				"test-search-search-1",
+				"test-search-search-2",
+			},
+			notExpectedKeys: []string{MongotConfigFilename},
 		},
 	}
 
@@ -1190,7 +1223,17 @@ func TestEnsureMongotConfig_PerPodModes(t *testing.T) {
 			embeddingMod := func(c *mongot.Config) {
 				c.Embedding = &mongot.EmbeddingConfig{IsAutoEmbeddingViewWriter: ptr.To(true)}
 			}
-			_, err := helper.ensureMongotConfig(t.Context(), zap.S(), fakeClient, cmName, stsName, "", search.GetOwnerReferences(), int(tc.replicas), embeddingMod)
+			_, err := helper.ensureMongotConfig(
+				t.Context(),
+				zap.S(),
+				fakeClient,
+				cmName,
+				stsName,
+				"",
+				search.GetOwnerReferences(),
+				int(tc.replicas),
+				embeddingMod,
+			)
 			require.NoError(t, err)
 
 			cm, err := fakeClient.GetConfigMap(t.Context(), cmName)
@@ -1280,7 +1323,11 @@ func TestEnsureMongotConfig_AdvancedMongotConfigs(t *testing.T) {
 		c.Storage.DataPath = "/mongot/data"
 	}
 	search := newTestMongoDBSearch("test-search", "test-ns")
-	withAdvancedMongotConfigs(t, search, `{"indexing":{"lucene":{"fieldLimit":1000}},"querying":{"lucene":{"enableConcurrentSearch":true}}}`)
+	withAdvancedMongotConfigs(
+		t,
+		search,
+		`{"indexing":{"lucene":{"fieldLimit":1000}},"querying":{"lucene":{"enableConcurrentSearch":true}}}`,
+	)
 
 	data := renderMongotConfig(t, search, operatorMod)
 
@@ -1334,7 +1381,11 @@ func TestEnsureMongotConfig_AdvancedMongotConfigsAbsentUnchanged(t *testing.T) {
 
 func TestReconcileReplicaSet_AdvancedMongotConfigs(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "test-ns")
-	withAdvancedMongotConfigs(t, search, `{"indexing":{"lucene":{"fieldLimit":1000}},"syncSource":{"replicaSet":{"hostAndPort":["evil:1"]}}}`)
+	withAdvancedMongotConfigs(
+		t,
+		search,
+		`{"indexing":{"lucene":{"fieldLimit":1000}},"syncSource":{"replicaSet":{"hostAndPort":["evil:1"]}}}`,
+	)
 	mdbc := newTestMongoDBCommunity("test-mongodb", "test-ns")
 	fakeClient := newTestFakeClient(search, mdbc)
 
@@ -1505,7 +1556,11 @@ func TestCreateShardMongotConfig(t *testing.T) {
 	config := mongot.Config{}
 	mongot.Apply(baseMongotConfig(search, seeds0), routerMongotMod(search, shardedSource), featureFlagsMongotMod(search))(&config)
 
-	assert.Equal(t, []string{"my-cluster-0-0.svc:27017", "my-cluster-0-1.svc:27017", "my-cluster-0-2.svc:27017"}, config.SyncSource.ReplicaSet.HostAndPort)
+	assert.Equal(
+		t,
+		[]string{"my-cluster-0-0.svc:27017", "my-cluster-0-1.svc:27017", "my-cluster-0-2.svc:27017"},
+		config.SyncSource.ReplicaSet.HostAndPort,
+	)
 	assert.Equal(t, search.SourceUsername(), config.SyncSource.ReplicaSet.ScramAuth.Username)
 
 	// OverloadRetrySignal defaults to true even when featureFlags is not set in CR
@@ -1523,7 +1578,11 @@ func TestCreateShardMongotConfig(t *testing.T) {
 	config2 := mongot.Config{}
 	mongot.Apply(baseMongotConfig(search, seeds1), routerMongotMod(search, shardedSource))(&config2)
 
-	assert.Equal(t, []string{"my-cluster-1-0.svc:27017", "my-cluster-1-1.svc:27017", "my-cluster-1-2.svc:27017"}, config2.SyncSource.ReplicaSet.HostAndPort)
+	assert.Equal(
+		t,
+		[]string{"my-cluster-1-0.svc:27017", "my-cluster-1-1.svc:27017", "my-cluster-1-2.svc:27017"},
+		config2.SyncSource.ReplicaSet.HostAndPort,
+	)
 }
 
 func TestShardedMongotConfigWithTLS(t *testing.T) {
@@ -2032,7 +2091,10 @@ func TestGetMongosConfigParametersForSharded_PinnedIndexNotSpecPosition(t *testi
 			},
 			Clusters: []searchv1.ClusterSpec{
 				{Name: "cluster-b", LoadBalancer: &searchv1.LoadBalancerConfig{
-					Managed: &searchv1.ManagedLBConfig{ExternalHostname: "{shardName}.b.example.com:443", RouterHostname: "b.example.com:443"},
+					Managed: &searchv1.ManagedLBConfig{
+						ExternalHostname: "{shardName}.b.example.com:443",
+						RouterHostname:   "b.example.com:443",
+					},
 				}},
 			},
 		},
@@ -2527,7 +2589,11 @@ func TestReconcileSharded_CertificateKeySecretRefRejected(t *testing.T) {
 
 	msgOpt, exists := status.GetOption(result.StatusOptions(), status.MessageOption{})
 	require.True(t, exists)
-	assert.Contains(t, msgOpt.(status.MessageOption).Message, "spec.security.tls.certificateKeySecretRef is not supported for sharded clusters")
+	assert.Contains(
+		t,
+		msgOpt.(status.MessageOption).Message,
+		"spec.security.tls.certificateKeySecretRef is not supported for sharded clusters",
+	)
 }
 
 func TestValidatePerShardTLSSecrets(t *testing.T) {
@@ -2858,7 +2924,12 @@ func TestEnsureX509ClientCertConfig_NoopWhenNotConfigured(t *testing.T) {
 	fakeClient := newTestFakeClient(search)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, "", nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search), search.GetOwnerReferences())
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(
+		t.Context(),
+		fakeClient,
+		searchOwnerLabels(search),
+		search.GetOwnerReferences(),
+	)
 	require.NoError(t, err)
 
 	// Apply modifications and verify no changes
@@ -2925,7 +2996,12 @@ func TestEnsureX509ClientCertConfig_MongotAndStsModification(t *testing.T) {
 	fakeClient := newTestFakeClient(search, x509Secret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, "", nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, mongotOwnerLabels(search), search.GetOwnerReferences())
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(
+		t.Context(),
+		fakeClient,
+		mongotOwnerLabels(search),
+		search.GetOwnerReferences(),
+	)
 	require.NoError(t, err)
 	operatorSecret, err := fakeClient.GetSecret(t.Context(), search.X509OperatorManagedSecret())
 	require.NoError(t, err)
@@ -3055,7 +3131,12 @@ func TestEnsureX509ClientCertConfig_KeyPassword(t *testing.T) {
 	fakeClient := newTestFakeClient(search, x509Secret, keyPasswordSecret)
 	helper := NewMongoDBSearchReconcileHelper(fakeClient, search, dbSource, newTestOperatorSearchConfig(), nil, "", nil)
 
-	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(t.Context(), fakeClient, searchOwnerLabels(search), search.GetOwnerReferences())
+	mongotMod, stsMod, err := helper.ensureX509ClientCertConfig(
+		t.Context(),
+		fakeClient,
+		searchOwnerLabels(search),
+		search.GetOwnerReferences(),
+	)
 	require.NoError(t, err)
 
 	// Verify mongot config has key password path
@@ -3318,17 +3399,53 @@ func TestCleanupStaleShardResources(t *testing.T) {
 			fakeClient := newTestFakeClient(search, activeSTS, staleSTS, staleTLSSecret, x509Secret, scramSecret, customerSecret)
 			helper := NewMongoDBSearchReconcileHelper(fakeClient, search, nil, newTestOperatorSearchConfig(), nil, "", nil)
 
-			require.NoError(t, helper.cleanupStaleShardResources(t.Context(), zap.S(), helper.buildClusterWorkList(), []reconcileUnit{newTestShardCleanupUnit(search, 0, "shard-0")}))
+			require.NoError(
+				t,
+				helper.cleanupStaleShardResources(
+					t.Context(),
+					zap.S(),
+					helper.buildClusterWorkList(),
+					[]reconcileUnit{newTestShardCleanupUnit(search, 0, "shard-0")},
+				),
+			)
 
 			assertObjectPresence(t, fakeClient, client.ObjectKeyFromObject(activeSTS), &appsv1.StatefulSet{}, true, "active StatefulSet")
 			assertObjectPresence(t, fakeClient, client.ObjectKeyFromObject(staleSTS), &appsv1.StatefulSet{}, false, "stale StatefulSet")
 			// The stale shard's ingress TLS Secret is swept even with TLS disabled,
 			// while the generated auth Secrets survive with their auth modes off:
 			// they go only with their shard/cluster/CR.
-			assertObjectPresence(t, fakeClient, client.ObjectKeyFromObject(staleTLSSecret), &corev1.Secret{}, false, "stale shard ingress TLS Secret")
-			assertObjectPresence(t, fakeClient, client.ObjectKeyFromObject(x509Secret), &corev1.Secret{}, true, "x509 operator-managed Secret")
-			assertObjectPresence(t, fakeClient, client.ObjectKeyFromObject(scramSecret), &corev1.Secret{}, true, "SCRAM client-cert operator-managed Secret")
-			assertObjectPresence(t, fakeClient, client.ObjectKeyFromObject(customerSecret), &corev1.Secret{}, true, "customer Secret with copied labels")
+			assertObjectPresence(
+				t,
+				fakeClient,
+				client.ObjectKeyFromObject(staleTLSSecret),
+				&corev1.Secret{},
+				false,
+				"stale shard ingress TLS Secret",
+			)
+			assertObjectPresence(
+				t,
+				fakeClient,
+				client.ObjectKeyFromObject(x509Secret),
+				&corev1.Secret{},
+				true,
+				"x509 operator-managed Secret",
+			)
+			assertObjectPresence(
+				t,
+				fakeClient,
+				client.ObjectKeyFromObject(scramSecret),
+				&corev1.Secret{},
+				true,
+				"SCRAM client-cert operator-managed Secret",
+			)
+			assertObjectPresence(
+				t,
+				fakeClient,
+				client.ObjectKeyFromObject(customerSecret),
+				&corev1.Secret{},
+				true,
+				"customer Secret with copied labels",
+			)
 		})
 	}
 }
@@ -3793,7 +3910,12 @@ func TestReplicationReaderTagSetsMod(t *testing.T) {
 func TestBuildReplicaSetPlan_PerClusterMatchTagSets(t *testing.T) {
 	mdb := newTestMongoDBSearch("mdb-search", "ns")
 	mdb.Spec.Clusters = []searchv1.ClusterSpec{
-		{Name: "cluster-a", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)), SyncSourceSelector: &searchv1.SyncSourceSelector{MatchTagSets: []map[string]string{{"region": "us-east"}}}},
+		{
+			Name:               "cluster-a",
+			Index:              ptr.To(int32(0)),
+			Replicas:           ptr.To(int32(1)),
+			SyncSourceSelector: &searchv1.SyncSourceSelector{MatchTagSets: []map[string]string{{"region": "us-east"}}},
+		},
 		{Name: "cluster-b", Index: ptr.To(int32(1)), Replicas: ptr.To(int32(1))},
 	}
 	mdb.Spec.Source = &searchv1.MongoDBSource{
@@ -3985,10 +4107,15 @@ func TestBuildShardedPlan_PerClusterShardUnitsForMC(t *testing.T) {
 func TestBuildShardedPlan_PerClusterMatchTagSets(t *testing.T) {
 	search := newTestMongoDBSearch("mdb-search", "ns")
 	search.Spec.Clusters = []searchv1.ClusterSpec{
-		{Name: "cluster-a", Index: ptr.To(int32(0)), SyncSourceSelector: &searchv1.SyncSourceSelector{MatchTagSets: []map[string]string{{"region": "us-east"}}}, LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
-			ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
-			RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
-		}}},
+		{
+			Name:               "cluster-a",
+			Index:              ptr.To(int32(0)),
+			SyncSourceSelector: &searchv1.SyncSourceSelector{MatchTagSets: []map[string]string{{"region": "us-east"}}},
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+				ExternalHostname: "{shardName}.mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+				RouterHostname:   "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			}},
+		},
 		{Name: "cluster-b", Index: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
 			ExternalHostname: "{shardName}.mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
 			RouterHostname:   "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
@@ -4024,7 +4151,15 @@ func TestBuildShardedPlan_PerClusterMatchTagSets(t *testing.T) {
 	for i, w := range want {
 		cfg := mongot.Config{}
 		plan.units[i].mongotConfigFn(&cfg)
-		assert.Equal(t, w, cfg.SyncSource.ReplicationReader, "unit %d (%s/%s) replicationReader", i, plan.units[i].clusterName, plan.units[i].additionalSvcLabels[shardLabelKey])
+		assert.Equal(
+			t,
+			w,
+			cfg.SyncSource.ReplicationReader,
+			"unit %d (%s/%s) replicationReader",
+			i,
+			plan.units[i].clusterName,
+			plan.units[i].additionalSvcLabels[shardLabelKey],
+		)
 	}
 }
 
@@ -4081,7 +4216,10 @@ func TestReconcileShardedMC_FanOutUsesPerClusterClient(t *testing.T) {
 	// Mirror reconcile()'s cluster-level proxy Service pass.
 	for _, res := range plan.clusterLevelResources {
 		require.NotNil(t, res.client, "cluster-level resource for %q must carry its cluster client", res.clusterName)
-		require.NoError(t, r.ensureSearchService(t.Context(), zap.S(), res.client, res.svcName, buildClusterLevelProxyService(r.mdbSearch, res)))
+		require.NoError(
+			t,
+			r.ensureSearchService(t.Context(), zap.S(), res.client, res.svcName, buildClusterLevelProxyService(r.mdbSearch, res)),
+		)
 	}
 
 	// Per-(cluster, shard) STS + ConfigMap + per-shard proxy Service on the right client.
@@ -4800,13 +4938,55 @@ func TestCleanupStaleShardResources_MCFanOut(t *testing.T) {
 	require.NoError(t, r.cleanupStaleShardResources(t.Context(), zap.S(), r.buildClusterWorkList(), activeUnits))
 
 	svcName := func(name string) types.NamespacedName { return types.NamespacedName{Name: name, Namespace: "ns"} }
-	assertObjectPresence(t, clusterA, svcName("mdb-search-search-0-sh-0-proxy-svc"), &corev1.Service{}, true, "cluster-a active per-shard proxy Service")
-	assertObjectPresence(t, clusterA, svcName("mdb-search-search-0-proxy-svc"), &corev1.Service{}, true, "cluster-a cluster-level proxy Service")
-	assertObjectPresence(t, clusterA, svcName("mdb-search-search-0-sh-stale-proxy-svc"), &corev1.Service{}, false, "cluster-a stale per-shard proxy Service")
+	assertObjectPresence(
+		t,
+		clusterA,
+		svcName("mdb-search-search-0-sh-0-proxy-svc"),
+		&corev1.Service{},
+		true,
+		"cluster-a active per-shard proxy Service",
+	)
+	assertObjectPresence(
+		t,
+		clusterA,
+		svcName("mdb-search-search-0-proxy-svc"),
+		&corev1.Service{},
+		true,
+		"cluster-a cluster-level proxy Service",
+	)
+	assertObjectPresence(
+		t,
+		clusterA,
+		svcName("mdb-search-search-0-sh-stale-proxy-svc"),
+		&corev1.Service{},
+		false,
+		"cluster-a stale per-shard proxy Service",
+	)
 	assertObjectPresence(t, clusterA, svcName("foreign-svc"), &corev1.Service{}, true, "cluster-a unowned Service")
-	assertObjectPresence(t, clusterA, search.TLSOperatorSecretForClusterShard(0, "sh-0"), &corev1.Secret{}, true, "cluster-a active shard TLS operator Secret")
-	assertObjectPresence(t, clusterA, search.TLSOperatorSecretForClusterShard(0, "sh-stale"), &corev1.Secret{}, false, "cluster-a stale shard TLS operator Secret")
-	assertObjectPresence(t, clusterB, svcName("mdb-search-search-1-sh-0-proxy-svc"), &corev1.Service{}, true, "cluster-b active per-shard proxy Service")
+	assertObjectPresence(
+		t,
+		clusterA,
+		search.TLSOperatorSecretForClusterShard(0, "sh-0"),
+		&corev1.Secret{},
+		true,
+		"cluster-a active shard TLS operator Secret",
+	)
+	assertObjectPresence(
+		t,
+		clusterA,
+		search.TLSOperatorSecretForClusterShard(0, "sh-stale"),
+		&corev1.Secret{},
+		false,
+		"cluster-a stale shard TLS operator Secret",
+	)
+	assertObjectPresence(
+		t,
+		clusterB,
+		svcName("mdb-search-search-1-sh-0-proxy-svc"),
+		&corev1.Service{},
+		true,
+		"cluster-b active per-shard proxy Service",
+	)
 	assertObjectPresence(t, clusterB, search.MongotStatefulSetForClusterShard(0, "sh-0"), &appsv1.StatefulSet{}, false,
 		"an active name on another physical cluster must not preserve a stale StatefulSet")
 }
@@ -5241,12 +5421,22 @@ func TestReconcileShardedMC_ShardOverrideReplicas(t *testing.T) {
 func newMCReplicaSetHelper(members map[string]kubernetesClient.Client, central kubernetesClient.Client) *MongoDBSearchReconcileHelper {
 	mdb := newTestMongoDBSearch("mdb-search", "ns")
 	mdb.Spec.Clusters = []searchv1.ClusterSpec{
-		{Name: "cluster-a", Index: ptr.To(int32(0)), Replicas: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
-			ExternalHostname: "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
-		}}},
-		{Name: "cluster-b", Index: ptr.To(int32(1)), Replicas: ptr.To(int32(1)), LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
-			ExternalHostname: "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
-		}}},
+		{
+			Name:     "cluster-a",
+			Index:    ptr.To(int32(0)),
+			Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+				ExternalHostname: "mdb-search-search-0-proxy-svc.ns.svc.cluster.local",
+			}},
+		},
+		{
+			Name:     "cluster-b",
+			Index:    ptr.To(int32(1)),
+			Replicas: ptr.To(int32(1)),
+			LoadBalancer: &searchv1.LoadBalancerConfig{Managed: &searchv1.ManagedLBConfig{
+				ExternalHostname: "mdb-search-search-1-proxy-svc.ns.svc.cluster.local",
+			}},
+		},
 	}
 	mdb.Spec.Source = &searchv1.MongoDBSource{
 		ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -102,7 +102,14 @@ type TLSSourceConfig struct {
 // sizing is the resolved per-(cluster, shard) ClusterSpec — see
 // MongoDBSearch.ResolveSizingForClusterShard — read for Replicas / Persistence /
 // ResourceRequirements / JVMFlags / StatefulSetConfiguration.
-func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searchv1.ClusterSpec, stsName, namespace, svcName, configMapName string, labels map[string]string, searchImage string, usePerPodConfig bool) statefulset.Modification {
+func CreateSearchStatefulSetFunc(
+	mdbSearch *searchv1.MongoDBSearch,
+	sizing searchv1.ClusterSpec,
+	stsName, namespace, svcName, configMapName string,
+	labels map[string]string,
+	searchImage string,
+	usePerPodConfig bool,
+) statefulset.Modification {
 	tmpVolume := statefulset.CreateVolumeFromEmptyDir("tmp")
 	tmpVolumeMount := statefulset.CreateVolumeMount(tmpVolume.Name, tempVolumePath, statefulset.WithReadOnly(false))
 
@@ -115,7 +122,11 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 
 	var mongotConfigVolumeMount corev1.VolumeMount
 	if usePerPodConfig {
-		mongotConfigVolumeMount = statefulset.CreateVolumeMount(mongotConfigVolumeName, MongotPerPodConfigDirPath, statefulset.WithReadOnly(true))
+		mongotConfigVolumeMount = statefulset.CreateVolumeMount(
+			mongotConfigVolumeName,
+			MongotPerPodConfigDirPath,
+			statefulset.WithReadOnly(true),
+		)
 	} else {
 		mongotConfigVolumeMount = statefulset.CreateVolumeMount(mongotConfigVolumeName, MongotConfigPath, statefulset.WithReadOnly(true), statefulset.WithSubPath(MongotConfigFilename))
 	}
@@ -126,7 +137,10 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 	}
 
 	defaultPersistenceConfig := v1.PersistenceConfig{Storage: util.DefaultMongodStorageSize}
-	dataVolumeClaim := statefulset.WithVolumeClaim(dataVolumeName, construct.PvcFunc(dataVolumeName, persistenceConfig, defaultPersistenceConfig, nil))
+	dataVolumeClaim := statefulset.WithVolumeClaim(
+		dataVolumeName,
+		construct.PvcFunc(dataVolumeName, persistenceConfig, defaultPersistenceConfig, nil),
+	)
 
 	podSecurityContext, _ := podtemplatespec.WithDefaultSecurityContextsModifications()
 
@@ -163,7 +177,10 @@ func CreateSearchStatefulSetFunc(mdbSearch *searchv1.MongoDBSearch, sizing searc
 				podtemplatespec.WithAffinity(labels[appLabelKey], appLabelKey, 100),
 				podtemplatespec.WithTopologyKey(util.DefaultAntiAffinityTopologyKey, 0),
 				nodeAffinityModification(sizing.NodeAffinity),
-				podtemplatespec.WithContainer(MongotContainerName, mongodbSearchContainer(mdbSearch, sizing, volumeMounts, searchImage, usePerPodConfig)),
+				podtemplatespec.WithContainer(
+					MongotContainerName,
+					mongodbSearchContainer(mdbSearch, sizing, volumeMounts, searchImage, usePerPodConfig),
+				),
 			),
 		),
 	}
@@ -221,7 +238,12 @@ func PasswordAuthModification(mdbSearch *searchv1.MongoDBSearch) statefulset.Mod
 	sourceUserPasswordVolumeName := "password"
 	sourceUserPasswordSecretKey := mdbSearch.SourceUserPasswordSecretRef()
 	sourceUserPasswordVolume := statefulset.CreateVolumeFromSecret(sourceUserPasswordVolumeName, sourceUserPasswordSecretKey.Name)
-	sourceUserPasswordVolumeMount := statefulset.CreateVolumeMount(sourceUserPasswordVolumeName, MongotSourceUserPasswordPath, statefulset.WithReadOnly(true), statefulset.WithSubPath(sourceUserPasswordSecretKey.Key))
+	sourceUserPasswordVolumeMount := statefulset.CreateVolumeMount(
+		sourceUserPasswordVolumeName,
+		MongotSourceUserPasswordPath,
+		statefulset.WithReadOnly(true),
+		statefulset.WithSubPath(sourceUserPasswordSecretKey.Key),
+	)
 
 	return statefulset.WithPodSpecTemplate(podtemplatespec.Apply(
 		podtemplatespec.WithVolume(sourceUserPasswordVolume),
@@ -235,7 +257,12 @@ func PasswordAuthModification(mdbSearch *searchv1.MongoDBSearch) statefulset.Mod
 func CreateKeyfileModificationFunc(keyfileSecretName string) statefulset.Modification {
 	keyfileVolumeName := "keyfile"
 	keyfileVolume := statefulset.CreateVolumeFromSecret(keyfileVolumeName, keyfileSecretName)
-	keyfileVolumeMount := statefulset.CreateVolumeMount(keyfileVolumeName, MongotKeyfilePath, statefulset.WithReadOnly(true), statefulset.WithSubPath(MongotKeyfileFilename))
+	keyfileVolumeMount := statefulset.CreateVolumeMount(
+		keyfileVolumeName,
+		MongotKeyfilePath,
+		statefulset.WithReadOnly(true),
+		statefulset.WithSubPath(MongotKeyfileFilename),
+	)
 
 	return statefulset.Apply(
 		statefulset.WithPodSpecTemplate(
@@ -286,7 +313,13 @@ func jvmFlags(userJVMFlags []string, resourceRequirements corev1.ResourceRequire
 	return fmt.Sprintf(`--jvm-flags "%s"`, flagsValue)
 }
 
-func mongodbSearchContainer(mdbSearch *searchv1.MongoDBSearch, perCluster searchv1.ClusterSpec, volumeMounts []corev1.VolumeMount, searchImage string, usePerPodConfig bool) container.Modification {
+func mongodbSearchContainer(
+	mdbSearch *searchv1.MongoDBSearch,
+	perCluster searchv1.ClusterSpec,
+	volumeMounts []corev1.VolumeMount,
+	searchImage string,
+	usePerPodConfig bool,
+) container.Modification {
 	_, containerSecurityContext := podtemplatespec.WithDefaultSecurityContextsModifications()
 	resourceRequirements := createSearchResourceRequirements(perCluster.ResourceRequirements)
 
@@ -324,11 +357,19 @@ sed -i "s/%s/$HOSTNAME/" %s
 func mongotPerPodConfigStartCommand(jvmFlags string) string {
 	// Copy the role-specific config from the read-only ConfigMap mount to writable /tmp,
 	// replace the server-name placeholder with the actual pod hostname, then start mongot.
-	return fmt.Sprintf(`ROLE=$(cat "%s/$HOSTNAME")
+	return fmt.Sprintf(
+		`ROLE=$(cat "%s/$HOSTNAME")
 cp "%s/config-${ROLE}.yml" %s
 sed -i "s/%s/$HOSTNAME/" %s
 /mongot-community/mongot --config %s %s`,
-		MongotPerPodConfigDirPath, MongotPerPodConfigDirPath, TempMongotConfigPath, ServerNamePlaceholder, TempMongotConfigPath, TempMongotConfigPath, jvmFlags)
+		MongotPerPodConfigDirPath,
+		MongotPerPodConfigDirPath,
+		TempMongotConfigPath,
+		ServerNamePlaceholder,
+		TempMongotConfigPath,
+		TempMongotConfigPath,
+		jvmFlags,
+	)
 }
 
 func mongotLivenessProbe(search *searchv1.MongoDBSearch) func(*corev1.Probe) {

--- a/controllers/searchcontroller/search_construction_test.go
+++ b/controllers/searchcontroller/search_construction_test.go
@@ -138,7 +138,17 @@ func TestCreateSearchStatefulSetFunc_JVMFlags(t *testing.T) {
 				s.Spec.Clusters = []searchv1.ClusterSpec{cluster}
 			})
 
-			stsModification := CreateSearchStatefulSetFunc(search, resolvedSizing(t, search, "", ""), "", "", "", "", nil, "mongot:latest", false)
+			stsModification := CreateSearchStatefulSetFunc(
+				search,
+				resolvedSizing(t, search, "", ""),
+				"",
+				"",
+				"",
+				"",
+				nil,
+				"mongot:latest",
+				false,
+			)
 			sts := statefulset.New(stsModification)
 
 			// Find the mongot container
@@ -255,7 +265,17 @@ func TestCreateSearchStatefulSetFunc_DefaultAntiAffinity(t *testing.T) {
 	search := newTestMongoDBSearch("test-search", "default")
 	labels := map[string]string{appLabelKey: "test-search-svc"}
 
-	stsMod := CreateSearchStatefulSetFunc(search, resolvedSizing(t, search, "", ""), "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+	stsMod := CreateSearchStatefulSetFunc(
+		search,
+		resolvedSizing(t, search, "", ""),
+		"test-search-db",
+		"default",
+		"test-search-svc",
+		"cm",
+		labels,
+		"mongot:latest",
+		false,
+	)
 	sts := statefulset.New(stsMod)
 
 	// Reclaim the index PVC immediately on both CR delete and scale-down.
@@ -304,7 +324,17 @@ func TestCreateSearchStatefulSetFunc_StatefulSetOverrideReplacesAntiAffinity(t *
 	labels := map[string]string{appLabelKey: "test-search-svc"}
 
 	sizing := resolvedSizing(t, search, "cluster-1", "")
-	stsMod := CreateSearchStatefulSetFunc(search, sizing, "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+	stsMod := CreateSearchStatefulSetFunc(
+		search,
+		sizing,
+		"test-search-db",
+		"default",
+		"test-search-svc",
+		"cm",
+		labels,
+		"mongot:latest",
+		false,
+	)
 	overrideMod := StatefulSetOverrideModification(sizing.StatefulSetConfiguration)
 	// The override is applied last in the reconcile pipeline, after all other modifications.
 	sts := statefulset.New(stsMod, overrideMod)
@@ -410,7 +440,17 @@ func TestCreateSearchStatefulSetFunc_NodeAffinity(t *testing.T) {
 			})
 
 			sizing := resolvedSizing(t, search, tc.clusterName, tc.shardName)
-			stsMod := CreateSearchStatefulSetFunc(search, sizing, "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+			stsMod := CreateSearchStatefulSetFunc(
+				search,
+				sizing,
+				"test-search-db",
+				"default",
+				"test-search-svc",
+				"cm",
+				labels,
+				"mongot:latest",
+				false,
+			)
 			// The override is applied last in the reconcile pipeline; a NOOP when unset.
 			sts := statefulset.New(stsMod, StatefulSetOverrideModification(sizing.StatefulSetConfiguration))
 
@@ -436,13 +476,33 @@ func TestCreateSearchStatefulSetFunc_ShardOverrideReplicas(t *testing.T) {
 	labels := map[string]string{appLabelKey: "test-search-svc"}
 
 	// The overridden shard's StatefulSet uses the override replica count.
-	stsMod := CreateSearchStatefulSetFunc(search, resolvedSizing(t, search, "", "shard-1"), "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+	stsMod := CreateSearchStatefulSetFunc(
+		search,
+		resolvedSizing(t, search, "", "shard-1"),
+		"test-search-db",
+		"default",
+		"test-search-svc",
+		"cm",
+		labels,
+		"mongot:latest",
+		false,
+	)
 	sts := statefulset.New(stsMod)
 	require.NotNil(t, sts.Spec.Replicas)
 	assert.Equal(t, int32(3), *sts.Spec.Replicas)
 
 	// A shard without an override keeps the cluster default.
-	stsMod = CreateSearchStatefulSetFunc(search, resolvedSizing(t, search, "", "shard-0"), "test-search-db", "default", "test-search-svc", "cm", labels, "mongot:latest", false)
+	stsMod = CreateSearchStatefulSetFunc(
+		search,
+		resolvedSizing(t, search, "", "shard-0"),
+		"test-search-db",
+		"default",
+		"test-search-svc",
+		"cm",
+		labels,
+		"mongot:latest",
+		false,
+	)
 	sts = statefulset.New(stsMod)
 	require.NotNil(t, sts.Spec.Replicas)
 	assert.Equal(t, int32(1), *sts.Spec.Replicas)

--- a/controllers/searchcontroller/search_resource_sweep.go
+++ b/controllers/searchcontroller/search_resource_sweep.go
@@ -20,7 +20,15 @@ import (
 // selects on owner labels only) and deletes every one accepted by eligible
 // (nil = all). Per-object failures are joined and never abort the sweep;
 // NotFound deletes are tolerated. clusterName is log context only.
-func deleteOwned(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, clusterName, kind, component string, list client.ObjectList, eligible func(client.Object) bool, log *zap.SugaredLogger) error {
+func deleteOwned(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName, kind, component string,
+	list client.ObjectList,
+	eligible func(client.Object) bool,
+	log *zap.SugaredLogger,
+) error {
 	selector := client.MatchingLabels(khandler.SearchOwnershipLabels(search, "", component))
 	if err := c.List(ctx, list, client.InNamespace(search.Namespace), selector); err != nil {
 		return xerrors.Errorf("failed listing MongoDBSearch %ss on cluster %q: %w", kind, clusterName, err)
@@ -36,7 +44,10 @@ func deleteOwned(ctx context.Context, c kubernetesClient.Client, search *searchv
 			continue
 		}
 		if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-			errs = errors.Join(errs, xerrors.Errorf("failed deleting MongoDBSearch %s %s on cluster %q: %w", kind, obj.GetName(), clusterName, err))
+			errs = errors.Join(
+				errs,
+				xerrors.Errorf("failed deleting MongoDBSearch %s %s on cluster %q: %w", kind, obj.GetName(), clusterName, err),
+			)
 			continue
 		}
 		log.Infof("Deleted MongoDBSearch %s %s (cluster=%q)", kind, obj.GetName(), clusterName)
@@ -46,7 +57,14 @@ func deleteOwned(ctx context.Context, c kubernetesClient.Client, search *searchv
 
 // DeleteAllOwnedResources deletes every owned object of one kind/component — the
 // broad removed-cluster sweeps.
-func DeleteAllOwnedResources(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, clusterName, kind, component string, list client.ObjectList, log *zap.SugaredLogger) error {
+func DeleteAllOwnedResources(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName, kind, component string,
+	list client.ObjectList,
+	log *zap.SugaredLogger,
+) error {
 	return deleteOwned(ctx, c, search, clusterName, kind, component, list, nil, log)
 }
 
@@ -57,7 +75,15 @@ func DeleteAllOwnedResources(ctx context.Context, c kubernetesClient.Client, sea
 // the delete attempt (even if the delete then fails): the metrics controller's
 // forwarder-before-host Pending gate relies on exists-semantics, and Foreground
 // propagation keeps it true until the pods are fully gone.
-func DeleteOwnedResource(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, clusterName, kind, component string, obj client.Object, log *zap.SugaredLogger, opts ...client.DeleteOption) (found bool, err error) {
+func DeleteOwnedResource(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	clusterName, kind, component string,
+	obj client.Object,
+	log *zap.SugaredLogger,
+	opts ...client.DeleteOption,
+) (found bool, err error) {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil

--- a/controllers/searchcontroller/search_state.go
+++ b/controllers/searchcontroller/search_state.go
@@ -75,7 +75,12 @@ func ReadSearchState(
 // with configmap.CreateOrUpdate — that is a blind no-RV Update). mutate returns
 // true when the state changed and must be persisted. Every update also repairs
 // owner labels missing from ConfigMaps written by released 1.9.x operators.
-func MutateSearchState(ctx context.Context, c kubernetesClient.Client, search *searchv1.MongoDBSearch, mutate func(*SearchDeploymentState) bool) (*SearchDeploymentState, error) {
+func MutateSearchState(
+	ctx context.Context,
+	c kubernetesClient.Client,
+	search *searchv1.MongoDBSearch,
+	mutate func(*SearchDeploymentState) bool,
+) (*SearchDeploymentState, error) {
 	cmName := SearchStateCMName(search)
 	cm := &corev1.ConfigMap{}
 	err := c.Get(ctx, kube.ObjectKey(search.Namespace, cmName), cm)

--- a/controllers/searchcontroller/sharded_external_search_source_test.go
+++ b/controllers/searchcontroller/sharded_external_search_source_test.go
@@ -109,19 +109,25 @@ func TestShardedExternalSearchSource_Validate(t *testing.T) {
 		{
 			name: "Valid config with multiple router hosts",
 			spec: &searchv1.ExternalMongoDBSource{
-				ShardedCluster: newExternalShardedConfig([]string{"mongos1.example.com:27017", "mongos2.example.com:27017"}, []searchv1.ExternalShardConfig{
-					{ShardName: "shard-0", Hosts: []string{"shard0-0.example.com:27017"}},
-				}),
+				ShardedCluster: newExternalShardedConfig(
+					[]string{"mongos1.example.com:27017", "mongos2.example.com:27017"},
+					[]searchv1.ExternalShardConfig{
+						{ShardName: "shard-0", Hosts: []string{"shard0-0.example.com:27017"}},
+					},
+				),
 			},
 			expectError: false,
 		},
 		{
 			name: "InValid config, multiple shards with same name",
 			spec: &searchv1.ExternalMongoDBSource{
-				ShardedCluster: newExternalShardedConfig([]string{"mongos1.example.com:27017", "mongos2.example.com:27017"}, []searchv1.ExternalShardConfig{
-					{ShardName: "shard-0", Hosts: []string{"shard0-0.example.com:27017"}},
-					{ShardName: "shard-0", Hosts: []string{"shard0-0.example.com:27017"}},
-				}),
+				ShardedCluster: newExternalShardedConfig(
+					[]string{"mongos1.example.com:27017", "mongos2.example.com:27017"},
+					[]searchv1.ExternalShardConfig{
+						{ShardName: "shard-0", Hosts: []string{"shard0-0.example.com:27017"}},
+						{ShardName: "shard-0", Hosts: []string{"shard0-0.example.com:27017"}},
+					},
+				),
 			},
 			expectError:    true,
 			expectedErrMsg: "shardNames can not be duplicate, shard name shard-0 is duplicate",
@@ -295,9 +301,12 @@ func TestShardedExternalSearchSource_MongosHostsAndPorts(t *testing.T) {
 		{
 			name: "Multiple router hosts returns all",
 			spec: &searchv1.ExternalMongoDBSource{
-				ShardedCluster: newExternalShardedConfig([]string{"mongos1.example.com:27017", "mongos2.example.com:27017"}, []searchv1.ExternalShardConfig{
-					{ShardName: "shard-0", Hosts: []string{"host:27017"}},
-				}),
+				ShardedCluster: newExternalShardedConfig(
+					[]string{"mongos1.example.com:27017", "mongos2.example.com:27017"},
+					[]searchv1.ExternalShardConfig{
+						{ShardName: "shard-0", Hosts: []string{"host:27017"}},
+					},
+				),
 			},
 			expected: []string{"mongos1.example.com:27017", "mongos2.example.com:27017"},
 		},

--- a/main.go
+++ b/main.go
@@ -78,7 +78,11 @@ var (
 
 	// List of allowed operator environments. The first element of this list is
 	// considered the default one.
-	operatorEnvironments = []string{util.OperatorEnvironmentDev.String(), util.OperatorEnvironmentLocal.String(), util.OperatorEnvironmentProd.String()}
+	operatorEnvironments = []string{
+		util.OperatorEnvironmentDev.String(),
+		util.OperatorEnvironmentLocal.String(),
+		util.OperatorEnvironmentProd.String(),
+	}
 
 	scheme = runtime.NewScheme()
 
@@ -150,7 +154,9 @@ func run() error {
 
 	agentDebug := env.ReadBoolOrDefault(util.EnvVarDebug, false)
 	agentDebugImage := env.ReadOrDefault(util.EnvVarDebugImage, "")
-	defaultArchitecture := architectures.DefaultArchitecture(env.ReadOrDefault(architectures.DefaultEnvArchitecture, string(architectures.NonStatic)))
+	defaultArchitecture := architectures.DefaultArchitecture(
+		env.ReadOrDefault(architectures.DefaultEnvArchitecture, string(architectures.NonStatic)),
+	)
 
 	enableClusterMongoDBRoles := slices.Contains(crds, clusterMongoDBRoleCRDPlural)
 
@@ -332,7 +338,16 @@ func run() error {
 	if telemetry.IsTelemetryActivated() {
 		log.Info("Running telemetry component!")
 		installerMethod := env.ReadOrDefault(telemetry.InstallerEnvVar, "")
-		telemetryRunnable, err := telemetry.NewLeaderRunnable(mgr, memberClusterObjectsMap, currentNamespace, imageUrls[util.MongodbImageEnv], imageUrls[util.NonStaticDatabaseEnterpriseImage], installerMethod, getOperatorEnv(), defaultArchitecture)
+		telemetryRunnable, err := telemetry.NewLeaderRunnable(
+			mgr,
+			memberClusterObjectsMap,
+			currentNamespace,
+			imageUrls[util.MongodbImageEnv],
+			imageUrls[util.NonStaticDatabaseEnterpriseImage],
+			installerMethod,
+			getOperatorEnv(),
+			defaultArchitecture,
+		)
 		if err != nil {
 			log.Errorf("Unable to enable telemetry; err: %s", err)
 		}
@@ -370,7 +385,11 @@ func startRootSpan(currentNamespace string, spanIDHex string, traceCtx context.C
 	}
 
 	ctx, operatorSpan := telemetry.TRACER.Start(traceCtx, "MONGODB_OPERATOR_ROOT", opts...)
-	log.Debugf("Started root operator span with ID: %s in trace %s", operatorSpan.SpanContext().SpanID().String(), operatorSpan.SpanContext().TraceID().String())
+	log.Debugf(
+		"Started root operator span with ID: %s in trace %s",
+		operatorSpan.SpanContext().SpanID().String(),
+		operatorSpan.SpanContext().TraceID().String(),
+	)
 	return ctx, operatorSpan
 }
 
@@ -385,7 +404,17 @@ func shutdownTracerProvider(signalCtx context.Context, tp *sdktrace.TracerProvid
 	}
 }
 
-func setupMongoDBCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClusterObjectsMap map[string]runtime_cluster.Cluster, backupEnableDelay time.Duration) error {
+func setupMongoDBCRD(
+	ctx context.Context,
+	mgr manager.Manager,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+	backupEnableDelay time.Duration,
+) error {
 	if err := operator.AddStandaloneController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture); err != nil {
 		return err
 	}
@@ -400,7 +429,14 @@ func setupMongoDBCRD(ctx context.Context, mgr manager.Manager, imageUrls images.
 		Complete()
 }
 
-func setupMongoDBOpsManagerCRD(ctx context.Context, mgr manager.Manager, memberClusterObjectsMap map[string]runtime_cluster.Cluster, imageUrls images.ImageUrls, initDatabaseVersion, initOpsManagerImageVersion string, defaultArchitecture architectures.DefaultArchitecture) error {
+func setupMongoDBOpsManagerCRD(
+	ctx context.Context,
+	mgr manager.Manager,
+	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+	imageUrls images.ImageUrls,
+	initDatabaseVersion, initOpsManagerImageVersion string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) error {
 	if err := operator.AddOpsManagerController(ctx, mgr, memberClusterObjectsMap, imageUrls, initDatabaseVersion, initOpsManagerImageVersion, defaultArchitecture); err != nil {
 		return err
 	}
@@ -409,11 +445,25 @@ func setupMongoDBOpsManagerCRD(ctx context.Context, mgr manager.Manager, memberC
 		Complete()
 }
 
-func setupMongoDBUserCRD(ctx context.Context, mgr manager.Manager, memberClusterObjectsMap map[string]runtime_cluster.Cluster, backupEnableDelay time.Duration) error {
+func setupMongoDBUserCRD(
+	ctx context.Context,
+	mgr manager.Manager,
+	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+	backupEnableDelay time.Duration,
+) error {
 	return operator.AddMongoDBUserController(ctx, mgr, memberClusterObjectsMap, backupEnableDelay)
 }
 
-func setupMongoDBMultiClusterCRD(ctx context.Context, mgr manager.Manager, imageUrls images.ImageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string, forceEnterprise, enableClusterMongoDBRoles, agentDebug bool, agentDebugImage string, defaultArchitecture architectures.DefaultArchitecture, memberClusterObjectsMap map[string]runtime_cluster.Cluster) error {
+func setupMongoDBMultiClusterCRD(
+	ctx context.Context,
+	mgr manager.Manager,
+	imageUrls images.ImageUrls,
+	initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion string,
+	forceEnterprise, enableClusterMongoDBRoles, agentDebug bool,
+	agentDebugImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	memberClusterObjectsMap map[string]runtime_cluster.Cluster,
+) error {
 	requiredHealthyStreak := env.ReadIntOrDefault(util.RequiredHealthyStreakEnv, util.DefaultRequiredHealthyStreak)
 	if err := operator.AddMultiReplicaSetController(ctx, mgr, imageUrls, initDatabaseNonStaticImageVersion, databaseNonStaticImageVersion, forceEnterprise, enableClusterMongoDBRoles, agentDebug, agentDebugImage, defaultArchitecture, requiredHealthyStreak, memberClusterObjectsMap); err != nil {
 		return err
@@ -506,7 +556,13 @@ func isInLocalMode() bool {
 
 // setupWebhook sets up the validation webhook for MongoDB resources in order
 // to give people early warning when their MongoDB resources are wrong.
-func setupWebhook(ctx context.Context, cfg *rest.Config, log *zap.SugaredLogger, svcSelector string, currentNamespace string) crWebhook.Options {
+func setupWebhook(
+	ctx context.Context,
+	cfg *rest.Config,
+	log *zap.SugaredLogger,
+	svcSelector string,
+	currentNamespace string,
+) crWebhook.Options {
 	// set webhook port — 1993 is chosen as Ben's birthday
 	webhookPort := env.ReadIntOrDefault(util.MdbWebhookPortEnv, 1993)
 

--- a/mongodb-community-operator/api/v1/mongodbcommunity_types.go
+++ b/mongodb-community-operator/api/v1/mongodbcommunity_types.go
@@ -754,7 +754,14 @@ func (m *MongoDBCommunity) MongoURI() string {
 func (m *MongoDBCommunity) MongoSRVURI() string {
 	optionsString := m.GetOptionsString()
 
-	return fmt.Sprintf("mongodb+srv://%s.%s.svc.%s/?replicaSet=%s%s", m.ServiceName(), m.Namespace, m.Spec.GetClusterDomain(), m.Name, optionsString)
+	return fmt.Sprintf(
+		"mongodb+srv://%s.%s.svc.%s/?replicaSet=%s%s",
+		m.ServiceName(),
+		m.Namespace,
+		m.Spec.GetClusterDomain(),
+		m.Name,
+		optionsString,
+	)
 }
 
 // MongoAuthUserURI returns a mongo uri which can be used to connect to this deployment
@@ -995,8 +1002,8 @@ func (a automationConfigReplicasScaler) ForcedIndividualScaling() bool {
 
 // MongoDBCommunityList contains a list of MongoDB
 type MongoDBCommunityList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `                   json:",inline"`
+	metav1.ListMeta `                   json:"metadata,omitempty"`
 	Items           []MongoDBCommunity `json:"items"`
 }
 

--- a/mongodb-community-operator/api/v1/mongodbcommunity_types_test.go
+++ b/mongodb-community-operator/api/v1/mongodbcommunity_types_test.go
@@ -411,8 +411,16 @@ func TestMongoDBCommunity_MongoAuthUserURI(t *testing.T) {
 	// space must be encoded as %20; + must be encoded as %2B (pymongo uses unquote_plus on userinfo)
 	mdb = newReplicaSet(2, "my-rs", "my-namespace")
 	spaceUser := authtypes.User{Username: "rob", Database: "admin"}
-	assert.Equal(t, mdb.MongoAuthUserURI(spaceUser, "pass word"), "mongodb://rob:pass%20word@my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:27017,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:27017/admin?replicaSet=my-rs&ssl=false")
-	assert.Equal(t, mdb.MongoAuthUserURI(spaceUser, "pass+word"), "mongodb://rob:pass%2Bword@my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:27017,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:27017/admin?replicaSet=my-rs&ssl=false")
+	assert.Equal(
+		t,
+		mdb.MongoAuthUserURI(spaceUser, "pass word"),
+		"mongodb://rob:pass%20word@my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:27017,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:27017/admin?replicaSet=my-rs&ssl=false",
+	)
+	assert.Equal(
+		t,
+		mdb.MongoAuthUserURI(spaceUser, "pass+word"),
+		"mongodb://rob:pass%2Bword@my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:27017,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:27017/admin?replicaSet=my-rs&ssl=false",
+	)
 
 	testuser = authtypes.User{
 		Username: "testuser",
@@ -420,7 +428,11 @@ func TestMongoDBCommunity_MongoAuthUserURI(t *testing.T) {
 	}
 	mdb = newReplicaSet(2, "my-rs", "my-namespace")
 
-	assert.Equal(t, mdb.MongoAuthUserURI(testuser, ""), "mongodb://my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:27017,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:27017/$external?replicaSet=my-rs&ssl=false")
+	assert.Equal(
+		t,
+		mdb.MongoAuthUserURI(testuser, ""),
+		"mongodb://my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:27017,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:27017/$external?replicaSet=my-rs&ssl=false",
+	)
 }
 
 func TestMongoDBCommunity_MongoAuthUserSRVURI(t *testing.T) {
@@ -478,8 +490,16 @@ func TestMongoDBCommunity_MongoAuthUserSRVURI(t *testing.T) {
 	// space must be encoded as %20; + must be encoded as %2B (pymongo uses unquote_plus on userinfo)
 	mdb = newReplicaSet(2, "my-rs", "my-namespace")
 	spaceUser := authtypes.User{Username: "rob", Database: "admin"}
-	assert.Equal(t, mdb.MongoAuthUserSRVURI(spaceUser, "pass word"), "mongodb+srv://rob:pass%20word@my-rs-svc.my-namespace.svc.cluster.local/admin?replicaSet=my-rs&ssl=false")
-	assert.Equal(t, mdb.MongoAuthUserSRVURI(spaceUser, "pass+word"), "mongodb+srv://rob:pass%2Bword@my-rs-svc.my-namespace.svc.cluster.local/admin?replicaSet=my-rs&ssl=false")
+	assert.Equal(
+		t,
+		mdb.MongoAuthUserSRVURI(spaceUser, "pass word"),
+		"mongodb+srv://rob:pass%20word@my-rs-svc.my-namespace.svc.cluster.local/admin?replicaSet=my-rs&ssl=false",
+	)
+	assert.Equal(
+		t,
+		mdb.MongoAuthUserSRVURI(spaceUser, "pass+word"),
+		"mongodb+srv://rob:pass%2Bword@my-rs-svc.my-namespace.svc.cluster.local/admin?replicaSet=my-rs&ssl=false",
+	)
 
 	testuser = authtypes.User{
 		Username: "testuser",
@@ -487,7 +507,11 @@ func TestMongoDBCommunity_MongoAuthUserSRVURI(t *testing.T) {
 	}
 	mdb = newReplicaSet(2, "my-rs", "my-namespace")
 
-	assert.Equal(t, mdb.MongoAuthUserSRVURI(testuser, ""), "mongodb+srv://my-rs-svc.my-namespace.svc.cluster.local/$external?replicaSet=my-rs&ssl=false")
+	assert.Equal(
+		t,
+		mdb.MongoAuthUserSRVURI(testuser, ""),
+		"mongodb+srv://my-rs-svc.my-namespace.svc.cluster.local/$external?replicaSet=my-rs&ssl=false",
+	)
 }
 
 func TestConvertAuthModeToAuthMechanism(t *testing.T) {

--- a/mongodb-community-operator/cmd/readiness/readiness_test.go
+++ b/mongodb-community-operator/cmd/readiness/readiness_test.go
@@ -259,7 +259,10 @@ func TestHeadlessAgentHasntReachedGoal(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv(headlessAgent, "true")
 	c := testConfig("testdata/health-status-ok.json")
-	c.ClientSet = fake.NewSimpleClientset(testdata.TestPod(c.Namespace, c.Hostname), testdata.TestSecret(c.Namespace, c.AutomationConfigSecretName, 6))
+	c.ClientSet = fake.NewSimpleClientset(
+		testdata.TestPod(c.Namespace, c.Hostname),
+		testdata.TestSecret(c.Namespace, c.AutomationConfigSecretName, 6),
+	)
 	ready, err := isPodReady(ctx, c)
 	assert.False(t, ready)
 	assert.NoError(t, err)
@@ -273,7 +276,10 @@ func TestHeadlessAgentReachedGoal(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv(headlessAgent, "true")
 	c := testConfig("testdata/health-status-ok.json")
-	c.ClientSet = fake.NewSimpleClientset(testdata.TestPod(c.Namespace, c.Hostname), testdata.TestSecret(c.Namespace, c.AutomationConfigSecretName, 5))
+	c.ClientSet = fake.NewSimpleClientset(
+		testdata.TestPod(c.Namespace, c.Hostname),
+		testdata.TestSecret(c.Namespace, c.AutomationConfigSecretName, 5),
+	)
 	ready, err := isPodReady(ctx, c)
 	assert.True(t, ready)
 	assert.NoError(t, err)

--- a/mongodb-community-operator/controllers/construct/build_statefulset_test.go
+++ b/mongodb-community-operator/controllers/construct/build_statefulset_test.go
@@ -35,7 +35,14 @@ func newTestReplicaSet() mdbv1.MongoDBCommunity {
 
 func TestMultipleCalls_DoNotCauseSideEffects(t *testing.T) {
 	mdb := newTestReplicaSet()
-	stsFunc := BuildMongoDBReplicaSetStatefulSetModificationFunction(&mdb, &mdb, "fake-mongodbImage", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	stsFunc := BuildMongoDBReplicaSetStatefulSetModificationFunction(
+		&mdb,
+		&mdb,
+		"fake-mongodbImage",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	sts := &appsv1.StatefulSet{}
 
 	t.Run("1st Call", func(t *testing.T) {
@@ -56,7 +63,14 @@ func TestManagedSecurityContext(t *testing.T) {
 	t.Setenv(podtemplatespec.ManagedSecurityContextEnv, "true")
 
 	mdb := newTestReplicaSet()
-	stsFunc := BuildMongoDBReplicaSetStatefulSetModificationFunction(&mdb, &mdb, "fake-mongodbImage", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	stsFunc := BuildMongoDBReplicaSetStatefulSetModificationFunction(
+		&mdb,
+		&mdb,
+		"fake-mongodbImage",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 
 	sts := &appsv1.StatefulSet{}
 	stsFunc(sts)

--- a/mongodb-community-operator/controllers/construct/mongodbstatefulset.go
+++ b/mongodb-community-operator/controllers/construct/mongodbstatefulset.go
@@ -107,7 +107,11 @@ type MongoDBStatefulSetOwner interface {
 // BuildMongoDBReplicaSetStatefulSetModificationFunction builds the parts of the replica set that are common between every resource that implements
 // MongoDBStatefulSetOwner.
 // It doesn't configure TLS or additional containers/env vars that the statefulset might need.
-func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSetOwner, scaler scale.ReplicaSetScaler, mongodbImage, agentImage, versionUpgradeHookImage, readinessProbeImage string) statefulset.Modification {
+func BuildMongoDBReplicaSetStatefulSetModificationFunction(
+	mdb MongoDBStatefulSetOwner,
+	scaler scale.ReplicaSetScaler,
+	mongodbImage, agentImage, versionUpgradeHookImage, readinessProbeImage string,
+) statefulset.Modification {
 	labels := map[string]string{
 		"app": mdb.ServiceName(),
 	}
@@ -128,8 +132,16 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 
 	keyFileNsName := mdb.GetAgentKeyfileSecretNamespacedName()
 	keyFileVolume := statefulset.CreateVolumeFromEmptyDir(keyFileNsName.Name)
-	keyFileVolumeVolumeMount := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
-	keyFileVolumeVolumeMountMongod := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
+	keyFileVolumeVolumeMount := statefulset.CreateVolumeMount(
+		keyFileVolume.Name,
+		"/var/lib/mongodb-mms-automation/authentication",
+		statefulset.WithReadOnly(false),
+	)
+	keyFileVolumeVolumeMountMongod := statefulset.CreateVolumeMount(
+		keyFileVolume.Name,
+		"/var/lib/mongodb-mms-automation/authentication",
+		statefulset.WithReadOnly(false),
+	)
 
 	mongodbAgentVolumeMounts := []corev1.VolumeMount{agentHealthStatusVolumeMount, keyFileVolumeVolumeMount, tmpVolumeMount}
 
@@ -137,7 +149,11 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 	if mdb.NeedsAutomationConfigVolume() {
 		automationConfigVolume := statefulset.CreateVolumeFromSecret("automation-config", mdb.AutomationConfigSecretName())
 		automationConfigVolumeFunc = podtemplatespec.WithVolume(automationConfigVolume)
-		automationConfigVolumeMount := statefulset.CreateVolumeMount(automationConfigVolume.Name, "/var/lib/automation/config", statefulset.WithReadOnly(true))
+		automationConfigVolumeMount := statefulset.CreateVolumeMount(
+			automationConfigVolume.Name,
+			"/var/lib/automation/config",
+			statefulset.WithReadOnly(true),
+		)
 		mongodbAgentVolumeMounts = append(mongodbAgentVolumeMounts, automationConfigVolumeMount)
 	}
 	mongodVolumeMounts := []corev1.VolumeMount{mongodHealthStatusVolumeMount, keyFileVolumeVolumeMountMongod, tmpVolumeMount}
@@ -152,8 +168,14 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 
 	mongodVolumeMounts = append(mongodVolumeMounts, hooksVolumeMount)
 	mongodbAgentVolumeMounts = append(mongodbAgentVolumeMounts, scriptsVolumeMount)
-	upgradeInitContainer := podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount}, versionUpgradeHookImage))
-	readinessInitContainer := podtemplatespec.WithInitContainer(ReadinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount}, readinessProbeImage))
+	upgradeInitContainer := podtemplatespec.WithInitContainer(
+		versionUpgradeHookName,
+		versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount}, versionUpgradeHookImage),
+	)
+	readinessInitContainer := podtemplatespec.WithInitContainer(
+		ReadinessProbeContainerName,
+		readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount}, readinessProbeImage),
+	)
 
 	dataVolumeClaim := statefulset.NOOP()
 	logVolumeClaim := statefulset.NOOP()
@@ -214,8 +236,21 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 				podtemplatespec.WithVolume(tmpVolume),
 				podtemplatespec.WithVolume(keyFileVolume),
 				podtemplatespec.WithServiceAccount(mongodbDatabaseServiceAccountName),
-				podtemplatespec.WithContainer(AgentName, mongodbAgentContainer(mdb.AutomationConfigSecretName(), mongodbAgentVolumeMounts, agentLogLevel, agentLogFile, agentMaxLogFileDurationHours, agentImage)),
-				podtemplatespec.WithContainer(MongodbName, mongodbContainer(mongodbImage, mongodVolumeMounts, mdb.GetMongodConfiguration(), false)),
+				podtemplatespec.WithContainer(
+					AgentName,
+					mongodbAgentContainer(
+						mdb.AutomationConfigSecretName(),
+						mongodbAgentVolumeMounts,
+						agentLogLevel,
+						agentLogFile,
+						agentMaxLogFileDurationHours,
+						agentImage,
+					),
+				),
+				podtemplatespec.WithContainer(
+					MongodbName,
+					mongodbContainer(mongodbImage, mongodVolumeMounts, mdb.GetMongodConfiguration(), false),
+				),
 				upgradeInitContainer,
 				readinessInitContainer,
 			),
@@ -240,7 +275,11 @@ func AutomationAgentCommand(withStatic bool, logLevel v1.LogLevel, logFile strin
 		agentLogOptions += " -logFile " + logFile + " -logLevel " + string(logLevel) + " -maxLogFileDurationHrs " + strconv.Itoa(maxLogFileDurationHours)
 	}
 
-	return []string{"/bin/bash", "-c", MongodbUserCommand + BaseAgentCommand() + " -cluster=" + clusterFilePath + automationAgentOptions + agentLogOptions}
+	return []string{
+		"/bin/bash",
+		"-c",
+		MongodbUserCommand + BaseAgentCommand() + " -cluster=" + clusterFilePath + automationAgentOptions + agentLogOptions,
+	}
 }
 
 func GetMongodbUserCommandWithAPIKeyExport(withStatic bool) string {
@@ -263,7 +302,14 @@ fi
 `, agentPrepareScript)
 }
 
-func mongodbAgentContainer(automationConfigSecretName string, volumeMounts []corev1.VolumeMount, logLevel v1.LogLevel, logFile string, maxLogFileDurationHours int, agentImage string) container.Modification {
+func mongodbAgentContainer(
+	automationConfigSecretName string,
+	volumeMounts []corev1.VolumeMount,
+	logLevel v1.LogLevel,
+	logFile string,
+	maxLogFileDurationHours int,
+	agentImage string,
+) container.Modification {
 	_, containerSecurityContext := podtemplatespec.WithDefaultSecurityContextsModifications()
 	return container.Apply(
 		container.WithName(AgentName),
@@ -433,7 +479,12 @@ echo "Starting mongod..."
 `, signalHandling, filePath, keyfileFilePath, mongodExec)
 }
 
-func mongodbContainer(mongodbImage string, volumeMounts []corev1.VolumeMount, additionalMongoDBConfig v1.MongodConfiguration, isStatic bool) container.Modification {
+func mongodbContainer(
+	mongodbImage string,
+	volumeMounts []corev1.VolumeMount,
+	additionalMongoDBConfig v1.MongodConfiguration,
+	isStatic bool,
+) container.Modification {
 	filePath := additionalMongoDBConfig.GetDBDataDir() + "/" + automationMongodConfFileName
 	mongoDbCommand := buildMongodbCommand(filePath, isStatic)
 

--- a/mongodb-community-operator/controllers/construct/mongodbstatefulset_test.go
+++ b/mongodb-community-operator/controllers/construct/mongodbstatefulset_test.go
@@ -136,10 +136,20 @@ func TestMongodbContainer_SignalHandling(t *testing.T) {
 			if tt.isStatic {
 				assert.Contains(t, commandScript, "trap cleanup SIGTERM", "Static architecture should include signal trap")
 				assert.Contains(t, commandScript, "cleanup() {", "Static architecture should include cleanup function")
-				assert.Contains(t, commandScript, "mongod -f /data/automation-mongod.conf &", "Static architecture should run mongod in background")
+				assert.Contains(
+					t,
+					commandScript,
+					"mongod -f /data/automation-mongod.conf &",
+					"Static architecture should run mongod in background",
+				)
 				assert.Contains(t, commandScript, "wait \"$MONGOD_PID\"", "Static architecture should wait for mongod process")
 				assert.Contains(t, commandScript, "termination_timeout_seconds", "Static architecture should include timeout configuration")
-				assert.Contains(t, commandScript, "while [ -e \"/proc/${MONGOD_PID}\" ]", "Static architecture should include robust process waiting")
+				assert.Contains(
+					t,
+					commandScript,
+					"while [ -e \"/proc/${MONGOD_PID}\" ]",
+					"Static architecture should include robust process waiting",
+				)
 				assert.Contains(t, commandScript, "kill -15 \"$MONGOD_PID\"", "Static architecture should send SIGTERM to mongod")
 			} else {
 				assert.NotContains(t, commandScript, "trap cleanup SIGTERM", "Non-static architecture should not include signal trap")
@@ -147,7 +157,12 @@ func TestMongodbContainer_SignalHandling(t *testing.T) {
 				assert.Contains(t, commandScript, "exec mongod -f /data/automation-mongod.conf", "Non-static architecture should exec mongod")
 			}
 
-			assert.Contains(t, commandScript, "Waiting for config and keyfile files to be created by the agent", "Should wait for agent files")
+			assert.Contains(
+				t,
+				commandScript,
+				"Waiting for config and keyfile files to be created by the agent",
+				"Should wait for agent files",
+			)
 			assert.Contains(t, commandScript, "Starting mongod...", "Should start mongod")
 		})
 	}

--- a/mongodb-community-operator/controllers/mongodb_cleanup.go
+++ b/mongodb-community-operator/controllers/mongodb_cleanup.go
@@ -12,7 +12,12 @@ import (
 )
 
 // cleanupPemSecret cleans up the old pem secret generated for the agent certificate.
-func (r *ReplicaSetReconciler) cleanupPemSecret(ctx context.Context, currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
+func (r *ReplicaSetReconciler) cleanupPemSecret(
+	ctx context.Context,
+	currentMDBSpec mdbv1.MongoDBCommunitySpec,
+	lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec,
+	namespace string,
+) {
 	if currentMDBSpec.GetAgentAuthMode() == lastAppliedMDBSpec.GetAgentAuthMode() {
 		return
 	}
@@ -33,7 +38,12 @@ func (r *ReplicaSetReconciler) cleanupPemSecret(ctx context.Context, currentMDBS
 }
 
 // cleanupScramSecrets cleans up old scram secrets based on the last successful applied mongodb spec.
-func (r *ReplicaSetReconciler) cleanupScramSecrets(ctx context.Context, currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
+func (r *ReplicaSetReconciler) cleanupScramSecrets(
+	ctx context.Context,
+	currentMDBSpec mdbv1.MongoDBCommunitySpec,
+	lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec,
+	namespace string,
+) {
 	secretsToDelete := getScramSecretsToDelete(currentMDBSpec, lastAppliedMDBSpec)
 
 	for _, s := range secretsToDelete {
@@ -49,7 +59,13 @@ func (r *ReplicaSetReconciler) cleanupScramSecrets(ctx context.Context, currentM
 }
 
 // cleanupConnectionStringSecrets cleans up old scram secrets based on the last successful applied mongodb spec.
-func (r *ReplicaSetReconciler) cleanupConnectionStringSecrets(ctx context.Context, currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string, resourceName string) {
+func (r *ReplicaSetReconciler) cleanupConnectionStringSecrets(
+	ctx context.Context,
+	currentMDBSpec mdbv1.MongoDBCommunitySpec,
+	lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec,
+	namespace string,
+	resourceName string,
+) {
 	secretsToDelete := getConnectionStringSecretsToDelete(currentMDBSpec, lastAppliedMDBSpec, resourceName)
 
 	for _, s := range secretsToDelete {
@@ -93,7 +109,11 @@ func getScramSecretsToDelete(currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppl
 	return secretsToDelete
 }
 
-func getConnectionStringSecretsToDelete(currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, resourceName string) []string {
+func getConnectionStringSecretsToDelete(
+	currentMDBSpec mdbv1.MongoDBCommunitySpec,
+	lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec,
+	resourceName string,
+) []string {
 	type user struct {
 		db   string
 		name string

--- a/mongodb-community-operator/controllers/mongodb_cleanup_test.go
+++ b/mongodb-community-operator/controllers/mongodb_cleanup_test.go
@@ -144,7 +144,15 @@ func TestReplicaSetReconcilerCleanupPemSecret(t *testing.T) {
 	err := createAgentCertPemSecret(ctx, client, mdb, "CERT", "KEY", "")
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 
 	secret, err := r.client.GetSecret(ctx, mdb.AgentCertificatePemSecretNamespacedName())
 	assert.NoError(t, err)

--- a/mongodb-community-operator/controllers/mongodb_tls.go
+++ b/mongodb-community-operator/controllers/mongodb_tls.go
@@ -86,7 +86,12 @@ func (r *ReplicaSetReconciler) validateTLSConfig(ctx context.Context, mdb mdbv1.
 
 // getTLSConfigModification creates a modification function which enables TLS in the automation config.
 // It will also ensure that the combined cert-key secret is created.
-func getTLSConfigModification(ctx context.Context, cmGetter configmap.Getter, secretGetter secret.Getter, mdb mdbv1.MongoDBCommunity) (automationconfig.Modification, error) {
+func getTLSConfigModification(
+	ctx context.Context,
+	cmGetter configmap.Getter,
+	secretGetter secret.Getter,
+	mdb mdbv1.MongoDBCommunity,
+) (automationconfig.Modification, error) {
 	if !mdb.Spec.Security.TLS.Enabled {
 		return automationconfig.NOOP(), nil
 	}
@@ -142,7 +147,12 @@ func getPemOrConcatenatedCrtAndKey(ctx context.Context, getter secret.Getter, se
 	certKey := getCertAndKey(ctx, getter, secretName)
 	pem := getPem(ctx, getter, secretName)
 	if certKey == "" && pem == "" {
-		return "", fmt.Errorf(`neither "%s" nor the pair "%s"/"%s" were present in the TLS secret`, tlsSecretPemName, tlsSecretCertName, tlsSecretKeyName)
+		return "", fmt.Errorf(
+			`neither "%s" nor the pair "%s"/"%s" were present in the TLS secret`,
+			tlsSecretPemName,
+			tlsSecretCertName,
+			tlsSecretKeyName,
+		)
 	}
 	if certKey == "" {
 		return pem, nil
@@ -151,7 +161,15 @@ func getPemOrConcatenatedCrtAndKey(ctx context.Context, getter secret.Getter, se
 		return certKey, nil
 	}
 	if certKey != pem {
-		return "", fmt.Errorf(`if all of "%s", "%s" and "%s" are present in the secret, the entry for "%s" must be equal to the concatenation of "%s" with "%s"`, tlsSecretCertName, tlsSecretKeyName, tlsSecretPemName, tlsSecretPemName, tlsSecretCertName, tlsSecretKeyName)
+		return "", fmt.Errorf(
+			`if all of "%s", "%s" and "%s" are present in the secret, the entry for "%s" must be equal to the concatenation of "%s" with "%s"`,
+			tlsSecretCertName,
+			tlsSecretKeyName,
+			tlsSecretPemName,
+			tlsSecretPemName,
+			tlsSecretCertName,
+			tlsSecretKeyName,
+		)
 	}
 	return certKey, nil
 }
@@ -173,7 +191,9 @@ func getCaCrt(ctx context.Context, cmGetter configmap.Getter, secretGetter secre
 	}
 
 	if caData == nil {
-		return "", fmt.Errorf("TLS field requires a reference to the CA certificate which signed the server certificates. Neither secret (field caCertificateSecretRef) not configMap (field CaConfigMap) reference present")
+		return "", fmt.Errorf(
+			"TLS field requires a reference to the CA certificate which signed the server certificates. Neither secret (field caCertificateSecretRef) not configMap (field CaConfigMap) reference present",
+		)
 	}
 
 	if cert, ok := caData[tlsCACertName]; !ok || cert == "" {
@@ -185,7 +205,13 @@ func getCaCrt(ctx context.Context, cmGetter configmap.Getter, secretGetter secre
 
 // ensureCASecret will create or update the operator managed Secret containing
 // the CA certficate from the user provided Secret or ConfigMap.
-func ensureCASecret(ctx context.Context, cmGetter configmap.Getter, secretGetter secret.Getter, getUpdateCreator secret.GetUpdateCreator, mdb mdbv1.MongoDBCommunity) error {
+func ensureCASecret(
+	ctx context.Context,
+	cmGetter configmap.Getter,
+	secretGetter secret.Getter,
+	getUpdateCreator secret.GetUpdateCreator,
+	mdb mdbv1.MongoDBCommunity,
+) error {
 	cert, err := getCaCrt(ctx, cmGetter, secretGetter, mdb)
 	if err != nil {
 		return err
@@ -343,7 +369,11 @@ func buildTLSPrometheus(mdb mdbv1.MongoDBCommunity) podtemplatespec.Modification
 	// The same key-certificate pair is used for all servers
 	tlsSecretVolume := statefulset.CreateVolumeFromSecret("prom-tls-secret", mdb.PrometheusTLSOperatorSecretNamespacedName().Name)
 
-	tlsSecretVolumeMount := statefulset.CreateVolumeMount(tlsSecretVolume.Name, tlsPrometheusSecretMountPath, statefulset.WithReadOnly(true))
+	tlsSecretVolumeMount := statefulset.CreateVolumeMount(
+		tlsSecretVolume.Name,
+		tlsPrometheusSecretMountPath,
+		statefulset.WithReadOnly(true),
+	)
 
 	// MongoDB expects both key and certificate to be provided in a single PEM file
 	// We are using a secret format where they are stored in separate fields, tls.crt and tls.key

--- a/mongodb-community-operator/controllers/mongodb_tls_test.go
+++ b/mongodb-community-operator/controllers/mongodb_tls_test.go
@@ -34,7 +34,15 @@ func TestStatefulSetIsCorrectlyConfiguredWithTLS(t *testing.T) {
 	err = createTLSConfigMap(ctx, client, mdb)
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -42,7 +50,14 @@ func TestStatefulSetIsCorrectlyConfiguredWithTLS(t *testing.T) {
 	err = mgr.GetClient().Get(ctx, types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
 	assert.NoError(t, err)
 
-	assertStatefulSetVolumesAndVolumeMounts(t, sts, mdb.TLSOperatorCASecretNamespacedName().Name, mdb.TLSOperatorSecretNamespacedName().Name, "", "")
+	assertStatefulSetVolumesAndVolumeMounts(
+		t,
+		sts,
+		mdb.TLSOperatorCASecretNamespacedName().Name,
+		mdb.TLSOperatorSecretNamespacedName().Name,
+		"",
+		"",
+	)
 }
 
 func TestStatefulSetIsCorrectlyConfiguredWithTLSAndX509(t *testing.T) {
@@ -61,7 +76,15 @@ func TestStatefulSetIsCorrectlyConfiguredWithTLSAndX509(t *testing.T) {
 	err = createAgentCertSecret(ctx, client, mdb, crt, key, "")
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -74,7 +97,14 @@ func TestStatefulSetIsCorrectlyConfiguredWithTLSAndX509(t *testing.T) {
 	err = mgr.GetClient().Get(ctx, mdb.AgentCertificatePemSecretNamespacedName(), &s)
 	assert.NoError(t, err)
 
-	assertStatefulSetVolumesAndVolumeMounts(t, sts, mdb.TLSOperatorCASecretNamespacedName().Name, mdb.TLSOperatorSecretNamespacedName().Name, "", mdb.AgentCertificatePemSecretNamespacedName().Name)
+	assertStatefulSetVolumesAndVolumeMounts(
+		t,
+		sts,
+		mdb.TLSOperatorCASecretNamespacedName().Name,
+		mdb.TLSOperatorSecretNamespacedName().Name,
+		"",
+		mdb.AgentCertificatePemSecretNamespacedName().Name,
+	)
 
 	// If we deactivate X509 for the agent, we expect the certificates to be unmounted.
 	mdb.Spec.Security.Authentication.Modes = []mdbv1.AuthMode{"SCRAM"}
@@ -88,10 +118,24 @@ func TestStatefulSetIsCorrectlyConfiguredWithTLSAndX509(t *testing.T) {
 	err = mgr.GetClient().Get(ctx, types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
 	assert.NoError(t, err)
 
-	assertStatefulSetVolumesAndVolumeMounts(t, sts, mdb.TLSOperatorCASecretNamespacedName().Name, mdb.TLSOperatorSecretNamespacedName().Name, "", "")
+	assertStatefulSetVolumesAndVolumeMounts(
+		t,
+		sts,
+		mdb.TLSOperatorCASecretNamespacedName().Name,
+		mdb.TLSOperatorSecretNamespacedName().Name,
+		"",
+		"",
+	)
 }
 
-func assertStatefulSetVolumesAndVolumeMounts(t *testing.T, sts appsv1.StatefulSet, expectedTLSCASecretName string, expectedTLSOperatorSecretName string, expectedPromTLSSecretName string, expectedAgentCertSecretName string) {
+func assertStatefulSetVolumesAndVolumeMounts(
+	t *testing.T,
+	sts appsv1.StatefulSet,
+	expectedTLSCASecretName string,
+	expectedTLSOperatorSecretName string,
+	expectedPromTLSSecretName string,
+	expectedAgentCertSecretName string,
+) {
 	prometheusTLSEnabled := expectedPromTLSSecretName != ""
 	agentX509Enabled := expectedAgentCertSecretName != ""
 
@@ -230,7 +274,15 @@ func TestStatefulSetIsCorrectlyConfiguredWithPrometheusTLS(t *testing.T) {
 	err = createTLSConfigMap(ctx, cli, mdb)
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -238,7 +290,14 @@ func TestStatefulSetIsCorrectlyConfiguredWithPrometheusTLS(t *testing.T) {
 	err = mgr.GetClient().Get(ctx, types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
 	assert.NoError(t, err)
 
-	assertStatefulSetVolumesAndVolumeMounts(t, sts, mdb.TLSOperatorCASecretNamespacedName().Name, mdb.TLSOperatorSecretNamespacedName().Name, mdb.PrometheusTLSOperatorSecretNamespacedName().Name, "")
+	assertStatefulSetVolumesAndVolumeMounts(
+		t,
+		sts,
+		mdb.TLSOperatorCASecretNamespacedName().Name,
+		mdb.TLSOperatorSecretNamespacedName().Name,
+		mdb.PrometheusTLSOperatorSecretNamespacedName().Name,
+		"",
+	)
 }
 
 func TestStatefulSetIsCorrectlyConfiguredWithTLSAfterChangingExistingVolumes(t *testing.T) {
@@ -259,7 +318,15 @@ func TestStatefulSetIsCorrectlyConfiguredWithTLSAfterChangingExistingVolumes(t *
 	err = createTLSConfigMap(ctx, cli, mdb)
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		"fake-agentImage",
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -383,7 +450,15 @@ func TestTLSOperatorSecret(t *testing.T) {
 		err = createTLSConfigMap(ctx, c, mdb)
 		assert.NoError(t, err)
 
-		r := NewReconciler(kubeClient.NewManagerWithClient(c), "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+		r := NewReconciler(
+			kubeClient.NewManagerWithClient(c),
+			"fake-mongodbRepoUrl",
+			"fake-mongodbImage",
+			"ubi8",
+			"fake-agentImage",
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)
 
 		err = r.ensureTLSResources(ctx, mdb)
 		assert.NoError(t, err)
@@ -391,7 +466,12 @@ func TestTLSOperatorSecret(t *testing.T) {
 		// Operator-managed secret should have been created and contains the
 		// concatenated certificate and key.
 		expectedCertificateKey := "CERT\nKEY"
-		certificateKey, err := secret.ReadKey(ctx, c, tlsOperatorSecretFileName(expectedCertificateKey), mdb.TLSOperatorSecretNamespacedName())
+		certificateKey, err := secret.ReadKey(
+			ctx,
+			c,
+			tlsOperatorSecretFileName(expectedCertificateKey),
+			mdb.TLSOperatorSecretNamespacedName(),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedCertificateKey, certificateKey)
 	})
@@ -413,7 +493,15 @@ func TestTLSOperatorSecret(t *testing.T) {
 		err = k8sclient.CreateSecret(ctx, s)
 		assert.NoError(t, err)
 
-		r := NewReconciler(kubeClient.NewManagerWithClient(k8sclient), "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+		r := NewReconciler(
+			kubeClient.NewManagerWithClient(k8sclient),
+			"fake-mongodbRepoUrl",
+			"fake-mongodbImage",
+			"ubi8",
+			"fake-agentImage",
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)
 
 		err = r.ensureTLSResources(ctx, mdb)
 		assert.NoError(t, err)
@@ -421,7 +509,12 @@ func TestTLSOperatorSecret(t *testing.T) {
 		// Operator-managed secret should have been updated with the concatenated
 		// certificate and key.
 		expectedCertificateKey := "CERT\nKEY"
-		certificateKey, err := secret.ReadKey(ctx, k8sclient, tlsOperatorSecretFileName(expectedCertificateKey), mdb.TLSOperatorSecretNamespacedName())
+		certificateKey, err := secret.ReadKey(
+			ctx,
+			k8sclient,
+			tlsOperatorSecretFileName(expectedCertificateKey),
+			mdb.TLSOperatorSecretNamespacedName(),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedCertificateKey, certificateKey)
 	})
@@ -456,7 +549,15 @@ func TestPemSupport(t *testing.T) {
 		err = createTLSConfigMap(ctx, c, mdb)
 		assert.NoError(t, err)
 
-		r := NewReconciler(kubeClient.NewManagerWithClient(c), "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+		r := NewReconciler(
+			kubeClient.NewManagerWithClient(c),
+			"fake-mongodbRepoUrl",
+			"fake-mongodbImage",
+			"ubi8",
+			"fake-agentImage",
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)
 
 		err = r.ensureTLSResources(ctx, mdb)
 		assert.NoError(t, err)
@@ -464,7 +565,12 @@ func TestPemSupport(t *testing.T) {
 		// Operator-managed secret should have been created and contains the
 		// concatenated certificate and key.
 		expectedCertificateKey := "CERT\nKEY"
-		certificateKey, err := secret.ReadKey(ctx, c, tlsOperatorSecretFileName(expectedCertificateKey), mdb.TLSOperatorSecretNamespacedName())
+		certificateKey, err := secret.ReadKey(
+			ctx,
+			c,
+			tlsOperatorSecretFileName(expectedCertificateKey),
+			mdb.TLSOperatorSecretNamespacedName(),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedCertificateKey, certificateKey)
 	})
@@ -476,7 +582,15 @@ func TestPemSupport(t *testing.T) {
 		err = createTLSConfigMap(ctx, c, mdb)
 		assert.NoError(t, err)
 
-		r := NewReconciler(kubeClient.NewManagerWithClient(c), "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+		r := NewReconciler(
+			kubeClient.NewManagerWithClient(c),
+			"fake-mongodbRepoUrl",
+			"fake-mongodbImage",
+			"ubi8",
+			"fake-agentImage",
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)
 
 		err = r.ensureTLSResources(ctx, mdb)
 		assert.NoError(t, err)
@@ -484,7 +598,12 @@ func TestPemSupport(t *testing.T) {
 		// Operator-managed secret should have been created and contains the
 		// concatenated certificate and key.
 		expectedCertificateKey := "CERT\nKEY"
-		certificateKey, err := secret.ReadKey(ctx, c, tlsOperatorSecretFileName(expectedCertificateKey), mdb.TLSOperatorSecretNamespacedName())
+		certificateKey, err := secret.ReadKey(
+			ctx,
+			c,
+			tlsOperatorSecretFileName(expectedCertificateKey),
+			mdb.TLSOperatorSecretNamespacedName(),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedCertificateKey, certificateKey)
 	})
@@ -496,11 +615,23 @@ func TestPemSupport(t *testing.T) {
 		err = createTLSConfigMap(ctx, c, mdb)
 		assert.NoError(t, err)
 
-		r := NewReconciler(kubeClient.NewManagerWithClient(c), "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+		r := NewReconciler(
+			kubeClient.NewManagerWithClient(c),
+			"fake-mongodbRepoUrl",
+			"fake-mongodbImage",
+			"ubi8",
+			"fake-agentImage",
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)
 
 		err = r.ensureTLSResources(ctx, mdb)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), `if all of "tls.crt", "tls.key" and "tls.pem" are present in the secret, the entry for "tls.pem" must be equal to the concatenation of "tls.crt" with "tls.key"`)
+		assert.Contains(
+			t,
+			err.Error(),
+			`if all of "tls.crt", "tls.key" and "tls.pem" are present in the secret, the entry for "tls.pem" must be equal to the concatenation of "tls.crt" with "tls.key"`,
+		)
 	})
 }
 
@@ -535,7 +666,9 @@ func TestTLSConfigReferencesToCACertAreValidated(t *testing.T) {
 		"Failure if reference to CA cert is missing": {
 			caConfigMap:         nil,
 			caCertificateSecret: nil,
-			expectedError:       errors.New("TLS field requires a reference to the CA certificate which signed the server certificates. Neither secret (field caCertificateSecretRef) not configMap (field CaConfigMap) reference present"),
+			expectedError: errors.New(
+				"TLS field requires a reference to the CA certificate which signed the server certificates. Neither secret (field caCertificateSecretRef) not configMap (field CaConfigMap) reference present",
+			),
 		},
 	}
 	for testName, tc := range tests {
@@ -548,7 +681,15 @@ func TestTLSConfigReferencesToCACertAreValidated(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", "fake-agentImage", "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+			r := NewReconciler(
+				mgr,
+				"fake-mongodbRepoUrl",
+				"fake-mongodbImage",
+				"ubi8",
+				"fake-agentImage",
+				"fake-versionUpgradeHookImage",
+				"fake-readinessProbeImage",
+			)
 
 			_, err = r.validateTLSConfig(ctx, mdb)
 			if tc.expectedError != nil {
@@ -574,7 +715,15 @@ func createTLSConfigMap(ctx context.Context, c k8sClient.Client, mdb mdbv1.Mongo
 	return c.Create(ctx, &configMap)
 }
 
-func createTLSSecretWithNamespaceAndName(ctx context.Context, c k8sClient.Client, namespace string, name string, crt string, key string, pem string) error {
+func createTLSSecretWithNamespaceAndName(
+	ctx context.Context,
+	c k8sClient.Client,
+	namespace string,
+	name string,
+	crt string,
+	key string,
+	pem string,
+) error {
 	sBuilder := secret.Builder().
 		SetName(name).
 		SetNamespace(namespace).
@@ -602,15 +751,35 @@ func createAgentCertSecret(ctx context.Context, c k8sClient.Client, mdb mdbv1.Mo
 	return createTLSSecretWithNamespaceAndName(ctx, c, mdb.Namespace, mdb.AgentCertificateSecretNamespacedName().Name, crt, key, pem)
 }
 
-func createAgentCertPemSecret(ctx context.Context, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, crt string, key string, pem string) error {
+func createAgentCertPemSecret(
+	ctx context.Context,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	crt string,
+	key string,
+	pem string,
+) error {
 	return createTLSSecretWithNamespaceAndName(ctx, c, mdb.Namespace, mdb.AgentCertificatePemSecretNamespacedName().Name, crt, key, pem)
 }
 
-func createPrometheusTLSSecret(ctx context.Context, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, crt string, key string, pem string) error {
+func createPrometheusTLSSecret(
+	ctx context.Context,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	crt string,
+	key string,
+	pem string,
+) error {
 	return createTLSSecretWithNamespaceAndName(ctx, c, mdb.Namespace, mdb.Spec.Prometheus.TLSSecretRef.Name, crt, key, pem)
 }
 
-func createUserPasswordSecret(ctx context.Context, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, userPasswordSecretName string, password string) error {
+func createUserPasswordSecret(
+	ctx context.Context,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	userPasswordSecretName string,
+	password string,
+) error {
 	sBuilder := secret.Builder().
 		SetName(userPasswordSecretName).
 		SetNamespace(mdb.Namespace).

--- a/mongodb-community-operator/controllers/prometheus.go
+++ b/mongodb-community-operator/controllers/prometheus.go
@@ -20,7 +20,11 @@ const (
 )
 
 // PrometheusModification adds Prometheus configuration to AutomationConfig.
-func getPrometheusModification(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, mdb mdbv1.MongoDBCommunity) (automationconfig.Modification, error) {
+func getPrometheusModification(
+	ctx context.Context,
+	getUpdateCreator secret.GetUpdateCreator,
+	mdb mdbv1.MongoDBCommunity,
+) (automationconfig.Modification, error) {
 	if mdb.Spec.Prometheus == nil {
 		return automationconfig.NOOP(), nil
 	}

--- a/mongodb-community-operator/controllers/replica_set_controller.go
+++ b/mongodb-community-operator/controllers/replica_set_controller.go
@@ -67,7 +67,10 @@ func init() {
 	zap.ReplaceGlobals(logger)
 }
 
-func NewReconciler(mgr manager.Manager, mongodbRepoUrl, mongodbImage, mongodbImageType, agentImage, versionUpgradeHookImage, readinessProbeImage string) *ReplicaSetReconciler {
+func NewReconciler(
+	mgr manager.Manager,
+	mongodbRepoUrl, mongodbImage, mongodbImageType, agentImage, versionUpgradeHookImage, readinessProbeImage string,
+) *ReplicaSetReconciler {
 	mgrClient := mgr.GetClient()
 	secretWatcher := watch.New()
 	configMapWatcher := watch.New()
@@ -93,7 +96,12 @@ func findMdbcForSearch(ctx context.Context, rawObj k8sClient.Object) []reconcile
 		return nil
 	}
 	return []reconcile.Request{
-		{NamespacedName: types.NamespacedName{Namespace: mdbSearch.GetMongoDBResourceRef().Namespace, Name: mdbSearch.GetMongoDBResourceRef().Name}},
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: mdbSearch.GetMongoDBResourceRef().Namespace,
+				Name:      mdbSearch.GetMongoDBResourceRef().Name,
+			},
+		},
 	}
 }
 
@@ -363,7 +371,11 @@ func (r *ReplicaSetReconciler) deployStatefulSet(ctx context.Context, mdb mdbv1.
 
 // deployAutomationConfig deploys the AutomationConfig for the MongoDBCommunity resource.
 // The returned boolean indicates whether or not that Agents have all reached goal state.
-func (r *ReplicaSetReconciler) deployAutomationConfig(ctx context.Context, mdb mdbv1.MongoDBCommunity, lastAppliedSpec *mdbv1.MongoDBCommunitySpec) (bool, error) {
+func (r *ReplicaSetReconciler) deployAutomationConfig(
+	ctx context.Context,
+	mdb mdbv1.MongoDBCommunity,
+	lastAppliedSpec *mdbv1.MongoDBCommunitySpec,
+) (bool, error) {
 	r.log.Infof("Creating/Updating AutomationConfig")
 
 	sts, err := r.client.GetStatefulSet(ctx, mdb.NamespacedName())
@@ -440,7 +452,11 @@ func (r *ReplicaSetReconciler) shouldRunInOrder(ctx context.Context, mdb mdbv1.M
 // deployMongoDBReplicaSet will ensure that both the AutomationConfig secret and backing StatefulSet
 // have been successfully created. A boolean is returned indicating if the process is complete
 // and an error if there was one.
-func (r *ReplicaSetReconciler) deployMongoDBReplicaSet(ctx context.Context, mdb mdbv1.MongoDBCommunity, lastAppliedSpec *mdbv1.MongoDBCommunitySpec) (bool, error) {
+func (r *ReplicaSetReconciler) deployMongoDBReplicaSet(
+	ctx context.Context,
+	mdb mdbv1.MongoDBCommunity,
+	lastAppliedSpec *mdbv1.MongoDBCommunitySpec,
+) (bool, error) {
 	return functions.RunSequentially(r.shouldRunInOrder(ctx, mdb),
 		func() (bool, error) {
 			return r.deployAutomationConfig(ctx, mdb, lastAppliedSpec)
@@ -480,13 +496,28 @@ func (r *ReplicaSetReconciler) ensureService(ctx context.Context, mdb mdbv1.Mong
 // createProcessPortManager is a helper method for creating new ReplicaSetPortManager.
 // ReplicaSetPortManager needs current automation config and current pod state and the code for getting them
 // was extracted here as it is used in ensureService and buildAutomationConfig.
-func (r *ReplicaSetReconciler) createProcessPortManager(ctx context.Context, mdb mdbv1.MongoDBCommunity) (*mcoagent.ReplicaSetPortManager, error) {
-	currentAC, err := automationconfig.ReadFromSecret(ctx, r.client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+func (r *ReplicaSetReconciler) createProcessPortManager(
+	ctx context.Context,
+	mdb mdbv1.MongoDBCommunity,
+) (*mcoagent.ReplicaSetPortManager, error) {
+	currentAC, err := automationconfig.ReadFromSecret(
+		ctx,
+		r.client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not read existing automation config: %s", err)
 	}
 
-	currentPodStates, err := agent.GetAllDesiredMembersAndArbitersPodState(ctx, mdb.NamespacedName(), r.client, mdb.StatefulSetReplicasThisReconciliation(), mdb.StatefulSetArbitersThisReconciliation(), currentAC.Version, r.log)
+	currentPodStates, err := agent.GetAllDesiredMembersAndArbitersPodState(
+		ctx,
+		mdb.NamespacedName(),
+		r.client,
+		mdb.StatefulSetReplicasThisReconciliation(),
+		mdb.StatefulSetArbitersThisReconciliation(),
+		currentAC.Version,
+		r.log,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get all pods goal state: %w", err)
 	}
@@ -522,20 +553,37 @@ func (r *ReplicaSetReconciler) createOrUpdateStatefulSet(ctx context.Context, md
 
 // ensureAutomationConfig makes sure the AutomationConfig secret has been successfully created. The automation config
 // that was updated/created is returned.
-func (r ReplicaSetReconciler) ensureAutomationConfig(mdb mdbv1.MongoDBCommunity, ctx context.Context, lastAppliedSpec *mdbv1.MongoDBCommunitySpec) (automationconfig.AutomationConfig, error) {
+func (r ReplicaSetReconciler) ensureAutomationConfig(
+	mdb mdbv1.MongoDBCommunity,
+	ctx context.Context,
+	lastAppliedSpec *mdbv1.MongoDBCommunitySpec,
+) (automationconfig.AutomationConfig, error) {
 	ac, err := r.buildAutomationConfig(ctx, mdb, lastAppliedSpec)
 	if err != nil {
 		return automationconfig.AutomationConfig{}, fmt.Errorf("could not build automation config: %s", err)
 	}
 
-	return automationconfig.EnsureSecret(ctx, r.client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace}, mdb.GetOwnerReferences(), ac)
+	return automationconfig.EnsureSecret(
+		ctx,
+		r.client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+		mdb.GetOwnerReferences(),
+		ac,
+	)
 }
 
-func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, isEnterprise bool, auth automationconfig.Auth, currentAc automationconfig.AutomationConfig, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
+func buildAutomationConfig(
+	mdb mdbv1.MongoDBCommunity,
+	isEnterprise bool,
+	auth automationconfig.Auth,
+	currentAc automationconfig.AutomationConfig,
+	modifications ...automationconfig.Modification,
+) (automationconfig.AutomationConfig, error) {
 	domain := getDomain(mdb.ServiceName(), mdb.Namespace, mdb.Spec.GetClusterDomain())        // nolint:forbidigo
 	arbiterDomain := getDomain(mdb.ServiceName(), mdb.Namespace, mdb.Spec.GetClusterDomain()) // nolint:forbidigo
 
-	zap.S().Debugw("AutomationConfigMembersThisReconciliation", "mdb.AutomationConfigMembersThisReconciliation()", mdb.AutomationConfigMembersThisReconciliation())
+	zap.S().
+		Debugw("AutomationConfigMembersThisReconciliation", "mdb.AutomationConfigMembersThisReconciliation()", mdb.AutomationConfigMembersThisReconciliation())
 
 	arbitersCount := mdb.AutomationConfigArbitersThisReconciliation()
 	if mdb.AutomationConfigMembersThisReconciliation() < mdb.Spec.Members {
@@ -571,7 +619,12 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, isEnterprise bool, auth a
 		AddModifications(getMongodConfigModification(mdb)).
 		AddModifications(modifications...).
 		AddProcessModification(func(_ int, p *automationconfig.Process) {
-			automationconfig.ConfigureAgentConfiguration(mdb.Spec.AgentConfiguration.SystemLog, mdb.Spec.AgentConfiguration.LogRotate, mdb.Spec.AgentConfiguration.AuditLogRotate, p)
+			automationconfig.ConfigureAgentConfiguration(
+				mdb.Spec.AgentConfiguration.SystemLog,
+				mdb.Spec.AgentConfiguration.LogRotate,
+				mdb.Spec.AgentConfiguration.AuditLogRotate,
+				p,
+			)
 		}).
 		Build()
 }
@@ -658,7 +711,11 @@ func getCustomRolesModification(mdb mdbv1.MongoDBCommunity) (automationconfig.Mo
 	}, nil
 }
 
-func (r ReplicaSetReconciler) buildAutomationConfig(ctx context.Context, mdb mdbv1.MongoDBCommunity, lastAppliedSpec *mdbv1.MongoDBCommunitySpec) (automationconfig.AutomationConfig, error) {
+func (r ReplicaSetReconciler) buildAutomationConfig(
+	ctx context.Context,
+	mdb mdbv1.MongoDBCommunity,
+	lastAppliedSpec *mdbv1.MongoDBCommunitySpec,
+) (automationconfig.AutomationConfig, error) {
 	tlsModification, err := getTLSConfigModification(ctx, r.client, r.client, mdb)
 	if err != nil {
 		return automationconfig.AutomationConfig{}, fmt.Errorf("could not configure TLS modification: %s", err)
@@ -669,7 +726,11 @@ func (r ReplicaSetReconciler) buildAutomationConfig(ctx context.Context, mdb mdb
 		return automationconfig.AutomationConfig{}, fmt.Errorf("could not configure custom roles: %s", err)
 	}
 
-	currentAC, err := automationconfig.ReadFromSecret(ctx, r.client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAC, err := automationconfig.ReadFromSecret(
+		ctx,
+		r.client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	if err != nil {
 		return automationconfig.AutomationConfig{}, fmt.Errorf("could not read existing automation config: %s", err)
 	}
@@ -781,7 +842,11 @@ func getMongodConfigSearchModification(search *searchv1.MongoDBSearch, clusterDo
 		return automationconfig.NOOP()
 	}
 
-	searchConfigParameters := searchcontroller.GetMongodConfigParameters(search, clusterDomain, searchcontroller.ResolveSingleClusterIndex(search))
+	searchConfigParameters := searchcontroller.GetMongodConfigParameters(
+		search,
+		clusterDomain,
+		searchcontroller.ResolveSingleClusterIndex(search),
+	)
 	return func(ac *automationconfig.AutomationConfig) {
 		for i := range ac.Processes {
 			err := mergo.Merge(&ac.Processes[i].Args26, objx.New(searchConfigParameters), mergo.WithOverride)
@@ -794,8 +859,18 @@ func getMongodConfigSearchModification(search *searchv1.MongoDBSearch, clusterDo
 
 // buildStatefulSetModificationFunction takes a MongoDB resource and converts it into
 // the corresponding stateful set
-func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity, mongodbImage, agentImage, versionUpgradeHookImage, readinessProbeImage string) statefulset.Modification {
-	commonModification := construct.BuildMongoDBReplicaSetStatefulSetModificationFunction(&mdb, &mdb, mongodbImage, agentImage, versionUpgradeHookImage, readinessProbeImage)
+func buildStatefulSetModificationFunction(
+	mdb mdbv1.MongoDBCommunity,
+	mongodbImage, agentImage, versionUpgradeHookImage, readinessProbeImage string,
+) statefulset.Modification {
+	commonModification := construct.BuildMongoDBReplicaSetStatefulSetModificationFunction(
+		&mdb,
+		&mdb,
+		mongodbImage,
+		agentImage,
+		versionUpgradeHookImage,
+		readinessProbeImage,
+	)
 	return statefulset.Apply(
 		commonModification,
 		statefulset.WithOwnerReference(mdb.GetOwnerReferences()),

--- a/mongodb-community-operator/controllers/replicaset_controller_test.go
+++ b/mongodb-community-operator/controllers/replicaset_controller_test.go
@@ -155,7 +155,15 @@ func TestKubernetesResources_AreCreated(t *testing.T) {
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
@@ -174,7 +182,15 @@ func TestStatefulSet_IsCorrectlyConfigured(t *testing.T) {
 
 	mdb := newTestReplicaSet()
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "docker.io/mongodb", "mongodb-community-server", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"docker.io/mongodb",
+		"mongodb-community-server",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -315,7 +331,15 @@ func TestChangingVersion_ResultsInRollingUpdateStrategyType(t *testing.T) {
 	mdb := newTestReplicaSet()
 	mgr := client.NewManager(ctx, &mdb)
 	mgrClient := mgr.GetClient()
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: mdb.NamespacedName()})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -357,7 +381,15 @@ func TestBuildStatefulSet_ConfiguresUpdateStrategyCorrectly(t *testing.T) {
 		mdb.Spec.Version = "4.0.0"
 		mdb.Annotations[annotations.LastAppliedMongoDBVersion] = "4.0.0"
 		sts := appsv1.StatefulSet{}
-		buildStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")(&sts)
+		buildStatefulSetModificationFunction(
+			mdb,
+			"fake-mongodbImage",
+			AgentImage,
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)(
+			&sts,
+		)
 		assert.Equal(t, appsv1.RollingUpdateStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 	})
 	t.Run("On No Version Change, First Version", func(t *testing.T) {
@@ -365,7 +397,15 @@ func TestBuildStatefulSet_ConfiguresUpdateStrategyCorrectly(t *testing.T) {
 		mdb.Spec.Version = "4.0.0"
 		delete(mdb.Annotations, annotations.LastAppliedMongoDBVersion)
 		sts := appsv1.StatefulSet{}
-		buildStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")(&sts)
+		buildStatefulSetModificationFunction(
+			mdb,
+			"fake-mongodbImage",
+			AgentImage,
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)(
+			&sts,
+		)
 		assert.Equal(t, appsv1.RollingUpdateStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 	})
 	t.Run("On Version Change", func(t *testing.T) {
@@ -382,7 +422,15 @@ func TestBuildStatefulSet_ConfiguresUpdateStrategyCorrectly(t *testing.T) {
 
 		mdb.Annotations[annotations.LastAppliedMongoDBVersion] = string(bytes)
 		sts := appsv1.StatefulSet{}
-		buildStatefulSetModificationFunction(mdb, "fake-mongodbImage", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")(&sts)
+		buildStatefulSetModificationFunction(
+			mdb,
+			"fake-mongodbImage",
+			AgentImage,
+			"fake-versionUpgradeHookImage",
+			"fake-readinessProbeImage",
+		)(
+			&sts,
+		)
 		assert.Equal(t, appsv1.OnDeleteStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 	})
 }
@@ -392,7 +440,15 @@ func TestService_isCorrectlyCreatedAndUpdated(t *testing.T) {
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -417,7 +473,15 @@ func TestService_usesCustomMongodPortWhenSpecified(t *testing.T) {
 	mdb.Spec.AdditionalMongodConfig.Object = mongodConfig
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -481,7 +545,15 @@ func TestService_changesMongodPortOnRunningClusterWithArbiters(t *testing.T) {
 
 	mgr := client.NewManager(ctx, &mdb)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 
 	t.Run("Prepare cluster with arbiters and change port", func(t *testing.T) {
 		err := createUserPasswordSecret(ctx, mgr.Client, mdb, "password-secret-name", "pass")
@@ -643,11 +715,21 @@ func TestService_changesMongodPortOnRunningClusterWithArbiters(t *testing.T) {
 }
 
 // assertConnectionStringSecretPorts checks that connection string secret has expectedPort and does not have notExpectedPort.
-func assertConnectionStringSecretPorts(ctx context.Context, t *testing.T, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, expectedPort int, notExpectedPort int) {
+func assertConnectionStringSecretPorts(
+	ctx context.Context,
+	t *testing.T,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	expectedPort int,
+	notExpectedPort int,
+) {
 	connectionStringSecret := corev1.Secret{}
 	scramUsers := mdb.GetAuthUsers()
 	require.Len(t, scramUsers, 1)
-	secretNamespacedName := types.NamespacedName{Name: scramUsers[0].ConnectionStringSecretName, Namespace: scramUsers[0].ConnectionStringSecretNamespace}
+	secretNamespacedName := types.NamespacedName{
+		Name:      scramUsers[0].ConnectionStringSecretName,
+		Namespace: scramUsers[0].ConnectionStringSecretNamespace,
+	}
 	err := c.Get(ctx, secretNamespacedName, &connectionStringSecret)
 	require.NoError(t, err)
 	require.Contains(t, connectionStringSecret.Data, "connectionString.standard")
@@ -655,7 +737,13 @@ func assertConnectionStringSecretPorts(ctx context.Context, t *testing.T, c k8sC
 	assert.NotContains(t, string(connectionStringSecret.Data["connectionString.standard"]), fmt.Sprintf("%d", notExpectedPort))
 }
 
-func assertServicePorts(ctx context.Context, t *testing.T, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, expectedServicePorts map[int]string) {
+func assertServicePorts(
+	ctx context.Context,
+	t *testing.T,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	expectedServicePorts map[int]string,
+) {
 	svc := corev1.Service{}
 
 	err := c.Get(ctx, types.NamespacedName{Name: mdb.ServiceName(), Namespace: mdb.Namespace}, &svc)
@@ -672,8 +760,18 @@ func assertServicePorts(ctx context.Context, t *testing.T, c k8sClient.Client, m
 	assert.Equal(t, expectedServicePorts, actualServicePorts)
 }
 
-func assertAutomationConfigVersion(ctx context.Context, t *testing.T, c client.Client, mdb mdbv1.MongoDBCommunity, expectedVersion int) automationconfig.AutomationConfig {
-	ac, err := automationconfig.ReadFromSecret(ctx, c, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+func assertAutomationConfigVersion(
+	ctx context.Context,
+	t *testing.T,
+	c client.Client,
+	mdb mdbv1.MongoDBCommunity,
+	expectedVersion int,
+) automationconfig.AutomationConfig {
+	ac, err := automationconfig.ReadFromSecret(
+		ctx,
+		c,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, expectedVersion, ac.Version)
 	return ac
@@ -707,17 +805,34 @@ func TestService_connectionStringSecretAnnotationsAreApplied(t *testing.T) {
 	err := createUserPasswordSecret(ctx, mgr.Client, mdb, "password-secret-name", "pass")
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 	assertConnectionStringSecretAnnotations(ctx, t, mgr.Client, mdb, secretAnnotations)
 }
 
-func assertConnectionStringSecretAnnotations(ctx context.Context, t *testing.T, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, expectedAnnotations map[string]string) {
+func assertConnectionStringSecretAnnotations(
+	ctx context.Context,
+	t *testing.T,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	expectedAnnotations map[string]string,
+) {
 	connectionStringSecret := corev1.Secret{}
 	scramUsers := mdb.GetAuthUsers()
 	require.Len(t, scramUsers, 1)
-	secretNamespacedName := types.NamespacedName{Name: scramUsers[0].ConnectionStringSecretName, Namespace: scramUsers[0].ConnectionStringSecretNamespace}
+	secretNamespacedName := types.NamespacedName{
+		Name:      scramUsers[0].ConnectionStringSecretName,
+		Namespace: scramUsers[0].ConnectionStringSecretNamespace,
+	}
 	err := c.Get(ctx, secretNamespacedName, &connectionStringSecret)
 	require.NoError(t, err)
 	assert.Subset(t, connectionStringSecret.Annotations, expectedAnnotations)
@@ -746,7 +861,15 @@ func TestService_configuresPrometheusCustomPorts(t *testing.T) {
 		Build())
 
 	assert.NoError(t, err)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -783,7 +906,15 @@ func TestService_configuresPrometheus(t *testing.T) {
 		Build())
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -809,11 +940,23 @@ func TestAutomationConfig_versionIsBumpedOnChange(t *testing.T) {
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, currentAc.Version)
 
@@ -824,7 +967,11 @@ func TestAutomationConfig_versionIsBumpedOnChange(t *testing.T) {
 	res, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err = automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err = automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, currentAc.Version)
 }
@@ -834,18 +981,34 @@ func TestAutomationConfig_versionIsNotBumpedWithNoChanges(t *testing.T) {
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, currentAc.Version, 1)
 
 	res, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err = automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err = automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, currentAc.Version, 1)
 }
@@ -855,11 +1018,23 @@ func TestAutomationConfigFCVIsNotIncreasedWhenUpgradingMinorVersion(t *testing.T
 	mdb := newTestReplicaSet()
 	mdb.Spec.Version = "4.2.2"
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.Len(t, currentAc.Processes, 3)
 	assert.Equal(t, currentAc.Processes[0].FeatureCompatibilityVersion, "4.2")
@@ -871,7 +1046,11 @@ func TestAutomationConfigFCVIsNotIncreasedWhenUpgradingMinorVersion(t *testing.T
 	res, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err = automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err = automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.Len(t, currentAc.Processes, 3)
 	assert.Equal(t, currentAc.Processes[0].FeatureCompatibilityVersion, "4.2")
@@ -888,11 +1067,23 @@ func TestAutomationConfig_CustomMongodConfig(t *testing.T) {
 	mdb.Spec.AdditionalMongodConfig.Object = mongodConfig
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 
 	for _, p := range currentAc.Processes {
@@ -932,11 +1123,23 @@ func TestExistingPasswordAndKeyfile_AreUsedWhenTheSecretExists(t *testing.T) {
 		Build())
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, currentAc.Auth.KeyFileWindows)
 	assert.False(t, currentAc.Auth.Disabled)
@@ -962,7 +1165,15 @@ func TestReplicaSet_IsScaledDown_OneMember_AtATime_WhenItAlreadyExists(t *testin
 	mdb.Spec.Members = 5
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -1006,7 +1217,15 @@ func TestReplicaSet_IsScaledUp_OneMember_AtATime_WhenItAlreadyExists(t *testing.
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -1075,7 +1294,15 @@ func TestAnnotationsAreAppliedToResource(t *testing.T) {
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -1083,15 +1310,32 @@ func TestAnnotationsAreAppliedToResource(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NotNil(t, mdb.Annotations)
-	assert.NotEmpty(t, mdb.Annotations[lastSuccessfulConfiguration], "last successful spec should have been saved as annotation but was not")
-	assert.Equal(t, mdb.Annotations[lastAppliedMongoDBVersion], mdb.Spec.Version, "last version should have been saved as an annotation but was not")
+	assert.NotEmpty(
+		t,
+		mdb.Annotations[lastSuccessfulConfiguration],
+		"last successful spec should have been saved as annotation but was not",
+	)
+	assert.Equal(
+		t,
+		mdb.Annotations[lastAppliedMongoDBVersion],
+		mdb.Spec.Version,
+		"last version should have been saved as an annotation but was not",
+	)
 }
 
 // assertAuthoritativeSet asserts that a reconciliation of the given MongoDBCommunity resource
 // results in the AuthoritativeSet of the created AutomationConfig to have the expectedValue provided.
 func assertAuthoritativeSet(ctx context.Context, t *testing.T, mdb mdbv1.MongoDBCommunity, expectedValue bool) {
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -1107,11 +1351,23 @@ func assertAuthoritativeSet(ctx context.Context, t *testing.T, mdb mdbv1.MongoDB
 
 func assertReplicaSetIsConfiguredWithScram(ctx context.Context, t *testing.T, mdb mdbv1.MongoDBCommunity) {
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	t.Run("Automation Config is configured with SCRAM", func(t *testing.T) {
 		assert.NotEmpty(t, currentAc.Auth.Key)
 		assert.NoError(t, err)
@@ -1141,11 +1397,23 @@ func assertReplicaSetIsConfiguredWithScramTLS(ctx context.Context, t *testing.T,
 	assert.NoError(t, err)
 	err = createTLSConfigMap(ctx, newClient, mdb)
 	assert.NoError(t, err)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 	t.Run("Automation Config is configured with SCRAM", func(t *testing.T) {
 		assert.Empty(t, currentAc.TLSConfig.AutoPEMKeyFilePath)
 		assert.NotEmpty(t, currentAc.Auth.Key)
@@ -1181,15 +1449,31 @@ func assertReplicaSetIsConfiguredWithX509(ctx context.Context, t *testing.T, mdb
 	err = createAgentCertSecret(ctx, newClient, mdb, crt, key, "")
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
-	currentAc, err := automationconfig.ReadFromSecret(ctx, mgr.Client, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace})
+	currentAc, err := automationconfig.ReadFromSecret(
+		ctx,
+		mgr.Client,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+	)
 
 	t.Run("Automation Config is configured with X509", func(t *testing.T) {
 		assert.NotEmpty(t, currentAc.TLSConfig.AutoPEMKeyFilePath)
-		assert.Equal(t, automationAgentPemMountPath+"/"+mdb.AgentCertificatePemSecretNamespacedName().Name, currentAc.TLSConfig.AutoPEMKeyFilePath)
+		assert.Equal(
+			t,
+			automationAgentPemMountPath+"/"+mdb.AgentCertificatePemSecretNamespacedName().Name,
+			currentAc.TLSConfig.AutoPEMKeyFilePath,
+		)
 		assert.NotEmpty(t, currentAc.Auth.Key)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, currentAc.Auth.KeyFileWindows)
@@ -1241,7 +1525,15 @@ func TestReplicaSet_IsScaledUpToDesiredMembers_WhenFirstCreated(t *testing.T) {
 	mdb := newTestReplicaSet()
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -1344,7 +1636,15 @@ func TestInconsistentReplicas(t *testing.T) {
 	mdb.Spec.Members = 4
 
 	mgr := client.NewManager(ctx, &mdb)
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assert.NoError(t, err)
 }
@@ -1364,7 +1664,15 @@ func performReconciliationAndGetStatefulSet(ctx context.Context, t *testing.T, f
 	assert.NoError(t, err)
 	mgr := client.NewManager(ctx, &mdb)
 	assert.NoError(t, generatePasswordsForAllUsers(ctx, mdb, mgr.Client))
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: mdb.NamespacedName()})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -1378,7 +1686,15 @@ func performReconciliationAndGetService(ctx context.Context, t *testing.T, fileP
 	assert.NoError(t, err)
 	mgr := client.NewManager(ctx, &mdb)
 	assert.NoError(t, generatePasswordsForAllUsers(ctx, mdb, mgr.Client))
-	r := NewReconciler(mgr, "fake-mongodbRepoUrl", "fake-mongodbImage", "ubi8", AgentImage, "fake-versionUpgradeHookImage", "fake-readinessProbeImage")
+	r := NewReconciler(
+		mgr,
+		"fake-mongodbRepoUrl",
+		"fake-mongodbImage",
+		"ubi8",
+		AgentImage,
+		"fake-versionUpgradeHookImage",
+		"fake-readinessProbeImage",
+	)
 	res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: mdb.NamespacedName()})
 	assertReconciliationSuccessful(t, res, err)
 	svc, err := mgr.Client.GetService(ctx, types.NamespacedName{Name: mdb.ServiceName(), Namespace: mdb.Namespace})
@@ -1429,7 +1745,13 @@ func setStatefulSetReadyReplicas(ctx context.Context, t *testing.T, c k8sClient.
 	assert.NoError(t, err)
 }
 
-func setArbiterStatefulSetReadyReplicas(ctx context.Context, t *testing.T, c k8sClient.Client, mdb mdbv1.MongoDBCommunity, readyReplicas int) {
+func setArbiterStatefulSetReadyReplicas(
+	ctx context.Context,
+	t *testing.T,
+	c k8sClient.Client,
+	mdb mdbv1.MongoDBCommunity,
+	readyReplicas int,
+) {
 	sts := appsv1.StatefulSet{}
 	err := c.Get(ctx, mdb.ArbiterNamespacedName(), &sts)
 	assert.NoError(t, err)

--- a/mongodb-community-operator/controllers/validation/validation.go
+++ b/mongodb-community-operator/controllers/validation/validation.go
@@ -128,8 +128,10 @@ func validateUsers(mdb mdbv1.MongoDBCommunity) error {
 		}
 	}
 	if len(nameCollisions) > 0 {
-		return fmt.Errorf("connection string secret names collision, update at least one of the users so that the resulted secret names (<resource name>-<user>-<db>) are unique: %s",
-			strings.Join(nameCollisions, ", "))
+		return fmt.Errorf(
+			"connection string secret names collision, update at least one of the users so that the resulted secret names (<resource name>-<user>-<db>) are unique: %s",
+			strings.Join(nameCollisions, ", "),
+		)
 	}
 
 	if len(scramSecretNameCollisions) > 0 {
@@ -146,7 +148,11 @@ func validateArbiterSpec(mdb mdbv1.MongoDBCommunity) error {
 		return fmt.Errorf("number of arbiters must be greater or equal than 0")
 	}
 	if mdb.Spec.Arbiters >= mdb.Spec.Members {
-		return fmt.Errorf("number of arbiters specified (%v) is greater or equal than the number of members in the replicaset (%v). At least one member must not be an arbiter", mdb.Spec.Arbiters, mdb.Spec.Members)
+		return fmt.Errorf(
+			"number of arbiters specified (%v) is greater or equal than the number of members in the replicaset (%v). At least one member must not be an arbiter",
+			mdb.Spec.Arbiters,
+			mdb.Spec.Members,
+		)
 	}
 
 	return nil
@@ -179,7 +185,9 @@ func validateAuthModeSpec(mdb mdbv1.MongoDBCommunity, log *zap.SugaredLogger) er
 
 	agentMode := mdb.Spec.GetAgentAuthMode()
 	if agentMode == "" && len(allModes) > 1 {
-		return fmt.Errorf("if spec.security.authentication.modes contains different authentication modes, the agent mode must be specified ")
+		return fmt.Errorf(
+			"if spec.security.authentication.modes contains different authentication modes, the agent mode must be specified ",
+		)
 	}
 	if _, present := mapMechanisms[mdbv1.ConvertAuthModeToAuthMechanism(agentMode)]; !present {
 		return fmt.Errorf("agent authentication mode: %s must be part of the spec.security.authentication.modes", agentMode)

--- a/mongodb-community-operator/controllers/watch/watch.go
+++ b/mongodb-community-operator/controllers/watch/watch.go
@@ -46,19 +46,35 @@ func (w ResourceWatcher) Watch(ctx context.Context, watchedName, dependentName t
 	w.watched[watchedName] = append(existing, dependentName)
 }
 
-func (w ResourceWatcher) Create(ctx context.Context, event event.TypedCreateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (w ResourceWatcher) Create(
+	ctx context.Context,
+	event event.TypedCreateEvent[client.Object],
+	queue workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	w.handleEvent(event.Object, queue)
 }
 
-func (w ResourceWatcher) Update(ctx context.Context, event event.TypedUpdateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (w ResourceWatcher) Update(
+	ctx context.Context,
+	event event.TypedUpdateEvent[client.Object],
+	queue workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	w.handleEvent(event.ObjectOld, queue)
 }
 
-func (w ResourceWatcher) Delete(ctx context.Context, event event.TypedDeleteEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (w ResourceWatcher) Delete(
+	ctx context.Context,
+	event event.TypedDeleteEvent[client.Object],
+	queue workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	w.handleEvent(event.Object, queue)
 }
 
-func (w ResourceWatcher) Generic(ctx context.Context, event event.TypedGenericEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (w ResourceWatcher) Generic(
+	ctx context.Context,
+	event event.TypedGenericEvent[client.Object],
+	queue workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	w.handleEvent(event.Object, queue)
 }
 

--- a/mongodb-community-operator/pkg/agent/replica_set_port_manager.go
+++ b/mongodb-community-operator/pkg/agent/replica_set_port_manager.go
@@ -29,8 +29,18 @@ type ReplicaSetPortManager struct {
 	currentACProcesses []automationconfig.Process
 }
 
-func NewReplicaSetPortManager(log *zap.SugaredLogger, expectedPort int, currentPodStates []agent.PodState, currentACProcesses []automationconfig.Process) *ReplicaSetPortManager {
-	return &ReplicaSetPortManager{log: log, expectedPort: expectedPort, currentPodStates: currentPodStates, currentACProcesses: currentACProcesses}
+func NewReplicaSetPortManager(
+	log *zap.SugaredLogger,
+	expectedPort int,
+	currentPodStates []agent.PodState,
+	currentACProcesses []automationconfig.Process,
+) *ReplicaSetPortManager {
+	return &ReplicaSetPortManager{
+		log:                log,
+		expectedPort:       expectedPort,
+		currentPodStates:   currentPodStates,
+		currentACProcesses: currentACProcesses,
+	}
 }
 
 // GetPortsModification returns automation config modification function to be used in config builder.

--- a/mongodb-community-operator/pkg/authentication/authentication.go
+++ b/mongodb-community-operator/pkg/authentication/authentication.go
@@ -15,7 +15,13 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 )
 
-func Enable(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdb authtypes.Configurable, agentCertSecret types.NamespacedName) error {
+func Enable(
+	ctx context.Context,
+	auth *automationconfig.Auth,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdb authtypes.Configurable,
+	agentCertSecret types.NamespacedName,
+) error {
 	scramEnabled := false
 	for _, authMode := range mdb.GetAuthOptions().AuthMechanisms {
 		switch authMode {
@@ -41,7 +47,10 @@ func AddRemovedUsers(auth *automationconfig.Auth, mdb mdbv1.MongoDBCommunity, la
 	auth.UsersDeleted = append(auth.UsersDeleted, deletedUsers...)
 }
 
-func getRemovedUsersFromSpec(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec *mdbv1.MongoDBCommunitySpec) []automationconfig.DeletedUser {
+func getRemovedUsersFromSpec(
+	currentMDB mdbv1.MongoDBCommunitySpec,
+	lastAppliedMDBSpec *mdbv1.MongoDBCommunitySpec,
+) []automationconfig.DeletedUser {
 	type user struct {
 		db   string
 		name string

--- a/mongodb-community-operator/pkg/authentication/x509/x509.go
+++ b/mongodb-community-operator/pkg/authentication/x509/x509.go
@@ -28,7 +28,13 @@ import (
 // Enable will configure all of the required Kubernetes resources for X509 to be enabled.
 // The agent password and keyfile contents will be configured and stored in a secret.
 // the user credentials will be generated if not present, or existing credentials will be read.
-func Enable(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdb authtypes.Configurable, agentCertSecret types.NamespacedName) error {
+func Enable(
+	ctx context.Context,
+	auth *automationconfig.Auth,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdb authtypes.Configurable,
+	agentCertSecret types.NamespacedName,
+) error {
 	opts := mdb.GetAuthOptions()
 
 	desiredUsers := convertMongoDBResourceUsersToAutomationConfigUsers(mdb)
@@ -42,14 +48,27 @@ func Enable(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCre
 	return enableClientAuthentication(auth, opts, desiredUsers)
 }
 
-func ensureAgent(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdb authtypes.Configurable, agentCertSecret types.NamespacedName) error {
+func ensureAgent(
+	ctx context.Context,
+	auth *automationconfig.Auth,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdb authtypes.Configurable,
+	agentCertSecret types.NamespacedName,
+) error {
 	generatedContents, err := generate.KeyFileContents()
 	if err != nil {
 		return fmt.Errorf("could not generate keyfile contents: %s", err)
 	}
 
 	// ensure that the agent keyfile secret exists or read existing keyfile.
-	agentKeyFile, err := secret.EnsureSecretWithKey(ctx, secretGetUpdateCreateDeleter, mdb.GetAgentKeyfileSecretNamespacedName(), mdb.GetOwnerReferences(), constants.AgentKeyfileKey, generatedContents)
+	agentKeyFile, err := secret.EnsureSecretWithKey(
+		ctx,
+		secretGetUpdateCreateDeleter,
+		mdb.GetAgentKeyfileSecretNamespacedName(),
+		mdb.GetOwnerReferences(),
+		constants.AgentKeyfileKey,
+		generatedContents,
+	)
 	if err != nil {
 		return err
 	}

--- a/mongodb-community-operator/pkg/authentication/x509/x509_enabler_test.go
+++ b/mongodb-community-operator/pkg/authentication/x509/x509_enabler_test.go
@@ -95,7 +95,12 @@ func TestX509AutomationConfig(t *testing.T) {
 }
 
 // configureInAutomationConfig updates the provided auth struct and fully configures Scram authentication.
-func configureInAutomationConfig(auth *automationconfig.Auth, agentKeyFile, agentName string, users []automationconfig.MongoDBUser, opts authtypes.Options) error {
+func configureInAutomationConfig(
+	auth *automationconfig.Auth,
+	agentKeyFile, agentName string,
+	users []automationconfig.MongoDBUser,
+	opts authtypes.Options,
+) error {
 	err := enableAgentAuthentication(auth, agentKeyFile, agentName, opts)
 	if err != nil {
 		return err

--- a/mongodb-community-operator/pkg/authentication/x509/x509_test.go
+++ b/mongodb-community-operator/pkg/authentication/x509/x509_test.go
@@ -146,7 +146,9 @@ func Test_convertMongoDBResourceUsersToAutomationConfigUsers(t *testing.T) {
 	}{
 		{
 			name: "Only x.509 users",
-			args: args{mdb: buildX509Configurable("mongodb", mocks.BuildX509MongoDBUser("my-user-1"), mocks.BuildX509MongoDBUser("my-user-2"))},
+			args: args{
+				mdb: buildX509Configurable("mongodb", mocks.BuildX509MongoDBUser("my-user-1"), mocks.BuildX509MongoDBUser("my-user-2")),
+			},
 			want: []automationconfig.MongoDBUser{
 				{
 					Mechanisms: []string{},
@@ -184,12 +186,16 @@ func Test_convertMongoDBResourceUsersToAutomationConfigUsers(t *testing.T) {
 		},
 		{
 			name: "Only SCRAM users",
-			args: args{mdb: buildX509Configurable("mongodb", mocks.BuildScramMongoDBUser("my-user-1"), mocks.BuildScramMongoDBUser("my-user-2"))},
+			args: args{
+				mdb: buildX509Configurable("mongodb", mocks.BuildScramMongoDBUser("my-user-1"), mocks.BuildScramMongoDBUser("my-user-2")),
+			},
 			want: nil,
 		},
 		{
 			name: "X.509 and SCRAM users",
-			args: args{mdb: buildX509Configurable("mongodb", mocks.BuildX509MongoDBUser("my-user-1"), mocks.BuildScramMongoDBUser("my-user-2"))},
+			args: args{
+				mdb: buildX509Configurable("mongodb", mocks.BuildX509MongoDBUser("my-user-1"), mocks.BuildScramMongoDBUser("my-user-2")),
+			},
 			want: []automationconfig.MongoDBUser{
 				{
 					Mechanisms: []string{},

--- a/mongodb-community-operator/pkg/readiness/health/health_test.go
+++ b/mongodb-community-operator/pkg/readiness/health/health_test.go
@@ -9,7 +9,12 @@ import (
 // TestIsReadyState checks that Primary, Secondary, Arbiter, and Undefined always result
 // in Ready State.
 func TestIsReadyStateNotPrimaryNorSecondary(t *testing.T) {
-	status := []replicationStatus{replicationStatusUndefined, replicationStatusPrimary, replicationStatusSecondary, replicationStatusArbiter}
+	status := []replicationStatus{
+		replicationStatusUndefined,
+		replicationStatusPrimary,
+		replicationStatusSecondary,
+		replicationStatusArbiter,
+	}
 
 	for i := range status {
 		h := processStatus{ReplicaStatus: &status[i]}

--- a/mongodb-community-operator/pkg/readiness/pod/podannotation.go
+++ b/mongodb-community-operator/pkg/readiness/pod/podannotation.go
@@ -13,7 +13,13 @@ import (
 
 const mongodbAgentVersionAnnotation = "agent.mongodb.com/version"
 
-func PatchPodAnnotation(ctx context.Context, podNamespace string, lastVersionAchieved int64, memberName string, clientSet kubernetes.Interface) error {
+func PatchPodAnnotation(
+	ctx context.Context,
+	podNamespace string,
+	lastVersionAchieved int64,
+	memberName string,
+	clientSet kubernetes.Interface,
+) error {
 	pod, err := clientSet.CoreV1().Pods(podNamespace).Get(ctx, memberName, metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/mongodb-community-operator/pkg/readiness/secret/automationconfig.go
+++ b/mongodb-community-operator/pkg/readiness/secret/automationconfig.go
@@ -13,7 +13,12 @@ const (
 	automationConfigKey = "cluster-config.json"
 )
 
-func ReadAutomationConfigVersionFromSecret(ctx context.Context, namespace string, clientSet kubernetes.Interface, automationConfigSecret string) (int64, error) {
+func ReadAutomationConfigVersionFromSecret(
+	ctx context.Context,
+	namespace string,
+	clientSet kubernetes.Interface,
+	automationConfigSecret string,
+) (int64, error) {
 	secretReader := newKubernetesSecretReader(clientSet)
 	theSecret, secretReadErr := secretReader.ReadSecret(ctx, namespace, automationConfigSecret)
 	if secretReadErr != nil {
@@ -22,12 +27,23 @@ func ReadAutomationConfigVersionFromSecret(ctx context.Context, namespace string
 
 	var existingDeployment map[string]interface{}
 	if err := json.Unmarshal(theSecret.Data[automationConfigKey], &existingDeployment); err != nil {
-		return -1, fmt.Errorf("failed to unmarshal automation config %s key from %s/%s secret: %w", automationConfigKey, namespace, automationConfigSecret, err)
+		return -1, fmt.Errorf(
+			"failed to unmarshal automation config %s key from %s/%s secret: %w",
+			automationConfigKey,
+			namespace,
+			automationConfigSecret,
+			err,
+		)
 	}
 
 	version, ok := existingDeployment["version"]
 	if !ok {
-		return -1, fmt.Errorf("version field is missing in the automation config %s key from %s/%s secret", automationConfigKey, namespace, automationConfigSecret)
+		return -1, fmt.Errorf(
+			"version field is missing in the automation config %s key from %s/%s secret",
+			automationConfigKey,
+			namespace,
+			automationConfigSecret,
+		)
 	}
 
 	return cast.ToInt64(version), nil

--- a/mongodb-community-operator/pkg/util/status/status.go
+++ b/mongodb-community-operator/pkg/util/status/status.go
@@ -19,7 +19,12 @@ type OptionBuilder interface {
 }
 
 // Update takes the options provided by the given option builder, applies them all and then updates the resource
-func Update(ctx context.Context, statusWriter client.StatusWriter, mdb *mdbv1.MongoDBCommunity, optionBuilder OptionBuilder) (reconcile.Result, error) {
+func Update(
+	ctx context.Context,
+	statusWriter client.StatusWriter,
+	mdb *mdbv1.MongoDBCommunity,
+	optionBuilder OptionBuilder,
+) (reconcile.Result, error) {
 	options := optionBuilder.GetOptions()
 	for _, opt := range options {
 		opt.ApplyOption(mdb)

--- a/mongodb-community-operator/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/mongodb-community-operator/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -68,7 +68,10 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	})
 
 	t.Run("Test Basic Connectivity after upgrade has completed", tester.ConnectivitySucceeds())
-	t.Run(fmt.Sprintf("Test FeatureCompatibilityVersion, after upgrade, is %s", featureCompatibility), tester.HasFCV(featureCompatibility, 3))
+	t.Run(
+		fmt.Sprintf("Test FeatureCompatibilityVersion, after upgrade, is %s", featureCompatibility),
+		tester.HasFCV(featureCompatibility, 3),
+	)
 
 	// Downgrade while keeping the Feature Compatibility intact
 	t.Run("MongoDB is reachable while version is downgraded", func(t *testing.T) {
@@ -77,7 +80,10 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(ctx, &mdb))
 	})
 
-	t.Run(fmt.Sprintf("Test FeatureCompatibilityVersion, after downgrade, is %s", featureCompatibility), tester.HasFCV(featureCompatibility, 3))
+	t.Run(
+		fmt.Sprintf("Test FeatureCompatibilityVersion, after downgrade, is %s", featureCompatibility),
+		tester.HasFCV(featureCompatibility, 3),
+	)
 
 	// Upgrade the Feature Compatibility keeping the MongoDB version the same
 	t.Run("Test FeatureCompatibilityVersion can be upgraded", func(t *testing.T) {
@@ -85,9 +91,18 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 			db.Spec.FeatureCompatibilityVersion = upgradedFeatureCompatibility
 		})
 		assert.NoError(t, err)
-		t.Run("Stateful Set Reaches Ready State, after Upgrading FeatureCompatibilityVersion", mongodbtests.StatefulSetBecomesReady(ctx, &mdb))
-		t.Run("MongoDB Reaches Running Phase, after Upgrading FeatureCompatibilityVersion", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
+		t.Run(
+			"Stateful Set Reaches Ready State, after Upgrading FeatureCompatibilityVersion",
+			mongodbtests.StatefulSetBecomesReady(ctx, &mdb),
+		)
+		t.Run(
+			"MongoDB Reaches Running Phase, after Upgrading FeatureCompatibilityVersion",
+			mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb),
+		)
 	})
 
-	t.Run(fmt.Sprintf("Test FeatureCompatibilityVersion, after upgrading FeatureCompatibilityVersion, is %s", upgradedFeatureCompatibility), tester.HasFCV(upgradedFeatureCompatibility, 10))
+	t.Run(
+		fmt.Sprintf("Test FeatureCompatibilityVersion, after upgrading FeatureCompatibilityVersion, is %s", upgradedFeatureCompatibility),
+		tester.HasFCV(upgradedFeatureCompatibility, 10),
+	)
 }

--- a/mongodb-community-operator/test/e2e/mongodbtests/mongodbtests.go
+++ b/mongodb-community-operator/test/e2e/mongodbtests/mongodbtests.go
@@ -119,7 +119,11 @@ func statefulSetIsNotReady(ctx context.Context, mdb *mdbv1.MongoDBCommunity, opt
 	}
 }
 
-func StatefulSetHasOwnerReference(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedOwnerReference metav1.OwnerReference) func(t *testing.T) {
+func StatefulSetHasOwnerReference(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedOwnerReference metav1.OwnerReference,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		stsNamespacedName := types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}
 		sts := appsv1.StatefulSet{}
@@ -141,7 +145,11 @@ func StatefulSetIsDeleted(ctx context.Context, mdb *mdbv1.MongoDBCommunity) func
 	}
 }
 
-func ServiceHasOwnerReference(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedOwnerReference metav1.OwnerReference) func(t *testing.T) {
+func ServiceHasOwnerReference(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedOwnerReference metav1.OwnerReference,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		serviceNamespacedName := types.NamespacedName{Name: mdb.ServiceName(), Namespace: mdb.Namespace}
 		srv := corev1.Service{}
@@ -178,7 +186,11 @@ func AgentX509SecretsExists(ctx context.Context, mdb *mdbv1.MongoDBCommunity) fu
 	}
 }
 
-func AgentSecretsHaveOwnerReference(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedOwnerReference metav1.OwnerReference) func(t *testing.T) {
+func AgentSecretsHaveOwnerReference(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedOwnerReference metav1.OwnerReference,
+) func(t *testing.T) {
 	checkSecret := func(t *testing.T, resourceNamespacedName types.NamespacedName) {
 		secret := corev1.Secret{}
 		err := e2eutil.TestClient.Get(ctx, resourceNamespacedName, &secret)
@@ -195,7 +207,11 @@ func AgentSecretsHaveOwnerReference(ctx context.Context, mdb *mdbv1.MongoDBCommu
 
 // ConnectionStringSecretsAreConfigured verifies that secrets storing the connection string were generated for all scram users
 // and that they have the expected owner reference
-func ConnectionStringSecretsAreConfigured(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedOwnerReference metav1.OwnerReference) func(t *testing.T) {
+func ConnectionStringSecretsAreConfigured(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedOwnerReference metav1.OwnerReference,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		for _, user := range mdb.GetAuthUsers() {
 			secret := corev1.Secret{}
@@ -204,16 +220,33 @@ func ConnectionStringSecretsAreConfigured(ctx context.Context, mdb *mdbv1.MongoD
 
 			assert.NoError(t, err)
 			assertEqualOwnerReference(t, "Secret", secretNamespacedName, secret.GetOwnerReferences(), expectedOwnerReference)
-			containsMetadata(t, secret.ObjectMeta, map[string]string{}, user.ConnectionStringSecretAnnotations, "secret "+secretNamespacedName.Name)
+			containsMetadata(
+				t,
+				secret.ObjectMeta,
+				map[string]string{},
+				user.ConnectionStringSecretAnnotations,
+				"secret "+secretNamespacedName.Name,
+			)
 		}
 	}
 }
 
 // StatefulSetHasUpdateStrategy verifies that the StatefulSet holding this MongoDB
 // resource has the correct Update Strategy
-func StatefulSetHasUpdateStrategy(ctx context.Context, mdb *mdbv1.MongoDBCommunity, strategy appsv1.StatefulSetUpdateStrategyType) func(t *testing.T) {
+func StatefulSetHasUpdateStrategy(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	strategy appsv1.StatefulSetUpdateStrategyType,
+) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := wait.ForStatefulSetToHaveUpdateStrategy(ctx, t, mdb, strategy, wait.RetryInterval(time.Second*15), wait.Timeout(time.Minute*8))
+		err := wait.ForStatefulSetToHaveUpdateStrategy(
+			ctx,
+			t,
+			mdb,
+			strategy,
+			wait.RetryInterval(time.Second*15),
+			wait.Timeout(time.Minute*8),
+		)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -249,7 +282,12 @@ func HasExpectedPersistentVolumes(ctx context.Context, volumes []corev1.Persiste
 	}
 }
 
-func HasExpectedMetadata(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedLabels map[string]string, expectedAnnotations map[string]string) func(t *testing.T) {
+func HasExpectedMetadata(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedLabels map[string]string,
+	expectedAnnotations map[string]string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		namespace := mdb.Namespace
 
@@ -305,7 +343,13 @@ func HasExpectedMetadata(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expec
 	}
 }
 
-func containsMetadata(t *testing.T, metadata metav1.ObjectMeta, expectedLabels map[string]string, expectedAnnotations map[string]string, msg string) {
+func containsMetadata(
+	t *testing.T,
+	metadata metav1.ObjectMeta,
+	expectedLabels map[string]string,
+	expectedAnnotations map[string]string,
+	msg string,
+) {
 	labels := metadata.Labels
 	for k, v := range expectedLabels {
 		assert.Contains(t, labels, k, msg+" has label "+k)
@@ -369,7 +413,11 @@ func AutomationConfigSecretExists(ctx context.Context, mdb *mdbv1.MongoDBCommuni
 func getAutomationConfig(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity) automationconfig.AutomationConfig {
 	currentSecret := corev1.Secret{}
 	currentAc := automationconfig.AutomationConfig{}
-	err := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace}, &currentSecret)
+	err := e2eutil.TestClient.Get(
+		ctx,
+		types.NamespacedName{Name: mdb.AutomationConfigSecretName(), Namespace: mdb.Namespace},
+		&currentSecret,
+	)
 	assert.NoError(t, err)
 	err = json.Unmarshal(currentSecret.Data[automationconfig.ConfigKey], &currentAc)
 	assert.NoError(t, err)
@@ -377,7 +425,11 @@ func getAutomationConfig(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCo
 }
 
 // AutomationConfigVersionHasTheExpectedVersion verifies that the automation config has the expected version.
-func AutomationConfigVersionHasTheExpectedVersion(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedVersion int) func(t *testing.T) {
+func AutomationConfigVersionHasTheExpectedVersion(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedVersion int,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		currentAc := getAutomationConfig(ctx, t, mdb)
 		assert.Equal(t, expectedVersion, currentAc.Version)
@@ -385,7 +437,11 @@ func AutomationConfigVersionHasTheExpectedVersion(ctx context.Context, mdb *mdbv
 }
 
 // AutomationConfigHasLogRotationConfig verifies that the automation config contains the given logRotate config.
-func AutomationConfigHasLogRotationConfig(ctx context.Context, mdb *mdbv1.MongoDBCommunity, lrc *automationconfig.CrdLogRotate) func(t *testing.T) {
+func AutomationConfigHasLogRotationConfig(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	lrc *automationconfig.CrdLogRotate,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		currentAc := getAutomationConfig(ctx, t, mdb)
 		for _, p := range currentAc.Processes {
@@ -402,7 +458,11 @@ func AutomationConfigHasSettings(ctx context.Context, mdb *mdbv1.MongoDBCommunit
 }
 
 // AutomationConfigReplicaSetsHaveExpectedArbiters verifies that the automation config has the expected version.
-func AutomationConfigReplicaSetsHaveExpectedArbiters(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expectedArbiters int) func(t *testing.T) {
+func AutomationConfigReplicaSetsHaveExpectedArbiters(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	expectedArbiters int,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		currentAc := getAutomationConfig(ctx, t, mdb)
 		lsRs := currentAc.ReplicaSets
@@ -419,14 +479,22 @@ func AutomationConfigReplicaSetsHaveExpectedArbiters(ctx context.Context, mdb *m
 }
 
 // AutomationConfigHasTheExpectedCustomRoles verifies that the automation config has the expected custom roles.
-func AutomationConfigHasTheExpectedCustomRoles(ctx context.Context, mdb *mdbv1.MongoDBCommunity, roles []automationconfig.CustomRole) func(t *testing.T) {
+func AutomationConfigHasTheExpectedCustomRoles(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	roles []automationconfig.CustomRole,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		currentAc := getAutomationConfig(ctx, t, mdb)
 		assert.ElementsMatch(t, roles, currentAc.Roles)
 	}
 }
 
-func AutomationConfigHasVoteTagPriorityConfigured(ctx context.Context, mdb *mdbv1.MongoDBCommunity, memberOptions []automationconfig.MemberOptions) func(t *testing.T) {
+func AutomationConfigHasVoteTagPriorityConfigured(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	memberOptions []automationconfig.MemberOptions,
+) func(t *testing.T) {
 	acMemberOptions := make([]automationconfig.MemberOptions, 0)
 
 	return func(t *testing.T) {
@@ -437,7 +505,10 @@ func AutomationConfigHasVoteTagPriorityConfigured(ctx context.Context, mdb *mdbv
 		})
 
 		for _, m := range rsMembers[0].Members {
-			acMemberOptions = append(acMemberOptions, automationconfig.MemberOptions{Votes: m.Votes, Priority: floatPtrTostringPtr(m.Priority), Tags: m.Tags})
+			acMemberOptions = append(
+				acMemberOptions,
+				automationconfig.MemberOptions{Votes: m.Votes, Priority: floatPtrTostringPtr(m.Priority), Tags: m.Tags},
+			)
 		}
 		assert.ElementsMatch(t, memberOptions, acMemberOptions)
 	}
@@ -685,7 +756,11 @@ func AddConnectionStringOptionToUser(ctx context.Context, mdb *mdbv1.MongoDBComm
 	}
 }
 
-func AddConnectionStringAnnotationsToUser(ctx context.Context, mdb *mdbv1.MongoDBCommunity, annotations map[string]string) func(t *testing.T) {
+func AddConnectionStringAnnotationsToUser(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	annotations map[string]string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Logf("Adding %v to connection string annotations", annotations)
 		err := e2eutil.UpdateMongoDBResource(ctx, mdb, func(db *mdbv1.MongoDBCommunity) {
@@ -697,7 +772,12 @@ func AddConnectionStringAnnotationsToUser(ctx context.Context, mdb *mdbv1.MongoD
 	}
 }
 
-func StatefulSetContainerConditionIsTrue(ctx context.Context, mdb *mdbv1.MongoDBCommunity, containerName string, condition func(c corev1.Container) bool) func(*testing.T) {
+func StatefulSetContainerConditionIsTrue(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	containerName string,
+	condition func(c corev1.Container) bool,
+) func(*testing.T) {
 	return func(t *testing.T) {
 		sts := appsv1.StatefulSet{}
 		err := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
@@ -717,7 +797,11 @@ func StatefulSetContainerConditionIsTrue(ctx context.Context, mdb *mdbv1.MongoDB
 	}
 }
 
-func StatefulSetConditionIsTrue(ctx context.Context, mdb *mdbv1.MongoDBCommunity, condition func(s appsv1.StatefulSet) bool) func(*testing.T) {
+func StatefulSetConditionIsTrue(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	condition func(s appsv1.StatefulSet) bool,
+) func(*testing.T) {
 	return func(t *testing.T) {
 		sts := appsv1.StatefulSet{}
 		err := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
@@ -756,7 +840,11 @@ func ExecInContainer(ctx context.Context, mdb *mdbv1.MongoDBCommunity, podNum in
 }
 
 // StatefulSetMessageIsReceived waits (up to 5 minutes) to get desiredMessageStatus as a mongodb message status or returns a fatal error.
-func StatefulSetMessageIsReceived(mdb *mdbv1.MongoDBCommunity, testCtx *e2eutil.TestContext, desiredMessageStatus string) func(t *testing.T) {
+func StatefulSetMessageIsReceived(
+	mdb *mdbv1.MongoDBCommunity,
+	testCtx *e2eutil.TestContext,
+	desiredMessageStatus string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		err := wait.ForMongoDBMessageStatus(testCtx.Ctx, t, mdb, time.Second*15, time.Minute*5, desiredMessageStatus)
 		if err != nil {
@@ -774,8 +862,19 @@ func podFromMongoDBCommunity(mdb *mdbv1.MongoDBCommunity, podNum int) corev1.Pod
 	}
 }
 
-func assertEqualOwnerReference(t *testing.T, resourceType string, resourceNamespacedName types.NamespacedName, ownerReferences []metav1.OwnerReference, expectedOwnerReference metav1.OwnerReference) {
-	assert.Len(t, ownerReferences, 1, fmt.Sprintf("%s %s/%s doesn't have OwnerReferences", resourceType, resourceNamespacedName.Name, resourceNamespacedName.Namespace))
+func assertEqualOwnerReference(
+	t *testing.T,
+	resourceType string,
+	resourceNamespacedName types.NamespacedName,
+	ownerReferences []metav1.OwnerReference,
+	expectedOwnerReference metav1.OwnerReference,
+) {
+	assert.Len(
+		t,
+		ownerReferences,
+		1,
+		fmt.Sprintf("%s %s/%s doesn't have OwnerReferences", resourceType, resourceNamespacedName.Name, resourceNamespacedName.Namespace),
+	)
 
 	assert.Equal(t, expectedOwnerReference.APIVersion, ownerReferences[0].APIVersion)
 	assert.Equal(t, "MongoDBCommunity", ownerReferences[0].Kind)
@@ -805,10 +904,18 @@ func EditConnectionStringSecretNameOfLastUser(ctx context.Context, mdb *mdbv1.Mo
 	}
 }
 
-func ConnectionStringSecretIsCleanedUp(ctx context.Context, mdb *mdbv1.MongoDBCommunity, removedConnectionString string) func(t *testing.T) {
+func ConnectionStringSecretIsCleanedUp(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	removedConnectionString string,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		connectionStringSecret := corev1.Secret{}
-		newErr := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: removedConnectionString, Namespace: mdb.Namespace}, &connectionStringSecret)
+		newErr := e2eutil.TestClient.Get(
+			ctx,
+			types.NamespacedName{Name: removedConnectionString, Namespace: mdb.Namespace},
+			&connectionStringSecret,
+		)
 
 		assert.EqualError(t, newErr, fmt.Sprintf("secrets \"%s\" not found", removedConnectionString))
 	}

--- a/mongodb-community-operator/test/e2e/replica_set/replica_set_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set/replica_set_test.go
@@ -106,6 +106,9 @@ func TestReplicaSet(t *testing.T) {
 		tester.ConnectivitySucceeds(WithURI(mongodbtests.GetSrvConnectionStringForUser(ctx, mdb, scramUser))))
 	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 1))
-	t.Run("AutomationConfig has correct member options", mongodbtests.AutomationConfigHasVoteTagPriorityConfigured(ctx, &mdb, memberOptions))
+	t.Run(
+		"AutomationConfig has correct member options",
+		mongodbtests.AutomationConfigHasVoteTagPriorityConfigured(ctx, &mdb, memberOptions),
+	)
 	t.Run("AutomationConfig has correct settings", mongodbtests.AutomationConfigHasSettings(ctx, &mdb, settings))
 }

--- a/mongodb-community-operator/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -41,10 +41,14 @@ func TestReplicaSetArbiter(t *testing.T) {
 	}
 	tests := map[string]args{
 		"Number of Arbiters must be less than number of nodes": {
-			numberOfArbiters:     3,
-			numberOfMembers:      3,
-			expectedErrorMessage: fmt.Sprintf("error validating new Spec: number of arbiters specified (%v) is greater or equal than the number of members in the replicaset (%v). At least one member must not be an arbiter", 3, 3),
-			resourceName:         "mdb0",
+			numberOfArbiters: 3,
+			numberOfMembers:  3,
+			expectedErrorMessage: fmt.Sprintf(
+				"error validating new Spec: number of arbiters specified (%v) is greater or equal than the number of members in the replicaset (%v). At least one member must not be an arbiter",
+				3,
+				3,
+			),
+			resourceName: "mdb0",
 		},
 		"Number of Arbiters must be greater than 0": {
 			numberOfArbiters:     -1,

--- a/mongodb-community-operator/test/e2e/replica_set_authentication/replica_set_authentication_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_authentication/replica_set_authentication_test.go
@@ -69,7 +69,13 @@ func withSha1() func(*authOptions) {
 }
 
 // testConfigAuthentication run the tests using the auth options to update mdb and then checks that the resources are correctly configured
-func testConfigAuthentication(ctx context.Context, mdb mdbv1.MongoDBCommunity, user mdbv1.MongoDBUser, pw string, allOptions ...func(*authOptions)) func(t *testing.T) {
+func testConfigAuthentication(
+	ctx context.Context,
+	mdb mdbv1.MongoDBCommunity,
+	user mdbv1.MongoDBUser,
+	pw string,
+	allOptions ...func(*authOptions),
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		pickedOpts := authOptions{
 			sha256: true,
@@ -111,21 +117,33 @@ func testConfigAuthentication(ctx context.Context, mdb mdbv1.MongoDBCommunity, u
 
 		t.Run("Basic tests", mongodbtests.BasicFunctionality(ctx, &mdb))
 		if pickedOpts.sha256 {
-			t.Run("Test Basic Connectivity with accepted auth", tester.ConnectivitySucceeds(WithScramWithAuth(user.Name, pw, "SCRAM-SHA-256")))
+			t.Run(
+				"Test Basic Connectivity with accepted auth",
+				tester.ConnectivitySucceeds(WithScramWithAuth(user.Name, pw, "SCRAM-SHA-256")),
+			)
 		} else {
 			t.Run("Test Basic Connectivity with unaccepted auth", tester.ConnectivityFails(WithScramWithAuth(user.Name, pw, "SCRAM-SHA-256")))
 		}
 		if pickedOpts.sha1 {
-			t.Run("Test Basic Connectivity with accepted auth", tester.ConnectivitySucceeds(WithScramWithAuth(user.Name, pw, "SCRAM-SHA-1")))
+			t.Run(
+				"Test Basic Connectivity with accepted auth",
+				tester.ConnectivitySucceeds(WithScramWithAuth(user.Name, pw, "SCRAM-SHA-1")),
+			)
 		} else {
 			t.Run("Test Basic Connectivity with unaccepted auth", tester.ConnectivityFails(WithScramWithAuth(user.Name, pw, "SCRAM-SHA-1")))
 		}
 
 		if pickedOpts.sha256 {
-			t.Run("Ensure Authentication", tester.EnsureAuthenticationWithAuthIsConfigured(3, enabledMechanisms, WithScramWithAuth(user.Name, pw, "SCRAM-SHA-256")))
+			t.Run(
+				"Ensure Authentication",
+				tester.EnsureAuthenticationWithAuthIsConfigured(3, enabledMechanisms, WithScramWithAuth(user.Name, pw, "SCRAM-SHA-256")),
+			)
 		}
 		if pickedOpts.sha1 {
-			t.Run("Ensure Authentication", tester.EnsureAuthenticationWithAuthIsConfigured(3, enabledMechanisms, WithScramWithAuth(user.Name, pw, "SCRAM-SHA-1")))
+			t.Run(
+				"Ensure Authentication",
+				tester.EnsureAuthenticationWithAuthIsConfigured(3, enabledMechanisms, WithScramWithAuth(user.Name, pw, "SCRAM-SHA-1")),
+			)
 		}
 	}
 }

--- a/mongodb-community-operator/test/e2e/replica_set_change_version/replica_set_change_version_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_change_version/replica_set_change_version_test.go
@@ -57,20 +57,32 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while minor version is upgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Minor Version can be upgraded", mongodbtests.ChangeVersion(ctx, &mdb, upgradedMDBVersion))
-		t.Run("StatefulSet has OnDelete update strategy", mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.OnDeleteStatefulSetStrategyType))
+		t.Run(
+			"StatefulSet has OnDelete update strategy",
+			mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.OnDeleteStatefulSetStrategyType),
+		)
 		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(ctx, &mdb))
 		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 2))
 	})
 
-	t.Run("StatefulSet has RollingUpgrade restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.RollingUpdateStatefulSetStrategyType))
+	t.Run(
+		"StatefulSet has RollingUpgrade restart strategy",
+		mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.RollingUpdateStatefulSetStrategyType),
+	)
 
 	// Upgrade patch version to upgradedWithIncreasedPatchMDBVersion
 	t.Run("MongoDB is reachable while patch version is upgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Patch Version can be upgraded", mongodbtests.ChangeVersion(ctx, &mdb, upgradedWithIncreasedPatchMDBVersion))
-		t.Run("StatefulSet has OnDelete restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.OnDeleteStatefulSetStrategyType))
+		t.Run(
+			"StatefulSet has OnDelete restart strategy",
+			mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.OnDeleteStatefulSetStrategyType),
+		)
 		t.Run("Stateful Set Reaches Ready State, after upgrading", mongodbtests.StatefulSetBecomesReady(ctx, &mdb))
 		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 3))
 	})
-	t.Run("StatefulSet has RollingUpgrade restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.RollingUpdateStatefulSetStrategyType))
+	t.Run(
+		"StatefulSet has RollingUpgrade restart strategy",
+		mongodbtests.StatefulSetHasUpdateStrategy(ctx, &mdb, appsv1.RollingUpdateStatefulSetStrategyType),
+	)
 }

--- a/mongodb-community-operator/test/e2e/replica_set_connection_string_options/replica_set_connection_string_options_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_connection_string_options/replica_set_connection_string_options_test.go
@@ -50,11 +50,17 @@ func TestReplicaSetWithConnectionString(t *testing.T) {
 	User options only.
 	*/
 	t.Run("Connection String With User Options Only", func(t *testing.T) {
-		t.Run("Test Add New Connection String Option to User", mongodbtests.AddConnectionStringOptionToUser(ctx, &mdb, "readPreference", "primary"))
+		t.Run(
+			"Test Add New Connection String Option to User",
+			mongodbtests.AddConnectionStringOptionToUser(ctx, &mdb, "readPreference", "primary"),
+		)
 		t.Run("Test Secrets Are Updated", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 		scramUser = mdb.GetAuthUsers()[0]
 		t.Run("Test Basic Connectivity With User Options", tester.ConnectivitySucceeds())
-		t.Run("Test SRV Connectivity With User Options", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI()), WithoutTls(), WithReplicaSet(mdb.Name)))
+		t.Run(
+			"Test SRV Connectivity With User Options",
+			tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI()), WithoutTls(), WithReplicaSet(mdb.Name)),
+		)
 		t.Run("Test Basic Connectivity with generated connection string secret with user options",
 			tester.ConnectivitySucceeds(WithURI(mongodbtests.GetConnectionStringForUser(ctx, mdb, scramUser))))
 		t.Run("Test SRV Connectivity with generated connection string secret with user options",
@@ -66,11 +72,17 @@ func TestReplicaSetWithConnectionString(t *testing.T) {
 	*/
 	t.Run("Connection String With General Options Only", func(t *testing.T) {
 		t.Run("Resetting Connection String Options", mongodbtests.ResetConnectionStringOptions(ctx, &mdb))
-		t.Run("Test Add New Connection String Option to Resource", mongodbtests.AddConnectionStringOption(ctx, &mdb, "readPreference", "primary"))
+		t.Run(
+			"Test Add New Connection String Option to Resource",
+			mongodbtests.AddConnectionStringOption(ctx, &mdb, "readPreference", "primary"),
+		)
 		t.Run("Test Secrets Are Updated", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 		scramUser = mdb.GetAuthUsers()[0]
 		t.Run("Test Basic Connectivity With Resource Options", tester.ConnectivitySucceeds())
-		t.Run("Test SRV Connectivity With Resource Options", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI()), WithoutTls(), WithReplicaSet(mdb.Name)))
+		t.Run(
+			"Test SRV Connectivity With Resource Options",
+			tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI()), WithoutTls(), WithReplicaSet(mdb.Name)),
+		)
 		t.Run("Test Basic Connectivity with generated connection string secret with resource options",
 			tester.ConnectivitySucceeds(WithURI(mongodbtests.GetConnectionStringForUser(ctx, mdb, scramUser))))
 		t.Run("Test SRV Connectivity with generated connection string secret with resource options",
@@ -81,12 +93,21 @@ func TestReplicaSetWithConnectionString(t *testing.T) {
 	Overwritten options.
 	*/
 	t.Run("Connection String With Overwritten Options", func(t *testing.T) {
-		t.Run("Test Add New Connection String Option to Resource", mongodbtests.AddConnectionStringOption(ctx, &mdb, "readPreference", "primary"))
-		t.Run("Test Add New Connection String Option to User", mongodbtests.AddConnectionStringOptionToUser(ctx, &mdb, "readPreference", "secondary"))
+		t.Run(
+			"Test Add New Connection String Option to Resource",
+			mongodbtests.AddConnectionStringOption(ctx, &mdb, "readPreference", "primary"),
+		)
+		t.Run(
+			"Test Add New Connection String Option to User",
+			mongodbtests.AddConnectionStringOptionToUser(ctx, &mdb, "readPreference", "secondary"),
+		)
 		t.Run("Test Secrets Are Updated", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 		scramUser = mdb.GetAuthUsers()[0]
 		t.Run("Test Basic Connectivity With Overwritten Options", tester.ConnectivitySucceeds())
-		t.Run("Test SRV Connectivity With Overwritten Options", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI()), WithoutTls(), WithReplicaSet(mdb.Name)))
+		t.Run(
+			"Test SRV Connectivity With Overwritten Options",
+			tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI()), WithoutTls(), WithReplicaSet(mdb.Name)),
+		)
 		t.Run("Test Basic Connectivity with generated connection string secret with overwritten options",
 			tester.ConnectivitySucceeds(WithURI(mongodbtests.GetConnectionStringForUser(ctx, mdb, scramUser))))
 		t.Run("Test SRV Connectivity with generated connection string secret with overwritten options",
@@ -98,7 +119,10 @@ func TestReplicaSetWithConnectionString(t *testing.T) {
 	*/
 	t.Run("Connection String With Wrong Options", func(t *testing.T) {
 		t.Run("Resetting Connection String Options", mongodbtests.ResetConnectionStringOptions(ctx, &mdb))
-		t.Run("Test Add New Connection String Option to Resource", mongodbtests.AddConnectionStringOption(ctx, &mdb, "readPreference", "wrong"))
+		t.Run(
+			"Test Add New Connection String Option to Resource",
+			mongodbtests.AddConnectionStringOption(ctx, &mdb, "readPreference", "wrong"),
+		)
 		t.Run("Test Secrets Are Updated", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 		scramUser = mdb.GetAuthUsers()[0]
 		t.Run("Test Basic Connectivity", tester.ConnectivityRejected(ctx, WithURI(mdb.MongoURI()), WithoutTls(), WithReplicaSet(mdb.Name)))
@@ -114,7 +138,14 @@ func TestReplicaSetWithConnectionString(t *testing.T) {
 	*/
 	t.Run("Connection String With Annotations", func(t *testing.T) {
 		t.Run("Resetting Connection String Options", mongodbtests.ResetConnectionStringOptions(ctx, &mdb))
-		t.Run("Test Add New Connection String Annotations to Resource", mongodbtests.AddConnectionStringAnnotationsToUser(ctx, &mdb, map[string]string{"mongodbcommunity.mongodb.com/test-annotation": "test-value"}))
+		t.Run(
+			"Test Add New Connection String Annotations to Resource",
+			mongodbtests.AddConnectionStringAnnotationsToUser(
+				ctx,
+				&mdb,
+				map[string]string{"mongodbcommunity.mongodb.com/test-annotation": "test-value"},
+			),
+		)
 		t.Run("Test Secrets Are Updated", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 
 		scramUser = mdb.GetAuthUsers()[0]

--- a/mongodb-community-operator/test/e2e/replica_set_custom_annotations_test/replica_set_custom_annotations_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_custom_annotations_test/replica_set_custom_annotations_test.go
@@ -79,5 +79,8 @@ func TestReplicaSetCustomAnnotations(t *testing.T) {
 		tester.ConnectivitySucceeds(WithURI(mongodbtests.GetSrvConnectionStringForUser(ctx, mdb, scramUser))))
 	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 1))
-	t.Run("Cluster has the expected labels and annotations", mongodbtests.HasExpectedMetadata(ctx, &mdb, e2eutil.TestLabels(), e2eutil.TestAnnotations()))
+	t.Run(
+		"Cluster has the expected labels and annotations",
+		mongodbtests.HasExpectedMetadata(ctx, &mdb, e2eutil.TestLabels(), e2eutil.TestAnnotations()),
+	)
 }

--- a/mongodb-community-operator/test/e2e/replica_set_enterprise_upgrade/replica_set_enterprise_upgrade.go
+++ b/mongodb-community-operator/test/e2e/replica_set_enterprise_upgrade/replica_set_enterprise_upgrade.go
@@ -43,7 +43,10 @@ func DeployEnterpriseAndUpgradeTest(ctx context.Context, t *testing.T, versionsT
 			t.Run(fmt.Sprintf("Upgrading to %s", versionsToBeTested[i]), mongodbtests.ChangeVersion(ctx, &mdb, versionsToBeTested[i]))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(ctx, &mdb))
 			t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
-			t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, i+1))
+			t.Run(
+				"AutomationConfig's version has been increased",
+				mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, i+1),
+			)
 		})
 	}
 }

--- a/mongodb-community-operator/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -36,7 +36,10 @@ func TestReplicaSet(t *testing.T) {
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, testCtx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(ctx, &mdb))
 	t.Run("Ensure Agent container is marked as non-ready", func(t *testing.T) {
-		t.Run("Break mongod data files", mongodbtests.ExecInContainer(ctx, &mdb, 0, "mongod", "mkdir /data/tmp; mv /data/WiredTiger.wt /data/tmp"))
+		t.Run(
+			"Break mongod data files",
+			mongodbtests.ExecInContainer(ctx, &mdb, 0, "mongod", "mkdir /data/tmp; mv /data/WiredTiger.wt /data/tmp"),
+		)
 		// Just moving the file doesn't fail the mongod until any data is written - the easiest way is to kill the mongod
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(ctx, &mdb, 0, "mongod", "kill 1"))

--- a/mongodb-community-operator/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -48,7 +48,8 @@ func TestReplicaSetOperatorUpgradeMCOToMCK(t *testing.T) {
 			},
 		},
 	})
-	_, err := e2eutil.TestClient.CoreV1Client.Namespaces().Patch(ctx, testConfig.Namespace, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err := e2eutil.TestClient.CoreV1Client.Namespaces().
+		Patch(ctx, testConfig.Namespace, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	require.NoError(t, err)
 
 	err = setup.InstallCommunityOperatorViaHelm(ctx, t, testConfig, testConfig.Namespace)
@@ -103,7 +104,10 @@ func TestReplicaSetOperatorUpgradeMCOToMCK(t *testing.T) {
 		t.Run("Scale MongoDB Resource Up", mongodbtests.Scale(ctx, &mdb, 5))
 		t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(ctx, &mdb))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
-		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 4)) // 4, because the mck upgrade already forces one version bump
+		t.Run(
+			"AutomationConfig's version has been increased",
+			mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 4),
+		) // 4, because the mck upgrade already forces one version bump
 		t.Run("Test Status Was Updated", mongodbtests.Status(ctx, &mdb, mdbv1.MongoDBCommunityStatus{
 			MongoURI:                           mdb.MongoURI(),
 			Phase:                              mdbv1.Running,

--- a/mongodb-community-operator/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
@@ -118,14 +118,23 @@ func TestCleanupUsers(t *testing.T) {
 	t.Run("Add new user to MongoDB Resource", mongodbtests.AddUserToMongoDBCommunity(ctx, &mdb, newUser))
 	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 	editedUser := mdb.Spec.Users[1]
-	t.Run("Edit connection string secret name of the added user", mongodbtests.EditConnectionStringSecretNameOfLastUser(ctx, &mdb, "other-secret-name"))
+	t.Run(
+		"Edit connection string secret name of the added user",
+		mongodbtests.EditConnectionStringSecretNameOfLastUser(ctx, &mdb, "other-secret-name"),
+	)
 	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
-	t.Run("Old connection string secret is cleaned up", mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, editedUser.GetConnectionStringSecretName(mdb.Name)))
+	t.Run(
+		"Old connection string secret is cleaned up",
+		mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, editedUser.GetConnectionStringSecretName(mdb.Name)),
+	)
 	deletedUser := mdb.Spec.Users[1]
 	t.Run("Remove last user from MongoDB Resource", mongodbtests.RemoveLastUserFromMongoDBCommunity(ctx, &mdb))
 	t.Run("MongoDB reaches Pending phase", mongodbtests.MongoDBReachesPendingPhase(ctx, &mdb))
 	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, deletedUser))
 	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
-	t.Run("Connection string secrets are cleaned up", mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, deletedUser.GetConnectionStringSecretName(mdb.Name)))
+	t.Run(
+		"Connection string secrets are cleaned up",
+		mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, deletedUser.GetConnectionStringSecretName(mdb.Name)),
+	)
 	t.Run("Delete MongoDB Resource", mongodbtests.DeleteMongoDBResource(&mdb, testCtx))
 }

--- a/mongodb-community-operator/test/e2e/replica_set_x509/replica_set_x509_test.go
+++ b/mongodb-community-operator/test/e2e/replica_set_x509/replica_set_x509_test.go
@@ -58,8 +58,23 @@ func TestReplicaSetX509(t *testing.T) {
 		cert, root, dir := createCerts(ctx, t, &mdb)
 		defer os.RemoveAll(dir)
 
-		t.Run("Connectivity Fails without certs", tester.ConnectivityFails(WithURI(mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0])), WithTls(ctx, mdb)))
-		t.Run("Connectivity Fails with invalid certs", tester.ConnectivityFails(WithURI(fmt.Sprintf("%s&tlsCAFile=%s&tlsCertificateKeyFile=%s", mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]), root, cert))))
+		t.Run(
+			"Connectivity Fails without certs",
+			tester.ConnectivityFails(WithURI(mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0])), WithTls(ctx, mdb)),
+		)
+		t.Run(
+			"Connectivity Fails with invalid certs",
+			tester.ConnectivityFails(
+				WithURI(
+					fmt.Sprintf(
+						"%s&tlsCAFile=%s&tlsCertificateKeyFile=%s",
+						mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]),
+						root,
+						cert,
+					),
+				),
+			),
+		)
 	})
 
 	t.Run("Connection with valid certificate", func(t *testing.T) {
@@ -77,7 +92,19 @@ func TestReplicaSetX509(t *testing.T) {
 
 		t.Run("Basic tests", mongodbtests.BasicFunctionalityX509(ctx, &mdb))
 		t.Run("Agent certificate secrets configured", mongodbtests.AgentX509SecretsExists(ctx, &mdb))
-		t.Run("Connectivity Succeeds", tester.ConnectivitySucceeds(WithURI(fmt.Sprintf("%s&tlsCAFile=%s&tlsCertificateKeyFile=%s", mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]), root, cert))))
+		t.Run(
+			"Connectivity Succeeds",
+			tester.ConnectivitySucceeds(
+				WithURI(
+					fmt.Sprintf(
+						"%s&tlsCAFile=%s&tlsCertificateKeyFile=%s",
+						mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]),
+						root,
+						cert,
+					),
+				),
+			),
+		)
 	})
 
 	t.Run("Rotate agent certificate", func(t *testing.T) {
@@ -113,7 +140,19 @@ func TestReplicaSetX509(t *testing.T) {
 
 		assert.NotEqual(t, finalAgentPem.Data, initialAgentPem.Data)
 
-		t.Run("Connectivity Succeeds", tester.ConnectivitySucceeds(WithURI(fmt.Sprintf("%s&tlsCAFile=%s&tlsCertificateKeyFile=%s", mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]), root, cert))))
+		t.Run(
+			"Connectivity Succeeds",
+			tester.ConnectivitySucceeds(
+				WithURI(
+					fmt.Sprintf(
+						"%s&tlsCAFile=%s&tlsCertificateKeyFile=%s",
+						mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]),
+						root,
+						cert,
+					),
+				),
+			),
+		)
 	})
 
 	t.Run("Transition to also allow SCRAM", func(t *testing.T) {
@@ -132,7 +171,19 @@ func TestReplicaSetX509(t *testing.T) {
 
 		t.Run("Basic tests", mongodbtests.BasicFunctionalityX509(ctx, &mdb))
 		t.Run("Agent certificate secrets configured", mongodbtests.AgentX509SecretsExists(ctx, &mdb))
-		t.Run("Connectivity Succeeds", tester.ConnectivitySucceeds(WithURI(fmt.Sprintf("%s&tlsCAFile=%s&tlsCertificateKeyFile=%s", mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]), root, cert))))
+		t.Run(
+			"Connectivity Succeeds",
+			tester.ConnectivitySucceeds(
+				WithURI(
+					fmt.Sprintf(
+						"%s&tlsCAFile=%s&tlsCertificateKeyFile=%s",
+						mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]),
+						root,
+						cert,
+					),
+				),
+			),
+		)
 	})
 
 	t.Run("Transition to SCRAM agent", func(t *testing.T) {
@@ -149,7 +200,19 @@ func TestReplicaSetX509(t *testing.T) {
 		users := mdb.GetAuthUsers()
 
 		t.Run("Basic tests", mongodbtests.BasicFunctionality(ctx, &mdb))
-		t.Run("Connectivity Succeeds", tester.ConnectivitySucceeds(WithURI(fmt.Sprintf("%s&tlsCAFile=%s&tlsCertificateKeyFile=%s", mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]), root, cert))))
+		t.Run(
+			"Connectivity Succeeds",
+			tester.ConnectivitySucceeds(
+				WithURI(
+					fmt.Sprintf(
+						"%s&tlsCAFile=%s&tlsCertificateKeyFile=%s",
+						mongodbtests.GetConnectionStringForUser(ctx, mdb, users[0]),
+						root,
+						cert,
+					),
+				),
+			),
+		)
 	})
 }
 

--- a/mongodb-community-operator/test/e2e/setup/setup.go
+++ b/mongodb-community-operator/test/e2e/setup/setup.go
@@ -55,7 +55,14 @@ func Setup(ctx context.Context, t *testing.T) *e2eutil.TestContext {
 	return testCtx
 }
 
-func SetupWithTLS(ctx context.Context, t *testing.T, resourceName string, useX509 bool, userX509Cert bool, additionalHelmArgs ...HelmArg) (*e2eutil.TestContext, TestConfig) {
+func SetupWithTLS(
+	ctx context.Context,
+	t *testing.T,
+	resourceName string,
+	useX509 bool,
+	userX509Cert bool,
+	additionalHelmArgs ...HelmArg,
+) (*e2eutil.TestContext, TestConfig) {
 	textCtx, err := e2eutil.NewContext(ctx, t, env.ReadBoolOrDefault(performCleanupEnv, false)) // nolint:forbidigo
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +84,13 @@ func SetupWithTLS(ctx context.Context, t *testing.T, resourceName string, useX50
 	return textCtx, config
 }
 
-func SetupWithTestConfig(ctx context.Context, t *testing.T, testConfig TestConfig, withTLS, defaultOperator bool, resourceName string) *e2eutil.TestContext {
+func SetupWithTestConfig(
+	ctx context.Context,
+	t *testing.T,
+	testConfig TestConfig,
+	withTLS, defaultOperator bool,
+	resourceName string,
+) *e2eutil.TestContext {
 	testCtx, err := e2eutil.NewContext(ctx, t, env.ReadBoolOrDefault(performCleanupEnv, false)) // nolint:forbidigo
 	if err != nil {
 		t.Fatal(err)
@@ -154,9 +167,17 @@ func extractRegistryNameAndVersion(fullImage string) (string, string, string) {
 }
 
 // getHelmArgs returns a map of helm arguments that are required to install the operator.
-func getHelmArgs(testConfig TestConfig, watchNamespace string, withTLS bool, defaultOperator bool, additionalHelmArgs ...HelmArg) map[string]string {
+func getHelmArgs(
+	testConfig TestConfig,
+	watchNamespace string,
+	withTLS bool,
+	defaultOperator bool,
+	additionalHelmArgs ...HelmArg,
+) map[string]string {
 	agentRegistry, agentName, agentVersion := extractRegistryNameAndVersion(testConfig.AgentImage)
-	versionUpgradeHookRegistry, versionUpgradeHookName, versionUpgradeHookVersion := extractRegistryNameAndVersion(testConfig.VersionUpgradeHookImage)
+	versionUpgradeHookRegistry, versionUpgradeHookName, versionUpgradeHookVersion := extractRegistryNameAndVersion(
+		testConfig.VersionUpgradeHookImage,
+	)
 	readinessProbeRegistry, readinessProbeName, readinessProbeVersion := extractRegistryNameAndVersion(testConfig.ReadinessProbeImage)
 	helmArgs := make(map[string]string)
 
@@ -196,7 +217,9 @@ func getHelmArgs(testConfig TestConfig, watchNamespace string, withTLS bool, def
 // getMCOHelmArgs returns a map of helm arguments that were used to install mco with the mco chart
 func getMCOHelmArgs(testConfig TestConfig, watchNamespace string, additionalHelmArgs ...HelmArg) map[string]string {
 	agentRegistry, agentName, agentVersion := extractRegistryNameAndVersion(testConfig.AgentImage)
-	versionUpgradeHookRegistry, versionUpgradeHookName, versionUpgradeHookVersion := extractRegistryNameAndVersion(testConfig.VersionUpgradeHookImage)
+	versionUpgradeHookRegistry, versionUpgradeHookName, versionUpgradeHookVersion := extractRegistryNameAndVersion(
+		testConfig.VersionUpgradeHookImage,
+	)
 	readinessProbeRegistry, readinessProbeName, readinessProbeVersion := extractRegistryNameAndVersion(testConfig.ReadinessProbeImage)
 	helmArgs := make(map[string]string)
 
@@ -232,7 +255,14 @@ func getMCOHelmArgs(testConfig TestConfig, watchNamespace string, additionalHelm
 }
 
 // DeployMCKOperator installs all resources required by the operator using helm.
-func DeployMCKOperator(ctx context.Context, t *testing.T, config TestConfig, withTLS bool, defaultOperator bool, additionalHelmArgs ...HelmArg) error {
+func DeployMCKOperator(
+	ctx context.Context,
+	t *testing.T,
+	config TestConfig,
+	withTLS bool,
+	defaultOperator bool,
+	additionalHelmArgs ...HelmArg,
+) error {
 	e2eutil.OperatorNamespace = config.Namespace
 
 	if config.LocalOperator {
@@ -355,7 +385,13 @@ func hasDeploymentRequiredReplicas(dep *appsv1.Deployment) wait.ConditionWithCon
 }
 
 // InstallCommunityOperatorViaHelm installs the community operator using the public MongoDB Helm chart.
-func InstallCommunityOperatorViaHelm(ctx context.Context, t *testing.T, config TestConfig, namespace string, additionalHelmArgs ...HelmArg) error {
+func InstallCommunityOperatorViaHelm(
+	ctx context.Context,
+	t *testing.T,
+	config TestConfig,
+	namespace string,
+	additionalHelmArgs ...HelmArg,
+) error {
 	e2eutil.OperatorNamespace = config.Namespace
 
 	// Uninstall any existing chart with the same name

--- a/mongodb-community-operator/test/e2e/setup/test_config.go
+++ b/mongodb-community-operator/test/e2e/setup/test_config.go
@@ -46,16 +46,37 @@ func LoadTestConfigFromEnv() TestConfig {
 		CertManagerVersion:   env.ReadOrDefault(testCertManagerVersionEnvName, "v1.5.3"),         // nolint:forbidigo
 		OperatorImageRepoUrl: env.ReadOrDefault(operatorImageRepoEnvName, "quay.io/mongodb"),     // nolint:forbidigo
 		// TODO: MCK
-		MongoDBImage:            env.ReadOrDefault("MDB_COMMUNITY_IMAGE", "mongodb-community-server"),                                                                         // nolint:forbidigo
-		MongoDBRepoUrl:          env.ReadOrDefault(util.MongodbRepoUrlEnv, "quay.io/mongodb"),                                                                                 // nolint:forbidigo
-		VersionUpgradeHookImage: env.ReadOrDefault(construct.VersionUpgradeHookImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"), // nolint:forbidigo
+		MongoDBImage: env.ReadOrDefault(
+			"MDB_COMMUNITY_IMAGE",
+			"mongodb-community-server",
+		), // nolint:forbidigo
+		MongoDBRepoUrl: env.ReadOrDefault(
+			util.MongodbRepoUrlEnv,
+			"quay.io/mongodb",
+		), // nolint:forbidigo
+		VersionUpgradeHookImage: env.ReadOrDefault(
+			construct.VersionUpgradeHookImageEnv,
+			"quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2",
+		), // nolint:forbidigo
 		// TODO: MCK better way to decide default agent image.
-		AgentImage:          env.ReadOrDefault("MDB_COMMUNITY_AGENT_IMAGE", "quay.io/mongodb/mongodb-agent:108.0.25.9029-1"),                // nolint:forbidigo
-		ClusterWide:         env.ReadBoolOrDefault(clusterWideEnvName, false),                                                               // nolint:forbidigo
-		PerformCleanup:      env.ReadBoolOrDefault(performCleanupEnvName, false),                                                            // nolint:forbidigo
-		ReadinessProbeImage: env.ReadOrDefault(construct.ReadinessProbeImageEnv, "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.3"), // nolint:forbidigo
-		HelmChartPath:       "../../../../helm_chart",                                                                                       // TODO: MCK update this later once we change folder or choose a different solution, alternatives, copy helm chart to test folder/search for helm_chart folder
-		TestPKIChartPath:    "../../test-pki",
-		LocalOperator:       env.ReadBoolOrDefault(LocalOperatorEnvName, false), // nolint:forbidigo // TODO MCK: combine with meko one
+		AgentImage: env.ReadOrDefault(
+			"MDB_COMMUNITY_AGENT_IMAGE",
+			"quay.io/mongodb/mongodb-agent:108.0.25.9029-1",
+		), // nolint:forbidigo
+		ClusterWide: env.ReadBoolOrDefault(
+			clusterWideEnvName,
+			false,
+		), // nolint:forbidigo
+		PerformCleanup: env.ReadBoolOrDefault(
+			performCleanupEnvName,
+			false,
+		), // nolint:forbidigo
+		ReadinessProbeImage: env.ReadOrDefault(
+			construct.ReadinessProbeImageEnv,
+			"quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.3",
+		), // nolint:forbidigo
+		HelmChartPath:    "../../../../helm_chart", // TODO: MCK update this later once we change folder or choose a different solution, alternatives, copy helm chart to test folder/search for helm_chart folder
+		TestPKIChartPath: "../../test-pki",
+		LocalOperator:    env.ReadBoolOrDefault(LocalOperatorEnvName, false), // nolint:forbidigo // TODO MCK: combine with meko one
 	}
 }

--- a/mongodb-community-operator/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
+++ b/mongodb-community-operator/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
@@ -68,9 +68,12 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 	t.Run("Test setting Service Name", mongodbtests.ServiceWithNameExists(ctx, customServiceName, mdb.Namespace))
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(ctx, &mdb, 1))
-	t.Run("Container has been merged by name", mongodbtests.StatefulSetContainerConditionIsTrue(ctx, &mdb, "mongodb-agent", func(container corev1.Container) bool {
-		return container.ReadinessProbe.TimeoutSeconds == 100
-	}))
+	t.Run(
+		"Container has been merged by name",
+		mongodbtests.StatefulSetContainerConditionIsTrue(ctx, &mdb, "mongodb-agent", func(container corev1.Container) bool {
+			return container.ReadinessProbe.TimeoutSeconds == 100
+		}),
+	)
 	t.Run("Tolerations have been added correctly", mongodbtests.StatefulSetConditionIsTrue(ctx, &mdb, func(sts appsv1.StatefulSet) bool {
 		return reflect.DeepEqual(overrideTolerations, sts.Spec.Template.Spec.Tolerations)
 	}))

--- a/mongodb-community-operator/test/e2e/statefulset_arbitrary_config_update/statefulset_arbitrary_config_update_test.go
+++ b/mongodb-community-operator/test/e2e/statefulset_arbitrary_config_update/statefulset_arbitrary_config_update_test.go
@@ -75,9 +75,12 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 
 	t.Run("Basic tests after update", mongodbtests.BasicFunctionality(ctx, &mdb))
 	t.Run("Test basic connectivity after update", tester.ConnectivitySucceeds())
-	t.Run("Container has been merged by name", mongodbtests.StatefulSetContainerConditionIsTrue(ctx, &mdb, "mongodb-agent", func(container corev1.Container) bool {
-		return container.ReadinessProbe.TimeoutSeconds == 100
-	}))
+	t.Run(
+		"Container has been merged by name",
+		mongodbtests.StatefulSetContainerConditionIsTrue(ctx, &mdb, "mongodb-agent", func(container corev1.Container) bool {
+			return container.ReadinessProbe.TimeoutSeconds == 100
+		}),
+	)
 	t.Run("Tolerations have been added correctly", mongodbtests.StatefulSetConditionIsTrue(ctx, &mdb, func(sts appsv1.StatefulSet) bool {
 		return reflect.DeepEqual(overrideTolerations, sts.Spec.Template.Spec.Tolerations)
 	}))

--- a/mongodb-community-operator/test/e2e/util/mongotester/mongotester.go
+++ b/mongodb-community-operator/test/e2e/util/mongotester/mongotester.go
@@ -64,11 +64,20 @@ func FromResource(ctx context.Context, t *testing.T, mdb mdbv1.MongoDBCommunity,
 	if len(users) == 1 {
 		user := users[0]
 		passwordSecret := corev1.Secret{}
-		err := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: user.PasswordSecretRef.Name, Namespace: mdb.Namespace}, &passwordSecret)
+		err := e2eutil.TestClient.Get(
+			ctx,
+			types.NamespacedName{Name: user.PasswordSecretRef.Name, Namespace: mdb.Namespace},
+			&passwordSecret,
+		)
 		if err != nil {
 			return nil, err
 		}
-		t.Logf("Configuring SCRAM username: %s and password from secret %s for MongoDB: %s", user.Name, user.PasswordSecretRef.Name, mdb.NamespacedName())
+		t.Logf(
+			"Configuring SCRAM username: %s and password from secret %s for MongoDB: %s",
+			user.Name,
+			user.PasswordSecretRef.Name,
+			mdb.NamespacedName(),
+		)
 		clientOpts = WithScram(user.Name, string(passwordSecret.Data[user.PasswordSecretRef.Key])).ApplyOption(clientOpts...)
 	}
 
@@ -153,7 +162,11 @@ func (m *Tester) EnsureAuthenticationIsConfigured(tries int, opts ...OptionAppli
 	}
 }
 
-func (m *Tester) EnsureAuthenticationWithAuthIsConfigured(tries int, enabledMechanisms primitive.A, opts ...OptionApplier) func(t *testing.T) {
+func (m *Tester) EnsureAuthenticationWithAuthIsConfigured(
+	tries int,
+	enabledMechanisms primitive.A,
+	opts ...OptionApplier,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("Ensure keyFile authentication is configured", m.HasKeyfileAuth(tries, opts...))
 		t.Run(fmt.Sprintf("%q is configured", enabledMechanisms), m.ScramWithAuthIsConfigured(tries, enabledMechanisms, opts...))
@@ -253,24 +266,30 @@ func (m *Tester) connectivityCheck(shouldSucceed bool, opts ...OptionApplier) fu
 
 		attempts := 0
 		// There can be a short time before the user can auth as the user
-		err := wait.PollUntilContextTimeout(ctx, connectivityOpts.IntervalTime, connectivityOpts.TimeoutTime, false, func(ctx context.Context) (done bool, err error) {
-			attempts++
-			collection := m.mongoClient.Database(connectivityOpts.Database).Collection(connectivityOpts.Collection)
-			_, err = collection.InsertOne(ctx, bson.M{"name": "pi", "value": 3.14159})
-			if err != nil && shouldSucceed {
-				t.Logf("Was not able to connect, when we should have been able to!")
-				return false, nil
-			}
-			if err == nil && !shouldSucceed {
-				t.Logf("Was successfully able to connect, when we should not have been able to!")
-				return false, nil
-			}
-			// this information is only useful if we needed more than one attempt.
-			if attempts >= 2 {
-				t.Logf("Connectivity check was successful after %d attempt(s)", attempts)
-			}
-			return true, nil
-		})
+		err := wait.PollUntilContextTimeout(
+			ctx,
+			connectivityOpts.IntervalTime,
+			connectivityOpts.TimeoutTime,
+			false,
+			func(ctx context.Context) (done bool, err error) {
+				attempts++
+				collection := m.mongoClient.Database(connectivityOpts.Database).Collection(connectivityOpts.Collection)
+				_, err = collection.InsertOne(ctx, bson.M{"name": "pi", "value": 3.14159})
+				if err != nil && shouldSucceed {
+					t.Logf("Was not able to connect, when we should have been able to!")
+					return false, nil
+				}
+				if err == nil && !shouldSucceed {
+					t.Logf("Was successfully able to connect, when we should not have been able to!")
+					return false, nil
+				}
+				// this information is only useful if we needed more than one attempt.
+				if attempts >= 2 {
+					t.Logf("Connectivity check was successful after %d attempt(s)", attempts)
+				}
+				return true, nil
+			},
+		)
 		if err != nil {
 			t.Fatal(fmt.Errorf("error during connectivity check: %s", err))
 		}
@@ -313,14 +332,20 @@ func (m *Tester) WaitForRotatedCertificate(mdb mdbv1.MongoDBCommunity, initialCe
 func (m *Tester) EnsureMongodConfig(selector string, expected interface{}) func(*testing.T) {
 	return func(t *testing.T) {
 		connectivityOpts := defaults()
-		err := wait.PollUntilContextTimeout(m.ctx, connectivityOpts.IntervalTime, connectivityOpts.TimeoutTime, false, func(ctx context.Context) (done bool, err error) {
-			opts, err := m.getCommandLineOptions()
-			assert.NoError(t, err)
+		err := wait.PollUntilContextTimeout(
+			m.ctx,
+			connectivityOpts.IntervalTime,
+			connectivityOpts.TimeoutTime,
+			false,
+			func(ctx context.Context) (done bool, err error) {
+				opts, err := m.getCommandLineOptions()
+				assert.NoError(t, err)
 
-			parsed := objx.New(bsonToMap(opts)).Get("parsed").ObjxMap()
+				parsed := objx.New(bsonToMap(opts)).Get("parsed").ObjxMap()
 
-			return expected == parsed.Get(selector).Data(), nil
-		})
+				return expected == parsed.Get(selector).Data(), nil
+			},
+		)
 
 		assert.NoError(t, err)
 	}
@@ -410,7 +435,14 @@ func (m *Tester) PrometheusEndpointIsReachable(username, password string, useTls
 			// Verify that the Prometheus port is enabled and responding with 200
 			// on every Pod.
 			for idx = 0; idx < m.resource.Spec.Members; idx++ {
-				url := fmt.Sprintf("%s://%s-%d.%s-svc.%s.svc.cluster.local:9216/metrics", scheme, m.resource.Name, idx, m.resource.Name, m.resource.Namespace)
+				url := fmt.Sprintf(
+					"%s://%s-%d.%s-svc.%s.svc.cluster.local:9216/metrics",
+					scheme,
+					m.resource.Name,
+					idx,
+					m.resource.Name,
+					m.resource.Namespace,
+				)
 				req, err := http.NewRequest("GET", url, nil)
 				assert.NoError(t, err)
 				req.SetBasicAuth(username, password)

--- a/mongodb-community-operator/test/e2e/util/wait/wait.go
+++ b/mongodb-community-operator/test/e2e/util/wait/wait.go
@@ -40,7 +40,13 @@ func ForSecretToExist(ctx context.Context, cmName string, retryInterval, timeout
 }
 
 // ForMongoDBToReachPhase waits until the given MongoDB resource reaches the expected phase
-func ForMongoDBToReachPhase(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity, phase mdbv1.Phase, retryInterval, timeout time.Duration) error {
+func ForMongoDBToReachPhase(
+	ctx context.Context,
+	t *testing.T,
+	mdb *mdbv1.MongoDBCommunity,
+	phase mdbv1.Phase,
+	retryInterval, timeout time.Duration,
+) error {
 	return waitForMongoDBCondition(ctx, mdb, retryInterval, timeout, func(db mdbv1.MongoDBCommunity) bool {
 		t.Logf("current phase: %s, waiting for phase: %s", db.Status.Phase, phase)
 		return db.Status.Phase == phase
@@ -48,7 +54,13 @@ func ForMongoDBToReachPhase(ctx context.Context, t *testing.T, mdb *mdbv1.MongoD
 }
 
 // ForMongoDBMessageStatus waits until the given MongoDB resource gets the expected message status
-func ForMongoDBMessageStatus(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity, retryInterval, timeout time.Duration, message string) error {
+func ForMongoDBMessageStatus(
+	ctx context.Context,
+	t *testing.T,
+	mdb *mdbv1.MongoDBCommunity,
+	retryInterval, timeout time.Duration,
+	message string,
+) error {
 	return waitForMongoDBCondition(ctx, mdb, retryInterval, timeout, func(db mdbv1.MongoDBCommunity) bool {
 		t.Logf("current message: %s, waiting for message: %s", db.Status.Message, message)
 		return db.Status.Message == message
@@ -56,7 +68,12 @@ func ForMongoDBMessageStatus(ctx context.Context, t *testing.T, mdb *mdbv1.Mongo
 }
 
 // waitForMongoDBCondition polls and waits for a given condition to be true
-func waitForMongoDBCondition(ctx context.Context, mdb *mdbv1.MongoDBCommunity, retryInterval, timeout time.Duration, condition func(mdbv1.MongoDBCommunity) bool) error {
+func waitForMongoDBCondition(
+	ctx context.Context,
+	mdb *mdbv1.MongoDBCommunity,
+	retryInterval, timeout time.Duration,
+	condition func(mdbv1.MongoDBCommunity) bool,
+) error {
 	mdbNew := mdbv1.MongoDBCommunity{}
 	return wait.PollUntilContextTimeout(ctx, retryInterval, timeout, false, func(ctx context.Context) (done bool, err error) {
 		err = e2eutil.TestClient.Get(ctx, mdb.NamespacedName(), &mdbNew)
@@ -70,14 +87,24 @@ func waitForMongoDBCondition(ctx context.Context, mdb *mdbv1.MongoDBCommunity, r
 
 // ForDeploymentToExist waits until a Deployment of the given name exists
 // using the provided retryInterval and timeout
-func ForDeploymentToExist(ctx context.Context, deployName string, retryInterval, timeout time.Duration, namespace string) (appsv1.Deployment, error) {
+func ForDeploymentToExist(
+	ctx context.Context,
+	deployName string,
+	retryInterval, timeout time.Duration,
+	namespace string,
+) (appsv1.Deployment, error) {
 	deploy := appsv1.Deployment{}
 	return deploy, waitForRuntimeObjectToExist(ctx, deployName, retryInterval, timeout, &deploy, namespace)
 }
 
 // ForStatefulSetToExist waits until a StatefulSet of the given name exists
 // using the provided retryInterval and timeout
-func ForStatefulSetToExist(ctx context.Context, stsName string, retryInterval, timeout time.Duration, namespace string) (appsv1.StatefulSet, error) {
+func ForStatefulSetToExist(
+	ctx context.Context,
+	stsName string,
+	retryInterval, timeout time.Duration,
+	namespace string,
+) (appsv1.StatefulSet, error) {
 	sts := appsv1.StatefulSet{}
 	return sts, waitForRuntimeObjectToExist(ctx, stsName, retryInterval, timeout, &sts, namespace)
 }
@@ -91,7 +118,13 @@ func ForStatefulSetToBeDeleted(ctx context.Context, stsName string, retryInterva
 
 // ForStatefulSetToHaveUpdateStrategy waits until all replicas of the StatefulSet with the given name
 // have reached the ready status
-func ForStatefulSetToHaveUpdateStrategy(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity, strategy appsv1.StatefulSetUpdateStrategyType, opts ...Configuration) error {
+func ForStatefulSetToHaveUpdateStrategy(
+	ctx context.Context,
+	t *testing.T,
+	mdb *mdbv1.MongoDBCommunity,
+	strategy appsv1.StatefulSetUpdateStrategyType,
+	opts ...Configuration,
+) error {
 	options := newOptions(opts...)
 	return waitForStatefulSetCondition(ctx, t, mdb, options, func(sts appsv1.StatefulSet) bool {
 		return sts.Spec.UpdateStrategy.Type == strategy
@@ -134,7 +167,14 @@ func ForStatefulSetToBeReadyAfterScaleDown(ctx context.Context, t *testing.T, md
 	})
 }
 
-func waitForStatefulSetConditionWithSpecificSts(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity, statefulSetType StatefulSetType, waitOpts Options, condition func(set appsv1.StatefulSet) bool) error {
+func waitForStatefulSetConditionWithSpecificSts(
+	ctx context.Context,
+	t *testing.T,
+	mdb *mdbv1.MongoDBCommunity,
+	statefulSetType StatefulSetType,
+	waitOpts Options,
+	condition func(set appsv1.StatefulSet) bool,
+) error {
 	_, err := ForStatefulSetToExist(ctx, mdb.Name, waitOpts.RetryInterval, waitOpts.Timeout, mdb.Namespace)
 	if err != nil {
 		return fmt.Errorf("error waiting for stateful set to be created: %s", err)
@@ -145,19 +185,38 @@ func waitForStatefulSetConditionWithSpecificSts(ctx context.Context, t *testing.
 	if statefulSetType == ArbitersStatefulSet {
 		name = mdb.ArbiterNamespacedName()
 	}
-	return wait.PollUntilContextTimeout(ctx, waitOpts.RetryInterval, waitOpts.Timeout, false, func(ctx context.Context) (done bool, err error) {
-		err = e2eutil.TestClient.Get(ctx, name, &sts)
-		if err != nil {
-			return false, err
-		}
-		t.Logf("Waiting for %s to have %d replicas. Current ready replicas: %d, Current updated replicas: %d, Current generation: %d, Observed Generation: %d\n",
-			name, *sts.Spec.Replicas, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas, sts.Generation, sts.Status.ObservedGeneration)
-		ready := condition(sts)
-		return ready, nil
-	})
+	return wait.PollUntilContextTimeout(
+		ctx,
+		waitOpts.RetryInterval,
+		waitOpts.Timeout,
+		false,
+		func(ctx context.Context) (done bool, err error) {
+			err = e2eutil.TestClient.Get(ctx, name, &sts)
+			if err != nil {
+				return false, err
+			}
+			t.Logf(
+				"Waiting for %s to have %d replicas. Current ready replicas: %d, Current updated replicas: %d, Current generation: %d, Observed Generation: %d\n",
+				name,
+				*sts.Spec.Replicas,
+				sts.Status.ReadyReplicas,
+				sts.Status.UpdatedReplicas,
+				sts.Generation,
+				sts.Status.ObservedGeneration,
+			)
+			ready := condition(sts)
+			return ready, nil
+		},
+	)
 }
 
-func waitForStatefulSetCondition(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity, waitOpts Options, condition func(set appsv1.StatefulSet) bool) error {
+func waitForStatefulSetCondition(
+	ctx context.Context,
+	t *testing.T,
+	mdb *mdbv1.MongoDBCommunity,
+	waitOpts Options,
+	condition func(set appsv1.StatefulSet) bool,
+) error {
 	// uses members statefulset
 	return waitForStatefulSetConditionWithSpecificSts(ctx, t, mdb, MembersStatefulSet, waitOpts, condition)
 }
@@ -191,7 +250,13 @@ func ForPodPhase(ctx context.Context, t *testing.T, timeout time.Duration, pod c
 
 // waitForRuntimeObjectToExist waits until a runtime.Object of the given name exists
 // using the provided retryInterval and timeout provided.
-func waitForRuntimeObjectToExist(ctx context.Context, name string, retryInterval, timeout time.Duration, obj client.Object, namespace string) error {
+func waitForRuntimeObjectToExist(
+	ctx context.Context,
+	name string,
+	retryInterval, timeout time.Duration,
+	obj client.Object,
+	namespace string,
+) error {
 	return wait.PollUntilContextTimeout(ctx, retryInterval, timeout, false, func(ctx context.Context) (done bool, err error) {
 		return runtimeObjectExists(ctx, name, obj, namespace)
 	})
@@ -199,7 +264,13 @@ func waitForRuntimeObjectToExist(ctx context.Context, name string, retryInterval
 
 // waitForRuntimeObjectToBeDeleted waits until a runtime.Object of the given name is deleted
 // using the provided retryInterval and timeout provided.
-func waitForRuntimeObjectToBeDeleted(ctx context.Context, name string, retryInterval, timeout time.Duration, obj client.Object, namespace string) error {
+func waitForRuntimeObjectToBeDeleted(
+	ctx context.Context,
+	name string,
+	retryInterval, timeout time.Duration,
+	obj client.Object,
+	namespace string,
+) error {
 	return wait.PollUntilContextTimeout(ctx, retryInterval, timeout, false, func(ctx context.Context) (done bool, err error) {
 		exists, err := runtimeObjectExists(ctx, name, obj, namespace)
 		return !exists, err

--- a/pkg/agent/agent_readiness.go
+++ b/pkg/agent/agent_readiness.go
@@ -30,7 +30,13 @@ type PodState struct {
 
 // AllReachedGoalState returns whether the agents associated with a given StatefulSet have reached goal state.
 // it achieves this by reading the Pod annotations and checking to see if they have reached the expected config versions.
-func AllReachedGoalState(ctx context.Context, sts appsv1.StatefulSet, podGetter pod.Getter, desiredMemberCount, targetConfigVersion int, log *zap.SugaredLogger) (bool, error) {
+func AllReachedGoalState(
+	ctx context.Context,
+	sts appsv1.StatefulSet,
+	podGetter pod.Getter,
+	desiredMemberCount, targetConfigVersion int,
+	log *zap.SugaredLogger,
+) (bool, error) {
 	// AllReachedGoalState does not use desiredArbitersCount for backwards compatibility
 	podStates, err := GetAllDesiredMembersAndArbitersPodState(ctx, types.NamespacedName{
 		Namespace: sts.Namespace,
@@ -67,7 +73,13 @@ func AllReachedGoalState(ctx context.Context, sts appsv1.StatefulSet, podGetter 
 // GetAllDesiredMembersAndArbitersPodState returns states of all desired pods in a replica set.
 // Pod names to search for are calculated using desiredMemberCount and desiredArbitersCount. Each pod is then checked if it exists
 // or if it reached goal state vs targetConfigVersion.
-func GetAllDesiredMembersAndArbitersPodState(ctx context.Context, namespacedName types.NamespacedName, podGetter pod.Getter, desiredMembersCount, desiredArbitersCount, targetConfigVersion int, log *zap.SugaredLogger) ([]PodState, error) {
+func GetAllDesiredMembersAndArbitersPodState(
+	ctx context.Context,
+	namespacedName types.NamespacedName,
+	podGetter pod.Getter,
+	desiredMembersCount, desiredArbitersCount, targetConfigVersion int,
+	log *zap.SugaredLogger,
+) ([]PodState, error) {
 	podStates := make([]PodState, desiredMembersCount+desiredArbitersCount)
 
 	membersPodNames := statefulSetPodNames(namespacedName.Name, desiredMembersCount)
@@ -111,7 +123,12 @@ func ReachedGoalState(pod corev1.Pod, targetConfigVersion int, log *zap.SugaredL
 		return false
 	}
 	if cast.ToInt(currentAgentVersion) != targetConfigVersion {
-		log.Debugf("The Agent in the Pod '%s' hasn't reached the goal state yet (goal: %d, agent: %s)", pod.Name, targetConfigVersion, currentAgentVersion)
+		log.Debugf(
+			"The Agent in the Pod '%s' hasn't reached the goal state yet (goal: %d, agent: %s)",
+			pod.Name,
+			targetConfigVersion,
+			currentAgentVersion,
+		)
 		return false
 	}
 	return true

--- a/pkg/agentVersionManagement/get_agent_version.go
+++ b/pkg/agentVersionManagement/get_agent_version.go
@@ -151,7 +151,12 @@ func (m *AgentVersionManager) GetAgentVersion(conn om.Connection, omVersion stri
 	}
 
 	if !supportsStatic {
-		return "", xerrors.Errorf("Ops Manager version %s does not support static containers, please use Ops Manager version of at least %s or %s", omVersion, om6StaticContainersSupport, om7StaticContainersSupport)
+		return "", xerrors.Errorf(
+			"Ops Manager version %s does not support static containers, please use Ops Manager version of at least %s or %s",
+			omVersion,
+			om6StaticContainersSupport,
+			om7StaticContainersSupport,
+		)
 	}
 
 	version, err := m.getAgentVersionFromOpsManager(conn)

--- a/pkg/authentication/mocks/mocks.go
+++ b/pkg/authentication/mocks/mocks.go
@@ -57,7 +57,12 @@ type MockConfigurable struct {
 	refs   []metav1.OwnerReference
 }
 
-func NewMockConfigurable(opts authtypes.Options, users []authtypes.User, nsName types.NamespacedName, refs []metav1.OwnerReference) MockConfigurable {
+func NewMockConfigurable(
+	opts authtypes.Options,
+	users []authtypes.User,
+	nsName types.NamespacedName,
+	refs []metav1.OwnerReference,
+) MockConfigurable {
 	return MockConfigurable{opts: opts, users: users, nsName: nsName, refs: refs}
 }
 

--- a/pkg/authentication/scram/scram.go
+++ b/pkg/authentication/scram/scram.go
@@ -32,7 +32,12 @@ const (
 // Enable will configure all of the required Kubernetes resources for SCRAM-SHA to be enabled.
 // The agent password and keyfile contents will be configured and stored in a secret.
 // the user credentials will be generated if not present, or existing credentials will be read.
-func Enable(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdb authtypes.Configurable) error {
+func Enable(
+	ctx context.Context,
+	auth *automationconfig.Auth,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdb authtypes.Configurable,
+) error {
 	opts := mdb.GetAuthOptions()
 
 	desiredUsers, err := convertMongoDBResourceUsersToAutomationConfigUsers(ctx, secretGetUpdateCreateDeleter, mdb)
@@ -49,7 +54,12 @@ func Enable(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCre
 	return enableClientAuthentication(auth, opts, desiredUsers)
 }
 
-func ensureAgent(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdb authtypes.Configurable) error {
+func ensureAgent(
+	ctx context.Context,
+	auth *automationconfig.Auth,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdb authtypes.Configurable,
+) error {
 	generatedPassword, err := generate.RandomFixedLengthStringOfSize(20)
 	if err != nil {
 		return fmt.Errorf("could not generate password: %s", err)
@@ -61,13 +71,27 @@ func ensureAgent(ctx context.Context, auth *automationconfig.Auth, secretGetUpda
 	}
 
 	// ensure that the agent password secret exists or read existing password.
-	agentPassword, err := secret.EnsureSecretWithKey(ctx, secretGetUpdateCreateDeleter, mdb.GetAgentPasswordSecretNamespacedName(), mdb.GetOwnerReferences(), constants.AgentPasswordKey, generatedPassword)
+	agentPassword, err := secret.EnsureSecretWithKey(
+		ctx,
+		secretGetUpdateCreateDeleter,
+		mdb.GetAgentPasswordSecretNamespacedName(),
+		mdb.GetOwnerReferences(),
+		constants.AgentPasswordKey,
+		generatedPassword,
+	)
 	if err != nil {
 		return err
 	}
 
 	// ensure that the agent keyfile secret exists or read existing keyfile.
-	agentKeyFile, err := secret.EnsureSecretWithKey(ctx, secretGetUpdateCreateDeleter, mdb.GetAgentKeyfileSecretNamespacedName(), mdb.GetOwnerReferences(), constants.AgentKeyfileKey, generatedContents)
+	agentKeyFile, err := secret.EnsureSecretWithKey(
+		ctx,
+		secretGetUpdateCreateDeleter,
+		mdb.GetAgentKeyfileSecretNamespacedName(),
+		mdb.GetOwnerReferences(),
+		constants.AgentKeyfileKey,
+		generatedContents,
+	)
 	if err != nil {
 		return err
 	}
@@ -77,8 +101,19 @@ func ensureAgent(ctx context.Context, auth *automationconfig.Auth, secretGetUpda
 
 // ensureScramCredentials will ensure that the ScramSha1 & ScramSha256 credentials exist and are stored in the credentials
 // secret corresponding to user of the given MongoDB deployment.
-func ensureScramCredentials(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, user authtypes.User, mdbNamespacedName types.NamespacedName, ownerRef []metav1.OwnerReference) (scramcredentials.ScramCreds, scramcredentials.ScramCreds, error) {
-	password, err := secret.ReadKey(ctx, getUpdateCreator, user.PasswordSecretKey, types.NamespacedName{Name: user.PasswordSecretName, Namespace: mdbNamespacedName.Namespace})
+func ensureScramCredentials(
+	ctx context.Context,
+	getUpdateCreator secret.GetUpdateCreator,
+	user authtypes.User,
+	mdbNamespacedName types.NamespacedName,
+	ownerRef []metav1.OwnerReference,
+) (scramcredentials.ScramCreds, scramcredentials.ScramCreds, error) {
+	password, err := secret.ReadKey(
+		ctx,
+		getUpdateCreator,
+		user.PasswordSecretKey,
+		types.NamespacedName{Name: user.PasswordSecretName, Namespace: mdbNamespacedName.Namespace},
+	)
 	if err != nil {
 		// if the password is deleted, that's fine we can read from the stored credentials that were previously generated
 		if secret.SecretNotExist(err) {
@@ -91,9 +126,19 @@ func ensureScramCredentials(ctx context.Context, getUpdateCreator secret.GetUpda
 	// we should only need to generate new credentials in two situations.
 	// 1. We are creating the credentials for the first time
 	// 2. We are changing the password
-	shouldGenerateNewCredentials, err := needToGenerateNewCredentials(ctx, getUpdateCreator, user.Username, user.ScramCredentialsSecretName, mdbNamespacedName, password)
+	shouldGenerateNewCredentials, err := needToGenerateNewCredentials(
+		ctx,
+		getUpdateCreator,
+		user.Username,
+		user.ScramCredentialsSecretName,
+		mdbNamespacedName,
+		password,
+	)
 	if err != nil {
-		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf("could not determine if new credentials need to be generated: %s", err)
+		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf(
+			"could not determine if new credentials need to be generated: %s",
+			err,
+		)
 	}
 
 	// there are no changes required, we can re-use the same credentials.
@@ -111,7 +156,11 @@ func ensureScramCredentials(ctx context.Context, getUpdateCreator secret.GetUpda
 
 	// create or update our credentials secret for this user
 	if err := createScramCredentialsSecret(ctx, getUpdateCreator, mdbNamespacedName, ownerRef, user.ScramCredentialsSecretName, sha1Creds, sha256Creds); err != nil {
-		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf("faild to create scram credentials secret %s: %s", user.ScramCredentialsSecretName, err)
+		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf(
+			"faild to create scram credentials secret %s: %s",
+			user.ScramCredentialsSecretName,
+			err,
+		)
 	}
 
 	zap.S().Debugf("Successfully generated SCRAM credentials")
@@ -120,7 +169,13 @@ func ensureScramCredentials(ctx context.Context, getUpdateCreator secret.GetUpda
 
 // needToGenerateNewCredentials determines if it is required to generate new credentials or not.
 // this will be the case if we are either changing password, or are generating credentials for the first time.
-func needToGenerateNewCredentials(ctx context.Context, secretGetter secret.Getter, username, scramCredentialsSecretName string, mdbNamespacedName types.NamespacedName, password string) (bool, error) {
+func needToGenerateNewCredentials(
+	ctx context.Context,
+	secretGetter secret.Getter,
+	username, scramCredentialsSecretName string,
+	mdbNamespacedName types.NamespacedName,
+	password string,
+) (bool, error) {
 	s, err := secretGetter.GetSecret(ctx, types.NamespacedName{Name: scramCredentialsSecretName, Namespace: mdbNamespacedName.Namespace})
 	if err != nil {
 		// haven't generated credentials yet, so we are changing password
@@ -178,7 +233,10 @@ func generateScramShaCredentials(username string, password string) (scramcredent
 }
 
 // computeScramShaCredentials computes ScramSha 1 & 256 credentials using the provided salts
-func computeScramShaCredentials(username, password string, sha1Salt, sha256Salt []byte) (scramcredentials.ScramCreds, scramcredentials.ScramCreds, error) {
+func computeScramShaCredentials(
+	username, password string,
+	sha1Salt, sha256Salt []byte,
+) (scramcredentials.ScramCreds, scramcredentials.ScramCreds, error) {
 	scram1Creds, err := scramcredentials.ComputeScramSha1Creds(username, password, sha1Salt)
 	if err != nil {
 		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf("could not generate scramSha1Creds: %s", err)
@@ -194,7 +252,14 @@ func computeScramShaCredentials(username, password string, sha1Salt, sha256Salt 
 
 // createScramCredentialsSecret will create a Secret that contains all of the fields required to read these credentials
 // back in the future.
-func createScramCredentialsSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, mdbObjectKey types.NamespacedName, ref []metav1.OwnerReference, scramCredentialsSecretName string, sha1Creds, sha256Creds scramcredentials.ScramCreds) error {
+func createScramCredentialsSecret(
+	ctx context.Context,
+	getUpdateCreator secret.GetUpdateCreator,
+	mdbObjectKey types.NamespacedName,
+	ref []metav1.OwnerReference,
+	scramCredentialsSecretName string,
+	sha1Creds, sha256Creds scramcredentials.ScramCreds,
+) error {
 	scramCredsSecret := secret.Builder().
 		SetName(scramCredentialsSecretName).
 		SetNamespace(mdbObjectKey.Namespace).
@@ -210,15 +275,38 @@ func createScramCredentialsSecret(ctx context.Context, getUpdateCreator secret.G
 }
 
 // readExistingCredentials reads the existing set of credentials for both ScramSha 1 & 256
-func readExistingCredentials(ctx context.Context, secretGetter secret.Getter, mdbObjectKey types.NamespacedName, scramCredentialsSecretName string) (scramcredentials.ScramCreds, scramcredentials.ScramCreds, error) {
-	credentialsSecret, err := secretGetter.GetSecret(ctx, types.NamespacedName{Name: scramCredentialsSecretName, Namespace: mdbObjectKey.Namespace})
+func readExistingCredentials(
+	ctx context.Context,
+	secretGetter secret.Getter,
+	mdbObjectKey types.NamespacedName,
+	scramCredentialsSecretName string,
+) (scramcredentials.ScramCreds, scramcredentials.ScramCreds, error) {
+	credentialsSecret, err := secretGetter.GetSecret(
+		ctx,
+		types.NamespacedName{Name: scramCredentialsSecretName, Namespace: mdbObjectKey.Namespace},
+	)
 	if err != nil {
-		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf("could not get secret %s/%s: %s", mdbObjectKey.Namespace, scramCredentialsSecretName, err)
+		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf(
+			"could not get secret %s/%s: %s",
+			mdbObjectKey.Namespace,
+			scramCredentialsSecretName,
+			err,
+		)
 	}
 
 	// we should really never hit this situation. It would only be possible if the secret storing credentials is manually edited.
-	if !secret.HasAllKeys(credentialsSecret, sha1SaltKey, sha1ServerKeyKey, sha1ServerKeyKey, sha256SaltKey, sha256ServerKeyKey, sha256StoredKeyKey) {
-		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf("credentials secret did not have all of the required keys")
+	if !secret.HasAllKeys(
+		credentialsSecret,
+		sha1SaltKey,
+		sha1ServerKeyKey,
+		sha1ServerKeyKey,
+		sha256SaltKey,
+		sha256ServerKeyKey,
+		sha256StoredKeyKey,
+	) {
+		return scramcredentials.ScramCreds{}, scramcredentials.ScramCreds{}, fmt.Errorf(
+			"credentials secret did not have all of the required keys",
+		)
 	}
 
 	scramSha1Creds := scramcredentials.ScramCreds{
@@ -239,11 +327,21 @@ func readExistingCredentials(ctx context.Context, secretGetter secret.Getter, md
 }
 
 // convertMongoDBResourceUsersToAutomationConfigUsers returns a list of users that are able to be set in the AutomationConfig
-func convertMongoDBResourceUsersToAutomationConfigUsers(ctx context.Context, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdb authtypes.Configurable) ([]automationconfig.MongoDBUser, error) {
+func convertMongoDBResourceUsersToAutomationConfigUsers(
+	ctx context.Context,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdb authtypes.Configurable,
+) ([]automationconfig.MongoDBUser, error) {
 	var usersWanted []automationconfig.MongoDBUser
 	for _, u := range mdb.GetAuthUsers() {
 		if u.Database != constants.ExternalDB {
-			acUser, err := convertMongoDBUserToAutomationConfigUser(ctx, secretGetUpdateCreateDeleter, mdb.NamespacedName(), mdb.GetOwnerReferences(), u)
+			acUser, err := convertMongoDBUserToAutomationConfigUser(
+				ctx,
+				secretGetUpdateCreateDeleter,
+				mdb.NamespacedName(),
+				mdb.GetOwnerReferences(),
+				u,
+			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert scram user %s to Automation Config user: %s", u.Username, err)
 			}
@@ -255,7 +353,13 @@ func convertMongoDBResourceUsersToAutomationConfigUsers(ctx context.Context, sec
 
 // convertMongoDBUserToAutomationConfigUser converts a single user configured in the MongoDB resource and converts it to a user
 // that can be added directly to the AutomationConfig.
-func convertMongoDBUserToAutomationConfigUser(ctx context.Context, secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter, mdbNsName types.NamespacedName, ownerRef []metav1.OwnerReference, user authtypes.User) (automationconfig.MongoDBUser, error) {
+func convertMongoDBUserToAutomationConfigUser(
+	ctx context.Context,
+	secretGetUpdateCreateDeleter secret.GetUpdateCreateDeleter,
+	mdbNsName types.NamespacedName,
+	ownerRef []metav1.OwnerReference,
+	user authtypes.User,
+) (automationconfig.MongoDBUser, error) {
 	acUser := automationconfig.MongoDBUser{
 		Username: user.Username,
 		Database: user.Database,

--- a/pkg/authentication/scram/scram_enabler_test.go
+++ b/pkg/authentication/scram/scram_enabler_test.go
@@ -97,7 +97,12 @@ func TestScramAutomationConfig(t *testing.T) {
 }
 
 // configureInAutomationConfig updates the provided auth struct and fully configures Scram authentication.
-func configureInAutomationConfig(auth *automationconfig.Auth, agentPassword, agentKeyFile string, users []automationconfig.MongoDBUser, opts authtypes.Options) error {
+func configureInAutomationConfig(
+	auth *automationconfig.Auth,
+	agentPassword, agentKeyFile string,
+	users []automationconfig.MongoDBUser,
+	opts authtypes.Options,
+) error {
 	err := enableAgentAuthentication(auth, agentPassword, agentKeyFile, opts)
 	if err != nil {
 		return err

--- a/pkg/authentication/scram/scram_test.go
+++ b/pkg/authentication/scram/scram_test.go
@@ -46,19 +46,34 @@ func TestReadExistingCredentials(t *testing.T) {
 	user := mocks.BuildScramMongoDBUser("mdbuser-0")
 	t.Run("credentials are successfully generated when all fields are present", func(t *testing.T) {
 		scramCredsSecret := validScramCredentialsSecret(mdbObjectKey, user.ScramCredentialsSecretName)
-		scram1Creds, scram256Creds, err := readExistingCredentials(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredsSecret), mdbObjectKey, user.ScramCredentialsSecretName)
+		scram1Creds, scram256Creds, err := readExistingCredentials(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredsSecret),
+			mdbObjectKey,
+			user.ScramCredentialsSecretName,
+		)
 		assert.NoError(t, err)
 		assertScramCredsCredentialsValidity(t, scram1Creds, scram256Creds)
 	})
 	t.Run("credentials are not generated if a field is missing", func(t *testing.T) {
 		scramCredsSecret := invalidSecret(mdbObjectKey, user.ScramCredentialsSecretName)
-		_, _, err := readExistingCredentials(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredsSecret), mdbObjectKey, user.ScramCredentialsSecretName)
+		_, _, err := readExistingCredentials(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredsSecret),
+			mdbObjectKey,
+			user.ScramCredentialsSecretName,
+		)
 		assert.Error(t, err)
 	})
 
 	t.Run("credentials are not generated if the secret does not exist", func(t *testing.T) {
 		scramCredsSecret := validScramCredentialsSecret(mdbObjectKey, user.ScramCredentialsSecretName)
-		_, _, err := readExistingCredentials(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredsSecret), mdbObjectKey, "different-username")
+		_, _, err := readExistingCredentials(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredsSecret),
+			mdbObjectKey,
+			"different-username",
+		)
 		assert.Error(t, err)
 	})
 }
@@ -90,7 +105,13 @@ func TestEnsureScramCredentials(t *testing.T) {
 	})
 	t.Run("Existing credentials are used when password does not exist, but credentials secret has been created", func(t *testing.T) {
 		scramCredentialsSecret := validScramCredentialsSecret(mdb.NamespacedName(), user.ScramCredentialsSecretName)
-		scram1Creds, scram256Creds, err := ensureScramCredentials(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredentialsSecret), user, mdb.NamespacedName(), nil)
+		scram1Creds, scram256Creds, err := ensureScramCredentials(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredentialsSecret),
+			user,
+			mdb.NamespacedName(),
+			nil,
+		)
 		assert.NoError(t, err)
 		assertScramCredsCredentialsValidity(t, scram1Creds, scram256Creds)
 	})
@@ -105,7 +126,13 @@ func TestEnsureScramCredentials(t *testing.T) {
 			Build()
 
 		scramCredentialsSecret := validScramCredentialsSecret(mdb.NamespacedName(), user.ScramCredentialsSecretName)
-		scram1Creds, scram256Creds, err := ensureScramCredentials(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredentialsSecret, differentPasswordSecret), user, mdb.NamespacedName(), nil)
+		scram1Creds, scram256Creds, err := ensureScramCredentials(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(scramCredentialsSecret, differentPasswordSecret),
+			user,
+			mdb.NamespacedName(),
+			nil,
+		)
 		assert.NoError(t, err)
 		assert.NotEqual(t, testSha1Salt, scram1Creds.Salt)
 		assert.NotEmpty(t, scram1Creds.Salt)
@@ -136,7 +163,13 @@ func TestConvertMongoDBUserToAutomationConfigUser(t *testing.T) {
 			SetField(user.PasswordSecretKey, "TDg_DESiScDrJV6").
 			Build()
 
-		acUser, err := convertMongoDBUserToAutomationConfigUser(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(passwordSecret), mdb.NamespacedName(), nil, user)
+		acUser, err := convertMongoDBUserToAutomationConfigUser(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(passwordSecret),
+			mdb.NamespacedName(),
+			nil,
+			user,
+		)
 
 		assert.NoError(t, err)
 		assert.Equal(t, user.Username, acUser.Username)
@@ -151,7 +184,13 @@ func TestConvertMongoDBUserToAutomationConfigUser(t *testing.T) {
 	})
 
 	t.Run("If there is no password secret, the creation fails", func(t *testing.T) {
-		_, err := convertMongoDBUserToAutomationConfigUser(ctx, mocks.NewMockedSecretGetUpdateCreateDeleter(), mdb.NamespacedName(), nil, user)
+		_, err := convertMongoDBUserToAutomationConfigUser(
+			ctx,
+			mocks.NewMockedSecretGetUpdateCreateDeleter(),
+			mdb.NamespacedName(),
+			nil,
+			user,
+		)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/authentication/scramcredentials/scram_credentials.go
+++ b/pkg/authentication/scramcredentials/scram_credentials.go
@@ -67,7 +67,11 @@ func hmacIteration(hashConstructor func() hash.Hash, input, salt []byte, iterati
 	// incorrect salt size will pass validation, but the credentials will be invalid. i.e. it will not
 	// be possible to auth with the password provided to create the credentials.
 	if len(salt) != hashSize-RFC5802MandatedSaltSize {
-		return nil, fmt.Errorf("salt should have a size of %d bytes, but instead has a size of %d bytes", hashSize-RFC5802MandatedSaltSize, len(salt))
+		return nil, fmt.Errorf(
+			"salt should have a size of %d bytes, but instead has a size of %d bytes",
+			hashSize-RFC5802MandatedSaltSize,
+			len(salt),
+		)
 	}
 
 	startKey := append(salt, 0, 0, 0, 1)
@@ -115,7 +119,12 @@ func generateStoredKey(hashConstructor func() hash.Hash, clientKey []byte) ([]by
 	return h.Sum(nil), nil
 }
 
-func generateSecrets(hashConstructor func() hash.Hash, password string, salt []byte, iterationCount int) (storedKey, serverKey []byte, err error) {
+func generateSecrets(
+	hashConstructor func() hash.Hash,
+	password string,
+	salt []byte,
+	iterationCount int,
+) (storedKey, serverKey []byte, err error) {
 	saltedPassword, err := generateSaltedPassword(hashConstructor, password, salt, iterationCount)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating salted password: %s", err)
@@ -139,7 +148,11 @@ func generateSecrets(hashConstructor func() hash.Hash, password string, salt []b
 	return storedKey, serverKey, err
 }
 
-func generateB64EncodedSecrets(hashConstructor func() hash.Hash, password, b64EncodedSalt string, iterationCount int) (storedKey, serverKey string, err error) {
+func generateB64EncodedSecrets(
+	hashConstructor func() hash.Hash,
+	password, b64EncodedSalt string,
+	iterationCount int,
+) (storedKey, serverKey string, err error) {
 	salt, err := base64.StdEncoding.DecodeString(b64EncodedSalt)
 	if err != nil {
 		return "", "", fmt.Errorf("error decoding salt: %s", err)
@@ -156,7 +169,12 @@ func generateB64EncodedSecrets(hashConstructor func() hash.Hash, password, b64En
 }
 
 // password should be encrypted in the case of SCRAM-SHA-1 and unencrypted in the case of SCRAM-SHA-256
-func computeScramCredentials(hashConstructor func() hash.Hash, iterationCount int, base64EncodedSalt string, password string) (ScramCreds, error) {
+func computeScramCredentials(
+	hashConstructor func() hash.Hash,
+	iterationCount int,
+	base64EncodedSalt string,
+	password string,
+) (ScramCreds, error) {
 	storedKey, serverKey, err := generateB64EncodedSecrets(hashConstructor, password, base64EncodedSalt, iterationCount)
 	if err != nil {
 		return ScramCreds{}, fmt.Errorf("error generating SCRAM-SHA keys: %s", err)

--- a/pkg/authentication/scramcredentials/scram_credentials_test.go
+++ b/pkg/authentication/scramcredentials/scram_credentials_test.go
@@ -10,16 +10,72 @@ import (
 )
 
 func TestScramSha1SecretsMatch(t *testing.T) {
-	assertSecretsMatch(t, sha1.New, "caeec61ba3b15b15b188d29e876514e8", 10, "S3cuk2Rnu/MlbewzxrmmVA==", "sYBa3XlSPKNrgjzhOuEuRlJY4dQ=", "zuAxRSQb3gZkbaB1IGlusK4jy1M=")
-	assertSecretsMatch(t, sha1.New, "4d9625b297999b3ca786d4a9622d04f1", 10, "kW9KbCQiCOll5Ljd44cjkQ==", "VJ8fFVHkPltibvT//mG/OWw44Hc=", "ceDRsgj9HezpZ4/vkZX8GZNNN50=")
-	assertSecretsMatch(t, sha1.New, "fd0a78e418dcef39f8c768222810b894", 10, "hhX6xsoID6FeWjXncuNgAg==", "TxgaZJ4cIn+S9EfTcc9IOEG7RGc=", "d6/qjwBs0qkPKfUAjSh5eemsySE=")
+	assertSecretsMatch(
+		t,
+		sha1.New,
+		"caeec61ba3b15b15b188d29e876514e8",
+		10,
+		"S3cuk2Rnu/MlbewzxrmmVA==",
+		"sYBa3XlSPKNrgjzhOuEuRlJY4dQ=",
+		"zuAxRSQb3gZkbaB1IGlusK4jy1M=",
+	)
+	assertSecretsMatch(
+		t,
+		sha1.New,
+		"4d9625b297999b3ca786d4a9622d04f1",
+		10,
+		"kW9KbCQiCOll5Ljd44cjkQ==",
+		"VJ8fFVHkPltibvT//mG/OWw44Hc=",
+		"ceDRsgj9HezpZ4/vkZX8GZNNN50=",
+	)
+	assertSecretsMatch(
+		t,
+		sha1.New,
+		"fd0a78e418dcef39f8c768222810b894",
+		10,
+		"hhX6xsoID6FeWjXncuNgAg==",
+		"TxgaZJ4cIn+S9EfTcc9IOEG7RGc=",
+		"d6/qjwBs0qkPKfUAjSh5eemsySE=",
+	)
 }
 
 func TestScramSha256SecretsMatch(t *testing.T) {
-	assertSecretsMatch(t, sha256.New, "Gy4ZNMr-SYEsEpAEZv", 15000, "ajdf1E1QTsNAQdBEodB4vzQOFuvcw9K6PmouVg==", "/pBk9XBwSm9UyeQmyJ3LfogfHu9Z/XTjGmRhQDHx/4I=", "Avm8mjtMyg659LAyeD4VmuzQb5lxL5iy3dCuzfscfMc=")
-	assertSecretsMatch(t, sha256.New, "Y9SPYSJYUJB_", 15000, "Oplsu3uju+lYyX4apKb0K6xfHpmFtH99Oyk4Ow==", "oTJhml8KKZUSt9k4tg+tS6D/ygR+a2Xfo8JKjTpQoAI=", "SUfA2+SKL35u665WY5NnJJmA9L5dHu/TnWXX/0nm42Y=")
-	assertSecretsMatch(t, sha256.New, "157VDZr0h-Pz-wj72", 15000, "P/4xs3anygxu3/l2p35CSBe4Z47IV/FtE/e44A==", "jOb27nFF72SQoY7WUqKXOTR4e8jETXxMS67SONrcbjA=", "3FnslkgUweautAfPRCOEjhS+YbUYUNmdDQUGxB+oaFE=")
-	assertSecretsMatch(t, sha256.New, "P8z1sDfELCePTNbVqX", 15000, "RPNhenwTHlqW5OE597XpuwvPLaiecPpYFa58Pg==", "sJ8UhQRszLNo15cOe62+HLjt2NxmSkJGjdJpclTIMBs=", "CSg02ODAvh9+swUHoimXcDsT9lLp/A5IhQXavXl7+qA=")
+	assertSecretsMatch(
+		t,
+		sha256.New,
+		"Gy4ZNMr-SYEsEpAEZv",
+		15000,
+		"ajdf1E1QTsNAQdBEodB4vzQOFuvcw9K6PmouVg==",
+		"/pBk9XBwSm9UyeQmyJ3LfogfHu9Z/XTjGmRhQDHx/4I=",
+		"Avm8mjtMyg659LAyeD4VmuzQb5lxL5iy3dCuzfscfMc=",
+	)
+	assertSecretsMatch(
+		t,
+		sha256.New,
+		"Y9SPYSJYUJB_",
+		15000,
+		"Oplsu3uju+lYyX4apKb0K6xfHpmFtH99Oyk4Ow==",
+		"oTJhml8KKZUSt9k4tg+tS6D/ygR+a2Xfo8JKjTpQoAI=",
+		"SUfA2+SKL35u665WY5NnJJmA9L5dHu/TnWXX/0nm42Y=",
+	)
+	assertSecretsMatch(
+		t,
+		sha256.New,
+		"157VDZr0h-Pz-wj72",
+		15000,
+		"P/4xs3anygxu3/l2p35CSBe4Z47IV/FtE/e44A==",
+		"jOb27nFF72SQoY7WUqKXOTR4e8jETXxMS67SONrcbjA=",
+		"3FnslkgUweautAfPRCOEjhS+YbUYUNmdDQUGxB+oaFE=",
+	)
+	assertSecretsMatch(
+		t,
+		sha256.New,
+		"P8z1sDfELCePTNbVqX",
+		15000,
+		"RPNhenwTHlqW5OE597XpuwvPLaiecPpYFa58Pg==",
+		"sJ8UhQRszLNo15cOe62+HLjt2NxmSkJGjdJpclTIMBs=",
+		"CSg02ODAvh9+swUHoimXcDsT9lLp/A5IhQXavXl7+qA=",
+	)
 }
 
 func assertSecretsMatch(t *testing.T, hash func() hash.Hash, passwordHash string, iterationCount int, salt, storedKey, serverKey string) {

--- a/pkg/automationconfig/automation_config_secret.go
+++ b/pkg/automationconfig/automation_config_secret.go
@@ -30,7 +30,13 @@ func ReadFromSecret(ctx context.Context, secretGetter secret.Getter, secretNsNam
 // if the desired config is the same as the current contents, no change is made.
 // The most recent AutomationConfig is returned. If no change is made, it will return the existing one, if there
 // is a change, the new AutomationConfig is returned.
-func EnsureSecret(ctx context.Context, secretGetUpdateCreator secret.GetUpdateCreator, secretNsName types.NamespacedName, owner []metav1.OwnerReference, desiredAutomationConfig AutomationConfig) (AutomationConfig, error) {
+func EnsureSecret(
+	ctx context.Context,
+	secretGetUpdateCreator secret.GetUpdateCreator,
+	secretNsName types.NamespacedName,
+	owner []metav1.OwnerReference,
+	desiredAutomationConfig AutomationConfig,
+) (AutomationConfig, error) {
 	existingSecret, err := secretGetUpdateCreator.GetSecret(ctx, secretNsName)
 	if err != nil {
 		if secret.SecretNotExist(err) {
@@ -68,7 +74,13 @@ func EnsureSecret(ctx context.Context, secretGetUpdateCreator secret.GetUpdateCr
 	return desiredAutomationConfig, secretGetUpdateCreator.UpdateSecret(ctx, existingSecret)
 }
 
-func createNewAutomationConfigSecret(ctx context.Context, secretGetUpdateCreator secret.GetUpdateCreator, secretNsName types.NamespacedName, owner []metav1.OwnerReference, desiredAutomation AutomationConfig) (AutomationConfig, error) {
+func createNewAutomationConfigSecret(
+	ctx context.Context,
+	secretGetUpdateCreator secret.GetUpdateCreator,
+	secretNsName types.NamespacedName,
+	owner []metav1.OwnerReference,
+	desiredAutomation AutomationConfig,
+) (AutomationConfig, error) {
 	acBytes, err := json.Marshal(desiredAutomation)
 	if err != nil {
 		return AutomationConfig{}, err

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -463,7 +463,15 @@ func TestAreEqual(t *testing.T) {
 
 	t.Run("Automation Configs with different values are not equal", func(t *testing.T) {
 		areEqual, err := AreEqual(
-			createAutomationConfig("name0", "differentVersion", "domain0", Options{DownloadBase: "downloadBase1"}, Auth{Disabled: false}, 2, 2),
+			createAutomationConfig(
+				"name0",
+				"differentVersion",
+				"domain0",
+				Options{DownloadBase: "downloadBase1"},
+				Auth{Disabled: false},
+				2,
+				2,
+			),
 			createAutomationConfig("name0", "mdbVersion0", "domain0", Options{DownloadBase: "downloadBase0"}, Auth{Disabled: true}, 5, 2),
 		)
 
@@ -474,11 +482,21 @@ func TestAreEqual(t *testing.T) {
 	t.Run("Automation Configs with nil and zero values are not equal", func(t *testing.T) {
 		votes := 1
 		priority := "0.0"
-		firstBuilder := NewBuilder().SetName("name0").SetMongoDBVersion("mdbVersion0").SetOptions(Options{DownloadBase: "downloadBase0"}).SetDomain("domain0").SetMembers(2).SetAuth(Auth{Disabled: true})
+		firstBuilder := NewBuilder().SetName("name0").
+			SetMongoDBVersion("mdbVersion0").
+			SetOptions(Options{DownloadBase: "downloadBase0"}).
+			SetDomain("domain0").
+			SetMembers(2).
+			SetAuth(Auth{Disabled: true})
 		firstBuilder.SetMemberOptions([]MemberOptions{{Votes: &votes, Priority: &priority}})
 		firstAc, _ := firstBuilder.Build()
 		firstAc.Version = 2
-		secondBuilder := NewBuilder().SetName("name0").SetMongoDBVersion("mdbVersion0").SetOptions(Options{DownloadBase: "downloadBase0"}).SetDomain("domain0").SetMembers(2).SetAuth(Auth{Disabled: true})
+		secondBuilder := NewBuilder().SetName("name0").
+			SetMongoDBVersion("mdbVersion0").
+			SetOptions(Options{DownloadBase: "downloadBase0"}).
+			SetDomain("domain0").
+			SetMembers(2).
+			SetAuth(Auth{Disabled: true})
 		secondBuilder.SetMemberOptions([]MemberOptions{{Votes: &votes, Priority: nil}})
 		secondAc, _ := secondBuilder.Build()
 		secondAc.Version = 2

--- a/pkg/deployment/deployment_util.go
+++ b/pkg/deployment/deployment_util.go
@@ -51,10 +51,16 @@ func GetDeploymentStatus(ctx context.Context, namespace, name string, expectedGe
 		dep.Status.ObservedGeneration == expectedGeneration
 
 	if !ready {
-		zap.S().Debugf("Deployment %s/%s (wanted: %d, ready: %d, updated: %d, generation: %d, observedGeneration: %d, expectedGeneration: %d)",
-			namespace, name, wantedReplicas, dep.Status.ReadyReplicas, dep.Status.UpdatedReplicas,
-			dep.Generation, dep.Status.ObservedGeneration, expectedGeneration)
-		msg := fmt.Sprintf("Not all the Pods are ready (wanted: %d, updated: %d, ready: %d)", wantedReplicas, dep.Status.UpdatedReplicas, dep.Status.ReadyReplicas)
+		zap.S().
+			Debugf("Deployment %s/%s (wanted: %d, ready: %d, updated: %d, generation: %d, observedGeneration: %d, expectedGeneration: %d)",
+				namespace, name, wantedReplicas, dep.Status.ReadyReplicas, dep.Status.UpdatedReplicas,
+				dep.Generation, dep.Status.ObservedGeneration, expectedGeneration)
+		msg := fmt.Sprintf(
+			"Not all the Pods are ready (wanted: %d, updated: %d, ready: %d)",
+			wantedReplicas,
+			dep.Status.UpdatedReplicas,
+			dep.Status.ReadyReplicas,
+		)
 		return workflow.Pending("%s", msg).
 			WithResourcesNotReady([]status.ResourceNotReady{{
 				Kind:    status.DeploymentKind,

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -45,12 +45,22 @@ func GetMultiServiceExternalDomain(stsName, externalDomain string, clusterNum, p
 }
 
 // GetMultiClusterProcessHostnames returns the agent hostnames, which they should be registered in OM in multi-cluster mode.
-func GetMultiClusterProcessHostnames(stsName, namespace string, clusterNum, members int, clusterDomain string, externalDomain *string) []string {
+func GetMultiClusterProcessHostnames(
+	stsName, namespace string,
+	clusterNum, members int,
+	clusterDomain string,
+	externalDomain *string,
+) []string {
 	hostnames, _ := GetMultiClusterProcessHostnamesAndPodNames(stsName, namespace, clusterNum, members, clusterDomain, externalDomain)
 	return hostnames
 }
 
-func GetMultiClusterProcessHostnamesAndPodNames(stsName, namespace string, clusterNum, members int, clusterDomain string, externalDomain *string) ([]string, []string) {
+func GetMultiClusterProcessHostnamesAndPodNames(
+	stsName, namespace string,
+	clusterNum, members int,
+	clusterDomain string,
+	externalDomain *string,
+) ([]string, []string) {
 	hostnames := make([]string, 0)
 	podNames := make([]string, 0)
 
@@ -62,7 +72,14 @@ func GetMultiClusterProcessHostnamesAndPodNames(stsName, namespace string, clust
 	return hostnames, podNames
 }
 
-func GetMultiClusterPodServiceFQDN(stsName string, namespace string, clusterNum int, externalDomain *string, podNum int, clusterDomain string) string {
+func GetMultiClusterPodServiceFQDN(
+	stsName string,
+	namespace string,
+	clusterNum int,
+	externalDomain *string,
+	podNum int,
+	clusterDomain string,
+) string {
 	if externalDomain != nil {
 		return GetMultiServiceExternalDomain(stsName, *externalDomain, clusterNum, podNum)
 	}
@@ -87,7 +104,12 @@ func GetDnsForStatefulSet(set appsv1.StatefulSet, clusterDomain string, external
 
 // GetDnsForStatefulSetReplicasSpecified is similar to GetDnsForStatefulSet but expects the number of replicas to be specified
 // (important for scale-down operations to support hostnames for old statefulset)
-func GetDnsForStatefulSetReplicasSpecified(set appsv1.StatefulSet, clusterDomain string, replicas int, externalDomain *string) ([]string, []string) {
+func GetDnsForStatefulSetReplicasSpecified(
+	set appsv1.StatefulSet,
+	clusterDomain string,
+	replicas int,
+	externalDomain *string,
+) ([]string, []string) {
 	if replicas == 0 {
 		replicas = int(*set.Spec.Replicas)
 	}
@@ -97,7 +119,11 @@ func GetDnsForStatefulSetReplicasSpecified(set appsv1.StatefulSet, clusterDomain
 // GetDNSNames returns hostnames and names of pods in stateful set, it's less preferable than "GetDnsForStatefulSet" and
 // should be used only in situations when statefulset doesn't exist any more (the main example is when the mongodb custom
 // resource is being deleted - then the dependant statefulsets cannot be read any more as they get into Terminated state)
-func GetDNSNames(statefulSetName, service, namespace, clusterDomain string, replicas int, externalDomain *string) (hostnames, names []string) {
+func GetDNSNames(
+	statefulSetName, service, namespace, clusterDomain string,
+	replicas int,
+	externalDomain *string,
+) (hostnames, names []string) {
 	names = make([]string, replicas)
 	hostnames = make([]string, replicas)
 

--- a/pkg/handler/enqueue_owner_multi.go
+++ b/pkg/handler/enqueue_owner_multi.go
@@ -25,14 +25,22 @@ var _ handler.EventHandler = &EnqueueRequestForOwnerMultiCluster{}
 // We cannot reuse the "EnqueueRequestForOwner" because it uses OwnerReference which doesn't work across clusters
 type EnqueueRequestForOwnerMultiCluster struct{}
 
-func (e *EnqueueRequestForOwnerMultiCluster) Create(ctx context.Context, evt event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (e *EnqueueRequestForOwnerMultiCluster) Create(
+	ctx context.Context,
+	evt event.TypedCreateEvent[client.Object],
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	req := getOwnerMDBCRD(evt.Object.GetAnnotations(), evt.Object.GetNamespace())
 	if req != (reconcile.Request{}) {
 		q.Add(req)
 	}
 }
 
-func (e *EnqueueRequestForOwnerMultiCluster) Update(ctx context.Context, evt event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (e *EnqueueRequestForOwnerMultiCluster) Update(
+	ctx context.Context,
+	evt event.TypedUpdateEvent[client.Object],
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	reqs := []reconcile.Request{
 		getOwnerMDBCRD(evt.ObjectOld.GetAnnotations(), evt.ObjectOld.GetNamespace()),
 		getOwnerMDBCRD(evt.ObjectNew.GetAnnotations(), evt.ObjectNew.GetNamespace()),
@@ -45,12 +53,20 @@ func (e *EnqueueRequestForOwnerMultiCluster) Update(ctx context.Context, evt eve
 	}
 }
 
-func (e *EnqueueRequestForOwnerMultiCluster) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (e *EnqueueRequestForOwnerMultiCluster) Delete(
+	ctx context.Context,
+	evt event.TypedDeleteEvent[client.Object],
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	req := getOwnerMDBCRD(evt.Object.GetAnnotations(), evt.Object.GetNamespace())
 	q.Add(req)
 }
 
-func (e *EnqueueRequestForOwnerMultiCluster) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (e *EnqueueRequestForOwnerMultiCluster) Generic(
+	context.Context,
+	event.TypedGenericEvent[client.Object],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 }
 
 func getOwnerMDBCRD(annotations map[string]string, namespace string) reconcile.Request {

--- a/pkg/images/Imageurls.go
+++ b/pkg/images/Imageurls.go
@@ -114,7 +114,12 @@ func ContainerImage(imageUrls ImageUrls, imageName string, version string) strin
 	return fmt.Sprintf("%s:%s", imageURL, version)
 }
 
-func GetOfficialImage(imageUrls ImageUrls, version string, annotations map[string]string, defaultArchitecture architectures.DefaultArchitecture) string {
+func GetOfficialImage(
+	imageUrls ImageUrls,
+	version string,
+	annotations map[string]string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) string {
 	repoUrl := imageUrls[util.MongodbRepoUrlEnv]
 	// TODO: rethink the logic of handling custom image types. We are currently only handling ubi9 and ubi8 and we never
 	// were really handling erroneus types, we just leave them be if specified (e.g. -ubuntu).

--- a/pkg/images/Imageurls_test.go
+++ b/pkg/images/Imageurls_test.go
@@ -13,11 +13,34 @@ import (
 const deprecatedImageAppdbUbiName = "mongodb-enterprise-appdb-database-ubi"
 
 func TestReplaceImageTagOrDigestToTag(t *testing.T) {
-	assert.Equal(t, "quay.io/mongodb/mongodb-agent:9876-54321", replaceImageTagOrDigestToTag("quay.io/mongodb/mongodb-agent:1234-567", "9876-54321"))
-	assert.Equal(t, "docker.io/mongodb/mongodb-enterprise-server:9876-54321", replaceImageTagOrDigestToTag("docker.io/mongodb/mongodb-enterprise-server:1234-567", "9876-54321"))
-	assert.Equal(t, "quay.io/mongodb/mongodb-agent:9876-54321", replaceImageTagOrDigestToTag("quay.io/mongodb/mongodb-agent@sha256:6a82abae27c1ba1133f3eefaad71ea318f8fa87cc57fe9355d6b5b817ff97f1a", "9876-54321"))
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-database:some-tag", replaceImageTagOrDigestToTag("quay.io/mongodb/mongodb-kubernetes-database:45678", "some-tag"))
-	assert.Equal(t, "quay.io:3000/mongodb/mongodb-enterprise-database:some-tag", replaceImageTagOrDigestToTag("quay.io:3000/mongodb/mongodb-enterprise-database:45678", "some-tag"))
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-agent:9876-54321",
+		replaceImageTagOrDigestToTag("quay.io/mongodb/mongodb-agent:1234-567", "9876-54321"),
+	)
+	assert.Equal(
+		t,
+		"docker.io/mongodb/mongodb-enterprise-server:9876-54321",
+		replaceImageTagOrDigestToTag("docker.io/mongodb/mongodb-enterprise-server:1234-567", "9876-54321"),
+	)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-agent:9876-54321",
+		replaceImageTagOrDigestToTag(
+			"quay.io/mongodb/mongodb-agent@sha256:6a82abae27c1ba1133f3eefaad71ea318f8fa87cc57fe9355d6b5b817ff97f1a",
+			"9876-54321",
+		),
+	)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-database:some-tag",
+		replaceImageTagOrDigestToTag("quay.io/mongodb/mongodb-kubernetes-database:45678", "some-tag"),
+	)
+	assert.Equal(
+		t,
+		"quay.io:3000/mongodb/mongodb-enterprise-database:some-tag",
+		replaceImageTagOrDigestToTag("quay.io:3000/mongodb/mongodb-enterprise-database:45678", "some-tag"),
+	)
 }
 
 func TestContainerImage(t *testing.T) {
@@ -26,19 +49,48 @@ func TestContainerImage(t *testing.T) {
 	initDatabaseRelatedImageEnv3 := fmt.Sprintf("RELATED_IMAGE_%s_2_0_0_b20220912000000", util.InitDatabaseImageUrlEnv)
 
 	t.Setenv(util.InitDatabaseImageUrlEnv, "quay.io/mongodb/mongodb-kubernetes-init-database")
-	t.Setenv(initDatabaseRelatedImageEnv1, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd")
-	t.Setenv(initDatabaseRelatedImageEnv2, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c")
-	t.Setenv(initDatabaseRelatedImageEnv3, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad")
+	t.Setenv(
+		initDatabaseRelatedImageEnv1,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd",
+	)
+	t.Setenv(
+		initDatabaseRelatedImageEnv2,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c",
+	)
+	t.Setenv(
+		initDatabaseRelatedImageEnv3,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad",
+	)
 
 	// there is no related image for 0.0.1
 	imageUrls := LoadImageUrlsFromEnv()
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database:0.0.1", ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "0.0.1"))
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database:0.0.1",
+		ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "0.0.1"),
+	)
 	// for 10.2.25.6008-1 there is no RELATED_IMAGE variable set, so we use input instead of digest
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database:10.2.25.6008-1", ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "10.2.25.6008-1"))
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database:10.2.25.6008-1",
+		ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "10.2.25.6008-1"),
+	)
 	// for following versions we set RELATED_IMAGE_MONGODB_IMAGE_* env variables to sha256 digest
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd", ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "1.0.0"))
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c", ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "12.0.4.7554-1"))
-	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-init-database@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad", ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "2.0.0-b20220912000000"))
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd",
+		ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "1.0.0"),
+	)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c",
+		ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "12.0.4.7554-1"),
+	)
+	assert.Equal(
+		t,
+		"quay.io/mongodb/mongodb-kubernetes-init-database@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad",
+		ContainerImage(imageUrls, util.InitDatabaseImageUrlEnv, "2.0.0-b20220912000000"),
+	)
 
 	t.Setenv(util.OpsManagerImageUrl, "quay.io:3000/mongodb/mongodb-kubernetes")
 	imageUrls = LoadImageUrlsFromEnv()
@@ -177,7 +229,13 @@ func TestGetAppDBImage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupEnvs(t)
 			imageUrlsMock := LoadImageUrlsFromEnv()
-			assert.Equalf(t, tt.want, GetOfficialImage(imageUrlsMock, tt.input, tt.annotations, architectures.NonStatic), "getOfficialImage(%v)", tt.input)
+			assert.Equalf(
+				t,
+				tt.want,
+				GetOfficialImage(imageUrlsMock, tt.input, tt.annotations, architectures.NonStatic),
+				"getOfficialImage(%v)",
+				tt.input,
+			)
 		})
 	}
 }

--- a/pkg/kube/client/mocked_client.go
+++ b/pkg/kube/client/mocked_client.go
@@ -113,7 +113,12 @@ type mockedStatusWriter struct {
 	parent mockedClient
 }
 
-func (m mockedStatusWriter) Create(ctx context.Context, obj k8sClient.Object, _ k8sClient.Object, _ ...k8sClient.SubResourceCreateOption) error {
+func (m mockedStatusWriter) Create(
+	ctx context.Context,
+	obj k8sClient.Object,
+	_ k8sClient.Object,
+	_ ...k8sClient.SubResourceCreateOption,
+) error {
 	return m.parent.Create(ctx, obj)
 }
 
@@ -121,7 +126,12 @@ func (m mockedStatusWriter) Update(ctx context.Context, obj k8sClient.Object, _ 
 	return m.parent.Update(ctx, obj)
 }
 
-func (m mockedStatusWriter) Patch(ctx context.Context, obj k8sClient.Object, patch k8sClient.Patch, _ ...k8sClient.SubResourcePatchOption) error {
+func (m mockedStatusWriter) Patch(
+	ctx context.Context,
+	obj k8sClient.Object,
+	patch k8sClient.Patch,
+	_ ...k8sClient.SubResourcePatchOption,
+) error {
 	return m.parent.Patch(ctx, obj, patch)
 }
 

--- a/pkg/kube/commoncontroller/resource.go
+++ b/pkg/kube/commoncontroller/resource.go
@@ -14,7 +14,13 @@ import (
 )
 
 // GetResource populates the provided runtime.Object with some additional error handling
-func GetResource(ctx context.Context, kubeClient kubernetesClient.Client, request reconcile.Request, resource v1.CustomResourceReadWriter, log *zap.SugaredLogger) (reconcile.Result, error) {
+func GetResource(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	request reconcile.Request,
+	resource v1.CustomResourceReadWriter,
+	log *zap.SugaredLogger,
+) (reconcile.Result, error) {
 	err := kubeClient.Get(ctx, request.NamespacedName, resource)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {

--- a/pkg/kube/commoncontroller/resourcestatus.go
+++ b/pkg/kube/commoncontroller/resourcestatus.go
@@ -20,7 +20,14 @@ import (
 
 // updateStatus updates the status for the CR using patch operation. Note, that the resource status is mutated and
 // it's important to pass resource by pointer to all methods which invoke current 'updateStatus'.
-func UpdateStatus(ctx context.Context, kubeClient kubernetesClient.Client, reconciledResource v1.CustomResourceReadWriter, st workflow.Status, log *zap.SugaredLogger, statusOptions ...status.Option) (reconcile.Result, error) {
+func UpdateStatus(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	reconciledResource v1.CustomResourceReadWriter,
+	st workflow.Status,
+	log *zap.SugaredLogger,
+	statusOptions ...status.Option,
+) (reconcile.Result, error) {
 	mergedOptions := append(statusOptions, st.StatusOptions()...)
 	log.Infof("Updating status: phase=%v, options=%+v", st.Phase(), mergedOptions)
 	reconciledResource.UpdateStatus(st.Phase(), mergedOptions...)
@@ -43,7 +50,12 @@ type patchValue struct {
 // Note, that this method enforces update ONLY to the status, so the reconciliation events happening because of this
 // can be filtered out by 'controller.shouldReconcile'
 // The "jsonPatch" merge allows to update only status field
-func patchUpdateStatus(ctx context.Context, kubeClient kubernetesClient.Client, resource v1.CustomResourceReadWriter, options ...status.Option) error {
+func patchUpdateStatus(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	resource v1.CustomResourceReadWriter,
+	options ...status.Option,
+) error {
 	payload := []patchValue{{
 		Op:   "replace",
 		Path: resource.GetStatusPath(options...),
@@ -78,7 +90,12 @@ func patchUpdateStatus(ctx context.Context, kubeClient kubernetesClient.Client, 
 // Each path (ancestors and leaf) is probed before being added: JSON-patch add
 // REPLACES an existing member, so an unconditional add at /status would wipe
 // sibling status fields written by another controller.
-func ensureStatusSubresourceExists(ctx context.Context, kubeClient kubernetesClient.Client, resource v1.CustomResourceReadWriter, options ...status.Option) error {
+func ensureStatusSubresourceExists(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	resource v1.CustomResourceReadWriter,
+	options ...status.Option,
+) error {
 	for _, pathStr := range statusSubresourcePatchPaths(resource.GetStatusPath(options...)) {
 		if !statusPathAbsent(ctx, kubeClient, resource, pathStr) {
 			continue

--- a/pkg/kube/commoncontroller/resourcestatus_test.go
+++ b/pkg/kube/commoncontroller/resourcestatus_test.go
@@ -26,7 +26,11 @@ func TestStatusSubresourcePatchPaths(t *testing.T) {
 	}{
 		{name: "status root", fullPath: "/status", want: []string{"/status"}},
 		{name: "nested substatus", fullPath: "/status/loadBalancer", want: []string{"/status", "/status/loadBalancer"}},
-		{name: "deeply nested substatus", fullPath: "/status/opsManager/backup", want: []string{"/status", "/status/opsManager", "/status/opsManager/backup"}},
+		{
+			name:     "deeply nested substatus",
+			fullPath: "/status/opsManager/backup",
+			want:     []string{"/status", "/status/opsManager", "/status/opsManager/backup"},
+		},
 		{name: "empty path", fullPath: "", want: nil},
 		{name: "bare slash never patches the document root", fullPath: "/", want: nil},
 	}

--- a/pkg/kube/configmap/configmap.go
+++ b/pkg/kube/configmap/configmap.go
@@ -111,7 +111,13 @@ func filelikePropertiesToMap(s string) (map[string]string, error) {
 }
 
 // ReadFileLikeField reads a ConfigMap with file-like properties and returns the value inside one of the fields.
-func ReadFileLikeField(ctx context.Context, getter Getter, objectKey client.ObjectKey, externalKey string, internalKey string) (string, error) {
+func ReadFileLikeField(
+	ctx context.Context,
+	getter Getter,
+	objectKey client.ObjectKey,
+	externalKey string,
+	internalKey string,
+) (string, error) {
 	cmData, err := ReadData(ctx, getter, objectKey)
 	if err != nil {
 		return "", err

--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -123,7 +123,13 @@ func HasAllKeys(secret corev1.Secret, keys ...string) bool {
 
 // EnsureSecretWithKey makes sure the Secret with the given name has a key with the given value if the key is not already present.
 // if the key is present, it will return the existing value associated with this key.
-func EnsureSecretWithKey(ctx context.Context, secretGetUpdateCreateDeleter GetUpdateCreateDeleter, nsName types.NamespacedName, ownerReferences []metav1.OwnerReference, key, value string) (string, error) {
+func EnsureSecretWithKey(
+	ctx context.Context,
+	secretGetUpdateCreateDeleter GetUpdateCreateDeleter,
+	nsName types.NamespacedName,
+	ownerReferences []metav1.OwnerReference,
+	key, value string,
+) (string, error) {
 	existingSecret, err0 := secretGetUpdateCreateDeleter.GetSecret(ctx, nsName)
 	if err0 != nil {
 		if SecretNotExist(err0) {
@@ -145,7 +151,12 @@ func EnsureSecretWithKey(ctx context.Context, secretGetUpdateCreateDeleter GetUp
 }
 
 // CopySecret copies secret object(data) from one cluster client to another, the from and to cluster-client can belong to the same or different clusters
-func CopySecret(ctx context.Context, fromClient Getter, toClient GetUpdateCreator, sourceSecretNsName, destNsName types.NamespacedName) error {
+func CopySecret(
+	ctx context.Context,
+	fromClient Getter,
+	toClient GetUpdateCreator,
+	sourceSecretNsName, destNsName types.NamespacedName,
+) error {
 	s, err := fromClient.GetSecret(ctx, sourceSecretNsName)
 	if err != nil {
 		return err

--- a/pkg/kubectl-mongodb/common/common.go
+++ b/pkg/kubectl-mongodb/common/common.go
@@ -355,7 +355,12 @@ func createKubeConfigSecret(ctx context.Context, centralClusterClient kubernetes
 		},
 	}
 
-	fmt.Printf("Creating KubeConfig secret %s/%s in cluster %s\n", flags.CentralClusterNamespace, kubeConfigSecret.Name, flags.CentralCluster)
+	fmt.Printf(
+		"Creating KubeConfig secret %s/%s in cluster %s\n",
+		flags.CentralClusterNamespace,
+		kubeConfigSecret.Name,
+		flags.CentralCluster,
+	)
 	_, err := centralClusterClient.CoreV1().Secrets(flags.CentralClusterNamespace).Create(ctx, &kubeConfigSecret, metav1.CreateOptions{})
 
 	if !errors.IsAlreadyExists(err) && err != nil {
@@ -568,7 +573,10 @@ func buildRoleBinding(role rbacv1.Role, serviceAccount string, serviceAccountNam
 }
 
 // buildClusterRoleBinding creates the ClusterRoleBinding which binds the ClusterRole to the given ServiceAccount.
-func buildClusterRoleBinding(clusterRole rbacv1.ClusterRole, serviceAccountName, serviceAccountNamespace, clusterRoleBindingName string) rbacv1.ClusterRoleBinding {
+func buildClusterRoleBinding(
+	clusterRole rbacv1.ClusterRole,
+	serviceAccountName, serviceAccountNamespace, clusterRoleBindingName string,
+) rbacv1.ClusterRoleBinding {
 	return rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   clusterRoleBindingName,
@@ -590,7 +598,14 @@ func buildClusterRoleBinding(clusterRole rbacv1.ClusterRole, serviceAccountName,
 }
 
 // createRoles creates the ServiceAccount and Roles, RoleBindings, ClusterRoles and ClusterRoleBindings required.
-func createRoles(ctx context.Context, c KubeClient, serviceAccountName, serviceAccountNamespace, namespace string, clusterScoped, telemetryClusterRoles bool, mongodbRolesClusterRole bool, clusterType clusterType) error {
+func createRoles(
+	ctx context.Context,
+	c KubeClient,
+	serviceAccountName, serviceAccountNamespace, namespace string,
+	clusterScoped, telemetryClusterRoles bool,
+	mongodbRolesClusterRole bool,
+	clusterType clusterType,
+) error {
 	var err error
 
 	if telemetryClusterRoles {
@@ -686,7 +701,14 @@ func createRoles(ctx context.Context, c KubeClient, serviceAccountName, serviceA
 	return nil
 }
 
-func createClusterRoleBinding(ctx context.Context, c KubeClient, serviceAccountName string, serviceAccountNamespace string, clusterRoleBindingName string, clusterRole rbacv1.ClusterRole) error {
+func createClusterRoleBinding(
+	ctx context.Context,
+	c KubeClient,
+	serviceAccountName string,
+	serviceAccountNamespace string,
+	clusterRoleBindingName string,
+	clusterRole rbacv1.ClusterRole,
+) error {
 	clusterRoleBinding := buildClusterRoleBinding(clusterRole, serviceAccountName, serviceAccountNamespace, clusterRoleBindingName)
 	_, err := c.RbacV1().ClusterRoleBindings().Create(ctx, &clusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
@@ -830,7 +852,11 @@ func createKubeConfigFromServiceAccountTokens(serviceAccountTokens map[string]co
 
 // getAllMemberClusterServiceAccountSecretTokens returns a slice of secrets that should all be
 // copied in the central cluster for the operator to use.
-func getAllMemberClusterServiceAccountSecretTokens(ctx context.Context, clientSetMap map[string]KubeClient, flags Flags) (map[string]corev1.Secret, error) {
+func getAllMemberClusterServiceAccountSecretTokens(
+	ctx context.Context,
+	clientSetMap map[string]KubeClient,
+	flags Flags,
+) (map[string]corev1.Secret, error) {
 	allSecrets := map[string]corev1.Secret{}
 
 	for _, cluster := range flags.MemberClusters {
@@ -870,7 +896,13 @@ func getAllMemberClusterServiceAccountSecretTokens(ctx context.Context, clientSe
 	return allSecrets, nil
 }
 
-func getServiceAccount(ctx context.Context, lister kubernetes.Interface, namespace string, name string, memberClusterName string) (*corev1.ServiceAccount, error) {
+func getServiceAccount(
+	ctx context.Context,
+	lister kubernetes.Interface,
+	namespace string,
+	name string,
+	memberClusterName string,
+) (*corev1.ServiceAccount, error) {
 	sa, err := lister.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get service account %s/%s in member cluster %s: %w", namespace, name, memberClusterName, err)
@@ -913,7 +945,12 @@ func copySecret(ctx context.Context, src, dst KubeClient, namespace, name string
 	return nil
 }
 
-func createServiceAccount(ctx context.Context, c KubeClient, serviceAccountName, namespace string, imagePullSecrets string) (corev1.ServiceAccount, error) {
+func createServiceAccount(
+	ctx context.Context,
+	c KubeClient,
+	serviceAccountName, namespace string,
+	imagePullSecrets string,
+) (corev1.ServiceAccount, error) {
 	sa := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
@@ -1011,15 +1048,30 @@ func createDatabaseRoles(ctx context.Context, client KubeClient, f Flags) error 
 func copyDatabaseRoles(ctx context.Context, src, dst KubeClient, namespace string) error {
 	appdbSA, err := src.CoreV1().ServiceAccounts(namespace).Get(ctx, AppdbServiceAccount, metav1.GetOptions{})
 	if err != nil {
-		return xerrors.Errorf("failed retrieving service account %s, from ns: %s from source cluster: %w", AppdbServiceAccount, namespace, err)
+		return xerrors.Errorf(
+			"failed retrieving service account %s, from ns: %s from source cluster: %w",
+			AppdbServiceAccount,
+			namespace,
+			err,
+		)
 	}
 	dbpodsSA, err := src.CoreV1().ServiceAccounts(namespace).Get(ctx, DatabasePodsServiceAccount, metav1.GetOptions{})
 	if err != nil {
-		return xerrors.Errorf("failed retrieving service account %s, from ns: %s from source cluster: %w", DatabasePodsServiceAccount, namespace, err)
+		return xerrors.Errorf(
+			"failed retrieving service account %s, from ns: %s from source cluster: %w",
+			DatabasePodsServiceAccount,
+			namespace,
+			err,
+		)
 	}
 	opsManagerSA, err := src.CoreV1().ServiceAccounts(namespace).Get(ctx, OpsManagerServiceAccount, metav1.GetOptions{})
 	if err != nil {
-		return xerrors.Errorf("failed retrieving service account %s, from ns: %s from source cluster: %w", OpsManagerServiceAccount, namespace, err)
+		return xerrors.Errorf(
+			"failed retrieving service account %s, from ns: %s from source cluster: %w",
+			OpsManagerServiceAccount,
+			namespace,
+			err,
+		)
 	}
 	appdbR, err := src.RbacV1().Roles(namespace).Get(ctx, AppdbRole, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/kubectl-mongodb/common/common_test.go
+++ b/pkg/kubectl-mongodb/common/common_test.go
@@ -281,16 +281,38 @@ func TestCreateKubeConfig_IsComposedOf_ServiceAccountTokens_InAllClusters(t *tes
 
 	for i, kubeConfigCluster := range kubeConfig.Clusters {
 		assert.Equal(t, flags.MemberClusters[i], kubeConfigCluster.Name, "Name of cluster should be set to the member clusters.")
-		expectedCaBytes, err := readSecretKey(ctx, clientMap[flags.MemberClusters[i]], fmt.Sprintf("%s-token-secret", flags.ServiceAccount), flags.CentralClusterNamespace, "ca.crt")
+		expectedCaBytes, err := readSecretKey(
+			ctx,
+			clientMap[flags.MemberClusters[i]],
+			fmt.Sprintf("%s-token-secret", flags.ServiceAccount),
+			flags.CentralClusterNamespace,
+			"ca.crt",
+		)
 
 		assert.NoError(t, err)
 		assert.Contains(t, string(expectedCaBytes), flags.MemberClusters[i])
-		assert.Equal(t, 0, bytes.Compare(expectedCaBytes, kubeConfigCluster.Cluster.CertificateAuthorityData), "CA should be read from Service Account token Secret.")
-		assert.Equal(t, fmt.Sprintf("https://api.%s", flags.MemberClusters[i]), kubeConfigCluster.Cluster.Server, "Server should be correctly configured based on cluster name.")
+		assert.Equal(
+			t,
+			0,
+			bytes.Compare(expectedCaBytes, kubeConfigCluster.Cluster.CertificateAuthorityData),
+			"CA should be read from Service Account token Secret.",
+		)
+		assert.Equal(
+			t,
+			fmt.Sprintf("https://api.%s", flags.MemberClusters[i]),
+			kubeConfigCluster.Cluster.Server,
+			"Server should be correctly configured based on cluster name.",
+		)
 	}
 
 	for i, user := range kubeConfig.Users {
-		tokenBytes, err := readSecretKey(ctx, clientMap[flags.MemberClusters[i]], fmt.Sprintf("%s-token-secret", flags.ServiceAccount), flags.CentralClusterNamespace, "token")
+		tokenBytes, err := readSecretKey(
+			ctx,
+			clientMap[flags.MemberClusters[i]],
+			fmt.Sprintf("%s-token-secret", flags.ServiceAccount),
+			flags.CentralClusterNamespace,
+			"token",
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, flags.MemberClusters[i], user.Name, "User name should be the name of the cluster.")
 		assert.Equal(t, string(tokenBytes), user.User.Token, "Token from the service account secret should be set.")
@@ -306,7 +328,9 @@ func TestKubeConfigSecret_IsCreated_InCentralCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	centralClusterClient := clientMap[flags.CentralCluster]
-	kubeConfigSecret, err := centralClusterClient.CoreV1().Secrets(flags.CentralClusterNamespace).Get(ctx, KubeConfigSecretName, metav1.GetOptions{})
+	kubeConfigSecret, err := centralClusterClient.CoreV1().
+		Secrets(flags.CentralClusterNamespace).
+		Get(ctx, KubeConfigSecretName, metav1.GetOptions{})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, kubeConfigSecret)
@@ -322,7 +346,9 @@ func TestKubeConfigSecret_IsNotCreated_InMemberClusters(t *testing.T) {
 
 	for _, memberCluster := range flags.MemberClusters {
 		memberClient := clientMap[memberCluster]
-		kubeConfigSecret, err := memberClient.CoreV1().Secrets(flags.CentralClusterNamespace).Get(ctx, KubeConfigSecretName, metav1.GetOptions{})
+		kubeConfigSecret, err := memberClient.CoreV1().
+			Secrets(flags.CentralClusterNamespace).
+			Get(ctx, KubeConfigSecretName, metav1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))
 		assert.Equal(t, &corev1.Secret{}, kubeConfigSecret)
 	}
@@ -367,7 +393,12 @@ func TestChangingOneServiceAccountToken_ChangesOnlyThatEntry_InKubeConfig(t *tes
 	assert.NotEqual(t, kubeConfigBefore.Clusters[0], kubeConfigAfter.Clusters[0], "Cluster 1 clusters should have been modified")
 
 	assert.Equal(t, "new-token-data", kubeConfigAfter.Users[0].User.Token, "first user token should have been updated.")
-	assert.Equal(t, []byte("new-ca-crt"), kubeConfigAfter.Clusters[0].Cluster.CertificateAuthorityData, "CA for cluster 0 should have been updated.")
+	assert.Equal(
+		t,
+		[]byte("new-ca-crt"),
+		kubeConfigAfter.Clusters[0].Cluster.CertificateAuthorityData,
+		"CA for cluster 0 should have been updated.",
+	)
 
 	assert.Equal(t, kubeConfigBefore.Users[1], kubeConfigAfter.Users[1], "Cluster 1 users should have remained unchanged")
 	assert.Equal(t, kubeConfigBefore.Clusters[1], kubeConfigAfter.Clusters[1], "Cluster 1 clusters should have remained unchanged")
@@ -483,10 +514,21 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sa, _ := clientMap[flags.CentralCluster].CoreV1().ServiceAccounts(flags.CentralClusterNamespace).List(ctx, metav1.ListOptions{})
 
 		sb = marshalToYaml(t, sb, "Central Cluster, cluster-scoped resources", "rbac.authorization.k8s.io/v1", "ClusterRole", cr.Items)
-		sb = marshalToYaml(t, sb, "Central Cluster, cluster-scoped resources", "rbac.authorization.k8s.io/v1", "ClusterRoleBinding", crb.Items)
+		sb = marshalToYaml(
+			t,
+			sb,
+			"Central Cluster, cluster-scoped resources",
+			"rbac.authorization.k8s.io/v1",
+			"ClusterRoleBinding",
+			crb.Items,
+		)
 		sb = marshalToYaml(t, sb, "Central Cluster, cluster-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile(
+			"../../../public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_central_cluster.yaml",
+			[]byte(sb.String()),
+			os.ModePerm,
+		)
 		assert.NoError(t, err)
 	}
 
@@ -502,10 +544,21 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sa, _ := clientMap[flags.MemberClusters[0]].CoreV1().ServiceAccounts(flags.MemberClusterNamespace).List(ctx, metav1.ListOptions{})
 
 		sb = marshalToYaml(t, sb, "Member Cluster, cluster-scoped resources", "rbac.authorization.k8s.io/v1", "ClusterRole", cr.Items)
-		sb = marshalToYaml(t, sb, "Member Cluster, cluster-scoped resources", "rbac.authorization.k8s.io/v1", "ClusterRoleBinding", crb.Items)
+		sb = marshalToYaml(
+			t,
+			sb,
+			"Member Cluster, cluster-scoped resources",
+			"rbac.authorization.k8s.io/v1",
+			"ClusterRoleBinding",
+			crb.Items,
+		)
 		sb = marshalToYaml(t, sb, "Member Cluster, cluster-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_member_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile(
+			"../../../public/samples/multi-cluster-cli-gitops/resources/rbac/cluster_scoped_member_cluster.yaml",
+			[]byte(sb.String()),
+			os.ModePerm,
+		)
 		assert.NoError(t, err)
 	}
 
@@ -526,7 +579,11 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sb = marshalToYaml(t, sb, "Central Cluster, namespace-scoped resources", "rbac.authorization.k8s.io/v1", "RoleBinding", rb.Items)
 		sb = marshalToYaml(t, sb, "Central Cluster, namespace-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile(
+			"../../../public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_central_cluster.yaml",
+			[]byte(sb.String()),
+			os.ModePerm,
+		)
 		assert.NoError(t, err)
 	}
 
@@ -547,12 +604,23 @@ func TestPrintingOutRolesServiceAccountsAndRoleBindings(t *testing.T) {
 		sb = marshalToYaml(t, sb, "Member Cluster, namespace-scoped resources", "rbac.authorization.k8s.io/v1", "RoleBinding", rb.Items)
 		sb = marshalToYaml(t, sb, "Member Cluster, namespace-scoped resources", "v1", "ServiceAccount", sa.Items)
 
-		err = os.WriteFile("../../../public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_member_cluster.yaml", []byte(sb.String()), os.ModePerm)
+		err = os.WriteFile(
+			"../../../public/samples/multi-cluster-cli-gitops/resources/rbac/namespace_scoped_member_cluster.yaml",
+			[]byte(sb.String()),
+			os.ModePerm,
+		)
 		assert.NoError(t, err)
 	}
 }
 
-func marshalToYaml[T interface{}](t *testing.T, sb *strings.Builder, comment string, apiVersion string, kind string, items []T) *strings.Builder {
+func marshalToYaml[T interface{}](
+	t *testing.T,
+	sb *strings.Builder,
+	comment string,
+	apiVersion string,
+	kind string,
+	items []T,
+) *strings.Builder {
 	fmt.Fprintf(sb, "# %s\n", comment)
 	for _, cr := range items {
 		fmt.Fprintf(sb, "apiVersion: %s\n", apiVersion)
@@ -721,7 +789,15 @@ func assertMemberClusterRolesDoNotExist(t *testing.T, ctx context.Context, clien
 // assertClusterRoles should be used to assert the existence of member-cluster cluster roles. The boolean
 // shouldExist should be true for roles existing, and false for cluster roles not existing.
 // telemetryShouldExist should be true for roles existing, and false for cluster roles not existing.
-func assertClusterRoles(t *testing.T, ctx context.Context, clientMap map[string]KubeClient, flags Flags, clusterScopeShouldExist bool, telemetryShouldExist bool, clusterType clusterType) {
+func assertClusterRoles(
+	t *testing.T,
+	ctx context.Context,
+	clientMap map[string]KubeClient,
+	flags Flags,
+	clusterScopeShouldExist bool,
+	telemetryShouldExist bool,
+	clusterType clusterType,
+) {
 	var expectedClusterRole rbacv1.ClusterRole
 	if clusterType == clusterTypeCentral {
 		expectedClusterRole = buildCentralEntityClusterRole()
@@ -736,7 +812,14 @@ func assertClusterRoles(t *testing.T, ctx context.Context, clientMap map[string]
 	assertClusterRoleCentral(t, ctx, clientMap, flags, telemetryShouldExist, expectedClusterRoleTelemetry)
 }
 
-func assertClusterRoleCentral(t *testing.T, ctx context.Context, clientMap map[string]KubeClient, flags Flags, shouldExist bool, expectedClusterRole rbacv1.ClusterRole) {
+func assertClusterRoleCentral(
+	t *testing.T,
+	ctx context.Context,
+	clientMap map[string]KubeClient,
+	flags Flags,
+	shouldExist bool,
+	expectedClusterRole rbacv1.ClusterRole,
+) {
 	clusterRole, err := clientMap[flags.CentralCluster].RbacV1().ClusterRoles().Get(ctx, expectedClusterRole.Name, metav1.GetOptions{})
 	if shouldExist {
 		assert.Nil(t, err)
@@ -746,7 +829,14 @@ func assertClusterRoleCentral(t *testing.T, ctx context.Context, clientMap map[s
 	}
 }
 
-func assertClusterRoleMembers(t *testing.T, ctx context.Context, clientMap map[string]KubeClient, flags Flags, shouldExist bool, expectedClusterRole rbacv1.ClusterRole) {
+func assertClusterRoleMembers(
+	t *testing.T,
+	ctx context.Context,
+	clientMap map[string]KubeClient,
+	flags Flags,
+	shouldExist bool,
+	expectedClusterRole rbacv1.ClusterRole,
+) {
 	for _, clusterName := range flags.MemberClusters {
 		client := clientMap[clusterName]
 		role, err := client.RbacV1().ClusterRoles().Get(ctx, expectedClusterRole.Name, metav1.GetOptions{})

--- a/pkg/kubectl-mongodb/common/kubeclientcontainer.go
+++ b/pkg/kubectl-mongodb/common/kubeclientcontainer.go
@@ -314,7 +314,11 @@ func (k *KubeClientContainer) GetRestConfig() *rest.Config {
 	return k.restConfig
 }
 
-func NewKubeClientContainer(restConfig *rest.Config, staticClient kubernetes.Interface, dynamicClient dynamic.Interface) *KubeClientContainer {
+func NewKubeClientContainer(
+	restConfig *rest.Config,
+	staticClient kubernetes.Interface,
+	dynamicClient dynamic.Interface,
+) *KubeClientContainer {
 	return &KubeClientContainer{
 		staticClient:  staticClient,
 		dynamicClient: dynamicClient,

--- a/pkg/kubectl-mongodb/common/kubeconfig.go
+++ b/pkg/kubectl-mongodb/common/kubeconfig.go
@@ -40,7 +40,11 @@ func GetMemberClusterApiServerUrls(kubeconfig *clientcmdapi.Config, clusterNames
 }
 
 // CreateClientMap crates a map of all MultiClusterClient for every member cluster, and the operator cluster.
-func CreateClientMap(memberClusters []string, operatorCluster, kubeConfigPath string, getClient func(clusterName string, kubeConfigPath string) (KubeClient, error)) (map[string]KubeClient, error) {
+func CreateClientMap(
+	memberClusters []string,
+	operatorCluster, kubeConfigPath string,
+	getClient func(clusterName string, kubeConfigPath string) (KubeClient, error),
+) (map[string]KubeClient, error) {
 	clientMap := map[string]KubeClient{}
 	for _, c := range memberClusters {
 		clientset, err := getClient(c, kubeConfigPath)

--- a/pkg/mongot/mongot_config.go
+++ b/pkg/mongot/mongot_config.go
@@ -30,9 +30,9 @@ type ConfigFeatureFlags struct {
 }
 
 type EmbeddingConfig struct {
-	QueryKeyFile              string `json:"queryKeyFile" yaml:"queryKeyFile,omitempty"`
-	IndexingKeyFile           string `json:"indexingKeyFile" yaml:"indexingKeyFile,omitempty"`
-	ProviderEndpoint          string `json:"providerEndpoint" yaml:"providerEndpoint,omitempty"`
+	QueryKeyFile              string `json:"queryKeyFile"              yaml:"queryKeyFile,omitempty"`
+	IndexingKeyFile           string `json:"indexingKeyFile"           yaml:"indexingKeyFile,omitempty"`
+	ProviderEndpoint          string `json:"providerEndpoint"          yaml:"providerEndpoint,omitempty"`
 	IsAutoEmbeddingViewWriter *bool  `json:"isAutoEmbeddingViewWriter" yaml:"isAutoEmbeddingViewWriter,omitempty"`
 }
 

--- a/pkg/multicluster/memberwatch/memberwatch.go
+++ b/pkg/multicluster/memberwatch/memberwatch.go
@@ -102,7 +102,13 @@ func (m *MemberClusterHealthChecker) populateCache(clustersMap map[string]cluste
 
 // WatchMemberClusterHealth watches member clusters healthcheck. If a cluster fails healthcheck it re-enqueues the
 // MongoDBMultiCluster resources. It is spun up in the mongodb multi reconciler as a go-routine, and is executed every 10 seconds.
-func (m *MemberClusterHealthChecker) WatchMemberClusterHealth(ctx context.Context, log *zap.SugaredLogger, watchChannel chan event.GenericEvent, centralClient kubernetesClient.Client, clustersMap map[string]cluster.Cluster) {
+func (m *MemberClusterHealthChecker) WatchMemberClusterHealth(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	watchChannel chan event.GenericEvent,
+	centralClient kubernetesClient.Client,
+	clustersMap map[string]cluster.Cluster,
+) {
 	// check if the local cache is populated if not let's do that
 	if len(m.Cache) == 0 {
 		m.populateCache(clustersMap, log)
@@ -245,7 +251,12 @@ func distributeFailedMembers(clusters mdb.ClusterSpecList, clustername string) m
 
 // AddFailoverAnnotation adds the failed cluster spec to the annotation of the MongoDBMultiCluster CR for it to be used
 // while performing the reconcilliation
-func AddFailoverAnnotation(ctx context.Context, mrs mdbmulti.MongoDBMultiCluster, clustername string, client kubernetesClient.Client) error {
+func AddFailoverAnnotation(
+	ctx context.Context,
+	mrs mdbmulti.MongoDBMultiCluster,
+	clustername string,
+	client kubernetesClient.Client,
+) error {
 	if mrs.Annotations == nil {
 		mrs.Annotations = map[string]string{}
 	}
@@ -263,10 +274,20 @@ func AddFailoverAnnotation(ctx context.Context, mrs mdbmulti.MongoDBMultiCluster
 		return err
 	}
 
-	return annotations.SetAnnotations(ctx, &mrs, map[string]string{failedcluster.ClusterSpecOverrideAnnotation: string(updatedClusterSpec)}, client)
+	return annotations.SetAnnotations(
+		ctx,
+		&mrs,
+		map[string]string{failedcluster.ClusterSpecOverrideAnnotation: string(updatedClusterSpec)},
+		client,
+	)
 }
 
-func removeClusterFromFailedAnnotation(ctx context.Context, mrs mdbmulti.MongoDBMultiCluster, clustername string, client kubernetesClient.Client) error {
+func removeClusterFromFailedAnnotation(
+	ctx context.Context,
+	mrs mdbmulti.MongoDBMultiCluster,
+	clustername string,
+	client kubernetesClient.Client,
+) error {
 	failedClusters := readFailedClusterAnnotation(mrs.Annotations)
 
 	remaining := slices.DeleteFunc(failedClusters, func(c failedcluster.FailedCluster) bool { return c.ClusterName == clustername })
@@ -282,7 +303,12 @@ func removeClusterFromFailedAnnotation(ctx context.Context, mrs mdbmulti.MongoDB
 	return annotations.SetAnnotations(ctx, &mrs, map[string]string{failedcluster.FailedClusterAnnotation: string(clusterDataBytes)}, client)
 }
 
-func addFailedClustersAnnotation(ctx context.Context, mrs mdbmulti.MongoDBMultiCluster, clustername string, client kubernetesClient.Client) error {
+func addFailedClustersAnnotation(
+	ctx context.Context,
+	mrs mdbmulti.MongoDBMultiCluster,
+	clustername string,
+	client kubernetesClient.Client,
+) error {
 	if mrs.Annotations == nil {
 		mrs.Annotations = map[string]string{}
 	}

--- a/pkg/multicluster/memberwatch/memberwatch_test.go
+++ b/pkg/multicluster/memberwatch/memberwatch_test.go
@@ -150,7 +150,9 @@ func TestShouldAddFailedClusterAnnotation(t *testing.T) {
 			out:         false,
 		},
 		{
-			annotations: map[string]string{failedcluster.FailedClusterAnnotation: getFailedClusterList([]string{"cluster1", "cluster2", "cluster4"})},
+			annotations: map[string]string{
+				failedcluster.FailedClusterAnnotation: getFailedClusterList([]string{"cluster1", "cluster2", "cluster4"}),
+			},
 			clusterName: "cluster3",
 			out:         true,
 		},

--- a/pkg/multicluster/multicluster.go
+++ b/pkg/multicluster/multicluster.go
@@ -207,7 +207,12 @@ const LegacyCentralClusterName = "__default"
 // GetLegacyCentralMemberCluster returns a legacy central member cluster for unit tests.
 // Such member cluster is created in the reconcile loop in SingleCluster topology
 // in order to simulate multi-cluster deployment on one member cluster that has legacy naming conventions enabled.
-func GetLegacyCentralMemberCluster(replicas int, index int, client kubernetesClient.Client, secretClient secrets.SecretClient) MemberCluster {
+func GetLegacyCentralMemberCluster(
+	replicas int,
+	index int,
+	client kubernetesClient.Client,
+	secretClient secrets.SecretClient,
+) MemberCluster {
 	return MemberCluster{
 		Name:         LegacyCentralClusterName,
 		Index:        index,
@@ -266,7 +271,10 @@ func IsMemberClusterMapInitializedForMultiCluster(memberClusterMap map[string]cl
 	return true
 }
 
-func InitializeGlobalMemberClusterMapForSingleCluster(globalMemberClustersMap map[string]client.Client, defaultKubeClient client.Client) map[string]client.Client {
+func InitializeGlobalMemberClusterMapForSingleCluster(
+	globalMemberClustersMap map[string]client.Client,
+	defaultKubeClient client.Client,
+) map[string]client.Client {
 	memberClusterMapMutex.Lock()
 	defer memberClusterMapMutex.Unlock()
 

--- a/pkg/statefulset/merge_statefulset_mco_test.go
+++ b/pkg/statefulset/merge_statefulset_mco_test.go
@@ -51,7 +51,10 @@ func TestGetLabelSelectorRequirementByKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := merge.LabelSelectorRequirementByKey(tt.args.labelSelectorRequirements, tt.args.key); !reflect.DeepEqual(got, tt.want) {
+			if got := merge.LabelSelectorRequirementByKey(tt.args.labelSelectorRequirements, tt.args.key); !reflect.DeepEqual(
+				got,
+				tt.want,
+			) {
 				t.Errorf("getLabelSelectorRequirementByKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -34,7 +34,12 @@ func CreateOrUpdate(ctx context.Context, kubeClient kubernetesClient.Client, sta
 }
 
 // GetAndUpdate applies the provided function to the most recent version of the object
-func GetAndUpdate(ctx context.Context, kubeClient kubernetesClient.Client, nsName types.NamespacedName, updateFunc func(*appsv1.StatefulSet)) (appsv1.StatefulSet, error) {
+func GetAndUpdate(
+	ctx context.Context,
+	kubeClient kubernetesClient.Client,
+	nsName types.NamespacedName,
+	updateFunc func(*appsv1.StatefulSet),
+) (appsv1.StatefulSet, error) {
 	sts, err := kubeClient.GetStatefulSet(ctx, nsName)
 	if err != nil {
 		return appsv1.StatefulSet{}, err

--- a/pkg/statefulset/statefulset_mco_test.go
+++ b/pkg/statefulset/statefulset_mco_test.go
@@ -58,12 +58,18 @@ func TestAddVolumeAndMount_MCO(t *testing.T) {
 		Volume:    CreateVolumeFromConfigMap("mount-name", "config-map"),
 	}
 
-	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).AddVolumeAndMount(vmd, "container-name")
+	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).
+		AddVolumeAndMount(vmd, "container-name")
 	sts, err = stsBuilder.Build()
 
 	// assert container was correctly updated with the volumes
 	assert.NoError(t, err, "volume should successfully mount when the container exists")
-	assert.Len(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts, 1, "volume mount should have been added to the container in the stateful set")
+	assert.Len(
+		t,
+		sts.Spec.Template.Spec.Containers[0].VolumeMounts,
+		1,
+		"volume mount should have been added to the container in the stateful set",
+	)
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name, "mount-name")
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath, "mount-path")
 
@@ -73,7 +79,8 @@ func TestAddVolumeAndMount_MCO(t *testing.T) {
 	assert.NotNil(t, sts.Spec.Template.Spec.Volumes[0].ConfigMap, "volume should have been configured from a config map source")
 	assert.Nil(t, sts.Spec.Template.Spec.Volumes[0].Secret, "volume should not have been configured from a secret source")
 
-	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}, {Name: "container-1"}})).AddVolumeAndMount(vmd, "container-0")
+	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}, {Name: "container-1"}})).
+		AddVolumeAndMount(vmd, "container-0")
 	sts, err = stsBuilder.Build()
 
 	assert.NoError(t, err, "volume should successfully mount when the container exists")
@@ -88,7 +95,12 @@ func TestAddVolumeAndMount_MCO(t *testing.T) {
 	sts, err = stsBuilder.AddVolumeAndMount(secretVmd, "container-1").Build()
 
 	assert.NoError(t, err, "volume should successfully mount when the container exists")
-	assert.Len(t, sts.Spec.Template.Spec.Containers[1].VolumeMounts, 1, "volume mount should have been added to the container in the stateful set")
+	assert.Len(
+		t,
+		sts.Spec.Template.Spec.Containers[1].VolumeMounts,
+		1,
+		"volume mount should have been added to the container in the stateful set",
+	)
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[1].VolumeMounts[0].Name, "mount-name-secret")
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[1].VolumeMounts[0].MountPath, "mount-path-secret")
 
@@ -108,7 +120,10 @@ func TestMCOAddVolumeClaimTemplates(t *testing.T) {
 	mount := corev1.VolumeMount{
 		Name: "mount-0",
 	}
-	sts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).AddVolumeClaimTemplates([]corev1.PersistentVolumeClaim{claim}).AddVolumeMounts("container-name", []corev1.VolumeMount{mount}).Build()
+	sts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).
+		AddVolumeClaimTemplates([]corev1.PersistentVolumeClaim{claim}).
+		AddVolumeMounts("container-name", []corev1.VolumeMount{mount}).
+		Build()
 
 	assert.NoError(t, err)
 	assert.Len(t, sts.Spec.VolumeClaimTemplates, 1)

--- a/pkg/statefulset/statefulset_test.go
+++ b/pkg/statefulset/statefulset_test.go
@@ -71,12 +71,18 @@ func TestAddVolumeAndMount(t *testing.T) {
 		Volume:    CreateVolumeFromConfigMap("mount-name", "config-map"),
 	}
 
-	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).AddVolumeAndMount(vmd, "container-name")
+	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).
+		AddVolumeAndMount(vmd, "container-name")
 	sts, err = stsBuilder.Build()
 
 	// assert container was correctly updated with the volumes
 	assert.NoError(t, err, "volume should successfully mount when the container exists")
-	assert.Len(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts, 1, "volume mount should have been added to the container in the stateful set")
+	assert.Len(
+		t,
+		sts.Spec.Template.Spec.Containers[0].VolumeMounts,
+		1,
+		"volume mount should have been added to the container in the stateful set",
+	)
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name, "mount-name")
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath, "mount-path")
 
@@ -86,7 +92,8 @@ func TestAddVolumeAndMount(t *testing.T) {
 	assert.NotNil(t, sts.Spec.Template.Spec.Volumes[0].ConfigMap, "volume should have been configured from a config map source")
 	assert.Nil(t, sts.Spec.Template.Spec.Volumes[0].Secret, "volume should not have been configured from a secret source")
 
-	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}, {Name: "container-1"}})).AddVolumeAndMount(vmd, "container-0")
+	stsBuilder = defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}, {Name: "container-1"}})).
+		AddVolumeAndMount(vmd, "container-0")
 	sts, err = stsBuilder.Build()
 
 	assert.NoError(t, err, "volume should successfully mount when the container exists")
@@ -102,7 +109,12 @@ func TestAddVolumeAndMount(t *testing.T) {
 	sts, err = stsBuilder.AddVolumeAndMount(secretVmd, "container-1").Build()
 
 	assert.NoError(t, err, "volume should successfully mount when the container exists")
-	assert.Len(t, sts.Spec.Template.Spec.Containers[1].VolumeMounts, 1, "volume mount should have been added to the container in the stateful set")
+	assert.Len(
+		t,
+		sts.Spec.Template.Spec.Containers[1].VolumeMounts,
+		1,
+		"volume mount should have been added to the container in the stateful set",
+	)
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[1].VolumeMounts[0].Name, "mount-name-secret")
 	assert.Equal(t, sts.Spec.Template.Spec.Containers[1].VolumeMounts[0].MountPath, "mount-path-secret")
 
@@ -121,7 +133,10 @@ func TestAddVolumeClaimTemplates(t *testing.T) {
 	mount := corev1.VolumeMount{
 		Name: "mount-0",
 	}
-	sts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).AddVolumeClaimTemplates([]corev1.PersistentVolumeClaim{claim}).AddVolumeMounts("container-name", []corev1.VolumeMount{mount}).Build()
+	sts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-name"}})).
+		AddVolumeClaimTemplates([]corev1.PersistentVolumeClaim{claim}).
+		AddVolumeMounts("container-name", []corev1.VolumeMount{mount}).
+		Build()
 
 	assert.NoError(t, err)
 	assert.Len(t, sts.Spec.VolumeClaimTemplates, 1)
@@ -362,7 +377,8 @@ func TestMergeSpec(t *testing.T) {
 	t.Run("Add Container to PodSpecTemplate", func(t *testing.T) {
 		sts, err := defaultStatefulSetBuilder().Build()
 		assert.NoError(t, err)
-		customSts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}})).Build()
+		customSts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}})).
+			Build()
 		assert.NoError(t, err)
 
 		mergedSpec := merge.StatefulSetSpecs(sts.Spec, customSts.Spec)
@@ -372,7 +388,8 @@ func TestMergeSpec(t *testing.T) {
 		sts, err := defaultStatefulSetBuilder().Build()
 		assert.NoError(t, err)
 		sts.Spec.Template.Spec.TerminationGracePeriodSeconds = int64Ref(30)
-		customSts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}})).Build()
+		customSts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}})).
+			Build()
 		sts.Spec.Template.Spec.TerminationGracePeriodSeconds = int64Ref(600)
 		assert.NoError(t, err)
 
@@ -381,9 +398,11 @@ func TestMergeSpec(t *testing.T) {
 		assert.Equal(t, mergedSpec.Template.Spec.TerminationGracePeriodSeconds, int64Ref(600))
 	})
 	t.Run("Containers are added to existing list", func(t *testing.T) {
-		sts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}})).Build()
+		sts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-0"}})).
+			Build()
 		assert.NoError(t, err)
-		customSts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-1"}})).Build()
+		customSts, err := defaultStatefulSetBuilder().SetPodTemplateSpec(podTemplateWithContainers([]corev1.Container{{Name: "container-1"}})).
+			Build()
 		assert.NoError(t, err)
 
 		mergedSpec := merge.StatefulSetSpecs(sts.Spec, customSts.Spec)

--- a/pkg/statefulset/statefulset_util.go
+++ b/pkg/statefulset/statefulset_util.go
@@ -72,7 +72,8 @@ func isStatefulSetEqualOnForbiddenFields(existing, desired appsv1.StatefulSet) b
 	selectorsEqual := desired.Spec.Selector == nil || gocmp.Equal(existing.Spec.Selector, desired.Spec.Selector, cmpopts.EquateEmpty())
 	serviceNamesEqual := existing.Spec.ServiceName == desired.Spec.ServiceName
 	podMgmtEqual := desired.Spec.PodManagementPolicy == "" || desired.Spec.PodManagementPolicy == existing.Spec.PodManagementPolicy
-	revHistoryLimitEqual := desired.Spec.RevisionHistoryLimit == nil || reflect.DeepEqual(desired.Spec.RevisionHistoryLimit, existing.Spec.RevisionHistoryLimit)
+	revHistoryLimitEqual := desired.Spec.RevisionHistoryLimit == nil ||
+		reflect.DeepEqual(desired.Spec.RevisionHistoryLimit, existing.Spec.RevisionHistoryLimit)
 
 	if len(existing.Spec.VolumeClaimTemplates) != len(desired.Spec.VolumeClaimTemplates) {
 		return false
@@ -105,7 +106,13 @@ func (s StatefulSetCantBeUpdatedError) Error() string {
 // (the random port will be allocated by Kubernetes) otherwise only one service of type "ClusterIP" is created and it
 // won't be connectible from external (unless pods in statefulset expose themselves to outside using "hostNetwork: true")
 // Function returns the service port number assigned
-func CreateOrUpdateStatefulset(ctx context.Context, getUpdateCreator kubernetesClient.Client, ns string, log *zap.SugaredLogger, statefulSetToCreate *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
+func CreateOrUpdateStatefulset(
+	ctx context.Context,
+	getUpdateCreator kubernetesClient.Client,
+	ns string,
+	log *zap.SugaredLogger,
+	statefulSetToCreate *appsv1.StatefulSet,
+) (*appsv1.StatefulSet, error) {
 	log = log.With("statefulset", kube.ObjectKey(ns, statefulSetToCreate.Name))
 	existingStatefulSet, err := getUpdateCreator.GetStatefulSet(ctx, kube.ObjectKey(ns, statefulSetToCreate.Name))
 	if err != nil {
@@ -183,7 +190,12 @@ func AddPVCAnnotation(statefulSetToCreate *appsv1.StatefulSet) error {
 // `expectedGeneration` is the `meta.generation` returned from create/update statefulset API calls.
 // It is used to compare with `status.observedGeneration` to avoid reading stale StatefulSet object.
 // We can rely on `meta.generation` because create/update statefulset API calls are idempotent.
-func GetStatefulSetStatus(ctx context.Context, namespace, name string, expectedGeneration int64, client kubernetesClient.Client) workflow.Status {
+func GetStatefulSetStatus(
+	ctx context.Context,
+	namespace, name string,
+	expectedGeneration int64,
+	client kubernetesClient.Client,
+) workflow.Status {
 	set, err := client.GetStatefulSet(ctx, kube.ObjectKey(namespace, name))
 	i := 0
 

--- a/pkg/statefulset/statefulset_util_test.go
+++ b/pkg/statefulset/statefulset_util_test.go
@@ -86,7 +86,14 @@ func TestIsStatefulSetUpdatableTo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, isStatefulSetEqualOnForbiddenFields(tt.existing, tt.desired), "isStatefulSetEqualOnForbiddenFields(%v, %v)", tt.existing, tt.desired)
+			assert.Equalf(
+				t,
+				tt.want,
+				isStatefulSetEqualOnForbiddenFields(tt.existing, tt.desired),
+				"isStatefulSetEqualOnForbiddenFields(%v, %v)",
+				tt.existing,
+				tt.desired,
+			)
 		})
 	}
 }
@@ -206,7 +213,14 @@ func TestIsVolumeClaimUpdatableTo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, isVolumeClaimEqualOnForbiddenFields(tt.existing, tt.desired), "isVolumeClaimEqualOnForbiddenFields(%v, %v)", tt.existing, tt.desired)
+			assert.Equalf(
+				t,
+				tt.want,
+				isVolumeClaimEqualOnForbiddenFields(tt.existing, tt.desired),
+				"isVolumeClaimEqualOnForbiddenFields(%v, %v)",
+				tt.existing,
+				tt.desired,
+			)
 		})
 	}
 }
@@ -279,7 +293,14 @@ func TestGetStatefulSetStatus(t *testing.T) {
 }
 
 // createStatefulSet creates a StatefulSet with specific generation and status for testing purposes
-func createStatefulSet(name, namespace string, generation int64, observedGeneration int64, replicas int32, readyReplicas int32, updatedReplicas int32) *v1.StatefulSet {
+func createStatefulSet(
+	name, namespace string,
+	generation int64,
+	observedGeneration int64,
+	replicas int32,
+	readyReplicas int32,
+	updatedReplicas int32,
+) *v1.StatefulSet {
 	return &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,

--- a/pkg/telemetry/cluster.go
+++ b/pkg/telemetry/cluster.go
@@ -59,7 +59,11 @@ func detectClusterInfos(ctx context.Context, memberClusterMap map[string]ConfigC
 // - kubernetes cluster uid
 // Notes: We are using a non-cached client to ensure we are properly timing out in case we don't have the
 // necessary RBACs.
-func getKubernetesClusterProperty(ctx context.Context, discoveryClient discovery.DiscoveryInterface, uncachedClient kubeclient.Reader) KubernetesClusterUsageSnapshotProperties {
+func getKubernetesClusterProperty(
+	ctx context.Context,
+	discoveryClient discovery.DiscoveryInterface,
+	uncachedClient kubeclient.Reader,
+) KubernetesClusterUsageSnapshotProperties {
 	kubernetesAPIVersion := unknown
 	kubeClusterUUID := getKubernetesClusterUUID(ctx, uncachedClient)
 

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -63,7 +63,13 @@ func (l *LeaderRunnable) NeedLeaderElection() bool {
 	return true
 }
 
-func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[string]cluster.Cluster, currentNamespace, mongodbImage, databaseNonStaticImage, installerMethod string, operatorEnv util.OperatorEnvironment, defaultArchitecture architectures.DefaultArchitecture) (*LeaderRunnable, error) {
+func NewLeaderRunnable(
+	operatorMgr manager.Manager,
+	memberClusterObjectsMap map[string]cluster.Cluster,
+	currentNamespace, mongodbImage, databaseNonStaticImage, installerMethod string,
+	operatorEnv util.OperatorEnvironment,
+	defaultArchitecture architectures.DefaultArchitecture,
+) (*LeaderRunnable, error) {
 	atlasClient, err := NewClient(nil)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed creating atlas telemetry client: %w", err)
@@ -83,7 +89,18 @@ func NewLeaderRunnable(operatorMgr manager.Manager, memberClusterObjectsMap map[
 
 func (l *LeaderRunnable) Start(ctx context.Context) error {
 	Logger.Debug("Starting leader-only telemetry goroutine")
-	RunTelemetry(ctx, l.mongodbImage, l.databaseNonStaticImage, l.currentNamespace, l.installerMethod, l.operatorMgr, l.memberClusterObjectsMap, l.atlasClient, l.configuredOperatorEnv, l.defaultArchitecture)
+	RunTelemetry(
+		ctx,
+		l.mongodbImage,
+		l.databaseNonStaticImage,
+		l.currentNamespace,
+		l.installerMethod,
+		l.operatorMgr,
+		l.memberClusterObjectsMap,
+		l.atlasClient,
+		l.configuredOperatorEnv,
+		l.defaultArchitecture,
+	)
 
 	return nil
 }
@@ -91,7 +108,15 @@ func (l *LeaderRunnable) Start(ctx context.Context) error {
 type snapshotCollector func(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event
 
 // RunTelemetry lists the specified CRDs and sends them as events to Segment
-func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticImage, namespace, installerMethod string, operatorClusterMgr manager.Manager, clusterMap map[string]cluster.Cluster, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment, defaultArchitecture architectures.DefaultArchitecture) {
+func RunTelemetry(
+	leaderTrace context.Context,
+	mongodbImage, databaseNonStaticImage, namespace, installerMethod string,
+	operatorClusterMgr manager.Manager,
+	clusterMap map[string]cluster.Cluster,
+	atlasClient *Client,
+	configuredOperatorEnv util.OperatorEnvironment,
+	defaultArchitecture architectures.DefaultArchitecture,
+) {
 	Logger.Debug("Collecting telemetry!")
 	ctx, span := TRACER.Start(leaderTrace, "RunTelemetry")
 	span.SetAttributes(
@@ -102,7 +127,10 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 	intervalStr := env.ReadOrDefault(CollectionFrequency, DefaultCollectionFrequencyStr) // nolint:forbidigo
 	duration, err := time.ParseDuration(intervalStr)
 	if err != nil || duration < time.Minute {
-		Logger.Warn("Failed converting %s to a duration or value is too small (minimum is one minute), using default 1h", CollectionFrequency)
+		Logger.Warn(
+			"Failed converting %s to a duration or value is too small (minimum is one minute), using default 1h",
+			CollectionFrequency,
+		)
 		duration = DefaultCollectionFrequency
 	}
 	Logger.Debugf("%s is set to: %s", CollectionFrequency, duration)
@@ -123,7 +151,14 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 			return collectClustersSnapshot(ctx, cc, operatorClusterMgr)
 		},
 		Deployments: func(ctx context.Context, _ map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string) []Event {
-			return collectDeploymentsSnapshot(ctx, operatorClusterMgr, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture)
+			return collectDeploymentsSnapshot(
+				ctx,
+				operatorClusterMgr,
+				operatorUUID,
+				mongodbImage,
+				databaseNonStaticImage,
+				defaultArchitecture,
+			)
 		},
 	}
 
@@ -134,7 +169,19 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 		operatorUUID := getOrGenerateOperatorUUID(ctx, operatorClusterMgr.GetClient(), namespace)
 
 		for eventType, f := range snapshotCollectors {
-			collectAndSendSnapshot(ctx, eventType, f, cc, operatorClusterMgr, operatorUUID, mongodbImage, databaseNonStaticImage, namespace, atlasClient, configuredOperatorEnv)
+			collectAndSendSnapshot(
+				ctx,
+				eventType,
+				f,
+				cc,
+				operatorClusterMgr,
+				operatorUUID,
+				mongodbImage,
+				databaseNonStaticImage,
+				namespace,
+				atlasClient,
+				configuredOperatorEnv,
+			)
 		}
 	}
 
@@ -154,7 +201,16 @@ func RunTelemetry(leaderTrace context.Context, mongodbImage, databaseNonStaticIm
 	}
 }
 
-func collectAndSendSnapshot(ctx context.Context, eventType EventType, cf snapshotCollector, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage, namespace string, atlasClient *Client, configuredOperatorEnv util.OperatorEnvironment) {
+func collectAndSendSnapshot(
+	ctx context.Context,
+	eventType EventType,
+	cf snapshotCollector,
+	memberClusterMap map[string]ConfigClient,
+	operatorClusterMgr manager.Manager,
+	operatorUUID, mongodbImage, databaseNonStaticImage, namespace string,
+	atlasClient *Client,
+	configuredOperatorEnv util.OperatorEnvironment,
+) {
 	telemetryIsEnabled := ReadBoolWithTrueAsDefault(EventTypeMappingToEnvVar[eventType])
 	if !telemetryIsEnabled {
 		return
@@ -170,7 +226,12 @@ func collectAndSendSnapshot(ctx context.Context, eventType EventType, cf snapsho
 	handleEvents(ctx, atlasClient, events, eventType, namespace, operatorClusterMgr.GetClient())
 }
 
-func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager, operatorUUID, installerMethod string) []Event {
+func collectOperatorSnapshot(
+	ctx context.Context,
+	memberClusterMap map[string]ConfigClient,
+	operatorClusterMgr manager.Manager,
+	operatorUUID, installerMethod string,
+) []Event {
 	var kubeClusterUUIDList []string
 	uncachedClient := operatorClusterMgr.GetAPIReader()
 	kubeClusterOperatorUUID := getKubernetesClusterUUID(ctx, uncachedClient)
@@ -207,7 +268,12 @@ func collectOperatorSnapshot(ctx context.Context, memberClusterMap map[string]Co
 	return []Event{*event}
 }
 
-func collectDeploymentsSnapshot(ctx context.Context, operatorClusterMgr manager.Manager, operatorUUID, mongodbImage, databaseNonStaticImage string, defaultArchitecture architectures.DefaultArchitecture) []Event {
+func collectDeploymentsSnapshot(
+	ctx context.Context,
+	operatorClusterMgr manager.Manager,
+	operatorUUID, mongodbImage, databaseNonStaticImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+) []Event {
 	var events []Event
 	operatorClusterClient := operatorClusterMgr.GetClient()
 	if operatorClusterClient == nil {
@@ -216,8 +282,12 @@ func collectDeploymentsSnapshot(ctx context.Context, operatorClusterMgr manager.
 	}
 
 	now := time.Now()
-	events = append(events, getMdbEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture, now)...)
-	events = append(events, addMultiEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture, now)...)
+	events = append(
+		events,
+		getMdbEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture, now)...)
+	events = append(
+		events,
+		addMultiEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, databaseNonStaticImage, defaultArchitecture, now)...)
 	// No need to pass databaseNonStaticImage because it is for sure not enterprise image
 	events = append(events, addOmEvents(ctx, operatorClusterClient, operatorUUID, mongodbImage, defaultArchitecture, now)...)
 	events = append(events, addCommunityEvents(ctx, operatorClusterClient, operatorUUID, now)...)
@@ -225,7 +295,13 @@ func collectDeploymentsSnapshot(ctx context.Context, operatorClusterMgr manager.
 	return events
 }
 
-func getMdbEvents(ctx context.Context, operatorClusterClient kubeclient.Client, operatorUUID, mongodbImage, databaseNonStaticImage string, defaultArchitecture architectures.DefaultArchitecture, now time.Time) []Event {
+func getMdbEvents(
+	ctx context.Context,
+	operatorClusterClient kubeclient.Client,
+	operatorUUID, mongodbImage, databaseNonStaticImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	now time.Time,
+) []Event {
 	var events []Event
 	mdbList := &mdbv1.MongoDBList{}
 
@@ -264,7 +340,13 @@ func getMdbEvents(ctx context.Context, operatorClusterClient kubeclient.Client, 
 	return events
 }
 
-func addMultiEvents(ctx context.Context, operatorClusterClient kubeclient.Client, operatorUUID, mongodbImage, databaseNonStaticImage string, defaultArchitecture architectures.DefaultArchitecture, now time.Time) []Event {
+func addMultiEvents(
+	ctx context.Context,
+	operatorClusterClient kubeclient.Client,
+	operatorUUID, mongodbImage, databaseNonStaticImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	now time.Time,
+) []Event {
 	var events []Event
 
 	mdbMultiList := &mdbmultiv1.MongoDBMultiClusterList{}
@@ -301,7 +383,13 @@ func addMultiEvents(ctx context.Context, operatorClusterClient kubeclient.Client
 	return events
 }
 
-func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, operatorUUID, mongodbImage string, defaultArchitecture architectures.DefaultArchitecture, now time.Time) []Event {
+func addOmEvents(
+	ctx context.Context,
+	operatorClusterClient kubeclient.Client,
+	operatorUUID, mongodbImage string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	now time.Time,
+) []Event {
 	var events []Event
 	omList := &omv1.MongoDBOpsManagerList{}
 
@@ -388,7 +476,12 @@ func isCommunityRunningEnterpriseImage(mdb mcov1.MongoDBCommunity) bool {
 	return false
 }
 
-func resolveSearchSource(ctx context.Context, operatorClusterClient kubeclient.Client, source *userv1.MongoDBResourceRef, defaultArchitecture architectures.DefaultArchitecture) (architecture string, isEnterprise bool, ok bool) {
+func resolveSearchSource(
+	ctx context.Context,
+	operatorClusterClient kubeclient.Client,
+	source *userv1.MongoDBResourceRef,
+	defaultArchitecture architectures.DefaultArchitecture,
+) (architecture string, isEnterprise bool, ok bool) {
 	if source == nil {
 		return "external", false, true // we cheat and hijack the Architecture field to indicate this Search resource is configured with an external MongoDB source
 	}
@@ -408,7 +501,13 @@ func resolveSearchSource(ctx context.Context, operatorClusterClient kubeclient.C
 	return "", false, false // likely the database resource doesn't exist yet, skip telemetry for this item for now
 }
 
-func addSearchEvents(ctx context.Context, operatorClusterClient kubeclient.Client, operatorUUID string, defaultArchitecture architectures.DefaultArchitecture, now time.Time) []Event {
+func addSearchEvents(
+	ctx context.Context,
+	operatorClusterClient kubeclient.Client,
+	operatorUUID string,
+	defaultArchitecture architectures.DefaultArchitecture,
+	now time.Time,
+) []Event {
 	var events []Event
 	searchList := &searchv1.MongoDBSearchList{}
 
@@ -459,7 +558,14 @@ func ReadBoolWithTrueAsDefault(envVarName string) bool {
 	return strings.TrimSpace(strings.ToLower(envVar)) == "true"
 }
 
-func handleEvents(ctx context.Context, atlasClient *Client, events []Event, eventType EventType, namespace string, operatorClusterClient kubeclient.Client) {
+func handleEvents(
+	ctx context.Context,
+	atlasClient *Client,
+	events []Event,
+	eventType EventType,
+	namespace string,
+	operatorClusterClient kubeclient.Client,
+) {
 	if err := updateTelemetryConfigMapPayload(ctx, operatorClusterClient, events, namespace, OperatorConfigMapTelemetryConfigMapName, eventType); err != nil {
 		Logger.Debugf("Failed to save last collected events: %s. Not sending data", err)
 		return
@@ -470,7 +576,13 @@ func handleEvents(ctx context.Context, atlasClient *Client, events []Event, even
 		return
 	}
 
-	isOlder, err := isTimestampOlderThanConfiguredFrequency(ctx, operatorClusterClient, namespace, OperatorConfigMapTelemetryConfigMapName, eventType)
+	isOlder, err := isTimestampOlderThanConfiguredFrequency(
+		ctx,
+		operatorClusterClient,
+		namespace,
+		OperatorConfigMapTelemetryConfigMapName,
+		eventType,
+	)
 	if err != nil {
 		Logger.Debugf("Failed to check for timestamp in configmap; not sending data: %s", err)
 		return
@@ -505,7 +617,11 @@ func collectClustersSnapshot(ctx context.Context, memberClusterMap map[string]Co
 	return events
 }
 
-func getClusterProperties(ctx context.Context, memberClusterMap map[string]ConfigClient, operatorClusterMgr manager.Manager) []KubernetesClusterUsageSnapshotProperties {
+func getClusterProperties(
+	ctx context.Context,
+	memberClusterMap map[string]ConfigClient,
+	operatorClusterMgr manager.Manager,
+) []KubernetesClusterUsageSnapshotProperties {
 	operatorMemberClusterProperties := detectClusterInfos(ctx, map[string]ConfigClient{"operator": operatorClusterMgr})
 	memberClustersProperties := detectClusterInfos(ctx, memberClusterMap)
 

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1129,7 +1129,14 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 			ctx := context.Background()
 
 			beforeCallTimestamp := time.Now()
-			events := collectDeploymentsSnapshot(ctx, mgr, testOperatorUUID, testDatabaseStaticImage, testDatabaseNonStaticImage, architectures.NonStatic)
+			events := collectDeploymentsSnapshot(
+				ctx,
+				mgr,
+				testOperatorUUID,
+				testDatabaseStaticImage,
+				testDatabaseNonStaticImage,
+				architectures.NonStatic,
+			)
 			afterCallTimestamp := time.Now()
 
 			require.Len(t, events, len(test.expectedEventsWithProperties), "expected and collected events count don't match")
@@ -1297,8 +1304,20 @@ func TestAddSearchEvents(t *testing.T) {
 	operatorUUID := "test-operator-uuid"
 	now := time.Now()
 
-	mdbStatic := &mdbv1.MongoDB{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "mdb-static", Annotations: map[string]string{architectures.ArchitectureAnnotation: string(architectures.Static)}}}
-	mdbNonStatic := &mdbv1.MongoDB{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "mdb-nonstatic", Annotations: map[string]string{architectures.ArchitectureAnnotation: string(architectures.NonStatic)}}}
+	mdbStatic := &mdbv1.MongoDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "default",
+			Name:        "mdb-static",
+			Annotations: map[string]string{architectures.ArchitectureAnnotation: string(architectures.Static)},
+		},
+	}
+	mdbNonStatic := &mdbv1.MongoDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "default",
+			Name:        "mdb-nonstatic",
+			Annotations: map[string]string{architectures.ArchitectureAnnotation: string(architectures.NonStatic)},
+		},
+	}
 	community := &mcov1.MongoDBCommunity{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "community-db"}}
 
 	testCases := []struct {
@@ -1310,7 +1329,12 @@ func TestAddSearchEvents(t *testing.T) {
 		{
 			name: "External source",
 			searchItems: []searchv1.MongoDBSearch{
-				{ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-external"), Name: "search-external", Namespace: "default"}, Spec: searchv1.MongoDBSearchSpec{Source: &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{}}}},
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-external"), Name: "search-external", Namespace: "default"},
+					Spec: searchv1.MongoDBSearchSpec{
+						Source: &searchv1.MongoDBSource{ExternalMongoDBSource: &searchv1.ExternalMongoDBSource{}},
+					},
+				},
 			},
 			events: []SearchDeploymentUsageSnapshotProperties{{
 				DeploymentUsageSnapshotProperties: DeploymentUsageSnapshotProperties{
@@ -1326,8 +1350,18 @@ func TestAddSearchEvents(t *testing.T) {
 		{
 			name: "Enterprise static and non-static",
 			searchItems: []searchv1.MongoDBSearch{
-				{ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-static"), Name: "search-static", Namespace: "default"}, Spec: searchv1.MongoDBSearchSpec{Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "mdb-static"}}}},
-				{ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-nonstatic"), Name: "search-nonstatic", Namespace: "default"}, Spec: searchv1.MongoDBSearchSpec{Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "mdb-nonstatic"}}}},
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-static"), Name: "search-static", Namespace: "default"},
+					Spec: searchv1.MongoDBSearchSpec{
+						Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "mdb-static"}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-nonstatic"), Name: "search-nonstatic", Namespace: "default"},
+					Spec: searchv1.MongoDBSearchSpec{
+						Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "mdb-nonstatic"}},
+					},
+				},
 			},
 			events: []SearchDeploymentUsageSnapshotProperties{
 				{
@@ -1358,7 +1392,12 @@ func TestAddSearchEvents(t *testing.T) {
 		{
 			name: "Community source",
 			searchItems: []searchv1.MongoDBSearch{
-				{ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-community"), Name: "search-community", Namespace: "default"}, Spec: searchv1.MongoDBSearchSpec{Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "community-db"}}}},
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-community"), Name: "search-community", Namespace: "default"},
+					Spec: searchv1.MongoDBSearchSpec{
+						Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "community-db"}},
+					},
+				},
 			},
 			events: []SearchDeploymentUsageSnapshotProperties{{
 				DeploymentUsageSnapshotProperties: DeploymentUsageSnapshotProperties{
@@ -1378,14 +1417,22 @@ func TestAddSearchEvents(t *testing.T) {
 			name: "Auto embedding",
 			searchItems: []searchv1.MongoDBSearch{
 				{
-					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-auto-embedding-enabled"), Name: "search-auto-embedding-enabled", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("search-auto-embedding-enabled"),
+						Name:      "search-auto-embedding-enabled",
+						Namespace: "default",
+					},
 					Spec: searchv1.MongoDBSearchSpec{
 						Source:        &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "mdb-static"}},
 						AutoEmbedding: &searchv1.EmbeddingConfig{},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-auto-embedding-disabled"), Name: "search-auto-embedding-disabled", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("search-auto-embedding-disabled"),
+						Name:      "search-auto-embedding-disabled",
+						Namespace: "default",
+					},
 					Spec: searchv1.MongoDBSearchSpec{
 						Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "mdb-nonstatic"}},
 					},
@@ -1422,7 +1469,12 @@ func TestAddSearchEvents(t *testing.T) {
 		{
 			name: "Missing underlying resource (skipped)",
 			searchItems: []searchv1.MongoDBSearch{
-				{ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-missing"), Name: "search-missing", Namespace: "default"}, Spec: searchv1.MongoDBSearchSpec{Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "does-not-exist"}}}},
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: types.UID("search-missing"), Name: "search-missing", Namespace: "default"},
+					Spec: searchv1.MongoDBSearchSpec{
+						Source: &searchv1.MongoDBSource{MongoDBResourceRef: &userv1.MongoDBResourceRef{Name: "does-not-exist"}},
+					},
+				},
 			},
 			events: []SearchDeploymentUsageSnapshotProperties{},
 		},

--- a/pkg/telemetry/configmap.go
+++ b/pkg/telemetry/configmap.go
@@ -121,7 +121,13 @@ func createInitialConfigmap(namespace string) (string, *corev1.ConfigMap) {
 
 // isTimestampOlderThanConfiguredFrequency is used to get the timestamp from the ConfigMap and check whether it's time to
 // send the data to atlas.
-func isTimestampOlderThanConfiguredFrequency(ctx context.Context, k8sClient kubeclient.Client, namespace string, OperatorConfigMapTelemetryConfigMapName string, et EventType) (bool, error) {
+func isTimestampOlderThanConfiguredFrequency(
+	ctx context.Context,
+	k8sClient kubeclient.Client,
+	namespace string,
+	OperatorConfigMapTelemetryConfigMapName string,
+	et EventType,
+) (bool, error) {
 	durationStr := env.ReadOrDefault(SendFrequency, DefaultSendFrequencyStr) // nolint:forbidigo
 	duration, err := time.ParseDuration(durationStr)
 	if err != nil || duration < 10*time.Minute {
@@ -159,7 +165,14 @@ func isTimestampOlderThanConfiguredFrequency(ctx context.Context, k8sClient kube
 }
 
 // updateTelemetryConfigMapPayload updates the configmap with the current collected telemetry data
-func updateTelemetryConfigMapPayload(ctx context.Context, k8sClient kubeclient.Client, events []Event, namespace string, OperatorConfigMapTelemetryConfigMapName string, eventType EventType) error {
+func updateTelemetryConfigMapPayload(
+	ctx context.Context,
+	k8sClient kubeclient.Client,
+	events []Event,
+	namespace string,
+	OperatorConfigMapTelemetryConfigMapName string,
+	eventType EventType,
+) error {
 	cm := &corev1.ConfigMap{}
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: OperatorConfigMapTelemetryConfigMapName, Namespace: namespace}, cm)
 	if err != nil {
@@ -185,7 +198,13 @@ func updateTelemetryConfigMapPayload(ctx context.Context, k8sClient kubeclient.C
 }
 
 // updateTelemetryConfigMapTimeStamp updates the configmap with the current timestamp
-func updateTelemetryConfigMapTimeStamp(ctx context.Context, k8sClient kubeclient.Client, namespace string, OperatorConfigMapTelemetryConfigMapName string, eventType EventType) error {
+func updateTelemetryConfigMapTimeStamp(
+	ctx context.Context,
+	k8sClient kubeclient.Client,
+	namespace string,
+	OperatorConfigMapTelemetryConfigMapName string,
+	eventType EventType,
+) error {
 	cm := &corev1.ConfigMap{}
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: OperatorConfigMapTelemetryConfigMapName, Namespace: namespace}, cm)
 	if err != nil {

--- a/pkg/telemetry/configmap_test.go
+++ b/pkg/telemetry/configmap_test.go
@@ -146,7 +146,9 @@ func TestGetOrGenerateOperatorUUID(t *testing.T) {
 			},
 		}
 
-		client := &failingUpdateFakeClient{fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM).Build()} // Simulate update failure
+		client := &failingUpdateFakeClient{
+			fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM).Build(),
+		} // Simulate update failure
 
 		result := getOrGenerateOperatorUUID(ctx, client, testNamespace)
 

--- a/pkg/telemetry/trace.go
+++ b/pkg/telemetry/trace.go
@@ -17,7 +17,10 @@ import (
 var TRACER = otel.Tracer("mongodb-kubernetes-operator")
 
 // SetupTracingFromParent initializes OpenTelemetry tracing given a remote trace and span.
-func SetupTracingFromParent(ctx context.Context, traceIDHex, parentIDHex, endpoint string) (context.Context, *sdktrace.TracerProvider, error) {
+func SetupTracingFromParent(
+	ctx context.Context,
+	traceIDHex, parentIDHex, endpoint string,
+) (context.Context, *sdktrace.TracerProvider, error) {
 	if traceIDHex == "" || parentIDHex == "" || endpoint == "" {
 		Logger.Debug("tracing environment variables missing, not configuring tracing from a remote span and trace")
 		return ctx, nil, nil

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -74,7 +74,7 @@ func (u DeploymentUsageSnapshotProperties) ConvertToFlatMap() (map[string]any, e
 }
 
 type SearchDeploymentUsageSnapshotProperties struct {
-	DeploymentUsageSnapshotProperties `json:",inline"`
+	DeploymentUsageSnapshotProperties `     json:",inline"`
 	IsAutoEmbeddingEnabled            bool `json:"isAutoEmbeddingEnabled"`
 }
 

--- a/pkg/telemetry/types_test.go
+++ b/pkg/telemetry/types_test.go
@@ -79,7 +79,15 @@ func TestSearchDeploymentUsageSnapshotProperties_ConvertToFlatMap(t *testing.T) 
 
 	// Assert all expected keys are present in the result map
 	for _, key := range expectedKeys {
-		assert.Contains(t, result, key, "Expected key %s to be present in the result map. Expected keys: %v, Actual keys: %v", key, expectedKeys, actualKeys)
+		assert.Contains(
+			t,
+			result,
+			key,
+			"Expected key %s to be present in the result map. Expected keys: %v, Actual keys: %v",
+			key,
+			expectedKeys,
+			actualKeys,
+		)
 	}
 
 	// Ensure AuthenticationModes field is not in the map (it's marked with json:"-")

--- a/pkg/tls/tls_secret.go
+++ b/pkg/tls/tls_secret.go
@@ -31,7 +31,13 @@ type TLSConfigurableResource interface {
 // EnsureTLSSecret will create or update the operator-managed Secret containing
 // the concatenated certificate and key from the user-provided Secret.
 // Returns the file name of the concatenated certificate and key
-func EnsureTLSSecret(ctx context.Context, getUpdateCreator secret.GetUpdateCreator, resource TLSConfigurableResource, labels map[string]string, ownerReferences []metav1.OwnerReference) (string, error) {
+func EnsureTLSSecret(
+	ctx context.Context,
+	getUpdateCreator secret.GetUpdateCreator,
+	resource TLSConfigurableResource,
+	labels map[string]string,
+	ownerReferences []metav1.OwnerReference,
+) (string, error) {
 	certKey, err := getPemOrConcatenatedCrtAndKey(ctx, getUpdateCreator, resource.TLSSecretNamespacedName())
 	if err != nil {
 		return "", err
@@ -88,7 +94,12 @@ func getPemOrConcatenatedCrtAndKey(ctx context.Context, getter secret.Getter, se
 	certKey := getCertAndKey(ctx, getter, secretName)
 	pem := getPem(ctx, getter, secretName)
 	if certKey == "" && pem == "" {
-		return "", fmt.Errorf(`neither "%s" nor the pair "%s"/"%s" were present in the TLS secret`, tlsSecretPemName, tlsSecretCertName, tlsSecretKeyName)
+		return "", fmt.Errorf(
+			`neither "%s" nor the pair "%s"/"%s" were present in the TLS secret`,
+			tlsSecretPemName,
+			tlsSecretCertName,
+			tlsSecretKeyName,
+		)
 	}
 	if certKey == "" {
 		return pem, nil
@@ -97,7 +108,15 @@ func getPemOrConcatenatedCrtAndKey(ctx context.Context, getter secret.Getter, se
 		return certKey, nil
 	}
 	if certKey != pem {
-		return "", fmt.Errorf(`if all of "%s", "%s" and "%s" are present in the secret, the entry for "%s" must be equal to the concatenation of "%s" with "%s"`, tlsSecretCertName, tlsSecretKeyName, tlsSecretPemName, tlsSecretPemName, tlsSecretCertName, tlsSecretKeyName)
+		return "", fmt.Errorf(
+			`if all of "%s", "%s" and "%s" are present in the secret, the entry for "%s" must be equal to the concatenation of "%s" with "%s"`,
+			tlsSecretCertName,
+			tlsSecretKeyName,
+			tlsSecretPemName,
+			tlsSecretPemName,
+			tlsSecretCertName,
+			tlsSecretKeyName,
+		)
 	}
 	return certKey, nil
 }

--- a/pkg/util/apierrors/apierrors_test.go
+++ b/pkg/util/apierrors/apierrors_test.go
@@ -13,12 +13,16 @@ func TestIsTransientError(t *testing.T) {
 	}{
 		{
 			"Test Transient capitalised error",
-			fmt.Errorf("Error updating the status of the MongoDB resource: Operation cannot be fulfilled on mongodbcommunity.mongodb.com \"mdb0\": The object has been modified; please apply your changes to the latest version and try again"),
+			fmt.Errorf(
+				"Error updating the status of the MongoDB resource: Operation cannot be fulfilled on mongodbcommunity.mongodb.com \"mdb0\": The object has been modified; please apply your changes to the latest version and try again",
+			),
 			true,
 		},
 		{
 			"Test Transient lower case error",
-			fmt.Errorf("error updating the status of the MongoDB resource: Operation cannot be fulfilled on mongodbcommunity.mongodb.com \"mdb0\": the object has been modified; please apply your changes to the latest version and try again"),
+			fmt.Errorf(
+				"error updating the status of the MongoDB resource: Operation cannot be fulfilled on mongodbcommunity.mongodb.com \"mdb0\": the object has been modified; please apply your changes to the latest version and try again",
+			),
 			true,
 		},
 		{

--- a/pkg/util/merge/merge_podtemplate_spec.go
+++ b/pkg/util/merge/merge_podtemplate_spec.go
@@ -131,7 +131,10 @@ func PodTemplateSpecs(original, override corev1.PodTemplateSpec) corev1.PodTempl
 	}
 
 	if override.Spec.TopologySpreadConstraints != nil {
-		merged.Spec.TopologySpreadConstraints = TopologySpreadConstraints(original.Spec.TopologySpreadConstraints, override.Spec.TopologySpreadConstraints)
+		merged.Spec.TopologySpreadConstraints = TopologySpreadConstraints(
+			original.Spec.TopologySpreadConstraints,
+			override.Spec.TopologySpreadConstraints,
+		)
 	}
 
 	return merged

--- a/pkg/util/merge/merge_statefulset.go
+++ b/pkg/util/merge/merge_statefulset.go
@@ -71,7 +71,10 @@ func LabelSelectors(originalLabelSelector, overrideLabelSelector *metav1.LabelSe
 	// we have specified both, so we must merge them
 	mergedLabelSelector := &metav1.LabelSelector{}
 	mergedLabelSelector.MatchLabels = StringToStringMap(originalLabelSelector.MatchLabels, overrideLabelSelector.MatchLabels)
-	mergedLabelSelector.MatchExpressions = LabelSelectorRequirements(originalLabelSelector.MatchExpressions, overrideLabelSelector.MatchExpressions)
+	mergedLabelSelector.MatchExpressions = LabelSelectorRequirements(
+		originalLabelSelector.MatchExpressions,
+		overrideLabelSelector.MatchExpressions,
+	)
 	return mergedLabelSelector
 }
 
@@ -118,7 +121,10 @@ func LabelSelectorRequirements(original, override []metav1.LabelSelectorRequirem
 
 // LabelSelectorRequirementByKey returns the LabelSelectorRequirement with the given key if present in the slice.
 // returns nil if not present.
-func LabelSelectorRequirementByKey(labelSelectorRequirements []metav1.LabelSelectorRequirement, key string) *metav1.LabelSelectorRequirement {
+func LabelSelectorRequirementByKey(
+	labelSelectorRequirements []metav1.LabelSelectorRequirement,
+	key string,
+) *metav1.LabelSelectorRequirement {
 	for _, lsr := range labelSelectorRequirements {
 		if lsr.Key == key {
 			return &lsr
@@ -127,7 +133,10 @@ func LabelSelectorRequirementByKey(labelSelectorRequirements []metav1.LabelSelec
 	return nil
 }
 
-func VolumeClaimTemplates(defaultTemplates []corev1.PersistentVolumeClaim, overrideTemplates []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
+func VolumeClaimTemplates(
+	defaultTemplates []corev1.PersistentVolumeClaim,
+	overrideTemplates []corev1.PersistentVolumeClaim,
+) []corev1.PersistentVolumeClaim {
 	defaultMountsMap := createVolumeClaimMap(defaultTemplates)
 	overrideMountsMap := createVolumeClaimMap(overrideTemplates)
 

--- a/pkg/util/merge/merge_test.go
+++ b/pkg/util/merge/merge_test.go
@@ -236,11 +236,26 @@ func TestMergeContainer(t *testing.T) {
 		)
 		mergedContainer := Container(defaultContainer, overrideContainer)
 		assert.Equal(t, overrideContainer.Name, mergedContainer.Name, "Name was overridden, and should be used.")
-		assert.Equal(t, []string{"d", "f", "e"}, mergedContainer.Command, "Command specified in the override container overrides the default container.")
+		assert.Equal(
+			t,
+			[]string{"d", "f", "e"},
+			mergedContainer.Command,
+			"Command specified in the override container overrides the default container.",
+		)
 		assert.Equal(t, overrideContainer.Image, mergedContainer.Image, "Image was overridden, and should be used.")
-		assert.Equal(t, defaultContainer.ImagePullPolicy, mergedContainer.ImagePullPolicy, "No ImagePullPolicy was specified in the override, so the default should be used.")
+		assert.Equal(
+			t,
+			defaultContainer.ImagePullPolicy,
+			mergedContainer.ImagePullPolicy,
+			"No ImagePullPolicy was specified in the override, so the default should be used.",
+		)
 		assert.Equal(t, overrideContainer.WorkingDir, mergedContainer.WorkingDir)
-		assert.Equal(t, []string{"arg3", "arg2"}, mergedContainer.Args, "Args specified in the override container overrides the default container.")
+		assert.Equal(
+			t,
+			[]string{"arg3", "arg2"},
+			mergedContainer.Args,
+			"Args specified in the override container overrides the default container.",
+		)
 
 		assert.Equal(t, overrideContainer.Resources, mergedContainer.Resources)
 
@@ -259,15 +274,35 @@ func TestMergeContainer(t *testing.T) {
 
 				assert.NotNil(t, livenessProbe)
 				assert.Equal(t, int32(15), livenessProbe.InitialDelaySeconds, "value is specified in override and so should be used.")
-				assert.Equal(t, int32(20), livenessProbe.FailureThreshold, "value is not specified in override so the original should be used.")
-				assert.Equal(t, []string{"exec", "command", "override"}, livenessProbe.Exec.Command, "value is not specified in override so the original should be used.")
+				assert.Equal(
+					t,
+					int32(20),
+					livenessProbe.FailureThreshold,
+					"value is not specified in override so the original should be used.",
+				)
+				assert.Equal(
+					t,
+					[]string{"exec", "command", "override"},
+					livenessProbe.Exec.Command,
+					"value is not specified in override so the original should be used.",
+				)
 			})
 			t.Run("Readiness probe", func(t *testing.T) {
 				readinessProbe := mergedContainer.ReadinessProbe
 				assert.NotNil(t, readinessProbe)
 				assert.Equal(t, int32(5), readinessProbe.InitialDelaySeconds, "value is specified in override and so should be used.")
-				assert.Equal(t, int32(6), readinessProbe.FailureThreshold, "value is not specified in override so the original should be used.")
-				assert.Equal(t, []string{"exec", "command", "readiness", "override"}, readinessProbe.Exec.Command, "value is not specified in override so the original should be used.")
+				assert.Equal(
+					t,
+					int32(6),
+					readinessProbe.FailureThreshold,
+					"value is not specified in override so the original should be used.",
+				)
+				assert.Equal(
+					t,
+					[]string{"exec", "command", "readiness", "override"},
+					readinessProbe.Exec.Command,
+					"value is not specified in override so the original should be used.",
+				)
 			})
 		})
 
@@ -293,7 +328,12 @@ func TestMergeContainer(t *testing.T) {
 
 		t.Run("Volume Mounts are overridden", func(t *testing.T) {
 			volumeMounts := mergedContainer.VolumeMounts
-			assert.Len(t, volumeMounts, 3, "volume mounts can have the same name, the uniqueness is the combination of name, path and subpath")
+			assert.Len(
+				t,
+				volumeMounts,
+				3,
+				"volume mounts can have the same name, the uniqueness is the combination of name, path and subpath",
+			)
 			t.Run("First VolumeMount is still present", func(t *testing.T) {
 				vm0 := volumeMounts[0]
 				assert.Equal(t, "volume-mount-0", vm0.Name)
@@ -314,7 +354,12 @@ func TestMergeContainer(t *testing.T) {
 		mergedContainer := Container(defaultContainer, corev1.Container{})
 		assert.Equal(t, defaultContainer.Name, mergedContainer.Name, "Name was not overridden, and should not be used.")
 		assert.Equal(t, defaultContainer.Image, mergedContainer.Image, "Image was not overridden, and should not be used.")
-		assert.Equal(t, defaultContainer.ImagePullPolicy, mergedContainer.ImagePullPolicy, "No ImagePullPolicy was specified in the override, so the default should be used.")
+		assert.Equal(
+			t,
+			defaultContainer.ImagePullPolicy,
+			mergedContainer.ImagePullPolicy,
+			"No ImagePullPolicy was specified in the override, so the default should be used.",
+		)
 		assert.Equal(t, defaultContainer.WorkingDir, mergedContainer.WorkingDir)
 
 		assert.Equal(t, defaultContainer.Resources, mergedContainer.Resources)
@@ -333,16 +378,46 @@ func TestMergeContainer(t *testing.T) {
 				livenessProbe := mergedContainer.LivenessProbe
 
 				assert.NotNil(t, livenessProbe)
-				assert.Equal(t, int32(10), livenessProbe.InitialDelaySeconds, "value is not specified in override so the original should be used.")
-				assert.Equal(t, int32(20), livenessProbe.FailureThreshold, "value is not specified in override so the original should be used.")
-				assert.Equal(t, []string{"exec", "command", "liveness"}, livenessProbe.Exec.Command, "value is not specified in override so the original should be used.")
+				assert.Equal(
+					t,
+					int32(10),
+					livenessProbe.InitialDelaySeconds,
+					"value is not specified in override so the original should be used.",
+				)
+				assert.Equal(
+					t,
+					int32(20),
+					livenessProbe.FailureThreshold,
+					"value is not specified in override so the original should be used.",
+				)
+				assert.Equal(
+					t,
+					[]string{"exec", "command", "liveness"},
+					livenessProbe.Exec.Command,
+					"value is not specified in override so the original should be used.",
+				)
 			})
 			t.Run("Readiness probe", func(t *testing.T) {
 				readinessProbe := mergedContainer.ReadinessProbe
 				assert.NotNil(t, readinessProbe)
-				assert.Equal(t, int32(20), readinessProbe.InitialDelaySeconds, "value is not specified in override so the original should be used.")
-				assert.Equal(t, int32(30), readinessProbe.FailureThreshold, "value is not specified in override so the original should be used.")
-				assert.Equal(t, []string{"exec", "command", "readiness"}, readinessProbe.Exec.Command, "value is not specified in override so the original should be used.")
+				assert.Equal(
+					t,
+					int32(20),
+					readinessProbe.InitialDelaySeconds,
+					"value is not specified in override so the original should be used.",
+				)
+				assert.Equal(
+					t,
+					int32(30),
+					readinessProbe.FailureThreshold,
+					"value is not specified in override so the original should be used.",
+				)
+				assert.Equal(
+					t,
+					[]string{"exec", "command", "readiness"},
+					readinessProbe.Exec.Command,
+					"value is not specified in override so the original should be used.",
+				)
 			})
 		})
 
@@ -584,8 +659,12 @@ func TestMergeSecurityContext(t *testing.T) {
 
 func TestMergeVolumesSecret(t *testing.T) {
 	permission := int32(416)
-	vol0 := []corev1.Volume{{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "Secret-name"}}}}
-	vol1 := []corev1.Volume{{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &permission}}}}
+	vol0 := []corev1.Volume{
+		{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "Secret-name"}}},
+	}
+	vol1 := []corev1.Volume{
+		{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &permission}}},
+	}
 	mergedVolumes := Volumes(vol0, vol1)
 	assert.Len(t, mergedVolumes, 1)
 	volume := mergedVolumes[0]
@@ -596,7 +675,9 @@ func TestMergeVolumesSecret(t *testing.T) {
 func TestMergeNonNilValueNotFilledByOperator(t *testing.T) {
 	// Tests that providing a custom volume with a volume source
 	// That the operator does not manage overwrites the original
-	vol0 := []corev1.Volume{{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "Secret-name"}}}}
+	vol0 := []corev1.Volume{
+		{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "Secret-name"}}},
+	}
 	vol1 := []corev1.Volume{{Name: "volume", VolumeSource: corev1.VolumeSource{GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{}}}}
 	mergedVolumes := Volumes(vol0, vol1)
 	assert.Len(t, mergedVolumes, 1)
@@ -610,7 +691,9 @@ func TestMergeNonNilValueFilledByOperatorButDifferent(t *testing.T) {
 	// Tests that providing a custom volume with a volume source
 	// That the operator does manage, but different from the one
 	// That already exists, overwrites the original
-	vol0 := []corev1.Volume{{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "Secret-name"}}}}
+	vol0 := []corev1.Volume{
+		{Name: "volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "Secret-name"}}},
+	}
 	vol1 := []corev1.Volume{{Name: "volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}}
 	mergedVolumes := Volumes(vol0, vol1)
 	assert.Len(t, mergedVolumes, 1)

--- a/pkg/util/stringutil/stringutil_test.go
+++ b/pkg/util/stringutil/stringutil_test.go
@@ -31,12 +31,30 @@ func TestContainsAny(t *testing.T) {
 }
 
 func TestCheckCertificateDomains(t *testing.T) {
-	assert.True(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com"}, "abc.cluster.local"))
-	assert.True(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com"}, "*.cluster.local"))
+	assert.True(
+		t,
+		CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com"}, "abc.cluster.local"),
+	)
+	assert.True(
+		t,
+		CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com"}, "*.cluster.local"),
+	)
 	assert.True(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com"}, "abd.efg.com"))
-	assert.True(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com", "abcdefg"}, "abcdefg"))
+	assert.True(
+		t,
+		CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com", "abcdefg"}, "abcdefg"),
+	)
 
 	assert.False(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com"}, "abc.efg.com"))
-	assert.False(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com", "abcdef"}, "abdcdefg"))
-	assert.False(t, CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com", "abcdef"}, "*.somethingthatdoesntfit"))
+	assert.False(
+		t,
+		CheckCertificateAddresses([]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com", "abcdef"}, "abdcdefg"),
+	)
+	assert.False(
+		t,
+		CheckCertificateAddresses(
+			[]string{"abd.efg.com", "*.cluster.local", "*.dev.local", "abc.mongodb.com", "abcdef"},
+			"*.somethingthatdoesntfit",
+		),
+	)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -154,8 +154,16 @@ func TestSetIntersection(t *testing.T) {
 	leftNotIdentifiable := []someId{oneLeft, twoLeft}
 	rightNotIdentifiable := []someId{oneRight, twoRight, threeRight}
 
-	assert.Equal(t, [][]identifiable.Identifiable{pair(oneLeft, oneRight), pair(twoLeft, twoRight)}, identifiable.SetIntersectionGeneric(leftNotIdentifiable, rightNotIdentifiable))
-	assert.Equal(t, [][]identifiable.Identifiable{pair(oneRight, oneLeft), pair(twoRight, twoLeft)}, identifiable.SetIntersectionGeneric(rightNotIdentifiable, leftNotIdentifiable))
+	assert.Equal(
+		t,
+		[][]identifiable.Identifiable{pair(oneLeft, oneRight), pair(twoLeft, twoRight)},
+		identifiable.SetIntersectionGeneric(leftNotIdentifiable, rightNotIdentifiable),
+	)
+	assert.Equal(
+		t,
+		[][]identifiable.Identifiable{pair(oneRight, oneLeft), pair(twoRight, twoLeft)},
+		identifiable.SetIntersectionGeneric(rightNotIdentifiable, leftNotIdentifiable),
+	)
 
 	leftNotIdentifiable = []someId{oneLeft, twoLeft}
 	rightNotIdentifiable = []someId{oneLeft, twoLeft}
@@ -193,9 +201,13 @@ func TestTransformToMap(t *testing.T) {
 		str string
 		int int
 	}
-	assert.Equal(t, map[string]int{"a": 0, "b": 1, "c": 2}, TransformToMap([]tmpStruct{{"a", 0}, {"b", 1}, {"c", 2}}, func(v tmpStruct, idx int) (string, int) {
-		return v.str, v.int
-	}))
+	assert.Equal(
+		t,
+		map[string]int{"a": 0, "b": 1, "c": 2},
+		TransformToMap([]tmpStruct{{"a", 0}, {"b", 1}, {"c", 2}}, func(v tmpStruct, idx int) (string, int) {
+			return v.str, v.int
+		}),
+	)
 }
 
 // TestIsURL tests the ParseURL function with various inputs.

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -111,7 +111,10 @@ type VaultClient struct {
 }
 
 func readVaultConfig(ctx context.Context, client *kubernetes.Clientset) VaultConfiguration {
-	cm, err := client.CoreV1().ConfigMaps(env.ReadOrPanic(util.CurrentNamespace)).Get(ctx, "secret-configuration", v1.GetOptions{}) // nolint:forbidigo
+	cm, err := client.CoreV1().
+		ConfigMaps(env.ReadOrPanic(util.CurrentNamespace)).
+		Get(ctx, "secret-configuration", v1.GetOptions{})
+		// nolint:forbidigo
 	if err != nil {
 		panic(xerrors.Errorf("error reading vault configmap: %w", err))
 	}
@@ -137,7 +140,10 @@ func setTLSConfig(ctx context.Context, config *api.Config, client *kubernetes.Cl
 	}
 	var secret *corev1.Secret
 	var err error
-	secret, err = client.CoreV1().Secrets(env.ReadOrPanic(util.CurrentNamespace)).Get(ctx, tlsSecretRef, v1.GetOptions{}) // nolint:forbidigo
+	secret, err = client.CoreV1().
+		Secrets(env.ReadOrPanic(util.CurrentNamespace)).
+		Get(ctx, tlsSecretRef, v1.GetOptions{})
+		// nolint:forbidigo
 	if err != nil {
 		return xerrors.Errorf("can't read tls secret %s for vault: %w", tlsSecretRef, err)
 	}

--- a/pkg/vault/vaultwatcher/vaultsecretwatch.go
+++ b/pkg/vault/vaultwatcher/vaultsecretwatch.go
@@ -16,7 +16,14 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/vault"
 )
 
-func WatchSecretChangeForMDB(ctx context.Context, log *zap.SugaredLogger, watchChannel chan event.GenericEvent, k8sClient kubernetesClient.Client, vaultClient *vault.VaultClient, resourceType mdbv1.ResourceType) {
+func WatchSecretChangeForMDB(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	watchChannel chan event.GenericEvent,
+	k8sClient kubernetesClient.Client,
+	vaultClient *vault.VaultClient,
+	resourceType mdbv1.ResourceType,
+) {
 	for {
 		mdbList := &mdbv1.MongoDBList{}
 		err := k8sClient.List(ctx, mdbList, &client.ListOptions{Namespace: ""})
@@ -31,7 +38,13 @@ func WatchSecretChangeForMDB(ctx context.Context, log *zap.SugaredLogger, watchC
 			}
 			// the credentials secret is mandatory and stored in a different path
 			path := fmt.Sprintf("%s/%s/%s", vaultClient.OperatorScretMetadataPath(), mdb.Namespace, mdb.Spec.Credentials)
-			latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, mdb.Spec.Credentials, mdb.Annotations, log)
+			latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(
+				vaultClient,
+				path,
+				mdb.Spec.Credentials,
+				mdb.Annotations,
+				log,
+			)
 			if latestResourceVersion > currentResourceVersion {
 				watchChannel <- event.GenericEvent{Object: &mdbList.Items[n]}
 				break
@@ -39,7 +52,13 @@ func WatchSecretChangeForMDB(ctx context.Context, log *zap.SugaredLogger, watchC
 
 			for _, secretName := range mdb.GetSecretsMountedIntoDBPod() {
 				path := fmt.Sprintf("%s/%s/%s", vaultClient.DatabaseSecretMetadataPath(), mdb.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, mdb.Annotations, log)
+				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(
+					vaultClient,
+					path,
+					secretName,
+					mdb.Annotations,
+					log,
+				)
 
 				if latestResourceVersion > currentResourceVersion {
 					watchChannel <- event.GenericEvent{Object: &mdbList.Items[n]}
@@ -52,7 +71,13 @@ func WatchSecretChangeForMDB(ctx context.Context, log *zap.SugaredLogger, watchC
 	}
 }
 
-func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchChannel chan event.GenericEvent, k8sClient kubernetesClient.Client, vaultClient *vault.VaultClient) {
+func WatchSecretChangeForOM(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	watchChannel chan event.GenericEvent,
+	k8sClient kubernetesClient.Client,
+	vaultClient *vault.VaultClient,
+) {
 	for {
 		omList := &omv1.MongoDBOpsManagerList{}
 		err := k8sClient.List(ctx, omList, &client.ListOptions{Namespace: ""})
@@ -64,7 +89,13 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 		for n, om := range omList.Items {
 			for _, secretName := range om.GetSecretsMountedIntoPod() {
 				path := fmt.Sprintf("%s/%s/%s", vaultClient.OpsManagerSecretMetadataPath(), om.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)
+				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(
+					vaultClient,
+					path,
+					secretName,
+					om.Annotations,
+					log,
+				)
 
 				if latestResourceVersion > currentResourceVersion {
 					watchChannel <- event.GenericEvent{Object: &omList.Items[n]}
@@ -77,7 +108,13 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 			}
 			for _, secretName := range om.Spec.AppDB.GetSecretsMountedIntoPod() {
 				path := fmt.Sprintf("%s/%s/%s", vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)
+				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(
+					vaultClient,
+					path,
+					secretName,
+					om.Annotations,
+					log,
+				)
 
 				if latestResourceVersion > currentResourceVersion {
 					watchChannel <- event.GenericEvent{Object: &omList.Items[n]}
@@ -90,7 +127,13 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 	}
 }
 
-func getCurrentAndLatestVersion(vaultClient *vault.VaultClient, path string, annotationKey string, annotations map[string]string, log *zap.SugaredLogger) (int, int) {
+func getCurrentAndLatestVersion(
+	vaultClient *vault.VaultClient,
+	path string,
+	annotationKey string,
+	annotations map[string]string,
+	log *zap.SugaredLogger,
+) (int, int) {
 	latestResourceVersion, err := vaultClient.ReadSecretVersion(path)
 	if err != nil {
 		log.Errorf("failed to fetch secret revision for the path %s, err: %v", path, err)

--- a/pkg/webhook/setup.go
+++ b/pkg/webhook/setup.go
@@ -35,7 +35,13 @@ func getWebhookName() string {
 }
 
 // createWebhookService creates a Kubernetes service for the webhook.
-func createWebhookService(ctx context.Context, client client.Client, location types.NamespacedName, webhookPort int, svcSelector string) error {
+func createWebhookService(
+	ctx context.Context,
+	client client.Client,
+	location types.NamespacedName,
+	webhookPort int,
+	svcSelector string,
+) error {
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      location.Name,
@@ -193,7 +199,15 @@ func shouldRegisterWebhookConfiguration() bool {
 	return env.ReadBoolOrDefault(util.MdbWebhookRegisterConfigurationEnv, true) // nolint:forbidigo
 }
 
-func Setup(ctx context.Context, client client.Client, serviceLocation types.NamespacedName, certDirectory string, webhookPort int, svcSelector string, log *zap.SugaredLogger) error {
+func Setup(
+	ctx context.Context,
+	client client.Client,
+	serviceLocation types.NamespacedName,
+	certDirectory string,
+	webhookPort int,
+	svcSelector string,
+	log *zap.SugaredLogger,
+) error {
 	if !shouldRegisterWebhookConfiguration() {
 		log.Debugf("Skipping configuration of ValidatingWebhookConfiguration")
 		// After upgrading OLM version after migrating to proper OLM webhooks we don't need that `operator-service` anymore.
@@ -211,7 +225,11 @@ func Setup(ctx context.Context, client client.Client, serviceLocation types.Name
 		}
 		if err := client.Delete(ctx, &webhookConfig); err != nil {
 			if !apiErrors.IsNotFound(err) {
-				log.Warnf("Failed to perform cleanup of ValidatingWebhookConfiguration %s. The operator might not have necessary permissions. Remove the configuration manually. Error: %s", webhookConfig.Name, err)
+				log.Warnf(
+					"Failed to perform cleanup of ValidatingWebhookConfiguration %s. The operator might not have necessary permissions. Remove the configuration manually. Error: %s",
+					webhookConfig.Name,
+					err,
+				)
 				// we don't want to fail the operator startup if we cannot do the cleanup
 			}
 		}

--- a/scripts/dev/prepare-multi-cluster/main.go
+++ b/scripts/dev/prepare-multi-cluster/main.go
@@ -119,21 +119,42 @@ func main() {
 		if cfg.clusterType == clusterTypeKind && kindKubeconfig != "" {
 			kubeconfigPath = kindKubeconfig
 		}
-		createKubeconfigSecret(ctx, clients[cfg.testPodCluster], cfg.testPodCluster, cfg.namespace, kubeconfigPath, collectErrorFor(cfg.testPodCluster))
+		createKubeconfigSecret(
+			ctx,
+			clients[cfg.testPodCluster],
+			cfg.testPodCluster,
+			cfg.namespace,
+			kubeconfigPath,
+			collectErrorFor(cfg.testPodCluster),
+		)
 	}()
 
 	// Project ConfigMap in central cluster
 	phase3wg.Add(1)
 	go func() {
 		defer phase3wg.Done()
-		createProjectConfigMap(ctx, clients[cfg.centralCluster], cfg.centralCluster, cfg.namespace, cfg, collectErrorFor(cfg.centralCluster))
+		createProjectConfigMap(
+			ctx,
+			clients[cfg.centralCluster],
+			cfg.centralCluster,
+			cfg.namespace,
+			cfg,
+			collectErrorFor(cfg.centralCluster),
+		)
 	}()
 
 	// Credentials Secret in central cluster
 	phase3wg.Add(1)
 	go func() {
 		defer phase3wg.Done()
-		createCredentialsSecret(ctx, clients[cfg.centralCluster], cfg.centralCluster, cfg.namespace, cfg, collectErrorFor(cfg.centralCluster))
+		createCredentialsSecret(
+			ctx,
+			clients[cfg.centralCluster],
+			cfg.centralCluster,
+			cfg.namespace,
+			cfg,
+			collectErrorFor(cfg.centralCluster),
+		)
 	}()
 
 	phase3wg.Wait()
@@ -314,7 +335,13 @@ func runParallel(clusters []string, fn func(string)) {
 }
 
 // Phase 1: Override kubeconfig for KIND clusters
-func overrideKindKubeconfig(ctx context.Context, cfg config, clients map[string]*kubernetes.Clientset, allClusters []string, collectError func(error, string)) string {
+func overrideKindKubeconfig(
+	ctx context.Context,
+	cfg config,
+	clients map[string]*kubernetes.Clientset,
+	allClusters []string,
+	collectError func(error, string),
+) string {
 	// Load the kubeconfig file
 	kubeconfigBytes, err := os.ReadFile(cfg.kubeconfigPath)
 	if err != nil {
@@ -380,7 +407,12 @@ func overrideKindKubeconfig(ctx context.Context, cfg config, clients map[string]
 }
 
 // Phase 2: Ensure namespace exists with labels and annotations
-func ensureNamespace(ctx context.Context, client *kubernetes.Clientset, cluster, namespace, taskID string, collectError func(error, string)) {
+func ensureNamespace(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	cluster, namespace, taskID string,
+	collectError func(error, string),
+) {
 	evgTaskURL := "https://evergreen.mongodb.com/task/" + taskID
 
 	ns := &corev1.Namespace{
@@ -450,7 +482,12 @@ func labelNamespaceIstio(ctx context.Context, client *kubernetes.Clientset, clus
 
 // applyPeerAuthentication ensures a PeerAuthentication resource exists with STRICT mTLS
 // using the dynamic client, since PeerAuthentication is an Istio CRD with no typed Go client.
-func applyPeerAuthentication(ctx context.Context, dynClient dynamic.Interface, cluster, namespace string, collectError func(error, string)) {
+func applyPeerAuthentication(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	cluster, namespace string,
+	collectError func(error, string),
+) {
 	peerAuthGVR := schema.GroupVersionResource{
 		Group:    "security.istio.io",
 		Version:  "v1beta1",
@@ -524,7 +561,12 @@ func ensureServiceAccount(ctx context.Context, client *kubernetes.Clientset, clu
 }
 
 // Phase 3: Create ClusterRoleBinding
-func ensureClusterRoleBinding(ctx context.Context, client *kubernetes.Clientset, cluster, namespace string, collectError func(error, string)) {
+func ensureClusterRoleBinding(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	cluster, namespace string,
+	collectError func(error, string),
+) {
 	crbName := fmt.Sprintf("operator-multi-cluster-tests-role-binding-%s", namespace)
 
 	crb := &rbacv1.ClusterRoleBinding{
@@ -565,7 +607,12 @@ func ensureClusterRoleBinding(ctx context.Context, client *kubernetes.Clientset,
 }
 
 // Phase 3: Create kubeconfig secret for test pod
-func createKubeconfigSecret(ctx context.Context, client *kubernetes.Clientset, cluster, namespace, kubeconfigPath string, collectError func(error, string)) {
+func createKubeconfigSecret(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	cluster, namespace, kubeconfigPath string,
+	collectError func(error, string),
+) {
 	secretName := kubeconfigSecretName
 
 	// Delete existing
@@ -595,7 +642,13 @@ func createKubeconfigSecret(ctx context.Context, client *kubernetes.Clientset, c
 }
 
 // Phase 3: Create project ConfigMap
-func createProjectConfigMap(ctx context.Context, client *kubernetes.Clientset, cluster, namespace string, cfg config, collectError func(error, string)) {
+func createProjectConfigMap(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	cluster, namespace string,
+	cfg config,
+	collectError func(error, string),
+) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      projectConfigMapName,
@@ -627,7 +680,13 @@ func createProjectConfigMap(ctx context.Context, client *kubernetes.Clientset, c
 }
 
 // Phase 3: Create credentials Secret
-func createCredentialsSecret(ctx context.Context, client *kubernetes.Clientset, cluster, namespace string, cfg config, collectError func(error, string)) {
+func createCredentialsSecret(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	cluster, namespace string,
+	cfg config,
+	collectError func(error, string),
+) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      credentialsSecretName,
@@ -724,7 +783,13 @@ func findExistingTokenSecret(ctx context.Context, client *kubernetes.Clientset, 
 }
 
 // Phase 5: Create multi-cluster config secret
-func createMultiClusterConfigSecret(ctx context.Context, client *kubernetes.Clientset, cfg config, tokens map[string]string, collectError func(error, string)) {
+func createMultiClusterConfigSecret(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	cfg config,
+	tokens map[string]string,
+	collectError func(error, string),
+) {
 	secretName := multiClusterSecretName
 
 	// Delete existing
@@ -823,7 +888,11 @@ func setupKubectlMongodb(cfg config) error {
 		if err != nil {
 			return fmt.Errorf("failed to read pre-compiled binary: %v", err)
 		}
-		return os.WriteFile(cfg.kubeconfigCreatorPath, data, 0o755) //nolint:gosec // executable binary requires world-executable permissions
+		return os.WriteFile(
+			cfg.kubeconfigCreatorPath,
+			data,
+			0o755,
+		) //nolint:gosec // executable binary requires world-executable permissions
 	}
 
 	// Build from source
@@ -839,7 +908,13 @@ func setupKubectlMongodb(cfg config) error {
 	}
 	env = append(env, fmt.Sprintf("GOOS=%s", goos), fmt.Sprintf("GOARCH=%s", goarch))
 
-	cmd := exec.Command("go", "build", "-o", cfg.kubeconfigCreatorPath, "main.go") //nolint:gosec // developer script, inputs are trusted CLI config
+	cmd := exec.Command(
+		"go",
+		"build",
+		"-o",
+		cfg.kubeconfigCreatorPath,
+		"main.go",
+	) //nolint:gosec // developer script, inputs are trusted CLI config
 	cmd.Dir = cmdDir
 	cmd.Env = env
 	cmd.Stdout = os.Stdout

--- a/scripts/dev/reset/main.go
+++ b/scripts/dev/reset/main.go
@@ -61,7 +61,13 @@ func waitForBackupPodDeletion(kubeClient *kubernetes.Clientset, namespace string
 }
 
 // deleteDynamicResources deletes a list of dynamic resources
-func deleteDynamicResources(ctx context.Context, dynamicClient dynamic.Interface, namespace string, resources []DynamicResource, collectError func(error, string)) {
+func deleteDynamicResources(
+	ctx context.Context,
+	dynamicClient dynamic.Interface,
+	namespace string,
+	resources []DynamicResource,
+	collectError func(error, string),
+) {
 	for _, resource := range resources {
 		err := dynamicClient.Resource(resource.GVR).Namespace(namespace).DeleteCollection(ctx, deleteOptionsNoGrace, v1.ListOptions{})
 		collectError(err, fmt.Sprintf("failed to delete %s", resource.ResourceName))
@@ -162,7 +168,13 @@ func resetContext(ctx context.Context, contextName string, deleteCRD bool, colle
 
 // removeIstioConfig removes Istio sidecar injection label and PeerAuthentication from the namespace.
 // This prevents Istio artifacts from a multi-cluster run from leaking into subsequent single-cluster tests.
-func removeIstioConfig(ctx context.Context, kubeClient *kubernetes.Clientset, dynamicClient dynamic.Interface, namespace string, collectError func(error, string)) {
+func removeIstioConfig(
+	ctx context.Context,
+	kubeClient *kubernetes.Clientset,
+	dynamicClient dynamic.Interface,
+	namespace string,
+	collectError func(error, string),
+) {
 	// Remove istio-injection label from namespace
 	ns, err := kubeClient.CoreV1().Namespaces().Get(ctx, namespace, v1.GetOptions{})
 	if err == nil && ns.Labels["istio-injection"] != "" {
@@ -328,7 +340,9 @@ func resetNamespace(ctx context.Context, contextName string, namespace string, d
 	collectError(err, "failed to list mongodb users")
 	if err == nil {
 		for _, customRole := range list.Items {
-			_, err := dynamicClient.Resource(userGVR).Namespace(namespace).Patch(ctx, customRole.GetName(), types.MergePatchType, []byte(`{"metadata":{"finalizers":null}}`), v1.PatchOptions{})
+			_, err := dynamicClient.Resource(userGVR).
+				Namespace(namespace).
+				Patch(ctx, customRole.GetName(), types.MergePatchType, []byte(`{"metadata":{"finalizers":null}}`), v1.PatchOptions{})
 			collectError(err, fmt.Sprintf("failed to patch custom role %s", customRole.GetName()))
 		}
 	}

--- a/test/envtest/env/env.go
+++ b/test/envtest/env/env.go
@@ -73,7 +73,11 @@ var shared *TestEnv
 func RunShared(m *testing.M, opts ...Option) int {
 	testEnv, err := start(opts...)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "failed to start the envtest control plane; run `make envtest-assets` to download the required binaries: %v\n", err)
+		_, _ = fmt.Fprintf(
+			os.Stderr,
+			"failed to start the envtest control plane; run `make envtest-assets` to download the required binaries: %v\n",
+			err,
+		)
 		return 1
 	}
 	shared = testEnv


### PR DESCRIPTION
Experiment to show the blast radius of enabling the `golines` formatter (built into golangci-lint v2) at `max-len: 140`.

The only hand-written change is in `.golangci.yml`; everything else is the mechanical reformat.

236 files, +14.6k/-2.4k. Verified token-identical to master (modulo gofmt struct-tag alignment), `go build` and `go vet` clean, idempotent. Lines over 140 drop 2316 -> 464; the remainder are long string literals, comments and kubebuilder markers, which golines does not touch.