### PR TITLE
KUBE-309: Validate Vault Secret Paths

### DIFF
--- a/changelog/20260812_fix_sanitize_cr_supplied_names_in_vault_secret_paths.md
+++ b/changelog/20260812_fix_sanitize_cr_supplied_names_in_vault_secret_paths.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-08-12
+---
+
+* Validate CR-supplied namespace and secret names when building Vault secret paths on Vault-backed deployments, preventing path traversal that could read or overwrite secrets belonging to another namespace.

--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -1050,7 +1050,10 @@ func (r *ReconcileAppDbReplicaSet) ensureTLSSecretAndCreatePEMIfNeeded(ctx conte
 
 	if vault.IsVaultSecretBackend() {
 		needToCreatePEM = true
-		path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretPath(), om.Namespace, secretName)
+		path, err := vault.SecretPath(r.VaultClient.AppDBSecretPath(), om.Namespace, secretName)
+		if err != nil {
+			return workflow.Failed(err)
+		}
 		secretData, err = r.VaultClient.ReadSecretBytes(path)
 		if err != nil {
 			return workflow.Failed(xerrors.Errorf("can't read current certificate secret from vault: %w", err))
@@ -1489,7 +1492,10 @@ func buildPrometheusModification(ctx context.Context, sClient secrets.SecretClie
 	secretName := prometheus.PasswordSecretRef.Name
 	if vault.IsVaultSecretBackend() {
 		operatorSecretPath := sClient.VaultClient.OperatorSecretPath()
-		passwordString := fmt.Sprintf("%s/%s/%s", operatorSecretPath, om.GetNamespace(), secretName)
+		passwordString, err := vault.SecretPath(operatorSecretPath, om.GetNamespace(), secretName)
+		if err != nil {
+			return automationconfig.NOOP(), err
+		}
 		keyedPassword, err := sClient.VaultClient.ReadSecretString(passwordString)
 		if err != nil {
 			return automationconfig.NOOP(), err

--- a/controllers/operator/certs/certificates.go
+++ b/controllers/operator/certs/certificates.go
@@ -180,7 +180,11 @@ func VerifyAndEnsureCertificatesForStatefulSet(ctx context.Context, secretReadCl
 
 	if vault.IsVaultSecretBackend() {
 		databaseSecretPath = secretReadClient.VaultClient.DatabaseSecretPath()
-		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", databaseSecretPath, opts.Namespace, secretName))
+		secretPath, err := vault.SecretPath(databaseSecretPath, opts.Namespace, secretName)
+		if err != nil {
+			return err
+		}
+		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(secretPath)
 		if err != nil {
 			return err
 		}
@@ -307,7 +311,11 @@ func VerifyAndEnsureClientCertificatesForAgentsAndTLSType(ctx context.Context, s
 
 	if vault.IsVaultSecretBackend() {
 		databaseSecretPath = secretReadClient.VaultClient.DatabaseSecretPath()
-		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", secretReadClient.VaultClient.DatabaseSecretPath(), secret.Namespace, secret.Name))
+		secretPath, err := vault.SecretPath(databaseSecretPath, secret.Namespace, secret.Name)
+		if err != nil {
+			return err
+		}
+		secretData, err = secretReadClient.VaultClient.ReadSecretBytes(secretPath)
 		if err != nil {
 			return err
 		}
@@ -368,7 +376,11 @@ func EnsureTLSCertsForPrometheus(ctx context.Context, secretClient secrets.Secre
 			secretPath = secretClient.VaultClient.AppDBSecretPath()
 		}
 
-		secretData, err = secretClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", secretPath, namespace, prom.TLSSecretRef.Name))
+		promSecretPath, err := vault.SecretPath(secretPath, namespace, prom.TLSSecretRef.Name)
+		if err != nil {
+			return "", err
+		}
+		secretData, err = secretClient.VaultClient.ReadSecretBytes(promSecretPath)
 		if err != nil {
 			return "", err
 		}

--- a/controllers/operator/common_controller.go
+++ b/controllers/operator/common_controller.go
@@ -887,7 +887,11 @@ func UpdatePrometheus(ctx context.Context, d *om.Deployment, conn om.Connection,
 	secretName := prometheus.PasswordSecretRef.Name
 	if vault.IsVaultSecretBackend() {
 		operatorSecretPath := sClient.VaultClient.OperatorSecretPath()
-		passwordString := fmt.Sprintf("%s/%s/%s", operatorSecretPath, namespace, secretName)
+		passwordString, err := vault.SecretPath(operatorSecretPath, namespace, secretName)
+		if err != nil {
+			log.Infof("Prometheus can't be enabled, %s", err)
+			return err
+		}
 		keyedPassword, err := sClient.VaultClient.ReadSecretString(passwordString)
 		if err != nil {
 			log.Infof("Prometheus can't be enabled, %s", err)

--- a/controllers/operator/construct/opsmanager_construction.go
+++ b/controllers/operator/construct/opsmanager_construction.go
@@ -197,7 +197,11 @@ func (opts *OpsManagerStatefulSetOptions) updateHTTPSCertSecret(ctx context.Cont
 
 	if vault.IsVaultSecretBackend() {
 		opsManagerSecretPath = centralClusterSecretClient.VaultClient.OpsManagerSecretPath()
-		secretData, err = centralClusterSecretClient.VaultClient.ReadSecretBytes(fmt.Sprintf("%s/%s/%s", opsManagerSecretPath, opts.Namespace, opts.HTTPSCertSecretName))
+		secretPath, err := vault.SecretPath(opsManagerSecretPath, opts.Namespace, opts.HTTPSCertSecretName)
+		if err != nil {
+			return err
+		}
+		secretData, err = centralClusterSecretClient.VaultClient.ReadSecretBytes(secretPath)
 		if err != nil {
 			return err
 		}

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -493,12 +493,10 @@ func (r *OpsManagerReconciler) Reconcile(ctx context.Context, request reconcile.
 	if vault.IsVaultSecretBackend() {
 		vaultMap := make(map[string]string)
 		for _, s := range opsManager.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OpsManagerSecretMetadataPath(), appDBReplicaSet.Namespace, s)
-			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotationForSecret(r.VaultClient.OpsManagerSecretMetadataPath(), appDBReplicaSet.Namespace, s))
 		}
 		for _, s := range opsManager.Spec.AppDB.GetSecretsMountedIntoPod() {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.AppDBSecretMetadataPath(), appDBReplicaSet.Namespace, s)
-			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotationForSecret(r.VaultClient.AppDBSecretMetadataPath(), appDBReplicaSet.Namespace, s))
 		}
 
 		for k, val := range vaultMap {

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -150,14 +150,12 @@ func (r *ReplicaSetReconcilerHelper) getVaultAnnotations() map[string]string {
 	secrets := r.resource.GetSecretsMountedIntoDBPod()
 
 	for _, s := range secrets {
-		path := fmt.Sprintf("%s/%s/%s", r.reconciler.VaultClient.DatabaseSecretMetadataPath(),
-			r.resource.Namespace, s)
-		vaultMap = merge.StringToStringMap(vaultMap, r.reconciler.VaultClient.GetSecretAnnotation(path))
+		vaultMap = merge.StringToStringMap(vaultMap, r.reconciler.VaultClient.GetSecretAnnotationForSecret(
+			r.reconciler.VaultClient.DatabaseSecretMetadataPath(), r.resource.Namespace, s))
 	}
 
-	path := fmt.Sprintf("%s/%s/%s", r.reconciler.VaultClient.OperatorScretMetadataPath(),
-		r.resource.Namespace, r.resource.Spec.Credentials)
-	vaultMap = merge.StringToStringMap(vaultMap, r.reconciler.VaultClient.GetSecretAnnotation(path))
+	vaultMap = merge.StringToStringMap(vaultMap, r.reconciler.VaultClient.GetSecretAnnotationForSecret(
+		r.reconciler.VaultClient.OperatorScretMetadataPath(), r.resource.Namespace, r.resource.Spec.Credentials))
 
 	return vaultMap
 }

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -974,11 +974,9 @@ func (r *ShardedClusterReconcileHelper) Reconcile(ctx context.Context, log *zap.
 		secrets := sc.GetSecretsMountedIntoDBPod()
 		vaultMap := make(map[string]string)
 		for _, s := range secrets {
-			path := fmt.Sprintf("%s/%s/%s", r.commonController.VaultClient.DatabaseSecretMetadataPath(), sc.Namespace, s)
-			vaultMap = merge.StringToStringMap(vaultMap, r.commonController.VaultClient.GetSecretAnnotation(path))
+			vaultMap = merge.StringToStringMap(vaultMap, r.commonController.VaultClient.GetSecretAnnotationForSecret(r.commonController.VaultClient.DatabaseSecretMetadataPath(), sc.Namespace, s))
 		}
-		path := fmt.Sprintf("%s/%s/%s", r.commonController.VaultClient.OperatorScretMetadataPath(), sc.Namespace, sc.Spec.Credentials)
-		vaultMap = merge.StringToStringMap(vaultMap, r.commonController.VaultClient.GetSecretAnnotation(path))
+		vaultMap = merge.StringToStringMap(vaultMap, r.commonController.VaultClient.GetSecretAnnotationForSecret(r.commonController.VaultClient.OperatorScretMetadataPath(), sc.Namespace, sc.Spec.Credentials))
 		for k, val := range vaultMap {
 			annotationsToAdd[k] = val
 		}

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
@@ -320,11 +319,9 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 		secrets := s.GetSecretsMountedIntoDBPod()
 		vaultMap := make(map[string]string)
 		for _, secret := range secrets {
-			path := fmt.Sprintf("%s/%s/%s", r.VaultClient.DatabaseSecretMetadataPath(), s.Namespace, secret)
-			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+			vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotationForSecret(r.VaultClient.DatabaseSecretMetadataPath(), s.Namespace, secret))
 		}
-		path := fmt.Sprintf("%s/%s/%s", r.VaultClient.OperatorScretMetadataPath(), s.Namespace, s.Spec.Credentials)
-		vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotation(path))
+		vaultMap = merge.StringToStringMap(vaultMap, r.VaultClient.GetSecretAnnotationForSecret(r.VaultClient.OperatorScretMetadataPath(), s.Namespace, s.Spec.Credentials))
 		for k, val := range vaultMap {
 			annotationsToAdd[k] = val
 		}

--- a/controllers/operator/pem/secret.go
+++ b/controllers/operator/pem/secret.go
@@ -2,7 +2,6 @@ package pem
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 
@@ -17,9 +16,14 @@ import (
 // the secret that stores this StatefulSet's Pem collection.
 func ReadHashFromSecret(ctx context.Context, secretClient secrets.SecretClient, namespace, name, basePath string, log *zap.SugaredLogger) string {
 	var secretData map[string]string
-	var err error
 	if vault.IsVaultSecretBackend() {
-		path := fmt.Sprintf("%s/%s/%s", basePath, namespace, name)
+		path, err := vault.SecretPath(basePath, namespace, name)
+		if err != nil {
+			// The name comes from a CR field; a rejected path means it is not a
+			// plain secret name, which is worth surfacing rather than hiding.
+			log.Warnf("cannot compute hash of pem for tls secret %s: %v", name, err)
+			return ""
+		}
 		secretData, err = secretClient.VaultClient.ReadSecretString(path)
 		if err != nil {
 			log.Debugf("tls secret %s doesn't exist yet, unable to compute hash of pem", name)

--- a/controllers/operator/secrets/secrets.go
+++ b/controllers/operator/secrets/secrets.go
@@ -3,7 +3,6 @@ package secrets
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -28,8 +27,11 @@ type SecretClient struct {
 	KubeClient  kubernetesClient.KubernetesSecretClient
 }
 
-func namespacedNameToVaultPath(nsName types.NamespacedName, basePath string) string {
-	return fmt.Sprintf("%s/%s/%s", basePath, nsName.Namespace, nsName.Name)
+// namespacedNameToVaultPath builds the Vault path for a secret. The name may
+// originate from a user-supplied CR field, so it is validated rather than
+// concatenated verbatim.
+func namespacedNameToVaultPath(nsName types.NamespacedName, basePath string) (string, error) {
+	return vault.SecretPath(basePath, nsName.Namespace, nsName.Name)
 }
 
 func secretNamespacedName(s corev1.Secret) types.NamespacedName {
@@ -54,8 +56,10 @@ func (r SecretClient) ReadSecretKey(ctx context.Context, secretName types.Namesp
 func (r SecretClient) ReadSecret(ctx context.Context, secretName types.NamespacedName, basePath string) (map[string]string, error) {
 	secrets := make(map[string]string)
 	if vault.IsVaultSecretBackend() {
-		var err error
-		secretPath := namespacedNameToVaultPath(secretName, basePath)
+		secretPath, err := namespacedNameToVaultPath(secretName, basePath)
+		if err != nil {
+			return nil, err
+		}
 		secrets, err = r.VaultClient.ReadSecretString(secretPath)
 		if err != nil {
 			return nil, err
@@ -76,7 +80,10 @@ func (r SecretClient) ReadBinarySecret(ctx context.Context, secretName types.Nam
 	var secrets map[string][]byte
 	var err error
 	if vault.IsVaultSecretBackend() {
-		secretPath := namespacedNameToVaultPath(secretName, basePath)
+		secretPath, err := namespacedNameToVaultPath(secretName, basePath)
+		if err != nil {
+			return nil, err
+		}
 		secrets, err = r.VaultClient.ReadSecretBytes(secretPath)
 		if err != nil {
 			return nil, err
@@ -93,7 +100,10 @@ func (r SecretClient) ReadBinarySecret(ctx context.Context, secretName types.Nam
 // PutSecret copies secret.Data into vault. Note: we don't rely on secret.StringData since our builder does not use the field.
 func (r SecretClient) PutSecret(ctx context.Context, s corev1.Secret, basePath string) error {
 	if vault.IsVaultSecretBackend() {
-		secretPath := namespacedNameToVaultPath(secretNamespacedName(s), basePath)
+		secretPath, err := namespacedNameToVaultPath(secretNamespacedName(s), basePath)
+		if err != nil {
+			return err
+		}
 		secretData := map[string]interface{}{}
 		for k, v := range s.Data {
 			secretData[k] = string(v)
@@ -110,7 +120,10 @@ func (r SecretClient) PutSecret(ctx context.Context, s corev1.Secret, basePath s
 // PutBinarySecret copies secret.Data as base64 into vault.
 func (r SecretClient) PutBinarySecret(ctx context.Context, s corev1.Secret, basePath string) error {
 	if vault.IsVaultSecretBackend() {
-		secretPath := namespacedNameToVaultPath(secretNamespacedName(s), basePath)
+		secretPath, err := namespacedNameToVaultPath(secretNamespacedName(s), basePath)
+		if err != nil {
+			return err
+		}
 		secretData := map[string]interface{}{}
 		for k, v := range s.Data {
 			secretData[k] = base64.StdEncoding.EncodeToString(v)

--- a/controllers/operator/secrets/secrets_test.go
+++ b/controllers/operator/secrets/secrets_test.go
@@ -1,0 +1,57 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/mongodb/mongodb-kubernetes/pkg/vault"
+)
+
+func TestNamespacedNameToVaultPath(t *testing.T) {
+	path, err := namespacedNameToVaultPath(
+		types.NamespacedName{Namespace: "my-ns", Name: "my-cert"},
+		vault.DEFAULT_DATABASE_SECRET_PATH,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "mongodbenterprise/database/my-ns/my-cert", path)
+}
+
+// TestNamespacedNameToVaultPath_RejectsPathTraversal is the regression guard for
+// KUBE-309. The name reaching this function originates from free-form CR fields
+// (spec.prometheus.tlsSecretKeyRef.name, spec.security.certsSecretPrefix, the
+// agent clientCertificateSecretRef), so a traversing value must be rejected
+// rather than producing a path that escapes the resource's namespace prefix.
+func TestNamespacedNameToVaultPath_RejectsPathTraversal(t *testing.T) {
+	tests := []struct {
+		name   string
+		nsName types.NamespacedName
+	}{
+		{
+			name:   "traversal in secret name",
+			nsName: types.NamespacedName{Namespace: "attacker-ns", Name: "../victim-ns/victim-cert"},
+		},
+		{
+			name:   "traversal in namespace",
+			nsName: types.NamespacedName{Namespace: "../victim-ns", Name: "victim-cert"},
+		},
+		{
+			name:   "separator in secret name",
+			nsName: types.NamespacedName{Namespace: "attacker-ns", Name: "victim-ns/victim-cert"},
+		},
+		{
+			name:   "empty secret name",
+			nsName: types.NamespacedName{Namespace: "attacker-ns", Name: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := namespacedNameToVaultPath(tt.nsName, vault.DEFAULT_DATABASE_SECRET_PATH)
+			require.Error(t, err)
+			assert.Empty(t, path)
+		})
+	}
+}

--- a/pkg/vault/path.go
+++ b/pkg/vault/path.go
@@ -1,0 +1,56 @@
+package vault
+
+import (
+	"path"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// SecretPath joins basePath with the given CR-derived components into a Vault
+// logical path. Each component must be a single path segment: names taken from
+// custom resources are attacker-controlled, and a component such as
+// "../victim-ns/victim-cert" would otherwise walk the built path out of the
+// resource's own namespace prefix and into another tenant's secrets.
+func SecretPath(basePath string, components ...string) (string, error) {
+	segments := make([]string, 0, len(components)+1)
+	segments = append(segments, basePath)
+	for _, component := range components {
+		if err := validateSecretPathComponent(component); err != nil {
+			return "", err
+		}
+		segments = append(segments, component)
+	}
+	return strings.Join(segments, "/"), nil
+}
+
+func validateSecretPathComponent(component string) error {
+	if component == "" {
+		return xerrors.Errorf("invalid vault secret path component: must not be empty")
+	}
+	if component == "." || component == ".." {
+		return xerrors.Errorf("invalid vault secret path component %q: must not be a relative path element", component)
+	}
+	if strings.ContainsAny(component, `/\`) {
+		return xerrors.Errorf("invalid vault secret path component %q: must be a single path segment", component)
+	}
+	return nil
+}
+
+// validateSecretPath rejects logical paths that are not already in canonical
+// form. A path containing "..", "." or empty segments cannot have been built
+// from a trusted base path and namespace/name pair, so it must never reach
+// Vault. This is the backstop for any sink that does not yet build its path
+// through SecretPath.
+func validateSecretPath(secretPath string) error {
+	if secretPath == "" {
+		return xerrors.Errorf("invalid vault secret path: must not be empty")
+	}
+	if strings.HasPrefix(secretPath, "/") {
+		return xerrors.Errorf("invalid vault secret path %q: must not be absolute", secretPath)
+	}
+	if path.Clean(secretPath) != secretPath {
+		return xerrors.Errorf("invalid vault secret path %q: must be in canonical form", secretPath)
+	}
+	return nil
+}

--- a/pkg/vault/path_test.go
+++ b/pkg/vault/path_test.go
@@ -1,0 +1,128 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		basePath   string
+		components []string
+		expected   string
+	}{
+		{
+			name:       "plain namespace and name",
+			basePath:   DEFAULT_DATABASE_SECRET_PATH,
+			components: []string{"my-ns", "my-cert"},
+			expected:   "mongodbenterprise/database/my-ns/my-cert",
+		},
+		{
+			name:       "no components returns base path",
+			basePath:   DEFAULT_DATABASE_SECRET_PATH,
+			components: nil,
+			expected:   "mongodbenterprise/database",
+		},
+		{
+			name:       "dots inside a component are allowed",
+			basePath:   DEFAULT_DATABASE_SECRET_PATH,
+			components: []string{"my-ns", "my.cert..pem"},
+			expected:   "mongodbenterprise/database/my-ns/my.cert..pem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := SecretPath(tt.basePath, tt.components...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, path)
+		})
+	}
+}
+
+// TestSecretPath_RejectsPathTraversal is the regression guard for KUBE-309: a
+// CR-supplied secret name such as "../victim-ns/victim-cert" must never be
+// concatenated into a Vault path, since it would walk out of the resource's own
+// namespace prefix and into another tenant's secrets.
+func TestSecretPath_RejectsPathTraversal(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+	}{
+		{name: "parent directory traversal", component: "../victim-ns/victim-cert"},
+		{name: "bare parent directory", component: ".."},
+		{name: "current directory", component: "."},
+		{name: "leading slash", component: "/victim-ns/victim-cert"},
+		{name: "trailing slash", component: "victim-cert/"},
+		{name: "embedded separator", component: "victim-ns/victim-cert"},
+		{name: "backslash separator", component: `..\victim-ns\victim-cert`},
+		{name: "nested traversal", component: "a/../../victim-ns/victim-cert"},
+		{name: "empty component", component: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// as the secret name
+			path, err := SecretPath(DEFAULT_DATABASE_SECRET_PATH, "attacker-ns", tt.component)
+			require.Error(t, err, "traversing secret name must be rejected")
+			assert.Empty(t, path)
+
+			// and as the namespace
+			path, err = SecretPath(DEFAULT_DATABASE_SECRET_PATH, tt.component, "some-cert")
+			require.Error(t, err, "traversing namespace must be rejected")
+			assert.Empty(t, path)
+		})
+	}
+}
+
+// TestVaultClientRejectsTraversalBeforeLogin asserts the chokepoint guard: the
+// two methods that talk to Vault reject a non-canonical path before attempting
+// to log in, so no traversing path can reach Vault even from a sink that still
+// builds its path by concatenation.
+func TestVaultClientRejectsTraversalBeforeLogin(t *testing.T) {
+	traversalPath := "mongodbenterprise/database/attacker-ns/../victim-ns/victim-cert"
+
+	// A zero-value client has no transport; reaching Login would fail
+	// differently, so an "invalid vault secret path" error proves the guard ran
+	// first.
+	client := &VaultClient{}
+
+	_, err := client.ReadSecret(traversalPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid vault secret path")
+
+	err = client.PutSecret(traversalPath, map[string]any{"data": map[string]any{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid vault secret path")
+}
+
+func TestValidateSecretPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		expectErr bool
+	}{
+		{name: "canonical path", path: "mongodbenterprise/database/my-ns/my-cert", expectErr: false},
+		{name: "dots inside a segment", path: "mongodbenterprise/database/my-ns/my.cert..pem", expectErr: false},
+		{name: "empty", path: "", expectErr: true},
+		{name: "absolute", path: "/mongodbenterprise/database/my-ns/my-cert", expectErr: true},
+		{name: "parent traversal", path: "mongodbenterprise/database/attacker-ns/../victim-ns/victim-cert", expectErr: true},
+		{name: "current directory segment", path: "mongodbenterprise/database/./my-ns/my-cert", expectErr: true},
+		{name: "double separator", path: "mongodbenterprise/database//my-ns/my-cert", expectErr: true},
+		{name: "trailing separator", path: "mongodbenterprise/database/my-ns/my-cert/", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSecretPath(tt.path)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -213,6 +213,9 @@ func (v *VaultClient) Login() error {
 }
 
 func (v *VaultClient) PutSecret(path string, data map[string]interface{}) error {
+	if err := validateSecretPath(path); err != nil {
+		return err
+	}
 	if err := v.Login(); err != nil {
 		return xerrors.Errorf("unable to log in: %w", err)
 	}
@@ -238,6 +241,9 @@ func (v *VaultClient) ReadSecretVersion(path string) (int, error) {
 }
 
 func (v *VaultClient) ReadSecret(path string) (*api.Secret, error) {
+	if err := validateSecretPath(path); err != nil {
+		return nil, err
+	}
 	if err := v.Login(); err != nil {
 		return nil, xerrors.Errorf("unable to log in: %w", err)
 	}
@@ -494,6 +500,18 @@ func (s DatabaseSecretsToInject) DatabaseAnnotations(namespace string) map[strin
 	}
 
 	return annotations
+}
+
+// GetSecretAnnotationForSecret builds the Vault metadata path for the given
+// namespace/name under basePath and returns its version annotation. The name
+// may come from a CR field, so the path is built through SecretPath; an
+// invalid name yields no annotation rather than a traversing read.
+func (v *VaultClient) GetSecretAnnotationForSecret(basePath, namespace, name string) map[string]string {
+	path, err := SecretPath(basePath, namespace, name)
+	if err != nil {
+		return map[string]string{}
+	}
+	return v.GetSecretAnnotation(path)
 }
 
 func (v *VaultClient) GetSecretAnnotation(path string) map[string]string {

--- a/pkg/vault/vaultwatcher/vaultsecretwatch.go
+++ b/pkg/vault/vaultwatcher/vaultsecretwatch.go
@@ -2,7 +2,6 @@ package vaultwatcher
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -30,16 +29,14 @@ func WatchSecretChangeForMDB(ctx context.Context, log *zap.SugaredLogger, watchC
 				continue
 			}
 			// the credentials secret is mandatory and stored in a different path
-			path := fmt.Sprintf("%s/%s/%s", vaultClient.OperatorScretMetadataPath(), mdb.Namespace, mdb.Spec.Credentials)
-			latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, mdb.Spec.Credentials, mdb.Annotations, log)
+			latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, vaultClient.OperatorScretMetadataPath(), mdb.Namespace, mdb.Spec.Credentials, mdb.Annotations, log)
 			if latestResourceVersion > currentResourceVersion {
 				watchChannel <- event.GenericEvent{Object: &mdbList.Items[n]}
 				break
 			}
 
 			for _, secretName := range mdb.GetSecretsMountedIntoDBPod() {
-				path := fmt.Sprintf("%s/%s/%s", vaultClient.DatabaseSecretMetadataPath(), mdb.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, mdb.Annotations, log)
+				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, vaultClient.DatabaseSecretMetadataPath(), mdb.Namespace, secretName, mdb.Annotations, log)
 
 				if latestResourceVersion > currentResourceVersion {
 					watchChannel <- event.GenericEvent{Object: &mdbList.Items[n]}
@@ -63,8 +60,7 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 		triggeredReconciliation := false
 		for n, om := range omList.Items {
 			for _, secretName := range om.GetSecretsMountedIntoPod() {
-				path := fmt.Sprintf("%s/%s/%s", vaultClient.OpsManagerSecretMetadataPath(), om.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)
+				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, vaultClient.OpsManagerSecretMetadataPath(), om.Namespace, secretName, om.Annotations, log)
 
 				if latestResourceVersion > currentResourceVersion {
 					watchChannel <- event.GenericEvent{Object: &omList.Items[n]}
@@ -76,8 +72,7 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 				break
 			}
 			for _, secretName := range om.Spec.AppDB.GetSecretsMountedIntoPod() {
-				path := fmt.Sprintf("%s/%s/%s", vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName)
-				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, path, secretName, om.Annotations, log)
+				latestResourceVersion, currentResourceVersion := getCurrentAndLatestVersion(vaultClient, vaultClient.AppDBSecretMetadataPath(), om.Namespace, secretName, om.Annotations, log)
 
 				if latestResourceVersion > currentResourceVersion {
 					watchChannel <- event.GenericEvent{Object: &omList.Items[n]}
@@ -90,7 +85,18 @@ func WatchSecretChangeForOM(ctx context.Context, log *zap.SugaredLogger, watchCh
 	}
 }
 
-func getCurrentAndLatestVersion(vaultClient *vault.VaultClient, path string, annotationKey string, annotations map[string]string, log *zap.SugaredLogger) (int, int) {
+// getCurrentAndLatestVersion builds the Vault metadata path for the named
+// secret under basePath and compares its version against the one recorded in
+// the resource's annotations. The name originates from a CR field, so the path
+// is built through vault.SecretPath rather than concatenated.
+func getCurrentAndLatestVersion(vaultClient *vault.VaultClient, basePath, namespace, name string, annotations map[string]string, log *zap.SugaredLogger) (int, int) {
+	annotationKey := name
+	path, err := vault.SecretPath(basePath, namespace, name)
+	if err != nil {
+		log.Errorf("failed to build secret path for secret %s in namespace %s, err: %v", name, namespace, err)
+		return -1, -1
+	}
+
 	latestResourceVersion, err := vaultClient.ReadSecretVersion(path)
 	if err != nil {
 		log.Errorf("failed to fetch secret revision for the path %s, err: %v", path, err)


### PR DESCRIPTION
# Summary

Validate & sanitise secret paths used for vault, by using Go's `path.Clean`. This runs before any `Login` call. This is implemented into the `ReadSecret` function, which is the single read point for all calls (`ReadSecretVersion`, `ReadSecretBytes`, etc.).

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
