### PR TITLE
KUBE-310: Fix PutSecretIfChanged fallthrough

### DIFF
--- a/changelog/20260813_fix_vault_backend_no_longer_writes_secrets_to_kubernetes.md
+++ b/changelog/20260813_fix_vault_backend_no_longer_writes_secrets_to_kubernetes.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-08-13
+---
+
+* Fixed `PutSecretIfChanged` falling through to a Kubernetes write when the Vault secret backend is enabled and the Vault copy is already up to date.

--- a/controllers/operator/secrets/secrets.go
+++ b/controllers/operator/secrets/secrets.go
@@ -135,6 +135,9 @@ func (r SecretClient) PutSecretIfChanged(ctx context.Context, s corev1.Secret, b
 		if err != nil || !reflect.DeepEqual(secret, DataToStringData(s.Data)) {
 			return r.PutSecret(ctx, s, basePath)
 		}
+		// The Vault copy is already up to date. We must not fall through to the Kubernetes
+		// write below: on a Vault backend the secret is only ever meant to live in Vault.
+		return nil
 	}
 
 	return secret.CreateOrUpdateIfNeeded(ctx, r.KubeClient, s)

--- a/controllers/operator/secrets/secrets_test.go
+++ b/controllers/operator/secrets/secrets_test.go
@@ -1,0 +1,154 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+	"github.com/mongodb/mongodb-kubernetes/pkg/vault"
+)
+
+const testBasePath = "/secret/data/mongodbenterprise/operator"
+
+// fakeVault is a minimal Vault KV v2 stand-in: it serves the secrets it was seeded with
+// and records every write it receives.
+type fakeVault struct {
+	server *httptest.Server
+	// data maps a vault path to its stored key/value pairs.
+	data   map[string]map[string]string
+	writes []string
+}
+
+func newFakeVault(t *testing.T, data map[string]map[string]string) *fakeVault {
+	t.Helper()
+	fv := &fakeVault{data: data}
+	if fv.data == nil {
+		fv.data = map[string]map[string]string{}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path[len("/v1"):]
+
+		if r.Method != http.MethodGet {
+			fv.writes = append(fv.writes, path)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		secretData, ok := fv.data[path]
+		if !ok {
+			// Mirrors Vault's behaviour for a missing secret: 404 with no body, which the
+			// api client surfaces as a nil secret.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{"data": secretData},
+		}))
+	})
+
+	fv.server = httptest.NewServer(mux)
+	t.Cleanup(fv.server.Close)
+	return fv
+}
+
+func testSecret() corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-tls-cert", Namespace: "my-namespace"},
+		Data:       map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("private-key")},
+	}
+}
+
+func vaultPathFor(s corev1.Secret) string {
+	return fmt.Sprintf("%s/%s/%s", testBasePath, s.Namespace, s.Name)
+}
+
+func newSecretClient(t *testing.T, fv *fakeVault) SecretClient {
+	t.Helper()
+	vaultClient, err := vault.NewVaultClientForTesting(fv.server.URL, "test-token", vault.VaultConfiguration{})
+	require.NoError(t, err)
+
+	return SecretClient{
+		VaultClient: vaultClient,
+		KubeClient:  kubernetesClient.NewClient(fake.NewClientBuilder().Build()),
+	}
+}
+
+func secretExistsInKubernetes(t *testing.T, r SecretClient, s corev1.Secret) bool {
+	t.Helper()
+	_, err := r.KubeClient.GetSecret(context.Background(), types.NamespacedName{Name: s.Name, Namespace: s.Namespace})
+	return err == nil
+}
+
+// TestPutSecretIfChanged_VaultBackendNeverWritesToKubernetes is the regression test for
+// KUBE-310: on a Vault backend the Kubernetes API must never receive the secret, in
+// particular in the steady state where the Vault copy is already up to date.
+func TestPutSecretIfChanged_VaultBackendNeverWritesToKubernetes(t *testing.T) {
+	ctx := context.Background()
+	s := testSecret()
+
+	tests := map[string]struct {
+		vaultData        map[string]map[string]string
+		expectVaultWrite bool
+	}{
+		"vault copy is up to date": {
+			vaultData:        map[string]map[string]string{vaultPathFor(s): {"tls.crt": "cert", "tls.key": "private-key"}},
+			expectVaultWrite: false,
+		},
+		"vault copy is stale": {
+			vaultData:        map[string]map[string]string{vaultPathFor(s): {"tls.crt": "cert", "tls.key": "old-private-key"}},
+			expectVaultWrite: true,
+		},
+		"vault copy does not exist": {
+			vaultData:        nil,
+			expectVaultWrite: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("SECRET_BACKEND", vault.VaultBackend)
+
+			fv := newFakeVault(t, tc.vaultData)
+			r := newSecretClient(t, fv)
+
+			require.NoError(t, r.PutSecretIfChanged(ctx, s, testBasePath))
+
+			assert.False(t, secretExistsInKubernetes(t, r, s), "secret must not be persisted to Kubernetes on a Vault backend")
+			if tc.expectVaultWrite {
+				assert.Equal(t, []string{vaultPathFor(s)}, fv.writes)
+			} else {
+				assert.Empty(t, fv.writes)
+			}
+		})
+	}
+}
+
+func TestPutSecretIfChanged_KubernetesBackendWritesToKubernetes(t *testing.T) {
+	ctx := context.Background()
+	s := testSecret()
+
+	t.Setenv("SECRET_BACKEND", vault.K8sSecretBackend)
+
+	fv := newFakeVault(t, nil)
+	r := newSecretClient(t, fv)
+
+	require.NoError(t, r.PutSecretIfChanged(ctx, s, testBasePath))
+
+	assert.True(t, secretExistsInKubernetes(t, r, s))
+	assert.Empty(t, fv.writes)
+}

--- a/controllers/operator/secrets/secrets_test.go
+++ b/controllers/operator/secrets/secrets_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/vault"

--- a/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
+++ b/docker/mongodb-kubernetes-tests/tests/vaultintegration/mongodb_deployment_vault.py
@@ -21,6 +21,8 @@ from ..constants import DATABASE_SA_NAME, OPERATOR_NAME
 from . import run_command_in_vault, store_secret_in_vault
 
 MDB_RESOURCE = "my-replica-set"
+# Mirrors certs.OperatorGeneratedCertSuffix in controllers/operator/certs/certificates.go
+OPERATOR_GENERATED_CERT_SUFFIX = "-pem"
 
 USER_NAME = "my-user-1"
 PASSWORD_SECRET_NAME = "mms-user-1-password"
@@ -435,6 +437,20 @@ def test_no_certs_in_kubernetes(namespace: str):
         read_secret(namespace, f"{MDB_RESOURCE}-cert")
     with pytest.raises(ApiException):
         read_secret(namespace, "agent-certs")
+
+
+@mark.e2e_vault_setup
+def test_no_operator_generated_pem_secrets_in_kubernetes(namespace: str):
+    """Regression test for KUBE-310: on a Vault backend the operator-generated PEM secrets
+    must only live in Vault. They used to be written to Kubernetes as well from the second
+    reconcile onwards, leaking TLS private keys into etcd."""
+    for secret_name in (
+        f"{MDB_RESOURCE}-cert{OPERATOR_GENERATED_CERT_SUFFIX}",
+        f"{MDB_RESOURCE}-clusterfile{OPERATOR_GENERATED_CERT_SUFFIX}",
+        f"agent-certs{OPERATOR_GENERATED_CERT_SUFFIX}",
+    ):
+        with pytest.raises(ApiException):
+            read_secret(namespace, secret_name)
 
 
 @mark.e2e_vault_setup

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -108,6 +108,25 @@ type VaultConfiguration struct {
 type VaultClient struct {
 	client      *api.Client
 	VaultConfig VaultConfiguration
+	// skipLogin bypasses the Kubernetes auth flow in Login. It is only set by
+	// NewVaultClientForTesting, where no service account token is mounted.
+	skipLogin bool
+}
+
+// NewVaultClientForTesting returns a VaultClient talking to an arbitrary Vault address
+// (typically an httptest server) with a fixed token, skipping the Kubernetes auth flow.
+// It is only intended for use from tests.
+func NewVaultClientForTesting(address string, token string, config VaultConfiguration) (*VaultClient, error) {
+	apiConfig := api.DefaultConfig()
+	apiConfig.Address = address
+
+	vclient, err := api.NewClient(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+	vclient.SetToken(token)
+
+	return &VaultClient{client: vclient, VaultConfig: config, skipLogin: true}, nil
 }
 
 func readVaultConfig(ctx context.Context, client *kubernetes.Clientset) VaultConfiguration {
@@ -186,6 +205,9 @@ func InitVaultClient(ctx context.Context, client *kubernetes.Clientset) (*VaultC
 }
 
 func (v *VaultClient) Login() error {
+	if v.skipLogin {
+		return nil
+	}
 	// Read the service-account token from the path where the token's Kubernetes Secret is mounted.
 	jwt, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {


### PR DESCRIPTION
# Summary

<!-- Enter your PR summary here. Try to emphasize on WHY this change is needed, followed by what's being done in the PR. -->

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
