### PR TITLE
CLOUDP-429011 - Add telemetry for ExternalAppDB

### DIFF
--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -252,7 +252,7 @@ func getMdbEvents(ctx context.Context, operatorClusterClient kubeclient.Client, 
 			}
 
 			if numberOfClustersUsed > 0 {
-				properties.DatabaseClusters = new(numberOfClustersUsed)
+				properties.DatabaseClusters = &numberOfClustersUsed
 			}
 
 			if event := createEvent(properties, now, Deployments); event != nil {
@@ -279,7 +279,7 @@ func addMultiEvents(ctx context.Context, operatorClusterClient kubeclient.Client
 		clusters := len(item.Spec.ClusterSpecList)
 
 		properties := DeploymentUsageSnapshotProperties{
-			DatabaseClusters:         new(clusters), // cannot be null in mdbmulti
+			DatabaseClusters:         &clusters, // cannot be null in mdbmulti
 			DeploymentUID:            string(item.UID),
 			OperatorID:               operatorUUID,
 			Architecture:             string(architectures.GetArchitecture(item.Annotations, defaultArchitecture)),
@@ -324,11 +324,11 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 			}
 
 			if omClusters > 0 {
-				properties.OmClusters = new(omClusters)
+				properties.OmClusters = &omClusters
 			}
 
 			if appDBProperties.Clusters > 0 {
-				properties.AppDBClusters = new(appDBProperties.Clusters)
+				properties.AppDBClusters = &appDBProperties.Clusters
 			}
 
 			if event := createEvent(properties, now, Deployments); event != nil {

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -239,6 +239,7 @@ func getMdbEvents(ctx context.Context, operatorClusterClient kubeclient.Client, 
 
 			numberOfClustersUsed := getMaxNumberOfClustersSCIsDeployedOn(item)
 			properties := DeploymentUsageSnapshotProperties{
+				Role:                     item.Spec.Role,
 				DeploymentUID:            string(item.UID),
 				OperatorID:               operatorUUID,
 				Architecture:             string(architectures.GetArchitecture(item.Annotations, defaultArchitecture)),
@@ -280,6 +281,7 @@ func addMultiEvents(ctx context.Context, operatorClusterClient kubeclient.Client
 
 		properties := DeploymentUsageSnapshotProperties{
 			DatabaseClusters:         &clusters, // cannot be null in mdbmulti
+			Role:                     item.Spec.Role,
 			DeploymentUID:            string(item.UID),
 			OperatorID:               operatorUUID,
 			Architecture:             string(architectures.GetArchitecture(item.Annotations, defaultArchitecture)),

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -246,14 +245,14 @@ func getMdbEvents(ctx context.Context, operatorClusterClient kubeclient.Client, 
 				IsMultiCluster:           item.Spec.IsMultiCluster(),
 				Type:                     string(item.Spec.GetResourceType()),
 				IsRunningEnterpriseImage: images.IsEnterpriseImage(imageURL),
-				ExternalDomains:          getExternalDomainProperty(item),
+				ExternalDomains:          getExternalDomainPropertyForMongoDB(item),
 				CustomRoles:              getCustomRoles(item.Spec.Security),
 				AuthenticationModes:      getAuthenticationModes(item.Spec.Security),
 				AuthenticationAgentMode:  getAuthenticationAgentMode(item.Spec.Security),
 			}
 
 			if numberOfClustersUsed > 0 {
-				properties.DatabaseClusters = ptr.To(numberOfClustersUsed)
+				properties.DatabaseClusters = new(numberOfClustersUsed)
 			}
 
 			if event := createEvent(properties, now, Deployments); event != nil {
@@ -280,7 +279,7 @@ func addMultiEvents(ctx context.Context, operatorClusterClient kubeclient.Client
 		clusters := len(item.Spec.ClusterSpecList)
 
 		properties := DeploymentUsageSnapshotProperties{
-			DatabaseClusters:         ptr.To(clusters), // cannot be null in mdbmulti
+			DatabaseClusters:         new(clusters), // cannot be null in mdbmulti
 			DeploymentUID:            string(item.UID),
 			OperatorID:               operatorUUID,
 			Architecture:             string(architectures.GetArchitecture(item.Annotations, defaultArchitecture)),
@@ -311,28 +310,25 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 		for _, item := range omList.Items {
 			// Detect enterprise
 			omClusters := len(item.Spec.ClusterSpecList)
-			var appDBClusters int
-			var appDBExternalDomains string
-			if item.IsInternalAppDB() {
-				appDBClusters = len(item.Spec.AppDB.ClusterSpecList)
-				appDBExternalDomains = getExternalDomainPropertyForAppDB(item)
-			}
+			appDBProperties := getAppDBProperties(ctx, operatorClusterClient, item)
 			properties := DeploymentUsageSnapshotProperties{
+				AppDBBackupMode:          appDBProperties.BackupMode,
+				ExternalAppDB:            appDBProperties.ExternalAppDB,
 				DeploymentUID:            string(item.UID),
 				OperatorID:               operatorUUID,
 				Architecture:             string(architectures.GetArchitecture(item.Annotations, defaultArchitecture)),
 				IsMultiCluster:           item.Spec.IsMultiCluster(),
 				Type:                     "OpsManager",
 				IsRunningEnterpriseImage: images.IsEnterpriseImage(mongodbImage),
-				ExternalDomains:          appDBExternalDomains,
+				ExternalDomains:          appDBProperties.ExternalDomains,
 			}
 
 			if omClusters > 0 {
-				properties.OmClusters = ptr.To(omClusters)
+				properties.OmClusters = new(omClusters)
 			}
 
-			if appDBClusters > 0 {
-				properties.AppDBClusters = ptr.To(appDBClusters)
+			if appDBProperties.Clusters > 0 {
+				properties.AppDBClusters = new(appDBProperties.Clusters)
 			}
 
 			if event := createEvent(properties, now, Deployments); event != nil {
@@ -341,6 +337,25 @@ func addOmEvents(ctx context.Context, operatorClusterClient kubeclient.Client, o
 		}
 	}
 	return events
+}
+
+type AppDBProperties struct {
+	ExternalAppDB   string
+	BackupMode      string
+	Clusters        int
+	ExternalDomains string
+}
+
+func getAppDBProperties(ctx context.Context, operatorClusterClient kubeclient.Client, om omv1.MongoDBOpsManager) AppDBProperties {
+	ref := om.Spec.ExternalAppDBRef
+	if ref != nil {
+		return resolveExternalAppDBProperties(ctx, operatorClusterClient, ref)
+	}
+
+	return AppDBProperties{
+		Clusters:        len(om.Spec.AppDB.ClusterSpecList),
+		ExternalDomains: getExternalDomainPropertyForAppDB(om),
+	}
 }
 
 func createEvent(properties FlatProperties, now time.Time, eventType EventType) *Event {
@@ -534,28 +549,26 @@ const (
 	ExternalDomainNone            = "None"
 )
 
-func getExternalDomainProperty(mdb mdbv1.MongoDB) string {
-	isUniformExternalDomainSpecified := mdb.Spec.GetExternalDomain() != nil
-
+func getExternalDomainPropertyForMongoDB(mdb mdbv1.MongoDB) string {
 	isClusterSpecificExternalDomainSpecified := isExternalDomainSpecifiedInAnyShardedClusterSpec(mdb)
 
-	return mapExternalDomainConfigurationToEnum(isUniformExternalDomainSpecified, isClusterSpecificExternalDomainSpecified)
+	return getExternalDomainGeneric(mdb.Spec.GetExternalDomain(), isClusterSpecificExternalDomainSpecified)
 }
 
 func getExternalDomainPropertyForMongoDBMulti(mdb mdbmultiv1.MongoDBMultiCluster) string {
-	isUniformExternalDomainSpecified := mdb.Spec.GetExternalDomain() != nil
-
 	isClusterSpecificExternalDomainSpecified := isExternalDomainSpecifiedInClusterSpecList(mdb.Spec.ClusterSpecList)
 
-	return mapExternalDomainConfigurationToEnum(isUniformExternalDomainSpecified, isClusterSpecificExternalDomainSpecified)
+	return getExternalDomainGeneric(mdb.Spec.GetExternalDomain(), isClusterSpecificExternalDomainSpecified)
 }
 
 func getExternalDomainPropertyForAppDB(om omv1.MongoDBOpsManager) string {
-	isUniformExternalDomainSpecified := om.Spec.AppDB.GetExternalDomain() != nil
-
 	isClusterSpecificExternalDomainSpecified := isExternalDomainSpecifiedInClusterSpecList(om.Spec.AppDB.ClusterSpecList)
 
-	return mapExternalDomainConfigurationToEnum(isUniformExternalDomainSpecified, isClusterSpecificExternalDomainSpecified)
+	return getExternalDomainGeneric(om.Spec.AppDB.GetExternalDomain(), isClusterSpecificExternalDomainSpecified)
+}
+
+func getExternalDomainGeneric(externalDomain *string, isClusterSpecificExternalDomainSpecified bool) string {
+	return mapExternalDomainConfigurationToEnum(externalDomain != nil, isClusterSpecificExternalDomainSpecified)
 }
 
 func mapExternalDomainConfigurationToEnum(isUniformExternalDomainSpecified bool, isClusterSpecificExternalDomainSpecified bool) string {
@@ -642,4 +655,39 @@ func getAuthenticationAgentMode(security *mdbv1.Security) string {
 	}
 
 	return security.Authentication.Agents.Mode
+}
+
+func resolveExternalAppDBProperties(ctx context.Context, operatorClusterClient kubeclient.Client, ref *omv1.ExternalAppDBRef) AppDBProperties {
+	key := kubeclient.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
+
+	appDBProperties := AppDBProperties{
+		ExternalAppDB: ref.Kind,
+	}
+	if ref.Kind == "MongoDB" {
+		mdb := &mdbv1.MongoDB{}
+		if err := operatorClusterClient.Get(ctx, key, mdb); err != nil {
+			Logger.Warnf("Couldn't fetch MongoDB %s/%s for OpsManager external database reference: %v", ref.Namespace, ref.Name, err)
+			return appDBProperties
+		}
+
+		if mdb.Spec.Backup != nil {
+			appDBProperties.BackupMode = string(mdb.Spec.Backup.Mode)
+		}
+		appDBProperties.ExternalDomains = getExternalDomainGeneric(mdb.Spec.GetExternalDomain(), false)
+	} else if ref.Kind == "MongoDBMultiCluster" {
+		mdbm := &mdbmultiv1.MongoDBMultiCluster{}
+		if err := operatorClusterClient.Get(ctx, key, mdbm); err != nil {
+			Logger.Warnf("Couldn't fetch MongoDBMultiCluster %s/%s for OpsManager external database reference: %v", ref.Namespace, ref.Name, err)
+			return appDBProperties
+		}
+
+		if mdbm.Spec.Backup != nil {
+			appDBProperties.BackupMode = string(mdbm.Spec.Backup.Mode)
+		}
+		isClusterSpecificExternalDomainSpecified := isExternalDomainSpecifiedInClusterSpecList(mdbm.Spec.ClusterSpecList)
+		appDBProperties.ExternalDomains = getExternalDomainGeneric(mdbm.Spec.GetExternalDomain(), isClusterSpecificExternalDomainSpecified)
+		appDBProperties.Clusters = len(mdbm.Spec.ClusterSpecList)
+	}
+
+	return appDBProperties
 }

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -945,6 +945,254 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				},
 			},
 		},
+		"external appdb test": {
+			objects: []client.Object{
+				&mdbv1.MongoDB{
+					Spec: mdbv1.MongoDbSpec{
+						DbCommonSpec: mdbv1.DbCommonSpec{
+							ResourceType: mdbv1.ReplicaSet,
+							Backup: &mdbv1.Backup{
+								Mode: "enabled",
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-mdb-backup-none-uid",
+						Name:      "om-ext-appdb-backup-none-db",
+						Namespace: "test-ns",
+					},
+				},
+				&omv1.MongoDBOpsManager{
+					Spec: omv1.MongoDBOpsManagerSpec{
+						Topology: "Single",
+						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+							Name: "om-ext-appdb-backup-none-db",
+							Kind: "MongoDB",
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-om-backup-none-uid",
+						Name:      "om-ext-appdb-backup-none",
+						Namespace: "test-ns",
+					},
+				},
+				&mdbv1.MongoDB{
+					Spec: mdbv1.MongoDbSpec{
+						DbCommonSpec: mdbv1.DbCommonSpec{
+							ResourceType: mdbv1.ReplicaSet,
+							ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+								ExternalDomain: ptr.To("some.custom.domain"),
+							},
+							Backup: &mdbv1.Backup{
+								Mode: "disabled",
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-mdb-backup-uniform-uid",
+						Name:      "om-ext-appdb-backup-uniform-db",
+						Namespace: "test-ns",
+					},
+				},
+				&omv1.MongoDBOpsManager{
+					Spec: omv1.MongoDBOpsManagerSpec{
+						Topology: "Single",
+						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+							Name: "om-ext-appdb-backup-uniform-db",
+							Kind: "MongoDB",
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-om-backup-uniform-uid",
+						Name:      "om-ext-appdb-backup-uniform",
+						Namespace: "test-ns",
+					},
+				},
+				&mdbmulti.MongoDBMultiCluster{
+					Spec: mdbmulti.MongoDBMultiSpec{
+						DbCommonSpec: mdbv1.DbCommonSpec{
+							ResourceType: mdbv1.ReplicaSet,
+							Backup: &mdbv1.Backup{
+								Mode: "enabled",
+							},
+						},
+						ClusterSpecList: []mdbv1.ClusterSpecItem{
+							{ClusterName: "cluster1", Members: 3},
+							{ClusterName: "cluster2", Members: 3},
+							{ClusterName: "cluster3", Members: 3},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-mdbm-clusters-uid",
+						Name:      "om-ext-appdb-mdbm-clusters-db",
+						Namespace: "test-ns",
+					},
+				},
+				&omv1.MongoDBOpsManager{
+					Spec: omv1.MongoDBOpsManagerSpec{
+						Topology: "Single",
+						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+							Name: "om-ext-appdb-mdbm-clusters-db",
+							Kind: "MongoDBMultiCluster",
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-om-mdbm-clusters-uid",
+						Name:      "om-ext-appdb-mdbm-clusters",
+						Namespace: "test-ns",
+					},
+				},
+				&mdbmulti.MongoDBMultiCluster{
+					Spec: mdbmulti.MongoDBMultiSpec{
+						DbCommonSpec: mdbv1.DbCommonSpec{
+							ResourceType: mdbv1.ReplicaSet,
+							ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
+								ExternalDomain: ptr.To("some.default.domain"),
+							},
+							Backup: &mdbv1.Backup{
+								Mode: "terminated",
+							},
+						},
+						ClusterSpecList: []mdbv1.ClusterSpecItem{
+							{ClusterName: "cluster1", Members: 3, ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{ExternalDomain: ptr.To("cluster1.domain")}},
+							{ClusterName: "cluster2", Members: 3, ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{ExternalDomain: ptr.To("cluster2.domain")}},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-mdbm-mixed-terminated-uid",
+						Name:      "om-ext-appdb-mdbm-mixed-terminated-db",
+						Namespace: "test-ns",
+					},
+				},
+				&omv1.MongoDBOpsManager{
+					Spec: omv1.MongoDBOpsManagerSpec{
+						Topology: "Single",
+						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+							Name: "om-ext-appdb-mdbm-mixed-terminated-db",
+							Kind: "MongoDBMultiCluster",
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-om-mdbm-mixed-terminated-uid",
+						Name:      "om-ext-appdb-mdbm-mixed-terminated",
+						Namespace: "test-ns",
+					},
+				},
+				&omv1.MongoDBOpsManager{
+					Spec: omv1.MongoDBOpsManagerSpec{
+						Topology: "Single",
+						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+							Name: "non-existent-db",
+							Kind: "MongoDB",
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "ext-appdb-om-not-found-uid",
+						Name:      "om-ext-appdb-not-found",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			expectedEventsWithProperties: []map[string]any{
+				{
+					"deploymentUID":            "ext-appdb-mdb-backup-none-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     string(mdbv1.ReplicaSet),
+					"IsRunningEnterpriseImage": false,
+					"externalDomains":          ExternalDomainNone,
+					"customRoles":              CustomRoleNone,
+				},
+				{
+					"deploymentUID":            "ext-appdb-mdb-backup-uniform-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     string(mdbv1.ReplicaSet),
+					"IsRunningEnterpriseImage": false,
+					"externalDomains":          ExternalDomainUniform,
+					"customRoles":              CustomRoleNone,
+				},
+				{
+					"deploymentUID":            "ext-appdb-mdbm-clusters-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           true,
+					"type":                     string(mdbv1.ReplicaSet),
+					"IsRunningEnterpriseImage": false,
+					"externalDomains":          ExternalDomainNone,
+					"customRoles":              CustomRoleNone,
+					"databaseClusters":         float64(3),
+				},
+				{
+					"deploymentUID":            "ext-appdb-om-backup-none-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     "OpsManager",
+					"IsRunningEnterpriseImage": true,
+					"externalAppDB":            "MongoDB",
+					"appDBBackupMode":          "enabled",
+					"externalDomains":          ExternalDomainNone,
+				},
+				{
+					"deploymentUID":            "ext-appdb-om-backup-uniform-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     "OpsManager",
+					"IsRunningEnterpriseImage": true,
+					"externalAppDB":            "MongoDB",
+					"appDBBackupMode":          "disabled",
+					"externalDomains":          ExternalDomainUniform,
+				},
+				{
+					"deploymentUID":            "ext-appdb-om-mdbm-clusters-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     "OpsManager",
+					"IsRunningEnterpriseImage": true,
+					"externalAppDB":            "MongoDBMultiCluster",
+					"appDBBackupMode":          "enabled",
+					"externalDomains":          ExternalDomainNone,
+					"appDBClusters":            float64(3),
+				},
+				{
+					"deploymentUID":            "ext-appdb-mdbm-mixed-terminated-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           true,
+					"type":                     string(mdbv1.ReplicaSet),
+					"IsRunningEnterpriseImage": false,
+					"externalDomains":          ExternalDomainMixed,
+					"customRoles":              CustomRoleNone,
+					"databaseClusters":         float64(2),
+				},
+				{
+					"deploymentUID":            "ext-appdb-om-mdbm-mixed-terminated-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     "OpsManager",
+					"IsRunningEnterpriseImage": true,
+					"externalAppDB":            "MongoDBMultiCluster",
+					"appDBBackupMode":          "terminated",
+					"externalDomains":          ExternalDomainMixed,
+					"appDBClusters":            float64(2),
+				},
+				{
+					"deploymentUID":            "ext-appdb-om-not-found-uid",
+					"operatorID":               testOperatorUUID,
+					"architecture":             string(architectures.NonStatic),
+					"isMultiCluster":           false,
+					"type":                     "OpsManager",
+					"IsRunningEnterpriseImage": true,
+					"externalAppDB":            "MongoDB",
+				},
+			},
+		},
 		"custom roles test": {
 			objects: []client.Object{
 				&mdbv1.MongoDB{

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -951,6 +951,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbv1.MongoDbSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
+							Role:         "AppDB",
 							Backup: &mdbv1.Backup{
 								Mode: "enabled",
 							},
@@ -980,6 +981,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbv1.MongoDbSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
+							Role:         "AppDB",
 							ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
 								ExternalDomain: ptr.To("some.custom.domain"),
 							},
@@ -1012,6 +1014,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbmulti.MongoDBMultiSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
+							Role:         "AppDB",
 							Backup: &mdbv1.Backup{
 								Mode: "enabled",
 							},
@@ -1046,6 +1049,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					Spec: mdbmulti.MongoDBMultiSpec{
 						DbCommonSpec: mdbv1.DbCommonSpec{
 							ResourceType: mdbv1.ReplicaSet,
+							Role:         "AppDB",
 							ExternalAccessConfiguration: &mdbv1.ExternalAccessConfiguration{
 								ExternalDomain: ptr.To("some.default.domain"),
 							},
@@ -1096,6 +1100,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 			expectedEventsWithProperties: []map[string]any{
 				{
 					"deploymentUID":            "ext-appdb-mdb-backup-none-uid",
+					"role":                     "AppDB",
 					"operatorID":               testOperatorUUID,
 					"architecture":             string(architectures.NonStatic),
 					"isMultiCluster":           false,
@@ -1103,9 +1108,11 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					"IsRunningEnterpriseImage": false,
 					"externalDomains":          ExternalDomainNone,
 					"customRoles":              CustomRoleNone,
+					"authenticationModeSCRAM":  true,
 				},
 				{
 					"deploymentUID":            "ext-appdb-mdb-backup-uniform-uid",
+					"role":                     "AppDB",
 					"operatorID":               testOperatorUUID,
 					"architecture":             string(architectures.NonStatic),
 					"isMultiCluster":           false,
@@ -1113,9 +1120,11 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 					"IsRunningEnterpriseImage": false,
 					"externalDomains":          ExternalDomainUniform,
 					"customRoles":              CustomRoleNone,
+					"authenticationModeSCRAM":  true,
 				},
 				{
 					"deploymentUID":            "ext-appdb-mdbm-clusters-uid",
+					"role":                     "AppDB",
 					"operatorID":               testOperatorUUID,
 					"architecture":             string(architectures.NonStatic),
 					"isMultiCluster":           true,
@@ -1161,6 +1170,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				},
 				{
 					"deploymentUID":            "ext-appdb-mdbm-mixed-terminated-uid",
+					"role":                     "AppDB",
 					"operatorID":               testOperatorUUID,
 					"architecture":             string(architectures.NonStatic),
 					"isMultiCluster":           true,

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -966,7 +966,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				&omv1.MongoDBOpsManager{
 					Spec: omv1.MongoDBOpsManagerSpec{
 						Topology: "Single",
-						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+						ExternalAppDBRef: &omv1.ExternalAppDBRef{
 							Name: "om-ext-appdb-backup-none-db",
 							Kind: "MongoDB",
 						},
@@ -999,7 +999,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				&omv1.MongoDBOpsManager{
 					Spec: omv1.MongoDBOpsManagerSpec{
 						Topology: "Single",
-						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+						ExternalAppDBRef: &omv1.ExternalAppDBRef{
 							Name: "om-ext-appdb-backup-uniform-db",
 							Kind: "MongoDB",
 						},
@@ -1034,7 +1034,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				&omv1.MongoDBOpsManager{
 					Spec: omv1.MongoDBOpsManagerSpec{
 						Topology: "Single",
-						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+						ExternalAppDBRef: &omv1.ExternalAppDBRef{
 							Name: "om-ext-appdb-mdbm-clusters-db",
 							Kind: "MongoDBMultiCluster",
 						},
@@ -1071,7 +1071,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				&omv1.MongoDBOpsManager{
 					Spec: omv1.MongoDBOpsManagerSpec{
 						Topology: "Single",
-						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+						ExternalAppDBRef: &omv1.ExternalAppDBRef{
 							Name: "om-ext-appdb-mdbm-mixed-terminated-db",
 							Kind: "MongoDBMultiCluster",
 						},
@@ -1085,7 +1085,7 @@ func TestCollectDeploymentsSnapshot(t *testing.T) {
 				&omv1.MongoDBOpsManager{
 					Spec: omv1.MongoDBOpsManagerSpec{
 						Topology: "Single",
-						ExternalApplicationDatabaseRef: &omv1.ExternalApplicationDatabaseRef{
+						ExternalAppDBRef: &omv1.ExternalAppDBRef{
 							Name: "non-existent-db",
 							Kind: "MongoDB",
 						},

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -46,6 +46,7 @@ type DeploymentUsageSnapshotProperties struct {
 	AppDBClusters            *int     `json:"appDBClusters,omitempty"`
 	AppDBBackupMode          string   `json:"appDBBackupMode,omitempty"`
 	ExternalAppDB            string   `json:"externalAppDB,omitempty"`
+	Role                     string   `json:"role,omitempty"`
 	OmClusters               *int     `json:"OmClusters,omitempty"`
 	DeploymentUID            string   `json:"deploymentUID"`
 	OperatorID               string   `json:"operatorID"`

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -44,6 +44,8 @@ func (p KubernetesClusterUsageSnapshotProperties) ConvertToFlatMap() (map[string
 type DeploymentUsageSnapshotProperties struct {
 	DatabaseClusters         *int     `json:"databaseClusters,omitempty"` // pointers allow us to not send that value if it's not set.
 	AppDBClusters            *int     `json:"appDBClusters,omitempty"`
+	AppDBBackupMode          string   `json:"appDBBackupMode,omitempty"`
+	ExternalAppDB            string   `json:"externalAppDB,omitempty"`
 	OmClusters               *int     `json:"OmClusters,omitempty"`
 	DeploymentUID            string   `json:"deploymentUID"`
 	OperatorID               string   `json:"operatorID"`
@@ -51,8 +53,8 @@ type DeploymentUsageSnapshotProperties struct {
 	IsMultiCluster           bool     `json:"isMultiCluster"`
 	Type                     string   `json:"type"` // RS, SC, OM, Single
 	IsRunningEnterpriseImage bool     `json:"IsRunningEnterpriseImage"`
-	ExternalDomains          string   `json:"externalDomains"`                   // None, Uniform, ClusterSpecific, Mixed
-	CustomRoles              string   `json:"customRoles,omitempty"`             // Custom roles used 	// None, Uniform, ClusterSpecific, Mixed
+	ExternalDomains          string   `json:"externalDomains,omitempty"`         // None, Uniform, ClusterSpecific, Mixed
+	CustomRoles              string   `json:"customRoles,omitempty"`             // Custom roles used: None, Embedded, Referenced
 	AuthenticationAgentMode  string   `json:"authenticationAgentMode,omitempty"` // Agent authentication mode
 	AuthenticationModes      []string `json:"-"`                                 // Deployment authentication modes
 }

--- a/pkg/telemetry/types_test.go
+++ b/pkg/telemetry/types_test.go
@@ -47,6 +47,7 @@ func TestSearchDeploymentUsageSnapshotProperties_ConvertToFlatMap(t *testing.T) 
 			AppDBBackupMode:          "enabled",
 			ExternalAppDB:            "MongoDB",
 			OmClusters:               &omClusters,
+			Role:                     "AppDB",
 			DeploymentUID:            "test-deployment-uid",
 			OperatorID:               "test-operator-id",
 			Architecture:             "amd64",

--- a/pkg/telemetry/types_test.go
+++ b/pkg/telemetry/types_test.go
@@ -44,6 +44,8 @@ func TestSearchDeploymentUsageSnapshotProperties_ConvertToFlatMap(t *testing.T) 
 		DeploymentUsageSnapshotProperties: DeploymentUsageSnapshotProperties{
 			DatabaseClusters:         &databaseClusters,
 			AppDBClusters:            &appDBClusters,
+			AppDBBackupMode:          "enabled",
+			ExternalAppDB:            "MongoDB",
 			OmClusters:               &omClusters,
 			DeploymentUID:            "test-deployment-uid",
 			OperatorID:               "test-operator-id",


### PR DESCRIPTION
# Summary

Adds telemetry support for the ExternalAppDB feature. When an OpsManager references an external MongoDB/MongoDBMultiCluster resource as its AppDB, the deployment usage snapshot now reports the referenced resource kind, backup mode, external domain configuration, and cluster count.

**New telemetry fields** (`pkg/telemetry/types.go`):
- `externalAppDB` — the kind of the referenced external AppDB resource (`MongoDB` or `MongoDBMultiCluster`); empty for internally-managed AppDB
- `appDBBackupMode` — the backup mode (`enabled`/`disabled`/`terminated`) read from the referenced CR's `spec.backup.mode`; empty when no backup spec is set

**Updated telemetry fields**:
- `externalDomains` — now `omitempty` (was always sent, even when empty); for external AppDB, resolved from the referenced CR instead of the OM's internal `AppDBSpec`
- `appDBClusters` — for external AppDB of kind `MongoDBMultiCluster`, now reports the referenced CR's `ClusterSpecList` length

**Refactoring** (`pkg/telemetry/collector.go`):
- Extracted `getAppDBProperties` / `resolveExternalAppDBProperties` to centralize AppDB property resolution for both internal and external cases
- Extracted `getExternalDomainGeneric` to deduplicate the uniform-vs-cluster-specific domain logic across MongoDB, MongoDBMulti, and AppDB variants
- Renamed `getExternalDomainProperty` → `getExternalDomainPropertyForMongoDB` for consistency with the other variants
- Replaced `ptr.To(x)` with `&x` (removes `k8s.io/utils/ptr` dependency; fixes staticcheck SA4006)

## Proof of Work

- `pkg/telemetry/collector_test.go` — new `"external appdb test"` table case in `TestCollectDeploymentsSnapshot` covering:
  - MongoDB ref with backup enabled, no external domain
  - MongoDB ref with backup disabled, uniform external domain
  - MongoDBMultiCluster ref with backup enabled, 3 clusters, no external domain
  - MongoDBMultiCluster ref with backup terminated, mixed external domains (uniform + cluster-specific), 2 clusters
  - MongoDB ref not found (error path — only `externalAppDB` set, remaining fields omitted via `omitempty`)
- `pkg/telemetry/types_test.go` — updated `TestSearchDeploymentUsageSnapshotProperties_ConvertToFlatMap` fixture to set `AppDBBackupMode` and `ExternalAppDB` so the reflection-based key check passes for the new `omitempty` fields.
- `go test ./pkg/telemetry/... -v -count=1` — all 9 test functions pass.
- `go test ./...` — full suite, zero failures.
- `make precommit` — clean (golangci-lint, ty, all hooks pass).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details