### PR TITLE
Generate MongoDB and MongoDBUser CRs in migrate-to-mck

### DIFF
--- a/api/mongodb/v1/mdb/mongodb_types.go
+++ b/api/mongodb/v1/mdb/mongodb_types.go
@@ -1690,38 +1690,96 @@ func (m *MongoDB) ObjectKey() client.ObjectKey {
 	return kube.ObjectKey(m.Namespace, m.Name)
 }
 
+// ldapFieldMapping holds both directions of a single field conversion so they stay co-located.
+type ldapFieldMapping struct {
+	toAC func(*Ldap, *ldap.Ldap)
+	toCR func(*ldap.Ldap, *Ldap)
+}
+
+// ldapField creates a bidirectional mapping for fields that copy directly between CR and AC.
+func ldapField[T any](getCR func(*Ldap) *T, getAC func(*ldap.Ldap) *T) ldapFieldMapping {
+	return ldapFieldMapping{
+		toAC: func(c *Ldap, a *ldap.Ldap) { *getAC(a) = *getCR(c) },
+		toCR: func(a *ldap.Ldap, c *Ldap) { *getCR(c) = *getAC(a) },
+	}
+}
+
+// ldapCustomField creates a bidirectional mapping for fields that require custom conversion logic.
+func ldapCustomField(toAC func(*Ldap, *ldap.Ldap), toCR func(*ldap.Ldap, *Ldap)) ldapFieldMapping {
+	return ldapFieldMapping{toAC: toAC, toCR: toCR}
+}
+
+var ldapFieldMappings = []ldapFieldMapping{
+	// Simple fields: same type, direct copy.
+	ldapField(func(c *Ldap) *string { return &c.BindQueryUser }, func(a *ldap.Ldap) *string { return &a.BindQueryUser }),
+	ldapField(func(c *Ldap) *string { return &c.AuthzQueryTemplate }, func(a *ldap.Ldap) *string { return &a.AuthzQueryTemplate }),
+	ldapField(func(c *Ldap) *string { return &c.UserToDNMapping }, func(a *ldap.Ldap) *string { return &a.UserToDnMapping }),
+	ldapField(func(c *Ldap) *int { return &c.TimeoutMS }, func(a *ldap.Ldap) *int { return &a.TimeoutMS }),
+	ldapField(func(c *Ldap) *int { return &c.UserCacheInvalidationInterval }, func(a *ldap.Ldap) *int { return &a.UserCacheInvalidationInterval }),
+
+	// Fields requiring custom conversion logic.
+	ldapCustomField(
+		func(c *Ldap, a *ldap.Ldap) {
+			a.ValidateLDAPServerConfig = true
+			if c.ValidateLDAPServerConfig != nil {
+				a.ValidateLDAPServerConfig = *c.ValidateLDAPServerConfig
+			}
+		},
+		func(a *ldap.Ldap, c *Ldap) { c.ValidateLDAPServerConfig = &a.ValidateLDAPServerConfig },
+	),
+	ldapCustomField(
+		func(c *Ldap, a *ldap.Ldap) { a.Servers = strings.Join(c.Servers, ",") },
+		func(a *ldap.Ldap, c *Ldap) {
+			if a.Servers == "" {
+				return
+			}
+			parts := strings.Split(a.Servers, ",")
+			for i := range parts {
+				parts[i] = strings.TrimSpace(parts[i])
+			}
+			c.Servers = parts
+		},
+	),
+	ldapCustomField(
+		func(c *Ldap, a *ldap.Ldap) { a.TransportSecurity = string(GetTransportSecurity(c)) },
+		func(a *ldap.Ldap, c *Ldap) {
+			if a.TransportSecurity != "" {
+				ts := TransportSecurity(a.TransportSecurity)
+				c.TransportSecurity = &ts
+			}
+		},
+	),
+}
+
+// GetLDAP converts the CR LDAP spec to the AC representation. See ConvertACLdapToCR for the reverse.
 func (m *MongoDB) GetLDAP(password, caContents string) *ldap.Ldap {
 	if !m.IsLDAPEnabled() {
 		return nil
 	}
-
 	mdbLdap := m.Spec.Security.Authentication.Ldap
-	transportSecurity := GetTransportSecurity(mdbLdap)
-
-	validateServerConfig := true
-	if mdbLdap.ValidateLDAPServerConfig != nil {
-		validateServerConfig = *mdbLdap.ValidateLDAPServerConfig
-	}
-
-	return &ldap.Ldap{
-		BindQueryUser:            mdbLdap.BindQueryUser,
-		BindQueryPassword:        password,
-		Servers:                  strings.Join(mdbLdap.Servers, ","),
-		TransportSecurity:        string(transportSecurity),
-		CaFileContents:           caContents,
-		ValidateLDAPServerConfig: validateServerConfig,
-
-		// Related to LDAP Authorization
-		AuthzQueryTemplate: mdbLdap.AuthzQueryTemplate,
-		UserToDnMapping:    mdbLdap.UserToDNMapping,
-
-		// TODO: Enable LDAP SASL bind method
-		BindMethod:         "simple",
+	ac := &ldap.Ldap{
+		BindQueryPassword:  password,
+		CaFileContents:     caContents,
+		BindMethod:         "simple", // TODO: Enable LDAP SASL bind method
 		BindSaslMechanisms: "",
-
-		TimeoutMS:                     mdbLdap.TimeoutMS,
-		UserCacheInvalidationInterval: mdbLdap.UserCacheInvalidationInterval,
 	}
+	for _, f := range ldapFieldMappings {
+		f.toAC(mdbLdap, ac)
+	}
+	return ac
+}
+
+// ConvertACLdapToCR converts an AC LDAP config to the CR representation. See GetLDAP for the reverse.
+// BindQuerySecretRef and CAConfigMapRef must be set by the caller — they reference K8s resources not present in the AC.
+func ConvertACLdapToCR(l *ldap.Ldap) *Ldap {
+	if l == nil {
+		return nil
+	}
+	cr := &Ldap{}
+	for _, f := range ldapFieldMappings {
+		f.toCR(l, cr)
+	}
+	return cr
 }
 
 // ExternalAccessConfiguration holds the custom Service override that will be merged into the operator created one.

--- a/api/mongodb/v1/user/mongodbuser_types.go
+++ b/api/mongodb/v1/user/mongodbuser_types.go
@@ -3,11 +3,9 @@ package user
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"golang.org/x/xerrors"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +13,7 @@ import (
 	v1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/secrets"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/vault"
 )
 
@@ -166,34 +165,12 @@ func (u MongoDBUser) GetConnectionStringSecretName() string {
 		database = strings.TrimPrefix(database, "$")
 	}
 
-	return normalizeName(fmt.Sprintf("%s%s-%s", resourceRef, u.Name, database))
+	return NormalizeName(fmt.Sprintf("%s%s-%s", resourceRef, u.Name, database))
 }
 
-// normalizeName returns a string that conforms to RFC-1123.
-// This logic is duplicated in the community operator in https://github.com/mongodb/mongodb-kubernetes/mongodb-community-operator/blob/master/api/v1/mongodbcommunity_types.go.
-// The logic should be reused if/when we unify the user types or observe that the logic needs to be changed for business logic reasons, to avoid modifying it
-// in separate places in the future.
-func normalizeName(name string) string {
-	errors := validation.IsDNS1123Subdomain(name)
-	if len(errors) == 0 {
-		return name
-	}
-
-	// convert name to lowercase and replace invalid characters with '-'
-	name = strings.ToLower(name)
-	re := regexp.MustCompile("[^a-z0-9-]+")
-	name = re.ReplaceAllString(name, "-")
-
-	// Remove duplicate `-` resulting from contiguous non-allowed chars.
-	re = regexp.MustCompile(`\-+`)
-	name = re.ReplaceAllString(name, "-")
-
-	name = strings.Trim(name, "-")
-
-	if len(name) > validation.DNS1123SubdomainMaxLength {
-		name = name[0:validation.DNS1123SubdomainMaxLength]
-	}
-	return name
+// NormalizeName returns a string that conforms to RFC-1123.
+func NormalizeName(name string) string {
+	return util.NormalizeName(name)
 }
 
 func (u *MongoDBUser) SetWarnings(warnings []status.Warning, _ ...status.Option) {

--- a/cmd/kubectl-mongodb/migrate-to-mck/command.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/command.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
-	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 )
 
 const defaultNamespace = "default"

--- a/cmd/kubectl-mongodb/migrate-to-mck/command.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/command.go
@@ -1,16 +1,25 @@
 package migratetomck
 
 import (
+	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 )
 
 const defaultNamespace = "default"
+
+// promptOutput is the writer used for interactive prompts. Override in tests to suppress stderr noise.
+var promptOutput io.Writer = os.Stderr
 
 var MigrateCmd = &cobra.Command{
 	Use:   "migrate-to-mck",
@@ -53,4 +62,69 @@ func printValidationResults(w io.Writer, results []ValidationResult) int {
 		_, _ = fmt.Fprintf(w, "[%s] %s\n\n", r.Severity, r.Message)
 	}
 	return errorCount
+}
+
+func writeOutput(resources, outputFile string) error {
+	if outputFile == "" {
+		_, err := fmt.Fprint(os.Stdout, resources)
+		return err
+	}
+	f, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open output file %q: %w", outputFile, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := fmt.Fprint(f, resources); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "CRs written to %s\n", outputFile)
+	return nil
+}
+
+// requirePasswordSecret fetches secretName and returns its "password" key bytes.
+// Returns an error if the secret does not exist or is missing the key.
+func requirePasswordSecret(ctx context.Context, kubeClient kubernetesClient.Client, namespace, secretName string) ([]byte, error) {
+	secret, err := kubeClient.GetSecret(ctx, kube.ObjectKey(namespace, secretName))
+	if err != nil {
+		return nil, fmt.Errorf("secret %q not found in namespace %q: %w", secretName, namespace, err)
+	}
+	passwordBytes, ok := secret.Data[passwordSecretDataKey]
+	if !ok {
+		return nil, fmt.Errorf("secret %q does not contain key \"password\"", secretName)
+	}
+	return passwordBytes, nil
+}
+
+// promptKubernetesName prompts for a Kubernetes DNS name, re-prompting on empty or invalid input.
+// If suggested is non-empty it is used as the default when the user presses Enter.
+func promptKubernetesName(scanner *bufio.Scanner, prompt, suggested string) (string, error) {
+	for {
+		p, err := promptLine(scanner, prompt)
+		if err != nil {
+			return "", err
+		}
+		if p == "" {
+			if suggested != "" {
+				return suggested, nil
+			}
+			_, _ = fmt.Fprintln(promptOutput, "Value cannot be empty, please try again.")
+			continue
+		}
+		if errs := k8svalidation.IsDNS1123Subdomain(p); len(errs) > 0 {
+			_, _ = fmt.Fprintf(promptOutput, "%q is not a valid Kubernetes name: %s. Please try again.\n", p, errs[0])
+			continue
+		}
+		return p, nil
+	}
+}
+
+func promptLine(scanner *bufio.Scanner, prompt string) (string, error) {
+	_, _ = fmt.Fprint(promptOutput, prompt)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("input cancelled")
+	}
+	return strings.TrimSpace(scanner.Text()), nil
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/command_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/command_test.go
@@ -2,6 +2,7 @@ package migratetomck
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,12 +11,16 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 )
 
+func init() {
+	promptOutput = io.Discard
+}
+
 func TestFetchAndValidate_ValidDeployment(t *testing.T) {
 	d := om.Deployment(map[string]any{
 		"processes": []any{
 			map[string]any{
 				"name":        "host-0",
-				"processType": "mongod",
+				"processType": string(om.ProcessTypeMongod),
 				"hostname":    "host-0.example.com",
 				"args2_6": map[string]any{
 					"net":         map[string]any{"port": 27017},

--- a/cmd/kubectl-mongodb/migrate-to-mck/common_spec.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/common_spec.go
@@ -7,10 +7,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	mdbcv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 	authn "github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
-	mdbcv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )

--- a/cmd/kubectl-mongodb/migrate-to-mck/common_spec.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/common_spec.go
@@ -221,8 +221,9 @@ func applyClientCertificateMode(agentSSL *om.AgentSSL, additionalConfig *mdbv1.A
 	return additionalConfig
 }
 
-// extractAgentConfig builds spec.agent from project-level log rotation and the source process systemLog.
-func extractAgentConfig(sourceProcess *om.Process, projectConfigs *ProjectConfigs) mdbv1.AgentConfig {
+// extractAgentConfig builds spec.agent from project-level log rotation.
+// The source process systemLog is deliberately NOT carried over.
+func extractAgentConfig(projectConfigs *ProjectConfigs) mdbv1.AgentConfig {
 	var agentConfig mdbv1.AgentConfig
 	if projectConfigs != nil {
 		if lr := projectConfigs.SystemLogRotate; lr != nil && (lr.SizeThresholdMB != 0 || lr.TimeThresholdHrs != 0) {
@@ -233,9 +234,6 @@ func extractAgentConfig(sourceProcess *om.Process, projectConfigs *ProjectConfig
 		}
 		agentConfig.MonitoringAgent.LogRotate = om.LogRotateForAgentsFromAc(projectConfigs.SystemLogRotate)
 		agentConfig.BackupAgent.LogRotate = om.LogRotateForAgentsFromAc(projectConfigs.SystemLogRotate)
-	}
-	if sourceProcess != nil {
-		agentConfig.Mongod.SystemLog = automationconfig.SystemLogFromMap(sourceProcess.SystemLogMap())
 	}
 	return agentConfig
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/common_spec.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/common_spec.go
@@ -1,0 +1,241 @@
+package migratetomck
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	authn "github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
+	mdbcv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
+	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+// buildSecurity assembles spec.security. certsSecretPrefix non-empty means TLS is enabled
+// (set by ensureTLS, mirrors the operator's IsSecurityTLSConfigEnabled).
+func buildSecurity(ac *om.AutomationConfig, certsSecretPrefix, resourceName string) (*mdbv1.Security, error) {
+	security := &mdbv1.Security{}
+	hasSettings := false
+
+	if certsSecretPrefix != "" {
+		// certsSecretPrefix enables TLS (tls.enabled is deprecated, see RELEASE_NOTES_MEKO.md 1.15).
+		security.CertificatesSecretsPrefix = certsSecretPrefix
+		// Explicitly set the CA ConfigMap to the operator default "<resourceName>-ca" (see database_volumes.go).
+		security.TLSConfig = &mdbv1.TLSConfig{CA: fmt.Sprintf("%s-ca", resourceName)}
+		hasSettings = true
+	}
+
+	if ac.Auth != nil && ac.Auth.IsEnabled() {
+		authConfig, err := buildAuthenticationConfig(ac)
+		if err != nil {
+			return nil, err
+		}
+		if authConfig != nil {
+			security.Authentication = authConfig
+			hasSettings = true
+		}
+	}
+
+	if !hasSettings {
+		return nil, nil
+	}
+	return security, nil
+}
+
+func buildAuthenticationConfig(ac *om.AutomationConfig) (*mdbv1.Authentication, error) {
+	auth := ac.Auth
+	processMap := ac.Deployment.ProcessMap()
+	members := ac.Deployment.GetReplicaSets()[0].Members()
+	modes, err := buildAuthModes(auth)
+	if err != nil {
+		return nil, err
+	}
+	if len(modes) == 0 {
+		return nil, nil
+	}
+
+	authConfig := &mdbv1.Authentication{
+		Enabled:            true,
+		Modes:              modes,
+		IgnoreUnknownUsers: !auth.AuthoritativeSet,
+	}
+
+	// Empty result means keyFile (the implicit default); only set when explicitly x509.
+	internalCluster, err := extractInternalClusterAuthMode(processMap, members)
+	if err != nil {
+		return nil, err
+	}
+	if internalCluster != "" {
+		authConfig.InternalCluster = internalCluster
+	}
+
+	if ac.Ldap != nil && (ac.Ldap.Servers != "" || ac.Ldap.BindQueryUser != "") {
+		cr := mdbv1.ConvertACLdapToCR(ac.Ldap)
+		if ac.Ldap.BindQueryUser != "" {
+			cr.BindQuerySecretRef = mdbv1.SecretRef{Name: LdapBindQuerySecretName}
+		}
+		if ac.Ldap.CaFileContents != "" {
+			cr.CAConfigMapRef = &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: LdapCAConfigMapName},
+				Key:                  LdapCAKey,
+			}
+		}
+		authConfig.Ldap = cr
+	}
+
+	if crOIDC := authn.MapACOIDCToProviderConfigs(ac.OIDCProviderConfigs); len(crOIDC) > 0 {
+		authConfig.OIDCProviderConfigs = crOIDC
+	}
+
+	if agentMode, ok := authn.MapMechanismToAuthMode(auth.AutoAuthMechanism); ok {
+		authConfig.Agents.Mode = agentMode
+	}
+
+	if auth.AutoUser != "" && auth.AutoUser != util.AutomationAgentUserName {
+		authConfig.Agents.AutomationUserName = auth.AutoUser
+	}
+
+	if ac.AgentSSL != nil && ac.AgentSSL.AutoPEMKeyFilePath != "" {
+		authConfig.Agents.AutoPEMKeyFilePath = ac.AgentSSL.AutoPEMKeyFilePath
+	}
+
+	return authConfig, nil
+}
+
+// buildAuthModes deduplicates deploymentAuthMechanisms and autoAuthMechanisms into CR auth modes.
+func buildAuthModes(auth *om.Auth) ([]mdbv1.AuthMode, error) {
+	seen := map[mdbv1.AuthMode]bool{}
+	var modes []mdbv1.AuthMode
+
+	collect := func(mechs []string, source string) error {
+		for _, mech := range mechs {
+			mode, ok := authn.MapMechanismToAuthMode(mech)
+			if !ok {
+				return fmt.Errorf("unsupported authentication mechanism %q in automation config (%s)", mech, source)
+			}
+			authMode := mdbv1.AuthMode(mode)
+			if !seen[authMode] {
+				modes = append(modes, authMode)
+				seen[authMode] = true
+			}
+		}
+		return nil
+	}
+
+	if err := collect(auth.DeploymentAuthMechanisms, "deploymentAuthMechanisms"); err != nil {
+		return nil, err
+	}
+	if err := collect(auth.AutoAuthMechanisms, "autoAuthMechanisms"); err != nil {
+		return nil, err
+	}
+
+	return modes, nil
+}
+
+// extractInternalClusterAuthMode maps the first member's clusterAuthMode to the CR internalCluster field.
+func extractInternalClusterAuthMode(processMap map[string]om.Process, members []om.ReplicaSetMember) (string, error) {
+	for i, m := range members {
+		host := m.Name()
+		proc, ok := processMap[host]
+		if !ok {
+			return "", fmt.Errorf("process %q referenced by member at index %d was not found", host, i)
+		}
+		if proc.HasInternalClusterAuthentication() {
+			return mapClusterAuthMode(proc.ClusterAuthMode())
+		}
+	}
+	return "", nil
+}
+
+func mapClusterAuthMode(mode string) (string, error) {
+	switch mode {
+	case "x509":
+		return util.X509, nil
+	case "keyFile":
+		// keyFile is the default internal cluster auth when auth is enabled;
+		// the operator uses it implicitly, so no explicit CR field is needed.
+		return "", nil
+	default:
+		return "", fmt.Errorf("unsupported clusterAuthMode %q in automation config", mode)
+	}
+}
+
+// extractPrometheusConfig builds spec.prometheus from the deployment's Prometheus section.
+func extractPrometheusConfig(d om.Deployment) (*mdbcv1.Prometheus, error) {
+	acProm := d.GetPrometheus()
+	if acProm == nil || !acProm.Enabled {
+		return nil, nil
+	}
+
+	if acProm.Username == "" {
+		return nil, fmt.Errorf("prometheus is enabled but has no username configured")
+	}
+
+	prom := &mdbcv1.Prometheus{
+		Username: acProm.Username,
+		PasswordSecretRef: mdbcv1.SecretKeyReference{
+			Name: PrometheusPasswordSecretName,
+			Key:  passwordSecretDataKey,
+		},
+	}
+
+	if acProm.ListenAddress != "" {
+		s := acProm.ListenAddress
+		if i := strings.LastIndex(acProm.ListenAddress, ":"); i >= 0 {
+			s = acProm.ListenAddress[i+1:]
+		}
+		port, err := strconv.Atoi(s)
+		if err != nil || port <= 0 {
+			return nil, fmt.Errorf("prometheus listenAddress %q does not contain a valid port: %v", acProm.ListenAddress, err)
+		}
+		prom.Port = port
+	}
+
+	if acProm.MetricsPath != "" && acProm.MetricsPath != "/metrics" {
+		prom.MetricsPath = acProm.MetricsPath
+	}
+
+	if acProm.Scheme == "https" {
+		prom.TLSSecretRef = mdbcv1.SecretKeyReference{Name: PrometheusTLSSecretName}
+	}
+
+	return prom, nil
+}
+
+// applyClientCertificateMode sets net.tls.allowConnectionsWithoutCertificates to false when the
+// Ops Manager AgentSSL requires client certificates (clientCertificateMode: REQUIRE), preserving
+// that setting in the generated CR's additionalMongodConfig. The OPTIONAL case is the operator
+// default and needs no explicit field.
+func applyClientCertificateMode(agentSSL *om.AgentSSL, additionalConfig *mdbv1.AdditionalMongodConfig) *mdbv1.AdditionalMongodConfig {
+	if agentSSL == nil || agentSSL.ClientCertificateMode != util.RequireClientCertificates {
+		return additionalConfig
+	}
+	if additionalConfig == nil {
+		additionalConfig = mdbv1.NewEmptyAdditionalMongodConfig()
+	}
+	additionalConfig.AddOption("net.tls.allowConnectionsWithoutCertificates", false)
+	return additionalConfig
+}
+
+// extractAgentConfig builds spec.agent from project-level log rotation and the source process systemLog.
+func extractAgentConfig(sourceProcess *om.Process, projectConfigs *ProjectConfigs) mdbv1.AgentConfig {
+	var agentConfig mdbv1.AgentConfig
+	if projectConfigs != nil {
+		if lr := projectConfigs.SystemLogRotate; lr != nil && (lr.SizeThresholdMB != 0 || lr.TimeThresholdHrs != 0) {
+			agentConfig.Mongod.LogRotate = automationconfig.ConvertACLogRotateToCrd(lr)
+		}
+		if alr := projectConfigs.AuditLogRotate; alr != nil && (alr.SizeThresholdMB != 0 || alr.TimeThresholdHrs != 0) {
+			agentConfig.Mongod.AuditLogRotate = automationconfig.ConvertACLogRotateToCrd(alr)
+		}
+		agentConfig.MonitoringAgent.LogRotate = om.LogRotateForAgentsFromAc(projectConfigs.SystemLogRotate)
+		agentConfig.BackupAgent.LogRotate = om.LogRotateForAgentsFromAc(projectConfigs.SystemLogRotate)
+	}
+	if sourceProcess != nil {
+		agentConfig.Mongod.SystemLog = automationconfig.SystemLogFromMap(sourceProcess.SystemLogMap())
+	}
+	return agentConfig
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/common_spec_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/common_spec_test.go
@@ -1,0 +1,1035 @@
+package migratetomck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	authn "github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/ldap"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/oidc"
+	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
+	pkgtls "github.com/mongodb/mongodb-kubernetes/pkg/tls"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
+)
+
+func TestBuildAuthModes_FromDeploymentAuthMechanisms(t *testing.T) {
+	tests := []struct {
+		name     string
+		mechs    []string
+		expected []mdbv1.AuthMode
+	}{
+		{
+			name:     "SCRAM-SHA-256",
+			mechs:    []string{"SCRAM-SHA-256"},
+			expected: []mdbv1.AuthMode{"SCRAM"},
+		},
+		{
+			name:     "SCRAM-SHA-1",
+			mechs:    []string{"SCRAM-SHA-1"},
+			expected: []mdbv1.AuthMode{"SCRAM-SHA-1"},
+		},
+		{
+			name:     "MONGODB-CR",
+			mechs:    []string{"MONGODB-CR"},
+			expected: []mdbv1.AuthMode{"MONGODB-CR"},
+		},
+		{
+			name:     "X509",
+			mechs:    []string{"MONGODB-X509"},
+			expected: []mdbv1.AuthMode{"X509"},
+		},
+		{
+			name:     "LDAP from PLAIN",
+			mechs:    []string{"PLAIN"},
+			expected: []mdbv1.AuthMode{"LDAP"},
+		},
+		{
+			name:     "OIDC from MONGODB-OIDC",
+			mechs:    []string{"MONGODB-OIDC"},
+			expected: []mdbv1.AuthMode{"OIDC"},
+		},
+		{
+			name:     "multiple mechanisms",
+			mechs:    []string{"SCRAM-SHA-256", "MONGODB-X509"},
+			expected: []mdbv1.AuthMode{"SCRAM", "X509"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &om.Auth{DeploymentAuthMechanisms: tt.mechs}
+			modes, err := buildAuthModes(auth)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, modes)
+		})
+	}
+}
+
+func TestBuildAuthModes_UnknownMechanism(t *testing.T) {
+	auth := &om.Auth{DeploymentAuthMechanisms: []string{"UNKNOWN-MECH"}}
+	_, err := buildAuthModes(auth)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported authentication mechanism")
+	assert.Contains(t, err.Error(), "UNKNOWN-MECH")
+}
+
+func TestBuildAuthModes_MergesAutoAndDeploymentMechanisms(t *testing.T) {
+	auth := &om.Auth{
+		DeploymentAuthMechanisms: []string{"SCRAM-SHA-256"},
+		AutoAuthMechanisms:       []string{"MONGODB-X509"},
+	}
+	modes, err := buildAuthModes(auth)
+	require.NoError(t, err)
+	assert.Equal(t, []mdbv1.AuthMode{"SCRAM", "X509"}, modes)
+}
+
+func TestBuildAuthModes_DeduplicatesMechanisms(t *testing.T) {
+	auth := &om.Auth{
+		DeploymentAuthMechanisms: []string{"SCRAM-SHA-256", "MONGODB-X509"},
+		AutoAuthMechanisms:       []string{"SCRAM-SHA-256"},
+	}
+	modes, err := buildAuthModes(auth)
+	require.NoError(t, err)
+	assert.Equal(t, []mdbv1.AuthMode{"SCRAM", "X509"}, modes)
+}
+
+func TestBuildAuthModes_AutoOnlyMechanisms(t *testing.T) {
+	auth := &om.Auth{
+		AutoAuthMechanisms: []string{"SCRAM-SHA-256"},
+	}
+	modes, err := buildAuthModes(auth)
+	require.NoError(t, err)
+	assert.Equal(t, []mdbv1.AuthMode{"SCRAM"}, modes)
+}
+
+func TestBuildAuthModes_UnknownAutoMechanism(t *testing.T) {
+	auth := &om.Auth{
+		DeploymentAuthMechanisms: []string{"SCRAM-SHA-256"},
+		AutoAuthMechanisms:       []string{"UNKNOWN-AUTO"},
+	}
+	_, err := buildAuthModes(auth)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "autoAuthMechanisms")
+	assert.Contains(t, err.Error(), "UNKNOWN-AUTO")
+}
+
+func TestMapMechanismToAuthMode(t *testing.T) {
+	tests := []struct {
+		mech     string
+		expected string
+		ok       bool
+	}{
+		{"MONGODB-CR", "MONGODB-CR", true},
+		{"SCRAM-SHA-256", "SCRAM", true},
+		{"SCRAM-SHA-1", "SCRAM-SHA-1", true},
+		{"MONGODB-X509", "X509", true},
+		{"PLAIN", "LDAP", true},
+		{"MONGODB-OIDC", "OIDC", true},
+		{"UNKNOWN", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mech, func(t *testing.T) {
+			mode, ok := authn.MapMechanismToAuthMode(tt.mech)
+			assert.Equal(t, tt.ok, ok)
+			if ok {
+				assert.Equal(t, tt.expected, mode)
+			}
+		})
+	}
+}
+
+// testAC builds a minimal AutomationConfig for buildSecurity tests.
+func testAC(auth *om.Auth, processMap map[string]om.Process, members []om.ReplicaSetMember) *om.AutomationConfig {
+	processes := make([]interface{}, 0, len(processMap))
+	for name, proc := range processMap {
+		proc["name"] = name
+		processes = append(processes, map[string]interface{}(proc))
+	}
+	memberSlice := make([]interface{}, len(members))
+	for i, m := range members {
+		memberSlice[i] = map[string]interface{}(m)
+	}
+	var replicaSets []interface{}
+	if len(members) > 0 {
+		replicaSets = []interface{}{map[string]interface{}{"_id": "test-rs", "members": memberSlice}}
+	}
+	d := om.Deployment(map[string]interface{}{
+		"processes":   processes,
+		"replicaSets": replicaSets,
+	})
+	return &om.AutomationConfig{Auth: auth, Deployment: d}
+}
+
+func TestBuildSecurity_NilAuth(t *testing.T) {
+	ac := testAC(nil, nil, nil)
+	result, err := buildSecurity(ac, "", "")
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestBuildSecurity_AuthDisabled(t *testing.T) {
+	ac := testAC(&om.Auth{Disabled: true}, nil, nil)
+	result, err := buildSecurity(ac, "", "")
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestBuildSecurity_AuthEnabled(t *testing.T) {
+	ac := testAC(
+		&om.Auth{Disabled: false, DeploymentAuthMechanisms: []string{"SCRAM-SHA-256"}},
+		map[string]om.Process{"host-0": {}},
+		[]om.ReplicaSetMember{{"host": "host-0"}},
+	)
+	result, err := buildSecurity(ac, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Authentication)
+	assert.True(t, result.Authentication.Enabled)
+	assert.Equal(t, []mdbv1.AuthMode{"SCRAM"}, result.Authentication.Modes)
+}
+
+func TestBuildSecurity_TLSAndAuth(t *testing.T) {
+	ac := testAC(
+		&om.Auth{Disabled: false, DeploymentAuthMechanisms: []string{"MONGODB-X509"}},
+		map[string]om.Process{
+			"host-0": {
+				"args2_6": map[string]interface{}{
+					"net": map[string]interface{}{
+						"tls": map[string]interface{}{"mode": "requireTLS"},
+					},
+				},
+			},
+		},
+		[]om.ReplicaSetMember{{"host": "host-0"}},
+	)
+	result, err := buildSecurity(ac, "mdb", "my-rs")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "mdb", result.CertificatesSecretsPrefix, "TLS should be enabled via certsSecretPrefix (deprecated tls.enabled)")
+	assert.True(t, result.IsTLSEnabled())
+	require.NotNil(t, result.TLSConfig)
+	assert.Equal(t, "my-rs-ca", result.TLSConfig.CA, "TLS CA ConfigMap should default to <resourceName>-ca")
+	require.NotNil(t, result.Authentication)
+	assert.Equal(t, []mdbv1.AuthMode{"X509"}, result.Authentication.Modes)
+}
+
+// TestBuildSecurity_TLS_EmptyPrefix verifies that buildSecurity does not set TLS when certsSecretPrefix
+// is empty, regardless of the process config. The responsibility for ensuring the prefix is set when TLS
+// is detected lies with ensureTLS (which calls isTLSEnabled before buildSecurity is reached).
+func TestBuildSecurity_TLS_EmptyPrefix(t *testing.T) {
+	ac := testAC(nil, map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"tls": map[string]interface{}{"mode": "requireTLS"},
+				},
+			},
+		},
+	}, []om.ReplicaSetMember{{"host": "host-0"}})
+	result, err := buildSecurity(ac, "", "")
+	require.NoError(t, err)
+	assert.Nil(t, result, "expected no security config when certsSecretPrefix is empty")
+}
+
+func TestBuildSecurity_InternalClusterAuth(t *testing.T) {
+	ac := testAC(
+		&om.Auth{Disabled: false, DeploymentAuthMechanisms: []string{"SCRAM-SHA-256"}},
+		map[string]om.Process{
+			"host-0": {
+				"args2_6": map[string]interface{}{
+					"security": map[string]interface{}{
+						"clusterAuthMode": "x509",
+					},
+				},
+			},
+		},
+		[]om.ReplicaSetMember{{"host": "host-0"}},
+	)
+	result, err := buildSecurity(ac, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Authentication)
+	assert.Equal(t, "X509", result.Authentication.InternalCluster)
+}
+
+func TestExtractAdditionalMongodConfig_NonDefaultPort(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27018,
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	netMap, ok := m["net"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, 27018, netMap["port"])
+}
+
+func TestExtractAdditionalMongodConfig_DefaultPort(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	assert.Nil(t, config)
+}
+
+func TestExtractAdditionalMongodConfig_WiredTigerCache(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+				"storage": map[string]interface{}{
+					"wiredTiger": map[string]interface{}{
+						"engineConfig": map[string]interface{}{
+							"cacheSizeGB": 2.0,
+						},
+					},
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	storage, ok := m["storage"].(map[string]interface{})
+	require.True(t, ok)
+	wt, ok := storage["wiredTiger"].(map[string]interface{})
+	require.True(t, ok)
+	ec, ok := wt["engineConfig"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, 2.0, ec["cacheSizeGB"])
+}
+
+func TestExtractAdditionalMongodConfig_ZstdCompressionLevel(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{"port": 27017},
+				"storage": map[string]interface{}{
+					"wiredTiger": map[string]interface{}{
+						"engineConfig": map[string]interface{}{
+							"zstdCompressionLevel": 6,
+						},
+					},
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{{"host": "host-0"}}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	storage, ok := m["storage"].(map[string]interface{})
+	require.True(t, ok)
+	wt, ok := storage["wiredTiger"].(map[string]interface{})
+	require.True(t, ok)
+	ec, ok := wt["engineConfig"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, 6, ec["zstdCompressionLevel"])
+}
+
+func TestExtractAdditionalMongodConfig_WiredTigerConfigString(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]any{
+				"net": map[string]any{"port": 27017},
+				"storage": map[string]any{
+					"wiredTiger": map[string]any{
+						"engineConfig": map[string]any{
+							"configString": "builtin_extension_config=(zlib=(compression_level=2))",
+						},
+						"collectionConfig": map[string]any{
+							"configString": "block_compressor=zlib",
+						},
+					},
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{{"host": "host-0"}}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	storage, ok := m["storage"].(map[string]any)
+	require.True(t, ok)
+	wt, ok := storage["wiredTiger"].(map[string]any)
+	require.True(t, ok)
+	ec, ok := wt["engineConfig"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "builtin_extension_config=(zlib=(compression_level=2))", ec["configString"])
+	cc, ok := wt["collectionConfig"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "block_compressor=zlib", cc["configString"])
+}
+
+func TestExtractAdditionalMongodConfig_NoArgs(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	assert.Nil(t, config)
+}
+
+func TestExtractAdditionalMongodConfig_SetParameter(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+				"setParameter": map[string]interface{}{
+					"authenticationMechanisms": "SCRAM-SHA-256",
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	sp, ok := m["setParameter"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "SCRAM-SHA-256", sp["authenticationMechanisms"])
+}
+
+func TestExtractAdditionalMongodConfig_OplogSizeMB(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+				"replication": map[string]interface{}{
+					"replSetName": "my-rs",
+					"oplogSizeMB": 2048,
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	repl, ok := m["replication"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, 2048, repl["oplogSizeMB"])
+}
+
+func TestExtractAdditionalMongodConfig_AuditLog(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+				"auditLog": map[string]interface{}{
+					"destination": "file",
+					"format":      "JSON",
+					"path":        "/var/log/mongodb/audit.json",
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	al, ok := m["auditLog"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "file", al["destination"])
+	assert.Equal(t, "JSON", al["format"])
+}
+
+func TestExtractInternalClusterAuthMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		expected string
+	}{
+		{"x509", "x509", "X509"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processMap := map[string]om.Process{
+				"host-0": {
+					"args2_6": map[string]interface{}{
+						"security": map[string]interface{}{
+							"clusterAuthMode": tt.mode,
+						},
+					},
+				},
+			}
+			members := []om.ReplicaSetMember{
+				{"host": "host-0"},
+			}
+			result, err := extractInternalClusterAuthMode(processMap, members)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractInternalClusterAuthMode_KeyFileImplicit(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"security": map[string]interface{}{
+					"clusterAuthMode": "keyFile",
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+	result, err := extractInternalClusterAuthMode(processMap, members)
+	require.NoError(t, err)
+	assert.Equal(t, "", result, "keyFile is the default, so no explicit CR field is needed")
+}
+
+func TestExtractInternalClusterAuthMode_UnsupportedMode(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"security": map[string]interface{}{
+					"clusterAuthMode": "unsupported-mode",
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+	_, err := extractInternalClusterAuthMode(processMap, members)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported clusterAuthMode")
+}
+
+func TestExtractInternalClusterAuthMode_MissingProcess(t *testing.T) {
+	processMap := map[string]om.Process{}
+	members := []om.ReplicaSetMember{
+		{"host": "missing-host"},
+	}
+	_, err := extractInternalClusterAuthMode(processMap, members)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestConvertACLdapToCR(t *testing.T) {
+	l := &ldap.Ldap{
+		Servers:            "ldap.example.com:636",
+		TransportSecurity:  "tls",
+		BindQueryUser:      "cn=admin,dc=example,dc=com",
+		AuthzQueryTemplate: "{USER}?memberOf?base",
+		UserToDnMapping:    `[{"match":"(.+)","substitution":"cn={0},dc=example,dc=com"}]`,
+		TimeoutMS:          10000,
+	}
+
+	cr := mdbv1.ConvertACLdapToCR(l)
+	require.NotNil(t, cr)
+	assert.Equal(t, []string{"ldap.example.com:636"}, cr.Servers)
+	assert.Equal(t, mdbv1.TransportSecurity("tls"), *cr.TransportSecurity)
+	assert.Equal(t, "cn=admin,dc=example,dc=com", cr.BindQueryUser)
+	assert.Equal(t, "{USER}?memberOf?base", cr.AuthzQueryTemplate)
+	assert.Equal(t, 10000, cr.TimeoutMS)
+}
+
+func TestConvertACLdapToCR_MultipleServers(t *testing.T) {
+	l := &ldap.Ldap{
+		Servers: "ldap1.example.com:636, ldap2.example.com:636,ldap3.example.com:636",
+	}
+
+	cr := mdbv1.ConvertACLdapToCR(l)
+	require.NotNil(t, cr)
+	assert.Equal(t, []string{"ldap1.example.com:636", "ldap2.example.com:636", "ldap3.example.com:636"}, cr.Servers)
+}
+
+func TestConvertACLdapToCR_NoBindUser(t *testing.T) {
+	l := &ldap.Ldap{
+		Servers: "ldap.example.com:636",
+	}
+
+	cr := mdbv1.ConvertACLdapToCR(l)
+	require.NotNil(t, cr)
+	assert.Empty(t, cr.BindQuerySecretRef.Name)
+}
+
+func TestConvertACLdapToCR_CaFileContents(t *testing.T) {
+	l := &ldap.Ldap{
+		Servers:        "ldap.example.com:636",
+		CaFileContents: "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----",
+	}
+
+	cr := mdbv1.ConvertACLdapToCR(l)
+	require.NotNil(t, cr)
+	assert.Nil(t, cr.CAConfigMapRef, "CAConfigMapRef is set by the caller, not by ConvertACLdapToCR")
+}
+
+func TestConvertACLdapToCR_NoCaFileContents(t *testing.T) {
+	l := &ldap.Ldap{
+		Servers: "ldap.example.com:636",
+	}
+
+	cr := mdbv1.ConvertACLdapToCR(l)
+	require.NotNil(t, cr)
+	assert.Nil(t, cr.CAConfigMapRef)
+}
+
+func TestMapACOIDCToProviderConfigs(t *testing.T) {
+	configs := []oidc.ProviderConfig{
+		{
+			AuthNamePrefix:        "WORKFORCE",
+			Audience:              "my-audience",
+			IssuerUri:             "https://issuer.example.com",
+			UserClaim:             "sub",
+			SupportsHumanFlows:    true,
+			UseAuthorizationClaim: false,
+			ClientId:              strPtr("client-123"),
+			RequestedScopes:       []string{"openid", "profile"},
+		},
+		{
+			AuthNamePrefix:        "WORKLOAD",
+			Audience:              "api-audience",
+			IssuerUri:             "https://issuer.example.com",
+			UserClaim:             "sub",
+			SupportsHumanFlows:    false,
+			UseAuthorizationClaim: true,
+			GroupsClaim:           strPtr("groups"),
+		},
+	}
+
+	result := authn.MapACOIDCToProviderConfigs(configs)
+	require.Len(t, result, 2)
+
+	assert.Equal(t, "WORKFORCE", result[0].ConfigurationName)
+	assert.Equal(t, mdbv1.OIDCAuthorizationMethod("WorkforceIdentityFederation"), result[0].AuthorizationMethod)
+	assert.Equal(t, mdbv1.OIDCAuthorizationType("UserID"), result[0].AuthorizationType)
+	assert.Equal(t, "client-123", *result[0].ClientId)
+	assert.Equal(t, []string{"openid", "profile"}, result[0].RequestedScopes)
+
+	assert.Equal(t, "WORKLOAD", result[1].ConfigurationName)
+	assert.Equal(t, mdbv1.OIDCAuthorizationMethod("WorkloadIdentityFederation"), result[1].AuthorizationMethod)
+	assert.Equal(t, mdbv1.OIDCAuthorizationType("GroupMembership"), result[1].AuthorizationType)
+	assert.Equal(t, "groups", *result[1].GroupsClaim)
+}
+
+func TestExtractAdditionalMongodConfig_DbPathNotExtracted(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net":     map[string]interface{}{"port": 27017},
+				"storage": map[string]interface{}{"dbPath": "/data/custom"},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	assert.Nil(t, config, "dbPath should not be extracted into additionalMongodConfig because the operator always overwrites it")
+}
+
+func TestExtractAdditionalMongodConfig_DefaultDbPath(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net":     map[string]interface{}{"port": 27017},
+				"storage": map[string]interface{}{"dbPath": "/data"},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	assert.Nil(t, config)
+}
+
+func TestExtractAdditionalMongodConfig_SystemLogNotExtracted(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{"port": 27017},
+				"systemLog": map[string]interface{}{
+					"destination": "file",
+					"path":        "/var/log/mongodb/mongod.log",
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	assert.Nil(t, config, "systemLog should not be extracted into additionalMongodConfig because the operator always overwrites it. Use spec.agent.mongod.systemLog instead")
+}
+
+func TestExtractAdditionalMongodConfig_TLSModePrefer(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+					"tls":  map[string]interface{}{"mode": "preferSSL"},
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	m := config.ToMap()
+	net, ok := m["net"].(map[string]interface{})
+	require.True(t, ok)
+	tls, ok := net["tls"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "preferSSL", tls["mode"])
+}
+
+func TestExtractAdditionalMongodConfig_TLSModeRequireNotIncluded(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+					"tls":  map[string]interface{}{"mode": "requireSSL"},
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	assert.Nil(t, config)
+}
+
+func TestExtractAgentConfig_LogRotateFromEndpoint(t *testing.T) {
+	projectProcessConfigs := &ProjectConfigs{
+		SystemLogRotate: &automationconfig.AcLogRotate{
+			LogRotate: automationconfig.LogRotate{
+				TimeThresholdHrs: 24,
+				NumUncompressed:  5,
+			},
+			SizeThresholdMB: 1000,
+		},
+	}
+
+	agentConfig := extractAgentConfig(nil, projectProcessConfigs)
+	require.NotNil(t, agentConfig.Mongod.LogRotate)
+	assert.Equal(t, "1000", agentConfig.Mongod.LogRotate.SizeThresholdMB)
+	assert.Equal(t, 24, agentConfig.Mongod.LogRotate.TimeThresholdHrs)
+	assert.Equal(t, 5, agentConfig.Mongod.LogRotate.NumUncompressed)
+}
+
+func TestExtractAgentConfig_AuditLogRotateFromEndpoint(t *testing.T) {
+	projectProcessConfigs := &ProjectConfigs{
+		AuditLogRotate: &automationconfig.AcLogRotate{
+			LogRotate: automationconfig.LogRotate{
+				TimeThresholdHrs: 48,
+			},
+			SizeThresholdMB: 500,
+		},
+	}
+
+	agentConfig := extractAgentConfig(nil, projectProcessConfigs)
+	require.NotNil(t, agentConfig.Mongod.AuditLogRotate)
+	assert.Equal(t, "500", agentConfig.Mongod.AuditLogRotate.SizeThresholdMB)
+	assert.Equal(t, 48, agentConfig.Mongod.AuditLogRotate.TimeThresholdHrs)
+}
+
+func TestExtractAgentConfig_NilProcessConfigs(t *testing.T) {
+	agentConfig := extractAgentConfig(nil, nil)
+	assert.Nil(t, agentConfig.Mongod.LogRotate)
+	assert.Nil(t, agentConfig.Mongod.AuditLogRotate)
+	assert.Nil(t, agentConfig.MonitoringAgent.LogRotate)
+	assert.Nil(t, agentConfig.BackupAgent.LogRotate)
+}
+
+func TestExtractAgentConfig_EmptyEndpointData(t *testing.T) {
+	projectProcessConfigs := &ProjectConfigs{
+		SystemLogRotate: &automationconfig.AcLogRotate{},
+		AuditLogRotate:  &automationconfig.AcLogRotate{},
+	}
+
+	cfg := extractAgentConfig(nil, projectProcessConfigs)
+	assert.Nil(t, cfg.Mongod.LogRotate)
+	assert.Nil(t, cfg.Mongod.AuditLogRotate)
+	assert.Nil(t, cfg.MonitoringAgent.LogRotate)
+	assert.Nil(t, cfg.BackupAgent.LogRotate)
+}
+
+func TestExtractAgentConfig_AgentLogRotateMatchesMongod(t *testing.T) {
+	projectProcessConfigs := &ProjectConfigs{
+		SystemLogRotate: &automationconfig.AcLogRotate{
+			LogRotate:       automationconfig.LogRotate{TimeThresholdHrs: 24},
+			SizeThresholdMB: 1000,
+		},
+	}
+
+	agentConfig := extractAgentConfig(nil, projectProcessConfigs)
+	require.NotNil(t, agentConfig.MonitoringAgent.LogRotate)
+	assert.Equal(t, 1000, agentConfig.MonitoringAgent.LogRotate.SizeThresholdMB)
+	assert.Equal(t, 24, agentConfig.MonitoringAgent.LogRotate.TimeThresholdHrs)
+	require.NotNil(t, agentConfig.BackupAgent.LogRotate)
+	assert.Equal(t, 1000, agentConfig.BackupAgent.LogRotate.SizeThresholdMB)
+	assert.Equal(t, 24, agentConfig.BackupAgent.LogRotate.TimeThresholdHrs)
+}
+
+func TestGetTLSModeFromMongodConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     map[string]interface{}
+		expected pkgtls.Mode
+	}{
+		{"tls mode", map[string]interface{}{"net": map[string]interface{}{"tls": map[string]interface{}{"mode": "preferSSL"}}}, "preferSSL"},
+		{"ssl mode", map[string]interface{}{"net": map[string]interface{}{"ssl": map[string]interface{}{"mode": "requireSSL"}}}, "requireSSL"},
+		{"no net defaults to require", map[string]interface{}{}, pkgtls.Require},
+		{"empty tls defaults to require", map[string]interface{}{"net": map[string]interface{}{"tls": map[string]interface{}{}}}, pkgtls.Require},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pkgtls.GetTLSModeFromMongodConfig(tt.args))
+		})
+	}
+}
+
+func TestExtractPrometheusConfig_Enabled(t *testing.T) {
+	deployment := om.Deployment{
+		"prometheus": map[string]interface{}{
+			"enabled":       true,
+			"username":      "prom-user",
+			"passwordHash":  "hash123",
+			"passwordSalt":  "salt456",
+			"scheme":        "https",
+			"listenAddress": "0.0.0.0:9216",
+			"metricsPath":   "/metrics",
+			"tlsPemPath":    "/etc/ssl/prom.pem",
+		},
+	}
+
+	prom, err := extractPrometheusConfig(deployment)
+	require.NoError(t, err)
+	require.NotNil(t, prom)
+	assert.Equal(t, "prom-user", prom.Username)
+	assert.Equal(t, 9216, prom.Port)
+	assert.Equal(t, "prometheus-password", prom.PasswordSecretRef.Name)
+	assert.Equal(t, "prometheus-tls", prom.TLSSecretRef.Name)
+}
+
+func TestExtractPrometheusConfig_CustomPort(t *testing.T) {
+	deployment := om.Deployment{
+		"prometheus": map[string]interface{}{
+			"enabled":       true,
+			"username":      "prom-user",
+			"scheme":        "http",
+			"listenAddress": "0.0.0.0:9999",
+			"metricsPath":   "/custom-metrics",
+		},
+	}
+
+	prom, err := extractPrometheusConfig(deployment)
+	require.NoError(t, err)
+	require.NotNil(t, prom)
+	assert.Equal(t, 9999, prom.Port)
+	assert.Equal(t, "/custom-metrics", prom.MetricsPath)
+	assert.Empty(t, prom.TLSSecretRef.Name)
+}
+
+func TestExtractPrometheusConfig_Disabled(t *testing.T) {
+	deployment := om.Deployment{
+		"prometheus": map[string]interface{}{
+			"enabled": false,
+		},
+	}
+	prom, err := extractPrometheusConfig(deployment)
+	require.NoError(t, err)
+	assert.Nil(t, prom)
+}
+
+func TestExtractPrometheusConfig_Missing(t *testing.T) {
+	deployment := om.Deployment{}
+	prom, err := extractPrometheusConfig(deployment)
+	require.NoError(t, err)
+	assert.Nil(t, prom)
+}
+
+func TestExtractPrometheusConfig_MalformedNotMap(t *testing.T) {
+	deployment := om.Deployment{
+		"prometheus": "not-a-map",
+	}
+	assert.Panics(t, func() {
+		_, _ = extractPrometheusConfig(deployment)
+	})
+}
+
+func TestExtractPrometheusConfig_EnabledNoUsername(t *testing.T) {
+	deployment := om.Deployment{
+		"prometheus": map[string]interface{}{
+			"enabled":       true,
+			"listenAddress": "0.0.0.0:9216",
+		},
+	}
+	_, err := extractPrometheusConfig(deployment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no username configured")
+}
+
+func TestExtractPrometheusConfig_InvalidListenAddress(t *testing.T) {
+	deployment := om.Deployment{
+		"prometheus": map[string]interface{}{
+			"enabled":       true,
+			"username":      "prom-user",
+			"listenAddress": "invalid-no-port",
+		},
+	}
+	_, err := extractPrometheusConfig(deployment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "valid port")
+}
+
+func TestExtractCustomRoles(t *testing.T) {
+	deployment := om.Deployment{
+		"roles": []interface{}{
+			map[string]interface{}{
+				"role": "appReadOnly",
+				"db":   "myapp",
+				"privileges": []interface{}{
+					map[string]interface{}{
+						"actions":  []interface{}{"find", "listCollections"},
+						"resource": map[string]interface{}{"db": "myapp", "collection": ""},
+					},
+				},
+				"roles": []interface{}{
+					map[string]interface{}{"role": "read", "db": "myapp"},
+				},
+			},
+		},
+	}
+
+	roles := deployment.GetRoles()
+	require.Len(t, roles, 1)
+	assert.Equal(t, "appReadOnly", roles[0].Role)
+	assert.Equal(t, "myapp", roles[0].Db)
+	require.Len(t, roles[0].Privileges, 1)
+	assert.Contains(t, roles[0].Privileges[0].Actions, "find")
+	require.Len(t, roles[0].Roles, 1)
+	assert.Equal(t, "read", roles[0].Roles[0].Role)
+}
+
+func TestExtractCustomRoles_Empty(t *testing.T) {
+	deployment := om.Deployment{
+		"roles": []interface{}{},
+	}
+	roles := deployment.GetRoles()
+	assert.Empty(t, roles)
+}
+
+func TestExtractAdditionalMongodConfig_MultiMember_SamePort_Included(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {"args2_6": map[string]interface{}{"net": map[string]interface{}{"port": 27018}}},
+		"host-1": {"args2_6": map[string]interface{}{"net": map[string]interface{}{"port": 27018}}},
+	}
+	members := []om.ReplicaSetMember{{"host": "host-0"}, {"host": "host-1"}}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	assert.Equal(t, 27018, maputil.ReadMapValueAsInt(config.ToMap(), "net", "port"))
+}
+
+func TestApplyClientCertificateMode_RequireCreatesField(t *testing.T) {
+	agentSSL := &om.AgentSSL{ClientCertificateMode: "REQUIRE"}
+	result := applyClientCertificateMode(agentSSL, nil)
+	require.NotNil(t, result)
+	tlsMap, ok := result.ToMap()["net"].(map[string]interface{})
+	require.True(t, ok)
+	tlsSub, ok := tlsMap["tls"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, tlsSub["allowConnectionsWithoutCertificates"])
+}
+
+func TestApplyClientCertificateMode_RequireMergesIntoExisting(t *testing.T) {
+	agentSSL := &om.AgentSSL{ClientCertificateMode: "REQUIRE"}
+	existing := mdbv1.NewAdditionalMongodConfig("net.port", 27018)
+	result := applyClientCertificateMode(agentSSL, existing)
+	require.NotNil(t, result)
+	m := result.ToMap()
+	netMap, ok := m["net"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, 27018, netMap["port"])
+	tlsSub, ok := netMap["tls"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, tlsSub["allowConnectionsWithoutCertificates"])
+}
+
+func TestApplyClientCertificateMode_OptionalNoChange(t *testing.T) {
+	agentSSL := &om.AgentSSL{ClientCertificateMode: "OPTIONAL"}
+	result := applyClientCertificateMode(agentSSL, nil)
+	assert.Nil(t, result)
+}
+
+func TestApplyClientCertificateMode_NilAgentSSLNoChange(t *testing.T) {
+	result := applyClientCertificateMode(nil, nil)
+	assert.Nil(t, result)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func sourceProc(processMap map[string]om.Process, members []om.ReplicaSetMember) *om.Process {
+	p := processMap[members[0].Name()]
+	return &p
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/common_spec_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/common_spec_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/oidc"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	pkgtls "github.com/mongodb/mongodb-kubernetes/pkg/tls"
-	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 )
 
 func TestBuildAuthModes_FromDeploymentAuthMechanisms(t *testing.T) {
@@ -256,7 +255,9 @@ func TestBuildSecurity_InternalClusterAuth(t *testing.T) {
 	assert.Equal(t, "X509", result.Authentication.InternalCluster)
 }
 
-func TestExtractAdditionalMongodConfig_NonDefaultPort(t *testing.T) {
+// net.port is never migrated: Kubernetes members listen on the operator default while external
+// VM members keep their own port.
+func TestExtractAdditionalMongodConfig_NonDefaultPortNotMigrated(t *testing.T) {
 	processMap := map[string]om.Process{
 		"host-0": {
 			"args2_6": map[string]interface{}{
@@ -271,11 +272,7 @@ func TestExtractAdditionalMongodConfig_NonDefaultPort(t *testing.T) {
 	}
 
 	config := sourceProc(processMap, members).AdditionalMongodConfig()
-	require.NotNil(t, config)
-	m := config.ToMap()
-	netMap, ok := m["net"].(map[string]interface{})
-	require.True(t, ok)
-	assert.EqualValues(t, 27018, netMap["port"])
+	assert.Nil(t, config)
 }
 
 func TestExtractAdditionalMongodConfig_DefaultPort(t *testing.T) {
@@ -709,7 +706,7 @@ func TestExtractAdditionalMongodConfig_SystemLogNotExtracted(t *testing.T) {
 	}
 
 	config := sourceProc(processMap, members).AdditionalMongodConfig()
-	assert.Nil(t, config, "systemLog should not be extracted into additionalMongodConfig because the operator always overwrites it. Use spec.agent.mongod.systemLog instead")
+	assert.Nil(t, config, "systemLog should not be extracted into additionalMongodConfig because the operator always overwrites it")
 }
 
 func TestExtractAdditionalMongodConfig_TLSModePrefer(t *testing.T) {
@@ -767,7 +764,7 @@ func TestExtractAgentConfig_LogRotateFromEndpoint(t *testing.T) {
 		},
 	}
 
-	agentConfig := extractAgentConfig(nil, projectProcessConfigs)
+	agentConfig := extractAgentConfig(projectProcessConfigs)
 	require.NotNil(t, agentConfig.Mongod.LogRotate)
 	assert.Equal(t, "1000", agentConfig.Mongod.LogRotate.SizeThresholdMB)
 	assert.Equal(t, 24, agentConfig.Mongod.LogRotate.TimeThresholdHrs)
@@ -784,14 +781,14 @@ func TestExtractAgentConfig_AuditLogRotateFromEndpoint(t *testing.T) {
 		},
 	}
 
-	agentConfig := extractAgentConfig(nil, projectProcessConfigs)
+	agentConfig := extractAgentConfig(projectProcessConfigs)
 	require.NotNil(t, agentConfig.Mongod.AuditLogRotate)
 	assert.Equal(t, "500", agentConfig.Mongod.AuditLogRotate.SizeThresholdMB)
 	assert.Equal(t, 48, agentConfig.Mongod.AuditLogRotate.TimeThresholdHrs)
 }
 
 func TestExtractAgentConfig_NilProcessConfigs(t *testing.T) {
-	agentConfig := extractAgentConfig(nil, nil)
+	agentConfig := extractAgentConfig(nil)
 	assert.Nil(t, agentConfig.Mongod.LogRotate)
 	assert.Nil(t, agentConfig.Mongod.AuditLogRotate)
 	assert.Nil(t, agentConfig.MonitoringAgent.LogRotate)
@@ -804,7 +801,7 @@ func TestExtractAgentConfig_EmptyEndpointData(t *testing.T) {
 		AuditLogRotate:  &automationconfig.AcLogRotate{},
 	}
 
-	cfg := extractAgentConfig(nil, projectProcessConfigs)
+	cfg := extractAgentConfig(projectProcessConfigs)
 	assert.Nil(t, cfg.Mongod.LogRotate)
 	assert.Nil(t, cfg.Mongod.AuditLogRotate)
 	assert.Nil(t, cfg.MonitoringAgent.LogRotate)
@@ -819,13 +816,20 @@ func TestExtractAgentConfig_AgentLogRotateMatchesMongod(t *testing.T) {
 		},
 	}
 
-	agentConfig := extractAgentConfig(nil, projectProcessConfigs)
+	agentConfig := extractAgentConfig(projectProcessConfigs)
 	require.NotNil(t, agentConfig.MonitoringAgent.LogRotate)
 	assert.Equal(t, 1000, agentConfig.MonitoringAgent.LogRotate.SizeThresholdMB)
 	assert.Equal(t, 24, agentConfig.MonitoringAgent.LogRotate.TimeThresholdHrs)
 	require.NotNil(t, agentConfig.BackupAgent.LogRotate)
 	assert.Equal(t, 1000, agentConfig.BackupAgent.LogRotate.SizeThresholdMB)
 	assert.Equal(t, 24, agentConfig.BackupAgent.LogRotate.TimeThresholdHrs)
+}
+
+func TestExtractAgentConfig_SystemLogNotMigrated(t *testing.T) {
+	// systemLog.path is not carried over: only util.PvcMountPathLogs is mounted in the pod, so a VM
+	// path would be unbacked by a volume. The operator picks the default instead.
+	agentConfig := extractAgentConfig(&ProjectConfigs{})
+	assert.Nil(t, agentConfig.Mongod.SystemLog)
 }
 
 func TestGetTLSModeFromMongodConfig(t *testing.T) {
@@ -977,7 +981,7 @@ func TestExtractCustomRoles_Empty(t *testing.T) {
 	assert.Empty(t, roles)
 }
 
-func TestExtractAdditionalMongodConfig_MultiMember_SamePort_Included(t *testing.T) {
+func TestExtractAdditionalMongodConfig_MultiMember_SamePort_NotMigrated(t *testing.T) {
 	processMap := map[string]om.Process{
 		"host-0": {"args2_6": map[string]interface{}{"net": map[string]interface{}{"port": 27018}}},
 		"host-1": {"args2_6": map[string]interface{}{"net": map[string]interface{}{"port": 27018}}},
@@ -985,8 +989,7 @@ func TestExtractAdditionalMongodConfig_MultiMember_SamePort_Included(t *testing.
 	members := []om.ReplicaSetMember{{"host": "host-0"}, {"host": "host-1"}}
 
 	config := sourceProc(processMap, members).AdditionalMongodConfig()
-	require.NotNil(t, config)
-	assert.Equal(t, 27018, maputil.ReadMapValueAsInt(config.ToMap(), "net", "port"))
+	assert.Nil(t, config)
 }
 
 func TestApplyClientCertificateMode_RequireCreatesField(t *testing.T) {

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator.go
@@ -1,0 +1,199 @@
+package migratetomck
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+// operatorVersion returns the operator version stamped at build time, or "latest" for development builds.
+func operatorVersion() string {
+	if util.OperatorVersion == "" {
+		return "latest"
+	}
+	return util.OperatorVersion
+}
+
+const (
+	PrometheusPasswordSecretName = "prometheus-password"
+	PrometheusTLSSecretName      = "prometheus-tls"
+	LdapBindQuerySecretName      = "ldap-bind-query-password" //nolint:gosec // secret name, not a credential
+	LdapCAConfigMapName          = "ldap-ca"
+	LdapCAKey                    = "ca.pem"
+
+	migrateToolVersionAnnotation = "mongodb.com/migrate-tool-version"
+	MigrationDryRunAnnotation    = "mongodb.com/migration-dry-run"
+
+	externalDatabase = "$external" // MongoDB virtual database for X.509 and LDAP users.
+
+	// passwordSecretDataKey is the Secret data key used for all generated and referenced password Secrets.
+	passwordSecretDataKey = "password" //nolint:gosec // data key name, not a credential
+)
+
+// GenerateOptions holds CLI flags, OM-fetched configs, and validation outputs for CR generation.
+// It does not duplicate fields that are directly derivable from the automation config.
+type GenerateOptions struct {
+	// CLI flags
+	ResourceNameOverride  string
+	CredentialsSecretName string
+	ConfigMapName         string
+	Namespace             string
+	CertsSecretPrefix     string // spec.security.certsSecretPrefix, required when TLS is enabled
+
+	// Fetched from OM
+	ProjectConfigs *ProjectConfigs
+
+	// Output of ValidateMigration — the process used as the template for spec fields (e.g. version, args).
+	SourceProcess *om.Process
+
+	// User credentials — maps "username:database" to a pre-created Secret name; no Secret YAML is written
+	ExistingUserSecrets map[string]string
+
+	// Prometheus credentials
+	PrometheusSecretName string // name of a pre-created Secret; no Secret YAML is written when set
+}
+
+// GenerateMongoDBCR generates a MongoDB CR for the given topology.
+func GenerateMongoDBCR(ac *om.AutomationConfig, opts GenerateOptions) (client.Object, string, error) {
+	isSharded := len(ac.Deployment.GetShardedClusters()) > 0
+
+	if isSharded {
+		return nil, "", fmt.Errorf("sharded cluster migration is not yet supported")
+	}
+	return generateReplicaSet(ac, opts)
+}
+
+// generateExtraResources returns the supporting Secrets/ConfigMaps for LDAP and Prometheus.
+func generateExtraResources(ac *om.AutomationConfig, opts GenerateOptions) []client.Object {
+	var resources []client.Object
+	if ldap := ac.Ldap; ldap != nil {
+		if ldap.BindQueryPassword != "" {
+			resources = append(resources, GeneratePasswordSecret(LdapBindQuerySecretName, opts.Namespace, ldap.BindQueryPassword))
+		}
+		if ldap.CaFileContents != "" {
+			resources = append(resources, buildLdapCAConfigMap(opts.Namespace, ldap.CaFileContents))
+		}
+	}
+	return resources
+}
+
+// marshalMultiDoc serializes each object to YAML, joined by YAML document separator markers.
+func marshalMultiDoc(objects []client.Object) (string, error) {
+	var sb strings.Builder
+	for i, obj := range objects {
+		if i > 0 {
+			sb.WriteString("---\n")
+		}
+		y, err := marshalCRToYAML(obj)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal %T: %w", obj, err)
+		}
+		sb.WriteString(y)
+	}
+	return sb.String(), nil
+}
+
+// marshalCRToYAML marshals a resource to YAML, stripping status, creationTimestamp, and empty fields.
+func marshalCRToYAML(obj client.Object) (string, error) {
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(jsonBytes, &m); err != nil {
+		return "", err
+	}
+	delete(m, "status")
+	if meta, ok := m["metadata"].(map[string]any); ok {
+		delete(meta, "creationTimestamp")
+	}
+	stripZeroValues(m)
+	out, err := yaml.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// stripZeroValues recursively removes nil, empty strings, maps, and slices.
+func stripZeroValues(m map[string]any) {
+	for k, v := range m {
+		switch val := v.(type) {
+		case nil:
+			delete(m, k)
+		case string:
+			if val == "" {
+				delete(m, k)
+			}
+		case map[string]any:
+			stripZeroValues(val)
+			if len(val) == 0 {
+				delete(m, k)
+			}
+		case []any:
+			if len(val) == 0 {
+				delete(m, k)
+			} else {
+				for i, item := range val {
+					if sub, ok := item.(map[string]any); ok {
+						stripZeroValues(sub)
+						val[i] = sub
+					}
+				}
+			}
+		}
+	}
+}
+
+func buildCRObjectMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Annotations: map[string]string{
+			migrateToolVersionAnnotation: operatorVersion(),
+			MigrationDryRunAnnotation:    "true",
+		},
+	}
+}
+
+func buildLdapCAConfigMap(namespace, caFileContents string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LdapCAConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			LdapCAKey: caFileContents,
+		},
+	}
+}
+
+// GeneratePasswordSecret returns a Kubernetes Secret for a SCRAM user's password.
+func GeneratePasswordSecret(secretName, namespace, password string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{
+			passwordSecretDataKey: password,
+		},
+	}
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator.go
@@ -63,11 +63,11 @@ type GenerateOptions struct {
 }
 
 // GenerateMongoDBCR generates a MongoDB CR for the given topology.
-func GenerateMongoDBCR(ac *om.AutomationConfig, opts GenerateOptions) (client.Object, string, error) {
+func GenerateMongoDBCR(ac *om.AutomationConfig, opts GenerateOptions) (client.Object, error) {
 	isSharded := len(ac.Deployment.GetShardedClusters()) > 0
 
 	if isSharded {
-		return nil, "", fmt.Errorf("sharded cluster migration is not yet supported")
+		return nil, fmt.Errorf("sharded cluster migration is not yet supported")
 	}
 	return generateReplicaSet(ac, opts)
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -1,0 +1,116 @@
+package migratetomck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+)
+
+// withDeploymentData mirrors what runGenerate does before calling generateAll.
+func withDeploymentData(ac *om.AutomationConfig, opts GenerateOptions) GenerateOptions {
+	if rss := ac.Deployment.GetReplicaSets(); len(rss) > 0 {
+		members := rss[0].Members()
+		processMap := ac.Deployment.ProcessMap()
+		opts.SourceProcess, _ = pickSourceProcess(members, processMap)
+	}
+	return opts
+}
+
+func TestGenerateMongoDBCR_CustomResourceName(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes": []any{
+			map[string]any{
+				"name":                        "my-rs-0",
+				"hostname":                    "vm-0.example.com",
+				"version":                     "8.0.4-ent",
+				"featureCompatibilityVersion": "8.0",
+				"processType":                 string(om.ProcessTypeMongod),
+				"args2_6": map[string]any{
+					"net":         map[string]any{"port": 27017},
+					"replication": map[string]any{"replSetName": "my-rs"},
+				},
+			},
+		},
+		"replicaSets": []any{
+			map[string]any{
+				"_id":     "my-rs",
+				"members": []any{map[string]any{"_id": 0, "host": "my-rs-0", "priority": 1, "votes": 1}},
+			},
+		},
+		"sharding": []any{},
+	})
+
+	opts := withDeploymentData(ac, GenerateOptions{
+		ResourceNameOverride:  "custom-name",
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+		CertsSecretPrefix:     "mdb",
+	})
+
+	obj, _, err := GenerateMongoDBCR(ac, opts)
+	require.NoError(t, err)
+	yamlOutput, err := marshalCRToYAML(obj)
+	require.NoError(t, err)
+
+	assert.Contains(t, yamlOutput, "name: custom-name")
+	assert.Contains(t, yamlOutput, "replicaSetNameOverride: my-rs")
+}
+
+
+func TestGenerateMongoDBCR_AutoNormalizesRSName(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes": []any{
+			map[string]any{
+				"name":                        "My_RS-0",
+				"hostname":                    "vm-0.example.com",
+				"version":                     "8.0.4-ent",
+				"featureCompatibilityVersion": "8.0",
+				"processType":                 string(om.ProcessTypeMongod),
+				"args2_6": map[string]any{
+					"net":         map[string]any{"port": 27017},
+					"replication": map[string]any{"replSetName": "My_ReplicaSet"},
+				},
+			},
+		},
+		"replicaSets": []any{
+			map[string]any{
+				"_id":     "My_ReplicaSet",
+				"members": []any{map[string]any{"_id": 0, "host": "My_RS-0", "priority": 1, "votes": 1}},
+			},
+		},
+		"sharding": []any{},
+	})
+
+	opts := withDeploymentData(ac, GenerateOptions{
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+	})
+
+	obj, resourceName, err := GenerateMongoDBCR(ac, opts)
+	require.NoError(t, err)
+	assert.Equal(t, "my-replicaset", resourceName)
+	yamlOutput, err := marshalCRToYAML(obj)
+	require.NoError(t, err)
+	assert.Contains(t, yamlOutput, "name: my-replicaset")
+	assert.Contains(t, yamlOutput, "replicaSetNameOverride: My_ReplicaSet")
+}
+
+func TestGenerateMongoDBCR_NoReplicaSet(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+		"sharding":    []any{},
+	})
+
+	opts := GenerateOptions{
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+	}
+
+	_, _, err := GenerateMongoDBCR(ac, opts)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no replica sets found")
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -50,7 +50,7 @@ func TestGenerateMongoDBCR_CustomResourceName(t *testing.T) {
 		CertsSecretPrefix:     "mdb",
 	})
 
-	obj, _, err := GenerateMongoDBCR(ac, opts)
+	obj, err := GenerateMongoDBCR(ac, opts)
 	require.NoError(t, err)
 	yamlOutput, err := marshalCRToYAML(obj)
 	require.NoError(t, err)
@@ -88,9 +88,9 @@ func TestGenerateMongoDBCR_AutoNormalizesRSName(t *testing.T) {
 		ConfigMapName:         "my-om-config",
 	})
 
-	obj, resourceName, err := GenerateMongoDBCR(ac, opts)
+	obj, err := GenerateMongoDBCR(ac, opts)
 	require.NoError(t, err)
-	assert.Equal(t, "my-replicaset", resourceName)
+	assert.Equal(t, "my-replicaset", obj.GetName())
 	yamlOutput, err := marshalCRToYAML(obj)
 	require.NoError(t, err)
 	assert.Contains(t, yamlOutput, "name: my-replicaset")
@@ -109,7 +109,7 @@ func TestGenerateMongoDBCR_NoReplicaSet(t *testing.T) {
 		ConfigMapName:         "my-om-config",
 	}
 
-	_, _, err := GenerateMongoDBCR(ac, opts)
+	_, err := GenerateMongoDBCR(ac, opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no replica sets found")
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -59,7 +59,6 @@ func TestGenerateMongoDBCR_CustomResourceName(t *testing.T) {
 	assert.Contains(t, yamlOutput, "replicaSetNameOverride: my-rs")
 }
 
-
 func TestGenerateMongoDBCR_AutoNormalizesRSName(t *testing.T) {
 	ac := om.NewAutomationConfig(om.Deployment{
 		"processes": []any{

--- a/cmd/kubectl-mongodb/migrate-to-mck/mongodb.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/mongodb.go
@@ -1,10 +1,20 @@
 package migratetomck
 
 import (
+	"bufio"
+	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+	pkgtls "github.com/mongodb/mongodb-kubernetes/pkg/tls"
 )
 
 type mongodbFlags struct {
@@ -22,16 +32,54 @@ var mFlags mongodbFlags
 var MongodbCmd = &cobra.Command{
 	Use:   "mongodb",
 	Short: "Generate a MongoDB Kubernetes CR",
-	Long: `Generate a MongoDB Kubernetes CR from an Ops Manager/Cloud Manager
-automation config. The automation config is validated before generation. If any blockers are
-found, the command fails without producing output.
+	Long: `Generate a MongoDB CR from an Ops Manager or Cloud Manager automation config.
 
-Requires a ConfigMap (baseUrl, orgId, projectName) and a Secret (publicKey,
-privateKey) in the same format used by the operator.
+The automation config is validated before output is produced. The command exits
+with an error if any blockers are found.
 
-Example:
+PREREQUISITES
 
-kubectl mongodb migrate mongodb --config-map-name my-project --secret-name my-credentials --namespace mongodb`,
+  A ConfigMap and a Secret must exist in the target namespace before running this
+  command:
+
+    kubectl create configmap my-project \
+      --from-literal=baseUrl=<url> \
+      --from-literal=orgId=<id> \
+      --from-literal=projectName=<name>
+
+    kubectl create secret generic my-credentials \
+      --from-literal=publicKey=<key> \
+      --from-literal=privateKey=<key>
+
+  If Prometheus is enabled, create a Secret containing the Prometheus password:
+
+    kubectl create secret generic <secret-name> \
+      --from-literal=password=<password> \
+      -n <namespace>
+
+USAGE
+
+  When TLS is enabled, the command prompts for spec.security.certsSecretPrefix.
+  Pass --certs-secret-prefix to skip the prompt.
+
+  When Prometheus is enabled, the command prompts for the name of the password
+  Secret. Pass --prometheus-secret-name to skip the prompt.
+
+EXAMPLES
+
+  Interactive:
+    kubectl mongodb migrate mongodb \
+      --config-map-name my-project \
+      --secret-name my-credentials \
+      --namespace mongodb
+
+  Non-interactive:
+    kubectl mongodb migrate mongodb \
+      --config-map-name my-project \
+      --secret-name my-credentials \
+      --namespace mongodb \
+      --certs-secret-prefix mdb \
+      --prometheus-secret-name prom-secret`,
 	RunE: runGenerateMongodb,
 }
 
@@ -50,16 +98,104 @@ func init() {
 func runGenerateMongodb(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
-	conn, _, err := prepareConnection(ctx, mFlags.namespace, mFlags.configMapName, mFlags.secretName)
+	conn, kubeClient, err := prepareConnection(ctx, mFlags.namespace, mFlags.configMapName, mFlags.secretName)
 	if err != nil {
 		return err
 	}
 
-	_, _, _, err = fetchAndValidate(conn)
+	ac, projectConfigs, sourceProcess, err := fetchAndValidate(conn)
 	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Validation passed. CR generation is not yet available in this build.")
+	opts, err := buildMongodbOptions(ctx, kubeClient, ac, projectConfigs, sourceProcess, os.Stdin, mFlags)
+	if err != nil {
+		return err
+	}
+
+	mongodbCR, _, err := GenerateMongoDBCR(ac, opts)
+	if err != nil {
+		return err
+	}
+
+	extra := generateExtraResources(ac, opts)
+	objects := make([]client.Object, 0, 1+len(extra))
+	objects = append(objects, mongodbCR)
+	objects = append(objects, extra...)
+
+	resources, err := marshalMultiDoc(objects)
+	if err != nil {
+		return err
+	}
+	return writeOutput(resources, mFlags.outputFile)
+}
+
+func buildMongodbOptions(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, projectConfigs *ProjectConfigs, sourceProcess *om.Process, stdin io.Reader, flags mongodbFlags) (GenerateOptions, error) {
+	opts := GenerateOptions{
+		ResourceNameOverride:  flags.resourceNameOverride,
+		CredentialsSecretName: flags.secretName,
+		ConfigMapName:         flags.configMapName,
+		Namespace:             flags.namespace,
+		ProjectConfigs:        projectConfigs,
+		SourceProcess:         sourceProcess,
+	}
+
+	scanner := bufio.NewScanner(stdin)
+
+	if err := ensureTLS(ac, &opts, scanner, flags.certsSecretPrefix); err != nil {
+		return GenerateOptions{}, err
+	}
+	if err := collectPrometheusCreds(ctx, kubeClient, ac, &opts, scanner, flags.prometheusSecretName); err != nil {
+		return GenerateOptions{}, err
+	}
+	return opts, nil
+}
+
+func isTLSEnabled(processMap map[string]om.Process) bool {
+	for _, proc := range processMap {
+		if len(proc.NetTLSSections()) > 0 && pkgtls.GetTLSModeFromMongodConfig(proc.Args()) != pkgtls.Disabled {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureTLS(ac *om.AutomationConfig, opts *GenerateOptions, scanner *bufio.Scanner, certsSecretPrefix string) error {
+	if !isTLSEnabled(ac.Deployment.ProcessMap()) {
+		return nil
+	}
+	prefix := certsSecretPrefix
+	if prefix != "" {
+		if errs := k8svalidation.IsDNS1123Subdomain(prefix); len(errs) > 0 {
+			return fmt.Errorf("spec.security.certsSecretPrefix value %q is not a valid Kubernetes resource name: %s", prefix, errs[0])
+		}
+	} else {
+		var err error
+		prefix, err = promptKubernetesName(scanner, "Enter value for security.certsSecretPrefix (e.g. mdb): ", "")
+		if err != nil {
+			return fmt.Errorf("failed to read spec.security.certsSecretPrefix: %w", err)
+		}
+	}
+	opts.CertsSecretPrefix = prefix
+	return nil
+}
+
+func collectPrometheusCreds(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, opts *GenerateOptions, scanner *bufio.Scanner, prometheusSecretName string) error {
+	acProm := ac.Deployment.GetPrometheus()
+	if acProm == nil || !acProm.Enabled || acProm.Username == "" {
+		return nil
+	}
+	secretName := prometheusSecretName
+	if secretName == "" {
+		var err error
+		secretName, err = promptKubernetesName(scanner, fmt.Sprintf("Secret name for Prometheus user %q [%s]: ", acProm.Username, PrometheusPasswordSecretName), PrometheusPasswordSecretName)
+		if err != nil {
+			return fmt.Errorf("failed to read spec.prometheus.passwordSecretRef.name: %w", err)
+		}
+	}
+	if _, err := requirePasswordSecret(ctx, kubeClient, opts.Namespace, secretName); err != nil {
+		return err
+	}
+	opts.PrometheusSecretName = secretName
 	return nil
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/mongodb.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/mongodb.go
@@ -113,7 +113,7 @@ func runGenerateMongodb(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	mongodbCR, _, err := GenerateMongoDBCR(ac, opts)
+	mongodbCR, err := GenerateMongoDBCR(ac, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubectl-mongodb/migrate-to-mck/mongodb_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/mongodb_test.go
@@ -32,7 +32,6 @@ func TestBuildMongodbOptions_FlagTranslation(t *testing.T) {
 	assert.Equal(t, "my-rs", opts.ResourceNameOverride)
 }
 
-
 func TestCollectPrometheusCreds_NoPrometheus(t *testing.T) {
 	ac := om.NewAutomationConfig(om.Deployment{
 		"processes":   []any{},

--- a/cmd/kubectl-mongodb/migrate-to-mck/mongodb_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/mongodb_test.go
@@ -1,0 +1,175 @@
+package migratetomck
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+)
+
+func TestBuildMongodbOptions_FlagTranslation(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+
+	f := mongodbFlags{
+		configMapName:        "my-cm",
+		secretName:           "my-secret",
+		namespace:            "mongodb",
+		resourceNameOverride: "my-rs",
+	}
+	opts, err := buildMongodbOptions(context.Background(), nil, ac, &ProjectConfigs{}, nil, strings.NewReader(""), f)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cm", opts.ConfigMapName)
+	assert.Equal(t, "my-secret", opts.CredentialsSecretName)
+	assert.Equal(t, "mongodb", opts.Namespace)
+	assert.Equal(t, "my-rs", opts.ResourceNameOverride)
+}
+
+
+func TestCollectPrometheusCreds_NoPrometheus(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	opts := &GenerateOptions{Namespace: "mongodb"}
+	err := collectPrometheusCreds(context.Background(), nil, ac, opts, nil, "")
+	require.NoError(t, err)
+	assert.Empty(t, opts.PrometheusSecretName)
+}
+
+func TestCollectPrometheusCreds_InteractiveInvalidNameCancels(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+		"prometheus":  map[string]any{"enabled": true, "username": "prom-user"},
+	})
+	opts := &GenerateOptions{Namespace: "mongodb"}
+	// Invalid k8s name is rejected; input exhausted on the reprompt.
+	scanner := bufio.NewScanner(strings.NewReader("INVALID_NAME!\n"))
+	err := collectPrometheusCreds(context.Background(), nil, ac, opts, scanner, "")
+	assert.ErrorContains(t, err, "input cancelled")
+}
+
+func TestCollectPrometheusCreds_NoInputCancels(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+		"prometheus":  map[string]any{"enabled": true, "username": "prom-user"},
+	})
+	opts := &GenerateOptions{Namespace: "mongodb"}
+	scanner := bufio.NewScanner(strings.NewReader(""))
+	err := collectPrometheusCreds(context.Background(), nil, ac, opts, scanner, "")
+	assert.ErrorContains(t, err, "input cancelled")
+}
+
+func tlsEnabledAC() *om.AutomationConfig {
+	return om.NewAutomationConfig(om.Deployment{
+		"processes": []any{
+			map[string]any{
+				"name":        "host-0",
+				"processType": string(om.ProcessTypeMongod),
+				"args2_6": map[string]any{
+					"net": map[string]any{
+						"tls": map[string]any{"mode": "requireSSL"},
+					},
+				},
+			},
+		},
+		"replicaSets": []any{},
+	})
+}
+
+func TestEnsureTLS_InvalidFlagReturnsError(t *testing.T) {
+	ac := tlsEnabledAC()
+	opts := &GenerateOptions{}
+	err := ensureTLS(ac, opts, nil, "Invalid_Name!")
+	assert.ErrorContains(t, err, "not a valid Kubernetes resource name")
+}
+
+func TestEnsureTLS_InvalidInteractiveInputReprompts(t *testing.T) {
+	ac := tlsEnabledAC()
+	opts := &GenerateOptions{}
+	scanner := bufio.NewScanner(strings.NewReader("Invalid_Name!\nmdb\n"))
+	err := ensureTLS(ac, opts, scanner, "")
+	require.NoError(t, err)
+	assert.Equal(t, "mdb", opts.CertsSecretPrefix)
+}
+
+func TestEnsureTLS_ValidFlagUsedDirectly(t *testing.T) {
+	ac := tlsEnabledAC()
+	opts := &GenerateOptions{}
+	err := ensureTLS(ac, opts, nil, "mdb")
+	require.NoError(t, err)
+	assert.Equal(t, "mdb", opts.CertsSecretPrefix)
+}
+
+func TestIsTLSEnabled_TLSMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		enabled bool
+	}{
+		{"requireSSL", "requireSSL", true},
+		{"requireTLS", "requireTLS", true},
+		{"preferSSL", "preferSSL", true},
+		{"preferTLS", "preferTLS", true},
+		{"allowSSL", "allowSSL", true},
+		{"allowTLS", "allowTLS", true},
+		{"disabled", "disabled", false},
+		{"empty defaults to require", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processMap := map[string]om.Process{
+				"host-0": {
+					"args2_6": map[string]any{
+						"net": map[string]any{
+							"tls": map[string]any{
+								"mode": tt.mode,
+							},
+						},
+					},
+				},
+			}
+			assert.Equal(t, tt.enabled, isTLSEnabled(processMap))
+		})
+	}
+}
+
+func TestIsTLSEnabled_SSLMode(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]any{
+				"net": map[string]any{
+					"ssl": map[string]any{
+						"mode": "requireSSL",
+					},
+				},
+			},
+		},
+	}
+	assert.True(t, isTLSEnabled(processMap))
+}
+
+func TestIsTLSEnabled_NoArgs(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {},
+	}
+	assert.False(t, isTLSEnabled(processMap))
+}
+
+func TestIsTLSEnabled_NoNet(t *testing.T) {
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]any{},
+		},
+	}
+	assert.False(t, isTLSEnabled(processMap))
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
@@ -49,7 +49,6 @@ func generateReplicaSetSingleCluster(ac *om.AutomationConfig, opts GenerateOptio
 	}, resourceName, nil
 }
 
-
 // buildReplicaSetDbCommonSpec constructs the DbCommonSpec for a replica set deployment,
 // including security, Prometheus, TLS, and connection settings.
 func buildReplicaSetDbCommonSpec(ac *om.AutomationConfig, opts GenerateOptions, version, fcv, resourceName string) (mdbv1.DbCommonSpec, error) {

--- a/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
@@ -13,10 +13,10 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
-func generateReplicaSet(ac *om.AutomationConfig, opts GenerateOptions) (client.Object, string, error) {
+func generateReplicaSet(ac *om.AutomationConfig, opts GenerateOptions) (client.Object, error) {
 	replicaSets := ac.Deployment.GetReplicaSets()
 	if len(replicaSets) == 0 {
-		return nil, "", fmt.Errorf("no replica sets found in the automation config")
+		return nil, fmt.Errorf("no replica sets found in the automation config")
 	}
 	rs := replicaSets[0]
 
@@ -27,26 +27,26 @@ func generateReplicaSet(ac *om.AutomationConfig, opts GenerateOptions) (client.O
 	if resourceName == "" {
 		resourceName = util.NormalizeName(rsName)
 		if resourceName == "" {
-			return nil, "", fmt.Errorf("replica set name %q cannot be normalized to a valid Kubernetes resource name. Use --resource-name-override to provide one", rsName)
+			return nil, fmt.Errorf("replica set name %q cannot be normalized to a valid Kubernetes resource name. Use --resource-name-override to provide one", rsName)
 		}
 	}
 	if errs := k8svalidation.IsDNS1123Subdomain(resourceName); len(errs) > 0 {
-		return nil, "", fmt.Errorf("resource name %q is not a valid Kubernetes resource name: %s", resourceName, errs[0])
+		return nil, fmt.Errorf("resource name %q is not a valid Kubernetes resource name: %s", resourceName, errs[0])
 	}
 
 	return generateReplicaSetSingleCluster(ac, opts, rsName, resourceName, version, fcv, externalMembers)
 }
 
-func generateReplicaSetSingleCluster(ac *om.AutomationConfig, opts GenerateOptions, rsName, resourceName, version, fcv string, externalMembers []mdbv1.ExternalMember) (client.Object, string, error) {
+func generateReplicaSetSingleCluster(ac *om.AutomationConfig, opts GenerateOptions, rsName, resourceName, version, fcv string, externalMembers []mdbv1.ExternalMember) (client.Object, error) {
 	spec, err := buildReplicaSetSpec(ac, opts, version, fcv, externalMembers, rsName, resourceName)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to build MongoDB spec: %w", err)
+		return nil, fmt.Errorf("failed to build MongoDB spec: %w", err)
 	}
 	return &mdbv1.MongoDB{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "mongodb.com/v1", Kind: "MongoDB"},
 		ObjectMeta: buildCRObjectMeta(resourceName, opts.Namespace),
 		Spec:       spec,
-	}, resourceName, nil
+	}, nil
 }
 
 // buildReplicaSetDbCommonSpec constructs the DbCommonSpec for a replica set deployment,

--- a/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
@@ -96,7 +96,7 @@ func buildReplicaSetDbCommonSpec(ac *om.AutomationConfig, opts GenerateOptions, 
 		Security:               security,
 		Prometheus:             prom,
 		AdditionalMongodConfig: additionalConfig,
-		Agent:                  extractAgentConfig(opts.SourceProcess, opts.ProjectConfigs),
+		Agent:                  extractAgentConfig(opts.ProjectConfigs),
 	}, nil
 }
 

--- a/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/replica_set_generator.go
@@ -1,0 +1,118 @@
+package migratetomck
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+func generateReplicaSet(ac *om.AutomationConfig, opts GenerateOptions) (client.Object, string, error) {
+	replicaSets := ac.Deployment.GetReplicaSets()
+	if len(replicaSets) == 0 {
+		return nil, "", fmt.Errorf("no replica sets found in the automation config")
+	}
+	rs := replicaSets[0]
+
+	rsName := rs.Name()
+	externalMembers, version, fcv := om.ExtractMemberInfo(rs.Members(), ac.Deployment.ProcessMap())
+
+	resourceName := opts.ResourceNameOverride
+	if resourceName == "" {
+		resourceName = util.NormalizeName(rsName)
+		if resourceName == "" {
+			return nil, "", fmt.Errorf("replica set name %q cannot be normalized to a valid Kubernetes resource name. Use --resource-name-override to provide one", rsName)
+		}
+	}
+	if errs := k8svalidation.IsDNS1123Subdomain(resourceName); len(errs) > 0 {
+		return nil, "", fmt.Errorf("resource name %q is not a valid Kubernetes resource name: %s", resourceName, errs[0])
+	}
+
+	return generateReplicaSetSingleCluster(ac, opts, rsName, resourceName, version, fcv, externalMembers)
+}
+
+func generateReplicaSetSingleCluster(ac *om.AutomationConfig, opts GenerateOptions, rsName, resourceName, version, fcv string, externalMembers []mdbv1.ExternalMember) (client.Object, string, error) {
+	spec, err := buildReplicaSetSpec(ac, opts, version, fcv, externalMembers, rsName, resourceName)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to build MongoDB spec: %w", err)
+	}
+	return &mdbv1.MongoDB{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "mongodb.com/v1", Kind: "MongoDB"},
+		ObjectMeta: buildCRObjectMeta(resourceName, opts.Namespace),
+		Spec:       spec,
+	}, resourceName, nil
+}
+
+
+// buildReplicaSetDbCommonSpec constructs the DbCommonSpec for a replica set deployment,
+// including security, Prometheus, TLS, and connection settings.
+func buildReplicaSetDbCommonSpec(ac *om.AutomationConfig, opts GenerateOptions, version, fcv, resourceName string) (mdbv1.DbCommonSpec, error) {
+	security, err := buildSecurity(ac, opts.CertsSecretPrefix, resourceName)
+	if err != nil {
+		return mdbv1.DbCommonSpec{}, fmt.Errorf("failed to build security config: %w", err)
+	}
+	if roles := ac.Deployment.GetRoles(); len(roles) > 0 {
+		if security == nil {
+			security = &mdbv1.Security{}
+		}
+		security.Roles = roles
+	}
+
+	prom, err := extractPrometheusConfig(ac.Deployment)
+	if err != nil {
+		return mdbv1.DbCommonSpec{}, fmt.Errorf("failed to extract Prometheus config: %w", err)
+	}
+	if prom != nil && opts.PrometheusSecretName != "" {
+		prom.PasswordSecretRef.Name = opts.PrometheusSecretName
+	}
+
+	var additionalConfig *mdbv1.AdditionalMongodConfig
+	if opts.SourceProcess != nil {
+		additionalConfig = opts.SourceProcess.AdditionalMongodConfig()
+	}
+	additionalConfig = applyClientCertificateMode(ac.AgentSSL, additionalConfig)
+
+	var featureCompatibilityVersion *string
+	if fcv != "" {
+		featureCompatibilityVersion = &fcv
+	}
+	return mdbv1.DbCommonSpec{
+		Version:                     version,
+		ResourceType:                mdbv1.ReplicaSet,
+		FeatureCompatibilityVersion: featureCompatibilityVersion,
+		ConnectionSpec: mdbv1.ConnectionSpec{
+			SharedConnectionSpec: mdbv1.SharedConnectionSpec{
+				OpsManagerConfig: &mdbv1.PrivateCloudConfig{
+					ConfigMapRef: mdbv1.ConfigMapRef{Name: opts.ConfigMapName},
+				},
+			},
+			Credentials: opts.CredentialsSecretName,
+		},
+		Security:               security,
+		Prometheus:             prom,
+		AdditionalMongodConfig: additionalConfig,
+		Agent:                  extractAgentConfig(opts.SourceProcess, opts.ProjectConfigs),
+	}, nil
+}
+
+func buildReplicaSetSpec(ac *om.AutomationConfig, opts GenerateOptions, version, fcv string, externalMembers []mdbv1.ExternalMember, rsName, resourceName string) (mdbv1.MongoDbSpec, error) {
+	common, err := buildReplicaSetDbCommonSpec(ac, opts, version, fcv, resourceName)
+	if err != nil {
+		return mdbv1.MongoDbSpec{}, err
+	}
+	spec := mdbv1.MongoDbSpec{
+		DbCommonSpec:    common,
+		Members:         0,
+		ExternalMembers: externalMembers,
+	}
+	if resourceName != rsName {
+		spec.ReplicaSetNameOverride = rsName
+	}
+	return spec, nil
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/user_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/user_generator.go
@@ -1,0 +1,92 @@
+package migratetomck
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+)
+
+// GenerateUserCRs creates MongoDBUser CRs for each user in the automation config, skipping the agent user.
+// Each SCRAM user references a pre-created Secret from ExistingUserSecrets.
+// External users (X.509 and LDAP) never produce a Secret.
+func GenerateUserCRs(ac *om.AutomationConfig, mongodbResourceName, namespace string, opts GenerateOptions) ([]client.Object, error) {
+	if ac.Auth == nil || len(ac.Auth.Users) == 0 {
+		return nil, nil
+	}
+
+	crNameToUsername := map[string]string{}
+	var results []client.Object
+	for i, user := range ac.Auth.Users {
+		if user == nil {
+			return nil, fmt.Errorf("user at index %d is nil", i)
+		}
+		if user.Username == "" {
+			return nil, fmt.Errorf("user at index %d has an empty username", i)
+		}
+
+		if user.Username == ac.Auth.AutoUser && user.Database == util.DefaultUserDatabase {
+			continue
+		}
+
+		crName := userv1.NormalizeName(user.Username)
+		if crName == "" {
+			return nil, fmt.Errorf("username %q cannot be normalized to a valid Kubernetes name: no alphanumeric characters", user.Username)
+		}
+		if prev, exists := crNameToUsername[crName]; exists {
+			return nil, fmt.Errorf("users %q and %q normalize to the same Kubernetes name %q. Rename one before migration", prev, user.Username, crName)
+		}
+		crNameToUsername[crName] = user.Username
+
+		roles, err := convertRoles(user.Roles)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert roles for user %q: %w", user.Username, err)
+		}
+
+		spec := userv1.MongoDBUserSpec{
+			Username: user.Username,
+			Database: user.Database,
+			MongoDBResourceRef: userv1.MongoDBResourceRef{
+				Name: mongodbResourceName,
+			},
+			Roles: roles,
+		}
+
+		if user.Database != externalDatabase {
+			sName, ok := opts.ExistingUserSecrets[userKey(user.Username, user.Database)]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "[WARNING] skipping user %q (db: %s): no Secret name provided\n", user.Username, user.Database)
+				continue
+			}
+			spec.PasswordSecretKeyRef = userv1.SecretKeyRef{Name: sName, Key: passwordSecretDataKey}
+		}
+
+		results = append(results, &userv1.MongoDBUser{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "mongodb.com/v1", Kind: "MongoDBUser"},
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: namespace},
+			Spec:       spec,
+		})
+	}
+
+	return results, nil
+}
+
+func convertRoles(roles []*om.Role) ([]userv1.Role, error) {
+	var out []userv1.Role
+	for i, r := range roles {
+		if r == nil {
+			return nil, fmt.Errorf("role at index %d is nil", i)
+		}
+		out = append(out, userv1.Role{
+			RoleName: r.Role,
+			Database: r.Database,
+		})
+	}
+	return out, nil
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/user_generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/user_generator_test.go
@@ -1,0 +1,78 @@
+package migratetomck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+)
+
+// TestGenerateUserCRs_EmptyMechanisms verifies users with empty mechanisms generate successfully.
+func TestGenerateUserCRs_EmptyMechanisms(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	ac.Auth.Users = []*om.MongoDBUser{
+		{Username: "app-user", Database: "admin", Mechanisms: []string{}, Roles: []*om.Role{{Role: "readWrite", Database: "myapp"}}},
+	}
+
+	// Option 2: reference an existing secret so the empty Mechanisms slice doesn't gate generation.
+	users, err := GenerateUserCRs(ac, "scram-rs", "mongodb", GenerateOptions{
+		ExistingUserSecrets: map[string]string{
+			"app-user:admin": "app-user-secret",
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, users)
+}
+
+func TestGenerateUserCRs_DuplicateNormalizedNames(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	ac.Auth.Users = []*om.MongoDBUser{
+		{Username: "App_User", Database: "admin", Roles: []*om.Role{{Role: "read", Database: "test"}}},
+		{Username: "app-user", Database: "admin", Roles: []*om.Role{{Role: "read", Database: "test"}}},
+	}
+
+	// Use Option 2 so both users are processed past the password step; the duplicate check fires on
+	// the second user when it tries to register the same normalised CR name "app-user".
+	opts := GenerateOptions{
+		ExistingUserSecrets: map[string]string{
+			"App_User:admin": "app-user-secret",
+			"app-user:admin": "app-user2-secret",
+		},
+	}
+	_, err := GenerateUserCRs(ac, "my-rs", "mongodb", opts)
+	assert.ErrorContains(t, err, "normalize to the same Kubernetes name")
+}
+
+func TestNormalizeName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"app-user", "app-user"},
+		{"CN=x509-client,O=MongoDB", "cn-x509-client-o-mongodb"},
+		{"user@example.com", "user-example-com"},
+		{"UPPER_CASE", "upper-case"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := userv1.NormalizeName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeName_InvalidInput(t *testing.T) {
+	result := userv1.NormalizeName("---")
+	assert.Empty(t, result)
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/users.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/users.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"

--- a/cmd/kubectl-mongodb/migrate-to-mck/users.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/users.go
@@ -1,10 +1,21 @@
 package migratetomck
 
 import (
+	"bufio"
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+
+	userv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/user"
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
 type usersFlags struct {
@@ -21,16 +32,58 @@ var uFlags usersFlags
 var UsersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Generate MongoDBUser Kubernetes CRs",
-	Long: `Generate MongoDBUser Kubernetes CRs from an Ops Manager/Cloud Manager automation
-config. The automation config is validated before generation. If any blockers are
-found, the command fails without producing output.
+	Long: `Generate MongoDBUser CRs from an Ops Manager or Cloud Manager automation config.
 
-Requires a ConfigMap (baseUrl, orgId, projectName) and a Secret (publicKey,
-privateKey) in the same format used by the operator.
+The automation config is validated before output is produced. The command exits
+with an error if any blockers are found.
 
-Example:
+PREREQUISITES
 
-kubectl mongodb migrate users --config-map-name my-project --secret-name my-credentials --namespace mongodb`,
+  A ConfigMap and a Secret must exist in the target namespace before running this
+  command:
+
+    kubectl create configmap my-project \
+      --from-literal=baseUrl=<url> \
+      --from-literal=orgId=<id> \
+      --from-literal=projectName=<name>
+
+    kubectl create secret generic my-credentials \
+      --from-literal=publicKey=<key> \
+      --from-literal=privateKey=<key>
+
+  Each SCRAM user also requires a pre-created Secret containing their password
+  under the key "password":
+
+    kubectl create secret generic <secret-name> \
+      --from-literal=password=<password> \
+      -n <namespace>
+
+USAGE
+
+  Interactive mode: the command prompts for each user's Secret name in turn.
+  Press Enter to accept the suggested name (<username>-password).
+
+  Non-interactive mode: supply --users-secrets-file with a CSV file mapping
+  each user to a pre-created Secret:
+
+    # username:database,secret-name
+    alice:admin,alice-password
+    bob:reporting,bob-password
+
+EXAMPLES
+
+  Interactive:
+    kubectl mongodb migrate users \
+      --config-map-name my-project \
+      --secret-name my-credentials \
+      --namespace mongodb
+
+  Non-interactive:
+    kubectl mongodb migrate users \
+      --config-map-name my-project \
+      --secret-name my-credentials \
+      --namespace mongodb \
+      --users-secrets-file users-secrets.csv`,
 	RunE: runGenerateUsers,
 }
 
@@ -39,7 +92,7 @@ func init() {
 	UsersCmd.Flags().StringVar(&uFlags.secretName, "secret-name", "", "Name of the Secret containing the OM API credentials (publicKey, privateKey) (required)")
 	UsersCmd.Flags().StringVar(&uFlags.namespace, "namespace", defaultNamespace, "Namespace of the ConfigMap and Secret")
 	UsersCmd.Flags().StringVarP(&uFlags.outputFile, "output", "o", "", "Write generated CRs to this file instead of stdout")
-	UsersCmd.Flags().StringVar(&uFlags.usersSecretsFile, "users-secrets-file", "", "CSV file mapping 'username:database,secret-name' for SCRAM users. When provided, customer-owned Secrets are referenced instead of generated and interactive prompts for user passwords are suppressed")
+	UsersCmd.Flags().StringVar(&uFlags.usersSecretsFile, "users-secrets-file", "", "CSV file mapping 'username:database,secret-name' for SCRAM users. Each line maps one user to a pre-created Kubernetes Secret. When omitted, the command prompts for each secret name interactively")
 	UsersCmd.Flags().StringVar(&uFlags.resourceNameOverride, "resource-name-override", "", "Overrides the name of the existing MongoDB CR that the generated MongoDBUser resources reference via spec.mongodbResourceRef.name. Must match the value passed to \"migrate-to-mck mongodb --resource-name-override\". Defaults to the same derived, normalized replica set name")
 	_ = UsersCmd.MarkFlagRequired("config-map-name")
 	_ = UsersCmd.MarkFlagRequired("secret-name")
@@ -48,16 +101,172 @@ func init() {
 func runGenerateUsers(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
-	conn, _, err := prepareConnection(ctx, uFlags.namespace, uFlags.configMapName, uFlags.secretName)
+	conn, kubeClient, err := prepareConnection(ctx, uFlags.namespace, uFlags.configMapName, uFlags.secretName)
 	if err != nil {
 		return err
 	}
 
-	_, _, _, err = fetchAndValidate(conn)
+	ac, _, _, err := fetchAndValidate(conn)
 	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Validation passed. CR generation is not yet available in this build.")
+	mongodbResourceName := uFlags.resourceNameOverride
+	if mongodbResourceName == "" {
+		replicaSets := ac.Deployment.GetReplicaSets()
+		if len(replicaSets) == 0 {
+			return fmt.Errorf("no replica sets found in the automation config")
+		}
+		mongodbResourceName = util.NormalizeName(replicaSets[0].Name())
+		if mongodbResourceName == "" {
+			return fmt.Errorf("replica set name %q cannot be normalized to a valid Kubernetes name. Use --resource-name-override to provide one", replicaSets[0].Name())
+		}
+	}
+
+	opts, err := buildUsersOptions(ctx, kubeClient, ac, os.Stdin, uFlags.namespace, uFlags.usersSecretsFile)
+	if err != nil {
+		return err
+	}
+
+	userObjects, err := GenerateUserCRs(ac, mongodbResourceName, uFlags.namespace, opts)
+	if err != nil {
+		return err
+	}
+
+	resources, err := marshalMultiDoc(userObjects)
+	if err != nil {
+		return err
+	}
+	return writeOutput(resources, uFlags.outputFile)
+}
+
+func buildUsersOptions(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, stdin io.Reader, namespace, usersSecretsFile string) (GenerateOptions, error) {
+	opts := GenerateOptions{Namespace: namespace}
+	scanner := bufio.NewScanner(stdin)
+	if err := collectUserCreds(ctx, kubeClient, ac, &opts, scanner, usersSecretsFile); err != nil {
+		return GenerateOptions{}, err
+	}
+	return opts, nil
+}
+
+func userKey(username, database string) string { return username + ":" + database }
+
+func scramUsers(ac *om.AutomationConfig) []*om.MongoDBUser {
+	if ac.Auth == nil {
+		return nil
+	}
+	var users []*om.MongoDBUser
+	for _, u := range ac.Auth.Users {
+		if u == nil || u.Username == "" ||
+			(u.Username == ac.Auth.AutoUser && u.Database == util.DefaultUserDatabase) ||
+			u.Database == externalDatabase {
+			continue
+		}
+		users = append(users, u)
+	}
+	return users
+}
+
+func collectUserCreds(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, opts *GenerateOptions, scanner *bufio.Scanner, usersSecretsFile string) error {
+	if usersSecretsFile != "" {
+		fileMapping, err := parseUsersSecretsFile(usersSecretsFile)
+		if err != nil {
+			return fmt.Errorf("failed to parse --users-secrets-file: %w", err)
+		}
+		return collectExistingUserSecrets(ctx, kubeClient, ac, opts, fileMapping)
+	}
+	return collectUserSecretNamesInteractively(ctx, kubeClient, ac, opts, scanner)
+}
+
+func collectUserSecretNamesInteractively(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, opts *GenerateOptions, scanner *bufio.Scanner) error {
+	users := scramUsers(ac)
+	if len(users) == 0 {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(promptOutput, "SCRAM users found. Create a Kubernetes Secret for each user before continuing:\n\n")
+	_, _ = fmt.Fprintf(promptOutput, "  kubectl create secret generic <secret-name> --from-literal=password=<password> -n %s\n\n", opts.Namespace)
+
+	opts.ExistingUserSecrets = make(map[string]string)
+	for _, user := range users {
+		suggestedName := userv1.NormalizeName(user.Username) + "-password"
+		secretName, err := promptKubernetesName(scanner, fmt.Sprintf("Secret name for user %q (db: %s) [%s]: ", user.Username, user.Database, suggestedName), suggestedName)
+		if err != nil {
+			return fmt.Errorf("failed to read spec.passwordSecretKeyRef.name for user %q: %w", user.Username, err)
+		}
+		if err := validateUserSecret(ctx, kubeClient, user, secretName, ac, opts.Namespace); err != nil {
+			return err
+		}
+		opts.ExistingUserSecrets[userKey(user.Username, user.Database)] = secretName
+	}
 	return nil
+}
+
+func validatePasswordAgainstOM(username, database, password string, ac *om.AutomationConfig) error {
+	_, acUser := ac.Auth.GetUser(username, database)
+	matches, err := authentication.PasswordMatchesStoredCreds(username, password, acUser)
+	if err != nil {
+		return fmt.Errorf("failed to validate password for user %q: %w", username, err)
+	}
+	if !matches {
+		return fmt.Errorf("password for user %q does not match the existing credentials in Ops Manager", username)
+	}
+	return nil
+}
+
+func collectExistingUserSecrets(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, opts *GenerateOptions, fileMapping map[string]string) error {
+	opts.ExistingUserSecrets = make(map[string]string)
+	for _, user := range scramUsers(ac) {
+		key := userKey(user.Username, user.Database)
+		secretName, ok := fileMapping[key]
+		if !ok {
+			continue
+		}
+		if err := validateUserSecret(ctx, kubeClient, user, secretName, ac, opts.Namespace); err != nil {
+			return err
+		}
+		opts.ExistingUserSecrets[key] = secretName
+	}
+	return nil
+}
+
+func validateUserSecret(ctx context.Context, kubeClient kubernetesClient.Client, user *om.MongoDBUser, secretName string, ac *om.AutomationConfig, namespace string) error {
+	passwordBytes, err := requirePasswordSecret(ctx, kubeClient, namespace, secretName)
+	if err != nil {
+		return fmt.Errorf("%w for user %q", err, user.Username)
+	}
+	return validatePasswordAgainstOM(user.Username, user.Database, string(passwordBytes), ac)
+}
+
+func parseUsersSecretsFile(path string) (map[string]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	result := make(map[string]string)
+	sc := bufio.NewScanner(f)
+	for lineNum := 1; sc.Scan(); lineNum++ {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		userDB, sName, ok := strings.Cut(line, ",")
+		userDB, sName = strings.TrimSpace(userDB), strings.TrimSpace(sName)
+		if !ok || userDB == "" || sName == "" {
+			return nil, fmt.Errorf("line %d: expected \"username:database,secret-name\", got %q", lineNum, line)
+		}
+		if !strings.Contains(userDB, ":") {
+			return nil, fmt.Errorf("line %d: first field %q is missing the database part. Expected \"username:database\"", lineNum, userDB)
+		}
+		if errs := k8svalidation.IsDNS1123Subdomain(sName); len(errs) > 0 {
+			return nil, fmt.Errorf("line %d: secret name %q is not a valid Kubernetes name: %s", lineNum, sName, errs[0])
+		}
+		result[userDB] = sName
+	}
+	return result, sc.Err()
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/users_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/users_test.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"

--- a/cmd/kubectl-mongodb/migrate-to-mck/users_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/users_test.go
@@ -1,0 +1,185 @@
+package migratetomck
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+)
+
+func newFakeSecret(name, password string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Data:       map[string][]byte{passwordSecretDataKey: []byte(password)},
+	}
+}
+
+func newFakeKubeClient(objects ...runtime.Object) kubernetesClient.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	clientObjs := make([]runtime.Object, len(objects))
+	copy(clientObjs, objects)
+	return kubernetesClient.NewClient(fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(clientObjs...).Build())
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "secrets.csv")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestParseUsersSecretsFile_EmptyPath(t *testing.T) {
+	m, err := parseUsersSecretsFile("")
+	require.NoError(t, err)
+	assert.Nil(t, m)
+}
+
+func TestParseUsersSecretsFile_Valid(t *testing.T) {
+	content := `# comment
+alice:admin,alice-secret
+bob:mydb,bob-secret
+`
+	path := writeTempFile(t, content)
+	m, err := parseUsersSecretsFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "alice-secret", m["alice:admin"])
+	require.Equal(t, "bob-secret", m["bob:mydb"])
+}
+
+func TestParseUsersSecretsFile_InvalidFormat(t *testing.T) {
+	path := writeTempFile(t, "no-comma-here\n")
+	_, err := parseUsersSecretsFile(path)
+	assert.ErrorContains(t, err, "line 1")
+}
+
+func TestParseUsersSecretsFile_MissingDatabase(t *testing.T) {
+	path := writeTempFile(t, "username-without-db,some-secret\n")
+	_, err := parseUsersSecretsFile(path)
+	assert.ErrorContains(t, err, "missing the database part")
+}
+
+func TestParseUsersSecretsFile_InvalidSecretName(t *testing.T) {
+	path := writeTempFile(t, "alice:admin,Invalid_Name\n")
+	_, err := parseUsersSecretsFile(path)
+	assert.ErrorContains(t, err, "not a valid Kubernetes name")
+}
+
+func TestParseUsersSecretsFile_EmptyFields(t *testing.T) {
+	path := writeTempFile(t, ",\n")
+	_, err := parseUsersSecretsFile(path)
+	assert.ErrorContains(t, err, "expected \"username:database,secret-name\"")
+}
+
+func TestGenerateUserCRs_ExistingSecrets(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	ac.Auth.Users = []*om.MongoDBUser{
+		{Username: "alice", Database: "admin", Roles: []*om.Role{{Role: "readWrite", Database: "myapp"}}},
+	}
+
+	opts := GenerateOptions{
+		ExistingUserSecrets: map[string]string{
+			"alice:admin": "alice-secret",
+		},
+	}
+	users, err := GenerateUserCRs(ac, "my-rs", "default", opts)
+	require.NoError(t, err)
+	require.Len(t, users, 1, "Option 2 must not generate a Secret object")
+	y, err := marshalCRToYAML(users[0])
+	require.NoError(t, err)
+	assert.Contains(t, y, "alice-secret")
+}
+
+func TestGenerateUserCRs_ExistingSecrets_SkipsUnmappedUsers(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	ac.Auth.Users = []*om.MongoDBUser{
+		{Username: "alice", Database: "admin", Roles: []*om.Role{{Role: "read", Database: "test"}}},
+		{Username: "bob", Database: "admin", Roles: []*om.Role{{Role: "read", Database: "test"}}},
+	}
+
+	opts := GenerateOptions{
+		ExistingUserSecrets: map[string]string{
+			"alice:admin": "alice-secret",
+		},
+	}
+	users, err := GenerateUserCRs(ac, "my-rs", "default", opts)
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	y, err := marshalCRToYAML(users[0])
+	require.NoError(t, err)
+	assert.Contains(t, y, "alice")
+}
+
+func TestCollectUserSecretNamesInteractively_ExplicitName(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	alice := &om.MongoDBUser{Username: "alice", Database: "admin", Roles: []*om.Role{{Role: "read", Database: "test"}}}
+	ac.Auth.Users = []*om.MongoDBUser{alice}
+	_, err := authentication.ConfigureScramCredentials(alice, "correct-password", ac)
+	require.NoError(t, err)
+
+	secret := newFakeSecret("my-alice-secret", "correct-password")
+	kubeClient := newFakeKubeClient(secret)
+	opts := &GenerateOptions{Namespace: "default"}
+	scanner := bufio.NewScanner(strings.NewReader("my-alice-secret\n"))
+	err = collectUserSecretNamesInteractively(t.Context(), kubeClient, ac, opts, scanner)
+	require.NoError(t, err)
+	assert.Equal(t, "my-alice-secret", opts.ExistingUserSecrets["alice:admin"])
+}
+
+func TestCollectUserSecretNamesInteractively_DefaultName(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	alice := &om.MongoDBUser{Username: "alice", Database: "admin", Roles: []*om.Role{{Role: "read", Database: "test"}}}
+	ac.Auth.Users = []*om.MongoDBUser{alice}
+	_, err := authentication.ConfigureScramCredentials(alice, "correct-password", ac)
+	require.NoError(t, err)
+
+	// suggested name is "alice-password"
+	secret := newFakeSecret("alice-password", "correct-password")
+	kubeClient := newFakeKubeClient(secret)
+	opts := &GenerateOptions{Namespace: "default"}
+	scanner := bufio.NewScanner(strings.NewReader("\n")) // press Enter to accept suggested name
+	err = collectUserSecretNamesInteractively(t.Context(), kubeClient, ac, opts, scanner)
+	require.NoError(t, err)
+	assert.Equal(t, "alice-password", opts.ExistingUserSecrets["alice:admin"])
+}
+
+func TestCollectUserSecretNamesInteractively_NoUsers(t *testing.T) {
+	ac := om.NewAutomationConfig(om.Deployment{
+		"processes":   []any{},
+		"replicaSets": []any{},
+	})
+	ac.Auth.AutoUser = "mms-automation"
+	opts := &GenerateOptions{Namespace: "default"}
+	scanner := bufio.NewScanner(strings.NewReader(""))
+	err := collectUserSecretNamesInteractively(t.Context(), nil, ac, opts, scanner)
+	require.NoError(t, err)
+	assert.Nil(t, opts.ExistingUserSecrets)
+}

--- a/controllers/om/deployment.go
+++ b/controllers/om/deployment.go
@@ -194,6 +194,23 @@ func (d Deployment) DownloadBase() string {
 	return maputil.ReadMapValueAsString(d, "options", "downloadBase")
 }
 
+// GetPrometheus returns the Prometheus configuration from the deployment, or nil if absent.
+func (d Deployment) GetPrometheus() *automationconfig.Prometheus {
+	promMap := maputil.ReadMapValueAsMap(d, "prometheus")
+	if len(promMap) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(promMap)
+	if err != nil {
+		return nil
+	}
+	var p automationconfig.Prometheus
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil
+	}
+	return &p
+}
+
 // ConfigurePrometheus adds Prometheus configuration to `Deployment` resource.
 //
 // If basic auth is enabled, then `hash` and `salt` need to be calculated by caller and passed in.

--- a/controllers/om/monitoring_agent_config.go
+++ b/controllers/om/monitoring_agent_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 )
 
@@ -83,6 +84,19 @@ func (m *MonitoringAgentConfig) SetLogRotate(logRotateConfig mdbv1.LogRotateForB
 func (m *MonitoringAgentConfig) LogPath() string {
 	logPath, _ := m.BackingMap["logPath"].(string)
 	return logPath
+}
+
+// LogRotateForAgentsFromAc converts an AcLogRotate (OM API representation) to
+// the simpler LogRotateForBackupAndMonitoring type used by monitoring and backup
+// agent specs. Returns nil when the input is nil or has no meaningful thresholds.
+func LogRotateForAgentsFromAc(ac *automationconfig.AcLogRotate) *mdbv1.LogRotateForBackupAndMonitoring {
+	if ac == nil || (ac.SizeThresholdMB == 0 && ac.TimeThresholdHrs == 0) {
+		return nil
+	}
+	return &mdbv1.LogRotateForBackupAndMonitoring{
+		SizeThresholdMB:  int(ac.SizeThresholdMB),
+		TimeThresholdHrs: ac.TimeThresholdHrs,
+	}
 }
 
 func BuildMonitoringAgentConfigFromBytes(jsonBytes []byte) (*MonitoringAgentConfig, error) {

--- a/controllers/om/process.go
+++ b/controllers/om/process.go
@@ -27,6 +27,24 @@ const (
 	ProcessTypeMongod MongoType = "mongod"
 )
 
+// infrastructureFieldPaths lists args2_6 field paths that are set into the
+// mongod spec by the operator or deployment infrastructure, not by the
+// arguments present on the mongod config level. AdditionalMongodConfig
+// strips these to isolate user-supplied config. When a new
+// infrastructure-managed field is introduced, add its path here.
+var infrastructureFieldPaths = [][]string{
+	{"systemLog"},
+	{"storage", "dbPath"},
+	{"replication", "replSetName"},
+	{"security", "clusterAuthMode"},
+}
+
+// infrastructureTLSCertKeys lists TLS/SSL certificate-related keys under
+// net.{tls,ssl} that are set by the operator, not by the arguments present
+// on the mongod config level. Stripped by AdditionalMongodConfig when
+// extracting user config.
+var infrastructureTLSCertKeys = []string{"certificateKeyFile", "PEMKeyFile", "clusterFile"}
+
 /*
 This is a class for all types of processes.
 Note, that mongos types of processes don't have some fields (replication, storage etc.) but it's impossible to use a
@@ -40,6 +58,9 @@ the process that was read from Ops Manager.
 the other properties unmodified. That's why structs are not used anywhere as they would result in possible overriding of
 the whole elements which we don't want. Deal with data as with maps, create convenience methods (setters, getters,
 ensuremap etc.) and make sure not to override anything unrelated.
+- when adding a new infrastructure-managed field, also add its path to infrastructureFieldPaths (or
+  infrastructureTLSCertKeys for TLS cert keys) so it is automatically stripped during VM migration.
+
 The resulting json for this type (example):
 
 	{
@@ -310,6 +331,65 @@ func (p Process) IsDisabled() bool {
 	return cast.ToBool(p["disabled"])
 }
 
+// SystemLogMap returns the systemLog sub-map from args2_6, or nil if absent.
+func (p Process) SystemLogMap() map[string]interface{} {
+	return maputil.ReadMapValueAsMap(p.Args(), "systemLog")
+}
+
+// AdditionalMongodConfig recovers user-supplied mongod config from args2_6 during VM migration.
+// Infrastructure-managed fields listed in infrastructureFieldPaths and infrastructureTLSCertKeys
+// are stripped, along with default net.port and default TLS modes.
+// Returns nil when nothing user-relevant remains.
+func (p Process) AdditionalMongodConfig() *mdbv1.AdditionalMongodConfig {
+	if len(p.Args()) == 0 {
+		return nil
+	}
+	m, err := util.MapDeepCopy(p.Args())
+	if err != nil {
+		return nil
+	}
+
+	for _, path := range infrastructureFieldPaths {
+		if len(path) == 1 {
+			delete(m, path[0])
+		} else {
+			maputil.DeleteMapValue(m, path...)
+		}
+	}
+
+	if port := maputil.ReadMapValueAsInt(m, "net", "port"); port == 0 || port == util.MongoDbDefaultPort {
+		maputil.DeleteMapValue(m, "net", "port")
+	}
+	for _, tlsKey := range []string{"tls", "ssl"} {
+		for _, certKey := range infrastructureTLSCertKeys {
+			maputil.DeleteMapValue(m, "net", tlsKey, certKey)
+		}
+		if mode := maputil.ReadMapValueAsString(m, "net", tlsKey, "mode"); mode == string(tls.Require) || mode == "requireSSL" || mode == string(tls.Disabled) {
+			maputil.DeleteMapValue(m, "net", tlsKey, "mode")
+		}
+	}
+
+	// drop sections that became empty after stripping operator fields
+	for _, path := range [][]string{{"net", "tls"}, {"net", "ssl"}, {"net"}, {"storage"}, {"replication"}, {"security"}} {
+		if sub := maputil.ReadMapValueAsMap(m, path...); len(sub) == 0 && sub != nil {
+			maputil.DeleteMapValue(m, path...)
+		}
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+	cfg := mdbv1.NewEmptyAdditionalMongodConfig()
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil
+	}
+	return cfg
+}
+
 // NetTLSSections returns the TLS/SSL config maps from args2_6.net, keyed by
 // section name ("tls" or "ssl"). Only sections that are present are returned.
 func (p Process) NetTLSSections() map[string]map[string]interface{} {
@@ -558,7 +638,7 @@ func (p Process) setReplicaSetName(rsName string) Process {
 	return p
 }
 
-func (p Process) replicaSetName() string {
+func (p Process) ReplicaSetName() string {
 	return maputil.ReadMapValueAsString(p.Args(), "replication", "replSetName")
 }
 

--- a/controllers/om/process.go
+++ b/controllers/om/process.go
@@ -37,6 +37,9 @@ var infrastructureFieldPaths = [][]string{
 	{"storage", "dbPath"},
 	{"replication", "replSetName"},
 	{"security", "clusterAuthMode"},
+	// If external members are listening on a port different from 27017,
+	// there is no reason to make the MCK-managed members listen on the same port.
+	{"net", "port"},
 }
 
 // infrastructureTLSCertKeys lists TLS/SSL certificate-related keys under
@@ -331,14 +334,9 @@ func (p Process) IsDisabled() bool {
 	return cast.ToBool(p["disabled"])
 }
 
-// SystemLogMap returns the systemLog sub-map from args2_6, or nil if absent.
-func (p Process) SystemLogMap() map[string]interface{} {
-	return maputil.ReadMapValueAsMap(p.Args(), "systemLog")
-}
-
 // AdditionalMongodConfig recovers user-supplied mongod config from args2_6 during VM migration.
 // Infrastructure-managed fields listed in infrastructureFieldPaths and infrastructureTLSCertKeys
-// are stripped, along with default net.port and default TLS modes.
+// are stripped, along with default TLS modes.
 // Returns nil when nothing user-relevant remains.
 func (p Process) AdditionalMongodConfig() *mdbv1.AdditionalMongodConfig {
 	if len(p.Args()) == 0 {
@@ -357,9 +355,6 @@ func (p Process) AdditionalMongodConfig() *mdbv1.AdditionalMongodConfig {
 		}
 	}
 
-	if port := maputil.ReadMapValueAsInt(m, "net", "port"); port == 0 || port == util.MongoDbDefaultPort {
-		maputil.DeleteMapValue(m, "net", "port")
-	}
 	for _, tlsKey := range []string{"tls", "ssl"} {
 		for _, certKey := range infrastructureTLSCertKeys {
 			maputil.DeleteMapValue(m, "net", tlsKey, certKey)

--- a/controllers/om/process_test.go
+++ b/controllers/om/process_test.go
@@ -26,7 +26,7 @@ func TestCreateMongodProcess(t *testing.T) {
 		assert.Equal(t, "/data", process.DbPath())
 		assert.Equal(t, "/var/log/mongodb-mms-automation/mongodb.log", process.LogPath())
 		assert.Equal(t, 5, process.AuthSchemaVersion())
-		assert.Equal(t, "", process.replicaSetName())
+		assert.Equal(t, "", process.ReplicaSetName())
 		assert.Equal(t, nil, process.LogRotateSizeThresholdMB())
 
 		expectedMap := map[string]interface{}{"port": int32(util.MongoDbDefaultPort), "tls": map[string]interface{}{
@@ -61,7 +61,7 @@ func TestCreateMongodProcessStatic(t *testing.T) {
 		assert.Equal(t, "/data", process.DbPath())
 		assert.Equal(t, "/var/log/mongodb-mms-automation/mongodb.log", process.LogPath())
 		assert.Equal(t, 5, process.AuthSchemaVersion())
-		assert.Equal(t, "", process.replicaSetName())
+		assert.Equal(t, "", process.ReplicaSetName())
 
 		expectedMap := map[string]interface{}{"port": int32(util.MongoDbDefaultPort), "tls": map[string]interface{}{
 			"mode": "disabled",

--- a/controllers/om/replicaset.go
+++ b/controllers/om/replicaset.go
@@ -375,6 +375,34 @@ func findDifference(leftMap map[string]ReplicaSetMember, rightMap map[string]Rep
 	return ans
 }
 
+// ExtractMemberInfo reads version, FCV, and per-member metadata from the
+// given replica set members and process map. Each member becomes an
+// mdbv1.ExternalMember suitable for the CR's spec.externalMembers.
+func ExtractMemberInfo(members []ReplicaSetMember, processMap map[string]Process) ([]mdbv1.ExternalMember, string, string) {
+	if len(members) == 0 {
+		return nil, "", ""
+	}
+	firstProc := processMap[members[0].Name()]
+	version := firstProc.Version()
+	fcv := firstProc.FeatureCompatibilityVersion()
+
+	var externalMembers []mdbv1.ExternalMember
+	for _, m := range members {
+		host := m.Name()
+		proc := processMap[host]
+		port := maputil.ReadMapValueAsInt(proc.Args(), "net", "port")
+
+		externalMembers = append(externalMembers, mdbv1.ExternalMember{
+			ProcessName:    host,
+			Hostname:       fmt.Sprintf("%s:%d", proc.HostName(), port),
+			Type:           "mongod",
+			ReplicaSetName: proc.ReplicaSetName(),
+		})
+	}
+
+	return externalMembers, version, fcv
+}
+
 // Builds the map[<process name>]<replica set member>. This makes intersection easier
 func buildMapOfRsNodes(rs ReplicaSet) map[string]ReplicaSetMember {
 	ans := make(map[string]ReplicaSetMember)

--- a/controllers/om/replicaset.go
+++ b/controllers/om/replicaset.go
@@ -10,6 +10,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/stringutil"
 )
 

--- a/controllers/operator/authentication/authentication_mechanism.go
+++ b/controllers/operator/authentication/authentication_mechanism.go
@@ -70,6 +70,17 @@ func (m MechanismList) Contains(mechanismName MechanismName) bool {
 // that can be configured by the Operator
 var supportedMechanisms = []MechanismName{ScramSha256, MongoDBCR, MongoDBX509, LDAPPlain, MongoDBOIDC}
 
+// crModeToMechanismName maps CR AuthMode strings to their AC MechanismName.
+// util.SCRAM is omitted because its target mechanism depends on existing config state.
+var crModeToMechanismName = map[string]MechanismName{
+	util.X509:        MongoDBX509,
+	util.LDAP:        LDAPPlain,
+	util.SCRAMSHA1:   ScramSha1,
+	util.MONGODBCR:   MongoDBCR,
+	util.SCRAMSHA256: ScramSha256,
+	util.OIDC:        MongoDBOIDC,
+}
+
 // mechanismsToDisable returns mechanisms which need to be disabled
 // based on the currently supported authentication mechanisms and the desiredMechanisms
 func mechanismsToDisable(desiredMechanisms MechanismList) MechanismList {
@@ -105,10 +116,39 @@ func ConvertToMechanismOrPanic(mechanismModeInCR string, autoAuthMechanism strin
 }
 
 func convertToMechanismOrPanic(mechanismModeInCR string, ac *om.AutomationConfig) Mechanism {
-	if ac == nil || ac.Auth == nil {
-		panic(xerrors.Errorf("automation config auth required for mechanism %s", mechanismModeInCR))
+	if name, ok := crModeToMechanismName[mechanismModeInCR]; ok {
+		return getMechanismByName(name)
 	}
-	return ConvertToMechanismOrPanic(mechanismModeInCR, ac.Auth.AutoAuthMechanism, ac.Auth.IsEnabled())
+	if mechanismModeInCR == util.SCRAM {
+		// if we have already configured authentication, and it has been set to MONGODB-CR/SCRAM-SHA-1
+		// we can not transition. This needs to be done in the UI
+
+		// if no authentication has been configured, the default value for "AutoAuthMechanism" is "MONGODB-CR"
+		// even if authentication is disabled, so we need to ensure that auth has been enabled.
+		if ac.Auth.AutoAuthMechanism == string(MongoDBCR) && ac.Auth.IsEnabled() {
+			return getMechanismByName(MongoDBCR)
+		}
+		return getMechanismByName(ScramSha256)
+	}
+
+	// this should never be reached as validation of this string happens at the CR level
+	panic(xerrors.Errorf("unknown mechanism name %s", mechanismModeInCR))
+}
+
+var acMechanismToCRMode = map[string]string{
+	string(MongoDBCR):   util.MONGODBCR,
+	string(ScramSha256): util.SCRAM,
+	string(ScramSha1):   util.SCRAMSHA1,
+	string(MongoDBX509): util.X509,
+	string(LDAPPlain):   util.LDAP,
+	string(MongoDBOIDC): util.OIDC,
+}
+
+// MapMechanismToAuthMode converts an automation config mechanism string to
+// the corresponding CR AuthMode. This is the reverse of convertToMechanismOrPanic.
+func MapMechanismToAuthMode(mech string) (string, bool) {
+	mode, ok := acMechanismToCRMode[mech]
+	return mode, ok
 }
 
 func getMechanismByName(name MechanismName) Mechanism {

--- a/controllers/operator/authentication/oidc.go
+++ b/controllers/operator/authentication/oidc.go
@@ -91,47 +91,100 @@ func oidcProviderConfigEqual(l, r oidc.ProviderConfig) bool {
 		l.UseAuthorizationClaim == r.UseAuthorizationClaim
 }
 
+// oidcFieldMapping holds both directions of a single field conversion so they stay co-located.
+// Asymmetric fields (AuthorizationMethod, AuthorizationType) are handled inline below.
+type oidcFieldMapping struct {
+	toAC func(*mdbv1.OIDCProviderConfig, *oidc.ProviderConfig)
+	toCR func(*oidc.ProviderConfig, *mdbv1.OIDCProviderConfig)
+}
+
+var oidcFieldMappings = []oidcFieldMapping{
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.AuthNamePrefix = c.ConfigurationName },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.ConfigurationName = a.AuthNamePrefix },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.Audience = c.Audience },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.Audience = a.Audience },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.IssuerUri = c.IssuerURI },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.IssuerURI = a.IssuerUri },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.ClientId = c.ClientId },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.ClientId = a.ClientId },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.RequestedScopes = c.RequestedScopes },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.RequestedScopes = a.RequestedScopes },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.UserClaim = c.UserClaim },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.UserClaim = a.UserClaim },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) { a.GroupsClaim = c.GroupsClaim },
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) { c.GroupsClaim = a.GroupsClaim },
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) {
+			a.SupportsHumanFlows = c.AuthorizationMethod == mdbv1.OIDCAuthorizationMethodWorkforceIdentityFederation
+			if c.AuthorizationMethod != mdbv1.OIDCAuthorizationMethodWorkforceIdentityFederation &&
+				c.AuthorizationMethod != mdbv1.OIDCAuthorizationMethodWorkloadIdentityFederation {
+				panic(fmt.Sprintf("unsupported OIDC authorization method: %s", c.AuthorizationMethod))
+			}
+		},
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) {
+			if a.SupportsHumanFlows {
+				c.AuthorizationMethod = mdbv1.OIDCAuthorizationMethodWorkforceIdentityFederation
+			} else {
+				c.AuthorizationMethod = mdbv1.OIDCAuthorizationMethodWorkloadIdentityFederation
+			}
+		},
+	},
+	{
+		func(c *mdbv1.OIDCProviderConfig, a *oidc.ProviderConfig) {
+			a.UseAuthorizationClaim = c.AuthorizationType == mdbv1.OIDCAuthorizationTypeGroupMembership
+			if c.AuthorizationType != mdbv1.OIDCAuthorizationTypeGroupMembership &&
+				c.AuthorizationType != mdbv1.OIDCAuthorizationTypeUserID {
+				panic(fmt.Sprintf("unsupported OIDC authorization type: %s", c.AuthorizationType))
+			}
+		},
+		func(a *oidc.ProviderConfig, c *mdbv1.OIDCProviderConfig) {
+			if a.UseAuthorizationClaim {
+				c.AuthorizationType = mdbv1.OIDCAuthorizationTypeGroupMembership
+			} else {
+				c.AuthorizationType = mdbv1.OIDCAuthorizationTypeUserID
+			}
+		},
+	},
+}
+
+// MapOIDCProviderConfigs converts CR OIDC provider configs to the AC representation. See MapACOIDCToProviderConfigs for the reverse.
 func MapOIDCProviderConfigs(oidcProviderConfigs []mdbv1.OIDCProviderConfig) []oidc.ProviderConfig {
 	if len(oidcProviderConfigs) == 0 {
 		return nil
 	}
-
 	result := make([]oidc.ProviderConfig, len(oidcProviderConfigs))
-	for i, providerConfig := range oidcProviderConfigs {
-		result[i] = oidc.ProviderConfig{
-			AuthNamePrefix:        providerConfig.ConfigurationName,
-			Audience:              providerConfig.Audience,
-			IssuerUri:             providerConfig.IssuerURI,
-			ClientId:              providerConfig.ClientId,
-			RequestedScopes:       providerConfig.RequestedScopes,
-			UserClaim:             providerConfig.UserClaim,
-			GroupsClaim:           providerConfig.GroupsClaim,
-			SupportsHumanFlows:    mapToSupportHumanFlows(providerConfig.AuthorizationMethod),
-			UseAuthorizationClaim: mapToUseAuthorizationClaim(providerConfig.AuthorizationType),
+	for i := range oidcProviderConfigs {
+		for _, f := range oidcFieldMappings {
+			f.toAC(&oidcProviderConfigs[i], &result[i])
 		}
 	}
-
 	return result
 }
 
-func mapToSupportHumanFlows(authMethod mdbv1.OIDCAuthorizationMethod) bool {
-	switch authMethod {
-	case mdbv1.OIDCAuthorizationMethodWorkforceIdentityFederation:
-		return true
-	case mdbv1.OIDCAuthorizationMethodWorkloadIdentityFederation:
-		return false
+// MapACOIDCToProviderConfigs converts AC OIDC provider configs to the CR representation. See MapOIDCProviderConfigs for the reverse.
+func MapACOIDCToProviderConfigs(configs []oidc.ProviderConfig) []mdbv1.OIDCProviderConfig {
+	if len(configs) == 0 {
+		return nil
 	}
-
-	panic(fmt.Sprintf("unsupported OIDC authorization method: %s", authMethod))
-}
-
-func mapToUseAuthorizationClaim(authType mdbv1.OIDCAuthorizationType) bool {
-	switch authType {
-	case mdbv1.OIDCAuthorizationTypeGroupMembership:
-		return true
-	case mdbv1.OIDCAuthorizationTypeUserID:
-		return false
+	out := make([]mdbv1.OIDCProviderConfig, len(configs))
+	for i := range configs {
+		for _, f := range oidcFieldMappings {
+			f.toCR(&configs[i], &out[i])
+		}
 	}
-
-	panic(fmt.Sprintf("unsupported OIDC authorization type: %s", authType))
+	return out
 }

--- a/controllers/operator/authentication/scramsha_credentials.go
+++ b/controllers/operator/authentication/scramsha_credentials.go
@@ -50,6 +50,40 @@ func hasCreds(creds *om.ScramShaCreds) bool {
 	return creds != nil && creds.Salt != ""
 }
 
+// PasswordMatchesStoredCreds reports whether the password reproduces every complete set
+// of SCRAM credentials stored on the AC user. Incomplete creds are skipped. It returns
+// an error when the user is missing or has no creds to validate against.
+func PasswordMatchesStoredCreds(username, password string, acUser *om.MongoDBUser) (bool, error) {
+	if acUser == nil {
+		return false, xerrors.Errorf("user %s not found in the automation config", username)
+	}
+	validated := false
+	if hasCreds(acUser.ScramSha256Creds) {
+		changed, err := isCredChanged(username, password, acUser.ScramSha256Creds, ScramSha256)
+		if err != nil {
+			return false, err
+		}
+		if changed {
+			return false, nil
+		}
+		validated = true
+	}
+	if hasCreds(acUser.ScramSha1Creds) {
+		changed, err := isCredChanged(username, password, acUser.ScramSha1Creds, MongoDBCR)
+		if err != nil {
+			return false, err
+		}
+		if changed {
+			return false, nil
+		}
+		validated = true
+	}
+	if !validated {
+		return false, xerrors.Errorf("user %s has no SCRAM credentials to validate the supplied password against", username)
+	}
+	return true, nil
+}
+
 // ConfigureScramCredentials sets SCRAM credentials on user and returns needsFollowUp.
 // Three cases:
 //  1. User not in AC: generate both SHA-256 and SHA-1 creds.

--- a/controllers/operator/authentication/scramsha_credentials_test.go
+++ b/controllers/operator/authentication/scramsha_credentials_test.go
@@ -85,6 +85,95 @@ func Test_isCredChanged_PasswordChangeDetection(t *testing.T) {
 	assert.True(t, changed)
 }
 
+// Test_PasswordMatchesStoredCreds verifies password validation against the creds
+// stored on an AC user, including users with only one algorithm present.
+func Test_PasswordMatchesStoredCreds(t *testing.T) {
+	seed := om.MongoDBUser{Username: "mia", Database: "admin"}
+	_, err := ConfigureScramCredentials(&seed, "pass", emptyAC())
+	require.NoError(t, err)
+
+	stale := om.MongoDBUser{Username: "mia", Database: "admin"}
+	_, err = ConfigureScramCredentials(&stale, "oldpass", emptyAC())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		password    string
+		acUser      *om.MongoDBUser
+		wantMatches bool
+		wantErr     string
+	}{
+		{
+			name:     "correct password matches both cred sets",
+			password: "pass",
+			acUser: &om.MongoDBUser{
+				Username:         "mia",
+				Database:         "admin",
+				ScramSha256Creds: seed.ScramSha256Creds,
+				ScramSha1Creds:   seed.ScramSha1Creds,
+			},
+			wantMatches: true,
+		},
+		{
+			name:     "wrong password does not match",
+			password: "wrongpass",
+			acUser: &om.MongoDBUser{
+				Username:         "mia",
+				Database:         "admin",
+				ScramSha256Creds: seed.ScramSha256Creds,
+				ScramSha1Creds:   seed.ScramSha1Creds,
+			},
+			wantMatches: false,
+		},
+		{
+			name:     "only one algorithm present still validates",
+			password: "pass",
+			acUser: &om.MongoDBUser{
+				Username:       "mia",
+				Database:       "admin",
+				ScramSha1Creds: seed.ScramSha1Creds,
+			},
+			wantMatches: true,
+		},
+		{
+			name:     "stale cred set fails validation even when the other one matches",
+			password: "pass",
+			acUser: &om.MongoDBUser{
+				Username:         "mia",
+				Database:         "admin",
+				ScramSha256Creds: seed.ScramSha256Creds,
+				ScramSha1Creds:   stale.ScramSha1Creds,
+			},
+			wantMatches: false,
+		},
+		{
+			name:     "user missing from the automation config",
+			password: "pass",
+			acUser:   nil,
+			wantErr:  "not found in the automation config",
+		},
+		{
+			name:     "user without creds cannot be validated",
+			password: "pass",
+			acUser:   &om.MongoDBUser{Username: "mia", Database: "admin"},
+			wantErr:  "no SCRAM credentials to validate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := PasswordMatchesStoredCreds("mia", tt.password, tt.acUser)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMatches, matches)
+		})
+	}
+}
+
 // Test_ConfigureScramCredentials_MechanismsSetWithoutCreds_Errors verifies that an AC user
 // with mechanisms set but no SCRAM creds to validate against is rejected instead of
 // silently resetting the password via InitPassword.

--- a/docker/mongodb-kubernetes-tests/kubetester/omtester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/omtester.py
@@ -27,6 +27,8 @@ skip_if_cloud_manager = pytest.mark.skipif(is_cloud_qa(), reason="Do not run in 
 
 logger = test_logger.get_test_logger(__name__)
 
+from kubetester.scram import build_sha1_creds, build_sha256_creds
+
 
 class BackupStatus(str, Enum):
     """Enum for backup statuses in Ops Manager. Note that 'str' is inherited to fix json serialization issues"""
@@ -879,6 +881,42 @@ class OMTester(object):
 
     def api_put_automation_config(self, config: dict):
         self.om_request("put", f"/groups/{self.context.project_id}/automationConfig", json_object=config)
+
+    def add_user(
+        self,
+        username: str,
+        database: str,
+        password: str,
+        mechanisms: List[str],
+        roles: List[Dict[str, str]],
+    ) -> None:
+        """Injects a user directly into OM's automation config with the given mechanisms.
+
+        This simulates an OM-originated user (i.e. one that exists in the AC before a
+        MongoDBUser CR is created), which is needed to test mechanism-preservation logic.
+        """
+        config = self.api_get_automation_config()
+
+        user_entry: Dict = {
+            "user": username,
+            "db": database,
+            "mechanisms": mechanisms,
+            "roles": roles,
+        }
+
+        if "SCRAM-SHA-256" in mechanisms:
+            user_entry["scramSha256Creds"] = build_sha256_creds(password)
+        if "MONGODB-CR" in mechanisms or "SCRAM-SHA-1" in mechanisms:
+            user_entry["scramSha1Creds"] = build_sha1_creds(username, password)
+
+        # Replace any existing entry for this user/db pair.
+        config["auth"]["usersWanted"] = [
+            u for u in config["auth"]["usersWanted"] if not (u["user"] == username and u["db"] == database)
+        ]
+        config["auth"]["usersWanted"].append(user_entry)
+
+        self.api_put_automation_config(config)
+        self.wait_agents_ready()
 
     def wait_agents_ready(self, timeout: Optional[int] = 600):
         """Waits until all the agents reached the goal automation config version."""

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_scram_sha_256_connectivity.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_scram_sha_256_connectivity.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 import pytest
 from kubetester import (
@@ -732,7 +732,9 @@ def test_authentication_is_still_configured_after_remove_authentication(namespac
             tester.assert_has_user(USER_NAME)
             tester.assert_authentication_mechanism_enabled("SCRAM-SHA-256")
             tester.assert_authentication_enabled()
-            tester.assert_expected_users(5)
+            # 5 K8s MongoDBUsers (mms-user-1..5) plus the 2 OM-seeded users
+            # (om-user-sha256, om-user-no-mech) added by the tests above.
+            tester.assert_expected_users(7)
             tester.assert_authoritative_set(False)
             return True
         except AssertionError:
@@ -754,7 +756,9 @@ def test_authentication_can_be_disabled_without_modes(namespace: str, replica_se
         # we have explicitly set authentication to be disabled
         try:
             tester.assert_has_user(USER_NAME)
-            tester.assert_authentication_disabled(remaining_users=5)
+            # 5 K8s MongoDBUsers (mms-user-1..5) plus the 2 OM-seeded users
+            # (om-user-sha256, om-user-no-mech) added by the tests above.
+            tester.assert_authentication_disabled(remaining_users=7)
             return True
         except AssertionError:
             return False

--- a/mongodb-community-operator/api/v1/mongodbcommunity_types.go
+++ b/mongodb-community-operator/api/v1/mongodbcommunity_types.go
@@ -2,12 +2,10 @@ package v1
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +15,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/authentication/authtypes"
 	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/annotations"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/env"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/scale"
@@ -314,7 +313,7 @@ func (m MongoDBUser) GetConnectionStringSecretName(resourceName string) string {
 		return m.ConnectionStringSecretName
 	}
 
-	return normalizeName(fmt.Sprintf("%s-%s-%s", resourceName, m.DB, m.Name))
+	return util.NormalizeName(fmt.Sprintf("%s-%s-%s", resourceName, m.DB, m.Name))
 }
 
 // GetConnectionStringSecretNamespace gets the connection string secret namespace provided by the user or generated
@@ -325,30 +324,6 @@ func (m MongoDBUser) GetConnectionStringSecretNamespace(resourceNamespace string
 	}
 
 	return resourceNamespace
-}
-
-// normalizeName returns a string that conforms to RFC-1123
-func normalizeName(name string) string {
-	errors := validation.IsDNS1123Subdomain(name)
-	if len(errors) == 0 {
-		return name
-	}
-
-	// convert name to lowercase and replace invalid characters with '-'
-	name = strings.ToLower(name)
-	re := regexp.MustCompile("[^a-z0-9-]+")
-	name = re.ReplaceAllString(name, "-")
-
-	// Remove duplicate `-` resulting from contiguous non-allowed chars.
-	re = regexp.MustCompile(`\-+`)
-	name = re.ReplaceAllString(name, "-")
-
-	name = strings.Trim(name, "-")
-
-	if len(name) > validation.DNS1123SubdomainMaxLength {
-		name = name[0:validation.DNS1123SubdomainMaxLength]
-	}
-	return name
 }
 
 // Role is the database role this user should have

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -271,26 +271,6 @@ type SystemLog struct {
 	LogAppend   bool        `json:"logAppend"`
 }
 
-// SystemLogFromMap converts a raw map (e.g. from args2_6.systemLog) into a
-// typed SystemLog. Returns nil if the map is empty/nil or has no meaningful data.
-func SystemLogFromMap(m map[string]any) *SystemLog {
-	if len(m) == 0 {
-		return nil
-	}
-	data, err := json.Marshal(m)
-	if err != nil {
-		return nil
-	}
-	var sl SystemLog
-	if err := json.Unmarshal(data, &sl); err != nil {
-		return nil
-	}
-	if sl.Destination == "" && sl.Path == "" {
-		return nil
-	}
-	return &sl
-}
-
 type WiredTiger struct {
 	EngineConfig EngineConfig `json:"engineConfig"`
 }

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -214,6 +214,18 @@ func ConvertCrdLogRotateToAC(lr *CrdLogRotate) *AcLogRotate {
 	}
 }
 
+// ConvertACLogRotateToCrd converts an AcLogRotate to a CrdLogRotate representation.
+func ConvertACLogRotateToCrd(lr *AcLogRotate) *CrdLogRotate {
+	if lr == nil {
+		return nil
+	}
+	return &CrdLogRotate{
+		LogRotate:          lr.LogRotate,
+		SizeThresholdMB:    cast.ToString(lr.SizeThresholdMB),
+		PercentOfDiskspace: cast.ToString(lr.PercentOfDiskspace),
+	}
+}
+
 func (p *Process) SetWiredTigerCache(cacheSizeGb *float32) *Process {
 	if cacheSizeGb == nil {
 		return p
@@ -257,6 +269,26 @@ type SystemLog struct {
 	Destination Destination `json:"destination"`
 	Path        string      `json:"path"`
 	LogAppend   bool        `json:"logAppend"`
+}
+
+// SystemLogFromMap converts a raw map (e.g. from args2_6.systemLog) into a
+// typed SystemLog. Returns nil if the map is empty/nil or has no meaningful data.
+func SystemLogFromMap(m map[string]any) *SystemLog {
+	if len(m) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	var sl SystemLog
+	if err := json.Unmarshal(data, &sl); err != nil {
+		return nil
+	}
+	if sl.Destination == "" && sl.Path == "" {
+		return nil
+	}
+	return &sl
 }
 
 type WiredTiger struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,11 +14,33 @@ import (
 
 	"github.com/blang/semver"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/stringutil"
 )
 
 // ************** This is a file containing any general "algorithmic" or "util" functions used by other packages
+
+// NormalizeName returns a string that conforms to RFC-1123.
+func NormalizeName(name string) string {
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) == 0 {
+		return name
+	}
+
+	name = strings.ToLower(name)
+	re := regexp.MustCompile("[^a-z0-9-]+")
+	name = re.ReplaceAllString(name, "-")
+
+	re = regexp.MustCompile(`\-+`)
+	name = re.ReplaceAllString(name, "-")
+
+	name = strings.Trim(name, "-")
+
+	if len(name) > validation.DNS1123SubdomainMaxLength {
+		name = name[0:validation.DNS1123SubdomainMaxLength]
+	}
+	return name
+}
 
 // FindLeftDifference finds the difference between arrays of string - the elements that are present in "left" but absent
 // in "right" array


### PR DESCRIPTION
# Summary

Implements CR generation for the plugin: translates an Ops Manager deployment
into a MongoDB resource plus MongoDBUser resources, covering the shared spec
(TLS, authentication mechanisms, member options, additional mongod config) and
OIDC/SCRAM credential handling.

Layer 7 in the VM-to-Kubernetes migration stack.

**Stacked PR 7** (stack #1505), base `pr-06-plugin-subcommands`. This is one layer of the VM-to-Kubernetes
migration feature, split out of `vm-migration-feature-branch` so each piece can be reviewed on its own.
Review only this layer's diff; the base branch carries the layers below it.

## Proof of Work

The stack was carved from the merged feature branch (tip `6cc6feecd`) rather than replayed commit by
commit, so each layer's content is master's version of each file plus the patches of the commits
assigned to that layer and below.

Verified for this layer, on top of its base:

- `go build ./...` and `go vet ./...` clean (vet type-checks test files too)
- full unit suite green (88 packages; `api/mongodb/v1/search` is excluded — it needs
  `make envtest-assets`, which is unrelated to this change)
- changed Python files pass a syntax check

Verified for the stack as a whole: the layers carved out of `vm-migration-feature-branch` compose
back to it exactly, both as a git tree and as an on-disk worktree comparison — the only differences are the changelog
entry added on #1491 and two zero-byte rename leftovers deliberately dropped.

e2e coverage is not exercised per layer: CI runs only on the top PR of the stack, and Evergreen is
suppressed here with `[skip-ci]`. Targeted patches will be run per layer before any of these is
marked ready for review.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? Not needed for this layer — the feature-level entry lives on PR #1491 at the bottom of the stack, so this PR carries the `skip-changelog` label.

