### PR TITLE
Add fixture-based tests for migrate-to-mck generation

### DIFF
--- a/cmd/kubectl-mongodb/migrate-to-mck/generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator.go
@@ -86,8 +86,8 @@ func generateExtraResources(ac *om.AutomationConfig, opts GenerateOptions) []cli
 	return resources
 }
 
-// marshalMultiDoc serializes each object to YAML, joined by YAML document separator markers.
-func marshalMultiDoc(objects []client.Object) (string, error) {
+// renderObjects serializes objects to the same multi-document YAML written by the CLI output path.
+func renderObjects(objects []client.Object) (string, error) {
 	var sb strings.Builder
 	for i, obj := range objects {
 		if i > 0 {

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_fixture_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_fixture_test.go
@@ -1,0 +1,197 @@
+package migratetomck
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/mongodb-kubernetes/controllers/om"
+	"github.com/mongodb/mongodb-kubernetes/pkg/automationconfig"
+)
+
+var updateFixtures = flag.Bool("update-fixtures", false, "overwrite fixture files with current output")
+
+// runMongodb exercises the MongoDB CR generation pipeline (generate mongodb subcommand).
+func runMongodb(t *testing.T, ac *om.AutomationConfig, opts GenerateOptions) string {
+	t.Helper()
+	opts.Namespace = "mongodb"
+	objects, err := generateMongodbObjects(ac, withDeploymentData(ac, opts))
+	require.NoError(t, err)
+	result, err := renderObjects(objects)
+	require.NoError(t, err)
+	return result
+}
+
+// runUsers exercises the MongoDBUser CR generation pipeline (generate users subcommand).
+func runUsers(t *testing.T, ac *om.AutomationConfig, opts GenerateOptions) string {
+	t.Helper()
+	opts.Namespace = "mongodb"
+	crName, err := resolveMongoDBResourceName(ac, opts.ResourceNameOverride)
+	require.NoError(t, err)
+	if opts.ExistingUserSecrets == nil {
+		opts.ExistingUserSecrets = make(map[string]string)
+		for _, user := range scramUsers(ac) {
+			opts.ExistingUserSecrets[userKey(user.Username, user.Database)] = suggestedUserSecretName(user)
+		}
+	}
+	objects, err := GenerateUserCRs(ac, crName, opts.Namespace, opts)
+	require.NoError(t, err)
+	result, err := renderObjects(objects)
+	require.NoError(t, err)
+	return result
+}
+
+// fixtureCase declares one TestFixtureMatch entry.
+// fixture is the shared path stem for input + outputs, e.g. "singlecluster/replicaset/foo/foo".
+// The runner derives "<fixture>_input.json", "<fixture>_mongodb_cr.yaml", and "<fixture>_users.yaml" (when hasUsers).
+// opts is layered on top of defaultGenerateOptions, so cases only need to set fields that differ.
+type fixtureCase struct {
+	name     string
+	fixture  string
+	hasUsers bool
+	opts     GenerateOptions
+}
+
+// withDefaultBoilerplate fills in the credentials secret name and OM config-map name unless the case set them.
+func withDefaultBoilerplate(opts GenerateOptions) GenerateOptions {
+	if opts.CredentialsSecretName == "" {
+		opts.CredentialsSecretName = "my-credentials"
+	}
+	if opts.ConfigMapName == "" {
+		opts.ConfigMapName = "my-om-config"
+	}
+	return opts
+}
+
+// TestFixtureMatch_ReplicaSet covers replica-set generator output. To regenerate fixtures: go test -run TestFixtureMatch -update-fixtures
+func TestFixtureMatch_ReplicaSet(t *testing.T) {
+	projectCfg := fullTestConfigs()
+	cases := []fixtureCase{
+		{
+			name:     "complex replica set with SCRAM, TLS, LDAP, Prometheus and log rotation",
+			fixture:  "singlecluster/replicaset/complex_replicaset/complex_replicaset",
+			hasUsers: true,
+			opts: GenerateOptions{
+				CertsSecretPrefix:    "mdb",
+				PrometheusSecretName: PrometheusPasswordSecretName,
+				ProjectConfigs:       projectCfg,
+			},
+		},
+		{
+			name:    "unknown additionalMongodConfig fields like zstdCompressionLevel are passed through",
+			fixture: "singlecluster/replicaset/additional_mongod_config/additional_mongod_config",
+		},
+		{
+			name:    "additionalMongodConfig is taken from the first process when members differ",
+			fixture: "singlecluster/replicaset/different_mongod_config/different_mongod_config",
+		},
+		{
+			name:    "TLS requireSSL with clientCertificateMode OPTIONAL does not set allowConnectionsWithoutCertificates",
+			fixture: "singlecluster/replicaset/tls/require/require",
+			opts:    GenerateOptions{CertsSecretPrefix: "mdb"},
+		},
+		{
+			name:    "TLS allowTLS with clientCertificateMode REQUIRE sets allowConnectionsWithoutCertificates to false",
+			fixture: "singlecluster/replicaset/tls/allow/allow",
+			opts:    GenerateOptions{CertsSecretPrefix: "mdb"},
+		},
+		{
+			name:    "TLS disabled produces no TLS section in the CR",
+			fixture: "singlecluster/replicaset/tls/disabled/disabled",
+		},
+		{
+			name:    "auth disabled produces no security block",
+			fixture: "singlecluster/replicaset/authentication/disabled/disabled",
+		},
+		{
+			name:     "SCRAM-SHA-256 auth generates user CRs with password secrets",
+			fixture:  "singlecluster/replicaset/authentication/scram_sha256/scram_sha256",
+			hasUsers: true,
+		},
+		{
+			name:     "SCRAM and X509 auth generates both MongoDB CR and user CRs",
+			fixture:  "singlecluster/replicaset/authentication/x509/x509",
+			hasUsers: true,
+			opts:     GenerateOptions{CertsSecretPrefix: "mdb"},
+		},
+		{
+			name:    "X509-only auth with keyFile internal cluster auth",
+			fixture: "singlecluster/replicaset/authentication/x509_only/x509_only",
+			opts:    GenerateOptions{CertsSecretPrefix: "mdb"},
+		},
+		{
+			name:    "member tags are preserved in externalMembers",
+			fixture: "singlecluster/replicaset/member_options/member_options",
+		},
+	}
+	runFixtureCases(t, cases)
+}
+
+func runFixtureCases(t *testing.T, cases []fixtureCase) {
+	t.Helper()
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := withDefaultBoilerplate(tt.opts)
+			ac := loadTestAutomationConfig(t, tt.fixture+"_input.json")
+
+			mongodbOutput := runMongodb(t, ac, opts)
+			checkOrUpdateFixture(t, "testdata/"+tt.fixture+"_mongodb_cr.yaml", mongodbOutput)
+
+			if !tt.hasUsers {
+				return
+			}
+			usersOutput := runUsers(t, ac, opts)
+			checkOrUpdateFixture(t, "testdata/"+tt.fixture+"_users.yaml", usersOutput)
+		})
+	}
+}
+
+func checkOrUpdateFixture(t *testing.T, path, got string) {
+	t.Helper()
+	if *updateFixtures {
+		require.NoError(t, os.WriteFile(path, []byte(got), 0o644))
+		t.Logf("Updated fixture file %s", path)
+		return
+	}
+	expected, err := os.ReadFile(path)
+	require.NoError(t, err, "fixture file %s not found; run with -update-fixtures to create it", path)
+	assert.Equal(t, string(expected), got,
+		"generated output does not match fixture file %s; run with -update-fixtures to accept changes", path)
+}
+
+func fullTestConfigs() *ProjectConfigs {
+	return &ProjectConfigs{
+		MonitoringConfig: &om.MonitoringAgentConfig{
+			MonitoringAgentTemplate: &om.MonitoringAgentTemplate{},
+			BackingMap: map[string]interface{}{
+				"logRotate": map[string]interface{}{
+					"sizeThresholdMB":  500.0,
+					"timeThresholdHrs": 12,
+				},
+			},
+		},
+		SystemLogRotate: &automationconfig.AcLogRotate{
+			LogRotate: automationconfig.LogRotate{
+				TimeThresholdHrs:                24,
+				NumUncompressed:                 5,
+				NumTotal:                        10,
+				IncludeAuditLogsWithMongoDBLogs: true,
+			},
+			SizeThresholdMB:    1000,
+			PercentOfDiskspace: 0.4,
+		},
+		AuditLogRotate: &automationconfig.AcLogRotate{
+			LogRotate: automationconfig.LogRotate{
+				TimeThresholdHrs:                48,
+				NumUncompressed:                 2,
+				NumTotal:                        10,
+				IncludeAuditLogsWithMongoDBLogs: true,
+			},
+			SizeThresholdMB:    500,
+			PercentOfDiskspace: 0.4,
+		},
+	}
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/mongodb.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/mongodb.go
@@ -113,21 +113,24 @@ func runGenerateMongodb(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	mongodbCR, err := GenerateMongoDBCR(ac, opts)
+	objects, err := generateMongodbObjects(ac, opts)
 	if err != nil {
 		return err
 	}
-
-	extra := generateExtraResources(ac, opts)
-	objects := make([]client.Object, 0, 1+len(extra))
-	objects = append(objects, mongodbCR)
-	objects = append(objects, extra...)
-
-	resources, err := marshalMultiDoc(objects)
+	resources, err := renderObjects(objects)
 	if err != nil {
 		return err
 	}
 	return writeOutput(resources, mFlags.outputFile)
+}
+
+func generateMongodbObjects(ac *om.AutomationConfig, opts GenerateOptions) ([]client.Object, error) {
+	mongodbCR, err := GenerateMongoDBCR(ac, opts)
+	if err != nil {
+		return nil, err
+	}
+	extra := generateExtraResources(ac, opts)
+	return append([]client.Object{mongodbCR}, extra...), nil
 }
 
 func buildMongodbOptions(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, projectConfigs *ProjectConfigs, sourceProcess *om.Process, stdin io.Reader, flags mongodbFlags) (GenerateOptions, error) {

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/additional_mongod_config/additional_mongod_config_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/additional_mongod_config/additional_mongod_config_input.json
@@ -1,0 +1,194 @@
+{
+  "auth": {
+    "usersWanted": [
+      {
+        "user": "mms-automation-agent",
+        "db": "admin",
+        "roles": [{"role": "root", "db": "admin"}],
+        "mechanisms": ["SCRAM-SHA-256"],
+        "scramSha256Creds": {"iterationCount": 15000, "salt": "abc", "serverKey": "skey", "storedKey": "stkey"},
+        "authenticationRestrictions": []
+      }
+    ],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "compression": {"compressors": "zlib,zstd"},
+          "maxIncomingConnections": 512
+        },
+        "replication": {
+          "replSetName": "amc-rs",
+          "oplogSizeMB": 2048
+        },
+        "storage": {
+          "dbPath": "/data",
+          "indexBuildRetry": true,
+          "directoryPerDB": true,
+          "journal": {"enabled": true},
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 1.5,
+              "journalCompressor": "zlib",
+              "zstdCompressionLevel": 6,
+              "configString": "builtin_extension_config=(zlib=(compression_level=2))"
+            },
+            "collectionConfig": {
+              "blockCompressor": "snappy",
+              "configString": "block_compressor=zlib"
+            }
+          }
+        },
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log", "logAppend": true},
+        "auditLog": {
+          "destination": "file",
+          "format": "JSON",
+          "path": "/var/log/mongodb/audit.json"
+        },
+        "operationProfiling": {
+          "mode": "slowOp",
+          "slowOpThresholdMs": 200
+        },
+        "setParameter": {
+          "authenticationMechanisms": "SCRAM-SHA-256",
+          "connPoolMaxConnsPerHost": 800
+        }
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "amc-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "compression": {"compressors": "zlib,zstd"},
+          "maxIncomingConnections": 512
+        },
+        "replication": {
+          "replSetName": "amc-rs",
+          "oplogSizeMB": 2048
+        },
+        "storage": {
+          "dbPath": "/data",
+          "indexBuildRetry": true,
+          "directoryPerDB": true,
+          "journal": {"enabled": true},
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 1.5,
+              "journalCompressor": "zlib",
+              "zstdCompressionLevel": 6,
+              "configString": "builtin_extension_config=(zlib=(compression_level=2))"
+            },
+            "collectionConfig": {
+              "blockCompressor": "snappy",
+              "configString": "block_compressor=zlib"
+            }
+          }
+        },
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log", "logAppend": true},
+        "auditLog": {
+          "destination": "file",
+          "format": "JSON",
+          "path": "/var/log/mongodb/audit.json"
+        },
+        "operationProfiling": {
+          "mode": "slowOp",
+          "slowOpThresholdMs": 200
+        },
+        "setParameter": {
+          "authenticationMechanisms": "SCRAM-SHA-256",
+          "connPoolMaxConnsPerHost": 800
+        }
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "amc-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "compression": {"compressors": "zlib,zstd"},
+          "maxIncomingConnections": 512
+        },
+        "replication": {
+          "replSetName": "amc-rs",
+          "oplogSizeMB": 2048
+        },
+        "storage": {
+          "dbPath": "/data",
+          "indexBuildRetry": true,
+          "directoryPerDB": true,
+          "journal": {"enabled": true},
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 1.5,
+              "journalCompressor": "zlib",
+              "zstdCompressionLevel": 6,
+              "configString": "builtin_extension_config=(zlib=(compression_level=2))"
+            },
+            "collectionConfig": {
+              "blockCompressor": "snappy",
+              "configString": "block_compressor=zlib"
+            }
+          }
+        },
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log", "logAppend": true},
+        "auditLog": {
+          "destination": "file",
+          "format": "JSON",
+          "path": "/var/log/mongodb/audit.json"
+        },
+        "operationProfiling": {
+          "mode": "slowOp",
+          "slowOpThresholdMs": 200
+        },
+        "setParameter": {
+          "authenticationMechanisms": "SCRAM-SHA-256",
+          "connPoolMaxConnsPerHost": 800
+        }
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "amc-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "amc-rs",
+      "members": [
+        {"_id": 0, "host": "amc-rs-0", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "amc-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "amc-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/additional_mongod_config/additional_mongod_config_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/additional_mongod_config/additional_mongod_config_mongodb_cr.yaml
@@ -1,0 +1,76 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: amc-rs
+  namespace: mongodb
+spec:
+  additionalMongodConfig:
+    auditLog:
+      destination: file
+      format: JSON
+      path: /var/log/mongodb/audit.json
+    net:
+      compression:
+        compressors: zlib,zstd
+      maxIncomingConnections: 512
+      port: 27018
+    operationProfiling:
+      mode: slowOp
+      slowOpThresholdMs: 200
+    replication:
+      oplogSizeMB: 2048
+    setParameter:
+      authenticationMechanisms: SCRAM-SHA-256
+      connPoolMaxConnsPerHost: 800
+    storage:
+      directoryPerDB: true
+      indexBuildRetry: true
+      journal:
+        enabled: true
+      wiredTiger:
+        collectionConfig:
+          blockCompressor: snappy
+          configString: block_compressor=zlib
+        engineConfig:
+          cacheSizeGB: 1.5
+          configString: builtin_extension_config=(zlib=(compression_level=2))
+          journalCompressor: zlib
+          zstdCompressionLevel: 6
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: true
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27018
+    processName: amc-rs-0
+    replicaSetName: amc-rs
+    type: mongod
+  - hostname: vm-1.example.com:27018
+    processName: amc-rs-1
+    replicaSetName: amc-rs
+    type: mongod
+  - hostname: vm-2.example.com:27018
+    processName: amc-rs-2
+    replicaSetName: amc-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      modes:
+      - SCRAM
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/additional_mongod_config/additional_mongod_config_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/additional_mongod_config/additional_mongod_config_mongodb_cr.yaml
@@ -16,7 +16,6 @@ spec:
       compression:
         compressors: zlib,zstd
       maxIncomingConnections: 512
-      port: 27018
     operationProfiling:
       mode: slowOp
       slowOpThresholdMs: 200
@@ -41,11 +40,6 @@ spec:
           zstdCompressionLevel: 6
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: true
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27018

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/disabled/disabled_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/disabled/disabled_input.json
@@ -1,0 +1,74 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": true,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": [],
+    "autoAuthMechanisms": [],
+    "autoAuthMechanism": "",
+    "autoUser": "",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "minimal-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "minimal-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "minimal-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "minimal-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "minimal-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "minimal-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "minimal-rs",
+      "members": [
+        {"_id": 0, "host": "minimal-rs-0", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "minimal-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "minimal-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/disabled/disabled_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/disabled/disabled_mongodb_cr.yaml
@@ -1,0 +1,36 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: minimal-rs
+  namespace: mongodb
+spec:
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: minimal-rs-0
+    replicaSetName: minimal-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: minimal-rs-1
+    replicaSetName: minimal-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: minimal-rs-2
+    replicaSetName: minimal-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/disabled/disabled_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/disabled/disabled_mongodb_cr.yaml
@@ -9,11 +9,6 @@ metadata:
 spec:
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_input.json
@@ -1,0 +1,94 @@
+{
+  "auth": {
+    "usersWanted": [
+      {
+        "user": "mms-automation-agent",
+        "db": "admin",
+        "roles": [{"role": "root", "db": "admin"}],
+        "mechanisms": ["SCRAM-SHA-256"],
+        "scramSha256Creds": {"iterationCount": 15000, "salt": "abc", "serverKey": "skey", "storedKey": "stkey"},
+        "authenticationRestrictions": []
+      },
+      {
+        "user": "app-user",
+        "db": "admin",
+        "roles": [
+          {"role": "readWrite", "db": "myapp"},
+          {"role": "read", "db": "reporting"}
+        ],
+        "mechanisms": ["SCRAM-SHA-256"],
+        "scramSha256Creds": {"iterationCount": 15000, "salt": "def", "serverKey": "skey2", "storedKey": "stkey2"},
+        "authenticationRestrictions": []
+      }
+    ],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "scram-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "scram-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "scram-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "scram-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "scram-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "scram-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "scram-rs",
+      "members": [
+        {"_id": 0, "host": "scram-rs-0", "priority": 2, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "scram-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "scram-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_mongodb_cr.yaml
@@ -1,0 +1,44 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: scram-rs
+  namespace: mongodb
+spec:
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: scram-rs-0
+    replicaSetName: scram-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: scram-rs-1
+    replicaSetName: scram-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: scram-rs-2
+    replicaSetName: scram-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      modes:
+      - SCRAM
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_mongodb_cr.yaml
@@ -9,11 +9,6 @@ metadata:
 spec:
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_users.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/scram_sha256/scram_sha256_users.yaml
@@ -1,0 +1,18 @@
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: app-user
+  namespace: mongodb
+spec:
+  db: admin
+  mongodbResourceRef:
+    name: scram-rs
+  passwordSecretKeyRef:
+    key: password
+    name: app-user-password
+  roles:
+  - db: myapp
+    name: readWrite
+  - db: reporting
+    name: read
+  username: app-user

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_input.json
@@ -1,0 +1,122 @@
+{
+  "auth": {
+    "usersWanted": [
+      {
+        "user": "CN=x509-client,O=MongoDB",
+        "db": "$external",
+        "roles": [
+          {"role": "readWrite", "db": "secure-db"}
+        ],
+        "mechanisms": [],
+        "scramSha256Creds": null,
+        "scramSha1Creds": null,
+        "authenticationRestrictions": []
+      },
+      {
+        "user": "CN=x509-admin,OU=DevOps,O=MongoDB",
+        "db": "$external",
+        "roles": [
+          {"role": "root", "db": "admin"}
+        ],
+        "mechanisms": [],
+        "scramSha256Creds": null,
+        "scramSha1Creds": null,
+        "authenticationRestrictions": []
+      }
+    ],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256", "MONGODB-X509"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireSSL",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "x509-rs"},
+        "security": {"clusterAuthMode": "x509"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "x509-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireSSL",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "x509-rs"},
+        "security": {"clusterAuthMode": "x509"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "x509-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireSSL",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "x509-rs"},
+        "security": {"clusterAuthMode": "x509"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "x509-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "x509-rs",
+      "members": [
+        {"_id": 0, "host": "x509-rs-0", "priority": 2, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "x509-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "x509-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "tls": {
+    "CAFilePath": "/mongodb-automation/tls/ca/ca-pem",
+    "clientCertificateMode": "OPTIONAL"
+  },
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_mongodb_cr.yaml
@@ -1,0 +1,49 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: x509-rs
+  namespace: mongodb
+spec:
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: x509-rs-0
+    replicaSetName: x509-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: x509-rs-1
+    replicaSetName: x509-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: x509-rs-2
+    replicaSetName: x509-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      internalCluster: X509
+      modes:
+      - SCRAM
+      - X509
+    certsSecretPrefix: mdb
+    tls:
+      ca: x509-rs-ca
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_mongodb_cr.yaml
@@ -9,11 +9,6 @@ metadata:
 spec:
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_users.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509/x509_users.yaml
@@ -1,0 +1,27 @@
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: cn-x509-client-o-mongodb
+  namespace: mongodb
+spec:
+  db: $external
+  mongodbResourceRef:
+    name: x509-rs
+  roles:
+  - db: secure-db
+    name: readWrite
+  username: CN=x509-client,O=MongoDB
+---
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: cn-x509-admin-ou-devops-o-mongodb
+  namespace: mongodb
+spec:
+  db: $external
+  mongodbResourceRef:
+    name: x509-rs
+  roles:
+  - db: admin
+    name: root
+  username: CN=x509-admin,OU=DevOps,O=MongoDB

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509_only/x509_only_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509_only/x509_only_input.json
@@ -1,0 +1,100 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": true,
+    "deploymentAuthMechanisms": ["MONGODB-X509"],
+    "autoAuthMechanisms": ["MONGODB-X509"],
+    "autoAuthMechanism": "MONGODB-X509",
+    "autoUser": "CN=mms-automation-agent,OU=ENG,O=MongoDB,L=NY,ST=NY,C=US",
+    "autoAuthRestrictions": [],
+    "key": "dGVzdC1rZXlmaWxlLWNvbnRlbnQ=",
+    "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+    "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile"
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireTLS",
+            "certificateKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "x509only-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/data/mongodb.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "vm-0.example.com",
+      "name": "x509only-rs-0",
+      "processType": "mongod",
+      "version": "7.0.12"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireTLS",
+            "certificateKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "x509only-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/data/mongodb.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "vm-1.example.com",
+      "name": "x509only-rs-1",
+      "processType": "mongod",
+      "version": "7.0.12"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireTLS",
+            "certificateKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "x509only-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/data/mongodb.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "vm-2.example.com",
+      "name": "x509only-rs-2",
+      "processType": "mongod",
+      "version": "7.0.12"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "x509only-rs",
+      "members": [
+        {"_id": 0, "host": "x509only-rs-0", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "x509only-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "x509only-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "tls": {
+    "CAFilePath": "/mongodb-ca/ca.pem",
+    "autoPEMKeyFilePath": "/mongodb-agent/agent.pem",
+    "clientCertificateMode": "REQUIRE"
+  },
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509_only/x509_only_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509_only/x509_only_mongodb_cr.yaml
@@ -1,0 +1,52 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: x509only-rs
+  namespace: mongodb
+spec:
+  additionalMongodConfig:
+    net:
+      tls:
+        allowConnectionsWithoutCertificates: false
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /data/mongodb.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: x509only-rs-0
+    replicaSetName: x509only-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: x509only-rs-1
+    replicaSetName: x509only-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: x509only-rs-2
+    replicaSetName: x509only-rs
+    type: mongod
+  featureCompatibilityVersion: "7.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        autoPEMKeyFilePath: /mongodb-agent/agent.pem
+        automationUserName: CN=mms-automation-agent,OU=ENG,O=MongoDB,L=NY,ST=NY,C=US
+        mode: X509
+      enabled: true
+      modes:
+      - X509
+    certsSecretPrefix: mdb
+    tls:
+      ca: x509only-rs-ca
+  type: ReplicaSet
+  version: 7.0.12

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509_only/x509_only_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/authentication/x509_only/x509_only_mongodb_cr.yaml
@@ -13,11 +13,6 @@ spec:
         allowConnectionsWithoutCertificates: false
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /data/mongodb.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/complex_replicaset/complex_replicaset_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/complex_replicaset/complex_replicaset_mongodb_cr.yaml
@@ -1,0 +1,177 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: my-rs
+  namespace: mongodb
+spec:
+  additionalMongodConfig:
+    auditLog:
+      destination: file
+      format: JSON
+      path: /var/log/mongodb/audit.json
+    net:
+      compression:
+        compressors: zlib,zstd
+      maxIncomingConnections: 512
+      port: 27018
+      tls:
+        mode: preferSSL
+    operationProfiling:
+      mode: slowOp
+      slowOpThresholdMs: 200
+    replication:
+      oplogSizeMB: 2048
+    setParameter:
+      authenticationMechanisms: SCRAM-SHA-256,PLAIN
+    storage:
+      directoryPerDB: true
+      journal:
+        enabled: true
+      wiredTiger:
+        collectionConfig:
+          blockCompressor: snappy
+        engineConfig:
+          cacheSizeGB: 1.5
+          journalCompressor: zlib
+  agent:
+    backupAgent:
+      logRotate:
+        sizeThresholdMB: 1000
+        timeThresholdHrs: 24
+    maxLogFileDurationHours: 0
+    mongod:
+      auditlogRotate:
+        includeAuditLogsWithMongoDBLogs: true
+        numTotal: 10
+        numUncompressed: 2
+        percentOfDiskspace: "0.4"
+        sizeThresholdMB: "500"
+        timeThresholdHrs: 48
+      logRotate:
+        includeAuditLogsWithMongoDBLogs: true
+        numTotal: 10
+        numUncompressed: 5
+        percentOfDiskspace: "0.4"
+        sizeThresholdMB: "1000"
+        timeThresholdHrs: 24
+      systemLog:
+        destination: file
+        logAppend: true
+        path: /var/log/mongodb/mongod.log
+    monitoringAgent:
+      logRotate:
+        sizeThresholdMB: 1000
+        timeThresholdHrs: 24
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-mongo-0.prod.example.com:27018
+    processName: my-rs-0
+    replicaSetName: my-rs
+    type: mongod
+  - hostname: vm-mongo-1.prod.example.com:27018
+    processName: my-rs-1
+    replicaSetName: my-rs
+    type: mongod
+  - hostname: vm-mongo-2.prod.example.com:27018
+    processName: my-rs-2
+    replicaSetName: my-rs
+    type: mongod
+  featureCompatibilityVersion: "7.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  prometheus:
+    metricsPath: /custom-metrics
+    passwordSecretRef:
+      key: password
+      name: prometheus-password
+    port: 9216
+    tlsSecretKeyRef:
+      name: prometheus-tls
+    username: prom-user
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      internalCluster: X509
+      ldap:
+        authzQueryTemplate: '{USER}?memberOf?base'
+        bindQueryPasswordSecretRef:
+          name: ldap-bind-query-password
+        bindQueryUser: cn=admin,dc=example,dc=com
+        caConfigMapRef:
+          key: ca.pem
+          name: ldap-ca
+        servers:
+        - ldap1.example.com:636
+        - ldap2.example.com:636
+        timeoutMS: 10000
+        transportSecurity: tls
+        userCacheInvalidationInterval: 30
+        userToDNMapping: '[{"match":"(.+)","substitution":"uid={0},ou=users,dc=example,dc=com"}]'
+        validateLDAPServerConfig: true
+      modes:
+      - SCRAM
+      - X509
+      - LDAP
+      - OIDC
+      oidcProviderConfigs:
+      - audience: api://mongodb-cluster
+        authorizationMethod: WorkforceIdentityFederation
+        authorizationType: GroupMembership
+        clientId: 0oa1abc2def3ghi4j567
+        configurationName: okta
+        groupsClaim: groups
+        issuerURI: https://dev-123456.okta.com/oauth2/default
+        requestedScopes:
+        - openid
+        - profile
+        - groups
+        userClaim: sub
+      - audience: api://mongodb-workload
+        authorizationMethod: WorkloadIdentityFederation
+        authorizationType: UserID
+        configurationName: azure-svc
+        issuerURI: https://login.microsoftonline.com/tenant-id/v2.0
+        userClaim: sub
+    certsSecretPrefix: mdb
+    roles:
+    - db: myapp
+      privileges:
+      - actions:
+        - find
+        - listCollections
+        resource:
+          db: myapp
+      role: appReadOnly
+      roles:
+      - db: myapp
+        role: read
+    tls:
+      ca: my-rs-ca
+  type: ReplicaSet
+  version: 7.0.12-ent
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ldap-bind-query-password
+  namespace: mongodb
+stringData:
+  password: ldap-s3cret
+---
+apiVersion: v1
+data:
+  ca.pem: |-
+    -----BEGIN CERTIFICATE-----
+    MIIBxTCCAWugAwIBAgIUFakeCAContentsForTesting=
+    -----END CERTIFICATE-----
+kind: ConfigMap
+metadata:
+  name: ldap-ca
+  namespace: mongodb

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/complex_replicaset/complex_replicaset_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/complex_replicaset/complex_replicaset_mongodb_cr.yaml
@@ -16,7 +16,6 @@ spec:
       compression:
         compressors: zlib,zstd
       maxIncomingConnections: 512
-      port: 27018
       tls:
         mode: preferSSL
     operationProfiling:
@@ -57,10 +56,6 @@ spec:
         percentOfDiskspace: "0.4"
         sizeThresholdMB: "1000"
         timeThresholdHrs: 24
-      systemLog:
-        destination: file
-        logAppend: true
-        path: /var/log/mongodb/mongod.log
     monitoringAgent:
       logRotate:
         sizeThresholdMB: 1000

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/complex_replicaset/complex_replicaset_users.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/complex_replicaset/complex_replicaset_users.yaml
@@ -1,0 +1,46 @@
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: app-user
+  namespace: mongodb
+spec:
+  db: admin
+  mongodbResourceRef:
+    name: my-rs
+  passwordSecretKeyRef:
+    key: password
+    name: app-user-password
+  roles:
+  - db: myapp
+    name: readWrite
+  - db: reporting
+    name: read
+  username: app-user
+---
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: cn-x509-client-o-mongodb
+  namespace: mongodb
+spec:
+  db: $external
+  mongodbResourceRef:
+    name: my-rs
+  roles:
+  - db: secure-db
+    name: readWrite
+  username: CN=x509-client,O=MongoDB
+---
+apiVersion: mongodb.com/v1
+kind: MongoDBUser
+metadata:
+  name: ldap-reader
+  namespace: mongodb
+spec:
+  db: $external
+  mongodbResourceRef:
+    name: my-rs
+  roles:
+  - db: reporting
+    name: read
+  username: ldap-reader

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/different_mongod_config/different_mongod_config_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/different_mongod_config/different_mongod_config_input.json
@@ -1,0 +1,183 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": true,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": [],
+    "autoAuthMechanisms": [],
+    "autoAuthMechanism": "",
+    "autoUser": "",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "maxIncomingConnections": 512,
+          "compression": {
+            "compressors": "zlib,zstd"
+          }
+        },
+        "replication": {
+          "replSetName": "hetero-rs",
+          "oplogSizeMB": 2048
+        },
+        "storage": {
+          "dbPath": "/data",
+          "engine": "inMemory",
+          "directoryPerDB": true,
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 2.0,
+              "journalCompressor": "zlib"
+            },
+            "collectionConfig": {
+              "blockCompressor": "snappy"
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb/mongod0.log"
+        },
+        "setParameter": {
+          "authenticationMechanisms": "SCRAM-SHA-256"
+        },
+        "auditLog": {
+          "destination": "file",
+          "format": "JSON",
+          "path": "/var/log/mongodb/audit0.json"
+        },
+        "operationProfiling": {
+          "mode": "slowOp",
+          "slowOpThresholdMs": 200
+        }
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "hetero-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "maxIncomingConnections": 512,
+          "compression": {
+            "compressors": "zlib,zstd"
+          }
+        },
+        "replication": {
+          "replSetName": "hetero-rs",
+          "oplogSizeMB": 2048
+        },
+        "storage": {
+          "dbPath": "/data",
+          "directoryPerDB": true,
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 4.0,
+              "journalCompressor": "zlib"
+            },
+            "collectionConfig": {
+              "blockCompressor": "zstd"
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb/mongod1.log"
+        },
+        "setParameter": {
+          "authenticationMechanisms": "SCRAM-SHA-256"
+        },
+        "auditLog": {
+          "destination": "file",
+          "format": "BSON",
+          "path": "/var/log/mongodb/audit1.bson"
+        },
+        "operationProfiling": {
+          "mode": "all",
+          "slowOpThresholdMs": 100
+        }
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "hetero-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "maxIncomingConnections": 1024,
+          "compression": {
+            "compressors": "zlib,zstd"
+          }
+        },
+        "replication": {
+          "replSetName": "hetero-rs",
+          "oplogSizeMB": 2048
+        },
+        "storage": {
+          "dbPath": "/data",
+          "directoryPerDB": false,
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 2.0,
+              "journalCompressor": "snappy"
+            },
+            "collectionConfig": {
+              "blockCompressor": "snappy"
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb/mongod2.log"
+        },
+        "setParameter": {
+          "authenticationMechanisms": "SCRAM-SHA-256"
+        },
+        "auditLog": {
+          "destination": "file",
+          "format": "JSON",
+          "path": "/var/log/mongodb/audit2.json"
+        },
+        "operationProfiling": {
+          "mode": "slowOp",
+          "slowOpThresholdMs": 200
+        }
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "hetero-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "hetero-rs",
+      "members": [
+        {"_id": 0, "host": "hetero-rs-0", "priority": 2, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "hetero-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "hetero-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/different_mongod_config/different_mongod_config_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/different_mongod_config/different_mongod_config_mongodb_cr.yaml
@@ -1,0 +1,62 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: hetero-rs
+  namespace: mongodb
+spec:
+  additionalMongodConfig:
+    auditLog:
+      destination: file
+      format: JSON
+      path: /var/log/mongodb/audit0.json
+    net:
+      compression:
+        compressors: zlib,zstd
+      maxIncomingConnections: 512
+      port: 27018
+    operationProfiling:
+      mode: slowOp
+      slowOpThresholdMs: 200
+    replication:
+      oplogSizeMB: 2048
+    setParameter:
+      authenticationMechanisms: SCRAM-SHA-256
+    storage:
+      directoryPerDB: true
+      engine: inMemory
+      wiredTiger:
+        collectionConfig:
+          blockCompressor: snappy
+        engineConfig:
+          cacheSizeGB: 2
+          journalCompressor: zlib
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod0.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27018
+    processName: hetero-rs-0
+    replicaSetName: hetero-rs
+    type: mongod
+  - hostname: vm-1.example.com:27018
+    processName: hetero-rs-1
+    replicaSetName: hetero-rs
+    type: mongod
+  - hostname: vm-2.example.com:27018
+    processName: hetero-rs-2
+    replicaSetName: hetero-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/different_mongod_config/different_mongod_config_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/different_mongod_config/different_mongod_config_mongodb_cr.yaml
@@ -16,7 +16,6 @@ spec:
       compression:
         compressors: zlib,zstd
       maxIncomingConnections: 512
-      port: 27018
     operationProfiling:
       mode: slowOp
       slowOpThresholdMs: 200
@@ -35,11 +34,6 @@ spec:
           journalCompressor: zlib
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod0.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27018

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/member_options/member_options_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/member_options/member_options_input.json
@@ -1,0 +1,96 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "member-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "member-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "member-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "member-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "member-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "member-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "member-rs",
+      "members": [
+        {
+          "_id": 0,
+          "host": "member-rs-0",
+          "priority": 2,
+          "votes": 1,
+          "hidden": false,
+          "tags": {"region": "us-east-1", "role": "primary"}
+        },
+        {
+          "_id": 1,
+          "host": "member-rs-1",
+          "priority": 0,
+          "votes": 1,
+          "hidden": true,
+          "secondaryDelaySecs": 3600,
+          "tags": {"region": "us-east-1", "role": "delayed"}
+        },
+        {
+          "_id": 2,
+          "host": "member-rs-2",
+          "priority": 1,
+          "votes": 1,
+          "hidden": false,
+          "tags": {"region": "us-west-2"}
+        }
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/member_options/member_options_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/member_options/member_options_mongodb_cr.yaml
@@ -1,0 +1,44 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: member-rs
+  namespace: mongodb
+spec:
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: member-rs-0
+    replicaSetName: member-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: member-rs-1
+    replicaSetName: member-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: member-rs-2
+    replicaSetName: member-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      modes:
+      - SCRAM
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/member_options/member_options_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/member_options/member_options_mongodb_cr.yaml
@@ -9,11 +9,6 @@ metadata:
 spec:
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/allow/allow_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/allow/allow_input.json
@@ -1,0 +1,75 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "allowTLS",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "allow-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "allow-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "allowTLS",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "allow-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "allow-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "allow-rs",
+      "members": [
+        {"_id": 0, "host": "allow-rs-0", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "allow-rs-1", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "tls": {
+    "CAFilePath": "/mongodb-automation/tls/ca/ca-pem",
+    "clientCertificateMode": "REQUIRE"
+  },
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/allow/allow_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/allow/allow_mongodb_cr.yaml
@@ -1,0 +1,48 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: allow-rs
+  namespace: mongodb
+spec:
+  additionalMongodConfig:
+    net:
+      tls:
+        allowConnectionsWithoutCertificates: false
+        mode: allowTLS
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: allow-rs-0
+    replicaSetName: allow-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: allow-rs-1
+    replicaSetName: allow-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      modes:
+      - SCRAM
+    certsSecretPrefix: mdb
+    tls:
+      ca: allow-rs-ca
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/allow/allow_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/allow/allow_mongodb_cr.yaml
@@ -14,11 +14,6 @@ spec:
         mode: allowTLS
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/disabled/disabled_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/disabled/disabled_input.json
@@ -1,0 +1,74 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "notls-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-0.example.com",
+      "name": "notls-rs-0",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "notls-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-1.example.com",
+      "name": "notls-rs-1",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    },
+    {
+      "args2_6": {
+        "net": {"port": 27017},
+        "replication": {"replSetName": "notls-rs"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "8.0",
+      "hostname": "vm-2.example.com",
+      "name": "notls-rs-2",
+      "processType": "mongod",
+      "version": "8.0.4-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "notls-rs",
+      "members": [
+        {"_id": 0, "host": "notls-rs-0", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "notls-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "notls-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/disabled/disabled_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/disabled/disabled_mongodb_cr.yaml
@@ -1,0 +1,44 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: notls-rs
+  namespace: mongodb
+spec:
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: notls-rs-0
+    replicaSetName: notls-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: notls-rs-1
+    replicaSetName: notls-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: notls-rs-2
+    replicaSetName: notls-rs
+    type: mongod
+  featureCompatibilityVersion: "8.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      modes:
+      - SCRAM
+  type: ReplicaSet
+  version: 8.0.4-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/disabled/disabled_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/disabled/disabled_mongodb_cr.yaml
@@ -9,11 +9,6 @@ metadata:
 spec:
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/require/require_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/require/require_input.json
@@ -1,0 +1,99 @@
+{
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": false,
+    "authoritativeSet": false,
+    "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanisms": ["SCRAM-SHA-256"],
+    "autoAuthMechanism": "SCRAM-SHA-256",
+    "autoUser": "mms-automation-agent",
+    "autoAuthRestrictions": []
+  },
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireSSL",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "tls-rs"},
+        "security": {"clusterAuthMode": "x509"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "vm-0.example.com",
+      "name": "tls-rs-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireSSL",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "tls-rs"},
+        "security": {"clusterAuthMode": "x509"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "vm-1.example.com",
+      "name": "tls-rs-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017,
+          "tls": {
+            "mode": "requireSSL",
+            "PEMKeyFile": "/mongodb-automation/server.pem"
+          }
+        },
+        "replication": {"replSetName": "tls-rs"},
+        "security": {"clusterAuthMode": "x509"},
+        "storage": {"dbPath": "/data"},
+        "systemLog": {"destination": "file", "path": "/var/log/mongodb/mongod.log"}
+      },
+      "authSchemaVersion": 5,
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "vm-2.example.com",
+      "name": "tls-rs-2",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "tls-rs",
+      "members": [
+        {"_id": 0, "host": "tls-rs-0", "priority": 2, "votes": 1, "tags": {}},
+        {"_id": 1, "host": "tls-rs-1", "priority": 1, "votes": 1, "tags": {}},
+        {"_id": 2, "host": "tls-rs-2", "priority": 1, "votes": 1, "tags": {}}
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "sharding": [],
+  "tls": {
+    "CAFilePath": "/mongodb-automation/tls/ca/ca-pem",
+    "clientCertificateMode": "OPTIONAL"
+  },
+  "version": 1
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/require/require_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/require/require_mongodb_cr.yaml
@@ -1,0 +1,48 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: tls-rs
+  namespace: mongodb
+spec:
+  agent:
+    maxLogFileDurationHours: 0
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb/mongod.log
+  credentials: my-credentials
+  externalMembers:
+  - hostname: vm-0.example.com:27017
+    processName: tls-rs-0
+    replicaSetName: tls-rs
+    type: mongod
+  - hostname: vm-1.example.com:27017
+    processName: tls-rs-1
+    replicaSetName: tls-rs
+    type: mongod
+  - hostname: vm-2.example.com:27017
+    processName: tls-rs-2
+    replicaSetName: tls-rs
+    type: mongod
+  featureCompatibilityVersion: "7.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  security:
+    authentication:
+      agents:
+        mode: SCRAM
+      enabled: true
+      ignoreUnknownUsers: true
+      internalCluster: X509
+      modes:
+      - SCRAM
+    certsSecretPrefix: mdb
+    tls:
+      ca: tls-rs-ca
+  type: ReplicaSet
+  version: 7.0.12-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/require/require_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/replicaset/tls/require/require_mongodb_cr.yaml
@@ -9,11 +9,6 @@ metadata:
 spec:
   agent:
     maxLogFileDurationHours: 0
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb/mongod.log
   credentials: my-credentials
   externalMembers:
   - hostname: vm-0.example.com:27017

--- a/cmd/kubectl-mongodb/migrate-to-mck/users.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/users.go
@@ -114,13 +114,10 @@ func runGenerateUsers(cmd *cobra.Command, _ []string) error {
 
 	mongodbResourceName := uFlags.resourceNameOverride
 	if mongodbResourceName == "" {
-		replicaSets := ac.Deployment.GetReplicaSets()
-		if len(replicaSets) == 0 {
-			return fmt.Errorf("no replica sets found in the automation config")
-		}
-		mongodbResourceName = util.NormalizeName(replicaSets[0].Name())
-		if mongodbResourceName == "" {
-			return fmt.Errorf("replica set name %q cannot be normalized to a valid Kubernetes name. Use --resource-name-override to provide one", replicaSets[0].Name())
+		var err error
+		mongodbResourceName, err = resolveMongoDBResourceName(ac, "")
+		if err != nil {
+			return err
 		}
 	}
 
@@ -134,11 +131,26 @@ func runGenerateUsers(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resources, err := marshalMultiDoc(userObjects)
+	resources, err := renderObjects(userObjects)
 	if err != nil {
 		return err
 	}
 	return writeOutput(resources, uFlags.outputFile)
+}
+
+func resolveMongoDBResourceName(ac *om.AutomationConfig, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	replicaSets := ac.Deployment.GetReplicaSets()
+	if len(replicaSets) == 0 {
+		return "", fmt.Errorf("no replica sets found in the automation config")
+	}
+	name := util.NormalizeName(replicaSets[0].Name())
+	if name == "" {
+		return "", fmt.Errorf("replica set name %q cannot be normalized to a valid Kubernetes name. Use --resource-name-override to provide one", replicaSets[0].Name())
+	}
+	return name, nil
 }
 
 func buildUsersOptions(ctx context.Context, kubeClient kubernetesClient.Client, ac *om.AutomationConfig, stdin io.Reader, namespace, usersSecretsFile string) (GenerateOptions, error) {
@@ -151,6 +163,10 @@ func buildUsersOptions(ctx context.Context, kubeClient kubernetesClient.Client, 
 }
 
 func userKey(username, database string) string { return username + ":" + database }
+
+func suggestedUserSecretName(user *om.MongoDBUser) string {
+	return userv1.NormalizeName(user.Username) + "-password"
+}
 
 func scramUsers(ac *om.AutomationConfig) []*om.MongoDBUser {
 	if ac.Auth == nil {
@@ -190,7 +206,7 @@ func collectUserSecretNamesInteractively(ctx context.Context, kubeClient kuberne
 
 	opts.ExistingUserSecrets = make(map[string]string)
 	for _, user := range users {
-		suggestedName := userv1.NormalizeName(user.Username) + "-password"
+		suggestedName := suggestedUserSecretName(user)
 		secretName, err := promptKubernetesName(scanner, fmt.Sprintf("Secret name for user %q (db: %s) [%s]: ", user.Username, user.Database, suggestedName), suggestedName)
 		if err != nil {
 			return fmt.Errorf("failed to read spec.passwordSecretKeyRef.name for user %q: %w", user.Username, err)


### PR DESCRIPTION
# Summary

Adds golden-fixture coverage for the replica-set generator: JSON inputs
captured from Ops Manager deployments and the expected MongoDB/MongoDBUser
YAML, across TLS modes, authentication mechanisms, member options and
additional mongod config. Fixtures regenerate with
`go test -run TestFixtureMatch ./cmd/kubectl-mongodb/migrate-to-mck/... -update-fixtures`.

Layer 8 in the VM-to-Kubernetes migration stack.

**Stacked PR 8** (stack #1505), base `pr-07-plugin-cr-generation`. This is one layer of the VM-to-Kubernetes
migration feature, split out of `vm-migration-feature-branch` so each piece can be reviewed on its own.
Review only this layer's diff; the base branch carries the layers below it.

## Proof of Work

The stack was carved from the merged feature branch (tip `6cc6feecd`) rather than replayed commit by
commit, so each layer's content is master's version of each file plus the patches of the commits
assigned to that layer and below.

Verified for this layer, on top of its base:

- `go build ./...` and `go vet ./...` clean (vet type-checks test files too)
- full unit suite green (88 packages; `api/mongodb/v1/search` is excluded — it needs
  `make envtest-assets`, which is unrelated to this change)
- changed Python files pass a syntax check

Verified for the stack as a whole: the layers carved out of `vm-migration-feature-branch` compose
back to it exactly, both as a git tree and as an on-disk worktree comparison — the only differences are the changelog
entry added on #1491 and two zero-byte rename leftovers deliberately dropped.

e2e coverage is not exercised per layer: CI runs only on the top PR of the stack, and Evergreen is
suppressed here with `[skip-ci]`. Targeted patches will be run per layer before any of these is
marked ready for review.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? Not needed for this layer — the feature-level entry lives on PR #1491 at the bottom of the stack, so this PR carries the `skip-changelog` label.

