### PR TITLE
Add VM migration e2e coverage

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -314,6 +314,61 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_vm_migration_replicaset_scram_sha256
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_scram_sha1
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_scram_sha256_tls
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_no_auth
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_mck_to_mck
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_x509
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_ldap
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_prometheus
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_oidc
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_oidc_group
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_replicaset_oidc_workforce
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_replica_set_statefulset_status
     tags: [ "patch-run" ]
     commands:
@@ -375,6 +430,11 @@ tasks:
       - func: "e2e_test"
 
   - name: e2e_sharded_cluster_scale_shards
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_sharded_cluster_scale_shards_name_overrides
     tags: [ "patch-run" ]
     commands:
       - func: "e2e_test"
@@ -500,6 +560,11 @@ tasks:
       - func: "e2e_test"
 
   - name: e2e_replica_set_tls_require
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_replica_set_tls_require_custom_ca_path
     tags: [ "patch-run" ]
     commands:
       - func: "e2e_test"
@@ -1410,6 +1475,57 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_vm_migration_shardedcluster_no_auth
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_x509
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_scram_sha256
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_scram_sha1
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_scram_sha256_tls
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_ldap
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_oidc
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_oidc_group
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_oidc_workforce
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_prometheus
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+
   - name: e2e_search_sharded_internal_mongodb_multi_mongot_unmanaged_lb
     tags: [ "patch-run" ]
     commands:
@@ -1583,3 +1699,4 @@ tasks:
     tags: [ "patch-run" ]
     commands:
       - func: "e2e_test"
+

--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -334,6 +334,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_vm_migration_replicaset_manual_rollback
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_vm_migration_replicaset_mck_to_mck
     tags: [ "patch-run" ]
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -905,6 +905,7 @@ task_groups:
       - e2e_vm_migration_replicaset_scram_sha1
       - e2e_vm_migration_replicaset_scram_sha256_tls
       - e2e_vm_migration_replicaset_no_auth
+      - e2e_vm_migration_replicaset_manual_rollback
       - e2e_vm_migration_replicaset_mck_to_mck
       - e2e_vm_migration_shardedcluster_no_auth
       - e2e_vm_migration_shardedcluster_x509

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -796,10 +796,12 @@ task_groups:
       - e2e_replica_set_readiness_probe
       - e2e_replica_set_update_delete_parallel
       - e2e_sharded_cluster_scale_shards
+      - e2e_sharded_cluster_scale_shards_name_overrides
       - e2e_sharded_cluster_shard_overrides
       - e2e_sharded_cluster_mongod_options_and_log_rotation
       - e2e_tls_rs_external_access
       - e2e_replica_set_tls_require
+      - e2e_replica_set_tls_require_custom_ca_path
       - e2e_replica_set_tls_certs_secret_prefix
       - e2e_disable_tls_and_scale
       - e2e_replica_set_tls_require_and_disable
@@ -892,6 +894,28 @@ task_groups:
       - e2e_search_replicaset_external_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_mongot_replicaset_x509_auth
+      # VM Migration
+      - e2e_vm_migration_replicaset_x509
+      - e2e_vm_migration_replicaset_ldap
+      - e2e_vm_migration_replicaset_prometheus
+      - e2e_vm_migration_replicaset_oidc
+      - e2e_vm_migration_replicaset_oidc_group
+      - e2e_vm_migration_replicaset_oidc_workforce
+      - e2e_vm_migration_replicaset_scram_sha256
+      - e2e_vm_migration_replicaset_scram_sha1
+      - e2e_vm_migration_replicaset_scram_sha256_tls
+      - e2e_vm_migration_replicaset_no_auth
+      - e2e_vm_migration_replicaset_mck_to_mck
+      - e2e_vm_migration_shardedcluster_no_auth
+      - e2e_vm_migration_shardedcluster_x509
+      - e2e_vm_migration_shardedcluster_scram_sha256
+      - e2e_vm_migration_shardedcluster_scram_sha1
+      - e2e_vm_migration_shardedcluster_scram_sha256_tls
+      - e2e_vm_migration_shardedcluster_ldap
+      - e2e_vm_migration_shardedcluster_oidc
+      - e2e_vm_migration_shardedcluster_oidc_group
+      - e2e_vm_migration_shardedcluster_oidc_workforce
+      - e2e_vm_migration_shardedcluster_prometheus
 
   # MongoDBSearch tests that require a large instance (multiple mongots per shard:
   # 2 shards x 2 mongots x 2 CPU = 8 CPU). Added to cloudqa-large variants.
@@ -1095,6 +1119,7 @@ task_groups:
       - e2e_sharded_cluster_pv_resize
       - e2e_sharded_cluster_recovery
       - e2e_sharded_cluster_scale_shards
+      - e2e_sharded_cluster_scale_shards_name_overrides
       - e2e_sharded_cluster_shard_overrides
       - e2e_sharded_cluster_secret
       - e2e_sharded_cluster_statefulset_status

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	opMigration "github.com/mongodb/mongodb-kubernetes/controllers/operator/migration"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	opMigration "github.com/mongodb/mongodb-kubernetes/controllers/operator/migration"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/docker/mongodb-kubernetes-tests/Dockerfile
+++ b/docker/mongodb-kubernetes-tests/Dockerfile
@@ -99,8 +99,4 @@ COPY release.json /tests/release.json
 # we use the public directory to automatically test resources samples
 COPY public /mongodb-kubernetes/public
 
-RUN if [ -f "/tests/multi-cluster-kube-config-creator_${TARGETARCH}" ]; then \
-    install -m 755 "/tests/multi-cluster-kube-config-creator_${TARGETARCH}" /usr/local/bin/multi-cluster-kube-config-creator; \
-    fi
-
 ADD "docker/mongodb-kubernetes-tests/kubectl-mongodb_${TARGETARCH}" /usr/local/bin/kubectl-mongodb

--- a/docker/mongodb-kubernetes-tests/Dockerfile
+++ b/docker/mongodb-kubernetes-tests/Dockerfile
@@ -102,3 +102,5 @@ COPY public /mongodb-kubernetes/public
 RUN if [ -f "/tests/multi-cluster-kube-config-creator_${TARGETARCH}" ]; then \
     install -m 755 "/tests/multi-cluster-kube-config-creator_${TARGETARCH}" /usr/local/bin/multi-cluster-kube-config-creator; \
     fi
+
+ADD "docker/mongodb-kubernetes-tests/kubectl-mongodb_${TARGETARCH}" /usr/local/bin/kubectl-mongodb

--- a/docker/mongodb-kubernetes-tests/kubetester/mongodb_user.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/mongodb_user.py
@@ -69,7 +69,7 @@ class MongoDBUser(CustomObject, MongoDBCommon):
 
     def get_status_message(self) -> Optional[str]:
         try:
-            return self["status"]["msg"]
+            return self["status"]["message"]
         except KeyError:
             return None
 

--- a/docker/mongodb-kubernetes-tests/tests/conftest.py
+++ b/docker/mongodb-kubernetes-tests/tests/conftest.py
@@ -1364,8 +1364,8 @@ def run_kube_config_creation_tool(
     member_clusters_str = ",".join(member_clusters)
     args: list[str] = [
         os.getenv(
-            "MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH",
-            "multi-cluster-kube-config-creator",
+            "KUBECTL_MONGODB_PATH",
+            "kubectl-mongodb",
         ),
         "multicluster",
         "setup",
@@ -1443,8 +1443,8 @@ def run_multi_cluster_recovery_tool(
     member_clusters_str = ",".join(member_clusters)
     args: list[str] = [
         os.getenv(
-            "MULTI_CLUSTER_KUBE_CONFIG_CREATOR_PATH",
-            "multi-cluster-kube-config-creator",
+            "KUBECTL_MONGODB_PATH",
+            "kubectl-mongodb",
         ),
         "multicluster",
         "recover",

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_ldap.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_ldap.py
@@ -1,0 +1,395 @@
+"""
+VM migration from a generated MongoDB resource with LDAP (PLAIN) authentication.
+
+This test stands up an OpenLDAP server, configures VM members in Ops Manager with native LDAP
+authentication, runs kubectl-mongodb migrate-to-mck, applies the generated resources, and verifies
+dry-run validation, migration of an LDAP ($external) application user, data continuity, connection
+strings, process names, and the promote and prune flow.
+
+The LDAP agent user is the auth autoUser and is skipped by migrate-to-mck (like the X509 agent);
+the LDAP application user is emitted as a MongoDBUser CR with db: $external and no password Secret.
+"""
+
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version
+from kubetester.ldap import LDAPUser, OpenLDAP, add_user_to_group, create_user, ensure_group, ensure_organizational_unit
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.authentication.conftest import LDAP_PASSWORD, openldap_install
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+LDAP_BASE = "dc=example,dc=org"
+AGENT_UID = "mms-automation-agent"
+APP_USER_UID = "vm-ldap-app-user"
+# The migrate tool wires the generated CR to these fixed Secret names (bind-query + LDAP agent password).
+LDAP_BIND_QUERY_SECRET = "ldap-bind-query-password"
+LDAP_AGENT_PASSWORD_SECRET = "ldap-agent-password"
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def openldap(namespace: str) -> OpenLDAP:
+    return openldap_install(namespace, "openldap")
+
+
+@fixture(scope="module")
+def ldap_agent_user(openldap: OpenLDAP) -> LDAPUser:
+    """The automation agent's LDAP identity. Authenticates via simple bind with its full DN."""
+    user = LDAPUser(AGENT_UID, LDAP_PASSWORD, ou="groups")
+    ensure_organizational_unit(openldap, "groups")
+    create_user(openldap, user, ou="groups")
+    ensure_group(openldap, cn="agents", ou="groups")
+    add_user_to_group(openldap, user=AGENT_UID, group_cn="agents", ou="groups")
+    return user
+
+
+@fixture(scope="module")
+def ldap_app_user(openldap: OpenLDAP) -> LDAPUser:
+    """The migrated $external application user (readWrite on admin so it can run an auth-gated write)."""
+    user = LDAPUser(APP_USER_UID, LDAP_PASSWORD)
+    create_user(openldap, user)
+    return user
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts: dict,
+    vm_service: dict,
+    mdb_version: str,
+    openldap: OpenLDAP,
+    agent_dn: str,
+    app_user_dn: str,
+):
+    """Configure the VM replica set for native LDAP (PLAIN) authentication.
+
+    Authorization for application users is taken from explicit usersWanted entries (db: $external)
+    rather than LDAP groups, so only authentication flows through LDAP. The agent is referenced only by
+    auth.autoUser and has no usersWanted entry. Internal cluster auth uses the keyfile (SCRAM for
+    __system@local), so authenticationMechanisms keeps SCRAM-SHA-256 alongside PLAIN.
+    """
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["ldap"] = {
+        "servers": openldap.servers,
+        "bindMethod": "simple",
+        "bindQueryUser": f"cn=admin,{LDAP_BASE}",
+        "bindQueryPassword": openldap.admin_password,
+        "transportSecurity": "none",
+        "validateLDAPServerConfig": True,
+    }
+
+    ac["auth"] = {
+        "disabled": False,
+        "authoritativeSet": False,
+        "autoAuthMechanism": "PLAIN",
+        "autoAuthMechanisms": ["PLAIN"],
+        "autoAuthRestrictions": [],
+        "deploymentAuthMechanisms": ["SCRAM-SHA-256", "PLAIN"],
+        "autoUser": agent_dn,
+        "autoPwd": LDAP_PASSWORD,
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+        "usersWanted": [
+            {
+                "user": app_user_dn,
+                "db": "$external",
+                "roles": [
+                    {"role": "readWrite", "db": "admin"},
+                    {"role": "readWrite", "db": "migration_data"},
+                ],
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+    }
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    # LDAP ($external) users carry no password Secret, so no user_secrets mapping is needed.
+    return run_generate_cr(namespace)
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str, openldap: OpenLDAP) -> MongoDB:
+    # apply_generated_mongodb_resource only applies the MongoDB doc, so create the Secrets the generated
+    # CR references (the tool emits them, but the helper does not apply them): the bind-query password
+    # and the LDAP agent password.
+    def create_ldap_secrets(_resource_doc: dict) -> None:
+        create_or_update_secret(namespace, LDAP_BIND_QUERY_SECRET, {"password": openldap.admin_password})
+        create_or_update_secret(namespace, LDAP_AGENT_PASSWORD_SECRET, {"password": LDAP_PASSWORD})
+
+    return apply_generated_mongodb_resource(
+        namespace,
+        generated_cr_yaml,
+        customer_sets_disabled_tls_mode=True,
+        prepare_external_resources=create_ldap_secrets,
+    )
+
+
+def _ldap_opts(app_user_dn: str) -> list[dict]:
+    return [{"username": app_user_dn, "password": LDAP_PASSWORD, "authSource": "$external", "authMechanism": "PLAIN"}]
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, ldap_app_user: LDAPUser) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=False),
+        health_function_params={"attempts": 1, "opts": _ldap_opts(ldap_app_user.username)},
+    )
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts,
+    vm_service,
+    custom_mdb_version: str,
+    openldap: OpenLDAP,
+    ldap_agent_user: LDAPUser,
+    ldap_app_user: LDAPUser,
+):
+    _configure_ac(
+        namespace,
+        om_tester,
+        vm_sts,
+        vm_service,
+        custom_mdb_version,
+        openldap,
+        agent_dn=ldap_agent_user.username,
+        app_user_dn=ldap_app_user.username,
+    )
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_user_connectivity_before_migration(namespace: str, ldap_app_user: LDAPUser):
+    """The LDAP application user can authenticate against the VM replica set before migration."""
+    vm_replica_set_tester(namespace).assert_ldap_authentication(
+        username=ldap_app_user.username, password=LDAP_PASSWORD, attempts=10
+    )
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_insert_migration_data(namespace: str, ldap_app_user: LDAPUser):
+    insert_migration_data(vm_replica_set_tester(namespace), opts=_ldap_opts(ldap_app_user.username))
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_ldap_auth_in_cr(generated_cr: dict):
+    auth = generated_cr["spec"]["security"]["authentication"]
+    assert "LDAP" in auth["modes"], f"Expected LDAP in auth modes, got: {auth['modes']}"
+    ldap_section = auth["ldap"]
+    assert ldap_section["bindQueryPasswordSecretRef"]["name"] == LDAP_BIND_QUERY_SECRET
+    assert ldap_section["servers"]
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_user_cr_emitted(generated_cr_yaml: str, ldap_app_user: LDAPUser):
+    # The $external app user produces a MongoDBUser CR; the LDAP agent auto-user is skipped.
+    user_docs = generated_user_docs(generated_cr_yaml)
+    assert len(user_docs) == 1, f"Expected 1 user CR (app user; agent skipped), got {len(user_docs)}"
+    assert user_docs[0]["spec"]["db"] == "$external"
+    assert user_docs[0]["spec"]["username"] == ldap_app_user.username
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_ldap_user_connectivity_after_migration(mdb_migration: MongoDB, ldap_app_user: LDAPUser):
+    """The migrated $external LDAP user can authenticate via PLAIN after the operator takes over."""
+    mdb_migration.tester(use_ssl=False).assert_ldap_authentication(
+        username=ldap_app_user.username, password=LDAP_PASSWORD, attempts=10
+    )
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, ldap_app_user: LDAPUser):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=_ldap_opts(ldap_app_user.username))
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_ldap_user_connectivity_after_promote(mdb_migration: MongoDB, ldap_app_user: LDAPUser):
+    mdb_migration.tester(use_ssl=False).assert_ldap_authentication(
+        username=ldap_app_user.username, password=LDAP_PASSWORD, attempts=10
+    )
+
+
+@mark.e2e_vm_migration_replicaset_ldap
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, ldap_app_user: LDAPUser):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=_ldap_opts(ldap_app_user.username))

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_manual_rollback.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_manual_rollback.py
@@ -1,0 +1,354 @@
+"""Deleting a mid-migration MongoDB resource must not touch Ops Manager.
+
+This covers the accident, not the procedure. Deleting the CR is NOT how a VM-to-Kubernetes
+migration should be rolled back: it also tears down the StatefulSet, and once enough Kubernetes
+members have been promoted to voting, losing their pods can drop the replica set below a
+majority. The supported rollback is to stop the operator (scale its Deployment to zero) and edit
+the automation config by hand while the StatefulSets are still running, so the members stay
+available while they are removed from the replica set.
+
+What the operator guards against is somebody deleting the CR anyway -- by mistake, or by
+`kubectl delete -f` on a whole directory. The replica set in Ops Manager is then partly made of
+processes the operator does not own, and the normal cleanup path would take the VM-hosted
+processes with it: om.Deployment.RemoveReplicaSetByName iterates every member with no ownership
+filter. ReplicaSetReconcilerHelper.cleanOpsManagerState therefore returns early whenever
+spec.externalMembers is non-empty, leaving Ops Manager alone. A live VM deployment survives the
+mistake.
+
+This test provokes that mistake and asserts the blast radius is zero: bring up 3 VM members plus
+one non-voting Kubernetes member, delete the resource, and check the automation config is
+byte-identical. It then cleans up the entry the deleted pod left behind, confirming the
+deployment is back to its original three-VM shape, healthy, with its data intact.
+
+The single Kubernetes member here is deliberately non-voting (votes/priority 0), so the three VM
+members keep the whole majority and deleting the pod cannot cost the replica set its primary.
+That is what makes this scenario safe to provoke in a test; it is not a claim that deleting the
+CR is safe in general.
+"""
+
+from kubernetes.client.rest import ApiException
+from kubetester import get_statefulset, try_load
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version, skip_if_local
+from kubetester.mongodb import MongoDB
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    K8S_PROCESS_NAME_PREFIX,
+    assert_automation_config_unchanged,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    insert_migration_data,
+    k8s_process_name,
+    remove_k8s_member_from_automation_config,
+    run_generate_cr,
+    wait_for_automation_config_quiescence,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    MIN_VM_MONGOD,
+    apply_generated_mongodb_resource,
+    assert_connection_string_contains_current_hosts,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    vm_replica_set_tester,
+)
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac_no_auth(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mdb_version: str):
+    """Set up a replica set with auth DISABLED. Mirrors the no_auth migration scenario."""
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {"disabled": True, "authoritativeSet": False}
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {
+                        "port": 27017,
+                        "tls": {"mode": "disabled"},
+                        "compression": {"compressors": "snappy,zstd"},
+                    },
+                    "storage": {
+                        "dbPath": "/data/",
+                        "directoryPerDB": True,
+                    },
+                    "systemLog": {
+                        "path": "/data/mongodb.log",
+                        "destination": "file",
+                    },
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    return run_generate_cr(namespace)
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr: dict) -> MongoDB:
+    # Apply straight at one K8s member rather than growing from zero: the point of this test is
+    # what deletion does to Ops Manager, and a single non-voting member is already enough to make
+    # the deployment mixed VM + K8s. externalMembers stays at 3 and is never pruned, so the
+    # resource is unambiguously mid-migration when it gets deleted.
+    return apply_generated_mongodb_resource(
+        namespace, generated_cr, customer_sets_disabled_tls_mode=True, initial_members=1
+    )
+
+
+# Module-scoped mutable state: the AC snapshot taken just before deletion, and the resource name,
+# both needed by tests that run after mdb_migration has been deleted (the fixture object is stale
+# by then, and re-instantiating it would fail).
+@fixture(scope="module")
+def rollback_state() -> dict:
+    return {}
+
+
+# --- Setup: bring up the VM deployment, exactly as the other migration scenarios do ---
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_configure_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, custom_mdb_version):
+    _configure_ac_no_auth(namespace, om_tester, vm_sts, vm_service, custom_mdb_version)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_insert_migration_data(namespace: str):
+    insert_migration_data(vm_replica_set_tester(namespace))
+
+
+# --- Begin the migration: one K8s member alongside the three VM members, and stop there ---
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    """Validate connectivity to the VM members, then clear the dry-run annotation.
+
+    The generated CR ships with mongodb.com/migration-dry-run=true and the operator never removes
+    it -- this helper does (vm_migration_dry_run.py:142-146). Without it the resource would sit in
+    Migrating reason ``Validating`` forever and never provision a pod.
+    """
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_migration_reaches_running(mdb_migration: MongoDB, rollback_state: dict):
+    """The resource comes up with a single non-voting K8s member and all 3 VM members intact.
+
+    apply_generated_mongodb_resource pins the member to votes/priority 0, so the three VM members
+    still hold the entire voting majority. That is what makes the rollback safe: losing the K8s
+    pod later cannot cost the replica set its primary.
+    """
+    rollback_state["resource_name"] = mdb_migration.name
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+    assert len(mdb_migration["spec"]["externalMembers"]) == MIN_VM_MONGOD, (
+        "externalMembers must be untouched -- this scenario never prunes, so the resource is "
+        "still mid-migration when it gets deleted"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_automation_config_has_both_vm_and_k8s_processes(namespace: str, om_tester: OMTester, rollback_state: dict):
+    """Precondition for the whole test: OM now describes a mixed 3-VM + 1-K8s replica set."""
+    ac = om_tester.api_get_automation_config()
+    names = [p["name"] for p in ac["processes"]]
+
+    expected_k8s = k8s_process_name(namespace, rollback_state["resource_name"], 0)
+    assert expected_k8s in names, f"expected operator-managed process {expected_k8s} in {names}"
+
+    vm_names = [n for n in names if not n.startswith(K8S_PROCESS_NAME_PREFIX)]
+    assert len(vm_names) == MIN_VM_MONGOD, f"expected {MIN_VM_MONGOD} VM processes, got {vm_names}"
+    assert len(names) == MIN_VM_MONGOD + 1, f"expected exactly 4 processes total, got {names}"
+
+
+# --- Provoke the accident: delete the resource while it is still mid-migration ---
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_delete_mongodb_resource(mdb_migration: MongoDB, om_tester: OMTester, rollback_state: dict):
+    """Snapshot Ops Manager, then delete the CR while it still declares externalMembers.
+
+    Stands in for an accidental deletion. The supported rollback stops the operator and edits the
+    automation config with the StatefulSets still up; this deliberately does the unsupported thing
+    to prove the operator's guard holds.
+    """
+    rollback_state["ac_before_delete"] = wait_for_automation_config_quiescence(om_tester)
+
+    namespace = mdb_migration.namespace
+    name = mdb_migration.name
+    mdb_migration.delete()
+
+    def resource_is_gone() -> bool:
+        # try_load returns False on a 404 and re-raises anything else.
+        return not try_load(MongoDB(name, namespace))
+
+    KubernetesTester.wait_until(resource_is_gone, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_automation_config_unchanged_after_delete(om_tester: OMTester, rollback_state: dict):
+    """The core assertion: an accidental delete must not touch Ops Manager at all.
+
+    Not just the VM processes -- nothing. The operator's own K8s process stays too, because
+    cleanOpsManagerState returns early rather than removing the replica set (which would take the
+    VM processes with it: om.Deployment.RemoveReplicaSetByName has no ownership filter). Leaving
+    the orphaned entry behind is the correct trade: a stale automation config entry is repairable
+    by hand, a deleted VM deployment is not.
+
+    Deletion cleanup is a one-shot, best-effort watch handler with no completion signal, so this
+    polls over a window rather than checking once.
+    """
+    assert_automation_config_unchanged(om_tester, rollback_state["ac_before_delete"], duration=90, interval=10)
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_k8s_statefulset_is_gone(namespace: str, rollback_state: dict):
+    """Kubernetes garbage-collects the migration StatefulSet, orphaning the AC's K8s process.
+
+    This is precisely why deleting the CR is the wrong way to roll back: the pods go with it. Here
+    the lost member was non-voting so nothing is at risk, but had voting members been promoted
+    already, this step is where the replica set would have lost its majority.
+
+    It also leaves the state the repair below has to clean up: an automation config entry pointing
+    at a host that no longer exists.
+    """
+    name = rollback_state["resource_name"]
+
+    def sts_is_gone() -> bool:
+        try:
+            get_statefulset(namespace, name)
+            return False
+        except ApiException as e:
+            return e.status == 404
+
+    KubernetesTester.wait_until(sts_is_gone, timeout=300)
+
+
+# --- Repair the damage: take the orphaned K8s member out of the automation config ---
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_manually_remove_k8s_member_from_automation_config(namespace: str, om_tester: OMTester, rollback_state: dict):
+    # Applied at spec.members=1, so index 0 is the only operator-managed member to remove.
+    remove_k8s_member_from_automation_config(om_tester, namespace, rollback_state["resource_name"], 0)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_automation_config_back_to_vm_only(namespace: str, om_tester: OMTester, vm_sts, rollback_state: dict):
+    """The deployment is the three original VM processes again, with no operator residue."""
+    ac = om_tester.api_get_automation_config()
+
+    sts_name = vm_sts["metadata"]["name"]
+    expected_names = {f"{sts_name}-{i}" for i in range(MIN_VM_MONGOD)}
+
+    actual_names = {p["name"] for p in ac["processes"]}
+    assert actual_names == expected_names, f"expected exactly the VM processes {expected_names}, got {actual_names}"
+
+    assert len(ac["replicaSets"]) == 1, f"expected a single replica set, got {ac['replicaSets']}"
+    member_hosts = {m["host"] for m in ac["replicaSets"][0]["members"]}
+    assert member_hosts == expected_names, f"expected replica set members {expected_names}, got {member_hosts}"
+
+    monitoring_hostnames = {mv.get("hostname") for mv in ac.get("monitoringVersions", [])}
+    assert not any(
+        h and h.startswith(f"{rollback_state['resource_name']}-") for h in monitoring_hostnames
+    ), f"operator-managed hosts still monitored: {monitoring_hostnames}"
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+@skip_if_local()
+def test_vm_replica_set_healthy_after_rollback(namespace: str):
+    vm_replica_set_tester(namespace).assert_connectivity()
+
+
+@mark.e2e_vm_migration_replicaset_manual_rollback
+def test_migration_data_survived_rollback(namespace: str):
+    assert_migration_data_exists(vm_replica_set_tester(namespace))

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_mck_to_mck.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_mck_to_mck.py
@@ -1,0 +1,374 @@
+"""
+MCK-to-MCK VM migration.
+
+Deploys a real MCK-managed SCRAM-SHA-256 replica set (with an application MongoDBUser)
+in the source namespace, stops the source operator, then migrates the deployment into a
+second namespace using kubectl-mongodb migrate-to-mck and the VM-migration promote &
+prune flow. Unlike the other vm_migration replica set tests, the migration source is a
+genuine MCK deployment (MCK-style process names/hostnames, an operator-managed agent user
+and keyfile in the automation config) rather than the raw agent StatefulSet fixture, and
+the migration runs operator -> operator across namespaces.
+"""
+
+from kubetester import create_or_update_configmap, create_or_update_secret, read_configmap, read_secret
+from kubetester.kubetester import KubernetesTester, create_testing_namespace, ensure_ent_version
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import skip_if_local
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_user import MongoDBUser
+from kubetester.mongotester import MongoDBBackgroundTester, with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_scram_user_resource
+from pytest import fixture, mark
+from tests.conftest import get_central_cluster_client, get_evergreen_task_id, get_operator_installation_config
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    promote_and_prune,
+)
+
+SOURCE_MEMBERS = 3
+SOURCE_RS_NAME = "source-rs"
+# Application user created in the source namespace by the source operator and later re-created
+# in the target namespace from the MongoDBUser CR the import tool generates.
+APP_USER_NAME = "app-user"
+APP_USER_PASSWORD = "appUser123!"
+APP_USER_SECRET = "app-user-password"
+# Distinct from the source operator's default name so the two operators' cluster-scoped
+# Helm resources do not collide (see target_operator fixture).
+TARGET_OPERATOR_NAME = "mongodb-kubernetes-operator-target"
+
+
+def shared_project_name(namespace: str) -> str:
+    """Ops Manager project name shared by the source and target namespaces.
+
+    Derived from the (per-run unique) namespace: Cloud QA shares one OM organization
+    across all e2e runs, and project (group) names must be unique within an org, so a
+    fixed literal would 409 with GROUP_ALREADY_EXISTS across retries and parallel runs.
+    """
+    return f"{namespace}-mck-to-mck"
+
+
+# --- target-namespace bootstrap (inlined per design) ---
+
+
+def _ensure_shared_project_name(namespace: str, api_client=None):
+    """Pin an explicit projectName on the namespace's my-project ConfigMap.
+
+    Guarantees the source deployment registers into a per-run-unique, shared project so
+    the copy in the target namespace resolves the identical Ops Manager project.
+    """
+    project_name = shared_project_name(namespace)
+    project_cm = read_configmap(namespace, "my-project", api_client=api_client)
+    if project_cm.get("projectName") != project_name:
+        project_cm["projectName"] = project_name
+        create_or_update_configmap(namespace, "my-project", project_cm, api_client=api_client)
+
+
+def _prepare_target_namespace(source_ns: str, target_ns: str, api_client):
+    """Create target_ns and copy everything the target operator + import tool need.
+
+    Copies operator install config, image-pull secret, and the shared my-project /
+    my-credentials so the imported CR points at the same OM project as the source.
+
+    Database-role ServiceAccounts are intentionally NOT pre-created here: the operator
+    Helm chart installed into this namespace creates and owns them, and a pre-created
+    (non-Helm-owned) copy makes the operator's helm install fail on ownership metadata.
+    """
+    operator_installation_config = get_operator_installation_config(source_ns)
+    create_testing_namespace(get_evergreen_task_id(), target_ns, api_client=api_client)
+
+    image_pull_secret_name = operator_installation_config["registry.imagePullSecrets"]
+    image_pull_secret_data = read_secret(source_ns, image_pull_secret_name, api_client=api_client)
+    create_or_update_secret(
+        target_ns,
+        image_pull_secret_name,
+        image_pull_secret_data,
+        type="kubernetes.io/dockerconfigjson",
+        api_client=api_client,
+    )
+
+    op_config_cm = read_configmap(source_ns, "operator-installation-config", api_client=api_client)
+    create_or_update_configmap(target_ns, "operator-installation-config", op_config_cm, api_client=api_client)
+
+    project_cm = read_configmap(source_ns, "my-project", api_client=api_client)
+    create_or_update_configmap(target_ns, "my-project", project_cm, api_client=api_client)
+
+    credentials = read_secret(source_ns, "my-credentials", api_client=api_client)
+    create_or_update_secret(target_ns, "my-credentials", credentials, api_client=api_client)
+
+
+def _target_om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+# --- fixtures ---
+
+
+@fixture(scope="module")
+def target_namespace(namespace: str) -> str:
+    return f"{namespace}-target"
+
+
+@fixture(scope="module")
+def source_mdb(namespace: str, custom_mdb_version: str) -> MongoDB:
+    _ensure_shared_project_name(namespace)
+    resource = MongoDB.from_yaml(
+        yaml_fixture("replica-set-single.yaml"),
+        name=SOURCE_RS_NAME,
+        namespace=namespace,
+    )
+    resource["spec"]["members"] = SOURCE_MEMBERS
+    resource["spec"]["security"] = {"authentication": {"enabled": True, "modes": ["SCRAM"]}}
+    resource.set_version(ensure_ent_version(custom_mdb_version))
+    return resource
+
+
+@fixture(scope="module")
+def source_user(namespace: str) -> MongoDBUser:
+    """Application user managed by the source operator; also creates its password Secret."""
+    user = build_scram_user_resource(
+        namespace,
+        APP_USER_NAME,
+        APP_USER_PASSWORD,
+        APP_USER_SECRET,
+        SOURCE_RS_NAME,
+    )
+    # The migration sentinel lives in its own database, so readWrite on admin is not enough.
+    user["spec"]["roles"] = [
+        {"db": "admin", "name": "readWrite"},
+        {"db": "migration_data", "name": "readWrite"},
+    ]
+    return user
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(APP_USER_NAME, APP_USER_PASSWORD, "SCRAM-SHA-256")]
+
+
+@fixture(scope="module")
+def target_operator(target_namespace: str) -> Operator:
+    # Distinct operator.name (and Helm release name) so the target operator's
+    # cluster-scoped resources -- notably the "{operator.name}-cluster-telemetry"
+    # ClusterRole, whose name carries no namespace -- do not collide with the still-present
+    # source operator's Helm-owned cluster resources. The runtime webhook config
+    # (mdbpolicy.mongodb.com) is a shared singleton with failurePolicy=Ignore that the
+    # running operator takes over, so a distinct name here is safe.
+    helm_args = get_operator_installation_config(target_namespace).copy()
+    helm_args["operator.watchNamespace"] = target_namespace
+    helm_args["operator.name"] = TARGET_OPERATOR_NAME
+    return Operator(namespace=target_namespace, helm_args=helm_args, name=TARGET_OPERATOR_NAME).install()
+
+
+@fixture(scope="module")
+def generated_cr_yaml(target_namespace: str) -> str:
+    # migrate-to-mck users validates the password Secret in the namespace it generates for, so the
+    # app user's Secret has to exist in the target namespace before the tool runs.
+    create_or_update_secret(target_namespace, APP_USER_SECRET, {"password": APP_USER_PASSWORD})
+    return run_generate_cr(target_namespace, user_secrets={f"{APP_USER_NAME}:admin": APP_USER_SECRET})
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(target_namespace: str, generated_cr: dict) -> MongoDB:
+    return apply_generated_mongodb_resource(target_namespace, generated_cr, customer_sets_disabled_tls_mode=True)
+
+
+@fixture(scope="module")
+def source_stub() -> dict:
+    """Stand-in expected by promote_and_prune, which reads spec.replicas as the source count."""
+    return {"spec": {"replicas": SOURCE_MEMBERS}}
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, scram_opts: list[dict]) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=False),
+        health_function_params={"attempts": 1, "opts": scram_opts},
+    )
+
+
+# --- test flow (ordered; runs under -x) ---
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_install_source_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_deploy_source_mdb(source_mdb: MongoDB):
+    source_mdb.update()
+    source_mdb.assert_reaches_phase(Phase.Running, timeout=900)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_create_source_user(source_user: MongoDBUser):
+    """Created while operator A is still running -- it owns reconciling the user into the AC."""
+    source_user.update()
+    source_user.assert_reaches_phase(Phase.Updated, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+@skip_if_local()
+def test_user_connectivity_before_migration(source_mdb: MongoDB):
+    source_mdb.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER_NAME, password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_insert_migration_data(source_mdb: MongoDB, scram_opts: list[dict]):
+    insert_migration_data(source_mdb.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_stop_source_operator(operator: Operator):
+    """Stop operator A. Source pods and agents keep running; the OM automation config is frozen."""
+    operator.delete_operator_deployment()
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_release_source_user_finalizer(source_user: MongoDBUser):
+    """Strip the user finalizer the stopped source operator left behind.
+
+    The MongoDBUser controller adds mongodb.com/v1.userRemovalFinalizer; with operator A gone
+    nothing removes it, so tearing down the source namespace would hang on the orphaned CR.
+    Stripping it here (after operator A is stopped, so no reconcile re-adds it) leaves the
+    automation config -- the actual migration source -- untouched.
+    """
+    source_user.reload()
+    source_user["metadata"]["finalizers"] = []
+    source_user.patch()
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_prepare_target_namespace(namespace: str, target_namespace: str):
+    _prepare_target_namespace(namespace, target_namespace, get_central_cluster_client())
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_install_target_operator(target_operator: Operator):
+    """Installed after operator A is gone, so operator B owns the cluster webhook."""
+    target_operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_generate_cr_shape(generated_cr_yaml: str, generated_cr: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, SOURCE_MEMBERS)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_external_members_point_at_source(generated_cr: dict, namespace: str):
+    external_members = generated_cr["spec"]["externalMembers"]
+    assert len(external_members) == SOURCE_MEMBERS
+    for member in external_members:
+        assert (
+            f".{namespace}.svc.cluster.local" in member["hostname"]
+        ), f"external member should live in source namespace {namespace}: {member['hostname']}"
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_scram_in_cr(generated_cr: dict):
+    authentication = generated_cr["spec"]["security"]["authentication"]
+    assert authentication["enabled"] is True
+    assert authentication["modes"] == ["SCRAM"], f"Unexpected auth modes: {authentication}"
+    # The source operator's agent user is the operator default, so it is not spelled out in the CR.
+    assert "automationUserName" not in authentication.get("agents", {}), f"Unexpected agents block: {authentication}"
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_user_crs_emitted(generated_cr_yaml: str):
+    """Only the application user is emitted -- the automation agent user is skipped."""
+    usernames = {doc["spec"]["username"] for doc in generated_user_docs(generated_cr_yaml)}
+    assert usernames == {APP_USER_NAME}, f"Unexpected user CRs: {usernames}"
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_migrate_to_target(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_user_crs_reach_updated(generated_cr_yaml: str, target_namespace: str, mdb_migration: MongoDB):
+    """The generated MongoDBUser is adopted by the target operator, keeping both credential sets."""
+    apply_user_crs_and_verify_ac(generated_cr_yaml, target_namespace, _target_om_tester(target_namespace))
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+@skip_if_local()
+def test_user_connectivity_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER_NAME, password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+@skip_if_local()
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_promote_and_prune(mdb_migration: MongoDB, source_stub: dict):
+    promote_and_prune(mdb_migration, source_stub)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_process_names(mdb_migration: MongoDB, target_namespace: str):
+    om_tester = _target_om_tester(target_namespace)
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+@skip_if_local()
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+@skip_if_local()
+def test_user_connectivity_after_promote(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER_NAME, password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_mck_to_mck
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_no_auth.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_no_auth.py
@@ -1,0 +1,324 @@
+"""
+VM migration from a generated MongoDB resource with authentication disabled.
+
+This test configures VM members in Ops Manager, runs kubectl-mongodb migrate-to-mck,
+applies the generated resources, and verifies dry-run validation, data continuity,
+connection strings, process names, and the promote and prune flow.
+"""
+
+from kubetester import get_statefulset
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version, skip_if_local
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    connection_string_tester,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune_extend,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac_no_auth(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mdb_version: str):
+    """Set up a replica set with auth DISABLED, custom port 27018, and compression."""
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {"disabled": True, "authoritativeSet": False}
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {
+                        "port": 27017,
+                        "tls": {"mode": "disabled"},
+                        "compression": {"compressors": "snappy,zstd"},
+                    },
+                    "storage": {
+                        "dbPath": "/data/",
+                        "directoryPerDB": True,
+                    },
+                    "systemLog": {
+                        "path": "/data/mongodb.log",
+                        "destination": "file",
+                    },
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    """Raw stdout from migrate (no SCRAM users, so no secrets needed)."""
+    return run_generate_cr(namespace)
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr: dict) -> MongoDB:
+    # Start VM-only (spec.members == 0) so this scenario exercises the incremental extend flow:
+    # K8s members are grown one at a time in promote_and_prune_extend, asserting the Migrating
+    # reason Extending. The other replicaset scenarios use the pre-provisioned promote_and_prune.
+    return apply_generated_mongodb_resource(
+        namespace, generated_cr, customer_sets_disabled_tls_mode=True, initial_members=0
+    )
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB) -> MongoDBBackgroundTester:
+    # Seed from the connection-string secret so the checker tracks the current active members
+    # across the entire cutover (VM hosts -> K8s pods), not the empty K8s topology at members==0.
+    # allowed_sequential_failures is raised above the default of 1: each promote/prune step
+    # triggers a brief replica-set reconfig during which a majority-acknowledged write can fail
+    # transiently, and that must not fail the health assertion.
+    return MongoDBBackgroundTester(
+        connection_string_tester(mdb_migration, use_ssl=False),
+        allowed_sequential_failures=3,
+    )
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_configure_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, custom_mdb_version):
+    _configure_ac_no_auth(namespace, om_tester, vm_sts, vm_service, custom_mdb_version)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+@skip_if_local()
+def test_connectivity_before_migration(namespace: str):
+    """Replica set is reachable without authentication before migration."""
+    vm_replica_set_tester(namespace).assert_connectivity()
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_insert_migration_data(namespace: str):
+    insert_migration_data(vm_replica_set_tester(namespace))
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_no_security_in_cr(generated_cr: dict):
+    """Auth is disabled -- the generated CR must not contain a security section."""
+    spec = generated_cr.get("spec", {})
+    assert (
+        "security" not in spec
+    ), f"Expected no security section for auth-disabled deployment, got: {spec.get('security')}"
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_no_user_crs_emitted(generated_cr_yaml: str):
+    """Without auth, migrate must not emit any MongoDBUser documents."""
+    user_docs = generated_user_docs(generated_cr_yaml)
+    assert len(user_docs) == 0, f"Expected 0 user CRs, got {len(user_docs)}"
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_additional_mongod_config(generated_cr: dict):
+    """additionalMongodConfig must reflect the net.compression.compressors and storage settings."""
+    amc = generated_cr["spec"].get("additionalMongodConfig", {})
+    assert (
+        amc.get("net", {}).get("compression", {}).get("compressors") == "snappy,zstd"
+    ), f"Expected compressors 'snappy,zstd', got: {amc}"
+    assert amc.get("storage", {}).get("directoryPerDB") is True, f"Expected directoryPerDB=true, got: {amc}"
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_version_set(generated_cr: dict, custom_mdb_version: str):
+    """spec.version must match the MongoDB version used in the AC."""
+    assert generated_cr["spec"]["version"] == ensure_ent_version(custom_mdb_version)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_agent_config(generated_cr: dict):
+    """Agent config must include logRotate and systemLog from the (uniform) process config."""
+    agent = generated_cr["spec"].get("agent", {}).get("mongod", {})
+    lr = agent.get("logRotate", {})
+    assert (
+        lr.get("sizeThresholdMB") == "1000" or lr.get("sizeThresholdMB") == 1000
+    ), f"Expected logRotate.sizeThresholdMB=1000, got: {lr}"
+    sl = agent.get("systemLog", {})
+    assert sl.get("destination") == "file", f"Expected systemLog.destination=file, got: {sl}"
+    assert sl.get("path") == "/data/mongodb.log", f"Expected systemLog.path, got: {sl}"
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    """Operator validates connectivity to all externalMembers, then the annotation is removed."""
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+@skip_if_local()
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+# Note: the max-voting-members validation is covered by the other replicaset scenarios (which
+# pre-provision K8s members and flip their votes). It is intentionally omitted here: this scenario
+# starts VM-only and grows members incrementally, and the operator forbids removing Kubernetes
+# members during migration, so the "scale up to trip the limit, then scale back down" approach
+# cannot recover to a valid state.
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+@skip_if_local()
+def test_connectivity_after_migration(mdb_migration: MongoDB):
+    """Replica set remains reachable without authentication after migration."""
+    connection_string_tester(mdb_migration, use_ssl=False).assert_connectivity()
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB):
+    assert_migration_data_exists(connection_string_tester(mdb_migration, use_ssl=False))
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune_extend(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+@skip_if_local()
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+@skip_if_local()
+def test_connectivity_after_promote(mdb_migration: MongoDB):
+    """Replica set remains reachable without authentication after promote and prune."""
+    connection_string_tester(mdb_migration, use_ssl=False).assert_connectivity()
+
+
+@mark.e2e_vm_migration_replicaset_no_auth
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB):
+    assert_migration_data_exists(connection_string_tester(mdb_migration, use_ssl=False))

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_no_auth.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_no_auth.py
@@ -239,15 +239,15 @@ def test_version_set(generated_cr: dict, custom_mdb_version: str):
 
 @mark.e2e_vm_migration_replicaset_no_auth
 def test_agent_config(generated_cr: dict):
-    """Agent config must include logRotate and systemLog from the (uniform) process config."""
+    """Agent config must include logRotate from the (uniform) process config. systemLog is deliberately not
+    migrated: only /var/log/mongodb-mms-automation is volume-backed in the pod, so the operator picks
+    the mongod log path itself."""
     agent = generated_cr["spec"].get("agent", {}).get("mongod", {})
     lr = agent.get("logRotate", {})
     assert (
         lr.get("sizeThresholdMB") == "1000" or lr.get("sizeThresholdMB") == 1000
     ), f"Expected logRotate.sizeThresholdMB=1000, got: {lr}"
-    sl = agent.get("systemLog", {})
-    assert sl.get("destination") == "file", f"Expected systemLog.destination=file, got: {sl}"
-    assert sl.get("path") == "/data/mongodb.log", f"Expected systemLog.path, got: {sl}"
+    assert "systemLog" not in agent, f"systemLog should not be migrated, got: {agent}"
 
 
 # Lifecycle checks

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_oidc.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_oidc.py
@@ -1,0 +1,380 @@
+"""
+VM migration from a generated MongoDB resource with OIDC (workload M2M) authentication.
+
+The VM automation config enables MONGODB-OIDC alongside SCRAM (SCRAM for the agent and the application
+user, OIDC for a workforce/workload identity). The OIDC provider is AWS Cognito, configured the same way
+as the standalone OIDC e2e tests. This verifies that the migrate tool carries the OIDC provider configs
+into the generated CR and that an OIDC identity can still authenticate after the operator takes over.
+
+Requires the Cognito test environment (the cognito_* expansions). The test skips when they are absent.
+"""
+
+import kubetester.oidc as oidc
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.kubetester import KubernetesTester, fcv_from_version
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester, with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_sha256_creds
+from pytest import fixture, mark, skip
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+AGENT_USER = "mms-automation-agent"
+AGENT_PASSWORD = "agent-oidc-password"
+APP_USER = "app-user"
+APP_USER_PASSWORD = "appUserOidc!"
+SCRAM_MECHANISM = "SCRAM-SHA-256"
+OIDC_MECHANISM = "MONGODB-OIDC"
+MDB_VERSION = "8.0.4-ent"
+# configurationName / authNamePrefix; the OIDC username is "<prefix>/<subject>".
+OIDC_CONFIG_NAME = "OIDC-test-user"
+
+
+@fixture(scope="module")
+def cognito() -> dict:
+    client_id = oidc.get_cognito_workload_client_id()
+    issuer_uri = oidc.get_cognito_workload_url()
+    user_id = oidc.get_cognito_workload_user_id()
+    if not client_id or not issuer_uri or not user_id:
+        skip("Cognito OIDC test environment is not configured (cognito_* expansions missing)")
+    return {"client_id": client_id, "issuer_uri": issuer_uri, "user_id": user_id}
+
+
+@fixture(scope="module")
+def oidc_username(cognito: dict) -> str:
+    return f"{OIDC_CONFIG_NAME}/{cognito['user_id']}"
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts: dict,
+    vm_service: dict,
+    cognito: dict,
+    oidc_username: str,
+):
+    """SCRAM agent plus an OIDC (workload M2M) provider. The application user authenticates with SCRAM,
+    the OIDC identity authenticates via the external identity provider."""
+    mdb_version = MDB_VERSION
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": APP_USER,
+                "db": "admin",
+                "roles": [
+                    {"role": "readWrite", "db": "admin"},
+                    {"role": "readWrite", "db": "migration_data"},
+                ],
+                "mechanisms": [SCRAM_MECHANISM],
+                "scramSha256Creds": build_sha256_creds(APP_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+            {
+                "user": oidc_username,
+                "db": "$external",
+                "roles": [{"role": "readWriteAnyDatabase", "db": "admin"}],
+                "mechanisms": [],
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": [SCRAM_MECHANISM, OIDC_MECHANISM],
+        "autoAuthMechanisms": [SCRAM_MECHANISM],
+        "autoAuthMechanism": SCRAM_MECHANISM,
+        "autoUser": AGENT_USER,
+        "autoAuthRestrictions": [],
+        "autoPwd": AGENT_PASSWORD,
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    ac["oidcProviderConfigs"] = [
+        {
+            "authNamePrefix": OIDC_CONFIG_NAME,
+            "audience": cognito["client_id"],
+            "issuerUri": cognito["issuer_uri"],
+            "clientId": cognito["client_id"],
+            "requestedScopes": [],
+            "userClaim": "sub",
+            "groupsClaim": None,
+            "supportsHumanFlows": False,
+            "useAuthorizationClaim": False,
+        }
+    ]
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    create_or_update_secret(namespace, "app-user-secret", {"password": APP_USER_PASSWORD})
+    return run_generate_cr(namespace, user_secrets={f"{APP_USER}:admin": "app-user-secret"})
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr_yaml, customer_sets_disabled_tls_mode=True)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(APP_USER, APP_USER_PASSWORD, SCRAM_MECHANISM)]
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, scram_opts: list[dict]) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=False),
+        health_function_params={"attempts": 1, "opts": scram_opts},
+    )
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts,
+    vm_service,
+    cognito: dict,
+    oidc_username: str,
+):
+    _configure_ac(namespace, om_tester, vm_sts, vm_service, cognito, oidc_username)
+    om_tester.wait_agents_ready(timeout=1200)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_user_connectivity_before_migration(namespace: str):
+    vm_replica_set_tester(namespace).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_oidc_authentication_before_migration(namespace: str):
+    vm_replica_set_tester(namespace, use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_insert_migration_data(namespace: str, scram_opts: list[dict]):
+    insert_migration_data(vm_replica_set_tester(namespace), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_oidc_provider_in_cr(generated_cr: dict):
+    auth = generated_cr["spec"]["security"]["authentication"]
+    assert "OIDC" in auth["modes"]
+    configs = auth["oidcProviderConfigs"]
+    names = {c["configurationName"] for c in configs}
+    assert names == {OIDC_CONFIG_NAME}, f"Unexpected OIDC provider configs: {configs}"
+    provider = configs[0]
+    assert provider["authorizationMethod"] == "WorkloadIdentityFederation"
+    assert provider["authorizationType"] == "UserID"
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_user_crs_emitted(generated_cr_yaml: str, oidc_username: str):
+    user_docs = generated_user_docs(generated_cr_yaml)
+    usernames = {d["spec"]["username"] for d in user_docs}
+    assert usernames == {APP_USER, oidc_username}, f"Unexpected user CRs: {usernames}"
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=2400)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_scram_user_connectivity_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_oidc_authentication_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_oidc_authentication_after_promote(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_oidc_group.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_oidc_group.py
@@ -1,0 +1,355 @@
+"""
+VM migration from a generated MongoDB resource with OIDC workload GroupMembership authentication.
+
+The VM automation config enables MONGODB-OIDC alongside SCRAM. OIDC uses workload identity with
+group-based authorization (useAuthorizationClaim=true, supportsHumanFlows=false). The Cognito group
+"test" is mapped to the $external user OIDC-test-group/test. This verifies that the migrate tool
+carries the OIDC provider config into the generated CR with authorizationMethod=WorkloadIdentityFederation
+and authorizationType=GroupMembership.
+
+Requires the Cognito test environment (the cognito_* expansions). The test skips when they are absent.
+"""
+
+import kubetester.oidc as oidc
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.kubetester import KubernetesTester, fcv_from_version
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_sha256_creds
+from pytest import fixture, mark, skip
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+AGENT_USER = "mms-automation-agent"
+AGENT_PASSWORD = "agent-oidc-group-password"
+APP_USER = "app-user"
+APP_USER_PASSWORD = "appUserOidcGroup!"
+SCRAM_MECHANISM = "SCRAM-SHA-256"
+OIDC_MECHANISM = "MONGODB-OIDC"
+MDB_VERSION = "8.0.4-ent"
+OIDC_CONFIG_NAME = "OIDC-test-group"
+COGNITO_GROUP = "test"
+
+
+@fixture(scope="module")
+def cognito() -> dict:
+    client_id = oidc.get_cognito_workload_client_id()
+    issuer_uri = oidc.get_cognito_workload_url()
+    user_id = oidc.get_cognito_workload_user_id()
+    if not client_id or not issuer_uri or not user_id:
+        skip("Cognito OIDC test environment is not configured (cognito_* expansions missing)")
+    return {"client_id": client_id, "issuer_uri": issuer_uri, "user_id": user_id}
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts: dict,
+    vm_service: dict,
+    cognito: dict,
+):
+    """SCRAM agent plus a workload OIDC provider using group-based authorization.
+
+    GroupMembership OIDC uses a role in admin named <prefix>/<group> rather than a
+    user in $external. MongoDB resolves the cognito:groups claim from the JWT, then
+    grants the matching admin role to the connection.
+    """
+    mdb_version = MDB_VERSION
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": APP_USER,
+                "db": "admin",
+                "roles": [
+                    {"role": "readWrite", "db": "admin"},
+                    {"role": "readWrite", "db": "migration_data"},
+                ],
+                "mechanisms": [SCRAM_MECHANISM],
+                "scramSha256Creds": build_sha256_creds(APP_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": [SCRAM_MECHANISM, OIDC_MECHANISM],
+        "autoAuthMechanisms": [SCRAM_MECHANISM],
+        "autoAuthMechanism": SCRAM_MECHANISM,
+        "autoUser": AGENT_USER,
+        "autoAuthRestrictions": [],
+        "autoPwd": AGENT_PASSWORD,
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    ac["oidcProviderConfigs"] = [
+        {
+            "authNamePrefix": OIDC_CONFIG_NAME,
+            "audience": cognito["client_id"],
+            "issuerUri": cognito["issuer_uri"],
+            "clientId": cognito["client_id"],
+            "requestedScopes": [],
+            "userClaim": "sub",
+            "groupsClaim": "cognito:groups",
+            "supportsHumanFlows": False,
+            "useAuthorizationClaim": True,
+        }
+    ]
+
+    ac["roles"] = [
+        {
+            "role": f"{OIDC_CONFIG_NAME}/{COGNITO_GROUP}",
+            "db": "admin",
+            "privileges": [],
+            "roles": [{"role": "readWriteAnyDatabase", "db": "admin"}],
+        }
+    ]
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    create_or_update_secret(namespace, "app-user-secret", {"password": APP_USER_PASSWORD})
+    return run_generate_cr(namespace, user_secrets={f"{APP_USER}:admin": "app-user-secret"})
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr_yaml, customer_sets_disabled_tls_mode=True)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(APP_USER, APP_USER_PASSWORD, SCRAM_MECHANISM)]
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts,
+    vm_service,
+    cognito: dict,
+):
+    _configure_ac(namespace, om_tester, vm_sts, vm_service, cognito)
+    om_tester.wait_agents_ready(timeout=1200)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_user_connectivity_before_migration(namespace: str):
+    vm_replica_set_tester(namespace).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_oidc_authentication_before_migration(namespace: str):
+    vm_replica_set_tester(namespace, use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_insert_migration_data(namespace: str, scram_opts: list[dict]):
+    insert_migration_data(vm_replica_set_tester(namespace), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_oidc_provider_in_cr(generated_cr: dict):
+    auth = generated_cr["spec"]["security"]["authentication"]
+    assert "OIDC" in auth["modes"]
+    configs = auth["oidcProviderConfigs"]
+    names = {c["configurationName"] for c in configs}
+    assert names == {OIDC_CONFIG_NAME}, f"Unexpected OIDC provider configs: {configs}"
+    provider = configs[0]
+    assert provider["authorizationMethod"] == "WorkloadIdentityFederation"
+    assert provider["authorizationType"] == "GroupMembership"
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_user_crs_emitted(generated_cr_yaml: str):
+    user_docs = generated_user_docs(generated_cr_yaml)
+    usernames = {d["spec"]["username"] for d in user_docs}
+    assert usernames == {APP_USER}, f"Unexpected user CRs: {usernames}"
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=2400)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_scram_user_connectivity_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_oidc_authentication_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_group
+def test_oidc_authentication_after_promote(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_oidc_authentication()

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_oidc_workforce.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_oidc_workforce.py
@@ -1,0 +1,354 @@
+"""
+VM migration from a generated MongoDB resource with OIDC WorkforceIdentityFederation authentication.
+
+The VM automation config enables MONGODB-OIDC alongside SCRAM. OIDC uses workforce identity with
+group-based authorization (useAuthorizationClaim=true, supportsHumanFlows=true). The Cognito group
+"test" is mapped to the $external user OIDC-test-workforce/test. This verifies that the migrate tool
+carries the OIDC provider config into the generated CR with authorizationMethod=WorkforceIdentityFederation
+and authorizationType=GroupMembership.
+
+Requires the Cognito test environment (the cognito_* expansions). The test skips when they are absent.
+"""
+
+import kubetester.oidc as oidc
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.kubetester import KubernetesTester, fcv_from_version
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_sha256_creds
+from pytest import fixture, mark, skip
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+AGENT_USER = "mms-automation-agent"
+AGENT_PASSWORD = "agent-oidc-workforce-password"
+APP_USER = "app-user"
+APP_USER_PASSWORD = "appUserOidcWorkforce!"
+SCRAM_MECHANISM = "SCRAM-SHA-256"
+OIDC_MECHANISM = "MONGODB-OIDC"
+MDB_VERSION = "8.0.4-ent"
+OIDC_CONFIG_NAME = "OIDC-test-workforce"
+COGNITO_GROUP = "test"
+
+
+@fixture(scope="module")
+def cognito() -> dict:
+    client_id = oidc.get_cognito_workload_client_id()
+    issuer_uri = oidc.get_cognito_workload_url()
+    user_id = oidc.get_cognito_workload_user_id()
+    if not client_id or not issuer_uri or not user_id:
+        skip("Cognito OIDC test environment is not configured (cognito_* expansions missing)")
+    return {"client_id": client_id, "issuer_uri": issuer_uri, "user_id": user_id}
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts: dict,
+    vm_service: dict,
+    cognito: dict,
+):
+    """SCRAM agent plus a workforce OIDC provider using group-based authorization with human flows enabled.
+
+    WorkforceIdentityFederation + GroupMembership uses a role in admin named <prefix>/<group>.
+    MongoDB resolves the cognito:groups claim from the JWT and grants the matching admin role.
+    """
+    mdb_version = MDB_VERSION
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": APP_USER,
+                "db": "admin",
+                "roles": [
+                    {"role": "readWrite", "db": "admin"},
+                    {"role": "readWrite", "db": "migration_data"},
+                ],
+                "mechanisms": [SCRAM_MECHANISM],
+                "scramSha256Creds": build_sha256_creds(APP_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": [SCRAM_MECHANISM, OIDC_MECHANISM],
+        "autoAuthMechanisms": [SCRAM_MECHANISM],
+        "autoAuthMechanism": SCRAM_MECHANISM,
+        "autoUser": AGENT_USER,
+        "autoAuthRestrictions": [],
+        "autoPwd": AGENT_PASSWORD,
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    ac["oidcProviderConfigs"] = [
+        {
+            "authNamePrefix": OIDC_CONFIG_NAME,
+            "audience": cognito["client_id"],
+            "issuerUri": cognito["issuer_uri"],
+            "clientId": cognito["client_id"],
+            "requestedScopes": [],
+            "userClaim": "sub",
+            "groupsClaim": "cognito:groups",
+            "supportsHumanFlows": True,
+            "useAuthorizationClaim": True,
+        }
+    ]
+
+    ac["roles"] = [
+        {
+            "role": f"{OIDC_CONFIG_NAME}/{COGNITO_GROUP}",
+            "db": "admin",
+            "privileges": [],
+            "roles": [{"role": "readWriteAnyDatabase", "db": "admin"}],
+        }
+    ]
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    create_or_update_secret(namespace, "app-user-secret", {"password": APP_USER_PASSWORD})
+    return run_generate_cr(namespace, user_secrets={f"{APP_USER}:admin": "app-user-secret"})
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr_yaml, customer_sets_disabled_tls_mode=True)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(APP_USER, APP_USER_PASSWORD, SCRAM_MECHANISM)]
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_configure_ac(
+    namespace: str,
+    om_tester: OMTester,
+    vm_sts,
+    vm_service,
+    cognito: dict,
+):
+    _configure_ac(namespace, om_tester, vm_sts, vm_service, cognito)
+    om_tester.wait_agents_ready(timeout=1200)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_user_connectivity_before_migration(namespace: str):
+    vm_replica_set_tester(namespace).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_oidc_authentication_before_migration(namespace: str):
+    vm_replica_set_tester(namespace, use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_insert_migration_data(namespace: str, scram_opts: list[dict]):
+    insert_migration_data(vm_replica_set_tester(namespace), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_oidc_provider_in_cr(generated_cr: dict):
+    auth = generated_cr["spec"]["security"]["authentication"]
+    assert "OIDC" in auth["modes"]
+    configs = auth["oidcProviderConfigs"]
+    names = {c["configurationName"] for c in configs}
+    assert names == {OIDC_CONFIG_NAME}, f"Unexpected OIDC provider configs: {configs}"
+    provider = configs[0]
+    assert provider["authorizationMethod"] == "WorkforceIdentityFederation"
+    assert provider["authorizationType"] == "GroupMembership"
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_user_crs_emitted(generated_cr_yaml: str):
+    user_docs = generated_user_docs(generated_cr_yaml)
+    usernames = {d["spec"]["username"] for d in user_docs}
+    assert usernames == {APP_USER}, f"Unexpected user CRs: {usernames}"
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=2400)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_scram_user_connectivity_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_oidc_authentication_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_oidc_authentication()
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_oidc_workforce
+def test_oidc_authentication_after_promote(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_oidc_authentication()

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_prometheus.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_prometheus.py
@@ -1,0 +1,280 @@
+"""
+VM migration from a generated MongoDB resource with Prometheus metrics enabled.
+
+This test configures VM members in Ops Manager with an HTTP Prometheus endpoint (auth disabled on the
+database itself), runs kubectl-mongodb migrate-to-mck, applies the generated resources, and verifies
+that spec.prometheus is carried over and the operator-managed pods serve authenticated metrics.
+"""
+
+import base64
+import hashlib
+import os
+
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.http import get_retriable_session
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version, skip_if_local
+from kubetester.mongodb import MongoDB
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+PROM_USER = "prom-user"
+PROM_PASSWORD = "prom-password"
+PROM_PORT = 9216
+# The migrate tool wires spec.prometheus.passwordSecretRef to this fixed Secret name.
+PROMETHEUS_PASSWORD_SECRET = "prometheus-password"
+
+_PBKDF2_ITERATIONS = 256
+_PBKDF2_KEY_LENGTH = 32
+_PROM_SALT_SIZE = 8
+
+
+def _build_prometheus_hash(password: str, salt: bytes | None = None) -> tuple[str, str]:
+    if salt is None:
+        salt = os.urandom(_PROM_SALT_SIZE)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, _PBKDF2_ITERATIONS, dklen=_PBKDF2_KEY_LENGTH)
+    return base64.b64encode(dk).decode("utf-8"), base64.b64encode(salt).decode("utf-8")
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mdb_version: str):
+    """Auth disabled on the database, with an HTTP Prometheus endpoint on port 9216."""
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {"disabled": True, "authoritativeSet": False}
+    prom_hash, prom_salt = _build_prometheus_hash(PROM_PASSWORD)
+    ac["prometheus"] = {
+        "enabled": True,
+        "username": PROM_USER,
+        "passwordHash": prom_hash,
+        "passwordSalt": prom_salt,
+        "scheme": "http",
+        "listenAddress": f"0.0.0.0:{PROM_PORT}",
+        "metricsPath": "/metrics",
+    }
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    # The tool validates the Prometheus password Secret exists at generate time and references it by name.
+    create_or_update_secret(namespace, PROMETHEUS_PASSWORD_SECRET, {"password": PROM_PASSWORD})
+    return run_generate_cr(namespace, prometheus_secret_name=PROMETHEUS_PASSWORD_SECRET)
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr: dict) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr, customer_sets_disabled_tls_mode=True)
+
+
+def _assert_metrics_served(mdb_migration: MongoDB, namespace: str):
+    """Every operator-managed pod serves authenticated Prometheus metrics over HTTP on PROM_PORT.
+
+    Asserts both that the migrated credentials work (200 + metrics) and that auth is enforced
+    (an unauthenticated request is rejected).
+    """
+    session = get_retriable_session("http", tls_verify=False)
+    for i in range(mdb_migration.get_members()):
+        url = f"http://{mdb_migration.name}-{i}.{mdb_migration.name}-svc.{namespace}.svc.cluster.local:{PROM_PORT}/metrics"
+
+        unauth = session.get(url)
+        assert unauth.status_code == 401, f"{url} without auth returned {unauth.status_code}, expected 401"
+
+        resp = session.get(url, auth=(PROM_USER, PROM_PASSWORD))
+        assert resp.status_code == 200, f"{url} returned {resp.status_code}"
+        assert "# HELP" in resp.text, f"{url} did not return Prometheus metrics"
+        assert "mongodb" in resp.text.lower(), f"{url} did not return MongoDB metrics"
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_configure_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, custom_mdb_version):
+    _configure_ac(namespace, om_tester, vm_sts, vm_service, custom_mdb_version)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_insert_migration_data(namespace: str):
+    insert_migration_data(vm_replica_set_tester(namespace))
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_prometheus_in_cr(generated_cr: dict):
+    prom = generated_cr["spec"]["prometheus"]
+    assert prom["username"] == PROM_USER
+    assert prom["passwordSecretRef"]["name"] == PROMETHEUS_PASSWORD_SECRET
+    assert prom.get("port", PROM_PORT) == PROM_PORT
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+@skip_if_local()
+def test_prometheus_endpoint_after_migration(mdb_migration: MongoDB, namespace: str):
+    _assert_metrics_served(mdb_migration, namespace)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False))
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+@skip_if_local()
+def test_prometheus_endpoint_after_promote(mdb_migration: MongoDB, namespace: str):
+    _assert_metrics_served(mdb_migration, namespace)
+
+
+@mark.e2e_vm_migration_replicaset_prometheus
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False))

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha1.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha1.py
@@ -1,0 +1,316 @@
+"""
+VM migration from a generated MongoDB resource with SCRAM-SHA-1 authentication.
+
+This mirrors the SCRAM-SHA-256 migration test but exercises the legacy SCRAM-SHA-1 mechanism: the VM
+automation config seeds SCRAM-SHA-1 credentials (computed from the password), and the generated CR
+must carry auth mode SCRAM-SHA-1 and a MongoDBUser CR for the application user.
+"""
+
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester, with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_sha1_creds
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+AGENT_USER = "mms-automation-agent"
+AGENT_PASSWORD = "agent-sha1-password"
+APP_USER = "app-user"
+APP_USER_PASSWORD = "appUserSha1!"
+SCRAM_MECHANISM = "SCRAM-SHA-1"
+# SCRAM-SHA-1 requires MONGODB-CR in agent mode for legacy support.
+AGENT_MECHANISM = "MONGODB-CR"
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mdb_version: str):
+    """SCRAM-SHA-1 replica set. SCRAM-SHA-1 is deprecated and requires MONGODB-CR in agent mode for legacy
+    support, otherwise Ops Manager rejects it with "Cannot configure SCRAM-SHA-1 without using MONGODB-CR
+    in the Agent Mode". The agent therefore authenticates with MONGODB-CR while the deployment accepts both
+    SCRAM-SHA-1 and MONGODB-CR. Credentials are computed from the passwords so the agent and app user can
+    authenticate before migration. Internal cluster auth uses the keyfile, so authenticationMechanisms keeps
+    SCRAM-SHA-256 alongside SCRAM-SHA-1."""
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": APP_USER,
+                "db": "admin",
+                "roles": [
+                    {"role": "readWrite", "db": "admin"},
+                    {"role": "readWrite", "db": "migration_data"},
+                ],
+                "mechanisms": [SCRAM_MECHANISM],
+                "scramSha1Creds": build_sha1_creds(APP_USER, APP_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": [SCRAM_MECHANISM, AGENT_MECHANISM],
+        "autoAuthMechanisms": [AGENT_MECHANISM],
+        "autoAuthMechanism": AGENT_MECHANISM,
+        "autoUser": AGENT_USER,
+        "autoAuthRestrictions": [],
+        "autoPwd": AGENT_PASSWORD,
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    create_or_update_secret(namespace, "app-user-secret", {"password": APP_USER_PASSWORD})
+    return run_generate_cr(namespace, user_secrets={f"{APP_USER}:admin": "app-user-secret"})
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr_yaml, customer_sets_disabled_tls_mode=True)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(APP_USER, APP_USER_PASSWORD, SCRAM_MECHANISM)]
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, scram_opts: list[dict]) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=False),
+        health_function_params={"attempts": 1, "opts": scram_opts},
+    )
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_configure_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, custom_mdb_version):
+    _configure_ac(namespace, om_tester, vm_sts, vm_service, custom_mdb_version)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_user_connectivity_before_migration(namespace: str):
+    vm_replica_set_tester(namespace).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_insert_migration_data(namespace: str, scram_opts: list[dict]):
+    insert_migration_data(vm_replica_set_tester(namespace), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_scram_sha1_mode_in_cr(generated_cr: dict):
+    auth = generated_cr["spec"]["security"]["authentication"]
+    assert SCRAM_MECHANISM in auth["modes"]
+    assert AGENT_MECHANISM in auth["modes"]
+    assert auth["agents"]["mode"] == AGENT_MECHANISM
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_user_cr_emitted(generated_cr_yaml: str):
+    user_docs = generated_user_docs(generated_cr_yaml)
+    usernames = {d["spec"]["username"] for d in user_docs}
+    assert usernames == {APP_USER}, f"Unexpected user CRs: {usernames}"
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_user_connectivity_after_migration(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_user_connectivity_after_promote(mdb_migration: MongoDB):
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username=APP_USER, password=APP_USER_PASSWORD, auth_mechanism=SCRAM_MECHANISM
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha1
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256.py
@@ -1,0 +1,516 @@
+"""
+VM migration from a generated MongoDB resource with SCRAM authentication.
+
+This test configures VM members in Ops Manager, runs kubectl-mongodb migrate-to-mck,
+applies the generated resources, and verifies dry-run validation, data continuity,
+connection strings, process names, and the promote and prune flow.
+"""
+
+from kubetester import create_or_update_secret, get_statefulset
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester, with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    rotate_password_and_verify,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+DOWNLOAD_BASE = "/var/lib/custom-mms-automation"
+APP_USER_PASSWORD = "appUser123!"
+REPORTING_USER_PASSWORD = "reporting456!"
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mdb_version: str):
+    """Set up a SCRAM-authenticated replica set with users, roles, and rich mongod config."""
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": "app-user",
+                "db": "admin",
+                "roles": [
+                    {"role": "readWrite", "db": "admin"},
+                    {"role": "readWrite", "db": "migration_data"},
+                    {"role": "readWrite", "db": "myapp"},
+                    {"role": "read", "db": "reporting"},
+                ],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": {
+                    "iterationCount": 15000,
+                    "salt": "wksiNA03uUywS7DhdN062N8rpp2wgN535t9V+A==",
+                    "serverKey": "QWoYhFkf0f5fo3zM11wFVXw6eEDtWToNg3aCurCmIww=",
+                    "storedKey": "kQXatG95rq6ZysZFr00M8hK0kN13VuxX1pV3xxUpYSE=",
+                },
+                "authenticationRestrictions": [],
+            },
+            {
+                "user": "reporting-user",
+                "db": "admin",
+                "roles": [{"role": "read", "db": "reporting"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": {
+                    "iterationCount": 15000,
+                    "salt": "Usm13I846IhrVWvzO1BCXn17qe2tWMHP+GXtKg==",
+                    "serverKey": "0mGWp+V4qze1mWdoQLhss0OvL5smZ1VfineTeRYw4qE=",
+                    "storedKey": "fLNS6LPqK12byCGG6wFexh5eNpniyAWouhKhaqODt7g=",
+                },
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanism": "SCRAM-SHA-256",
+        "autoUser": "mms-automation-agent",
+        "autoAuthRestrictions": [],
+        "autoPwd": "mms-automation-agent-password",
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": f"{DOWNLOAD_BASE}/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+    ac["options"] = {"downloadBase": DOWNLOAD_BASE}
+
+    ac["roles"] = [
+        {
+            "role": "appReadOnly",
+            "db": "myapp",
+            "privileges": [
+                {
+                    "resource": {"db": "myapp", "collection": ""},
+                    "actions": ["find", "listCollections"],
+                }
+            ],
+            "roles": [{"role": "read", "db": "myapp"}],
+        },
+        {
+            "role": "metricsReader",
+            "db": "admin",
+            "privileges": [
+                {
+                    "resource": {"cluster": True},
+                    "actions": ["serverStatus", "replSetGetStatus"],
+                }
+            ],
+            "roles": [],
+        },
+    ]
+
+    tags_per_member = [
+        {"region": "us-east-1", "role": "primary"},
+        {"region": "us-east-1", "role": "secondary"},
+        {"region": "us-west-2", "role": "secondary"},
+    ]
+
+    # Member 2 intentionally diverges on logRotate, systemLog.logAppend, and oplogSizeMB
+    # to exercise the generator's first-process-wins behaviour for additionalMongodConfig.
+    log_rotate_per_member = [
+        {
+            "sizeThresholdMB": 1000,
+            "timeThresholdHrs": 24,
+            "numUncompressed": 5,
+            "numTotal": 10,
+            "percentOfDiskspace": 0.4,
+        },
+        {
+            "sizeThresholdMB": 1000,
+            "timeThresholdHrs": 24,
+            "numUncompressed": 5,
+            "numTotal": 10,
+            "percentOfDiskspace": 0.4,
+        },
+        {
+            "sizeThresholdMB": 2000,
+            "timeThresholdHrs": 24,
+            "numUncompressed": 3,
+            "numTotal": 10,
+            "percentOfDiskspace": 0.4,
+        },
+    ]
+    log_append_per_member = [True, True, False]
+    oplog_size_per_member = [2048, 2048, None]
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["backupVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+        member_config_index = i if i < len(log_rotate_per_member) else 0
+
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+
+        ac["backupVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/backup-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+
+        replication = {"replSetName": rs_name}
+        oplog_size = oplog_size_per_member[member_config_index]
+        if oplog_size is not None:
+            replication["oplogSizeMB"] = oplog_size
+
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": log_rotate_per_member[member_config_index],
+                "auditLogRotate": {
+                    "sizeThresholdMB": 500,
+                    "timeThresholdHrs": 48,
+                    "numUncompressed": 2,
+                    "numTotal": 10,
+                    "percentOfDiskspace": 0.4,
+                },
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {
+                        "port": 27017,
+                        "tls": {"mode": "disabled"},
+                        "compression": {"compressors": "zlib,zstd"},
+                    },
+                    "storage": {
+                        "dbPath": "/data/",
+                        "directoryPerDB": True,
+                    },
+                    "systemLog": {
+                        "path": "/data/mongodb.log",
+                        "destination": "file",
+                        "logAppend": log_append_per_member[member_config_index],
+                    },
+                    "replication": replication,
+                    "auditLog": {
+                        "destination": "file",
+                        "format": "JSON",
+                        "path": "/var/log/mongodb-mms-automation/mongodb-audit-changed.log",
+                    },
+                },
+            }
+        )
+
+        member_tags = tags_per_member[i] if i < len(tags_per_member) else {}
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+                "tags": member_tags,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    create_or_update_secret(namespace, "app-user-secret", {"password": APP_USER_PASSWORD})
+    create_or_update_secret(namespace, "reporting-user-secret", {"password": REPORTING_USER_PASSWORD})
+    return run_generate_cr(
+        namespace,
+        user_secrets={
+            "app-user:admin": "app-user-secret",
+            "reporting-user:admin": "reporting-user-secret",
+        },
+    )
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr_yaml, customer_sets_disabled_tls_mode=True)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram("app-user", APP_USER_PASSWORD, "SCRAM-SHA-256")]
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, scram_opts: list[dict]) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=False),
+        health_function_params={"attempts": 1, "opts": scram_opts},
+    )
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_configure_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, custom_mdb_version):
+    _configure_ac(namespace, om_tester, vm_sts, vm_service, custom_mdb_version)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_user_connectivity_before_migration(namespace: str, scram_opts: list[dict]):
+    """Users can authenticate against the VM replica set before migration."""
+    vm_replica_set_tester(namespace).assert_scram_sha_authentication(
+        username="app-user", password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_insert_migration_data(namespace: str, scram_opts: list[dict]):
+    insert_migration_data(vm_replica_set_tester(namespace), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_download_base_carried_over(generated_cr: dict):
+    """The non-default options.downloadBase is carried into spec.downloadBase."""
+    assert (
+        generated_cr["spec"].get("downloadBase") == DOWNLOAD_BASE
+    ), f"Expected spec.downloadBase={DOWNLOAD_BASE}, got: {generated_cr['spec'].get('downloadBase')}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_user_crs_emitted(generated_cr_yaml: str):
+    user_docs = generated_user_docs(generated_cr_yaml)
+    usernames = {d["spec"]["username"] for d in user_docs}
+    assert usernames == {"app-user", "reporting-user"}, f"Unexpected user CRs: {usernames}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_custom_roles_in_generated_cr(generated_cr: dict):
+    """The deployment's custom roles are carried into spec.security.roles."""
+    roles = generated_cr["spec"]["security"].get("roles", [])
+    names = {f"{r['role']}@{r['db']}" for r in roles}
+    assert names == {"appReadOnly@myapp", "metricsReader@admin"}, f"Unexpected roles in generated CR: {roles}"
+    app_role = next(r for r in roles if r["role"] == "appReadOnly")
+    assert set(app_role["privileges"][0]["actions"]) == {
+        "find",
+        "listCollections",
+    }, f"Unexpected privileges: {app_role}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_settings_sourced_from_source_process(generated_cr_yaml: str):
+    """When per-member config diverges, settings are taken from the source process (member 0).
+    Member 2 has logAppend=False and no oplogSizeMB -- neither should affect the generated CR."""
+    cr = generated_mongodb_doc(generated_cr_yaml)
+    sl = cr["spec"].get("agent", {}).get("mongod", {}).get("systemLog", {})
+    assert sl.get("destination") == "file", f"Expected destination=file, got: {sl}"
+    assert sl.get("path") == "/data/mongodb.log", f"Expected path=/data/mongodb.log, got: {sl}"
+    repl = cr["spec"].get("additionalMongodConfig", {}).get("replication", {})
+    assert repl.get("oplogSizeMB") == 2048, f"Expected oplogSizeMB=2048 from source process, got: {repl}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_vm_deployment_automation_config(om_tester: OMTester, vm_sts):
+    ac_tester = om_tester.get_automation_config_tester()
+
+    assert len(ac_tester.get_all_processes()) == vm_sts["spec"]["replicas"]
+    assert len(ac_tester.get_monitoring_versions()) == vm_sts["spec"]["replicas"]
+    assert len(ac_tester.get_backup_versions()) == vm_sts["spec"]["replicas"]
+    assert len(ac_tester.get_replica_set_processes(RS_NAME)) == vm_sts["spec"]["replicas"]
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_migration_dry_run_connectivity_passes(mdb_migration: MongoDB):
+    """Operator validates connectivity to all externalMembers, then the annotation is removed."""
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_keyfile_placed_in_operator_pods(namespace: str, vm_sts: dict, mdb_migration: MongoDB):
+    """The operator places the keyfile at <downloadBase>/keyfile in every migrated pod."""
+    keyfile_path = f"{DOWNLOAD_BASE}/keyfile"
+    for i in range(vm_sts["spec"]["replicas"]):
+        pod_name = f"{RS_NAME}-{i}"
+        output = KubernetesTester.run_command_in_pod_container(
+            pod_name,
+            namespace,
+            ["sh", "-c", f"test -f {keyfile_path} && echo FOUND"],
+            container="mongodb-enterprise-database",
+        )
+        assert "FOUND" in output, f"keyfile not found at {keyfile_path} in pod {pod_name}; got: {output!r}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_operator_preserves_download_base_and_keyfile(om_tester: OMTester):
+    """After the operator takes over, the automation config keeps the custom downloadBase/keyfile."""
+    ac = om_tester.api_get_automation_config()
+    assert (
+        ac.get("options", {}).get("downloadBase") == DOWNLOAD_BASE
+    ), f"Expected options.downloadBase={DOWNLOAD_BASE}, got: {ac.get('options', {}).get('downloadBase')}"
+    assert (
+        ac.get("auth", {}).get("keyfile") == f"{DOWNLOAD_BASE}/keyfile"
+    ), f"Expected auth.keyfile={DOWNLOAD_BASE}/keyfile, got: {ac.get('auth', {}).get('keyfile')}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_custom_roles_preserved_in_automation_config(om_tester: OMTester):
+    """The custom roles remain in the operator-managed automation config after migration."""
+    ac = om_tester.api_get_automation_config()
+    names = {f"{r['role']}@{r['db']}" for r in ac.get("roles", [])}
+    assert names >= {"appReadOnly@myapp", "metricsReader@admin"}, f"Custom roles missing after migration: {names}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_user_connectivity_after_migration(mdb_migration: MongoDB):
+    """Users can still authenticate after the operator takes over the replica set."""
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username="app-user", password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_user_connectivity_after_promote(mdb_migration: MongoDB):
+    """Users can still authenticate after promote and prune completes."""
+    mdb_migration.tester(use_ssl=False).assert_scram_sha_authentication(
+        username="app-user", password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256"
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256
+def test_password_rotation_keeps_migrated_flag(generated_cr_yaml: str, namespace: str, om_tester: OMTester):
+    rotate_password_and_verify(generated_cr_yaml, namespace, om_tester, target_username="app-user")

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256.py
@@ -380,11 +380,11 @@ def test_custom_roles_in_generated_cr(generated_cr: dict):
 @mark.e2e_vm_migration_replicaset_scram_sha256
 def test_settings_sourced_from_source_process(generated_cr_yaml: str):
     """When per-member config diverges, settings are taken from the source process (member 0).
-    Member 2 has logAppend=False and no oplogSizeMB -- neither should affect the generated CR."""
+    Member 2 has logAppend=False and no oplogSizeMB -- neither should affect the generated CR.
+    systemLog itself is not migrated at all, so member 2's divergence there is moot."""
     cr = generated_mongodb_doc(generated_cr_yaml)
-    sl = cr["spec"].get("agent", {}).get("mongod", {}).get("systemLog", {})
-    assert sl.get("destination") == "file", f"Expected destination=file, got: {sl}"
-    assert sl.get("path") == "/data/mongodb.log", f"Expected path=/data/mongodb.log, got: {sl}"
+    agent_mongod = cr["spec"].get("agent", {}).get("mongod", {})
+    assert "systemLog" not in agent_mongod, f"systemLog should not be migrated, got: {agent_mongod}"
     repl = cr["spec"].get("additionalMongodConfig", {}).get("replication", {})
     assert repl.get("oplogSizeMB") == 2048, f"Expected oplogSizeMB=2048 from source process, got: {repl}"
 

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256_tls.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_scram_sha256_tls.py
@@ -1,0 +1,539 @@
+"""
+VM migration from a generated MongoDB resource with SCRAM authentication and mongod TLS.
+
+This test configures VM members in Ops Manager, runs kubectl-mongodb migrate-to-mck,
+applies the generated resources, and verifies dry-run validation, data continuity,
+connection strings, process names, and the promote and prune flow.
+"""
+
+import os
+import ssl
+from copy import deepcopy
+
+from kubetester import create_or_update_configmap, create_or_update_secret, get_statefulset, read_secret
+from kubetester.certs import ISSUER_CA_NAME, create_mongodb_tls_certs
+from kubetester.kubetester import KubernetesTester, ensure_ent_version, fcv_from_version, skip_if_local
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester, with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_ca_file_present_in_pod,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    rotate_password_and_verify,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import create_wrong_ca_configmap, run_wrong_ca_dry_run_fails_then_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    MIN_K8S_MONGOD,
+    MIN_VM_MONGOD,
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+RS_NAME = "vm-mongodb-rs"
+VM_STS_NAME = "vm-mongodb"
+VM_SVC_NAME = "vm-mongodb"
+VM_CERT_SECRET = "vm-mongodb-cert"
+VM_TLS_PEM_SECRET = "vm-mongodb-tls-pem"
+# Match migration tool output: certsSecretPrefix: mdb -> secret name mdb-<resource-name>-cert
+CERT_SECRET_PREFIX = "mdb"
+OPERATOR_CERT_SECRET = f"{CERT_SECRET_PREFIX}-{RS_NAME}-cert"
+TLS_CERT_MOUNT = "/etc/mongodb/certs"
+APP_USER_PASSWORD = "tlsAppUser123!"
+VM_AGENT_OM_CA_PATH = "/etc/mongodb-mms-ca/ca.pem"
+VM_OM_CA_CONFIGMAP_NAME = "vm-mongodb-om-ca"
+WRONG_CA_NAME = "wrong-issuer-ca-mongod-tls"
+# Non-default CA file path: exercises spec.security.tls.caFilePath end to end.
+CUSTOM_CA_FILE_PATH = "/etc/mongodb-custom-ca/ca.pem"
+
+
+def _get_ca_bundle_content() -> str:
+    """Return PEM content of the system CA bundle."""
+
+    paths = ssl.get_default_verify_paths()
+    path = paths.cafile or paths.openssl_cafile or "/etc/ssl/certs/ca-certificates.crt"
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"No system CA bundle found at {path}; set SSL_CERT_FILE or install ca-certificates")
+    with open(path, "r") as f:
+        return f.read()
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_server_certs(issuer: str, namespace: str):
+    """Create TLS certs for the VM mongod pods via cert-manager."""
+    return create_mongodb_tls_certs(
+        ISSUER_CA_NAME,
+        namespace,
+        VM_STS_NAME,
+        VM_CERT_SECRET,
+        replicas=MIN_VM_MONGOD,
+        service_name=VM_SVC_NAME,
+    )
+
+
+@fixture(scope="module")
+def vm_tls_pem_secret(namespace: str, vm_server_certs: str):
+    """Combine tls.crt + tls.key from the cert-manager secret into a single
+    PEM file that mongod can use as certificateKeyFile."""
+    data = read_secret(namespace, vm_server_certs)
+    server_pem = data["tls.crt"] + data["tls.key"]
+    ca_pem = data["ca.crt"]
+    create_or_update_secret(
+        namespace,
+        VM_TLS_PEM_SECRET,
+        {"server.pem": server_pem, "ca.pem": ca_pem},
+    )
+    return VM_TLS_PEM_SECRET
+
+
+@fixture(scope="module")
+def operator_server_certs(issuer: str, namespace: str):
+    """Create TLS certs for the operator-managed pods (post-migration)."""
+    return create_mongodb_tls_certs(
+        ISSUER_CA_NAME,
+        namespace,
+        RS_NAME,
+        OPERATOR_CERT_SECRET,
+        replicas=MIN_K8S_MONGOD,
+    )
+
+
+@fixture(scope="module")
+def vm_om_ca_configmap(namespace: str):
+    """ConfigMap with CA bundle so VM agents can validate Ops Manager TLS."""
+    content = _get_ca_bundle_content()
+    create_or_update_configmap(namespace, VM_OM_CA_CONFIGMAP_NAME, {"ca.pem": content})
+    return VM_OM_CA_CONFIGMAP_NAME
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester, vm_tls_pem_secret: str, vm_om_ca_configmap: str):
+    """Deploy VM StatefulSet with mongod TLS cert volumes and OM CA bundle mounted."""
+    return deploy_vm_statefulset(
+        namespace,
+        om_tester,
+        extra_command_args=f"-httpsCAFile={VM_AGENT_OM_CA_PATH}",
+        extra_volumes=[
+            {"name": "mongodb-certs", "secret": {"secretName": vm_tls_pem_secret}},
+            {"name": "om-ca", "configMap": {"name": vm_om_ca_configmap}},
+        ],
+        extra_volume_mounts=[
+            {
+                "name": "mongodb-certs",
+                "mountPath": "/mongodb-automation/server.pem",
+                "subPath": "server.pem",
+                "readOnly": True,
+            },
+            {
+                "name": "mongodb-certs",
+                "mountPath": CUSTOM_CA_FILE_PATH,
+                "subPath": "ca.pem",
+                "readOnly": True,
+            },
+            {"name": "om-ca", "mountPath": "/etc/mongodb-mms-ca", "readOnly": True},
+        ],
+    )
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+def _configure_ac_with_tls(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mdb_version: str):
+    """Set up a TLS-enabled replica set (requireSSL) with SCRAM auth."""
+    mdb_version = ensure_ent_version(mdb_version)
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["ssl"] = {
+        "CAFilePath": CUSTOM_CA_FILE_PATH,
+        "clientCertificateMode": "OPTIONAL",
+    }
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": "app-user",
+                "db": "admin",
+                "roles": [{"role": "readWriteAnyDatabase", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": {
+                    "iterationCount": 15000,
+                    "salt": "Qll4OI2xpysKmK1jv03JhlYQn+P7SUKbF3kdxA==",
+                    "serverKey": "V4PfLQcW/aOwfXeCvgWYfvv9cS04HTB9nUPJy9JzNqM=",
+                    "storedKey": "i8dJpjHY0uyFh89TcjT7JS27N6FTY98TiRV/J+jRBDo=",
+                },
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanism": "SCRAM-SHA-256",
+        "autoUser": "mms-automation-agent",
+        "autoAuthRestrictions": [],
+        "autoPwd": "mms-automation-agent-password",
+        "key": "bXlrZXlmaWxlY29udGVudHM=",
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+
+        ac["processes"].append(
+            {
+                "version": mdb_version,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(mdb_version),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {
+                        "port": 27017,
+                        "tls": {
+                            "mode": "requireSSL",
+                            "certificateKeyFile": "/mongodb-automation/server.pem",
+                            "CAFile": CUSTOM_CA_FILE_PATH,
+                        },
+                    },
+                    "storage": {
+                        "dbPath": "/data/",
+                        "directoryPerDB": True,
+                    },
+                    "systemLog": {
+                        "path": "/data/mongodb.log",
+                        "destination": "file",
+                    },
+                    "replication": {"replSetName": rs_name},
+                },
+            }
+        )
+
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    create_or_update_secret(namespace, "app-user-secret", {"password": APP_USER_PASSWORD})
+    return run_generate_cr(
+        namespace,
+        user_secrets={"app-user:admin": "app-user-secret"},
+        certs_secret_prefix=CERT_SECRET_PREFIX,
+    )
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def migrate_tool_ca_configmap(namespace: str, issuer_ca_filepath: str, generated_cr: dict) -> str:
+    """Create the CA ConfigMap with the name the migrate tool outputs in security.tls.ca.
+
+    The generated CR sets security.tls.ca to '<resourceName>-ca' by default.
+    This fixture creates a ConfigMap with that exact name so the link between
+    the tool output and the actual resource is explicit.
+    """
+    ca_name = generated_cr["spec"]["security"]["tls"]["ca"]
+    ca_pem = open(issuer_ca_filepath).read()
+    create_or_update_configmap(namespace, ca_name, {"ca-pem": ca_pem})
+    return ca_name
+
+
+@fixture(scope="module")
+def mdb_migration(
+    namespace: str,
+    generated_cr: dict,
+    operator_server_certs: str,
+    migrate_tool_ca_configmap: str,
+) -> MongoDB:
+    resource_doc = deepcopy(generated_cr)
+    create_wrong_ca_configmap(namespace, WRONG_CA_NAME)
+    resource_doc["spec"]["security"]["tls"]["ca"] = WRONG_CA_NAME
+    return apply_generated_mongodb_resource(namespace, resource_doc)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram("app-user", APP_USER_PASSWORD, "SCRAM-SHA-256")]
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, ca_path: str, scram_opts: list[dict]) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=True, ca_path=ca_path),
+        health_function_params={"attempts": 1, "opts": scram_opts},
+    )
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_configure_ac(namespace: str, om_tester: OMTester, vm_sts, vm_service, custom_mdb_version):
+    _configure_ac_with_tls(namespace, om_tester, vm_sts, vm_service, custom_mdb_version)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_user_connectivity_before_migration(namespace: str, ca_path: str, scram_opts: list[dict]):
+    """Users can authenticate against the VM replica set (with TLS) before migration."""
+    vm_replica_set_tester(namespace, use_ssl=True, ca_path=ca_path).assert_scram_sha_authentication(
+        username="app-user", password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256", ssl=True, tlsCAFile=ca_path
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_insert_migration_data(namespace: str, ca_path: str, scram_opts: list[dict]):
+    insert_migration_data(vm_replica_set_tester(namespace, use_ssl=True, ca_path=ca_path), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_non_tls_connection_rejected_before_migration(namespace: str):
+    """TLS is enforced on the VM replica set -- plain connections must be rejected."""
+    vm_replica_set_tester(namespace, use_ssl=False).assert_no_connection()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_tls_enabled_in_cr(generated_cr: dict):
+    """The generated CR must have TLS enabled via spec.security.certsSecretPrefix (tls.enabled is deprecated)."""
+    security = generated_cr.get("spec", {}).get("security", {})
+    prefix = security.get("certsSecretPrefix")
+    assert prefix, f"Expected certsSecretPrefix to be set for TLS, got security: {security}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_ca_file_path_in_cr(generated_cr: dict):
+    """The generated CR must carry the non-default CA file path from the AC."""
+    assert generated_cr["spec"]["security"]["tls"]["caFilePath"] == CUSTOM_CA_FILE_PATH
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_no_disabled_tls_mode_in_additional_config(generated_cr: dict):
+    """additionalMongodConfig must NOT contain net.tls.mode: disabled."""
+    amc = generated_cr["spec"].get("additionalMongodConfig", {})
+    tls_mode = amc.get("net", {}).get("tls", {}).get("mode")
+    assert (
+        tls_mode != "disabled"
+    ), f"TLS is requireSSL -- additionalMongodConfig should not have mode=disabled, got: {amc}"
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_security_auth_present(generated_cr: dict):
+    """SCRAM auth must be present alongside TLS."""
+    auth = generated_cr["spec"]["security"].get("authentication", {})
+    assert auth.get("enabled") is True
+    assert "SCRAM" in auth.get("modes", [])
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_user_cr_emitted(generated_cr_yaml: str):
+    user_docs = generated_user_docs(generated_cr_yaml)
+    assert len(user_docs) == 1, f"Expected 1 user CR, got {len(user_docs)}"
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_migration_dry_run_wrong_ca_fails_then_passes(
+    namespace: str, mdb_migration: MongoDB, migrate_tool_ca_configmap: str
+):
+    run_wrong_ca_dry_run_fails_then_passes(
+        namespace,
+        mdb_migration,
+        f"{RS_NAME}-connectivity-check",
+        WRONG_CA_NAME,
+        correct_ca_name=migrate_tool_ca_configmap,
+    )
+
+
+# The passing dry-run is covered by test_migration_dry_run_wrong_ca_fails_then_passes above, which ends
+# with a full run_migration_dry_run_connectivity_passes. A second standalone dry-run test cannot work
+# here: the first one clears the annotation, which releases the migration, so re-adding the annotation
+# afterwards asks the operator to re-enter a one-way gate it has already passed — the Migrating reason
+# is legitimately Extending by then.
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_ca_file_mounted_at_custom_path(namespace: str, mdb_migration: MongoDB):
+    """The operator mounts the CA ConfigMap at the custom caFilePath in the migrated pod."""
+    assert_ca_file_present_in_pod(namespace, f"{mdb_migration.name}-0", CUSTOM_CA_FILE_PATH)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_user_connectivity_after_migration(mdb_migration: MongoDB, ca_path: str):
+    """Users can still authenticate (with TLS) after the operator takes over the replica set."""
+    mdb_migration.tester(use_ssl=True, ca_path=ca_path).assert_scram_sha_authentication(
+        username="app-user", password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256", ssl=True, tlsCAFile=ca_path
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, ca_path: str, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=True, ca_path=ca_path), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_non_tls_connection_rejected_after_migration(mdb_migration: MongoDB):
+    """TLS remains enforced after migration -- plain connections must still be rejected."""
+    mdb_migration.tester(use_ssl=False).assert_no_connection()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_user_connectivity_after_promote(mdb_migration: MongoDB, ca_path: str):
+    """Users can still authenticate with TLS after promote and prune completes."""
+    mdb_migration.tester(use_ssl=True, ca_path=ca_path).assert_scram_sha_authentication(
+        username="app-user", password=APP_USER_PASSWORD, auth_mechanism="SCRAM-SHA-256", ssl=True, tlsCAFile=ca_path
+    )
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, ca_path: str, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=True, ca_path=ca_path), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+@skip_if_local()
+def test_non_tls_connection_rejected_after_promote(mdb_migration: MongoDB):
+    """TLS remains enforced after promote and prune."""
+    mdb_migration.tester(use_ssl=False).assert_no_connection()
+
+
+@mark.e2e_vm_migration_replicaset_scram_sha256_tls
+def test_password_rotation_keeps_migrated_flag(generated_cr_yaml: str, namespace: str, om_tester: OMTester):
+    rotate_password_and_verify(generated_cr_yaml, namespace, om_tester)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_x509.py
@@ -1,0 +1,585 @@
+"""
+VM migration from a generated MongoDB resource with TLS and X509 agent authentication.
+
+This test configures VM members in Ops Manager, runs kubectl-mongodb migrate-to-mck,
+applies the generated resources, and verifies dry-run validation, data continuity,
+connection strings, process names, and the promote and prune flow.
+"""
+
+from copy import deepcopy
+
+import yaml
+from cryptography import x509 as crypto_x509
+from cryptography.hazmat.backends import default_backend
+from kubetester import create_or_update_configmap, create_or_update_secret, get_statefulset, read_secret
+from kubetester.certs import (
+    ISSUER_CA_NAME,
+    create_mongodb_tls_certs,
+    create_x509_agent_tls_certs,
+    create_x509_user_cert,
+)
+from kubetester.kubetester import KubernetesTester, fcv_from_version
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb import MongoDB
+from kubetester.mongotester import MongoDBBackgroundTester, MongoTester, build_mongodb_connection_uri, with_x509
+from kubetester.omtester import OMContext, OMTester
+from kubetester.phase import Phase
+from pytest import fixture, mark
+from tests.vm_migration.vm_migration_common_helper import (
+    apply_user_crs_and_verify_ac,
+    assert_ca_file_present_in_pod,
+    assert_max_voting_members_validation,
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    generated_user_docs,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import create_wrong_ca_configmap, run_wrong_ca_dry_run_fails_then_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    MIN_K8S_MONGOD,
+    MIN_VM_MONGOD,
+    apply_generated_mongodb_resource,
+    assert_common_generated_cr_shape,
+    assert_connection_string_after_full_migration,
+    assert_connection_string_contains_current_hosts,
+    assert_k8s_process_names,
+    deploy_vm_statefulset,
+    promote_and_prune,
+)
+
+VM_STS_NAME = "vm-mongodb"
+VM_RS_NAME = "vm-mongodb-rs"
+MDB_RESOURCE_NAME = "my-replica-set"
+SERVER_PEM_PATH = "/mongodb-automation/server.pem"
+# Non-default CA file path, intentionally different from the operator's default TLSCaMountPath,
+# to exercise spec.security.tls.caFilePath through the migrate-to-mck import and operator reconcile.
+CUSTOM_CA_PEM_PATH = "/etc/mongodb-custom-ca/ca.pem"
+
+# Custom cert path used for VM agents, intentionally different from the operator's default
+# AgentCertMountPath to test that the operator preserves an arbitrary existing autoPEMKeyFilePath
+# and creates a matching mount on K8s pods rather than overwriting with its own hash-based path.
+CUSTOM_AGENT_CERT_DIR = "/var/lib/mongodb-mms-automation/certs"
+CUSTOM_AGENT_CERT_FILENAME = "agent.pem"
+CUSTOM_AGENT_CERT_PATH = f"{CUSTOM_AGENT_CERT_DIR}/{CUSTOM_AGENT_CERT_FILENAME}"
+
+WRONG_CA_NAME = "wrong-issuer-ca"
+
+
+@fixture(scope="module")
+def om_tester(namespace: str, operator) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_server_certs(issuer: str, namespace: str):
+    """TLS certs for VM mongod processes (hostnames vm-mongodb-0, vm-mongodb-1, vm-mongodb-2)."""
+    return create_mongodb_tls_certs(
+        ISSUER_CA_NAME, namespace, VM_STS_NAME, f"{VM_STS_NAME}-cert", MIN_VM_MONGOD, None, VM_STS_NAME
+    )
+
+
+@fixture(scope="module")
+def vm_agent_certs(issuer: str, namespace: str) -> str:
+    return create_x509_agent_tls_certs(issuer, namespace, MDB_RESOURCE_NAME)
+
+
+@fixture(scope="module")
+def vm_agent_combined_pem(namespace: str, vm_agent_certs: str) -> tuple:
+    """Create a combined PEM secret for VM pod cert mount and extract the agent subject DN.
+
+    Ops Manager reads a single PEM path for tls.autoPEMKeyFilePath. The operator generated
+    PEM secret is not available before the MongoDB resource reconciles, so this fixture creates
+    the VM-side bootstrap secret directly.
+
+    Returns (secret_name, subject_dn).
+    """
+    data = read_secret(namespace, vm_agent_certs)
+    cert_pem = data.get("tls.crt", b"")
+    key_pem = data.get("tls.key", b"")
+    if isinstance(cert_pem, bytes):
+        cert_pem = cert_pem.decode("utf-8")
+    if isinstance(key_pem, bytes):
+        key_pem = key_pem.decode("utf-8")
+
+    cert_obj = crypto_x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
+    subject_dn = cert_obj.subject.rfc4514_string()
+
+    pem_secret_name = "vm-agent-cert-pem"
+    create_or_update_secret(namespace, pem_secret_name, {CUSTOM_AGENT_CERT_FILENAME: cert_pem + key_pem})
+    return pem_secret_name, subject_dn
+
+
+@fixture(scope="module")
+def vm_server_combined_pem(namespace: str, vm_server_certs: str) -> str:
+    """Create a combined cert+key PEM secret for certificateKeyFile (MongoDB requires both in one file)."""
+    data = read_secret(namespace, vm_server_certs)
+    cert_pem = data.get("tls.crt", b"")
+    key_pem = data.get("tls.key", b"")
+    if isinstance(cert_pem, bytes):
+        cert_pem = cert_pem.decode("utf-8")
+    if isinstance(key_pem, bytes):
+        key_pem = key_pem.decode("utf-8")
+    create_or_update_secret(namespace, "vm-mongodb-server-pem", {"server.pem": cert_pem + key_pem})
+    return "vm-mongodb-server-pem"
+
+
+@fixture(scope="module")
+def vm_sts(
+    namespace: str,
+    om_tester: OMTester,
+    vm_server_certs: str,
+    vm_agent_combined_pem: tuple[str, str],
+    vm_server_combined_pem: str,
+):
+    """Deploy VM StatefulSet with cert volumes (server combined PEM + CA + agent PEM)."""
+    agent_secret_name, _ = vm_agent_combined_pem
+    return deploy_vm_statefulset(
+        namespace,
+        om_tester,
+        extra_volumes=[
+            # MongoDB certificateKeyFile requires the cert and key in one file.
+            {
+                "name": "mongodb-certs",
+                "secret": {
+                    "secretName": vm_server_combined_pem,
+                    "items": [{"key": "server.pem", "path": "server.pem"}],
+                },
+            },
+            # CA cert mounted at the same path the operator sets in tls.CAFilePath
+            # (/etc/mongodb-custom-ca/ca.pem) so VM agents remain functional after operator reconcile.
+            {
+                "name": "ca-cert",
+                "secret": {
+                    "secretName": "ca-key-pair",
+                    "items": [{"key": "tls.crt", "path": "ca.pem"}],
+                },
+            },
+            # The VM path must match tls.autoPEMKeyFilePath before and after import.
+            {"name": "agent-cert", "secret": {"secretName": agent_secret_name}},
+        ],
+        extra_volume_mounts=[
+            {"name": "mongodb-certs", "mountPath": "/mongodb-automation", "readOnly": True},
+            {"name": "ca-cert", "mountPath": "/etc/mongodb-custom-ca", "readOnly": True},
+            {"name": "agent-cert", "mountPath": CUSTOM_AGENT_CERT_DIR, "readOnly": True},
+        ],
+    )
+
+
+@fixture(scope="module")
+def mdb_tls_certs(issuer: str, namespace: str):
+    return create_mongodb_tls_certs(
+        ISSUER_CA_NAME, namespace, MDB_RESOURCE_NAME, f"mdb-{MDB_RESOURCE_NAME}-cert", MIN_K8S_MONGOD
+    )
+
+
+@fixture(scope="module")
+def mdb_migration(
+    namespace: str,
+    issuer_ca_filepath: str,
+    generated_cr_yaml: str,
+    mdb_tls_certs: str,
+    vm_agent_certs: str,
+) -> MongoDB:
+    """MDB generated by migrate-to-mck, with test-created TLS resources wired in."""
+    resource_doc = deepcopy(generated_mongodb_doc(generated_cr_yaml))
+    correct_ca_name = resource_doc["spec"]["security"]["tls"]["ca"]
+    create_wrong_ca_configmap(namespace, WRONG_CA_NAME)
+    resource_doc["spec"]["security"]["tls"]["ca"] = WRONG_CA_NAME
+
+    def create_referenced_x509_resources(resource_doc: dict) -> None:
+        create_or_update_configmap(namespace, correct_ca_name, {"ca-pem": open(issuer_ca_filepath).read()})
+
+        certs_prefix = resource_doc["spec"]["security"]["certsSecretPrefix"]
+        resource_name = resource_doc["metadata"]["name"]
+        agent_cert_secret_name = f"{certs_prefix}-{resource_name}-agent-certs"
+        agent_cert = read_secret(namespace, vm_agent_certs)
+        create_or_update_secret(
+            namespace,
+            agent_cert_secret_name,
+            {"tls.crt": agent_cert["tls.crt"], "tls.key": agent_cert["tls.key"]},
+            type="kubernetes.io/tls",
+        )
+
+    return apply_generated_mongodb_resource(
+        namespace,
+        resource_doc,
+        prepare_external_resources=create_referenced_x509_resources,
+    )
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    return run_generate_cr(
+        namespace,
+        certs_secret_prefix="mdb",
+        resource_name_override=MDB_RESOURCE_NAME,
+    )
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def x509_client_pem_path(tmp_path_factory, namespace: str, vm_agent_certs: str) -> str:
+    data = read_secret(namespace, vm_agent_certs)
+    pem_path = tmp_path_factory.mktemp("x509-client") / "agent.pem"
+    pem_path.write_text(data["tls.crt"] + data["tls.key"])
+    return str(pem_path)
+
+
+@fixture(scope="module")
+def vm_app_user(issuer: str, namespace: str, tmp_path_factory) -> tuple[str, str]:
+    """X509 client cert for the $external application user that is migrated.
+
+    Returns (combined_pem_path, subject_dn). The subject DN is what mongod derives from the cert, so
+    it doubles as the username seeded into $external and carried through migration. We extract it from
+    the issued cert rather than hardcoding it so the seeded user and the connecting client always agree.
+    """
+    pem_path = str(tmp_path_factory.mktemp("x509-app-user") / "app-user.pem")
+    create_x509_user_cert(issuer, namespace, path=pem_path)
+    cert_pem = read_secret(namespace, "mongodbuser")["tls.crt"]
+    if isinstance(cert_pem, bytes):
+        cert_pem = cert_pem.decode("utf-8")
+    subject_dn = crypto_x509.load_pem_x509_certificate(cert_pem.encode(), default_backend()).subject.rfc4514_string()
+    return pem_path, subject_dn
+
+
+@fixture(scope="module")
+def x509_opts(x509_client_pem_path: str, issuer_ca_filepath: str) -> list[dict]:
+    return [with_x509(x509_client_pem_path, issuer_ca_filepath)]
+
+
+@fixture(scope="module")
+def vm_x509_tester(namespace: str, x509_client_pem_path: str, issuer_ca_filepath: str) -> MongoTester:
+    connection_string = build_mongodb_connection_uri(
+        mdb_resource=VM_STS_NAME,
+        namespace=namespace,
+        members=MIN_VM_MONGOD,
+        port="27017",
+        servicename=VM_STS_NAME,
+    )
+    return MongoTester(connection_string, use_ssl=True, ca_path=issuer_ca_filepath)
+
+
+@fixture(scope="module")
+def mdb_health_checker(
+    mdb_migration: MongoDB, issuer_ca_filepath: str, x509_opts: list[dict]
+) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=True, ca_path=issuer_ca_filepath),
+        health_function_params={"attempts": 1, "opts": x509_opts},
+    )
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    with open(yaml_fixture("vm_service.yaml"), "r") as f:
+        service_body = yaml.safe_load(f.read())
+    KubernetesTester.create_or_update_service(namespace, body=service_body)
+    return service_body
+
+
+def _build_processes(vm_sts: dict, vm_service: dict, namespace: str, custom_mdb_version: str, tls: bool) -> tuple:
+    """Build processes, monitoringVersions, and replicaSet members for the AC.
+
+    tls: enable requireTLS + certificateKeyFile on the process.
+    Internal cluster auth always uses keyFile (SCRAM-SHA-256 for __system@local);
+    clusterAuthMode: x509 is intentionally NOT set to avoid the rolling sendKeyFile→sendX509
+    transition which breaks replication in mixed-mode clusters.
+    """
+    processes = []
+    monitoring_versions = []
+    members = []
+    for i in range(vm_sts["spec"]["replicas"]):
+        process_name = f"{VM_STS_NAME}-{i}"
+        hostname = f"{process_name}.{vm_service['metadata']['name']}.{namespace}.svc.cluster.local"
+        mon_entry = {
+            "hostname": hostname,
+            "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+            "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+        }
+        if tls:
+            mon_entry["additionalParams"] = {
+                "sslTrustedServerCertificates": CUSTOM_CA_PEM_PATH,
+                "useSslForAllConnections": "true",
+            }
+        monitoring_versions.append(mon_entry)
+        net = {"port": 27017}
+        if tls:
+            net["tls"] = {
+                "mode": "requireTLS",
+                "certificateKeyFile": SERVER_PEM_PATH,
+            }
+        else:
+            net["tls"] = {"mode": "disabled"}
+        process = {
+            "version": custom_mdb_version,
+            "name": process_name,
+            "hostname": hostname,
+            "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            "authSchemaVersion": 5,
+            "featureCompatibilityVersion": fcv_from_version(custom_mdb_version),
+            "processType": "mongod",
+            "args2_6": {
+                "net": net,
+                "storage": {"dbPath": "/data/"},
+                "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                "replication": {"replSetName": VM_RS_NAME},
+            },
+        }
+        processes.append(process)
+        members.append(
+            {
+                "_id": i + 100,  # Avoid conflicts with member IDs assigned by operator to K8s pods (0, 1, 2)
+                "host": process_name,
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+    return processes, monitoring_versions, members
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_deploy_vm(namespace: str, vm_sts, vm_service):
+    def sts_is_ready():
+        sts = get_statefulset(namespace, vm_sts["metadata"]["name"])
+        return sts.status.ready_replicas == vm_sts["spec"]["replicas"]
+
+    KubernetesTester.wait_until(sts_is_ready, timeout=300)
+
+
+# Test flow
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_vm_ac_no_auth(om_tester: OMTester, vm_sts: dict, vm_service: dict, namespace: str, custom_mdb_version: str):
+    """Start the VM replica set without auth or TLS so agents can register."""
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    processes, monitoring_versions, members = _build_processes(
+        vm_sts, vm_service, namespace, custom_mdb_version, tls=False
+    )
+    ac["processes"] = processes
+    ac["monitoringVersions"] = monitoring_versions
+    ac["replicaSets"] = [{"_id": VM_RS_NAME, "members": members, "protocolVersion": "1"}]
+    om_tester.api_put_automation_config(ac)
+    om_tester.wait_agents_ready(timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_vm_ac_tls(
+    om_tester: OMTester,
+    vm_sts: dict,
+    vm_service: dict,
+    namespace: str,
+    custom_mdb_version: str,
+):
+    """Enable TLS on the running replica set while auth is still disabled.
+
+    Ops Manager rejects simultaneous TLS and auth changes, so TLS is configured first.
+    """
+    ac = om_tester.api_get_automation_config()
+    tls_mode = ac.get("processes", [{}])[0].get("args2_6", {}).get("net", {}).get("tls", {}).get("mode")
+    if tls_mode == "requireTLS":
+        return
+
+    # VM agents use CUSTOM_AGENT_CERT_PATH; the MDB CR sets the same path via agents.autoPEMKeyFilePath.
+    ac["tls"] = {
+        "CAFilePath": CUSTOM_CA_PEM_PATH,
+        "autoPEMKeyFilePath": CUSTOM_AGENT_CERT_PATH,
+        "clientCertificateMode": "REQUIRE",
+    }
+    processes, monitoring_versions, _ = _build_processes(vm_sts, vm_service, namespace, custom_mdb_version, tls=True)
+    ac["processes"] = processes
+    ac["monitoringVersions"] = monitoring_versions
+    om_tester.api_put_automation_config(ac)
+    om_tester.wait_agents_ready(timeout=1200)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_vm_ac_x509_auth(
+    om_tester: OMTester,
+    vm_sts: dict,
+    vm_service: dict,
+    namespace: str,
+    custom_mdb_version: str,
+    vm_agent_combined_pem: tuple[str, str],
+    vm_app_user: tuple[str, str],
+):
+    """Enable X509 client auth after TLS is already configured.
+
+    The automation user is referenced only by auth.autoUser; Ops Manager provisions it, so it has no
+    usersWanted entry (matching what the operator writes). Internal cluster auth continues to use keyFile (SCRAM-SHA-256 for __system@local).
+    """
+    ac = om_tester.api_get_automation_config()
+    if ac.get("auth", {}).get("disabled", True) is False:
+        return
+
+    _, agent_subject_dn = vm_agent_combined_pem
+    _, app_user_subject_dn = vm_app_user
+    ac["auth"] = {
+        "disabled": False,
+        "authoritativeSet": True,
+        "autoUser": agent_subject_dn,
+        "autoAuthMechanism": "MONGODB-X509",
+        "autoAuthMechanisms": ["MONGODB-X509"],
+        "autoAuthRestrictions": [],
+        "deploymentAuthMechanisms": ["MONGODB-X509"],
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+        "key": "dGVzdC1rZXlmaWxlLWNvbnRlbnQtZm9yLXZtLW1pZ3JhdGlvbi14NTA5",
+        "usersWanted": [
+            {
+                "user": app_user_subject_dn,
+                "db": "$external",
+                "roles": [{"role": "readWrite", "db": "admin"}],
+                "mechanisms": [],
+                "scramSha256Creds": None,
+                "scramSha1Creds": None,
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+    }
+    om_tester.api_put_automation_config(ac)
+    om_tester.wait_agents_ready(timeout=1800)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_insert_migration_data(vm_x509_tester: MongoTester, x509_opts: list[dict]):
+    insert_migration_data(vm_x509_tester, opts=x509_opts)
+
+
+# Generated CR checks
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_common_generated_cr_shape(generated_cr_yaml: str, generated_cr: dict, vm_sts: dict, version_id: str):
+    assert_common_generated_cr_shape(generated_cr_yaml, generated_cr, version_id, vm_sts["spec"]["replicas"])
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_x509_agent_auth_in_cr(generated_cr: dict):
+    agents = generated_cr["spec"]["security"]["authentication"]["agents"]
+    assert agents["mode"] == "X509"
+    assert agents["autoPEMKeyFilePath"] == CUSTOM_AGENT_CERT_PATH
+    assert agents["clientCertificateSecretRef"]["name"] == f"mdb-{MDB_RESOURCE_NAME}-agent-certs"
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_ca_file_path_in_cr(generated_cr: dict):
+    """The generated CR must carry the non-default CA file path from the AC."""
+    assert generated_cr["spec"]["security"]["tls"]["caFilePath"] == CUSTOM_CA_PEM_PATH
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_user_cr_emitted(generated_cr_yaml: str, vm_app_user: tuple[str, str]):
+    # The $external app user produces a MongoDBUser CR; the agent auto-user is skipped by the tool.
+    _, app_user_subject_dn = vm_app_user
+    user_docs = generated_user_docs(generated_cr_yaml)
+    assert len(user_docs) == 1, f"Expected 1 user CR (app user; agent skipped), got {len(user_docs)}"
+    assert user_docs[0]["spec"]["db"] == "$external"
+    assert user_docs[0]["spec"]["username"] == app_user_subject_dn
+
+
+# Lifecycle checks
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_migration_dry_run_wrong_ca_fails_then_passes(namespace: str, mdb_migration: MongoDB, generated_cr: dict):
+    """Dry-run with a wrong CA must fail; restoring the correct CA must make it pass."""
+    run_wrong_ca_dry_run_fails_then_passes(
+        namespace,
+        mdb_migration,
+        f"{MDB_RESOURCE_NAME}-connectivity-check",
+        WRONG_CA_NAME,
+        correct_ca_name=generated_cr["spec"]["security"]["tls"]["ca"],
+    )
+
+
+# The passing dry-run is covered by test_migration_dry_run_wrong_ca_fails_then_passes above, which ends
+# with a full run_migration_dry_run_connectivity_passes. A second standalone dry-run test cannot work
+# here: the first one clears the annotation, which releases the migration, so re-adding the annotation
+# afterwards asks the operator to re-enter a one-way gate it has already passed — the Migrating reason
+# is legitimately Extending by then.
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_migrate_vm_to_kubernetes(mdb_migration: MongoDB):
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1200)
+    assert_connection_string_contains_current_hosts(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_ca_file_mounted_at_custom_path(namespace: str, mdb_migration: MongoDB):
+    """The operator mounts the CA ConfigMap at the custom caFilePath in the migrated pod."""
+    assert_ca_file_present_in_pod(namespace, f"{mdb_migration.name}-0", CUSTOM_CA_PEM_PATH)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_migration_data_exists_after_migration(mdb_migration: MongoDB, issuer_ca_filepath: str, x509_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=True, ca_path=issuer_ca_filepath), opts=x509_opts)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_max_voting_members_validation(mdb_migration: MongoDB):
+    assert_max_voting_members_validation(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_user_crs_reach_updated(generated_cr_yaml: str, namespace: str, mdb_migration: MongoDB, om_tester: OMTester):
+    apply_user_crs_and_verify_ac(generated_cr_yaml, namespace, om_tester)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_app_user_x509_connectivity_after_migration(
+    mdb_migration: MongoDB, vm_app_user: tuple[str, str], issuer_ca_filepath: str
+):
+    """The migrated $external user can authenticate via X509 (readWrite on admin)."""
+    app_user_pem, _ = vm_app_user
+    mdb_migration.tester(use_ssl=True, ca_path=issuer_ca_filepath).assert_x509_authentication(
+        cert_file_name=app_user_pem, tlsCAFile=issuer_ca_filepath
+    )
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_x509
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, issuer_ca_filepath: str, x509_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=True, ca_path=issuer_ca_filepath), opts=x509_opts)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_common_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_common_helper.py
@@ -6,6 +6,7 @@ deploy primitive. Replica-set-specific helpers live in vm_migration_replicaset_h
 sharded-cluster-specific helpers in vm_migration_sharded_helper.
 """
 
+import copy
 import os
 import subprocess
 import tempfile
@@ -383,3 +384,158 @@ def assert_ca_file_present_in_pod(namespace: str, pod_name: str, ca_file_path: s
     assert (
         "-----BEGIN CERTIFICATE-----" in output
     ), f"CA file at {ca_file_path} in pod {pod_name} is missing or not PEM content, got: {output!r}"
+
+
+# Operator-managed processes are named "k8s/<namespace>/<pod-name>" in the automation config;
+# VM processes registered by a plain agent carry the bare hostname-derived name.
+K8S_PROCESS_NAME_PREFIX = "k8s/"
+
+# Fields Ops Manager or the agents mutate on their own schedule. They must be excluded from any
+# "the automation config did not change" comparison, otherwise the assertion is a flake: `version`
+# is bumped by every AC write from any source, and the agent/tools version fields drift as agents
+# check in and as OM decides to roll agents forward.
+_VOLATILE_AC_TOP_LEVEL_KEYS = (
+    "version",
+    "agentVersion",
+    "backupVersions",
+    "mongoDbVersions",
+    "mongosqldVersions",
+    "mongotVersions",
+)
+
+# Per-entry agent-version fields inside monitoringVersions/backupVersions. Ops Manager rolls these
+# forward on its own schedule, so they must not count as a change, but the entries themselves must
+# stay compared: losing one is exactly the destructive outcome being guarded against.
+_VOLATILE_AC_ENTRY_KEYS = ("name",)
+
+
+def k8s_process_name(namespace: str, resource_name: str, index: int) -> str:
+    """Automation-config process name the operator assigns to pod <resource_name>-<index>."""
+    return f"{K8S_PROCESS_NAME_PREFIX}{namespace}/{resource_name}-{index}"
+
+
+def normalize_automation_config(ac: dict) -> dict:
+    """Return a deep copy of the automation config with fields that drift on their own removed.
+
+    Everything that survives is state the operator would have had to deliberately write, so any
+    difference between two normalized snapshots is a real change to the deployment.
+    """
+    normalized = copy.deepcopy(ac)
+    for key in _VOLATILE_AC_TOP_LEVEL_KEYS:
+        normalized.pop(key, None)
+    for list_key in ("monitoringVersions", "backupVersions"):
+        for entry in normalized.get(list_key, []):
+            for entry_key in _VOLATILE_AC_ENTRY_KEYS:
+                entry.pop(entry_key, None)
+    return normalized
+
+
+def wait_for_automation_config_quiescence(
+    om_tester: OMTester,
+    *,
+    stable_for: int = 20,
+    interval: int = 5,
+    timeout: int = 300,
+) -> dict:
+    """Poll until the automation config's version stops changing, then return the settled config.
+
+    Snapshotting the AC while a reconcile is still in flight makes the later "nothing changed"
+    assertion race an operator write that is legitimate rather than the regression it hunts.
+    Waiting for the version to hold steady turns that race into a deterministic precondition.
+    """
+    deadline = time.time() + timeout
+    last_version = None
+    stable_since = None
+    while True:
+        ac = om_tester.api_get_automation_config()
+        version = ac.get("version")
+        now = time.time()
+        if version != last_version:
+            last_version, stable_since = version, now
+        elif now - stable_since >= stable_for:
+            return ac
+        if now >= deadline:
+            raise AssertionError(
+                f"automation config version still changing after {timeout}s "
+                f"(last version {last_version!r}); refusing to snapshot a moving target"
+            )
+        time.sleep(interval)
+
+
+def assert_automation_config_unchanged(
+    om_tester: OMTester,
+    snapshot: dict,
+    *,
+    duration: int = 90,
+    interval: int = 10,
+) -> None:
+    """Assert the automation config stays equal to ``snapshot`` for ``duration`` seconds.
+
+    A single comparison is not enough here. Deletion cleanup runs from a watch event handler
+    (controllers/operator/mongodbresource_event_handler.go), not a finalizer, so there is no
+    "cleanup finished" signal to wait on and no phase to poll: the CR is already gone. Checking
+    repeatedly over a window is what makes a late or slow cleanup call visible instead of racing
+    past the assertion.
+    """
+    expected = normalize_automation_config(snapshot)
+    deadline = time.time() + duration
+    while True:
+        actual = normalize_automation_config(om_tester.api_get_automation_config())
+        if actual != expected:
+            expected_processes = sorted(p["name"] for p in expected.get("processes", []))
+            actual_processes = sorted(p["name"] for p in actual.get("processes", []))
+            raise AssertionError(
+                "automation config changed after the MongoDB resource was deleted; the operator "
+                "must leave Ops Manager alone while spec.externalMembers is set.\n"
+                f"processes before: {expected_processes}\n"
+                f"processes after:  {actual_processes}\n"
+                f"full before: {expected}\n"
+                f"full after:  {actual}"
+            )
+        if time.time() >= deadline:
+            return
+        time.sleep(interval)
+
+
+def remove_k8s_member_from_automation_config(
+    om_tester: OMTester,
+    namespace: str,
+    resource_name: str,
+    index: int,
+) -> dict:
+    """Hand-edit the automation config to drop ONE operator-managed process, then PUT it.
+
+    The operator deliberately leaves its own K8s processes in the automation config when a
+    mid-migration resource is deleted -- removing them would take the VM-hosted processes with
+    them -- so somebody has to take them out afterwards. Removes the process, its replica-set
+    member entry, its monitoring entry, and its backup entry. Returns the config that was PUT.
+
+    Deliberately single-member. Dropping several replica set members in one automation config push
+    makes them leave in a single reconfig, which can take the replica set below a majority while it
+    is still applying. Removing them one at a time -- letting each reconfig settle before the next
+    -- is what a human does by hand, so a helper that batches them would be the wrong tool to reach
+    for. Call this once per member, lowest index last if any of them vote.
+
+    Note this is the repair for a CR that was already deleted, not the recommended way to roll a
+    migration back. Rolling back properly means stopping the operator and making these same edits
+    while the StatefulSets are still running, so the members being removed stay available and the
+    replica set never loses its majority.
+    """
+    ac = om_tester.api_get_automation_config()
+    process_name = k8s_process_name(namespace, resource_name, index)
+
+    matching = [p for p in ac.get("processes", []) if p["name"] == process_name]
+    assert len(matching) == 1, (
+        f"expected exactly one process named {process_name} in the automation config, found "
+        f"{len(matching)}. processes: {[p['name'] for p in ac.get('processes', [])]}"
+    )
+    hostname = matching[0]["hostname"]
+
+    ac["processes"] = [p for p in ac.get("processes", []) if p["name"] != process_name]
+    for replica_set in ac.get("replicaSets", []):
+        replica_set["members"] = [m for m in replica_set.get("members", []) if m["host"] != process_name]
+    ac["monitoringVersions"] = [mv for mv in ac.get("monitoringVersions", []) if mv.get("hostname") != hostname]
+    ac["backupVersions"] = [bv for bv in ac.get("backupVersions", []) if bv.get("hostname") != hostname]
+
+    om_tester.api_put_automation_config(ac)
+    return ac

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_common_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_common_helper.py
@@ -444,8 +444,10 @@ def wait_for_automation_config_quiescence(
     Waiting for the version to hold steady turns that race into a deterministic precondition.
     """
     deadline = time.time() + timeout
-    last_version = None
-    stable_since = None
+    # A missing "version" key reads as None, so seed with a sentinel no config can equal —
+    # otherwise the first poll would look stable before anything had been observed.
+    last_version = object()
+    stable_since = time.time()
     while True:
         ac = om_tester.api_get_automation_config()
         version = ac.get("version")

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_replicaset_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_replicaset_helper.py
@@ -19,6 +19,7 @@ from tests.vm_migration.vm_migration_common_helper import (
     _deploy_vm_statefulset_from_fixture,
     assert_migration_dry_run_annotation,
     assert_migration_tool_version_annotation,
+    cluster_connection_string_secret_name,
     generated_mongodb_doc,
 )
 from tests.vm_migration.vm_migration_dry_run import (
@@ -112,7 +113,8 @@ def apply_generated_mongodb_resource(
 
 
 def migration_connection_strings(mdb_migration: MongoDB) -> tuple[str, str]:
-    secret = KubernetesTester.read_secret(mdb_migration.namespace, f"{mdb_migration.name}-connection-string")
+    secret_name = cluster_connection_string_secret_name(mdb_migration)
+    secret = KubernetesTester.read_secret(mdb_migration.namespace, secret_name)
     return secret.get("connectionString.standard", ""), secret.get("connectionString.standardSrv", "")
 
 
@@ -129,7 +131,7 @@ def connection_string_tester(
     try_load(mdb_migration)
     conn_str, _ = migration_connection_strings(mdb_migration)
     assert conn_str, (
-        f"connection-string secret {mdb_migration.name}-connection-string has no "
+        f"connection-string secret {cluster_connection_string_secret_name(mdb_migration)} has no "
         f"'connectionString.standard' value yet"
     )
     return MongoTester(conn_str, use_ssl, ca_path)

--- a/pkg/migration/job.go
+++ b/pkg/migration/job.go
@@ -12,6 +12,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes/pkg/tls"

--- a/pkg/migration/job.go
+++ b/pkg/migration/job.go
@@ -12,7 +12,6 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
-	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes/pkg/tls"


### PR DESCRIPTION
# Summary

Adds the end-to-end suites covering VM-to-Kubernetes migration for replica sets
and sharded clusters across authentication modes (no auth, SCRAM-SHA-1,
SCRAM-SHA-256, SCRAM with TLS, X509, LDAP, OIDC in its group and workforce
variants) and Prometheus, plus the MCK-to-MCK migration case, their shared
helpers, and the Evergreen task and variant registration for all of them.

Layer 13 in the VM-to-Kubernetes migration stack.

**Stacked PR 13** (stack #1505), base `pr-12-migration-status`. This is one layer of the VM-to-Kubernetes
migration feature, split out of `vm-migration-feature-branch` so each piece can be reviewed on its own.
Review only this layer's diff; the base branch carries the layers below it.

## Proof of Work

The stack was carved from the merged feature branch (tip `6cc6feecd`) rather than replayed commit by
commit, so each layer's content is master's version of each file plus the patches of the commits
assigned to that layer and below.

Verified for this layer, on top of its base:

- `go build ./...` and `go vet ./...` clean (vet type-checks test files too)
- full unit suite green (88 packages; `api/mongodb/v1/search` is excluded — it needs
  `make envtest-assets`, which is unrelated to this change)
- changed Python files pass a syntax check

Verified for the stack as a whole: the layers carved out of `vm-migration-feature-branch` compose
back to it exactly, both as a git tree and as an on-disk worktree comparison — the only differences are the changelog
entry added on #1491 and two zero-byte rename leftovers deliberately dropped.

e2e coverage is not exercised per layer: CI runs only on the top PR of the stack, and Evergreen is
suppressed here with `[skip-ci]`. Targeted patches will be run per layer before any of these is
marked ready for review.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file? Not needed for this layer — the feature-level entry lives on PR #1491 at the bottom of the stack, so this PR carries the `skip-changelog` label.

