### PR TITLE
Bump Go to 1.26.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -219,8 +219,8 @@ repos:
       # staticcheck) see the full codebase and pre-existing violations are not silently skipped.
       - id: golangci-lint-full
         args: [--timeout=10m]
-        language_version: 1.26.5
+        language_version: 1.26.6
         priority: 6
       - id: golangci-lint-fmt
-        language_version: 1.26.5
+        language_version: 1.26.6
         priority: 6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.5
+golang 1.26.6

--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	github.com/josvazg/gobump


### PR DESCRIPTION
# Summary
New Go version patches some vulnerabilities govulncheck [found](https://github.com/mongodb/mongodb-kubernetes/actions/runs/31815577586/job/94816319200?pr=1506)

## Proof of Work

Passing govulncheck check

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details