### PR TITLE
Fix missing DevProd Platforms ECR AWS profile in release_om_and_agents

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -360,6 +360,8 @@ tasks:
       - func: setup_building_host
       - func: quay_login
       - func: setup_docker_sbom
+      - func: assume_devprod_platforms_ecr_role
+      - func: write_devprod_platforms_ecr_aws_profile
       - command: subprocess.exec
         params:
           working_dir: src/github.com/mongodb/mongodb-kubernetes


### PR DESCRIPTION
# Summary

Image signing pulls the garasign-cosign image from DevProd Platforms ECR and needs the "devprod-platforms-ecr" AWS profile. [DEVPROD-34208](https://github.com/mongodb/mongodb-kubernetes/pull/1397) added the assume-role + write-profile setup to the pipeline function, but the release_om_and_agents task invokes release_om_and_agents.py directly and so never got it, failing with "The config profile (devprod-platforms-ecr) could not be found". : https://spruce.corp.mongodb.com/task/mongodb_kubernetes_release_om_and_agents_release_om_and_agents_d569a84823aff2ffc4d400ace07a85951e2ee85c_26_08_17_10_12_39/logs?execution=0 . 

## Proof of Work

EVG patch: https://spruce.corp.mongodb.com/version/6a82eea16e74800007d2ce31/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC 

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
