### PR TITLE
Support MongoDB Search for migrated deployments

### DIFF
--- a/.evergreen-tasks.yml
+++ b/.evergreen-tasks.yml
@@ -339,6 +339,11 @@ tasks:
     commands:
       - func: "e2e_test"
 
+  - name: e2e_vm_migration_replicaset_search
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
   - name: e2e_vm_migration_replicaset_manual_rollback
     tags: [ "patch-run" ]
     commands:
@@ -1536,6 +1541,11 @@ tasks:
       - func: "e2e_test"
 
   - name: e2e_vm_migration_shardedcluster_external_access
+    tags: [ "patch-run" ]
+    commands:
+      - func: "e2e_test"
+
+  - name: e2e_vm_migration_shardedcluster_search
     tags: [ "patch-run" ]
     commands:
       - func: "e2e_test"

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -915,6 +915,7 @@ task_groups:
       - e2e_vm_migration_replicaset_manual_rollback
       - e2e_vm_migration_replicaset_mck_to_mck
       - e2e_vm_migration_replicaset_external_access
+      - e2e_vm_migration_replicaset_search
       - e2e_vm_migration_shardedcluster_no_auth
       - e2e_vm_migration_shardedcluster_x509
       - e2e_vm_migration_shardedcluster_scram_sha256
@@ -926,6 +927,7 @@ task_groups:
       - e2e_vm_migration_shardedcluster_oidc_workforce
       - e2e_vm_migration_shardedcluster_prometheus
       - e2e_vm_migration_shardedcluster_external_access
+      - e2e_vm_migration_shardedcluster_search
 
   # MongoDBSearch tests that require a large instance (multiple mongots per shard:
   # 2 shards x 2 mongots x 2 CPU = 8 CPU). Added to cloudqa-large variants.

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -894,28 +894,6 @@ task_groups:
       - e2e_search_replicaset_external_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_mongot_replicaset_x509_auth
-      # VM Migration
-      - e2e_vm_migration_replicaset_x509
-      - e2e_vm_migration_replicaset_ldap
-      - e2e_vm_migration_replicaset_prometheus
-      - e2e_vm_migration_replicaset_oidc
-      - e2e_vm_migration_replicaset_oidc_group
-      - e2e_vm_migration_replicaset_oidc_workforce
-      - e2e_vm_migration_replicaset_scram_sha256
-      - e2e_vm_migration_replicaset_scram_sha1
-      - e2e_vm_migration_replicaset_scram_sha256_tls
-      - e2e_vm_migration_replicaset_no_auth
-      - e2e_vm_migration_replicaset_mck_to_mck
-      - e2e_vm_migration_shardedcluster_no_auth
-      - e2e_vm_migration_shardedcluster_x509
-      - e2e_vm_migration_shardedcluster_scram_sha256
-      - e2e_vm_migration_shardedcluster_scram_sha1
-      - e2e_vm_migration_shardedcluster_scram_sha256_tls
-      - e2e_vm_migration_shardedcluster_ldap
-      - e2e_vm_migration_shardedcluster_oidc
-      - e2e_vm_migration_shardedcluster_oidc_group
-      - e2e_vm_migration_shardedcluster_oidc_workforce
-      - e2e_vm_migration_shardedcluster_prometheus
 
   # VM migration tests (migrating an existing VM-hosted deployment into Kubernetes).
   # Kept separate from the search task groups since they share no setup with MongoDBSearch.

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -894,6 +894,28 @@ task_groups:
       - e2e_search_replicaset_external_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_replicaset_internal_mongodb_multi_mongot_unmanaged_lb
       - e2e_search_mongot_replicaset_x509_auth
+      # VM Migration
+      - e2e_vm_migration_replicaset_x509
+      - e2e_vm_migration_replicaset_ldap
+      - e2e_vm_migration_replicaset_prometheus
+      - e2e_vm_migration_replicaset_oidc
+      - e2e_vm_migration_replicaset_oidc_group
+      - e2e_vm_migration_replicaset_oidc_workforce
+      - e2e_vm_migration_replicaset_scram_sha256
+      - e2e_vm_migration_replicaset_scram_sha1
+      - e2e_vm_migration_replicaset_scram_sha256_tls
+      - e2e_vm_migration_replicaset_no_auth
+      - e2e_vm_migration_replicaset_mck_to_mck
+      - e2e_vm_migration_shardedcluster_no_auth
+      - e2e_vm_migration_shardedcluster_x509
+      - e2e_vm_migration_shardedcluster_scram_sha256
+      - e2e_vm_migration_shardedcluster_scram_sha1
+      - e2e_vm_migration_shardedcluster_scram_sha256_tls
+      - e2e_vm_migration_shardedcluster_ldap
+      - e2e_vm_migration_shardedcluster_oidc
+      - e2e_vm_migration_shardedcluster_oidc_group
+      - e2e_vm_migration_shardedcluster_oidc_workforce
+      - e2e_vm_migration_shardedcluster_prometheus
 
   # VM migration tests (migrating an existing VM-hosted deployment into Kubernetes).
   # Kept separate from the search task groups since they share no setup with MongoDBSearch.

--- a/api/mongodb/v1/mdb/mongodb_cel_envtest_test.go
+++ b/api/mongodb/v1/mdb/mongodb_cel_envtest_test.go
@@ -64,6 +64,20 @@ func externalMembersForCEL(n int) []mdbv1.ExternalMember {
 	return members
 }
 
+// externalMongosForCEL returns n mongos entries, which the prune-rate rule does not count:
+// mongos routers are not replica set members, so removing several at once cannot cost a majority.
+func externalMongosForCEL(n int) []mdbv1.ExternalMember {
+	members := make([]mdbv1.ExternalMember, n)
+	for i := range members {
+		members[i] = mdbv1.ExternalMember{
+			ProcessName: fmt.Sprintf("mongos-%d", i),
+			Hostname:    fmt.Sprintf("mongos-%d:27017", i),
+			Type:        "mongos",
+		}
+	}
+	return members
+}
+
 func TestMongoDBCELValidation_AppDBRole(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := env.Shared(t).Client
@@ -240,7 +254,7 @@ func TestExternalMembersPruneRateCELValidation(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := env.Shared(t).Client
 
-	const errMsg = "at most one external member may be removed per update"
+	const errMsg = "at most one external mongod may be removed per update"
 
 	tests := []struct {
 		name string
@@ -283,4 +297,34 @@ func TestExternalMembersPruneRateCELValidation(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.errorContains)
 		})
 	}
+}
+
+// TestExternalMongosPruneRateCELValidation proves mongos entries are exempt from the prune-rate
+// rule: they hold no votes, so removing all of them in one update cannot break a majority.
+func TestExternalMongosPruneRateCELValidation(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := env.Shared(t).Client
+
+	t.Run("removing every mongos at once is allowed", func(t *testing.T) {
+		rs := newMongoDB(t, func(rs *mdbv1.MongoDB) {
+			rs.Spec.ExternalMembers = externalMongosForCEL(3)
+		})
+		require.NoError(t, k8sClient.Create(ctx, rs))
+
+		rs.Spec.ExternalMembers = nil
+		assert.NoError(t, k8sClient.Update(ctx, rs))
+	})
+
+	t.Run("mongos removals do not mask a mongod removal", func(t *testing.T) {
+		rs := newMongoDB(t, func(rs *mdbv1.MongoDB) {
+			rs.Spec.ExternalMembers = append(externalMembersForCEL(3), externalMongosForCEL(2)...)
+		})
+		require.NoError(t, k8sClient.Create(ctx, rs))
+
+		// Drops both mongos (allowed) and two of the three mongods (rejected).
+		rs.Spec.ExternalMembers = externalMembersForCEL(1)
+		err := k8sClient.Update(ctx, rs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at most one external mongod may be removed per update")
+	})
 }

--- a/api/mongodb/v1/mdb/mongodb_types.go
+++ b/api/mongodb/v1/mdb/mongodb_types.go
@@ -536,7 +536,7 @@ type DbCommonSpec struct {
 }
 
 // +kubebuilder:validation:XValidation:rule="!has(self.role) || self.role != 'AppDB' || (has(self.members) && self.members >= 3)",message="spec.members must be >= 3 when spec.role is AppDB"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.externalMembers) || (has(self.externalMembers) ? size(self.externalMembers) : 0) >= size(oldSelf.externalMembers) - 1",message="at most one external member may be removed per update: remove entries from spec.externalMembers one at a time so the replica set keeps its voting majority"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.externalMembers) || (has(self.externalMembers) ? size(self.externalMembers.filter(m, m.type != 'mongos')) : 0) >= size(oldSelf.externalMembers.filter(m, m.type != 'mongos')) - 1",message="at most one external mongod may be removed per update: remove mongod entries from spec.externalMembers one at a time so the replica set keeps its voting majority"
 type MongoDbSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	DbCommonSpec                           `json:",inline"`

--- a/api/mongodb/v1/mdb/shardedcluster.go
+++ b/api/mongodb/v1/mdb/shardedcluster.go
@@ -46,7 +46,7 @@ type ShardedClusterSpec struct {
 	// It replaces deprecated spec.shard.shardSpecificPodSpec field. When spec.shard.shardSpecificPodSpec is still defined then
 	// spec.shard.shardSpecificPodSpec is applied first to the particular shard and then spec.shardOverrides is applied on top
 	// of that (if defined for the same shard).
-	// +kubebuilder:pruning:PreserverUnknownFields
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	ShardOverrides []ShardOverride `json:"shardOverrides,omitempty"`
 
@@ -109,7 +109,7 @@ type ShardOverride struct {
 
 	// Number of member nodes in this shard. Used only in SingleCluster. For MultiCluster the number of members is specified in ShardOverride.ClusterSpecList.
 	// +optional
-	Members *int `json:"members"`
+	Members *int `json:"members,omitempty"`
 	// Process configuration override for this shard. Used in SingleCluster only. The number of items specified must be >= spec.mongodsPerShardCount or spec.shardOverride.members.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional

--- a/cmd/kubectl-mongodb/migrate-to-mck/common_spec_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/common_spec_test.go
@@ -510,6 +510,80 @@ func TestExtractAdditionalMongodConfig_SetParameter(t *testing.T) {
 	assert.Equal(t, "SCRAM-SHA-256", sp["authenticationMechanisms"])
 }
 
+func TestExtractAdditionalMongodConfig_SearchParametersExtracted(t *testing.T) {
+	// Ops Manager does not propagate search setParameters onto newly added Kubernetes
+	// processes, so the generated CR has to carry them. They are extracted alongside ordinary
+	// user setParameters rather than stripped as operator-managed infrastructure.
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+				"setParameter": map[string]interface{}{
+					"mongotHost":                                      "mdb-search-svc.ns.svc.cluster.local:27027",
+					"searchIndexManagementHostAndPort":                "mdb-search-svc.ns.svc.cluster.local:27027",
+					"skipAuthenticationToSearchIndexManagementServer": false,
+					"skipAuthenticationToMongot":                      false,
+					"searchTLSMode":                                   "disabled",
+					"useGrpcForSearch":                                true,
+					"authenticationMechanisms":                        "SCRAM-SHA-256",
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	sp, ok := config.ToMap()["setParameter"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, map[string]interface{}{
+		"mongotHost":                                      "mdb-search-svc.ns.svc.cluster.local:27027",
+		"searchIndexManagementHostAndPort":                "mdb-search-svc.ns.svc.cluster.local:27027",
+		"skipAuthenticationToSearchIndexManagementServer": false,
+		"skipAuthenticationToMongot":                      false,
+		"searchTLSMode":                                   "disabled",
+		"useGrpcForSearch":                                true,
+		"authenticationMechanisms":                        "SCRAM-SHA-256",
+	}, sp)
+}
+
+func TestExtractAdditionalMongodConfig_OnlySearchParameters(t *testing.T) {
+	// A process carrying nothing but search setParameters now yields a config rather than nil,
+	// which is what lets a search-only VM mongod produce a component spec at all.
+	processMap := map[string]om.Process{
+		"host-0": {
+			"args2_6": map[string]interface{}{
+				"net": map[string]interface{}{
+					"port": 27017,
+				},
+				"setParameter": map[string]interface{}{
+					"mongotHost":                                      "mdb-search-svc.ns.svc.cluster.local:27027",
+					"searchIndexManagementHostAndPort":                "mdb-search-svc.ns.svc.cluster.local:27027",
+					"skipAuthenticationToSearchIndexManagementServer": false,
+					"skipAuthenticationToMongot":                      false,
+					"searchTLSMode":                                   "disabled",
+					"useGrpcForSearch":                                true,
+				},
+			},
+		},
+	}
+	members := []om.ReplicaSetMember{
+		{"host": "host-0"},
+	}
+
+	config := sourceProc(processMap, members).AdditionalMongodConfig()
+	require.NotNil(t, config)
+	sp, ok := config.ToMap()["setParameter"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "mdb-search-svc.ns.svc.cluster.local:27027", sp["mongotHost"])
+	assert.Equal(t, true, sp["useGrpcForSearch"])
+	assert.Len(t, sp, 6, "all six search keys must survive extraction")
+}
+
 func TestExtractAdditionalMongodConfig_OplogSizeMB(t *testing.T) {
 	processMap := map[string]om.Process{
 		"host-0": {

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_fixture_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_fixture_test.go
@@ -187,6 +187,14 @@ func TestFixtureMatch_ShardedCluster(t *testing.T) {
 			fixture: "singlecluster/shardedcluster/default_config_rs/default_config_rs",
 		},
 		{
+			name:    "sharded cluster — heterogeneous shards: spec.shard omitted, one shardOverride per shard",
+			fixture: "singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards",
+		},
+		{
+			name:    "sharded cluster — per-shard mongot endpoints land in shardOverrides, mongos keeps its own",
+			fixture: "singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot",
+		},
+		{
 			name:     "sharded cluster — LDAP: ldap section + agent password secret generated, external agent skipped, app user CR generated",
 			fixture:  "singlecluster/shardedcluster/authentication/ldap/ldap",
 			hasUsers: true,

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -272,7 +272,7 @@ func shardRSWithConfig(t *testing.T, processMap map[string]om.Process, rsName st
 	t.Helper()
 	host := rsName + "-0"
 	rs := om.NewReplicaSet(rsName, "7.0.12-ent")
-	rs["members"] = []interface{}{map[string]interface{}{"host": host, "_id": 0}}
+	rs["members"] = []interface{}{map[string]interface{}{"host": host, "_id": 0, "priority": 1, "votes": 1}}
 	if cacheSizeGB == nil {
 		processMap[host] = om.Process{"name": host}
 		return rs
@@ -300,27 +300,114 @@ func TestShardAdditionalMongodConfigs_ExtractsPerShard(t *testing.T) {
 		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
 	}
 
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	require.Len(t, configs, 2)
 	assert.Equal(t, 4, readCacheSizeGB(t, configs[0]))
 	assert.Equal(t, 8, readCacheSizeGB(t, configs[1]))
 }
 
-func TestShardAdditionalMongodConfigs_NilForMissingProcessOrEmptyMembers(t *testing.T) {
-	// A shard whose member is absent from the process map, and a shard with no members at
-	// all, both yield nil. Nil means "nothing to say about this shard".
+func TestShardAdditionalMongodConfigs_ErrorWhenNoSourceProcess(t *testing.T) {
+	// A shard with no usable source process is an inconsistent automation config: the
+	// settings exist in Ops Manager but cannot be read, so generation stops rather than
+	// producing a resource that silently omits them.
 	processMap := map[string]om.Process{}
 	orphan := om.NewReplicaSet("shard0", "7.0.12-ent")
-	orphan["members"] = []interface{}{map[string]interface{}{"host": "missing-host", "_id": 0}}
+	orphan["members"] = []interface{}{map[string]interface{}{"host": "missing-host", "_id": 0, "priority": 1, "votes": 1}}
+
+	_, err := shardAdditionalMongodConfigs(nil, processMap, []om.ReplicaSet{orphan})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shard0")
+}
+
+func TestShardAdditionalMongodConfigs_FallsBackToLaterMember(t *testing.T) {
+	// The first member missing a process is not fatal on its own: pickSourceProcess moves
+	// on to the next voting member, so the config is read from that one instead.
+	processMap := map[string]om.Process{
+		"shard0-1": {
+			"name": "shard0-1",
+			"args2_6": map[string]interface{}{
+				"storage": map[string]interface{}{
+					"wiredTiger": map[string]interface{}{
+						"engineConfig": map[string]interface{}{"cacheSizeGB": 7},
+					},
+				},
+			},
+		},
+	}
+	rs := om.NewReplicaSet("shard0", "7.0.12-ent")
+	rs["members"] = []interface{}{
+		map[string]interface{}{"host": "shard0-0", "_id": 0, "priority": 1, "votes": 1},
+		map[string]interface{}{"host": "shard0-1", "_id": 1, "priority": 1, "votes": 1},
+	}
+
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, []om.ReplicaSet{rs})
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, 7, readCacheSizeGB(t, configs[0]))
+}
+
+func TestShardAdditionalMongodConfigs_SkipsNonVotingMember(t *testing.T) {
+	// A hidden or zero-vote member can carry deliberately different settings, so it must
+	// not be the source even when it comes first and resolves to a process.
+	mkProc := func(name string, cacheSizeGB int) om.Process {
+		return om.Process{
+			"name": name,
+			"args2_6": map[string]interface{}{
+				"storage": map[string]interface{}{
+					"wiredTiger": map[string]interface{}{
+						"engineConfig": map[string]interface{}{"cacheSizeGB": cacheSizeGB},
+					},
+				},
+			},
+		}
+	}
+	processMap := map[string]om.Process{
+		"shard0-0": mkProc("shard0-0", 1),
+		"shard0-1": mkProc("shard0-1", 9),
+	}
+	rs := om.NewReplicaSet("shard0", "7.0.12-ent")
+	rs["members"] = []interface{}{
+		map[string]interface{}{"host": "shard0-0", "_id": 0, "priority": 0, "votes": 0},
+		map[string]interface{}{"host": "shard0-1", "_id": 1, "priority": 1, "votes": 1},
+	}
+
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, []om.ReplicaSet{rs})
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, 9, readCacheSizeGB(t, configs[0]), "config must come from the voting member")
+}
+
+func TestShardComponentConfig_NilIsOmittedFromTheGeneratedResource(t *testing.T) {
+	// A component with nothing but operator-managed fields must produce no
+	// additionalMongodConfig key at all. The field is an omitempty pointer, so only a nil
+	// config is dropped: an empty one would serialise as "additionalMongodConfig: {}".
+	processMap := map[string]om.Process{}
+	rs := shardRSWithConfig(t, processMap, "shard0", nil)
+
+	cfg, err := shardComponentConfig(nil, processMap, rs.Members())
+	require.NoError(t, err)
+	require.Nil(t, cfg, "a component with no user config must yield nil, not an empty config")
+
+	spec, err := buildShardedComponentSpec(nil, processMap, rs.Members())
+	require.NoError(t, err)
+	assert.Nil(t, spec, "a nil config must leave the component out of the resource entirely")
+}
+
+func TestShardAdditionalMongodConfigs_ErrorForEmptyMembers(t *testing.T) {
+	// A shard replica set with no members has no source process either, so it is rejected
+	// for the same reason: nothing to read the shard's mongod settings from.
 	empty := om.NewReplicaSet("shard1", "7.0.12-ent")
 	empty["members"] = []interface{}{}
 
-	configs := shardAdditionalMongodConfigs(nil, processMap, []om.ReplicaSet{orphan, empty})
+	_, err := shardAdditionalMongodConfigs(nil, map[string]om.Process{}, []om.ReplicaSet{empty})
 
-	require.Len(t, configs, 2)
-	assert.Nil(t, configs[0])
-	assert.Nil(t, configs[1])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shard1")
 }
 
 func TestCommonShardConfig_AllIdentical(t *testing.T) {
@@ -331,7 +418,8 @@ func TestCommonShardConfig_AllIdentical(t *testing.T) {
 		shardRSWithConfig(t, processMap, "shard0", intPtr(4)),
 		shardRSWithConfig(t, processMap, "shard1", intPtr(4)),
 	}
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	common, uniform := commonShardConfig(configs)
 
@@ -353,7 +441,8 @@ func TestCommonShardConfig_Differing(t *testing.T) {
 		shardRSWithConfig(t, processMap, "shard0", intPtr(4)),
 		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
 	}
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	common, uniform := commonShardConfig(configs)
 
@@ -369,7 +458,8 @@ func TestCommonShardConfig_NilVersusSetIsNotUniform(t *testing.T) {
 		shardRSWithConfig(t, processMap, "shard0", nil),
 		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
 	}
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	_, uniform := commonShardConfig(configs)
 
@@ -380,7 +470,8 @@ func TestCommonShardConfig_SingleShard(t *testing.T) {
 	// A one-shard cluster is trivially uniform, so it keeps using spec.shard.
 	processMap := map[string]om.Process{}
 	shardRSes := []om.ReplicaSet{shardRSWithConfig(t, processMap, "shard0", intPtr(4))}
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	common, uniform := commonShardConfig(configs)
 
@@ -397,7 +488,8 @@ func TestBuildShardOverrides_OneEntryPerShardInIndexOrder(t *testing.T) {
 		shardRSWithConfig(t, processMap, "shard1", intPtr(4)),
 		shardRSWithConfig(t, processMap, "shard2", intPtr(8)),
 	}
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	overrides := buildShardOverrides("my-cluster", configs)
 
@@ -418,7 +510,8 @@ func TestBuildShardOverrides_SkipsShardsWithNilConfig(t *testing.T) {
 		shardRSWithConfig(t, processMap, "shard0", nil),
 		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
 	}
-	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	configs, err := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+	require.NoError(t, err)
 
 	overrides := buildShardOverrides("my-cluster", configs)
 

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/ldap"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/maputil"
 )
 
 func secretsByName(objs []client.Object) map[string]string {
@@ -261,4 +262,342 @@ func TestBuildDbCommonSpec_DownloadBase(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "", spec.DownloadBase)
 	})
+}
+
+// shardRSWithConfig builds a single-member shard replica set named rsName whose member
+// host is "<rsName>-0", and registers that member's process in processMap with the given
+// args2_6 storage config. Pass a nil cacheSizeGB to register a process with no args at all,
+// which is how Process.AdditionalMongodConfig comes back nil.
+func shardRSWithConfig(t *testing.T, processMap map[string]om.Process, rsName string, cacheSizeGB *int) om.ReplicaSet {
+	t.Helper()
+	host := rsName + "-0"
+	rs := om.NewReplicaSet(rsName, "7.0.12-ent")
+	rs["members"] = []interface{}{map[string]interface{}{"host": host, "_id": 0}}
+	if cacheSizeGB == nil {
+		processMap[host] = om.Process{"name": host}
+		return rs
+	}
+	processMap[host] = om.Process{
+		"name": host,
+		"args2_6": map[string]interface{}{
+			"storage": map[string]interface{}{
+				"wiredTiger": map[string]interface{}{
+					"engineConfig": map[string]interface{}{"cacheSizeGB": *cacheSizeGB},
+				},
+			},
+		},
+	}
+	return rs
+}
+
+func intPtr(i int) *int { return &i }
+
+func TestShardAdditionalMongodConfigs_ExtractsPerShard(t *testing.T) {
+	// Each shard's config comes from its own first member, not from shard 0's.
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{
+		shardRSWithConfig(t, processMap, "shard0", intPtr(4)),
+		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
+	}
+
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	require.Len(t, configs, 2)
+	assert.Equal(t, 4, readCacheSizeGB(t, configs[0]))
+	assert.Equal(t, 8, readCacheSizeGB(t, configs[1]))
+}
+
+func TestShardAdditionalMongodConfigs_NilForMissingProcessOrEmptyMembers(t *testing.T) {
+	// A shard whose member is absent from the process map, and a shard with no members at
+	// all, both yield nil. Nil means "nothing to say about this shard".
+	processMap := map[string]om.Process{}
+	orphan := om.NewReplicaSet("shard0", "7.0.12-ent")
+	orphan["members"] = []interface{}{map[string]interface{}{"host": "missing-host", "_id": 0}}
+	empty := om.NewReplicaSet("shard1", "7.0.12-ent")
+	empty["members"] = []interface{}{}
+
+	configs := shardAdditionalMongodConfigs(nil, processMap, []om.ReplicaSet{orphan, empty})
+
+	require.Len(t, configs, 2)
+	assert.Nil(t, configs[0])
+	assert.Nil(t, configs[1])
+}
+
+func TestCommonShardConfig_AllIdentical(t *testing.T) {
+	// Two shards built independently with the same settings must compare equal, since
+	// comparison is on the marshalled map rather than pointer identity.
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{
+		shardRSWithConfig(t, processMap, "shard0", intPtr(4)),
+		shardRSWithConfig(t, processMap, "shard1", intPtr(4)),
+	}
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	common, uniform := commonShardConfig(configs)
+
+	assert.True(t, uniform)
+	assert.Equal(t, 4, readCacheSizeGB(t, common))
+}
+
+func TestCommonShardConfig_AllNil(t *testing.T) {
+	// No shard has any config: uniform, and the shared config is nil so spec.shard stays absent.
+	common, uniform := commonShardConfig([]*mdbv1.AdditionalMongodConfig{nil, nil})
+
+	assert.True(t, uniform)
+	assert.Nil(t, common)
+}
+
+func TestCommonShardConfig_Differing(t *testing.T) {
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{
+		shardRSWithConfig(t, processMap, "shard0", intPtr(4)),
+		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
+	}
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	common, uniform := commonShardConfig(configs)
+
+	assert.False(t, uniform)
+	assert.Nil(t, common)
+}
+
+func TestCommonShardConfig_NilVersusSetIsNotUniform(t *testing.T) {
+	// A nil config and an empty-but-non-nil config both flatten to an empty map, but a nil
+	// alongside a populated config is genuine heterogeneity.
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{
+		shardRSWithConfig(t, processMap, "shard0", nil),
+		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
+	}
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	_, uniform := commonShardConfig(configs)
+
+	assert.False(t, uniform)
+}
+
+func TestCommonShardConfig_SingleShard(t *testing.T) {
+	// A one-shard cluster is trivially uniform, so it keeps using spec.shard.
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{shardRSWithConfig(t, processMap, "shard0", intPtr(4))}
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	common, uniform := commonShardConfig(configs)
+
+	assert.True(t, uniform)
+	assert.Equal(t, 4, readCacheSizeGB(t, common))
+}
+
+func TestBuildShardOverrides_OneEntryPerShardInIndexOrder(t *testing.T) {
+	// Every shard gets its own entry, named with the K8s StatefulSet name, in ascending
+	// shard index. Identical shards are not grouped: each line answers exactly one question.
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{
+		shardRSWithConfig(t, processMap, "shard0", intPtr(4)),
+		shardRSWithConfig(t, processMap, "shard1", intPtr(4)),
+		shardRSWithConfig(t, processMap, "shard2", intPtr(8)),
+	}
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	overrides := buildShardOverrides("my-cluster", configs)
+
+	require.Len(t, overrides, 3)
+	assert.Equal(t, []string{"my-cluster-0"}, overrides[0].ShardNames)
+	assert.Equal(t, []string{"my-cluster-1"}, overrides[1].ShardNames)
+	assert.Equal(t, []string{"my-cluster-2"}, overrides[2].ShardNames)
+	assert.Equal(t, 4, readCacheSizeGB(t, overrides[0].AdditionalMongodConfig))
+	assert.Equal(t, 4, readCacheSizeGB(t, overrides[1].AdditionalMongodConfig))
+	assert.Equal(t, 8, readCacheSizeGB(t, overrides[2].AdditionalMongodConfig))
+}
+
+func TestBuildShardOverrides_SkipsShardsWithNilConfig(t *testing.T) {
+	// An override carrying no additionalMongodConfig is a no-op in the operator, so shards
+	// with nothing to say are omitted rather than emitted as empty entries.
+	processMap := map[string]om.Process{}
+	shardRSes := []om.ReplicaSet{
+		shardRSWithConfig(t, processMap, "shard0", nil),
+		shardRSWithConfig(t, processMap, "shard1", intPtr(8)),
+	}
+	configs := shardAdditionalMongodConfigs(nil, processMap, shardRSes)
+
+	overrides := buildShardOverrides("my-cluster", configs)
+
+	require.Len(t, overrides, 1)
+	assert.Equal(t, []string{"my-cluster-1"}, overrides[0].ShardNames, "shard index must survive the skip")
+	assert.Equal(t, 8, readCacheSizeGB(t, overrides[0].AdditionalMongodConfig))
+}
+
+func TestBuildShardOverrides_EmptyWhenNoShardHasConfig(t *testing.T) {
+	overrides := buildShardOverrides("my-cluster", []*mdbv1.AdditionalMongodConfig{nil, nil})
+
+	assert.Empty(t, overrides)
+}
+
+// readCacheSizeGB pulls storage.wiredTiger.engineConfig.cacheSizeGB out of an
+// AdditionalMongodConfig. The wrapped map is private, so ToMap is the only way in, and the
+// value survives a JSON round-trip inside Process.AdditionalMongodConfig as a float64.
+func readCacheSizeGB(t *testing.T, cfg *mdbv1.AdditionalMongodConfig) int {
+	t.Helper()
+	require.NotNil(t, cfg)
+	return maputil.ReadMapValueAsInt(cfg.ToMap(), "storage", "wiredTiger", "engineConfig", "cacheSizeGB")
+}
+
+func TestGenerateMongoDBCR_HomogeneousShardsUseSpecShard(t *testing.T) {
+	// The existing two-shard fixture has identical shard configs, so output must keep using
+	// spec.shard with no shardOverrides. This is the guard against churning the common case.
+	ac := loadTestAutomationConfig(t, "singlecluster/shardedcluster/default_config_rs/default_config_rs_input.json")
+	opts := withDeploymentData(ac, GenerateOptions{
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+	})
+
+	obj, _, err := GenerateMongoDBCR(ac, opts)
+	require.NoError(t, err)
+	mdb, ok := obj.(*mdbv1.MongoDB)
+	require.True(t, ok)
+
+	assert.Empty(t, mdb.Spec.ShardOverrides, "identical shards must not produce overrides")
+}
+
+func TestGenerateMongoDBCR_HeterogeneousShardsUseOverridesAndOmitSpecShard(t *testing.T) {
+	// Shard 1 carries a mongod setting shard 0 does not. spec.shard must be left absent
+	// rather than assert shard 0's settings about shard 1, and each shard gets an explicit
+	// override.
+	ac := loadTestAutomationConfig(t, "singlecluster/shardedcluster/default_config_rs/default_config_rs_input.json")
+	setProcessCacheSizeGB(t, ac, "shard0-0", 4)
+	setProcessCacheSizeGB(t, ac, "shard0-1", 4)
+	setProcessCacheSizeGB(t, ac, "shard1-0", 8)
+	setProcessCacheSizeGB(t, ac, "shard1-1", 8)
+
+	opts := withDeploymentData(ac, GenerateOptions{
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+	})
+
+	obj, _, err := GenerateMongoDBCR(ac, opts)
+	require.NoError(t, err)
+	mdb, ok := obj.(*mdbv1.MongoDB)
+	require.True(t, ok)
+
+	assert.Nil(t, mdb.Spec.ShardSpec, "spec.shard must be absent when shards differ")
+	require.Len(t, mdb.Spec.ShardOverrides, 2)
+	assert.Equal(t, []string{"my-sharded-cluster-0"}, mdb.Spec.ShardOverrides[0].ShardNames)
+	assert.Equal(t, []string{"my-sharded-cluster-1"}, mdb.Spec.ShardOverrides[1].ShardNames)
+	assert.Equal(t, 4, readCacheSizeGB(t, mdb.Spec.ShardOverrides[0].AdditionalMongodConfig))
+	assert.Equal(t, 8, readCacheSizeGB(t, mdb.Spec.ShardOverrides[1].AdditionalMongodConfig))
+
+	// The config server and mongos components are unaffected by shard heterogeneity.
+	assert.NotNil(t, mdb.Spec.ConfigSrvSpec, "config server spec must still be populated")
+}
+
+// setProcessCacheSizeGB injects storage.wiredTiger.engineConfig.cacheSizeGB into the named
+// process's args2_6, creating the intermediate maps as needed.
+func setProcessCacheSizeGB(t *testing.T, ac *om.AutomationConfig, processName string, cacheSizeGB int) {
+	t.Helper()
+	for _, p := range ac.Deployment.GetProcesses() {
+		if p.Name() != processName {
+			continue
+		}
+		args, ok := p["args2_6"].(map[string]interface{})
+		if !ok {
+			args = map[string]interface{}{}
+			p["args2_6"] = args
+		}
+		maputil.SetMapValue(args, cacheSizeGB, "storage", "wiredTiger", "engineConfig", "cacheSizeGB")
+		return
+	}
+	t.Fatalf("process %q not found in the automation config", processName)
+}
+
+func TestGenerateMongoDBCR_PerShardMongotHostBecomesShardOverrides(t *testing.T) {
+	// Each shard in a search-enabled sharded source points at its own mongot endpoint, so the
+	// shards are heterogeneous and each states its own endpoint in an override. This is the
+	// real-world case the synthetic cacheSizeGB fixture stands in for.
+	ac := loadTestAutomationConfig(t, "singlecluster/shardedcluster/default_config_rs/default_config_rs_input.json")
+	shard0Host := "mdb-search-0-svc.mongodb.svc.cluster.local:27027"
+	shard1Host := "mdb-search-1-svc.mongodb.svc.cluster.local:27027"
+	setSearchParameters(t, ac, "shard0-0", shard0Host)
+	setSearchParameters(t, ac, "shard0-1", shard0Host)
+	setSearchParameters(t, ac, "shard1-0", shard1Host)
+	setSearchParameters(t, ac, "shard1-1", shard1Host)
+
+	opts := withDeploymentData(ac, GenerateOptions{
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+	})
+
+	obj, _, err := GenerateMongoDBCR(ac, opts)
+	require.NoError(t, err)
+	mdb, ok := obj.(*mdbv1.MongoDB)
+	require.True(t, ok)
+
+	assert.Nil(t, mdb.Spec.ShardSpec, "differing mongot endpoints must not collapse into spec.shard")
+	require.Len(t, mdb.Spec.ShardOverrides, 2)
+	assert.Equal(t, []string{"my-sharded-cluster-0"}, mdb.Spec.ShardOverrides[0].ShardNames)
+	assert.Equal(t, []string{"my-sharded-cluster-1"}, mdb.Spec.ShardOverrides[1].ShardNames)
+
+	sp0 := readSetParameter(t, mdb.Spec.ShardOverrides[0].AdditionalMongodConfig)
+	sp1 := readSetParameter(t, mdb.Spec.ShardOverrides[1].AdditionalMongodConfig)
+	assert.Equal(t, shard0Host, sp0["mongotHost"])
+	assert.Equal(t, shard1Host, sp1["mongotHost"])
+	assert.Equal(t, true, sp0["useGrpcForSearch"], "non-endpoint search keys are carried too")
+}
+
+func TestGenerateMongoDBCR_UniformMongotHostStaysInSpecShard(t *testing.T) {
+	// A single mongot endpoint shared by every shard is homogeneous, so it belongs in
+	// spec.shard. This is the shape the existing sharded search e2e exercises.
+	ac := loadTestAutomationConfig(t, "singlecluster/shardedcluster/default_config_rs/default_config_rs_input.json")
+	host := "mdb-search-svc.mongodb.svc.cluster.local:27027"
+	for _, name := range []string{"shard0-0", "shard0-1", "shard1-0", "shard1-1"} {
+		setSearchParameters(t, ac, name, host)
+	}
+
+	opts := withDeploymentData(ac, GenerateOptions{
+		CredentialsSecretName: "my-credentials",
+		ConfigMapName:         "my-om-config",
+	})
+
+	obj, _, err := GenerateMongoDBCR(ac, opts)
+	require.NoError(t, err)
+	mdb, ok := obj.(*mdbv1.MongoDB)
+	require.True(t, ok)
+
+	assert.Empty(t, mdb.Spec.ShardOverrides)
+	require.NotNil(t, mdb.Spec.ShardSpec)
+	assert.Equal(t, host, readSetParameter(t, mdb.Spec.ShardSpec.AdditionalMongodConfig)["mongotHost"])
+}
+
+// setSearchParameters writes the six mongot setParameters onto the named process, using
+// mongotHost for both endpoint keys the way the search controller does.
+func setSearchParameters(t *testing.T, ac *om.AutomationConfig, processName, mongotHost string) {
+	t.Helper()
+	for _, p := range ac.Deployment.GetProcesses() {
+		if p.Name() != processName {
+			continue
+		}
+		args, ok := p["args2_6"].(map[string]interface{})
+		if !ok {
+			args = map[string]interface{}{}
+			p["args2_6"] = args
+		}
+		args["setParameter"] = map[string]interface{}{
+			"mongotHost":                                      mongotHost,
+			"searchIndexManagementHostAndPort":                mongotHost,
+			"skipAuthenticationToSearchIndexManagementServer": false,
+			"skipAuthenticationToMongot":                      false,
+			"searchTLSMode":                                   "disabled",
+			"useGrpcForSearch":                                true,
+		}
+		return
+	}
+	t.Fatalf("process %q not found in the automation config", processName)
+}
+
+// readSetParameter pulls the setParameter submap out of an AdditionalMongodConfig.
+func readSetParameter(t *testing.T, cfg *mdbv1.AdditionalMongodConfig) map[string]interface{} {
+	t.Helper()
+	require.NotNil(t, cfg)
+	sp, ok := cfg.ToMap()["setParameter"].(map[string]interface{})
+	require.True(t, ok, "expected a setParameter section, got %v", cfg.ToMap())
+	return sp
 }

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -451,7 +451,7 @@ func TestGenerateMongoDBCR_HomogeneousShardsUseSpecShard(t *testing.T) {
 		ConfigMapName:         "my-om-config",
 	})
 
-	obj, _, err := GenerateMongoDBCR(ac, opts)
+	obj, err := GenerateMongoDBCR(ac, opts)
 	require.NoError(t, err)
 	mdb, ok := obj.(*mdbv1.MongoDB)
 	require.True(t, ok)
@@ -477,7 +477,7 @@ func TestGenerateMongoDBCR_HeterogeneousShardsUseOverridesAndOmitSpecShard(t *te
 		ConfigMapName:         "my-om-config",
 	})
 
-	obj, _, err := GenerateMongoDBCR(ac, opts)
+	obj, err := GenerateMongoDBCR(ac, opts)
 	require.NoError(t, err)
 	mdb, ok := obj.(*mdbv1.MongoDB)
 	require.True(t, ok)
@@ -529,7 +529,7 @@ func TestGenerateMongoDBCR_PerShardMongotHostBecomesShardOverrides(t *testing.T)
 		ConfigMapName:         "my-om-config",
 	})
 
-	obj, _, err := GenerateMongoDBCR(ac, opts)
+	obj, err := GenerateMongoDBCR(ac, opts)
 	require.NoError(t, err)
 	mdb, ok := obj.(*mdbv1.MongoDB)
 	require.True(t, ok)
@@ -560,7 +560,7 @@ func TestGenerateMongoDBCR_UniformMongotHostStaysInSpecShard(t *testing.T) {
 		ConfigMapName:         "my-om-config",
 	})
 
-	obj, _, err := GenerateMongoDBCR(ac, opts)
+	obj, err := GenerateMongoDBCR(ac, opts)
 	require.NoError(t, err)
 	mdb, ok := obj.(*mdbv1.MongoDB)
 	require.True(t, ok)

--- a/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/generator_test.go
@@ -468,6 +468,9 @@ func TestGenerateMongoDBCR_HeterogeneousShardsUseOverridesAndOmitSpecShard(t *te
 	setProcessCacheSizeGB(t, ac, "shard0-1", 4)
 	setProcessCacheSizeGB(t, ac, "shard1-0", 8)
 	setProcessCacheSizeGB(t, ac, "shard1-1", 8)
+	// Give the config server a setting of its own so the assertion below is not vacuous.
+	setProcessCacheSizeGB(t, ac, "my-sharded-cluster-config-0", 2)
+	setProcessCacheSizeGB(t, ac, "my-sharded-cluster-config-1", 2)
 
 	opts := withDeploymentData(ac, GenerateOptions{
 		CredentialsSecretName: "my-credentials",

--- a/cmd/kubectl-mongodb/migrate-to-mck/sharded_cluster_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/sharded_cluster_generator.go
@@ -58,22 +58,29 @@ func generateShardedCluster(ac *om.AutomationConfig, opts GenerateOptions) (clie
 		return nil, fmt.Errorf("failed to build MongoDB spec: %w", err)
 	}
 
-	overrides := buildShardedClusterOverrides(k8sResourceName, acClusterName, configRS, acShards)
-	overrides.ConfigSrvSpec = buildShardedComponentSpec(ac.AgentSSL, processMap, configRS.Members())
-	// Shards may differ in their mongod settings. When they all agree, that shared config
-	// belongs in spec.shard. When they differ, spec.shard is left absent — populating it
-	// from one shard would assert that shard's settings about all the others — and each
-	// shard states its own config in an override instead.
-	shardConfigs := shardAdditionalMongodConfigs(ac.AgentSSL, processMap, shardRSes)
+	shardedClusterSpec := buildShardedClusterOverrides(k8sResourceName, acClusterName, configRS, acShards)
+	shardedClusterSpec.ConfigSrvSpec, err = buildShardedComponentSpec(ac.AgentSSL, processMap, configRS.Members())
+	if err != nil {
+		return nil, fmt.Errorf("config server replica set %q: %w", configRS.Name(), err)
+	}
+	// Shard configs, on K8s, derive from one of two places: either the spec.shard field
+	// set once for the entire ShardedClusterSpec, or from a shard-specific override. We
+	// maintain the invariant that exactly one of these routes is used: either all shards
+	// are identical and spec.shard is present, or spec.shard is absent and there is an
+	// override for each shard.
+	shardConfigs, err := shardAdditionalMongodConfigs(ac.AgentSSL, processMap, shardRSes)
+	if err != nil {
+		return nil, err
+	}
 	if common, uniform := commonShardConfig(shardConfigs); uniform {
 		if common != nil {
-			overrides.ShardSpec = &mdbv1.ShardedClusterComponentSpec{AdditionalMongodConfig: common}
+			shardedClusterSpec.ShardSpec = &mdbv1.ShardedClusterComponentSpec{AdditionalMongodConfig: common}
 		}
 	} else {
-		overrides.ShardOverrides = buildShardOverrides(k8sResourceName, shardConfigs)
+		shardedClusterSpec.ShardOverrides = buildShardOverrides(k8sResourceName, shardConfigs)
 	}
-	overrides.MongosSpec = buildMongosComponentSpec(ac.AgentSSL, mongosProcs)
-	spec.ShardedClusterSpec = overrides
+	shardedClusterSpec.MongosSpec = buildMongosComponentSpec(ac.AgentSSL, mongosProcs)
+	spec.ShardedClusterSpec = shardedClusterSpec
 
 	cr := &mdbv1.MongoDB{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "mongodb.com/v1", Kind: "MongoDB"},
@@ -148,47 +155,60 @@ func buildShardedClusterOverrides(k8sResourceName, acClusterName string, configR
 	}
 }
 
-// shardComponentConfig extracts the additionalMongodConfig for one replica-set component,
-// using its first member as representative. Returns nil when the component has no members,
-// its first member is absent from the process map, or nothing survives stripping the
-// operator-managed infrastructure fields.
-func shardComponentConfig(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) *mdbv1.AdditionalMongodConfig {
-	if len(members) == 0 {
-		return nil
+// shardComponentConfig extracts representative additionalMongodConfig from one component's
+// replica set, using pickSourceProcess to choose the member it is read from so a component
+// of a sharded cluster and a plain replica set pick the same way.
+//
+// Returns a nil config, and no error, when nothing survives the filtering: every field was
+// operator-managed, so there is nothing for the generated resource to carry. Nil rather than
+// an empty config because the field is an omitempty pointer, and omitempty only drops a nil
+// one: returning an empty config would write "additionalMongodConfig: {}" into every
+// generated resource that configures nothing, and the operator fills the field in itself
+// when it is absent.
+//
+// A member list with no usable source process is an inconsistent automation config and
+// returns an error rather than being read as "no config": the settings do exist in Ops
+// Manager, and silently dropping them would generate a resource that quietly disagrees with
+// the deployment it is meant to reproduce.
+func shardComponentConfig(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) (*mdbv1.AdditionalMongodConfig, error) {
+	proc, err := pickSourceProcess(members, processMap)
+	if err != nil {
+		return nil, err
 	}
-	proc, ok := processMap[members[0].Name()]
-	if !ok {
-		return nil
-	}
-	return applyClientCertificateMode(agentSSL, proc.AdditionalMongodConfig())
+	return applyClientCertificateMode(agentSSL, proc.AdditionalMongodConfig()), nil
 }
 
 // buildShardedComponentSpec wraps shardComponentConfig in a component spec, or returns nil
-// when there is no config to carry.
-func buildShardedComponentSpec(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) *mdbv1.ShardedClusterComponentSpec {
-	cfg := shardComponentConfig(agentSSL, processMap, members)
-	if cfg == nil {
-		return nil
+// when there is no config to carry, so the component is left out of the generated resource
+// entirely rather than appearing as an empty section.
+func buildShardedComponentSpec(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) (*mdbv1.ShardedClusterComponentSpec, error) {
+	cfg, err := shardComponentConfig(agentSSL, processMap, members)
+	if err != nil {
+		return nil, err
 	}
-	return &mdbv1.ShardedClusterComponentSpec{AdditionalMongodConfig: cfg}
+	if cfg == nil {
+		return nil, nil
+	}
+	return &mdbv1.ShardedClusterComponentSpec{AdditionalMongodConfig: cfg}, nil
 }
 
 // shardAdditionalMongodConfigs returns each shard's additionalMongodConfig, index-aligned
-// with shardRSes. Entries are nil for shards whose config could not be determined.
-func shardAdditionalMongodConfigs(agentSSL *om.AgentSSL, processMap map[string]om.Process, shardRSes []om.ReplicaSet) []*mdbv1.AdditionalMongodConfig {
+// with shardRSes. Entries are nil for shards whose config is entirely operator-managed.
+func shardAdditionalMongodConfigs(agentSSL *om.AgentSSL, processMap map[string]om.Process, shardRSes []om.ReplicaSet) ([]*mdbv1.AdditionalMongodConfig, error) {
 	configs := make([]*mdbv1.AdditionalMongodConfig, 0, len(shardRSes))
 	for _, rs := range shardRSes {
-		configs = append(configs, shardComponentConfig(agentSSL, processMap, rs.Members()))
+		cfg, err := shardComponentConfig(agentSSL, processMap, rs.Members())
+		if err != nil {
+			return nil, fmt.Errorf("shard replica set %q: %w", rs.Name(), err)
+		}
+		configs = append(configs, cfg)
 	}
-	return configs
+	return configs, nil
 }
 
 // commonShardConfig reports whether every shard shares one additionalMongodConfig, and if
-// so returns it. Comparison is on the marshalled map rather than pointer identity, so two
-// independently built but equivalent configs count as identical and map key ordering cannot
-// manufacture a false difference. When shards agree the caller emits spec.shard; when they
-// differ, spec.shard is left absent because it would otherwise assert one shard's settings
-// about all the others.
+// so returns it. Equality is value-based on the AdditionalMongodConfig records, and
+// insensitive to key orderings.
 func commonShardConfig(configs []*mdbv1.AdditionalMongodConfig) (*mdbv1.AdditionalMongodConfig, bool) {
 	if len(configs) == 0 {
 		return nil, true
@@ -204,14 +224,9 @@ func commonShardConfig(configs []*mdbv1.AdditionalMongodConfig) (*mdbv1.Addition
 	return configs[0], true
 }
 
-// buildShardOverrides emits one ShardOverride per shard that has a config, in ascending
-// shard index. Shards are never grouped by identical config: an explicit entry per shard
-// keeps the reader from having to infer which grouping is the default. Each entry carries
-// the shard's complete config rather than a delta, because the operator replaces
-// additionalMongodConfig wholesale rather than merging it
-// (controllers/operator/mongodbshardedcluster_controller.go, processShardOverride).
-// Shards with a nil config are skipped: an override with no additionalMongodConfig is a
-// no-op in the operator.
+// buildShardOverrides returns one ShardOverride per shard that has a config, in ascending
+// shard index. Each entry carries the shard's complete config, not a delta. Shards with a
+// nil config are skipped.
 func buildShardOverrides(k8sResourceName string, configs []*mdbv1.AdditionalMongodConfig) []mdbv1.ShardOverride {
 	var overrides []mdbv1.ShardOverride
 	for i, cfg := range configs {

--- a/cmd/kubectl-mongodb/migrate-to-mck/sharded_cluster_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/sharded_cluster_generator.go
@@ -2,6 +2,7 @@ package migratetomck
 
 import (
 	"fmt"
+	"reflect"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -59,7 +60,18 @@ func generateShardedCluster(ac *om.AutomationConfig, opts GenerateOptions) (clie
 
 	overrides := buildShardedClusterOverrides(k8sResourceName, acClusterName, configRS, acShards)
 	overrides.ConfigSrvSpec = buildShardedComponentSpec(ac.AgentSSL, processMap, configRS.Members())
-	overrides.ShardSpec = buildShardedComponentSpec(ac.AgentSSL, processMap, shardRSes[0].Members())
+	// Shards may differ in their mongod settings. When they all agree, that shared config
+	// belongs in spec.shard. When they differ, spec.shard is left absent — populating it
+	// from one shard would assert that shard's settings about all the others — and each
+	// shard states its own config in an override instead.
+	shardConfigs := shardAdditionalMongodConfigs(ac.AgentSSL, processMap, shardRSes)
+	if common, uniform := commonShardConfig(shardConfigs); uniform {
+		if common != nil {
+			overrides.ShardSpec = &mdbv1.ShardedClusterComponentSpec{AdditionalMongodConfig: common}
+		}
+	} else {
+		overrides.ShardOverrides = buildShardOverrides(k8sResourceName, shardConfigs)
+	}
 	overrides.MongosSpec = buildMongosComponentSpec(ac.AgentSSL, mongosProcs)
 	spec.ShardedClusterSpec = overrides
 
@@ -136,8 +148,11 @@ func buildShardedClusterOverrides(k8sResourceName, acClusterName string, configR
 	}
 }
 
-// buildShardedComponentSpec extracts additionalMongodConfig for a replica set component using its first member.
-func buildShardedComponentSpec(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) *mdbv1.ShardedClusterComponentSpec {
+// shardComponentConfig extracts the additionalMongodConfig for one replica-set component,
+// using its first member as representative. Returns nil when the component has no members,
+// its first member is absent from the process map, or nothing survives stripping the
+// operator-managed infrastructure fields.
+func shardComponentConfig(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) *mdbv1.AdditionalMongodConfig {
 	if len(members) == 0 {
 		return nil
 	}
@@ -145,11 +160,74 @@ func buildShardedComponentSpec(agentSSL *om.AgentSSL, processMap map[string]om.P
 	if !ok {
 		return nil
 	}
-	cfg := applyClientCertificateMode(agentSSL, proc.AdditionalMongodConfig())
+	return applyClientCertificateMode(agentSSL, proc.AdditionalMongodConfig())
+}
+
+// buildShardedComponentSpec wraps shardComponentConfig in a component spec, or returns nil
+// when there is no config to carry.
+func buildShardedComponentSpec(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) *mdbv1.ShardedClusterComponentSpec {
+	cfg := shardComponentConfig(agentSSL, processMap, members)
 	if cfg == nil {
 		return nil
 	}
 	return &mdbv1.ShardedClusterComponentSpec{AdditionalMongodConfig: cfg}
+}
+
+// shardAdditionalMongodConfigs returns each shard's additionalMongodConfig, index-aligned
+// with shardRSes. Entries are nil for shards whose config could not be determined.
+func shardAdditionalMongodConfigs(agentSSL *om.AgentSSL, processMap map[string]om.Process, shardRSes []om.ReplicaSet) []*mdbv1.AdditionalMongodConfig {
+	configs := make([]*mdbv1.AdditionalMongodConfig, 0, len(shardRSes))
+	for _, rs := range shardRSes {
+		configs = append(configs, shardComponentConfig(agentSSL, processMap, rs.Members()))
+	}
+	return configs
+}
+
+// commonShardConfig reports whether every shard shares one additionalMongodConfig, and if
+// so returns it. Comparison is on the marshalled map rather than pointer identity, so two
+// independently built but equivalent configs count as identical and map key ordering cannot
+// manufacture a false difference. When shards agree the caller emits spec.shard; when they
+// differ, spec.shard is left absent because it would otherwise assert one shard's settings
+// about all the others.
+func commonShardConfig(configs []*mdbv1.AdditionalMongodConfig) (*mdbv1.AdditionalMongodConfig, bool) {
+	if len(configs) == 0 {
+		return nil, true
+	}
+	// ToMap is nil-safe and yields an empty map for a nil config, so nil and non-nil
+	// configs compare correctly without special-casing.
+	first := configs[0].ToMap()
+	for _, cfg := range configs[1:] {
+		if !reflect.DeepEqual(first, cfg.ToMap()) {
+			return nil, false
+		}
+	}
+	return configs[0], true
+}
+
+// buildShardOverrides emits one ShardOverride per shard that has a config, in ascending
+// shard index. Shards are never grouped by identical config: an explicit entry per shard
+// keeps the reader from having to infer which grouping is the default. Each entry carries
+// the shard's complete config rather than a delta, because the operator replaces
+// additionalMongodConfig wholesale rather than merging it
+// (controllers/operator/mongodbshardedcluster_controller.go, processShardOverride).
+// Shards with a nil config are skipped: an override with no additionalMongodConfig is a
+// no-op in the operator.
+func buildShardOverrides(k8sResourceName string, configs []*mdbv1.AdditionalMongodConfig) []mdbv1.ShardOverride {
+	var overrides []mdbv1.ShardOverride
+	for i, cfg := range configs {
+		if cfg == nil {
+			continue
+		}
+		overrides = append(overrides, mdbv1.ShardOverride{
+			// Must be the K8s StatefulSet name; sharded-cluster validation rejects any
+			// other form. Same formula as ShardNameOverrides above.
+			ShardNames: []string{fmt.Sprintf("%s-%d", k8sResourceName, i)},
+			ShardedClusterComponentOverrideSpec: mdbv1.ShardedClusterComponentOverrideSpec{
+				AdditionalMongodConfig: cfg,
+			},
+		})
+	}
+	return overrides
 }
 
 // buildMongosComponentSpec extracts additionalMongodConfig for the mongos component using the first active process.

--- a/cmd/kubectl-mongodb/migrate-to-mck/sharded_cluster_generator.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/sharded_cluster_generator.go
@@ -159,17 +159,12 @@ func buildShardedClusterOverrides(k8sResourceName, acClusterName string, configR
 // replica set, using pickSourceProcess to choose the member it is read from so a component
 // of a sharded cluster and a plain replica set pick the same way.
 //
-// Returns a nil config, and no error, when nothing survives the filtering: every field was
-// operator-managed, so there is nothing for the generated resource to carry. Nil rather than
-// an empty config because the field is an omitempty pointer, and omitempty only drops a nil
-// one: returning an empty config would write "additionalMongodConfig: {}" into every
-// generated resource that configures nothing, and the operator fills the field in itself
-// when it is absent.
+// The result is nil when there is no config for the generated additionalMongodConfig
+// resource to carry. This can happen if all fields were operator-managed, and results in
+// additionalMongodConfig being omitted, in preference to "additionalMongodConfig: {}".
 //
-// A member list with no usable source process is an inconsistent automation config and
-// returns an error rather than being read as "no config": the settings do exist in Ops
-// Manager, and silently dropping them would generate a resource that quietly disagrees with
-// the deployment it is meant to reproduce.
+// Inconsistent automation configs result in a non-nil error being returned, in particular
+// if there is no usable source process for the member list.
 func shardComponentConfig(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) (*mdbv1.AdditionalMongodConfig, error) {
 	proc, err := pickSourceProcess(members, processMap)
 	if err != nil {
@@ -179,8 +174,7 @@ func shardComponentConfig(agentSSL *om.AgentSSL, processMap map[string]om.Proces
 }
 
 // buildShardedComponentSpec wraps shardComponentConfig in a component spec, or returns nil
-// when there is no config to carry, so the component is left out of the generated resource
-// entirely rather than appearing as an empty section.
+// when there is no config to carry.
 func buildShardedComponentSpec(agentSSL *om.AgentSSL, processMap map[string]om.Process, members []om.ReplicaSetMember) (*mdbv1.ShardedClusterComponentSpec, error) {
 	cfg, err := shardComponentConfig(agentSSL, processMap, members)
 	if err != nil {

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards_input.json
@@ -1,0 +1,384 @@
+{
+  "agentVersion": {
+    "directoryUrl": "https://s3.amazonaws.com/mciuploads/mms-automation/mongodb-mms-build-agent/builds/automation-agent/qa/",
+    "name": "13.48.0.10348-1"
+  },
+  "atlasProxies": [],
+  "atlasUISes": [],
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": true,
+    "authoritativeSet": false,
+    "autoAuthMechanism": "MONGODB-CR",
+    "autoAuthMechanisms": [],
+    "autoAuthRestrictions": []
+  },
+  "backupVersions": [],
+  "balancer": {},
+  "clusterWideConfigurations": {},
+  "cpsModules": [],
+  "dbCheckModules": [],
+  "filebeat": {},
+  "indexConfigs": [],
+  "kerberos": {
+    "serviceName": "mongodb"
+  },
+  "ldap": {},
+  "lifecycleManagementModules": [],
+  "maintainedEnvoys": [],
+  "maintainedMonarchComponents": [],
+  "maintainedMongotunes": [],
+  "maintainedRamis": [],
+  "mongoDbVersions": [
+    {
+      "builds": [
+        {
+          "architecture": "amd64",
+          "gitVersion": "abc123",
+          "platform": "linux",
+          "url": "https://downloads.mongodb.com/linux/mongodb-linux-x86_64-enterprise-rhel80-7.0.12.tgz"
+        }
+      ],
+      "name": "7.0.12-ent"
+    }
+  ],
+  "mongosqlds": [],
+  "mongots": [],
+  "monitoringVersions": [],
+  "oidcProviderConfigs": [],
+  "onlineArchiveModules": [],
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation",
+    "downloadBaseWindows": "%SystemDrive%\\MMSAutomation\\versions"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard0"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard0",
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 4
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard0-a.example.com",
+      "name": "shard0-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard0"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard0",
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 4
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard0-b.example.com",
+      "name": "shard0-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard1"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard1",
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 8
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard1-a.example.com",
+      "name": "shard1-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard1"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard1",
+          "wiredTiger": {
+            "engineConfig": {
+              "cacheSizeGB": 8
+            }
+          }
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard1-b.example.com",
+      "name": "shard1-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27019,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "my-sharded-cluster-config"
+        },
+        "sharding": {
+          "clusterRole": "configsvr"
+        },
+        "storage": {
+          "dbPath": "/data/config"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "config-a.example.com",
+      "name": "my-sharded-cluster-config-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27019,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "my-sharded-cluster-config"
+        },
+        "sharding": {
+          "clusterRole": "configsvr"
+        },
+        "storage": {
+          "dbPath": "/data/config"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "config-b.example.com",
+      "name": "my-sharded-cluster-config-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongos.log"
+        }
+      },
+      "hostname": "mongos-0.example.com",
+      "name": "mongos-0",
+      "processType": "mongos",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongos.log"
+        }
+      },
+      "hostname": "mongos-1.example.com",
+      "name": "mongos-1",
+      "processType": "mongos",
+      "version": "7.0.12-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "shard0",
+      "members": [
+        {
+          "_id": 0,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard0-0",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        },
+        {
+          "_id": 1,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard0-1",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        }
+      ],
+      "protocolVersion": "1"
+    },
+    {
+      "_id": "shard1",
+      "members": [
+        {
+          "_id": 0,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard1-0",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        },
+        {
+          "_id": 1,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard1-1",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        }
+      ],
+      "protocolVersion": "1"
+    },
+    {
+      "_id": "my-sharded-cluster-config",
+      "members": [
+        {
+          "_id": 0,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "my-sharded-cluster-config-0",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        },
+        {
+          "_id": 1,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "my-sharded-cluster-config-1",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        }
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "serverlessStateCacheMaintainers": [],
+  "sharding": [
+    {
+      "_id": "my-sharded-cluster",
+      "name": "my-sharded-cluster",
+      "configServerReplica": "my-sharded-cluster-config",
+      "shards": [
+        {
+          "_id": "shard0",
+          "rs": "shard0"
+        },
+        {
+          "_id": "shard1",
+          "rs": "shard1"
+        }
+      ]
+    }
+  ],
+  "tls": {
+    "clientCertificateMode": "OPTIONAL"
+  },
+  "version": 5
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards_mongodb_cr.yaml
@@ -1,0 +1,84 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: my-sharded-cluster
+  namespace: mongodb
+spec:
+  agent:
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb-mms-automation/mongodb.log
+  configSrv:
+    additionalMongodConfig:
+      net:
+        port: 27019
+  credentials: my-credentials
+  externalMembers:
+  - hostname: config-a.example.com:27019
+    processName: my-sharded-cluster-config-0
+    replicaSetName: my-sharded-cluster-config
+    type: mongod
+  - hostname: config-b.example.com:27019
+    processName: my-sharded-cluster-config-1
+    replicaSetName: my-sharded-cluster-config
+    type: mongod
+  - hostname: shard0-a.example.com:27018
+    processName: shard0-0
+    replicaSetName: shard0
+    type: mongod
+  - hostname: shard0-b.example.com:27018
+    processName: shard0-1
+    replicaSetName: shard0
+    type: mongod
+  - hostname: shard1-a.example.com:27018
+    processName: shard1-0
+    replicaSetName: shard1
+    type: mongod
+  - hostname: shard1-b.example.com:27018
+    processName: shard1-1
+    replicaSetName: shard1
+    type: mongod
+  - hostname: mongos-0.example.com:27017
+    processName: mongos-0
+    type: mongos
+  - hostname: mongos-1.example.com:27017
+    processName: mongos-1
+    type: mongos
+  featureCompatibilityVersion: "7.0"
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  shardCount: 2
+  shardNameOverrides:
+  - replicaSetName: shard0
+    shardId: shard0
+    shardName: my-sharded-cluster-0
+  - replicaSetName: shard1
+    shardId: shard1
+    shardName: my-sharded-cluster-1
+  shardOverrides:
+  - additionalMongodConfig:
+      net:
+        port: 27018
+      storage:
+        wiredTiger:
+          engineConfig:
+            cacheSizeGB: 4
+    shardNames:
+    - my-sharded-cluster-0
+  - additionalMongodConfig:
+      net:
+        port: 27018
+      storage:
+        wiredTiger:
+          engineConfig:
+            cacheSizeGB: 8
+    shardNames:
+    - my-sharded-cluster-1
+  type: ShardedCluster
+  version: 7.0.12-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/heterogeneous_shards/heterogeneous_shards_mongodb_cr.yaml
@@ -7,16 +7,6 @@ metadata:
   name: my-sharded-cluster
   namespace: mongodb
 spec:
-  agent:
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb-mms-automation/mongodb.log
-  configSrv:
-    additionalMongodConfig:
-      net:
-        port: 27019
   credentials: my-credentials
   externalMembers:
   - hostname: config-a.example.com:27019
@@ -63,8 +53,6 @@ spec:
     shardName: my-sharded-cluster-1
   shardOverrides:
   - additionalMongodConfig:
-      net:
-        port: 27018
       storage:
         wiredTiger:
           engineConfig:
@@ -72,8 +60,6 @@ spec:
     shardNames:
     - my-sharded-cluster-0
   - additionalMongodConfig:
-      net:
-        port: 27018
       storage:
         wiredTiger:
           engineConfig:

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot_input.json
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot_input.json
@@ -1,0 +1,412 @@
+{
+  "agentVersion": {
+    "directoryUrl": "https://s3.amazonaws.com/mciuploads/mms-automation/mongodb-mms-build-agent/builds/automation-agent/qa/",
+    "name": "13.48.0.10348-1"
+  },
+  "atlasProxies": [],
+  "atlasUISes": [],
+  "auth": {
+    "usersWanted": [],
+    "usersDeleted": [],
+    "disabled": true,
+    "authoritativeSet": false,
+    "autoAuthMechanism": "MONGODB-CR",
+    "autoAuthMechanisms": [],
+    "autoAuthRestrictions": []
+  },
+  "backupVersions": [],
+  "balancer": {},
+  "clusterWideConfigurations": {},
+  "cpsModules": [],
+  "dbCheckModules": [],
+  "filebeat": {},
+  "indexConfigs": [],
+  "kerberos": {
+    "serviceName": "mongodb"
+  },
+  "ldap": {},
+  "lifecycleManagementModules": [],
+  "maintainedEnvoys": [],
+  "maintainedMonarchComponents": [],
+  "maintainedMongotunes": [],
+  "maintainedRamis": [],
+  "mongoDbVersions": [
+    {
+      "builds": [
+        {
+          "architecture": "amd64",
+          "gitVersion": "abc123",
+          "platform": "linux",
+          "url": "https://downloads.mongodb.com/linux/mongodb-linux-x86_64-enterprise-rhel80-7.0.12.tgz"
+        }
+      ],
+      "name": "7.0.12-ent"
+    }
+  ],
+  "mongosqlds": [],
+  "mongots": [],
+  "monitoringVersions": [],
+  "oidcProviderConfigs": [],
+  "onlineArchiveModules": [],
+  "options": {
+    "downloadBase": "/var/lib/mongodb-mms-automation",
+    "downloadBaseWindows": "%SystemDrive%\\MMSAutomation\\versions"
+  },
+  "processes": [
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard0"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard0"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        },
+        "setParameter": {
+          "mongotHost": "mdb-search-0-svc.mongodb.svc.cluster.local:27027",
+          "searchIndexManagementHostAndPort": "mdb-search-0-svc.mongodb.svc.cluster.local:27027",
+          "skipAuthenticationToSearchIndexManagementServer": false,
+          "skipAuthenticationToMongot": false,
+          "searchTLSMode": "disabled",
+          "useGrpcForSearch": true
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard0-a.example.com",
+      "name": "shard0-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard0"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard0"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        },
+        "setParameter": {
+          "mongotHost": "mdb-search-0-svc.mongodb.svc.cluster.local:27027",
+          "searchIndexManagementHostAndPort": "mdb-search-0-svc.mongodb.svc.cluster.local:27027",
+          "skipAuthenticationToSearchIndexManagementServer": false,
+          "skipAuthenticationToMongot": false,
+          "searchTLSMode": "disabled",
+          "useGrpcForSearch": true
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard0-b.example.com",
+      "name": "shard0-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard1"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard1"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        },
+        "setParameter": {
+          "mongotHost": "mdb-search-1-svc.mongodb.svc.cluster.local:27027",
+          "searchIndexManagementHostAndPort": "mdb-search-1-svc.mongodb.svc.cluster.local:27027",
+          "skipAuthenticationToSearchIndexManagementServer": false,
+          "skipAuthenticationToMongot": false,
+          "searchTLSMode": "disabled",
+          "useGrpcForSearch": true
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard1-a.example.com",
+      "name": "shard1-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27018,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "shard1"
+        },
+        "sharding": {
+          "clusterRole": "shardsvr"
+        },
+        "storage": {
+          "dbPath": "/data/shard1"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        },
+        "setParameter": {
+          "mongotHost": "mdb-search-1-svc.mongodb.svc.cluster.local:27027",
+          "searchIndexManagementHostAndPort": "mdb-search-1-svc.mongodb.svc.cluster.local:27027",
+          "skipAuthenticationToSearchIndexManagementServer": false,
+          "skipAuthenticationToMongot": false,
+          "searchTLSMode": "disabled",
+          "useGrpcForSearch": true
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "shard1-b.example.com",
+      "name": "shard1-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27019,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "my-sharded-cluster-config"
+        },
+        "sharding": {
+          "clusterRole": "configsvr"
+        },
+        "storage": {
+          "dbPath": "/data/config"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "config-a.example.com",
+      "name": "my-sharded-cluster-config-0",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27019,
+          "tls": {
+            "mode": "disabled"
+          }
+        },
+        "replication": {
+          "replSetName": "my-sharded-cluster-config"
+        },
+        "sharding": {
+          "clusterRole": "configsvr"
+        },
+        "storage": {
+          "dbPath": "/data/config"
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongodb.log"
+        }
+      },
+      "featureCompatibilityVersion": "7.0",
+      "hostname": "config-b.example.com",
+      "name": "my-sharded-cluster-config-1",
+      "processType": "mongod",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongos.log"
+        },
+        "setParameter": {
+          "mongotHost": "mdb-search-svc.mongodb.svc.cluster.local:27027",
+          "searchIndexManagementHostAndPort": "mdb-search-svc.mongodb.svc.cluster.local:27027",
+          "skipAuthenticationToSearchIndexManagementServer": false,
+          "skipAuthenticationToMongot": false,
+          "searchTLSMode": "disabled",
+          "useGrpcForSearch": true
+        }
+      },
+      "hostname": "mongos-0.example.com",
+      "name": "mongos-0",
+      "processType": "mongos",
+      "version": "7.0.12-ent"
+    },
+    {
+      "args2_6": {
+        "net": {
+          "port": 27017
+        },
+        "systemLog": {
+          "destination": "file",
+          "path": "/var/log/mongodb-mms-automation/mongos.log"
+        },
+        "setParameter": {
+          "mongotHost": "mdb-search-svc.mongodb.svc.cluster.local:27027",
+          "searchIndexManagementHostAndPort": "mdb-search-svc.mongodb.svc.cluster.local:27027",
+          "skipAuthenticationToSearchIndexManagementServer": false,
+          "skipAuthenticationToMongot": false,
+          "searchTLSMode": "disabled",
+          "useGrpcForSearch": true
+        }
+      },
+      "hostname": "mongos-1.example.com",
+      "name": "mongos-1",
+      "processType": "mongos",
+      "version": "7.0.12-ent"
+    }
+  ],
+  "replicaSets": [
+    {
+      "_id": "shard0",
+      "members": [
+        {
+          "_id": 0,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard0-0",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        },
+        {
+          "_id": 1,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard0-1",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        }
+      ],
+      "protocolVersion": "1"
+    },
+    {
+      "_id": "shard1",
+      "members": [
+        {
+          "_id": 0,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard1-0",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        },
+        {
+          "_id": 1,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "shard1-1",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        }
+      ],
+      "protocolVersion": "1"
+    },
+    {
+      "_id": "my-sharded-cluster-config",
+      "members": [
+        {
+          "_id": 0,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "my-sharded-cluster-config-0",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        },
+        {
+          "_id": 1,
+          "arbiterOnly": false,
+          "buildIndexes": true,
+          "hidden": false,
+          "host": "my-sharded-cluster-config-1",
+          "priority": 1,
+          "secondaryDelaySecs": 0,
+          "votes": 1,
+          "tags": {}
+        }
+      ],
+      "protocolVersion": "1"
+    }
+  ],
+  "roles": [],
+  "serverlessStateCacheMaintainers": [],
+  "sharding": [
+    {
+      "_id": "my-sharded-cluster",
+      "name": "my-sharded-cluster",
+      "configServerReplica": "my-sharded-cluster-config",
+      "shards": [
+        {
+          "_id": "shard0",
+          "rs": "shard0"
+        },
+        {
+          "_id": "shard1",
+          "rs": "shard1"
+        }
+      ]
+    }
+  ],
+  "tls": {
+    "clientCertificateMode": "OPTIONAL"
+  },
+  "version": 5
+}

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot_mongodb_cr.yaml
@@ -1,0 +1,99 @@
+apiVersion: mongodb.com/v1
+kind: MongoDB
+metadata:
+  annotations:
+    mongodb.com/migrate-tool-version: latest
+    mongodb.com/migration-dry-run: "true"
+  name: my-sharded-cluster
+  namespace: mongodb
+spec:
+  agent:
+    mongod:
+      systemLog:
+        destination: file
+        logAppend: false
+        path: /var/log/mongodb-mms-automation/mongodb.log
+  configSrv:
+    additionalMongodConfig:
+      net:
+        port: 27019
+  credentials: my-credentials
+  externalMembers:
+  - hostname: config-a.example.com:27019
+    processName: my-sharded-cluster-config-0
+    replicaSetName: my-sharded-cluster-config
+    type: mongod
+  - hostname: config-b.example.com:27019
+    processName: my-sharded-cluster-config-1
+    replicaSetName: my-sharded-cluster-config
+    type: mongod
+  - hostname: shard0-a.example.com:27018
+    processName: shard0-0
+    replicaSetName: shard0
+    type: mongod
+  - hostname: shard0-b.example.com:27018
+    processName: shard0-1
+    replicaSetName: shard0
+    type: mongod
+  - hostname: shard1-a.example.com:27018
+    processName: shard1-0
+    replicaSetName: shard1
+    type: mongod
+  - hostname: shard1-b.example.com:27018
+    processName: shard1-1
+    replicaSetName: shard1
+    type: mongod
+  - hostname: mongos-0.example.com:27017
+    processName: mongos-0
+    type: mongos
+  - hostname: mongos-1.example.com:27017
+    processName: mongos-1
+    type: mongos
+  featureCompatibilityVersion: "7.0"
+  mongos:
+    additionalMongodConfig:
+      setParameter:
+        mongotHost: mdb-search-svc.mongodb.svc.cluster.local:27027
+        searchIndexManagementHostAndPort: mdb-search-svc.mongodb.svc.cluster.local:27027
+        searchTLSMode: disabled
+        skipAuthenticationToMongot: false
+        skipAuthenticationToSearchIndexManagementServer: false
+        useGrpcForSearch: true
+  opsManager:
+    configMapRef:
+      name: my-om-config
+  shardCount: 2
+  shardNameOverrides:
+  - replicaSetName: shard0
+    shardId: shard0
+    shardName: my-sharded-cluster-0
+  - replicaSetName: shard1
+    shardId: shard1
+    shardName: my-sharded-cluster-1
+  shardOverrides:
+  - additionalMongodConfig:
+      net:
+        port: 27018
+      setParameter:
+        mongotHost: mdb-search-0-svc.mongodb.svc.cluster.local:27027
+        searchIndexManagementHostAndPort: mdb-search-0-svc.mongodb.svc.cluster.local:27027
+        searchTLSMode: disabled
+        skipAuthenticationToMongot: false
+        skipAuthenticationToSearchIndexManagementServer: false
+        useGrpcForSearch: true
+    shardNames:
+    - my-sharded-cluster-0
+  - additionalMongodConfig:
+      net:
+        port: 27018
+      setParameter:
+        mongotHost: mdb-search-1-svc.mongodb.svc.cluster.local:27027
+        searchIndexManagementHostAndPort: mdb-search-1-svc.mongodb.svc.cluster.local:27027
+        searchTLSMode: disabled
+        skipAuthenticationToMongot: false
+        skipAuthenticationToSearchIndexManagementServer: false
+        useGrpcForSearch: true
+    shardNames:
+    - my-sharded-cluster-1
+  type: ShardedCluster
+  version: 7.0.12-ent

--- a/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot_mongodb_cr.yaml
+++ b/cmd/kubectl-mongodb/migrate-to-mck/testdata/singlecluster/shardedcluster/search_per_shard_mongot/search_per_shard_mongot_mongodb_cr.yaml
@@ -7,16 +7,6 @@ metadata:
   name: my-sharded-cluster
   namespace: mongodb
 spec:
-  agent:
-    mongod:
-      systemLog:
-        destination: file
-        logAppend: false
-        path: /var/log/mongodb-mms-automation/mongodb.log
-  configSrv:
-    additionalMongodConfig:
-      net:
-        port: 27019
   credentials: my-credentials
   externalMembers:
   - hostname: config-a.example.com:27019
@@ -72,8 +62,6 @@ spec:
     shardName: my-sharded-cluster-1
   shardOverrides:
   - additionalMongodConfig:
-      net:
-        port: 27018
       setParameter:
         mongotHost: mdb-search-0-svc.mongodb.svc.cluster.local:27027
         searchIndexManagementHostAndPort: mdb-search-0-svc.mongodb.svc.cluster.local:27027
@@ -84,8 +72,6 @@ spec:
     shardNames:
     - my-sharded-cluster-0
   - additionalMongodConfig:
-      net:
-        port: 27018
       setParameter:
         mongotHost: mdb-search-1-svc.mongodb.svc.cluster.local:27027
         searchIndexManagementHostAndPort: mdb-search-1-svc.mongodb.svc.cluster.local:27027

--- a/cmd/kubectl-mongodb/migrate-to-mck/validation.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/validation.go
@@ -55,6 +55,7 @@ func ValidateMigration(ac *om.AutomationConfig, processMap map[string]om.Process
 	results = append(results, validatePrometheus(ac.Deployment)...)
 	results = append(results, validateProjectOptions(ac.Deployment)...)
 	results = append(results, validateMemberPreservedFields(ac.Deployment)...)
+	results = append(results, validateSourceProcessPerReplicaSet(ac.Deployment, processMap)...)
 	for _, r := range results {
 		if r.Severity == SeverityError {
 			return results, nil
@@ -196,6 +197,23 @@ func validateReplicaSetsExist(d om.Deployment) []ValidationResult {
 		}}
 	}
 	return nil
+}
+
+// validateSourceProcessPerReplicaSet checks that every replica set has a member the generator
+// can read spec.additionalMongodConfig from. Generation reads one per shard and one for the
+// config server, so checking only the first replica set would let a problem in any of the
+// others surface as a generation failure after validation had already passed.
+func validateSourceProcessPerReplicaSet(d om.Deployment, processMap map[string]om.Process) []ValidationResult {
+	var results []ValidationResult
+	for _, rs := range d.GetReplicaSets() {
+		if _, err := pickSourceProcess(rs.Members(), processMap); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Replica set %q: %s.", rs.Name(), err),
+			})
+		}
+	}
+	return results
 }
 
 // validateAuth checks autoUser, keyFile, and keyFileWindows against operator defaults.

--- a/cmd/kubectl-mongodb/migrate-to-mck/validation_test.go
+++ b/cmd/kubectl-mongodb/migrate-to-mck/validation_test.go
@@ -825,3 +825,36 @@ func TestValidation_AgentConfigDrift_Warning(t *testing.T) {
 	}
 	assert.True(t, hasWarning, "expected warning when per-process logRotate differs from project-level setting")
 }
+
+func TestValidateSourceProcessPerReplicaSet_ChecksEveryReplicaSet(t *testing.T) {
+	// Generation reads a source process per shard and one for the config server, so a
+	// problem in any replica set other than the first must still be caught by validation
+	// rather than surfacing later as a generation failure.
+	shard0 := om.NewReplicaSet("shard0", "7.0.12-ent")
+	shard0["members"] = []interface{}{map[string]interface{}{"host": "shard0-0", "_id": 0, "priority": 1, "votes": 1}}
+	shard1 := om.NewReplicaSet("shard1", "7.0.12-ent")
+	shard1["members"] = []interface{}{map[string]interface{}{"host": "shard1-0", "_id": 0, "priority": 1, "votes": 1}}
+	// Only shard0's member has a process, so shard1 has no source process.
+	processMap := map[string]om.Process{"shard0-0": {"name": "shard0-0"}}
+
+	results := validateSourceProcessPerReplicaSet(om.Deployment{
+		"replicaSets": []interface{}{map[string]interface{}(shard0), map[string]interface{}(shard1)},
+	}, processMap)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, SeverityError, results[0].Severity)
+	assert.Contains(t, results[0].Message, "shard1")
+	assert.NotContains(t, results[0].Message, "shard0-0")
+}
+
+func TestValidateSourceProcessPerReplicaSet_NoErrorWhenAllResolve(t *testing.T) {
+	rs := om.NewReplicaSet("shard0", "7.0.12-ent")
+	rs["members"] = []interface{}{map[string]interface{}{"host": "shard0-0", "_id": 0, "priority": 1, "votes": 1}}
+	processMap := map[string]om.Process{"shard0-0": {"name": "shard0-0"}}
+
+	results := validateSourceProcessPerReplicaSet(om.Deployment{
+		"replicaSets": []interface{}{map[string]interface{}(rs)},
+	}, processMap)
+
+	assert.Empty(t, results)
+}

--- a/config/crd/bases/mongodb.com_mongodb.yaml
+++ b/config/crd/bases/mongodb.com_mongodb.yaml
@@ -2847,12 +2847,12 @@ spec:
             - message: spec.members must be >= 3 when spec.role is AppDB
               rule: '!has(self.role) || self.role != ''AppDB'' || (has(self.members)
                 && self.members >= 3)'
-            - message: 'at most one external member may be removed per update: remove
-                entries from spec.externalMembers one at a time so the replica set
-                keeps its voting majority'
+            - message: 'at most one external mongod may be removed per update: remove
+                mongod entries from spec.externalMembers one at a time so the replica
+                set keeps its voting majority'
               rule: '!has(oldSelf.externalMembers) || (has(self.externalMembers) ?
-                size(self.externalMembers) : 0) >= size(oldSelf.externalMembers) -
-                1'
+                size(self.externalMembers.filter(m, m.type != ''mongos'')) : 0) >=
+                size(oldSelf.externalMembers.filter(m, m.type != ''mongos'')) - 1'
             - message: spec.security.authentication must be enabled with modes [SCRAM]
                 only when spec.role is AppDB, or omitted entirely
               rule: '!has(self.role) || self.role != ''AppDB'' || !has(self.security)

--- a/config/crd/bases/mongodb.com_mongodb.yaml
+++ b/config/crd/bases/mongodb.com_mongodb.yaml
@@ -2675,6 +2675,7 @@ spec:
                   - shardNames
                   type: object
                 type: array
+                x-kubernetes-preserve-unknown-fields: true
               shardPodSpec:
                 properties:
                   persistence:

--- a/controllers/om/process.go
+++ b/controllers/om/process.go
@@ -44,15 +44,10 @@ const (
 //
 // MongoDB Search setParameters (mongotHost, searchIndexManagementHostAndPort,
 // searchTLSMode, useGrpcForSearch, skipAuthenticationToMongot,
-// skipAuthenticationToSearchIndexManagementServer) are deliberately NOT listed. They were
-// stripped originally on the assumption that the search controller always rewrites them from
-// the MongoDBSearch CR, but during a VM migration the MongoDBSearch usually still targets the
-// VM mongods through an external source, so applySearchOverrides returns early and nothing in
-// Kubernetes writes them. Ops Manager was expected to propagate them onto the new processes
-// and does not. The generated CR is therefore their carrier: they are extracted like any other
-// user setParameter. When a MongoDBSearch does target the migrated resource, the controller
-// overwrites the whole setParameter subtree, so the CR-side values are superseded rather than
-// in conflict.
+// skipAuthenticationToSearchIndexManagementServer) are deliberately NOT listed: they are
+// extracted like any other user setParameter, so the generated CR carries them. Nothing else
+// does during a migration. Once a MongoDBSearch targets the migrated resource, the search
+// controller overwrites the whole setParameter subtree and the CR-side values are superseded.
 var infrastructureFieldPaths = [][]string{
 	{"systemLog"},
 	{"storage", "dbPath"},

--- a/controllers/om/process.go
+++ b/controllers/om/process.go
@@ -41,6 +41,18 @@ const (
 // arguments present on the mongod config level. AdditionalMongodConfig
 // strips these to isolate user-supplied config. When a new
 // infrastructure-managed field is introduced, add its path here.
+//
+// MongoDB Search setParameters (mongotHost, searchIndexManagementHostAndPort,
+// searchTLSMode, useGrpcForSearch, skipAuthenticationToMongot,
+// skipAuthenticationToSearchIndexManagementServer) are deliberately NOT listed. They were
+// stripped originally on the assumption that the search controller always rewrites them from
+// the MongoDBSearch CR, but during a VM migration the MongoDBSearch usually still targets the
+// VM mongods through an external source, so applySearchOverrides returns early and nothing in
+// Kubernetes writes them. Ops Manager was expected to propagate them onto the new processes
+// and does not. The generated CR is therefore their carrier: they are extracted like any other
+// user setParameter. When a MongoDBSearch does target the migrated resource, the controller
+// overwrites the whole setParameter subtree, so the CR-side values are superseded rather than
+// in conflict.
 var infrastructureFieldPaths = [][]string{
 	{"systemLog"},
 	{"storage", "dbPath"},

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	opMigration "github.com/mongodb/mongodb-kubernetes/controllers/operator/migration"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	opMigration "github.com/mongodb/mongodb-kubernetes/controllers/operator/migration"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -329,12 +329,13 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 		return r.updateStatus(ctx, workflow.Failed(err))
 	}
 
+	isDryRun := rs.IsMigrationDryRun()
+
 	// 4. Recovery
 	// Recovery prevents some deadlocks that can occur during reconciliation, e.g. the setting of an incorrect automation
 	// configuration and a subsequent attempt to overwrite it later, the operator would be stuck in Pending phase.
 	// See CLOUDP-189433 and CLOUDP-229222 for more details.
 	// Recovery is skipped when a migration dry-run is active.
-	isDryRun := rs.IsMigrationDryRun()
 	if !isDryRun && recovery.ShouldTriggerRecovery(rs.Status.Phase != mdbstatus.PhaseRunning, rs.Status.LastTransition) {
 		log.Warnf("Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s", rs.Namespace, rs.Name, rs.Status.Phase, rs.Status.LastTransition)
 		automationConfigStatus := r.updateOmDeploymentRs(ctx, conn, r.deploymentState.LastReconcileMemberCount, tlsCertPath, internalClusterCertPath, deploymentOpts, shouldMirrorKeyfileForMongot, true).OnErrorPrepend("failed to create/update (Ops Manager reconciliation phase):")

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -329,13 +329,12 @@ func (r *ReplicaSetReconcilerHelper) Reconcile(ctx context.Context) (reconcile.R
 		return r.updateStatus(ctx, workflow.Failed(err))
 	}
 
-	isDryRun := rs.IsMigrationDryRun()
-
 	// 4. Recovery
 	// Recovery prevents some deadlocks that can occur during reconciliation, e.g. the setting of an incorrect automation
 	// configuration and a subsequent attempt to overwrite it later, the operator would be stuck in Pending phase.
 	// See CLOUDP-189433 and CLOUDP-229222 for more details.
 	// Recovery is skipped when a migration dry-run is active.
+	isDryRun := rs.IsMigrationDryRun()
 	if !isDryRun && recovery.ShouldTriggerRecovery(rs.Status.Phase != mdbstatus.PhaseRunning, rs.Status.LastTransition) {
 		log.Warnf("Triggering Automatic Recovery. The MongoDB resource %s/%s is in %s state since %s", rs.Namespace, rs.Name, rs.Status.Phase, rs.Status.LastTransition)
 		automationConfigStatus := r.updateOmDeploymentRs(ctx, conn, r.deploymentState.LastReconcileMemberCount, tlsCertPath, internalClusterCertPath, deploymentOpts, shouldMirrorKeyfileForMongot, true).OnErrorPrepend("failed to create/update (Ops Manager reconciliation phase):")

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -1789,6 +1789,56 @@ func TestReplicaSetReconcile_PublishesConnectionStringSecret(t *testing.T) {
 	require.Len(t, secret.OwnerReferences, 1)
 }
 
+// vmProcessWithSearchSetParameters returns a deployment containing a single external VM
+// process carrying the mongod setParameters the operator writes when search is attached.
+func vmProcessWithSearchSetParameters(t *testing.T, withSearch bool) om.Deployment {
+	t.Helper()
+	spec := &mdbv1.MongoDbSpec{DbCommonSpec: mdbv1.DbCommonSpec{Version: "8.2.0"}}
+	additional := &mdbv1.AdditionalMongodConfig{}
+	if withSearch {
+		additional = mdbv1.NewAdditionalMongodConfig("setParameter", map[string]interface{}{
+			"mongotHost":                       "mdb-search-0.mdb-search-svc.my-namespace.svc.cluster.local:27028",
+			"searchIndexManagementHostAndPort": "mdb-search-0.mdb-search-svc.my-namespace.svc.cluster.local:27028",
+		})
+	}
+	vmProcess := om.NewMongodProcess(
+		"vm-0", "vm-0.example.com", "fake-image", false,
+		additional, spec, "", nil, "", architectures.NonStatic,
+	)
+	d := om.NewDeployment()
+	d.MergeReplicaSet(buildRsByProcessesHelper("search-rs", []om.Process{vmProcess}), nil, nil, nil, zap.S())
+	return d
+}
+
+func newReplicaSetWithExternalMember(name string) *mdbv1.MongoDB {
+	rs := mdbv1.NewDefaultReplicaSetBuilder().
+		SetName(name).
+		SetNamespace(mock.TestNamespace).
+		SetMembers(1).
+		SetVersion("8.2.0").
+		SetReplicaSetNameOverride("search-rs").
+		SetConnectionSpec(testConnectionSpec()).
+		Build()
+	rs.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-0", Hostname: "vm-0.example.com:27017", Type: "mongod", ReplicaSetName: "search-rs"},
+	}
+	return rs
+}
+
+func TestReplicaSetMigration_ProceedsWhenVMProcessHasSearchConfig(t *testing.T) {
+	ctx := context.Background()
+	rs := newReplicaSetWithExternalMember("search-on-vm-rs")
+
+	reconciler, kubeClient, omConnectionFactory := defaultReplicaSetReconciler(ctx, nil, "", "", rs, architectures.NonStatic)
+	omConnectionFactory.SetPostCreateHook(func(conn om.Connection) {
+		_, _ = conn.(*om.MockedOmConnection).UpdateDeployment(vmProcessWithSearchSetParameters(t, true))
+	})
+
+	// Search setParameters on the external (VM) process do not hold the migration back: the
+	// MongoDBSearch keeps its external source and its host seeds are maintained by the user.
+	checkReconcileSuccessful(ctx, t, reconciler, rs, kubeClient)
+}
+
 func TestEnsureAppDBRoleKeyfile(t *testing.T) {
 	const sharedKey = "shared-keyfile-contents"
 	const projectGeneratedKey = "project-generated-key"

--- a/controllers/operator/mongodbshardedcluster_controller_test.go
+++ b/controllers/operator/mongodbshardedcluster_controller_test.go
@@ -1837,6 +1837,93 @@ func newShardedClusterReconcilerFromResource(ctx context.Context, imageUrls imag
 	return r, reconcileHelper, nil
 }
 
+// vmShardProcessWithSearchSetParameters returns a full sharded-cluster deployment (mongos, config
+// server and a single shard) whose only shard member is an external VM process, optionally
+// carrying the mongod setParameters the operator writes when search is attached.
+func vmShardProcessWithSearchSetParameters(t *testing.T, sc *mdbv1.MongoDB, withSearch bool) om.Deployment {
+	t.Helper()
+	spec := &mdbv1.MongoDbSpec{DbCommonSpec: mdbv1.DbCommonSpec{Version: "8.2.0"}}
+	additional := &mdbv1.AdditionalMongodConfig{}
+	if withSearch {
+		additional = mdbv1.NewAdditionalMongodConfig("setParameter", map[string]interface{}{
+			"mongotHost":                       "sc-search-0-sc-0-0.sc-search-0-sc-0-svc.my-namespace.svc.cluster.local:27028",
+			"searchIndexManagementHostAndPort": "sc-search-0-sc-0-0.sc-search-0-sc-0-svc.my-namespace.svc.cluster.local:27028",
+		})
+	}
+	vmProcess := om.NewMongodProcess(
+		"vm-shard-0", "vm-shard-0.example.com", "fake-image", false,
+		additional, spec, "", nil, "", architectures.NonStatic,
+	)
+	shardRs, _ := buildReplicaSetFromProcesses(sc.ShardACRsName(0), []om.Process{vmProcess}, sc, nil, om.NewDeployment())
+
+	desiredMongosConfig := createMongosSpec(sc)
+	mongosOptions := construct.MongosOptions(desiredMongosConfig, multicluster.LegacyCentralClusterName, Replicas(sc.Spec.MongosCount), construct.GetPodEnvOptions())
+	mongosSts := construct.DatabaseStatefulSet(*sc, mongosOptions, zap.S())
+	hostnames, names := dns.GetDnsForStatefulSet(mongosSts, sc.Spec.GetClusterDomain(), nil)
+	mongosProcesses := make([]om.Process, len(hostnames))
+	for idx, hostname := range hostnames {
+		mongosProcesses[idx] = om.NewMongosProcess(names[idx], hostname, "fake-mongoDBImage", false, sc.Spec.MongosSpec.GetAdditionalMongodConfig(), sc.GetSpec(), util.PEMKeyFilePathInContainer, sc.Annotations, sc.CalculateFeatureCompatibilityVersion(), architectures.NonStatic)
+	}
+
+	desiredConfigSrvConfig := createConfigSrvSpec(sc)
+	configServerOptions := construct.ConfigServerOptions(desiredConfigSrvConfig, multicluster.LegacyCentralClusterName, Replicas(sc.Spec.ConfigServerCount), construct.GetPodEnvOptions())
+	configSvrSts := construct.DatabaseStatefulSet(*sc, configServerOptions, zap.S())
+	hostnames, names = dns.GetDnsForStatefulSet(configSvrSts, sc.Spec.GetClusterDomain(), nil)
+	configProcesses := make([]om.Process, len(hostnames))
+	for idx, hostname := range hostnames {
+		configProcesses[idx] = om.NewMongodProcess(names[idx], hostname, "fake-mongoDBImage", false, sc.Spec.ConfigSrvSpec.GetAdditionalMongodConfig(), &sc.Spec, "", sc.Annotations, sc.CalculateFeatureCompatibilityVersion(), architectures.NonStatic)
+	}
+	configRs, _ := buildReplicaSetFromProcesses(configSvrSts.Name, configProcesses, sc, sc.Spec.GetMemberOptions(), om.NewDeployment())
+
+	d := om.NewDeployment()
+	_, err := d.MergeShardedCluster(om.DeploymentShardedClusterMergeOptions{
+		Name:            sc.Name,
+		MongosProcesses: mongosProcesses,
+		ConfigServerRs:  configRs,
+		Shards:          []om.ReplicaSetWithProcesses{shardRs},
+		Finalizing:      false,
+	})
+	require.NoError(t, err)
+	d.ConfigureMonitoringAndBackup(zap.S(), sc.Spec.GetSecurity().IsTLSEnabled(), util.CAFilePathInContainer)
+	return d
+}
+
+// newShardedClusterWithExternalMember builds a sharded MongoDB with a single shard whose AC
+// replica set name ("vm-shard-0") differs from its K8s shard name ("<name>-0"), mirroring what
+// migrate-to-mck emits via shardNameOverrides, plus the corresponding external mongod member.
+func newShardedClusterWithExternalMember(name string) *mdbv1.MongoDB {
+	sc := test.DefaultClusterBuilder().
+		SetName(name).
+		SetVersion("8.2.0").
+		SetShardCountSpec(1).
+		SetShardCountStatus(1).
+		SetMongodsPerShardCountSpec(0).
+		SetMongodsPerShardCountStatus(0).
+		Build()
+	sc.Spec.ShardNameOverrides = []mdbv1.ShardNameOverride{
+		{ShardName: sc.ShardName(0), ShardId: "vm-shard-0", ReplicaSetName: "vm-shard-0"},
+	}
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-shard-0", Hostname: "vm-shard-0.example.com:27017", Type: "mongod", ReplicaSetName: "vm-shard-0"},
+	}
+	return sc
+}
+
+func TestShardedMigration_ProceedsWhenVMProcessHasSearchConfig(t *testing.T) {
+	ctx := context.Background()
+	sc := newShardedClusterWithExternalMember("search-on-vm-sc")
+
+	reconciler, _, kubeClient, omConnectionFactory, err := defaultShardedClusterReconciler(ctx, nil, "", "", sc, nil, testBackupEnableDelay, architectures.NonStatic)
+	require.NoError(t, err)
+	omConnectionFactory.SetPostCreateHook(func(conn om.Connection) {
+		_, _ = conn.(*om.MockedOmConnection).UpdateDeployment(vmShardProcessWithSearchSetParameters(t, sc, true))
+	})
+
+	// Search setParameters on the external (VM) shard process do not hold the migration back: the
+	// MongoDBSearch keeps its external source and its host seeds are maintained by the user.
+	checkReconcileSuccessful(ctx, t, reconciler, sc, kubeClient)
+}
+
 func computeSingleClusterShardOverridesFromDistribution(shardOverridesDistribution map[string]int) []mdbv1.ShardOverride {
 	var shardOverrides []mdbv1.ShardOverride
 

--- a/controllers/searchcontroller/sharded_internal_search_source.go
+++ b/controllers/searchcontroller/sharded_internal_search_source.go
@@ -40,9 +40,7 @@ func (r *ShardedInternalSearchSource) GetShardCount() int {
 // externalMembersForK8sShardName maps the Kubernetes shard name the search plan works with
 // (MongoDB.ShardName(i)) to the Automation Config replica set name that external members are
 // recorded under (MongoDB.ShardACRsName(i), which spec.shardNameOverrides can change), and
-// returns that shard's external mongod members. Filtering by the Kubernetes name directly
-// would silently return nothing whenever an override is set -- which is exactly what
-// migrate-to-mck emits when the VM replica set name differs from the Kubernetes shard name.
+// returns that shard's external mongod members.
 func (r *ShardedInternalSearchSource) externalMembersForK8sShardName(shardName string) []mdbv1.ExternalMember {
 	for i := 0; i < r.Spec.ShardCount; i++ {
 		if r.ShardName(i) == shardName {
@@ -52,9 +50,8 @@ func (r *ShardedInternalSearchSource) externalMembersForK8sShardName(shardName s
 	return nil
 }
 
-// HostSeeds returns the sync-source seed list for one shard: the Kubernetes mongods first, then
-// any external (VM) members still in the shard. During a VM migration mongodsPerShardCount may be
-// 0, in which case the external members are the only seeds.
+// HostSeeds returns the hosts mongot syncs one shard's data from. Kubernetes mongods come
+// first, then any external (VM) members still in the shard.
 func (r *ShardedInternalSearchSource) HostSeeds(shardName string) ([]string, error) {
 	members := r.Spec.MongodsPerShardCount
 	clusterDomain := r.Spec.GetClusterDomain()
@@ -67,10 +64,27 @@ func (r *ShardedInternalSearchSource) HostSeeds(shardName string) ([]string, err
 		seeds = append(seeds, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
 			shardName, i, r.ShardServiceName(), r.Namespace, clusterDomain, port))
 	}
-	for _, m := range externalMembers {
-		seeds = append(seeds, m.Hostname)
+	return append(seeds, externalHostnames(externalMembers)...), nil
+}
+
+// externalHostnames returns the hostnames of the given external members.
+func externalHostnames(members []mdbv1.ExternalMember) []string {
+	hostnames := make([]string, 0, len(members))
+	for _, m := range members {
+		hostnames = append(hostnames, m.Hostname)
 	}
-	return seeds, nil
+	return hostnames
+}
+
+// externalMongosHostnames returns the hostnames of the given external members that are mongos.
+func externalMongosHostnames(members []mdbv1.ExternalMember) []string {
+	hostnames := make([]string, 0, len(members))
+	for _, m := range members {
+		if m.Type == mdbv1.ExternalMemberTypeMongos {
+			hostnames = append(hostnames, m.Hostname)
+		}
+	}
+	return hostnames
 }
 
 // MongosHostsAndPorts returns the routers mongot should talk to: the Kubernetes mongos Service
@@ -84,12 +98,7 @@ func (r *ShardedInternalSearchSource) MongosHostsAndPorts() []string {
 	if r.Spec.MongosCount > 0 {
 		hosts = append(hosts, fmt.Sprintf("%s.%s.svc.%s:%d", r.ServiceName(), r.Namespace, clusterDomain, port))
 	}
-	for _, m := range r.Spec.ExternalMembers {
-		if m.Type == mdbv1.ExternalMemberTypeMongos {
-			hosts = append(hosts, m.Hostname)
-		}
-	}
-	return hosts
+	return append(hosts, externalMongosHostnames(r.Spec.ExternalMembers)...)
 }
 
 func (r *ShardedInternalSearchSource) TLSConfig() *TLSSourceConfig {

--- a/controllers/searchcontroller/sharded_internal_search_source.go
+++ b/controllers/searchcontroller/sharded_internal_search_source.go
@@ -37,24 +37,59 @@ func (r *ShardedInternalSearchSource) GetShardCount() int {
 	return r.Spec.ShardCount
 }
 
+// externalMembersForK8sShardName maps the Kubernetes shard name the search plan works with
+// (MongoDB.ShardName(i)) to the Automation Config replica set name that external members are
+// recorded under (MongoDB.ShardACRsName(i), which spec.shardNameOverrides can change), and
+// returns that shard's external mongod members. Filtering by the Kubernetes name directly
+// would silently return nothing whenever an override is set -- which is exactly what
+// migrate-to-mck emits when the VM replica set name differs from the Kubernetes shard name.
+func (r *ShardedInternalSearchSource) externalMembersForK8sShardName(shardName string) []mdbv1.ExternalMember {
+	for i := 0; i < r.Spec.ShardCount; i++ {
+		if r.ShardName(i) == shardName {
+			return r.Spec.GetExternalMembersForRS(r.ShardACRsName(i))
+		}
+	}
+	return nil
+}
+
+// HostSeeds returns the sync-source seed list for one shard: the Kubernetes mongods first, then
+// any external (VM) members still in the shard. During a VM migration mongodsPerShardCount may be
+// 0, in which case the external members are the only seeds.
 func (r *ShardedInternalSearchSource) HostSeeds(shardName string) ([]string, error) {
 	members := r.Spec.MongodsPerShardCount
 	clusterDomain := r.Spec.GetClusterDomain()
 	port := r.Spec.GetAdditionalMongodConfig().GetPortOrDefault()
 
-	seeds := make([]string, members)
+	externalMembers := r.externalMembersForK8sShardName(shardName)
+	seeds := make([]string, 0, members+len(externalMembers))
 	for i := 0; i < members; i++ {
 		// Format: <shardName>-<memberIdx>.<shardServiceName>.<namespace>.svc.<clusterDomain>:<port>
-		seeds[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
-			shardName, i, r.ShardServiceName(), r.Namespace, clusterDomain, port)
+		seeds = append(seeds, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
+			shardName, i, r.ShardServiceName(), r.Namespace, clusterDomain, port))
+	}
+	for _, m := range externalMembers {
+		seeds = append(seeds, m.Hostname)
 	}
 	return seeds, nil
 }
 
+// MongosHostsAndPorts returns the routers mongot should talk to: the Kubernetes mongos Service
+// plus any external (VM) mongos still in the cluster. The Service entry is omitted while
+// mongosCount is 0 (a valid mid-migration state) because it would resolve to no endpoints.
 func (r *ShardedInternalSearchSource) MongosHostsAndPorts() []string {
 	clusterDomain := r.Spec.GetClusterDomain()
 	port := r.Spec.GetAdditionalMongodConfig().GetPortOrDefault()
-	return []string{fmt.Sprintf("%s.%s.svc.%s:%d", r.ServiceName(), r.Namespace, clusterDomain, port)}
+
+	hosts := make([]string, 0, 1+len(r.Spec.ExternalMembers))
+	if r.Spec.MongosCount > 0 {
+		hosts = append(hosts, fmt.Sprintf("%s.%s.svc.%s:%d", r.ServiceName(), r.Namespace, clusterDomain, port))
+	}
+	for _, m := range r.Spec.ExternalMembers {
+		if m.Type == mdbv1.ExternalMemberTypeMongos {
+			hosts = append(hosts, m.Hostname)
+		}
+	}
+	return hosts
 }
 
 func (r *ShardedInternalSearchSource) TLSConfig() *TLSSourceConfig {

--- a/controllers/searchcontroller/sharded_internal_search_source.go
+++ b/controllers/searchcontroller/sharded_internal_search_source.go
@@ -53,18 +53,22 @@ func (r *ShardedInternalSearchSource) externalMembersForK8sShardName(shardName s
 // HostSeeds returns the hosts mongot syncs one shard's data from. Kubernetes mongods come
 // first, then any external (VM) members still in the shard.
 func (r *ShardedInternalSearchSource) HostSeeds(shardName string) ([]string, error) {
-	members := r.Spec.MongodsPerShardCount
+	externalMembers := r.externalMembersForK8sShardName(shardName)
+	return append(r.kubernetesMongodHosts(shardName), externalHostnames(externalMembers)...), nil
+}
+
+// kubernetesMongodHosts returns the pod FQDNs of the Kubernetes mongods in one shard, in the
+// form <shardName>-<memberIdx>.<shardServiceName>.<namespace>.svc.<clusterDomain>:<port>.
+func (r *ShardedInternalSearchSource) kubernetesMongodHosts(shardName string) []string {
 	clusterDomain := r.Spec.GetClusterDomain()
 	port := r.Spec.GetAdditionalMongodConfig().GetPortOrDefault()
 
-	externalMembers := r.externalMembersForK8sShardName(shardName)
-	seeds := make([]string, 0, members+len(externalMembers))
-	for i := 0; i < members; i++ {
-		// Format: <shardName>-<memberIdx>.<shardServiceName>.<namespace>.svc.<clusterDomain>:<port>
-		seeds = append(seeds, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
+	hosts := make([]string, 0, r.Spec.MongodsPerShardCount)
+	for i := 0; i < r.Spec.MongodsPerShardCount; i++ {
+		hosts = append(hosts, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
 			shardName, i, r.ShardServiceName(), r.Namespace, clusterDomain, port))
 	}
-	return append(seeds, externalHostnames(externalMembers)...), nil
+	return hosts
 }
 
 // externalHostnames returns the hostnames of the given external members.
@@ -87,18 +91,22 @@ func externalMongosHostnames(members []mdbv1.ExternalMember) []string {
 	return hostnames
 }
 
-// MongosHostsAndPorts returns the routers mongot should talk to: the Kubernetes mongos Service
-// plus any external (VM) mongos still in the cluster. The Service entry is omitted while
-// mongosCount is 0 (a valid mid-migration state) because it would resolve to no endpoints.
+// MongosHostsAndPorts returns the routers mongot should talk to. The Kubernetes mongos
+// Service comes first, then any external (VM) mongos still in the cluster.
 func (r *ShardedInternalSearchSource) MongosHostsAndPorts() []string {
+	return append(r.kubernetesMongosHosts(), externalMongosHostnames(r.Spec.ExternalMembers)...)
+}
+
+// kubernetesMongosHosts returns the Kubernetes mongos Service, or an empty slice while
+// mongosCount is 0, in which case the Service resolves to no endpoints.
+func (r *ShardedInternalSearchSource) kubernetesMongosHosts() []string {
+	hosts := make([]string, 0, 1)
+	if r.Spec.MongosCount == 0 {
+		return hosts
+	}
 	clusterDomain := r.Spec.GetClusterDomain()
 	port := r.Spec.GetAdditionalMongodConfig().GetPortOrDefault()
-
-	hosts := make([]string, 0, 1+len(r.Spec.ExternalMembers))
-	if r.Spec.MongosCount > 0 {
-		hosts = append(hosts, fmt.Sprintf("%s.%s.svc.%s:%d", r.ServiceName(), r.Namespace, clusterDomain, port))
-	}
-	return append(hosts, externalMongosHostnames(r.Spec.ExternalMembers)...)
+	return append(hosts, fmt.Sprintf("%s.%s.svc.%s:%d", r.ServiceName(), r.Namespace, clusterDomain, port))
 }
 
 func (r *ShardedInternalSearchSource) TLSConfig() *TLSSourceConfig {

--- a/controllers/searchcontroller/sharded_internal_search_source_test.go
+++ b/controllers/searchcontroller/sharded_internal_search_source_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"

--- a/controllers/searchcontroller/sharded_internal_search_source_test.go
+++ b/controllers/searchcontroller/sharded_internal_search_source_test.go
@@ -1,0 +1,151 @@
+package searchcontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
+	"github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/status"
+)
+
+// newShardedSourceMDB builds a minimal single-cluster sharded MongoDB named "sc" in "ns".
+func newShardedSourceMDB(shardCount, mongodsPerShard, mongosCount int) *mdbv1.MongoDB {
+	return &mdbv1.MongoDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "sc", Namespace: "ns"},
+		Spec: mdbv1.MongoDbSpec{
+			DbCommonSpec: mdbv1.DbCommonSpec{
+				Version:      "8.2.0-ent",
+				ResourceType: mdbv1.ShardedCluster,
+			},
+			MongodbShardedClusterSizeConfig: status.MongodbShardedClusterSizeConfig{
+				ShardCount:           shardCount,
+				MongodsPerShardCount: mongodsPerShard,
+				MongosCount:          mongosCount,
+				ConfigServerCount:    1,
+			},
+		},
+	}
+}
+
+func TestShardedInternalSearchSource_HostSeeds_InternalOnly(t *testing.T) {
+	sc := newShardedSourceMDB(1, 2, 1)
+	seeds, err := NewShardedInternalSearchSource(sc, nil).HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"sc-0-0.sc-sh.ns.svc.cluster.local:27017",
+		"sc-0-1.sc-sh.ns.svc.cluster.local:27017",
+	}, seeds)
+}
+
+func TestShardedInternalSearchSource_HostSeeds_ExternalOnly(t *testing.T) {
+	sc := newShardedSourceMDB(1, 0, 0)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-shard-0", Hostname: "vm-shard-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-0"},
+		{ProcessName: "vm-shard-1", Hostname: "vm-shard-1.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-0"},
+	}
+	seeds, err := NewShardedInternalSearchSource(sc, nil).HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"vm-shard-0.example.com:27017",
+		"vm-shard-1.example.com:27017",
+	}, seeds)
+}
+
+func TestShardedInternalSearchSource_HostSeeds_Mixed(t *testing.T) {
+	sc := newShardedSourceMDB(1, 1, 1)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-shard-0", Hostname: "vm-shard-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-0"},
+	}
+	seeds, err := NewShardedInternalSearchSource(sc, nil).HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"sc-0-0.sc-sh.ns.svc.cluster.local:27017",
+		"vm-shard-0.example.com:27017",
+	}, seeds)
+}
+
+// The migration tool emits shardNameOverrides whenever the VM replica set name differs from the
+// K8s shard name, so this is the shape a real migration produces. HostSeeds is called with the
+// K8s name but external members are recorded under the AC replica set name.
+func TestShardedInternalSearchSource_HostSeeds_HonoursShardNameOverrides(t *testing.T) {
+	sc := newShardedSourceMDB(1, 0, 0)
+	sc.Spec.ShardNameOverrides = []mdbv1.ShardNameOverride{
+		{ShardName: "sc-0", ReplicaSetName: "vm-shard-0"},
+	}
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-shard-0-0", Hostname: "vm-shard-0-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "vm-shard-0"},
+	}
+	seeds, err := NewShardedInternalSearchSource(sc, nil).HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vm-shard-0-0.example.com:27017"}, seeds)
+}
+
+// External members of a different shard must not leak into this shard's seeds.
+func TestShardedInternalSearchSource_HostSeeds_IsolatesShards(t *testing.T) {
+	sc := newShardedSourceMDB(2, 0, 0)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-a", Hostname: "vm-a.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-0"},
+		{ProcessName: "vm-b", Hostname: "vm-b.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-1"},
+	}
+	src := NewShardedInternalSearchSource(sc, nil)
+
+	seeds0, err := src.HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vm-a.example.com:27017"}, seeds0)
+
+	seeds1, err := src.HostSeeds("sc-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vm-b.example.com:27017"}, seeds1)
+}
+
+// Config-server external members are mongods too; mongot never syncs from them.
+func TestShardedInternalSearchSource_HostSeeds_ExcludesConfigServerMembers(t *testing.T) {
+	sc := newShardedSourceMDB(1, 0, 0)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-cfg-0", Hostname: "vm-cfg-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-config"},
+	}
+	seeds, err := NewShardedInternalSearchSource(sc, nil).HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.Empty(t, seeds)
+}
+
+func TestShardedInternalSearchSource_MongosHostsAndPorts_InternalOnly(t *testing.T) {
+	sc := newShardedSourceMDB(1, 2, 2)
+	assert.Equal(t,
+		[]string{"sc-svc.ns.svc.cluster.local:27017"},
+		NewShardedInternalSearchSource(sc, nil).MongosHostsAndPorts())
+}
+
+func TestShardedInternalSearchSource_MongosHostsAndPorts_ExternalOnly(t *testing.T) {
+	sc := newShardedSourceMDB(1, 0, 0)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-mongos-0", Hostname: "vm-mongos-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongos},
+		{ProcessName: "vm-shard-0", Hostname: "vm-shard-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-0"},
+	}
+	// The K8s mongos Service is omitted while mongosCount == 0: it would resolve to no endpoints.
+	assert.Equal(t,
+		[]string{"vm-mongos-0.example.com:27017"},
+		NewShardedInternalSearchSource(sc, nil).MongosHostsAndPorts())
+}
+
+func TestShardedInternalSearchSource_MongosHostsAndPorts_Mixed(t *testing.T) {
+	sc := newShardedSourceMDB(1, 1, 1)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-mongos-0", Hostname: "vm-mongos-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongos},
+	}
+	assert.Equal(t,
+		[]string{"sc-svc.ns.svc.cluster.local:27017", "vm-mongos-0.example.com:27017"},
+		NewShardedInternalSearchSource(sc, nil).MongosHostsAndPorts())
+}
+
+// mongodsPerShardCount == 0 is legal mid-migration and must not fail validation.
+func TestShardedInternalSearchSource_Validate_AllowsZeroMongodsPerShardDuringMigration(t *testing.T) {
+	sc := newShardedSourceMDB(1, 0, 0)
+	sc.Spec.ExternalMembers = []mdbv1.ExternalMember{
+		{ProcessName: "vm-shard-0", Hostname: "vm-shard-0.example.com:27017", Type: mdbv1.ExternalMemberTypeMongod, ReplicaSetName: "sc-0"},
+	}
+	assert.NoError(t, NewShardedInternalSearchSource(sc, nil).Validate())
+}

--- a/controllers/searchcontroller/sharded_internal_search_source_test.go
+++ b/controllers/searchcontroller/sharded_internal_search_source_test.go
@@ -142,6 +142,21 @@ func TestShardedInternalSearchSource_MongosHostsAndPorts_Mixed(t *testing.T) {
 		NewShardedInternalSearchSource(sc, nil).MongosHostsAndPorts())
 }
 
+// Both host lists feed mongot's hostAndPort field, which has no omitempty, so an empty
+// result must marshal as [] rather than null.
+func TestShardedInternalSearchSource_HostListsAreEmptyNotNil(t *testing.T) {
+	sc := newShardedSourceMDB(1, 0, 0)
+
+	seeds, err := NewShardedInternalSearchSource(sc, nil).HostSeeds("sc-0")
+	require.NoError(t, err)
+	assert.NotNil(t, seeds, "HostSeeds must return an empty slice, not nil")
+	assert.Empty(t, seeds)
+
+	routers := NewShardedInternalSearchSource(sc, nil).MongosHostsAndPorts()
+	assert.NotNil(t, routers, "MongosHostsAndPorts must return an empty slice, not nil")
+	assert.Empty(t, routers)
+}
+
 // mongodsPerShardCount == 0 is legal mid-migration and must not fail validation.
 func TestShardedInternalSearchSource_Validate_AllowsZeroMongodsPerShardDuringMigration(t *testing.T) {
 	sc := newShardedSourceMDB(1, 0, 0)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/replicaset/vm_migration_replicaset_search.py
@@ -1,0 +1,479 @@
+"""
+VM migration of a replica set that has a MongoDBSearch resource attached.
+
+Search is first attached to the VM replica set through an external source, proving it works
+before migration. The migration then proceeds without waiting for the MongoDBSearch to be
+repointed. The search resource keeps that external source for the whole migration: its host seeds
+are updated by hand as members move from the VMs to Kubernetes, and search must survive promote
+and prune.
+"""
+
+from kubetester import create_or_update_secret, try_load
+from kubetester.kubetester import KubernetesTester, fcv_from_version
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongotester import MongoDBBackgroundTester, with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_sha256_creds
+from pytest import fixture, mark
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import movies_search_helper, search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
+from tests.vm_migration.vm_migration_common_helper import (
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_replicaset_helper import (
+    apply_generated_mongodb_resource,
+    assert_connection_string_after_full_migration,
+    assert_k8s_process_names,
+    deploy_vm_service,
+    deploy_vm_statefulset,
+    k8s_hostnames,
+    promote_and_prune,
+    vm_replica_set_tester,
+)
+
+MDB_VERSION = "8.2.0-ent"
+
+# The mongot endpoint hand-written into the automation config below derives from this MongoDBSearch
+# resource's own name (<name>-search), which is what names the mongot StatefulSet. The name never
+# changes during the migration, so the endpoint stays resolvable throughout. The generated CR's own
+# name is independent and need not match.
+MDBS_RESOURCE_NAME = "vm-mongodb"
+
+AGENT_PASSWORD = "mms-automation-agent-password"
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+
+KEYFILE_SECRET_NAME = "vm-mongodb-keyfile"
+KEYFILE_CONTENTS = "dm0tbWlncmF0aW9uLXNlYXJjaC1rZXlmaWxlLWNvbnRlbnRzLXBhZGRpbmc="
+MONGOT_PASSWORD_SECRET_NAME = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
+
+# The mongot setParameters the operator would write itself. mongotHost and
+# searchIndexManagementHostAndPort are added once the endpoint is known. Kept in sync with
+# buildSearchSetParameters (controllers/searchcontroller/mongodbsearch_reconcile_helper.go); the same
+# keys are carried into the generated CR: they are no longer listed in infrastructureFieldPaths
+# in controllers/om/process.go, because Ops Manager does not propagate them onto new processes.
+SEARCH_SET_PARAMETER = {
+    "skipAuthenticationToSearchIndexManagementServer": False,
+    "skipAuthenticationToMongot": False,
+    "searchTLSMode": "disabled",
+    "useGrpcForSearch": True,
+}
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_service(namespace: str):
+    return deploy_vm_service(namespace)
+
+
+@fixture(scope="module")
+def mongot_host(namespace: str) -> str:
+    return search_resource_names.mongot_pod_fqdn(MDBS_RESOURCE_NAME, namespace, 27028)
+
+
+def _configure_ac_with_search(namespace: str, om_tester: OMTester, vm_sts: dict, vm_service: dict, mongot_host: str):
+    """SCRAM replica set with the mongot sync-source user and the mongot setParameters."""
+    ac = om_tester.api_get_automation_config()
+    if len(ac["processes"]) > 0:
+        return
+
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": "mms-automation-agent",
+                "db": "admin",
+                "roles": [{"role": "root", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": build_sha256_creds(AGENT_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+            {
+                "user": ADMIN_USER_NAME,
+                "db": "admin",
+                "roles": [{"role": "root", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": build_sha256_creds(ADMIN_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+            {
+                # Mirrors the roles in the mongodbuser-search-sync-source-user.yaml fixture,
+                # which cannot be used here because there is no MongoDB CR yet.
+                "user": MONGOT_USER_NAME,
+                "db": "admin",
+                "roles": [{"role": "searchCoordinator", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": build_sha256_creds(MONGOT_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanism": "SCRAM-SHA-256",
+        "autoUser": "mms-automation-agent",
+        "autoPwd": AGENT_PASSWORD,
+        "autoAuthRestrictions": [],
+        "key": KEYFILE_CONTENTS,
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    ac["processes"] = []
+    ac["monitoringVersions"] = []
+    ac["replicaSets"] = [{"_id": rs_name, "members": [], "protocolVersion": "1"}]
+
+    for i in range(vm_sts["spec"]["replicas"]):
+        hostname = f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local"
+
+        ac["monitoringVersions"].append(
+            {
+                "hostname": hostname,
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+            }
+        )
+
+        ac["processes"].append(
+            {
+                "version": MDB_VERSION,
+                "name": f"{sts_name}-{i}",
+                "hostname": hostname,
+                "logRotate": {"sizeThresholdMB": 1000, "timeThresholdHrs": 24},
+                "authSchemaVersion": 5,
+                "featureCompatibilityVersion": fcv_from_version(MDB_VERSION),
+                "processType": "mongod",
+                "args2_6": {
+                    "net": {"port": 27017, "tls": {"mode": "disabled"}},
+                    "storage": {"dbPath": "/data/"},
+                    "systemLog": {"path": "/data/mongodb.log", "destination": "file"},
+                    "replication": {"replSetName": rs_name},
+                    "setParameter": dict(
+                        SEARCH_SET_PARAMETER,
+                        mongotHost=mongot_host,
+                        searchIndexManagementHostAndPort=mongot_host,
+                    ),
+                },
+            }
+        )
+
+        ac["replicaSets"][0]["members"].append(
+            {
+                "_id": i + 100,
+                "host": f"{sts_name}-{i}",
+                "priority": 1,
+                "votes": 1,
+                "secondaryDelaySecs": 0,
+                "hidden": False,
+                "arbiterOnly": False,
+            }
+        )
+
+    om_tester.api_put_automation_config(ac)
+
+
+def _vm_host_seeds(namespace: str, vm_sts: dict, vm_service: dict) -> list[str]:
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    return [f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local:27017" for i in range(vm_sts["spec"]["replicas"])]
+
+
+@fixture(scope="module")
+def mdbs(namespace: str, vm_sts: dict, vm_service: dict) -> MongoDBSearch:
+    """MongoDBSearch pointing at the VM mongods through an external source."""
+    seeds = _vm_host_seeds(namespace, vm_sts, vm_service)
+
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-minimal.yaml"), namespace=namespace, name=MDBS_RESOURCE_NAME
+    )
+    if try_load(resource):
+        return resource
+
+    resource["spec"]["source"] = {
+        "username": MONGOT_USER_NAME,
+        "passwordSecretRef": {"name": MONGOT_PASSWORD_SECRET_NAME, "key": "password"},
+        # Field name is `keyfileSecretRef` on the wire (api/v1/search/mongodbsearch_types.go),
+        # despite the Go struct field being named KeyFileSecretKeyRef.
+        "external": {"hostAndPorts": seeds, "keyfileSecretRef": {"name": KEYFILE_SECRET_NAME, "key": "keyfile"}},
+    }
+    return resource
+
+
+def _vm_search_tester(namespace: str, vm_sts: dict, vm_service: dict, username: str, password: str) -> SearchTester:
+    """Build a SearchTester with credentials embedded in the connection string.
+
+    SearchTester.for_replicaset needs a MongoDB object, which does not exist yet during the VM
+    phase; vm_replica_set_tester()'s cnx_string carries no credentials (auth is normally supplied
+    via `opts` at query time instead), so a raw connection string is built by hand here, following
+    the same shape SearchTester.for_replicaset uses once a MongoDB resource exists.
+    """
+    sts_name = vm_sts["metadata"]["name"]
+    svc_name = vm_service["metadata"]["name"]
+    rs_name = f"{sts_name}-rs"
+    hosts = ",".join(
+        f"{sts_name}-{i}.{svc_name}.{namespace}.svc.cluster.local:27017" for i in range(vm_sts["spec"]["replicas"])
+    )
+    cnx_string = f"mongodb://{username}:{password}@{hosts}/?replicaSet={rs_name}&authSource=admin"
+    return SearchTester(cnx_string)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_deploy_vm_replicaset(namespace: str, om_tester: OMTester, vm_sts, vm_service, mongot_host: str):
+    _configure_ac_with_search(namespace, om_tester, vm_sts, vm_service, mongot_host)
+    om_tester.wait_agents_ready()
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_create_search_secrets(namespace: str):
+    create_or_update_secret(namespace, name=MONGOT_PASSWORD_SECRET_NAME, data={"password": MONGOT_USER_PASSWORD})
+    # Manual equivalent of mirrorKeyfileIntoSecretForMongot, which only runs for MongoDB CRs.
+    create_or_update_secret(namespace, name=KEYFILE_SECRET_NAME, data={"keyfile": KEYFILE_CONTENTS})
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_create_search_resource(mdbs: MongoDBSearch):
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_insert_migration_data(namespace: str):
+    insert_migration_data(
+        vm_replica_set_tester(namespace),
+        opts=[with_scram(ADMIN_USER_NAME, ADMIN_USER_PASSWORD, "SCRAM-SHA-256")],
+    )
+
+
+@fixture(scope="module")
+def sample_movies_helper(namespace: str, vm_sts: dict, vm_service: dict) -> SampleMoviesSearchHelper:
+    return movies_search_helper.SampleMoviesSearchHelper(
+        _vm_search_tester(namespace, vm_sts, vm_service, ADMIN_USER_NAME, ADMIN_USER_PASSWORD),
+        tools_pod=mongodb_tools_pod.get_tools_pod(namespace),
+    )
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_search_restore_sample_database(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.restore_sample_database()
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_search_create_index(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.create_search_index()
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_search_query_works_before_migration(sample_movies_helper: SampleMoviesSearchHelper):
+    """Establishes the baseline: without this, the post-migration assertion proves nothing."""
+    sample_movies_helper.assert_search_query(retry_timeout=120)
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    admin_secret = f"{ADMIN_USER_NAME}-migration-password"
+    create_or_update_secret(namespace, name=admin_secret, data={"password": ADMIN_USER_PASSWORD})
+    mongot_secret = f"{MONGOT_USER_NAME}-migration-password"
+    create_or_update_secret(namespace, name=mongot_secret, data={"password": MONGOT_USER_PASSWORD})
+    # user_secrets makes run_generate_cr also emit MongoDBUser CRs for the admin and mongot users,
+    # but generated_mongodb_doc() below picks out only the MongoDB document and those user CRs are
+    # never applied. That's deliberate, not an oversight: the hand-written automation config sets
+    # authoritativeSet: false, which the operator carries over as ignoreUnknownUsers: true, so it
+    # won't prune the VM-created users just because no matching MongoDBUser CRs exist in the
+    # cluster. Passing user_secrets here only exercises run_generate_cr's user-CR generation path.
+    return run_generate_cr(
+        namespace,
+        user_secrets={
+            f"{ADMIN_USER_NAME}:admin": admin_secret,
+            f"{MONGOT_USER_NAME}:admin": mongot_secret,
+        },
+    )
+
+
+@fixture(scope="module")
+def generated_cr(generated_cr_yaml: str) -> dict:
+    return generated_mongodb_doc(generated_cr_yaml)
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr: dict) -> MongoDB:
+    return apply_generated_mongodb_resource(namespace, generated_cr)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_generated_cr_carries_search_set_parameters(generated_cr: dict, mongot_host: str):
+    """The generated CR must carry the search setParameters.
+
+    Ops Manager does not propagate them onto the Kubernetes processes added by the migration, and
+    the MongoDBSearch here still targets the VM mongods through an external source, so
+    applySearchOverrides never runs. The CR is the only carrier; without it the migrated mongods
+    come up with no mongot wiring and search breaks.
+    """
+    expected = dict(SEARCH_SET_PARAMETER, mongotHost=mongot_host, searchIndexManagementHostAndPort=mongot_host)
+
+    set_parameter = generated_cr["spec"]["additionalMongodConfig"]["setParameter"]
+    for key, value in expected.items():
+        assert set_parameter.get(key) == value, f"setParameter.{key} is {set_parameter.get(key)!r}, expected {value!r}"
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_dry_run_passes(mdb_migration: MongoDB):
+    """run_migration_dry_run_connectivity_passes removes the MIGRATION_DRY_RUN_ANNOTATION itself once
+    connectivity verification passes, so the next reconcile mdb_migration goes through is already a
+    real (non-dry-run) one.
+    """
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_migration_proceeds_while_search_still_targets_vms(mdb_migration: MongoDB):
+    """The migration is not held back by the MongoDBSearch still pointing at the VM mongods."""
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1800)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_add_kubernetes_host_seeds_to_search_source(
+    namespace: str, mdbs: MongoDBSearch, mdb_migration: MongoDB, vm_sts: dict, vm_service: dict
+):
+    """The search resource keeps its external source for the whole migration; only the seed list
+    is maintained by hand.
+
+    The seeds are widened to the union of the VM and Kubernetes hostnames rather than swapped
+    outright: both address sets name members of the same replica set, and mongot has to keep at
+    least one reachable seed at every point of the promote/prune sequence that follows.
+    """
+    mdbs.load()
+    mdbs["spec"]["source"]["external"]["hostAndPorts"] = _vm_host_seeds(namespace, vm_sts, vm_service) + k8s_hostnames(
+        mdb_migration
+    )
+    mdbs.update()
+
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(ADMIN_USER_NAME, ADMIN_USER_PASSWORD, "SCRAM-SHA-256")]
+
+
+@fixture(scope="module")
+def mdb_health_checker(mdb_migration: MongoDB, scram_opts: list[dict]) -> MongoDBBackgroundTester:
+    return MongoDBBackgroundTester(
+        mdb_migration.tester(use_ssl=False),
+        health_function_params={"attempts": 1, "opts": scram_opts},
+    )
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_start_background_health_checker(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.start()
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_promote_and_prune(mdb_migration: MongoDB, vm_sts):
+    promote_and_prune(mdb_migration, vm_sts)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_drop_vm_host_seeds_from_search_source(mdbs: MongoDBSearch, mdb_migration: MongoDB):
+    """The VM members are gone from the replica set now, so their hostnames come out of the seed
+    list. This is the second and last hand-edit of the search resource in the whole flow."""
+    mdbs.load()
+    mdbs["spec"]["source"]["external"]["hostAndPorts"] = k8s_hostnames(mdb_migration)
+    mdbs.update()
+
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_mongodb_reachable_during_promote_and_prune(mdb_health_checker: MongoDBBackgroundTester):
+    mdb_health_checker.assert_healthiness()
+    mdb_health_checker.stop()
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_search_set_parameters_in_automation_config(om_tester: OMTester, mdb_migration: MongoDB, mongot_host: str):
+    """The Kubernetes mongods must carry the same search setParameters the VM processes had.
+
+    The generated CR is what puts them there (see test_generated_cr_carries_search_set_parameters):
+    no MongoDBSearch targets this MongoDB resource, so applySearchOverrides never runs, and Ops
+    Manager does not propagate the deployment's existing search configuration onto new processes.
+    This test is the end-to-end confirmation that the CR-side carrier reaches the automation
+    config.
+    """
+    expected = dict(SEARCH_SET_PARAMETER, mongotHost=mongot_host, searchIndexManagementHostAndPort=mongot_host)
+
+    ac = om_tester.api_get_automation_config()
+    k8s_processes = [p for p in ac["processes"] if p["name"].startswith(f"k8s/{mdb_migration.namespace}/")]
+    assert len(k8s_processes) == mdb_migration.get_members(), f"unexpected Kubernetes processes: {k8s_processes}"
+
+    for process in k8s_processes:
+        set_parameter = process["args2_6"].get("setParameter", {})
+        for key, value in expected.items():
+            assert (
+                set_parameter.get(key) == value
+            ), f"process {process['name']}: setParameter.{key} is {set_parameter.get(key)!r}, expected {value!r}"
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_search_resource_still_running(mdbs: MongoDBSearch):
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_search_query_works_after_migration(mdb_migration: MongoDB, namespace: str):
+    tester = SearchTester.for_replicaset(mdb_migration, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    helper = movies_search_helper.SampleMoviesSearchHelper(tester, tools_pod=mongodb_tools_pod.get_tools_pod(namespace))
+    helper.assert_search_query(retry_timeout=120)
+
+
+@mark.e2e_vm_migration_replicaset_search
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB):
+    assert_migration_data_exists(
+        mdb_migration.tester(use_ssl=False),
+        opts=[with_scram(ADMIN_USER_NAME, ADMIN_USER_PASSWORD, "SCRAM-SHA-256")],
+    )

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/shardedcluster/vm_migration_shardedcluster_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/shardedcluster/vm_migration_shardedcluster_search.py
@@ -1,0 +1,632 @@
+"""
+VM migration of a sharded cluster that has a MongoDBSearch resource attached.
+
+Search is first attached to the VM sharded cluster through an external sharded source, proving it
+works before migration. The search resource then keeps that external source for the whole
+migration: its shard seeds and router hosts are updated by hand as members move from the VMs to
+Kubernetes, and search must survive promote and prune.
+
+The VM shard replica set is deliberately named vm-shard-0, which differs from the Kubernetes shard
+name <MDB_RESOURCE_NAME>-0. migrate-to-mck therefore emits shardNameOverrides, and the per-shard
+seed lookup has to translate the Kubernetes shard name to the Automation Config replica set name.
+Renaming the VM shard to match the Kubernetes name would make this test pass even if that
+translation were wrong.
+"""
+
+from kubetester import create_or_update_secret, try_load
+from kubetester.kubetester import KubernetesTester, skip_if_local
+from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.mongodb import MongoDB
+from kubetester.mongodb_search import MongoDBSearch
+from kubetester.mongotester import with_scram
+from kubetester.omtester import OMContext, OMTester
+from kubetester.operator import Operator
+from kubetester.phase import Phase
+from kubetester.scram import build_sha256_creds
+from pytest import fixture, mark
+from tests.common.mongodb_tools_pod import mongodb_tools_pod
+from tests.common.search import movies_search_helper, search_resource_names
+from tests.common.search.movies_search_helper import SampleMoviesSearchHelper
+from tests.common.search.search_tester import SearchTester
+from tests.vm_migration.vm_migration_common_helper import (
+    assert_migration_data_exists,
+    generated_mongodb_doc,
+    insert_migration_data,
+    run_generate_cr,
+)
+from tests.vm_migration.vm_migration_dry_run import run_migration_dry_run_connectivity_passes
+from tests.vm_migration.vm_migration_sharded_helper import (
+    MIN_VM_CONFIGSRV,
+    MIN_VM_MONGOS,
+    MIN_VM_SHARD,
+    apply_generated_sharded_cluster_resource,
+    assert_connection_string_after_full_sharded_migration,
+    assert_k8s_sharded_process_names,
+    build_sharded_cluster_ac,
+    deploy_vm_sharded_configsrv_service,
+    deploy_vm_sharded_configsrv_statefulset,
+    deploy_vm_sharded_mongos_service,
+    deploy_vm_sharded_mongos_statefulset,
+    deploy_vm_sharded_shard_service,
+    deploy_vm_sharded_shard_statefulset,
+    promote_and_prune_shard,
+    vm_mongos_tester,
+)
+
+MDB_VERSION = "8.2.0-ent"
+
+CONFIGSRV_STS_NAME = "vm-sharded-configsrv"
+SHARD_STS_NAME = "vm-sharded-shard"
+MONGOS_STS_NAME = "vm-sharded-mongos"
+CONFIGSRV_SVC_NAME = "vm-sharded-configsrv"
+SHARD_SVC_NAME = "vm-sharded-shard"
+MONGOS_SVC_NAME = "vm-sharded-mongos"
+
+VM_CONFIG_RS_NAME = "vm-config"
+VM_SHARD_RS_NAME = "vm-shard-0"
+VM_MONGOS_NAME = "vm-mongos"
+
+# Pinned so the mongot endpoints hand-written into the automation config below can be computed
+# before the CR exists: they are derived from these two names, neither of which changes during the
+# migration, so the endpoints stay resolvable throughout.
+MDB_RESOURCE_NAME = "sharded-search-migration"
+MDBS_RESOURCE_NAME = "sharded-search"
+K8S_SHARD_NAME = f"{MDB_RESOURCE_NAME}-0"
+MONGOT_PORT = 27028
+
+AGENT_PASSWORD = "mms-automation-agent-password"
+ADMIN_USER_NAME = "mdb-admin-user"
+ADMIN_USER_PASSWORD = "mdb-admin-user-pass"
+MONGOT_USER_NAME = "search-sync-source"
+MONGOT_USER_PASSWORD = "search-sync-source-user-password"
+
+KEYFILE_SECRET_NAME = "vm-sharded-keyfile"
+KEYFILE_CONTENTS = "dm0tbWlncmF0aW9uLXNoYXJkZWQtc2VhcmNoLWtleWZpbGUtcGFk"
+MONGOT_PASSWORD_SECRET_NAME = f"{MDBS_RESOURCE_NAME}-{MONGOT_USER_NAME}-password"
+
+# The mongot setParameters the operator would write itself. mongotHost and
+# searchIndexManagementHostAndPort are added per-test once the endpoint is known. Kept in sync with
+# buildSearchSetParameters (controllers/searchcontroller/mongodbsearch_reconcile_helper.go); the same
+# keys are carried into the generated CR: they are no longer listed in infrastructureFieldPaths
+# in controllers/om/process.go, because Ops Manager does not propagate them onto new processes.
+SEARCH_SET_PARAMETER = {
+    "skipAuthenticationToSearchIndexManagementServer": False,
+    "skipAuthenticationToMongot": False,
+    "searchTLSMode": "disabled",
+    "useGrpcForSearch": True,
+}
+
+
+def _vm_shard_hosts(namespace: str) -> list[str]:
+    return [f"{SHARD_STS_NAME}-{i}.{SHARD_SVC_NAME}.{namespace}.svc.cluster.local:27017" for i in range(MIN_VM_SHARD)]
+
+
+def _vm_mongos_hosts(namespace: str) -> list[str]:
+    return [
+        f"{MONGOS_STS_NAME}-{i}.{MONGOS_SVC_NAME}.{namespace}.svc.cluster.local:27017" for i in range(MIN_VM_MONGOS)
+    ]
+
+
+def _k8s_shard_hosts(mdb_migration: MongoDB) -> list[str]:
+    """Pod FQDNs of the Kubernetes shard mongods, in the format the operator uses for the shard
+    StatefulSet's headless Service (<mdb>-sh)."""
+    return [
+        f"{K8S_SHARD_NAME}-{i}.{mdb_migration.name}-sh.{mdb_migration.namespace}.svc.cluster.local:27017"
+        for i in range(mdb_migration["spec"]["mongodsPerShardCount"])
+    ]
+
+
+def _k8s_mongos_hosts(mdb_migration: MongoDB) -> list[str]:
+    return [
+        f"{mdb_migration.name}-mongos-{i}.{mdb_migration.name}-svc.{mdb_migration.namespace}.svc.cluster.local:27017"
+        for i in range(mdb_migration["spec"]["mongosCount"])
+    ]
+
+
+@fixture(scope="module")
+def om_tester(namespace: str) -> OMTester:
+    config_map = KubernetesTester.read_configmap(namespace, "my-project")
+    secret = KubernetesTester.read_secret(namespace, "my-credentials")
+    tester = OMTester(OMContext.build_from_config_map_and_secret(config_map, secret))
+    tester.ensure_agent_api_key()
+    return tester
+
+
+@fixture(scope="module")
+def vm_configsrv_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_sharded_configsrv_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_shard_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_sharded_shard_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_mongos_sts(namespace: str, om_tester: OMTester):
+    return deploy_vm_sharded_mongos_statefulset(namespace, om_tester)
+
+
+@fixture(scope="module")
+def vm_configsrv_service(namespace: str):
+    return deploy_vm_sharded_configsrv_service(namespace)
+
+
+@fixture(scope="module")
+def vm_shard_service(namespace: str):
+    return deploy_vm_sharded_shard_service(namespace)
+
+
+@fixture(scope="module")
+def vm_mongos_service(namespace: str):
+    return deploy_vm_sharded_mongos_service(namespace)
+
+
+@fixture(scope="module")
+def mongot_host(namespace: str) -> str:
+    """The per-shard mongot endpoint, keyed by the KUBERNETES shard name.
+
+    This is the value written into the VM automation config below, and nothing rewrites it later:
+    the search resource keeps its external source, so the endpoint has to stay resolvable for the
+    whole migration. It does, because the mongot StatefulSet is named from the MongoDBSearch
+    resource and the shard entry's shardName, neither of which changes.
+    """
+    return search_resource_names.shard_pod_fqdn(MDBS_RESOURCE_NAME, K8S_SHARD_NAME, namespace, MONGOT_PORT)
+
+
+def _configure_ac_with_search(namespace: str, om_tester: OMTester, mongot_host: str):
+    """SCRAM sharded cluster with the mongot sync-source user and the mongot setParameters.
+
+    The setParameters go on the shard mongods and on the mongos, which is where the operator puts
+    them for a sharded cluster. The config server never gets them: mongot neither syncs from nor
+    routes through it.
+    """
+    existing = om_tester.api_get_automation_config()
+    if len(existing.get("processes", [])) > 0:
+        return
+
+    ac = build_sharded_cluster_ac(
+        om_tester,
+        configsrv_sts_name=CONFIGSRV_STS_NAME,
+        shard_sts_name=SHARD_STS_NAME,
+        mongos_sts_name=MONGOS_STS_NAME,
+        configsrv_service_name=CONFIGSRV_SVC_NAME,
+        shard_service_name=SHARD_SVC_NAME,
+        mongos_service_name=MONGOS_SVC_NAME,
+        namespace=namespace,
+        mongodb_version=MDB_VERSION,
+        config_rs_name=VM_CONFIG_RS_NAME,
+        shard_rs_name=VM_SHARD_RS_NAME,
+        config_server_count=MIN_VM_CONFIGSRV,
+        shard_count=MIN_VM_SHARD,
+        mongos_count=MIN_VM_MONGOS,
+        cluster_name=VM_MONGOS_NAME,
+    )
+
+    search_params = dict(SEARCH_SET_PARAMETER)
+    search_params["mongotHost"] = mongot_host
+    search_params["searchIndexManagementHostAndPort"] = mongot_host
+    for process in ac["processes"]:
+        is_shard_mongod = process["args2_6"].get("replication", {}).get("replSetName") == VM_SHARD_RS_NAME
+        if is_shard_mongod or process["processType"] == "mongos":
+            process["args2_6"]["setParameter"] = dict(search_params)
+
+    ac["auth"] = {
+        "usersWanted": [
+            {
+                "user": "mms-automation-agent",
+                "db": "admin",
+                "roles": [{"role": "root", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": build_sha256_creds(AGENT_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+            {
+                "user": ADMIN_USER_NAME,
+                "db": "admin",
+                "roles": [{"role": "root", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": build_sha256_creds(ADMIN_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+            {
+                # Mirrors the roles in the mongodbuser-search-sync-source-user.yaml fixture, which
+                # cannot be used here because there is no MongoDB CR yet.
+                "user": MONGOT_USER_NAME,
+                "db": "admin",
+                "roles": [{"role": "searchCoordinator", "db": "admin"}],
+                "mechanisms": ["SCRAM-SHA-256"],
+                "scramSha256Creds": build_sha256_creds(MONGOT_USER_PASSWORD),
+                "authenticationRestrictions": [],
+            },
+        ],
+        "usersDeleted": [],
+        "disabled": False,
+        "authoritativeSet": False,
+        "deploymentAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanisms": ["SCRAM-SHA-256"],
+        "autoAuthMechanism": "SCRAM-SHA-256",
+        "autoUser": "mms-automation-agent",
+        "autoPwd": AGENT_PASSWORD,
+        "autoAuthRestrictions": [],
+        "key": KEYFILE_CONTENTS,
+        "keyfile": "/var/lib/mongodb-mms-automation/keyfile",
+        "keyfileWindows": "%SystemDrive%\\MMSAutomation\\versions\\keyfile",
+    }
+
+    om_tester.api_put_automation_config(ac)
+
+
+@fixture(scope="module")
+def mdbs(namespace: str, vm_shard_sts: dict, vm_mongos_sts: dict) -> MongoDBSearch:
+    """MongoDBSearch pointing at the VM shard and VM mongos through an external sharded source.
+
+    shardName is the KUBERNETES shard name the generated CR will use, not the VM replica set name:
+    the mongot StatefulSet is named from it, and that name has to stay put for the whole migration,
+    otherwise the mongotHost baked into the automation config stops resolving.
+    """
+    resource = MongoDBSearch.from_yaml(
+        yaml_fixture("search-sharded-external-mongod.yaml"), namespace=namespace, name=MDBS_RESOURCE_NAME
+    )
+    if try_load(resource):
+        return resource
+
+    # The fixture ships security.tls.certsSecretPrefix for the TLS search suites; this deployment is
+    # plaintext, so the whole security block goes and external.tls is left out.
+    resource["spec"].pop("security", None)
+
+    resource["spec"]["source"] = {
+        "username": MONGOT_USER_NAME,
+        "passwordSecretRef": {"name": MONGOT_PASSWORD_SECRET_NAME, "key": "password"},
+        "external": {
+            "shardedCluster": {
+                "router": {"hosts": _vm_mongos_hosts(namespace)},
+                "shards": [{"shardName": K8S_SHARD_NAME, "hosts": _vm_shard_hosts(namespace)}],
+            },
+            # Field name is `keyfileSecretRef` on the wire (api/mongodb/v1/search/
+            # mongodbsearch_types.go), despite the Go struct field being named KeyFileSecretKeyRef.
+            "keyfileSecretRef": {"name": KEYFILE_SECRET_NAME, "key": "keyfile"},
+        },
+    }
+    return resource
+
+
+@fixture(scope="module")
+def scram_opts() -> list[dict]:
+    return [with_scram(ADMIN_USER_NAME, ADMIN_USER_PASSWORD, "SCRAM-SHA-256")]
+
+
+@fixture(scope="module")
+def sample_movies_helper(namespace: str) -> SampleMoviesSearchHelper:
+    # Built by hand rather than via SearchTester.for_sharded because no MongoDB CR exists yet, and
+    # vm_mongos_tester's URI carries no credentials. Mongos routers are not a replica set, so no
+    # replicaSet= option here.
+    hosts = ",".join(_vm_mongos_hosts(namespace))
+    cnx_string = f"mongodb://{ADMIN_USER_NAME}:{ADMIN_USER_PASSWORD}@{hosts}/?authSource=admin"
+    return movies_search_helper.SampleMoviesSearchHelper(
+        SearchTester(cnx_string), tools_pod=mongodb_tools_pod.get_tools_pod(namespace)
+    )
+
+
+@fixture(scope="module")
+def generated_cr_yaml(namespace: str) -> str:
+    admin_secret = f"{ADMIN_USER_NAME}-migration-password"
+    create_or_update_secret(namespace, name=admin_secret, data={"password": ADMIN_USER_PASSWORD})
+    mongot_secret = f"{MONGOT_USER_NAME}-migration-password"
+    create_or_update_secret(namespace, name=mongot_secret, data={"password": MONGOT_USER_PASSWORD})
+    # The SCRAM users in the hand-written automation config have to be mapped to Secrets here:
+    # without --users-secrets-file the users subcommand prompts for each Secret name on stdin
+    # (collectUserSecretNamesInteractively), which has nowhere to read from under pytest.
+    #
+    # Only the MongoDB document is applied (apply_generated_sharded_cluster_resource picks it out);
+    # the generated MongoDBUser CRs are never applied. That's deliberate: the automation config sets
+    # authoritativeSet: false, which the operator carries over as ignoreUnknownUsers: true, so it
+    # won't prune the VM-created users just because no matching MongoDBUser CRs exist.
+    return run_generate_cr(
+        namespace,
+        resource_name_override=MDB_RESOURCE_NAME,
+        user_secrets={
+            f"{ADMIN_USER_NAME}:admin": admin_secret,
+            f"{MONGOT_USER_NAME}:admin": mongot_secret,
+        },
+    )
+
+
+@fixture(scope="module")
+def mdb_migration(namespace: str, generated_cr_yaml: str) -> MongoDB:
+    return apply_generated_sharded_cluster_resource(namespace, generated_cr_yaml, VM_CONFIG_RS_NAME)
+
+
+# VM phase
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_install_operator(operator: Operator):
+    operator.wait_for_operator_ready()
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_deploy_vm_sharded_cluster(
+    namespace: str,
+    om_tester: OMTester,
+    vm_configsrv_sts,
+    vm_shard_sts,
+    vm_mongos_sts,
+    vm_configsrv_service,
+    vm_shard_service,
+    vm_mongos_service,
+    mongot_host: str,
+):
+    _configure_ac_with_search(namespace, om_tester, mongot_host)
+    om_tester.wait_agents_ready()
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_create_search_secrets(namespace: str):
+    create_or_update_secret(namespace, name=MONGOT_PASSWORD_SECRET_NAME, data={"password": MONGOT_USER_PASSWORD})
+    # Manual equivalent of mirrorKeyfileIntoSecretForMongot, which only runs for MongoDB CRs.
+    create_or_update_secret(namespace, name=KEYFILE_SECRET_NAME, data={"keyfile": KEYFILE_CONTENTS})
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_create_search_resource(mdbs: MongoDBSearch):
+    mdbs.update()
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+@skip_if_local
+def test_insert_migration_data(namespace: str, scram_opts: list[dict]):
+    insert_migration_data(vm_mongos_tester(MONGOS_STS_NAME, MONGOS_SVC_NAME, namespace), opts=scram_opts)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_restore_sample_database(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.restore_sample_database()
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_create_index(sample_movies_helper: SampleMoviesSearchHelper):
+    sample_movies_helper.create_search_index()
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_query_works_before_migration(sample_movies_helper: SampleMoviesSearchHelper):
+    """Establishes the baseline: without this, the post-migration assertion proves nothing."""
+    sample_movies_helper.assert_search_query(retry_timeout=120)
+
+
+# Migration phase
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_generated_cr_has_shard_name_override(mdb_migration: MongoDB):
+    """The VM shard replica set name differs from the Kubernetes shard name, so migrate-to-mck must
+    emit a shardNameOverride. The per-shard seed lookup depends on translating between the two."""
+    try_load(mdb_migration)
+    overrides = {o["shardName"]: o.get("replicaSetName") for o in mdb_migration["spec"].get("shardNameOverrides", [])}
+    assert overrides.get(K8S_SHARD_NAME) == VM_SHARD_RS_NAME, f"unexpected shardNameOverrides: {overrides}"
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_generated_cr_carries_search_set_parameters(generated_cr_yaml: str, mongot_host: str):
+    """The generated CR must carry the search setParameters for the shard mongods and mongos, and
+    none for the config servers.
+
+    This source has a single shard, so all shard mongods share one mongot endpoint and the config
+    lands in spec.shard rather than spec.shardOverrides. A multi-shard source has a different
+    endpoint per shard and produces one shardOverrides entry per shard instead; that shape is
+    covered by the search_per_shard_mongot Go fixture.
+
+    Asserted against the generated document rather than the applied CR: the customer step in
+    apply_generated_sharded_cluster_resource adds a per-shard shardOverride of its own for the
+    votes, so the applied CR always has shardOverrides regardless of the source topology.
+    """
+    spec = generated_mongodb_doc(generated_cr_yaml)["spec"]
+    expected = dict(SEARCH_SET_PARAMETER, mongotHost=mongot_host, searchIndexManagementHostAndPort=mongot_host)
+
+    for component in ("shard", "mongos"):
+        set_parameter = spec[component]["additionalMongodConfig"]["setParameter"]
+        for key, value in expected.items():
+            assert (
+                set_parameter.get(key) == value
+            ), f"spec.{component} setParameter.{key} is {set_parameter.get(key)!r}, expected {value!r}"
+
+    assert "additionalMongodConfig" not in spec.get(
+        "configSrv", {}
+    ), "config servers are not wired to mongot, so they must carry no additionalMongodConfig"
+
+    assert "shardOverrides" not in spec, "a single-shard source is homogeneous"
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_dry_run_passes(mdb_migration: MongoDB):
+    """run_migration_dry_run_connectivity_passes removes the dry-run annotation itself, so the next
+    reconcile is already a real one."""
+    run_migration_dry_run_connectivity_passes(mdb_migration)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_migration_proceeds_while_search_still_targets_vms(mdb_migration: MongoDB):
+    """The migration is not held back by the MongoDBSearch still pointing at the VM mongods."""
+    mdb_migration.assert_reaches_phase(Phase.Running, timeout=1800)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_add_kubernetes_host_seeds_to_search_source(namespace: str, mdbs: MongoDBSearch, mdb_migration: MongoDB):
+    """The search resource keeps its external sharded source for the whole migration; only the seed
+    lists are maintained by hand.
+
+    Both the shard seeds and the router hosts are widened to the union of the VM and Kubernetes
+    addresses rather than swapped outright: mongot has to keep at least one reachable seed and one
+    reachable router at every point of the promote/prune sequence that follows.
+
+    The shard entry's shardName stays K8S_SHARD_NAME throughout -- it names the mongot StatefulSet,
+    and changing it would move the mongot endpoint the automation config already points at.
+    """
+    mdbs.load()
+    sharded = mdbs["spec"]["source"]["external"]["shardedCluster"]
+    sharded["router"]["hosts"] = _vm_mongos_hosts(namespace) + _k8s_mongos_hosts(mdb_migration)
+    sharded["shards"] = [
+        {"shardName": K8S_SHARD_NAME, "hosts": _vm_shard_hosts(namespace) + _k8s_shard_hosts(mdb_migration)}
+    ]
+    mdbs.update()
+
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_mongot_config_contains_both_vm_and_kubernetes_hosts(
+    namespace: str, mdbs: MongoDBSearch, mdb_migration: MongoDB
+):
+    """The direct assertion on the hand-maintained seed lists.
+
+    Both address sets have to reach mongot's per-shard ConfigMap -- the shard seeds from
+    source.external.shardedCluster.shards[].hosts and the router hosts from ...router.hosts.
+    Asserting the ConfigMap contents rather than "search still works" pins the CR -> mongot-config
+    path regardless of which members happen to be serving at the time.
+    """
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+    cm_name = search_resource_names.shard_configmap_name(MDBS_RESOURCE_NAME, K8S_SHARD_NAME)
+    config = "".join(KubernetesTester.read_configmap(namespace, cm_name).values())
+
+    for host in _vm_shard_hosts(namespace) + _k8s_shard_hosts(mdb_migration):
+        assert host in config, f"shard seed {host} missing from mongot config {cm_name}:\n{config}"
+    for host in _vm_mongos_hosts(namespace) + _k8s_mongos_hosts(mdb_migration):
+        assert host in config, f"router host {host} missing from mongot router config {cm_name}:\n{config}"
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_query_works_mid_migration(sample_movies_helper: SampleMoviesSearchHelper):
+    """Queries still go through the VM mongos while both VM and Kubernetes members are in the
+    cluster, so search must keep working with a mixed membership."""
+    sample_movies_helper.assert_search_query(retry_timeout=180)
+
+
+# Promote and prune
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_promote_and_prune_config_server(mdb_migration: MongoDB, om_tester: OMTester):
+    """Promote one Kubernetes config member to voting, then prune one VM config member, repeat.
+
+    Kept as a per-member loop rather than a bulk clear of externalMembers: the migration validator
+    permits only one kind of change per update, and the Kubernetes config members start non-voting,
+    so pruning voting VM config members first would strand the config replica set.
+    """
+    try_load(mdb_migration)
+    for i in range(MIN_VM_CONFIGSRV):
+        mdb_migration["spec"]["memberConfig"][i]["priority"] = "1"
+        mdb_migration["spec"]["memberConfig"][i]["votes"] = 1
+        mdb_migration.update()
+        mdb_migration.assert_reaches_phase(Phase.Running)
+
+        config_external = [
+            m for m in mdb_migration["spec"]["externalMembers"] if m.get("replicaSetName") == VM_CONFIG_RS_NAME
+        ]
+        if config_external:
+            mdb_migration["spec"]["externalMembers"].remove(config_external[-1])
+            mdb_migration.update()
+            mdb_migration.assert_reaches_phase(Phase.Running)
+
+        om_tester.assert_cluster_available(VM_MONGOS_NAME)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_promote_and_prune_shard(mdb_migration: MongoDB, om_tester: OMTester):
+    promote_and_prune_shard(mdb_migration, om_tester, VM_SHARD_RS_NAME, VM_MONGOS_NAME)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_prune_mongos(mdb_migration: MongoDB):
+    """Mongos routers carry no votes, so all of them can go in one update -- still a single change
+    kind (removing external members), which the migration validator allows."""
+    try_load(mdb_migration)
+    for m in [m for m in mdb_migration["spec"]["externalMembers"] if m["type"] == "mongos"]:
+        mdb_migration["spec"]["externalMembers"].remove(m)
+    mdb_migration.update()
+    mdb_migration.assert_reaches_phase(Phase.Running)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_drop_vm_host_seeds_from_search_source(mdbs: MongoDBSearch, mdb_migration: MongoDB):
+    """The VM members are out of the cluster now, so their hostnames come out of the seed lists.
+    This is the second and last hand-edit of the search resource in the whole flow."""
+    mdbs.load()
+    sharded = mdbs["spec"]["source"]["external"]["shardedCluster"]
+    sharded["router"]["hosts"] = _k8s_mongos_hosts(mdb_migration)
+    sharded["shards"] = [{"shardName": K8S_SHARD_NAME, "hosts": _k8s_shard_hosts(mdb_migration)}]
+    mdbs.update()
+
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_connection_string_after_full_migration(mdb_migration: MongoDB):
+    assert_connection_string_after_full_sharded_migration(mdb_migration)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_process_names(om_tester: OMTester, mdb_migration: MongoDB):
+    assert_k8s_sharded_process_names(om_tester, mdb_migration)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_set_parameters_in_automation_config(om_tester: OMTester, namespace: str, mongot_host: str):
+    """The Kubernetes shard mongods and mongos must carry the same search setParameters the VM
+    processes had, and the config servers none.
+
+    The generated CR is what puts them there (see test_generated_cr_carries_search_set_parameters):
+    no MongoDBSearch targets this MongoDB resource, so the sharded reconciler's search overrides
+    never run, and Ops Manager does not propagate the deployment's existing search configuration
+    onto new processes. Because the values are carried verbatim from the VM processes, the mongos
+    keep the mongot pod FQDN the VM mongos were given rather than the per-shard proxy Service the
+    operator would compute for an internal source.
+    """
+    mongos_host = mongot_host
+
+    ac = om_tester.api_get_automation_config()
+    k8s_processes = [p for p in ac["processes"] if p["name"].startswith(f"k8s/{namespace}/")]
+
+    shard_mongods, mongos_procs, configsrv_procs = [], [], []
+    for p in k8s_processes:
+        if p["processType"] == "mongos":
+            mongos_procs.append(p)
+        elif p["args2_6"].get("replication", {}).get("replSetName") == VM_CONFIG_RS_NAME:
+            configsrv_procs.append(p)
+        else:
+            shard_mongods.append(p)
+
+    # Guards against the assertions below passing vacuously on an empty list.
+    assert shard_mongods and mongos_procs and configsrv_procs, f"unexpected process split: {k8s_processes}"
+
+    for processes, expected_host in ((shard_mongods, mongot_host), (mongos_procs, mongos_host)):
+        expected = dict(SEARCH_SET_PARAMETER, mongotHost=expected_host, searchIndexManagementHostAndPort=expected_host)
+        for process in processes:
+            set_parameter = process["args2_6"].get("setParameter", {})
+            for key, value in expected.items():
+                assert (
+                    set_parameter.get(key) == value
+                ), f"process {process['name']}: setParameter.{key} is {set_parameter.get(key)!r}, expected {value!r}"
+
+    for process in configsrv_procs:
+        set_parameter = process["args2_6"].get("setParameter", {})
+        assert "mongotHost" not in set_parameter, f"config server {process['name']} should not be wired to mongot"
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_resource_still_running(mdbs: MongoDBSearch):
+    mdbs.assert_reaches_phase(Phase.Running, timeout=600)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_search_query_works_after_migration(mdb_migration: MongoDB, namespace: str):
+    tester = SearchTester.for_sharded(mdb_migration, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+    helper = movies_search_helper.SampleMoviesSearchHelper(tester, tools_pod=mongodb_tools_pod.get_tools_pod(namespace))
+    helper.assert_search_query(retry_timeout=180)
+
+
+@mark.e2e_vm_migration_shardedcluster_search
+def test_migration_data_exists_after_promote(mdb_migration: MongoDB, scram_opts: list[dict]):
+    assert_migration_data_exists(mdb_migration.tester(use_ssl=False), opts=scram_opts)

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/shardedcluster/vm_migration_shardedcluster_search.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/shardedcluster/vm_migration_shardedcluster_search.py
@@ -14,8 +14,9 @@ translation were wrong.
 """
 
 from kubetester import create_or_update_secret, try_load
-from kubetester.kubetester import KubernetesTester, skip_if_local
+from kubetester.kubetester import KubernetesTester
 from kubetester.kubetester import fixture as yaml_fixture
+from kubetester.kubetester import skip_if_local
 from kubetester.mongodb import MongoDB
 from kubetester.mongodb_search import MongoDBSearch
 from kubetester.mongotester import with_scram

--- a/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_sharded_helper.py
+++ b/docker/mongodb-kubernetes-tests/tests/vm_migration/vm_migration_sharded_helper.py
@@ -129,6 +129,34 @@ def deploy_vm_sharded_mongos_service(namespace: str) -> dict:
     return service_body
 
 
+def _set_shard_member_configs(resource_doc: dict, member_config: list[dict]) -> None:
+    """Give every shard a shardOverride carrying member_config, preserving whatever the generated
+    CR already put in that override.
+
+    The merge matters for a heterogeneous source: migrate-to-mck leaves spec.shard absent and
+    states each shard's additionalMongodConfig in its own shardOverride, so overwriting the list
+    would discard the only copy of that config (sharded_cluster_generator.go, buildShardOverrides).
+    Shards the generator skipped -- those whose config could not be determined -- simply get an
+    entry with member_config alone.
+
+    buildShardOverrides emits one shardNames element per entry, so keying by shard name loses
+    nothing here.
+    """
+    generated = {name: o for o in resource_doc["spec"].get("shardOverrides", []) for name in o["shardNames"]}
+    resource_name_value = resource_doc["metadata"]["name"]
+    overrides = []
+    for shard_index in range(resource_doc["spec"]["shardCount"]):
+        shard_name = f"{resource_name_value}-{shard_index}"
+        overrides.append(
+            {
+                **generated.get(shard_name, {}),
+                "shardNames": [shard_name],
+                "memberConfig": member_config,
+            }
+        )
+    resource_doc["spec"]["shardOverrides"] = overrides
+
+
 def apply_generated_sharded_cluster_resource(
     namespace: str,
     generated_cr_yaml: str,
@@ -140,7 +168,9 @@ def apply_generated_sharded_cluster_resource(
     incremental: bool = False,
 ) -> MongoDB:
     """Apply the generated sharded cluster CR. The config server K8s members get their votes from
-    top-level memberConfig and each shard gets its own shardOverride, both non voting to start.
+    top-level memberConfig and each shard gets its votes from a per-shard shardOverride, both non
+    voting to start. The per-shard entries augment whatever shardOverrides the generated CR already
+    carried rather than replacing them -- see _set_shard_member_configs.
 
     When incremental=True, all K8s counts start at 0 and grow one member at a time via
     extend_and_prune_sharded_* operations."""
@@ -164,11 +194,7 @@ def apply_generated_sharded_cluster_resource(
         resource_doc["spec"]["mongodsPerShardCount"] = 0
         resource_doc["spec"]["mongosCount"] = 0
         resource_doc["spec"]["memberConfig"] = []
-        resource_name_value = resource_doc["metadata"]["name"]
-        resource_doc["spec"]["shardOverrides"] = [
-            {"shardNames": [f"{resource_name_value}-{shard_index}"], "memberConfig": []}
-            for shard_index in range(resource_doc["spec"]["shardCount"])
-        ]
+        _set_shard_member_configs(resource_doc, [])
     else:
         # The generated CR carries all Kubernetes node counts at 0, mirroring the replica set Members
         # field, so the customer sets the target Kubernetes counts here. The VM nodes stay in
@@ -179,14 +205,7 @@ def apply_generated_sharded_cluster_resource(
         # Shard K8s members default to voting, which would already put a shard over the limit once its
         # VM members are counted. A per-shard override pins them non voting and keeps shard votes
         # independent of the config server for the voting limit test.
-        resource_name_value = resource_doc["metadata"]["name"]
-        resource_doc["spec"]["shardOverrides"] = [
-            {
-                "shardNames": [f"{resource_name_value}-{shard_index}"],
-                "memberConfig": [{"votes": 0, "priority": "0"} for _ in range(MIN_K8S_SHARD)],
-            }
-            for shard_index in range(resource_doc["spec"]["shardCount"])
-        ]
+        _set_shard_member_configs(resource_doc, [{"votes": 0, "priority": "0"} for _ in range(MIN_K8S_SHARD)])
 
         config_members = [
             m for m in resource_doc["spec"].get("externalMembers", []) if m.get("replicaSetName") == config_rs_name

--- a/helm_chart/crds/mongodb.com_mongodb.yaml
+++ b/helm_chart/crds/mongodb.com_mongodb.yaml
@@ -2847,12 +2847,12 @@ spec:
             - message: spec.members must be >= 3 when spec.role is AppDB
               rule: '!has(self.role) || self.role != ''AppDB'' || (has(self.members)
                 && self.members >= 3)'
-            - message: 'at most one external member may be removed per update: remove
-                entries from spec.externalMembers one at a time so the replica set
-                keeps its voting majority'
+            - message: 'at most one external mongod may be removed per update: remove
+                mongod entries from spec.externalMembers one at a time so the replica
+                set keeps its voting majority'
               rule: '!has(oldSelf.externalMembers) || (has(self.externalMembers) ?
-                size(self.externalMembers) : 0) >= size(oldSelf.externalMembers) -
-                1'
+                size(self.externalMembers.filter(m, m.type != ''mongos'')) : 0) >=
+                size(oldSelf.externalMembers.filter(m, m.type != ''mongos'')) - 1'
             - message: spec.security.authentication must be enabled with modes [SCRAM]
                 only when spec.role is AppDB, or omitted entirely
               rule: '!has(self.role) || self.role != ''AppDB'' || !has(self.security)

--- a/helm_chart/crds/mongodb.com_mongodb.yaml
+++ b/helm_chart/crds/mongodb.com_mongodb.yaml
@@ -2675,6 +2675,7 @@ spec:
                   - shardNames
                   type: object
                 type: array
+                x-kubernetes-preserve-unknown-fields: true
               shardPodSpec:
                 properties:
                   persistence:

--- a/pkg/migration/job.go
+++ b/pkg/migration/job.go
@@ -12,6 +12,7 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
+	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes/pkg/tls"

--- a/pkg/migration/job.go
+++ b/pkg/migration/job.go
@@ -12,7 +12,6 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/mdb"
 	"github.com/mongodb/mongodb-kubernetes/controllers/operator/authentication"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
-	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes/pkg/tls"

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -3399,6 +3399,7 @@ spec:
                   - shardNames
                   type: object
                 type: array
+                x-kubernetes-preserve-unknown-fields: true
               shardPodSpec:
                 properties:
                   persistence:

--- a/public/crds.yaml
+++ b/public/crds.yaml
@@ -3571,12 +3571,12 @@ spec:
             - message: spec.members must be >= 3 when spec.role is AppDB
               rule: '!has(self.role) || self.role != ''AppDB'' || (has(self.members)
                 && self.members >= 3)'
-            - message: 'at most one external member may be removed per update: remove
-                entries from spec.externalMembers one at a time so the replica set
-                keeps its voting majority'
+            - message: 'at most one external mongod may be removed per update: remove
+                mongod entries from spec.externalMembers one at a time so the replica
+                set keeps its voting majority'
               rule: '!has(oldSelf.externalMembers) || (has(self.externalMembers) ?
-                size(self.externalMembers) : 0) >= size(oldSelf.externalMembers) -
-                1'
+                size(self.externalMembers.filter(m, m.type != ''mongos'')) : 0) >=
+                size(oldSelf.externalMembers.filter(m, m.type != ''mongos'')) - 1'
             - message: spec.security.authentication must be enabled with modes [SCRAM]
                 only when spec.role is AppDB, or omitted entirely
               rule: '!has(self.role) || self.role != ''AppDB'' || !has(self.security)

--- a/scripts/dev/prepare_local_e2e_run.sh
+++ b/scripts/dev/prepare_local_e2e_run.sh
@@ -68,9 +68,16 @@ cp -rf helm_chart docker/mongodb-kubernetes-tests/helm_chart
 
 # shellcheck disable=SC2154
 if [[ "${KUBE_ENVIRONMENT_NAME}" == "multi" ]]; then
+  # The multi-cluster setup below (and prepare_multi_cluster_e2e_run in launch_e2e.sh) builds
+  # the kubectl-mongodb plugin itself, so we don't build it again here.
   go build -o "${PROJECT_DIR}/bin/prepare_multi_cluster" "${PROJECT_DIR}/scripts/dev/prepare-multi-cluster/"
   "${PROJECT_DIR}/bin/prepare_multi_cluster" 2>&1 | prepend "prepare_multi_cluster_e2e_run"
   run_multi_cluster_kube_config_creator 2>&1 | prepend "run_multi_cluster_kube_config_creator"
+else
+  # Single-cluster runs still need the plugin (e.g. VM migration tests use it), and nothing
+  # else builds it, so build it here.
+  echo "Building kubectl-mongodb plugin"
+  build_kubectl_mongodb_plugin 2>&1 | prepend "build_kubectl_mongodb"
 fi
 
 # Wait for background operations before deploy step (which needs CRDs from make install)

--- a/scripts/funcs/multicluster
+++ b/scripts/funcs/multicluster
@@ -198,11 +198,9 @@ EOF
   kubectl --context "${test_pod_cluster}" create secret generic test-pod-multi-cluster-config -n "${NAMESPACE}" "${configuration_params[@]}"
 }
 
-prepare_multi_cluster_e2e_run() {
-  # shellcheck disable=SC2034
-  operator_context="${CENTRAL_CLUSTER}"
-  configure_multi_cluster_environment
-
+# Builds the kubectl-mongodb plugin natively and places it at ${KUBECTL_MONGODB_PATH}.
+# Needed for all local runs (not just multi-cluster), e.g. VM migration tests use the plugin too.
+build_kubectl_mongodb_plugin() {
   if [[ "$(uname)" == "Darwin" ]]; then
     goarch="amd64"
     if [[ "$(uname -m)" == "arm64" ]]; then
@@ -224,6 +222,14 @@ prepare_multi_cluster_e2e_run() {
     # shellcheck disable=SC2031
     PATH=${PATH}:docker/mongodb-kubernetes-tests
   fi
+}
+
+prepare_multi_cluster_e2e_run() {
+  # shellcheck disable=SC2034
+  operator_context="${CENTRAL_CLUSTER}"
+  configure_multi_cluster_environment
+
+  build_kubectl_mongodb_plugin
 
   test_pod_secret_name="test-pod-multi-cluster-config"
   echo "Creating local configuration for multi cluster test in ${MULTI_CLUSTER_CONFIG_DIR}"


### PR DESCRIPTION
Stacked PR 15 — depends on #1504. Review only the top commit.

Carries MongoDB Search (mongot) wiring through a VM-to-Kubernetes migration.

**`migrate-to-mck`** — shards whose mongod settings differ (as they do when only some shards run mongot) no longer silently inherit shard 0's `additionalMongodConfig`. When all shards agree, the shared config goes in `spec.shard`; when they differ, `spec.shard` is omitted and each shard gets its own complete `shardOverride` entry (the operator replaces `additionalMongodConfig` wholesale rather than merging, so each entry is complete, not a delta).

**`controllers/searchcontroller`** — resolve a shard's external (VM) members through its Automation Config replica set name, so `spec.shardNameOverrides` (which `migrate-to-mck` emits whenever the VM replica set name differs from the Kubernetes shard name) doesn't silently drop them. Include those members in the mongot sync-source seeds, and omit the mongos Service while `mongosCount` is 0, since it resolves to no endpoints.

**Also** — fix the `PreserveUnknownFields` marker typo, make `ShardOverride.Members` `omitempty`, add e2e coverage for replica-set and sharded-cluster search migration, and build the `kubectl-mongodb` plugin for single-cluster local e2e runs (VM migration tests need it and nothing else built it).

## Testing
`go build ./...`, `go vet`, and the full unit suite for the touched packages pass locally. New unit coverage: `sharded_internal_search_source_test.go`, `generator_test.go`, plus two `migrate-to-mck` golden fixtures (`heterogeneous_shards`, `search_per_shard_mongot`). E2E: `e2e_vm_migration_replicaset_search`, `e2e_vm_migration_shardedcluster_search`.

