### PR TITLE
CLOUDP-407997: Add recursive verification of signatures

### DIFF
--- a/ci/internal/cli/release_promote.go
+++ b/ci/internal/cli/release_promote.go
@@ -32,6 +32,7 @@ func newPromoteImageCmd() *cobra.Command {
 		latestMarker string
 		force        bool
 		dryRun       bool
+		allowPartial bool
 	)
 
 	cmd := &cobra.Command{
@@ -46,7 +47,7 @@ newer version has already been promoted), pass a distinct --latest-marker
 (e.g. "latestv1") so the backport doesn't steal the "latest" pointer away
 from the newest promoted version.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return promoteImage(cmd, image, commit, version, registryURL, repo, latestMarker, force, dryRun)
+			return promoteImage(cmd, image, commit, version, registryURL, repo, latestMarker, force, dryRun, allowPartial)
 		},
 	}
 
@@ -58,6 +59,7 @@ from the newest promoted version.`,
 	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite the promoted-{commit}-{version} tag even if it already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+	cmd.Flags().BoolVar(&allowPartial, "allow-partial-signatures", false, "don't fail when child manifest .sig tags are missing")
 
 	MustNotErr(cmd.MarkFlagRequired("image"))
 	MustNotErr(cmd.MarkFlagRequired("commit"))
@@ -75,6 +77,7 @@ func newPromoteImagesCmd() *cobra.Command {
 		latestMarker string
 		force        bool
 		dryRun       bool
+		allowPartial bool
 	)
 
 	cmd := &cobra.Command{
@@ -93,7 +96,7 @@ patching an older release branch after a newer version has already been
 promoted), pass a distinct --latest-marker (e.g. "latestv1") so the backport
 doesn't steal the "latest" pointer away from the newest promoted version.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return promoteAllImages(cmd, buildInfo, releaseJSON, commit, latestMarker, force, dryRun)
+			return promoteAllImages(cmd, buildInfo, releaseJSON, commit, latestMarker, force, dryRun, allowPartial)
 		},
 	}
 
@@ -103,6 +106,7 @@ doesn't steal the "latest" pointer away from the newest promoted version.`,
 	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable promoted-{marker} pointer tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
 	cmd.Flags().BoolVar(&force, "force", false, "promote every image even if any promoted tag already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+	cmd.Flags().BoolVar(&allowPartial, "allow-partial-signatures", false, "don't fail when child manifest .sig tags are missing")
 
 	MustNotErr(cmd.MarkFlagRequired("commit"))
 	MustNotErr(cmd.MarkFlagRequired("latest-marker"))
@@ -112,12 +116,12 @@ doesn't steal the "latest" pointer away from the newest promoted version.`,
 
 // promoteAllImages promotes every release image in build_info.json at the given
 // commit, writing promoted tags to each image's primary staging repository.
-func promoteAllImages(cmd *cobra.Command, buildInfo, releaseJSON, commit, latestMarker string, force, dryRun bool) error {
+func promoteAllImages(cmd *cobra.Command, buildInfo, releaseJSON, commit, latestMarker string, force, dryRun, allowPartial bool) error {
 	images, err := release.LoadReleaseImages(buildInfo, releaseJSON)
 	if err != nil {
 		return err
 	}
-	results, err := release.PromoteImages(images, commit, latestMarker, force, dryRun, release.DefaultRegistryConnector)
+	results, err := release.PromoteImages(images, commit, latestMarker, force, dryRun, allowPartial, release.DefaultRegistryConnector)
 	if err != nil {
 		return err
 	}
@@ -138,16 +142,17 @@ func promoteAllImages(cmd *cobra.Command, buildInfo, releaseJSON, commit, latest
 	return nil
 }
 
-func promoteImage(cmd *cobra.Command, image, commit, version, registryURL, repo, latestMarker string, force, dryRun bool) error {
+func promoteImage(cmd *cobra.Command, image, commit, version, registryURL, repo, latestMarker string, force, dryRun, allowPartial bool) error {
 	host := strings.TrimPrefix(strings.TrimPrefix(registryURL, "https://"), "http://")
 	result, err := release.Promote(release.PromoteInputs{
-		Image:        image,
-		Commit:       commit,
-		Version:      version,
-		Repo:         repo,
-		LatestMarker: latestMarker,
-		Force:        force,
-		DryRun:       dryRun,
+		Image:                  image,
+		Commit:                 commit,
+		Version:                version,
+		Repo:                   repo,
+		LatestMarker:           latestMarker,
+		Force:                  force,
+		DryRun:                 dryRun,
+		AllowPartialSignatures: allowPartial,
 	}, host, release.DefaultRegistryConnector(registryURL))
 	if err != nil {
 		return err

--- a/ci/internal/cli/release_publish.go
+++ b/ci/internal/cli/release_publish.go
@@ -30,6 +30,7 @@ func newPublishImageCmd() *cobra.Command {
 		latestMarker string
 		force        bool
 		dryRun       bool
+		allowPartial bool
 	)
 
 	cmd := &cobra.Command{
@@ -53,12 +54,13 @@ version.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			host := strings.TrimPrefix(strings.TrimPrefix(registryURL, "https://"), "http://")
 			result, err := release.Publish(release.PublishInputs{
-				StagingImage: stagingImage,
-				Commit:       commit,
-				ProdRepo:     prodRepo,
-				LatestMarker: latestMarker,
-				Force:        force,
-				DryRun:       dryRun,
+				StagingImage:           stagingImage,
+				Commit:                 commit,
+				ProdRepo:               prodRepo,
+				LatestMarker:           latestMarker,
+				Force:                  force,
+				DryRun:                 dryRun,
+				AllowPartialSignatures: allowPartial,
 			}, host, release.DefaultRegistryConnector(registryURL))
 			if err != nil {
 				return err
@@ -92,6 +94,7 @@ version.`,
 	cmd.Flags().StringVar(&latestMarker, "latest-marker", "", "marker used for the mutable :{marker} production tag (required; use a distinct value, e.g. \"latestv1\", for backports)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite the :{version} production tag even if it already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+	cmd.Flags().BoolVar(&allowPartial, "allow-partial-signatures", false, "don't fail when child manifest .sig tags are missing")
 
 	MustNotErr(cmd.MarkFlagRequired("staging-image"))
 	MustNotErr(cmd.MarkFlagRequired("latest-marker"))
@@ -108,6 +111,7 @@ func newPublishImagesCmd() *cobra.Command {
 		registryOverride string
 		force            bool
 		dryRun           bool
+		allowPartial     bool
 	)
 
 	cmd := &cobra.Command{
@@ -136,7 +140,7 @@ published version.`,
 			if err != nil {
 				return err
 			}
-			results, err := release.PublishImages(images, commit, latestMarker, registryOverride, force, dryRun, release.DefaultRegistryConnector)
+			results, err := release.PublishImages(images, commit, latestMarker, registryOverride, force, dryRun, allowPartial, release.DefaultRegistryConnector)
 			if err != nil {
 				return err
 			}
@@ -167,6 +171,7 @@ published version.`,
 	cmd.Flags().StringVar(&registryOverride, "registry-override", "", "if set, replaces every image's release-registry host+namespace with this prefix (keeping each image's own repo name suffix) — for testing against a non-production registry; e.g. \"quay.io/my-test-org\"")
 	cmd.Flags().BoolVar(&force, "force", false, "publish every image even if any production tag already points at a different digest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without copying any images")
+	cmd.Flags().BoolVar(&allowPartial, "allow-partial-signatures", false, "don't fail when child manifest .sig tags are missing")
 
 	MustNotErr(cmd.MarkFlagRequired("commit"))
 	MustNotErr(cmd.MarkFlagRequired("latest-marker"))

--- a/ci/internal/release/images_promote.go
+++ b/ci/internal/release/images_promote.go
@@ -41,7 +41,7 @@ func shortCommit(commit string) string {
 // commit-tagged source image is missing), so a broken merge build does not
 // silently promote a partial image set. connect resolves a Registry for an image's
 // host; the CLI passes DefaultRegistryConnector and tests inject a fake.
-func PromoteImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, connect RegistryConnector) ([]ImagesPromoteResult, error) {
+func PromoteImages(images []ReleaseImage, commit, latestMarker string, force, dryRun bool, allowPartialSignatures bool, connect RegistryConnector) ([]ImagesPromoteResult, error) {
 	if commit == "" {
 		return nil, errors.New("commit is required")
 	}
@@ -87,13 +87,14 @@ func PromoteImages(images []ReleaseImage, commit, latestMarker string, force, dr
 	results := make([]ImagesPromoteResult, 0, len(images))
 	for _, p := range prep {
 		result, err := Promote(PromoteInputs{
-			Image:        p.srcRef,
-			Commit:       commit,
-			Version:      p.img.Version,
-			Repo:         p.repoPath,
-			LatestMarker: latestMarker,
-			Force:        true,
-			DryRun:       dryRun,
+			Image:                  p.srcRef,
+			Commit:                 commit,
+			Version:                p.img.Version,
+			Repo:                   p.repoPath,
+			LatestMarker:           latestMarker,
+			Force:                  true,
+			DryRun:                 dryRun,
+			AllowPartialSignatures: allowPartialSignatures,
 		}, p.host, p.reg)
 		if err != nil {
 			return nil, fmt.Errorf("promote %s (%s): %w", p.img.Name, p.srcRef, err)

--- a/ci/internal/release/images_promote_test.go
+++ b/ci/internal/release/images_promote_test.go
@@ -31,7 +31,7 @@ func (f *fakeRegistry) CopyWithTags(srcRef, dstRepo string, tags []string) error
 	return nil
 }
 
-func (f *fakeRegistry) CopySignatures(srcRef, dstRepo string) error {
+func (f *fakeRegistry) CopySignatures(srcRef, dstRepo string, allowPartialSignatures bool) error {
 	if err := f.fail[srcRef]; err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func TestPromoteImages(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: "quay.io/staging/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
 	}
 
-	results, err := PromoteImages(images, "abc1234", "latest", false, false, connect)
+	results, err := PromoteImages(images, "abc1234", "latest", false, false, true, connect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestPromoteImagesHardFailsOnMissingSource(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: "quay.io/staging/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
 	}
 
-	_, err := PromoteImages(images, "abc1234", "latest", false, false, connect)
+	_, err := PromoteImages(images, "abc1234", "latest", false, false, true, connect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected hard failure mentioning readiness-probe, got %v", err)
 	}
@@ -132,7 +132,7 @@ func TestPromoteImagesUsesShortCommitAsSourceTag(t *testing.T) {
 
 	force := false
 	dryrun := false
-	results, err := PromoteImages(images, fullCommit, "latest", force, dryrun, connect)
+	results, err := PromoteImages(images, fullCommit, "latest", force, dryrun, true, connect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestPromoteImagesCommitRequired(t *testing.T) {
 		return nil
 	}
 	images := []ReleaseImage{{Name: "operator", StagingRepo: "h/staging/op", Version: "1.9.2"}}
-	_, err := PromoteImages(images, "", "", false, false, connect)
+	_, err := PromoteImages(images, "", "", false, false, true, connect)
 	if err == nil || !strings.Contains(err.Error(), "commit") {
 		t.Fatalf("expected commit error, got %v", err)
 	}
@@ -187,7 +187,7 @@ func TestPromoteImagesRefusesAllOnAnyConflict(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: rpRepo, Version: "1.0.24"},
 	}
 
-	_, err := PromoteImages(images, "abc1234", "latest", false, false, insecureConnect)
+	_, err := PromoteImages(images, "abc1234", "latest", false, false, true, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected conflict error mentioning readiness-probe, got %v", err)
 	}
@@ -196,7 +196,7 @@ func TestPromoteImagesRefusesAllOnAnyConflict(t *testing.T) {
 		t.Error("operator promoted tag should not exist: images must be refused before any writes")
 	}
 
-	results, err := PromoteImages(images, "abc1234", "latest", true, false, insecureConnect)
+	results, err := PromoteImages(images, "abc1234", "latest", true, false, true, insecureConnect)
 	if err != nil {
 		t.Fatalf("force: unexpected error: %v", err)
 	}

--- a/ci/internal/release/images_publish.go
+++ b/ci/internal/release/images_publish.go
@@ -29,7 +29,7 @@ func overrideRepoPrefix(override, originalRepo string) string {
 	return strings.TrimSuffix(override, "/") + "/" + name
 }
 
-func PublishImages(images []ReleaseImage, commit, latestMarker, registryOverride string, force, dryRun bool, connect RegistryConnector) ([]ImagesPublishResult, error) {
+func PublishImages(images []ReleaseImage, commit, latestMarker, registryOverride string, force, dryRun bool, allowPartialSignatures bool, connect RegistryConnector) ([]ImagesPublishResult, error) {
 	if commit == "" {
 		return nil, errors.New("commit is required")
 	}
@@ -82,12 +82,13 @@ func PublishImages(images []ReleaseImage, commit, latestMarker, registryOverride
 	results := make([]ImagesPublishResult, 0, len(images))
 	for _, p := range prep {
 		result, err := Publish(PublishInputs{
-			StagingImage: p.img.StagingRepo,
-			Commit:       commit,
-			ProdRepo:     p.prodPath,
-			LatestMarker: latestMarker,
-			Force:        true,
-			DryRun:       dryRun,
+			StagingImage:           p.img.StagingRepo,
+			Commit:                 commit,
+			ProdRepo:               p.prodPath,
+			LatestMarker:           latestMarker,
+			Force:                  true,
+			DryRun:                 dryRun,
+			AllowPartialSignatures: allowPartialSignatures,
 		}, p.host, p.reg)
 		if err != nil {
 			return nil, fmt.Errorf("publish %s (%s): %w", p.img.Name, p.img.StagingRepo, err)

--- a/ci/internal/release/images_publish_test.go
+++ b/ci/internal/release/images_publish_test.go
@@ -33,7 +33,7 @@ func TestPublishImages(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: rpStaging, ReleaseRepo: rpProd, Version: "1.0.24"},
 	}
 
-	results, err := PublishImages(images, "abc1234", "latest", "", false, false, insecureConnect)
+	results, err := PublishImages(images, "abc1234", "latest", "", false, false, true, insecureConnect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestPublishImagesRegistryOverride(t *testing.T) {
 	}
 
 	override := prodHost + "/test-namespace"
-	results, err := PublishImages(images, "abc1234", "latest", override, false, false, insecureConnect)
+	results, err := PublishImages(images, "abc1234", "latest", override, false, false, true, insecureConnect)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: stagingHost + "/staging/mongodb-kubernetes-readinessprobe", ReleaseRepo: prodHost + "/mongodb/mongodb-kubernetes-readinessprobe", Version: "1.0.24"},
 	}
 
-	_, err := PublishImages(images, "abc1234", "latest", "", false, false, insecureConnect)
+	_, err := PublishImages(images, "abc1234", "latest", "", false, false, true, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected hard failure mentioning readiness-probe, got %v", err)
 	}
@@ -108,7 +108,7 @@ func TestPublishImagesHardFailsOnMissingPromotedTag(t *testing.T) {
 
 func TestPublishImagesCommitRequired(t *testing.T) {
 	images := []ReleaseImage{{Name: "operator", StagingRepo: "h/staging/op", ReleaseRepo: "h/op"}}
-	_, err := PublishImages(images, "", "", "", false, false, insecureConnect)
+	_, err := PublishImages(images, "", "", "", false, false, true, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "commit") {
 		t.Fatalf("expected commit error, got %v", err)
 	}
@@ -138,7 +138,7 @@ func TestPublishImagesRefusesAllOnAnyConflict(t *testing.T) {
 		{Name: "readiness-probe", StagingRepo: rpStaging, ReleaseRepo: rpProd, Version: "1.0.24"},
 	}
 
-	_, err := PublishImages(images, "abc1234", "latest", "", false, false, insecureConnect)
+	_, err := PublishImages(images, "abc1234", "latest", "", false, false, true, insecureConnect)
 	if err == nil || !strings.Contains(err.Error(), "readiness-probe") {
 		t.Fatalf("expected conflict error mentioning readiness-probe, got %v", err)
 	}
@@ -147,7 +147,7 @@ func TestPublishImagesRefusesAllOnAnyConflict(t *testing.T) {
 		t.Error("operator production tag should not exist: images must be refused before any writes")
 	}
 
-	results, err := PublishImages(images, "abc1234", "latest", "", true, false, insecureConnect)
+	results, err := PublishImages(images, "abc1234", "latest", "", true, false, true, insecureConnect)
 	if err != nil {
 		t.Fatalf("force: unexpected error: %v", err)
 	}

--- a/ci/internal/release/promote.go
+++ b/ci/internal/release/promote.go
@@ -41,6 +41,9 @@ type PromoteInputs struct {
 	// conflict is a hard error (image stomping protection).
 	Force  bool
 	DryRun bool
+	// AllowPartialSignatures, when true, ignores missing child manifest
+	// signatures during CopySignatures instead of failing.
+	AllowPartialSignatures bool
 }
 
 // PromoteResult holds the tags applied (or that would be applied), any
@@ -109,7 +112,7 @@ func Promote(inputs PromoteInputs, host string, reg Registry) (PromoteResult, er
 	if err := reg.CopyWithTags(inputs.Image, inputs.Repo, []string{latestTag}); err != nil {
 		return PromoteResult{}, fmt.Errorf("promote %s (latest): %w", inputs.Image, err)
 	}
-	if err := reg.CopySignatures(inputs.Image, inputs.Repo); err != nil {
+	if err := reg.CopySignatures(inputs.Image, inputs.Repo, inputs.AllowPartialSignatures); err != nil {
 		return PromoteResult{}, fmt.Errorf("promote %s (signatures): %w", inputs.Image, err)
 	}
 	return result, nil

--- a/ci/internal/release/promote_test.go
+++ b/ci/internal/release/promote_test.go
@@ -29,26 +29,26 @@ func TestPromote(t *testing.T) {
 	}{
 		{
 			name:   "happy path",
-			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest"},
+			inputs: PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", AllowPartialSignatures: true},
 		},
 		{
 			name:    "image required",
-			inputs:  PromoteInputs{Commit: "abc1234", Version: "1.9.0", Repo: repo},
+			inputs:  PromoteInputs{Commit: "abc1234", Version: "1.9.0", Repo: repo, AllowPartialSignatures: true},
 			wantErr: "image",
 		},
 		{
 			name:    "commit required",
-			inputs:  PromoteInputs{Image: srcRef, Version: "1.9.0", Repo: repo},
+			inputs:  PromoteInputs{Image: srcRef, Version: "1.9.0", Repo: repo, AllowPartialSignatures: true},
 			wantErr: "commit",
 		},
 		{
 			name:    "version required",
-			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234", Repo: repo},
+			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234", Repo: repo, AllowPartialSignatures: true},
 			wantErr: "version",
 		},
 		{
 			name:    "repo required",
-			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0"},
+			inputs:  PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", AllowPartialSignatures: true},
 			wantErr: "repo",
 		},
 	}
@@ -97,12 +97,13 @@ func TestPromoteDryRun(t *testing.T) {
 	pushImage(t, srcRef, name.Insecure)
 
 	result, err := Promote(PromoteInputs{
-		Image:        srcRef,
-		Commit:       "abc1234",
-		Version:      "9.9.9",
-		Repo:         repo,
-		LatestMarker: "latest",
-		DryRun:       true,
+		Image:                  srcRef,
+		Commit:                 "abc1234",
+		Version:                "9.9.9",
+		Repo:                   repo,
+		LatestMarker:           "latest",
+		DryRun:                 true,
+		AllowPartialSignatures: true,
 	}, host, DefaultRegistryConnector(srv.URL))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -136,11 +137,12 @@ func TestPromoteCustomLatestMarker(t *testing.T) {
 	srcDigest := pushImage(t, srcRef, name.Insecure)
 
 	result, err := Promote(PromoteInputs{
-		Image:        srcRef,
-		Commit:       "abc1234",
-		Version:      "1.10.1",
-		Repo:         repo,
-		LatestMarker: "latestv1",
+		Image:                  srcRef,
+		Commit:                 "abc1234",
+		Version:                "1.10.1",
+		Repo:                   repo,
+		LatestMarker:           "latestv1",
+		AllowPartialSignatures: true,
 	}, host, DefaultRegistryConnector(srv.URL))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -189,14 +191,14 @@ func TestPromoteRefusesStompedTag(t *testing.T) {
 	reg := DefaultRegistryConnector(srv.URL)
 
 	t.Run("refused without force", func(t *testing.T) {
-		_, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest"}, host, reg)
+		_, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", AllowPartialSignatures: true}, host, reg)
 		if err == nil || !strings.Contains(err.Error(), "already exists at a different digest") {
 			t.Fatalf("expected stomp error, got %v", err)
 		}
 	})
 
 	t.Run("proceeds with force", func(t *testing.T) {
-		result, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", Force: true}, host, reg)
+		result, err := Promote(PromoteInputs{Image: newSrc, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", Force: true, AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -231,10 +233,11 @@ func TestPromoteRequiresLatestMarker(t *testing.T) {
 	pushImage(t, srcRef, name.Insecure)
 
 	_, err := Promote(PromoteInputs{
-		Image:   srcRef,
-		Commit:  "abc1234",
-		Version: "1.9.0",
-		Repo:    repo,
+		Image:                  srcRef,
+		Commit:                 "abc1234",
+		Version:                "1.9.0",
+		Repo:                   repo,
+		AllowPartialSignatures: true,
 	}, host, DefaultRegistryConnector(srv.URL))
 	if err == nil || !strings.Contains(err.Error(), "latest-marker is required") {
 		t.Fatalf("expected 'latest-marker is required' error, got %v", err)
@@ -251,7 +254,7 @@ func TestPromoteInfosOnIdempotentRerun(t *testing.T) {
 	pushImage(t, srcRef, name.Insecure)
 
 	reg := DefaultRegistryConnector(srv.URL)
-	inputs := PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest"}
+	inputs := PromoteInputs{Image: srcRef, Commit: "abc1234", Version: "1.9.0", Repo: repo, LatestMarker: "latest", AllowPartialSignatures: true}
 
 	if _, err := Promote(inputs, host, reg); err != nil {
 		t.Fatalf("first promote: unexpected error: %v", err)

--- a/ci/internal/release/publish.go
+++ b/ci/internal/release/publish.go
@@ -31,6 +31,9 @@ type PublishInputs struct {
 	Force bool
 	// DryRun prints what would happen without copying any images.
 	DryRun bool
+	// AllowPartialSignatures, when true, ignores missing child manifest
+	// signatures during CopySignatures instead of failing.
+	AllowPartialSignatures bool
 }
 
 // PublishResult holds the resolved inputs and the tags that were (or would be) applied.
@@ -101,7 +104,7 @@ func Publish(inputs PublishInputs, host string, reg Registry) (PublishResult, er
 	if err := reg.CopyWithTags(srcRef, inputs.ProdRepo, []string{marker}); err != nil {
 		return PublishResult{}, fmt.Errorf("publish %s (%s): %w", srcRef, marker, err)
 	}
-	if err := reg.CopySignatures(srcRef, inputs.ProdRepo); err != nil {
+	if err := reg.CopySignatures(srcRef, inputs.ProdRepo, inputs.AllowPartialSignatures); err != nil {
 		return PublishResult{}, fmt.Errorf("publish %s (signatures): %w", srcRef, err)
 	}
 	return result, nil

--- a/ci/internal/release/publish_test.go
+++ b/ci/internal/release/publish_test.go
@@ -34,7 +34,7 @@ func TestPublish(t *testing.T) {
 	reg := DefaultRegistryConnector(srv.URL)
 
 	t.Run("publish with explicit commit", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -70,7 +70,7 @@ func TestPublish(t *testing.T) {
 		backportDigest := pushImage(t, backportSrcRef, name.Insecure)
 		tagAs(t, backportSrcRef, fmt.Sprintf("%s:%s", stagingBase, promotedTagFor(marker)), name.Insecure)
 
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, ProdRepo: prodRepo, LatestMarker: marker}, host, reg)
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, ProdRepo: prodRepo, LatestMarker: marker, AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -110,7 +110,7 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("publish resolves latest when commit omitted", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, ProdRepo: prodRepo, LatestMarker: "latest", AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -123,7 +123,7 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("dry-run returns result without copying", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", DryRun: true}, host, reg)
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", DryRun: true, AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -133,14 +133,14 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("staging-image required", func(t *testing.T) {
-		_, err := Publish(PublishInputs{Commit: commit, ProdRepo: prodRepo}, host, reg)
+		_, err := Publish(PublishInputs{Commit: commit, ProdRepo: prodRepo, AllowPartialSignatures: true}, host, reg)
 		if err == nil || !strings.Contains(err.Error(), "staging-image") {
 			t.Errorf("expected error containing %q, got %v", "staging-image", err)
 		}
 	})
 
 	t.Run("prod-repo required", func(t *testing.T) {
-		_, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit}, host, reg)
+		_, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, AllowPartialSignatures: true}, host, reg)
 		if err == nil || !strings.Contains(err.Error(), "prod-repo") {
 			t.Errorf("expected error containing %q, got %v", "prod-repo", err)
 		}
@@ -148,10 +148,11 @@ func TestPublish(t *testing.T) {
 
 	t.Run("unknown commit returns error", func(t *testing.T) {
 		_, err := Publish(PublishInputs{
-			StagingImage: stagingBase,
-			Commit:       "0000000000000000000000000000000000000000",
-			ProdRepo:     prodRepo,
-			LatestMarker: "latest",
+			StagingImage:           stagingBase,
+			Commit:                 "0000000000000000000000000000000000000000",
+			ProdRepo:               prodRepo,
+			LatestMarker:           "latest",
+			AllowPartialSignatures: true,
 		}, host, reg)
 		if err == nil {
 			t.Error("expected error for unknown commit, got nil")
@@ -174,7 +175,7 @@ func TestPublish(t *testing.T) {
 		pushImage(t, newRef, name.Insecure)
 		tagAs(t, newRef, fmt.Sprintf("%s:%s", multiBase, promotedLatestTag()), name.Insecure)
 
-		result, err := Publish(PublishInputs{StagingImage: multiBase, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		result, err := Publish(PublishInputs{StagingImage: multiBase, ProdRepo: prodRepo, LatestMarker: "latest", AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -192,7 +193,7 @@ func TestPublish(t *testing.T) {
 		orphanBase := fmt.Sprintf("%s/%s", host, "myorg/staging/orphan")
 		pushImage(t, fmt.Sprintf("%s:%s", orphanBase, promotedLatestTag()), name.Insecure)
 
-		_, err := Publish(PublishInputs{StagingImage: orphanBase, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		_, err := Publish(PublishInputs{StagingImage: orphanBase, ProdRepo: prodRepo, LatestMarker: "latest", AllowPartialSignatures: true}, host, reg)
 		if err == nil || !strings.Contains(err.Error(), "matches promoted-latest") {
 			t.Errorf("expected 'matches promoted-latest' error, got %v", err)
 		}
@@ -221,14 +222,14 @@ func TestPublishRefusesStompedVersionTag(t *testing.T) {
 	reg := DefaultRegistryConnector(srv.URL)
 
 	t.Run("refused without force", func(t *testing.T) {
-		_, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest"}, host, reg)
+		_, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", AllowPartialSignatures: true}, host, reg)
 		if err == nil || !strings.Contains(err.Error(), "already exists at a different digest") {
 			t.Fatalf("expected stomp error, got %v", err)
 		}
 	})
 
 	t.Run("proceeds with force", func(t *testing.T) {
-		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", Force: true}, host, reg)
+		result, err := Publish(PublishInputs{StagingImage: stagingBase, Commit: commit, ProdRepo: prodRepo, LatestMarker: "latest", Force: true, AllowPartialSignatures: true}, host, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -260,8 +261,9 @@ func TestPublishRequiresLatestMarker(t *testing.T) {
 	stagingBase := fmt.Sprintf("%s/%s", host, stagingRepo)
 
 	_, err := Publish(PublishInputs{
-		StagingImage: stagingBase,
-		ProdRepo:     prodRepo,
+		StagingImage:           stagingBase,
+		ProdRepo:               prodRepo,
+		AllowPartialSignatures: true,
 	}, host, DefaultRegistryConnector(srv.URL))
 	if err == nil || !strings.Contains(err.Error(), "latest-marker is required") {
 		t.Fatalf("expected 'latest-marker is required' error, got %v", err)

--- a/ci/internal/release/registry.go
+++ b/ci/internal/release/registry.go
@@ -19,15 +19,20 @@ import (
 // exist yet (as opposed to a real registry-access failure).
 var ErrTagNotFound = errors.New("tag not found")
 
+// ErrSignatureNotFound is returned when a cosign .sig tag does not exist.
+var ErrSignatureNotFound = errors.New("signature not found")
+
 // Registry is the abstracted OCI interface. The default implementation talks to
 // a real registry via go-containerregistry; tests can substitute a fake.
 type Registry interface {
 	// CopyWithTags copies srcRef to dstRepo under each of the given tags.
 	CopyWithTags(srcRef string, dstRepo string, tags []string) error
 	// CopySignatures copies the cosign signature for srcRef's digest (and,
-	// if srcRef is a multiarch index, for each child manifest digest too)
-	// from srcRef's repository to dstRepo, under the registry's own host.
-	CopySignatures(srcRef string, dstRepo string) error
+	// if srcRef is a multiarch index, for each child manifest digest too —
+	// returning ErrSignatureNotFound when the top-level .sig tag is missing,
+	// or when a child manifest .sig tag is missing and
+	// allowPartialSignatures is false).
+	CopySignatures(srcRef string, dstRepo string, allowPartialSignatures bool) error
 	// ListTags returns all tags for the given image repository reference.
 	ListTags(repo string) ([]string, error)
 	// Digest returns the manifest digest for ref (a full "host/repo:tag"
@@ -104,7 +109,7 @@ func (t *cRegistry) CopyWithTags(srcRef string, dstRepo string, tags []string) e
 // CopySignatures copies the cosign signature for srcRef's digest (and, if
 // srcRef is a multiarch index, for each child manifest digest too) from
 // srcRef's repository to dstRepo.
-func (t *cRegistry) CopySignatures(srcRef string, dstRepo string) error {
+func (t *cRegistry) CopySignatures(srcRef string, dstRepo string, allowPartialSignatures bool) error {
 	src, err := name.ParseReference(srcRef, t.nameOpts()...)
 	if err != nil {
 		return fmt.Errorf("failed to parse source ref %s: %w", srcRef, err)
@@ -115,7 +120,11 @@ func (t *cRegistry) CopySignatures(srcRef string, dstRepo string) error {
 	}
 
 	if err := t.copySignature(src, desc.Digest, dstRepo); err != nil {
-		return fmt.Errorf("failed to copy signature for %s: %w", srcRef, err)
+		if allowPartialSignatures && errors.Is(err, ErrSignatureNotFound) {
+			log.Printf("no signature found for %s, skipping copy", srcRef)
+		} else {
+			return fmt.Errorf("failed to copy signature for %s: %w", srcRef, err)
+		}
 	}
 
 	if desc.MediaType.IsIndex() {
@@ -129,6 +138,10 @@ func (t *cRegistry) CopySignatures(srcRef string, dstRepo string) error {
 		}
 		for _, m := range idxManifest.Manifests {
 			if err := t.copySignature(src, m.Digest, dstRepo); err != nil {
+				if allowPartialSignatures && errors.Is(err, ErrSignatureNotFound) {
+					log.Printf("no signature found for child manifest %s, skipping copy (%s)", m.Digest, srcRef)
+					continue
+				}
 				return fmt.Errorf("failed to copy signature for %s (child %s): %w", srcRef, m.Digest, err)
 			}
 		}
@@ -146,8 +159,7 @@ func (t *cRegistry) copySignature(src name.Reference, digest v1.Hash, dstRepo st
 	if err != nil {
 		var terr *transport.Error
 		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
-			log.Printf("no signature found for %s, skipping copy (image may be unsigned or an unsigned child manifest)", srcSigRef)
-			return nil
+			return ErrSignatureNotFound
 		}
 		return fmt.Errorf("failed to get signature %s: %w", srcSigRef, err)
 	}

--- a/ci/internal/release/registry_test.go
+++ b/ci/internal/release/registry_test.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"errors"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -90,7 +91,7 @@ func TestCRegistry_CopySignatures_CopiesSignatureIfPresent(t *testing.T) {
 	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", []string{"latest", "v1.0.0"}),
 		"CopyWithTags failed")
 
-	require.NoError(t, reg.CopySignatures(host+"/source-repo:v1", "target-repo"),
+	require.NoError(t, reg.CopySignatures(host+"/source-repo:v1", "target-repo", false),
 		"CopySignatures failed")
 
 	// The signature tag name is derived from the (unchanged) image digest,
@@ -155,7 +156,7 @@ func TestCRegistry_CopySignatures_CopiesSignaturesForIndexAndChildManifests(t *t
 	require.NoError(t, reg.CopyWithTags(host+"/source-repo:v1", "target-repo", []string{"latest"}),
 		"CopyWithTags failed")
 
-	require.NoError(t, reg.CopySignatures(host+"/source-repo:v1", "target-repo"),
+	require.NoError(t, reg.CopySignatures(host+"/source-repo:v1", "target-repo", false),
 		"CopySignatures failed")
 
 	// Assert that the signature for the index digest AND each child digest
@@ -194,8 +195,10 @@ func TestCRegistry_CopySignatures_NoSignatureIsNotAnError(t *testing.T) {
 	require.NoError(t, reg.CopyWithTags(host+"/unsigned-repo:v1", "target-repo-unsigned", []string{"latest"}),
 		"CopyWithTags should succeed even when no signature exists")
 
-	require.NoError(t, reg.CopySignatures(host+"/unsigned-repo:v1", "target-repo-unsigned"),
-		"CopySignatures should succeed even when no signature exists")
+	err = reg.CopySignatures(host+"/unsigned-repo:v1", "target-repo-unsigned", false)
+	require.Error(t, err, "CopySignatures should return error when no signature exists")
+	require.True(t, errors.Is(err, ErrSignatureNotFound),
+		"CopySignatures should wrap ErrSignatureNotFound for missing top-level signature")
 
 	// Confirm no signature tag was created at the destination either.
 	sigTag := signatureTagFor(imgDigest)

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import subprocess
@@ -138,6 +139,58 @@ def get_image_digest(image_name: str) -> Optional[str]:
         logger.error(f"Failed to get digest for {image_name}: {e.stderr}")
 
 
+def get_platform_manifest_digests(image_name: str) -> List[str]:
+    """
+    Returns the per-platform manifest digests if image_name is a multi-arch manifest list/OCI index, or an
+    empty list otherwise. Buildx attestation manifests (platform "unknown/unknown") are skipped since they
+    are not signed container images.
+
+    :param image_name: The full image name with its tag or digest.
+    :return: A list of platform-specific manifest digests.
+    """
+
+    transport_protocol = "docker://"
+    raw_command = [
+        "docker",
+        "run",
+        "--rm",
+        f"--volume={os.path.expanduser('~')}/.aws:/root/.aws:ro",
+        "quay.io/skopeo/stable:latest",
+        "inspect",
+        "--raw",
+    ]
+
+    if is_ecr_registry(image_name):
+        aws_region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+        ecr_password = get_ecr_login_password(aws_region)
+        raw_command.append(f"--creds=AWS:{ecr_password}")
+
+    raw_command.append(f"{transport_protocol}{image_name}")
+
+    try:
+        result = run_command_with_retries(raw_command)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to get raw manifest for {image_name}: {e.stderr}")
+        return []
+
+    manifest = json.loads(result.stdout)
+    manifest_list_media_types = (
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.index.v1+json",
+    )
+    if manifest.get("mediaType") not in manifest_list_media_types:
+        # Single-arch image: nothing to recurse into.
+        return []
+
+    digests = []
+    for entry in manifest.get("manifests", []):
+        platform = entry.get("platform", {})
+        if platform.get("architecture") == "unknown" or platform.get("os") == "unknown":
+            continue
+        digests.append(entry["digest"])
+    return digests
+
+
 def build_cosign_docker_command(additional_args: List[str], cosign_command: List[str]) -> List[str]:
     """
     Common logic to build a cosign command with the garasign cosign image provided by DevProd.
@@ -246,14 +299,45 @@ def verify_signature(repository: str, tag: str):
         "--env",
         f"{public_key_var_name}={kubernetes_operator_public_key}",
     ]
-    cosign_command = ["verify", "--insecure-ignore-tlog=true", f"--key=env://{public_key_var_name}", image]
-    command = build_cosign_docker_command(additional_args, cosign_command)
 
-    try:
+    def verify_ref(image_ref: str) -> None:
+        cosign_command = [
+            "verify",
+            "--insecure-ignore-tlog=true",
+            f"--key=env://{public_key_var_name}",
+            image_ref,
+        ]
+        command = build_cosign_docker_command(additional_args, cosign_command)
         run_command_with_retries(command, retries=10)
+
+    # The top-level image ref (the multi-arch index digest, if applicable) must always
+    # have a valid signature.
+    try:
+        verify_ref(image)
     except subprocess.CalledProcessError as e:
         # Fail the pipeline if verification fails
         raise Exception(f"Failed to verify signature for image {image}")
+
+    # cosign verify has no --recursive flag. Since sign_image signs the top-level
+    # multi-arch image index AND each per-platform image individually (via
+    # --recursive), also verify every platform digest here. A *missing* signature
+    # on a platform digest is only a warning: images signed before recursive
+    # signing was introduced only have a signature on the index, and we don't
+    # want to break verification of those older images. An actual invalid
+    # signature on a platform digest is still a hard failure.
+    for digest in get_platform_manifest_digests(image):
+        platform_ref = f"{repository}@{digest}"
+        try:
+            verify_ref(platform_ref)
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ""
+            if "no signatures found" in stderr:
+                logger.warning(
+                    f"No recursive signature found for platform image {platform_ref}. "
+                    "This is expected for images signed before recursive signing was introduced."
+                )
+                continue
+            raise Exception(f"Failed to verify signature for platform image {platform_ref}: {stderr}")
 
     end_time = time.time()
     duration = end_time - start_time

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -141,9 +141,10 @@ def get_image_digest(image_name: str) -> Optional[str]:
 
 def get_platform_manifest_digests(image_name: str) -> List[str]:
     """
-    Returns the per-platform manifest digests if image_name is a multi-arch manifest list/OCI index, or an
-    empty list otherwise. Buildx attestation manifests (platform "unknown/unknown") are skipped since they
-    are not signed container images.
+    Returns the per-platform manifest digests if image_name is a multi-arch manifest list/OCI index,
+    or an empty list otherwise.
+    Buildx attestation manifests (platform "unknown/unknown") are skipped since they are not signed
+    container images.
 
     :param image_name: The full image name with its tag or digest.
     :return: A list of platform-specific manifest digests.

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -183,25 +183,6 @@ def get_manifest_digests(image_name: str) -> List[str]:
     return digests
 
 
-def _sig_tag_exists(repository: str, digest: str) -> bool:
-    sig_ref = f"{repository}:sha256-{digest.split(':', 1)[1]}.sig"
-    command = [
-        "docker",
-        "run",
-        "--rm",
-        f"--volume={os.path.expanduser('~')}/.aws:/root/.aws:ro",
-        "quay.io/skopeo/stable:latest",
-        "inspect",
-    ]
-    _append_ecr_creds(command, sig_ref)
-    command.append(f"docker://{sig_ref}")
-    try:
-        run_command_with_retries(command, retries=2)
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
-
 def build_cosign_docker_command(additional_args: List[str], cosign_command: List[str]) -> List[str]:
     """
     Common logic to build a cosign command with the garasign cosign image provided by DevProd.
@@ -331,19 +312,9 @@ def verify_signature(repository: str, tag: str):
 
     # cosign verify has no --recursive flag. Since sign_image signs the top-level
     # multi-arch image index AND each per-platform image individually (via
-    # --recursive), also verify every platform digest here. A *missing* signature
-    # on a platform digest is only a warning: images signed before recursive
-    # signing was introduced only have a signature on the index, and we don't
-    # want to break verification of those older images. An actual invalid
-    # signature on a platform digest is still a hard failure.
+    # --recursive), also verify every platform digest here.
     for digest in get_manifest_digests(image):
         platform_ref = f"{repository}@{digest}"
-        if not _sig_tag_exists(repository, digest):
-            logger.warning(
-                f"No recursive signature found for platform image {platform_ref}. "
-                "This is expected for images signed before recursive signing was introduced."
-            )
-            continue
         try:
             verify_ref(platform_ref)
         except subprocess.CalledProcessError as e:

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -141,7 +141,7 @@ def get_image_digest(image_name: str) -> Optional[str]:
         logger.error(f"Failed to get digest for {image_name}: {e.stderr}")
 
 
-def get_platform_manifest_digests(image_name: str) -> List[str]:
+def get_manifest_digests(image_name: str) -> List[str]:
     """
     Returns the per-platform manifest digests if image_name is a multi-arch manifest list/OCI index,
     or an empty list otherwise.
@@ -336,7 +336,7 @@ def verify_signature(repository: str, tag: str):
     # signing was introduced only have a signature on the index, and we don't
     # want to break verification of those older images. An actual invalid
     # signature on a platform digest is still a hard failure.
-    for digest in get_platform_manifest_digests(image):
+    for digest in get_manifest_digests(image):
         platform_ref = f"{repository}@{digest}"
         if not _sig_tag_exists(repository, digest):
             logger.warning(

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -168,11 +168,7 @@ def get_platform_manifest_digests(image_name: str) -> List[str]:
 
     raw_command.append(f"{transport_protocol}{image_name}")
 
-    try:
-        result = run_command_with_retries(raw_command)
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to get raw manifest for {image_name}: {e.stderr}")
-        return []
+    result = run_command_with_retries(raw_command)
 
     manifest = json.loads(result.stdout)
     manifest_list_media_types = (

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -145,8 +145,6 @@ def get_platform_manifest_digests(image_name: str) -> List[str]:
     """
     Returns the per-platform manifest digests if image_name is a multi-arch manifest list/OCI index,
     or an empty list otherwise.
-    Buildx attestation manifests (platform "unknown/unknown") are skipped since they are not signed
-    container images.
 
     :param image_name: The full image name with its tag or digest.
     :return: A list of platform-specific manifest digests.
@@ -181,8 +179,6 @@ def get_platform_manifest_digests(image_name: str) -> List[str]:
     digests = []
     for entry in manifest.get("manifests", []):
         platform = entry.get("platform", {})
-        if platform.get("architecture") == "unknown" or platform.get("os") == "unknown":
-            continue
         digests.append(entry["digest"])
     return digests
 

--- a/scripts/release/build/image_signing.py
+++ b/scripts/release/build/image_signing.py
@@ -104,6 +104,11 @@ def is_ecr_registry(image_name: str) -> bool:
     return "amazonaws.com" in image_name
 
 
+def _append_ecr_creds(command: List[str], image_name: str) -> None:
+    if is_ecr_registry(image_name):
+        command.append(f"--creds=AWS:{get_ecr_login_password(os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))}")
+
+
 def get_image_digest(image_name: str) -> Optional[str]:
     """
     Retrieves the digest of an image from its tag. Uses the skopeo container to be able to retrieve manifests tags as well.
@@ -124,10 +129,7 @@ def get_image_digest(image_name: str) -> Optional[str]:
     ]
 
     # Specify ECR credentials if necessary
-    if is_ecr_registry(image_name):
-        aws_region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-        ecr_password = get_ecr_login_password(aws_region)
-        digest_command.append(f"--creds=AWS:{ecr_password}")
+    _append_ecr_creds(digest_command, image_name)
 
     digest_command.append(f"{transport_protocol}{image_name}")
 
@@ -161,10 +163,7 @@ def get_platform_manifest_digests(image_name: str) -> List[str]:
         "--raw",
     ]
 
-    if is_ecr_registry(image_name):
-        aws_region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-        ecr_password = get_ecr_login_password(aws_region)
-        raw_command.append(f"--creds=AWS:{ecr_password}")
+    _append_ecr_creds(raw_command, image_name)
 
     raw_command.append(f"{transport_protocol}{image_name}")
 
@@ -186,6 +185,25 @@ def get_platform_manifest_digests(image_name: str) -> List[str]:
             continue
         digests.append(entry["digest"])
     return digests
+
+
+def _sig_tag_exists(repository: str, digest: str) -> bool:
+    sig_ref = f"{repository}:sha256-{digest.split(':', 1)[1]}.sig"
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        f"--volume={os.path.expanduser('~')}/.aws:/root/.aws:ro",
+        "quay.io/skopeo/stable:latest",
+        "inspect",
+    ]
+    _append_ecr_creds(command, sig_ref)
+    command.append(f"docker://{sig_ref}")
+    try:
+        run_command_with_retries(command, retries=2)
+        return True
+    except subprocess.CalledProcessError:
+        return False
 
 
 def build_cosign_docker_command(additional_args: List[str], cosign_command: List[str]) -> List[str]:
@@ -324,17 +342,16 @@ def verify_signature(repository: str, tag: str):
     # signature on a platform digest is still a hard failure.
     for digest in get_platform_manifest_digests(image):
         platform_ref = f"{repository}@{digest}"
+        if not _sig_tag_exists(repository, digest):
+            logger.warning(
+                f"No recursive signature found for platform image {platform_ref}. "
+                "This is expected for images signed before recursive signing was introduced."
+            )
+            continue
         try:
             verify_ref(platform_ref)
         except subprocess.CalledProcessError as e:
-            stderr = e.stderr or ""
-            if "no signatures found" in stderr:
-                logger.warning(
-                    f"No recursive signature found for platform image {platform_ref}. "
-                    "This is expected for images signed before recursive signing was introduced."
-                )
-                continue
-            raise Exception(f"Failed to verify signature for platform image {platform_ref}: {stderr}")
+            raise Exception(f"Failed to verify signature for platform image {platform_ref}: {e.stderr}")
 
     end_time = time.time()
     duration = end_time - start_time

--- a/scripts/release/tests/image_signing_test.py
+++ b/scripts/release/tests/image_signing_test.py
@@ -1,6 +1,6 @@
 import json
 from subprocess import CalledProcessError
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -25,9 +25,9 @@ SINGLE_ARCH_MANIFEST = {
     "name, manifest, want_digests",
     [
         (
-            "multi-arch index returns platform digests, skipping attestation manifests",
+            "multi-arch index returns all platform digests including attestation manifests",
             MULTI_ARCH_MANIFEST,
-            ["sha256:amd64digest", "sha256:arm64digest"],
+            ["sha256:amd64digest", "sha256:arm64digest", "sha256:attestationdigest"],
         ),
         (
             "single-arch image has nothing to recurse into",
@@ -45,49 +45,48 @@ def test_get_platform_manifest_digests(mock_run, name, manifest, want_digests):
     assert digests == want_digests
 
 
-OK = MagicMock()
+SIG_TAG_MISSING = CalledProcessError(1, ["skopeo", "inspect"], stderr="manifest unknown")
 NO_SIGNATURE_ERR = CalledProcessError(1, ["cosign", "verify"], stderr="Error: no signatures found")
 INVALID_SIGNATURE_ERR = CalledProcessError(
     1, ["cosign", "verify"], stderr="Error: no matching signatures: invalid signature when validating ASN.1"
 )
-# _sig_tag_exists calls run_command_with_retries; any CalledProcessError means the tag wasn't found.
-SIG_TAG_MISSING = CalledProcessError(1, ["skopeo", "inspect"], stderr="manifest unknown")
-
-
 @pytest.mark.parametrize(
-    "name, platform_digests, run_side_effect, want_err, want_call_count, want_digests_lookup",
+    "name, platform_digests, run_side_effect, want_err",
     [
         (
-            "top-level and all platform digests signed: passes",
+            "all platform digests signed: passes",
             ["sha256:amd64digest", "sha256:arm64digest"],
-            [OK, OK, OK, OK, OK],
+            {"return_value": MagicMock()},
             "",
-            5,
-            True,
         ),
         (
             "platform digest missing signature: warns only, does not raise",
             ["sha256:amd64digest"],
-            [OK, SIG_TAG_MISSING],
+            {
+                "side_effect": [
+                    MagicMock(),
+                    SIG_TAG_MISSING,
+                ]
+            },
             "",
-            2,
-            True,
         ),
         (
             "platform digest has invalid signature: raises",
             ["sha256:amd64digest"],
-            [OK, OK, INVALID_SIGNATURE_ERR],
+            {
+                "side_effect": [
+                    MagicMock(),
+                    MagicMock(),
+                    INVALID_SIGNATURE_ERR,
+                ]
+            },
             "Failed to verify signature for platform image",
-            3,
-            True,
         ),
         (
             "top-level signature missing: raises without checking platform digests",
             [],
-            NO_SIGNATURE_ERR,
+            {"side_effect": NO_SIGNATURE_ERR},
             "Failed to verify signature for image",
-            1,
-            False,
         ),
     ],
 )
@@ -102,18 +101,13 @@ def test_verify_signature(
     platform_digests,
     run_side_effect,
     want_err,
-    want_call_count,
-    want_digests_lookup,
 ):
     mock_requests.get.return_value = MagicMock(status_code=200, text="fake-public-key")
     mock_digests.return_value = platform_digests
-    mock_run.side_effect = run_side_effect
+    mock_run.configure_mock(**run_side_effect)
 
     if want_err:
         with pytest.raises(Exception, match=want_err):
             verify_signature("myrepo/myimage", "1.0.0")
     else:
         verify_signature("myrepo/myimage", "1.0.0")
-
-    assert mock_run.call_count == want_call_count
-    assert mock_digests.called == want_digests_lookup

--- a/scripts/release/tests/image_signing_test.py
+++ b/scripts/release/tests/image_signing_test.py
@@ -45,7 +45,6 @@ def test_get_manifest_digests(mock_run, name, manifest, want_digests):
     assert digests == want_digests
 
 
-SIG_TAG_MISSING = CalledProcessError(1, ["skopeo", "inspect"], stderr="manifest unknown")
 NO_SIGNATURE_ERR = CalledProcessError(1, ["cosign", "verify"], stderr="Error: no signatures found")
 INVALID_SIGNATURE_ERR = CalledProcessError(
     1, ["cosign", "verify"], stderr="Error: no matching signatures: invalid signature when validating ASN.1"
@@ -62,22 +61,21 @@ INVALID_SIGNATURE_ERR = CalledProcessError(
             "",
         ),
         (
-            "platform digest missing signature: warns only, does not raise",
+            "platform digest missing signature: raises",
             ["sha256:amd64digest"],
             {
                 "side_effect": [
                     MagicMock(),
-                    SIG_TAG_MISSING,
+                    NO_SIGNATURE_ERR,
                 ]
             },
-            "",
+            "Failed to verify signature for platform image",
         ),
         (
             "platform digest has invalid signature: raises",
             ["sha256:amd64digest"],
             {
                 "side_effect": [
-                    MagicMock(),
                     MagicMock(),
                     INVALID_SIGNATURE_ERR,
                 ]

--- a/scripts/release/tests/image_signing_test.py
+++ b/scripts/release/tests/image_signing_test.py
@@ -45,10 +45,13 @@ def test_get_platform_manifest_digests(mock_run, name, manifest, want_digests):
     assert digests == want_digests
 
 
+OK = MagicMock()
 NO_SIGNATURE_ERR = CalledProcessError(1, ["cosign", "verify"], stderr="Error: no signatures found")
 INVALID_SIGNATURE_ERR = CalledProcessError(
     1, ["cosign", "verify"], stderr="Error: no matching signatures: invalid signature when validating ASN.1"
 )
+# _sig_tag_exists calls run_command_with_retries; any CalledProcessError means the tag wasn't found.
+SIG_TAG_MISSING = CalledProcessError(1, ["skopeo", "inspect"], stderr="manifest unknown")
 
 
 @pytest.mark.parametrize(
@@ -57,15 +60,15 @@ INVALID_SIGNATURE_ERR = CalledProcessError(
         (
             "top-level and all platform digests signed: passes",
             ["sha256:amd64digest", "sha256:arm64digest"],
-            [MagicMock(), MagicMock(), MagicMock()],
+            [OK, OK, OK, OK, OK],
             "",
-            3,
+            5,
             True,
         ),
         (
             "platform digest missing signature: warns only, does not raise",
             ["sha256:amd64digest"],
-            [MagicMock(), NO_SIGNATURE_ERR],
+            [OK, SIG_TAG_MISSING],
             "",
             2,
             True,
@@ -73,9 +76,9 @@ INVALID_SIGNATURE_ERR = CalledProcessError(
         (
             "platform digest has invalid signature: raises",
             ["sha256:amd64digest"],
-            [MagicMock(), INVALID_SIGNATURE_ERR],
+            [OK, OK, INVALID_SIGNATURE_ERR],
             "Failed to verify signature for platform image",
-            2,
+            3,
             True,
         ),
         (

--- a/scripts/release/tests/image_signing_test.py
+++ b/scripts/release/tests/image_signing_test.py
@@ -1,0 +1,116 @@
+import json
+from subprocess import CalledProcessError
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.release.build.image_signing import get_platform_manifest_digests, verify_signature
+
+MULTI_ARCH_MANIFEST = {
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+        {"digest": "sha256:amd64digest", "platform": {"architecture": "amd64", "os": "linux"}},
+        {"digest": "sha256:arm64digest", "platform": {"architecture": "arm64", "os": "linux"}},
+        {"digest": "sha256:attestationdigest", "platform": {"architecture": "unknown", "os": "unknown"}},
+    ],
+}
+
+SINGLE_ARCH_MANIFEST = {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "config": {"digest": "sha256:configdigest"},
+}
+
+
+@pytest.mark.parametrize(
+    "name, manifest, want_digests",
+    [
+        (
+            "multi-arch index returns platform digests, skipping attestation manifests",
+            MULTI_ARCH_MANIFEST,
+            ["sha256:amd64digest", "sha256:arm64digest"],
+        ),
+        (
+            "single-arch image has nothing to recurse into",
+            SINGLE_ARCH_MANIFEST,
+            [],
+        ),
+    ],
+)
+@patch("scripts.release.build.image_signing.run_command_with_retries")
+def test_get_platform_manifest_digests(mock_run, name, manifest, want_digests):
+    mock_run.return_value = MagicMock(stdout=json.dumps(manifest))
+
+    digests = get_platform_manifest_digests("myrepo/myimage:1.0.0")
+
+    assert digests == want_digests
+
+
+NO_SIGNATURE_ERR = CalledProcessError(1, ["cosign", "verify"], stderr="Error: no signatures found")
+INVALID_SIGNATURE_ERR = CalledProcessError(
+    1, ["cosign", "verify"], stderr="Error: no matching signatures: invalid signature when validating ASN.1"
+)
+
+
+@pytest.mark.parametrize(
+    "name, platform_digests, run_side_effect, want_err, want_call_count, want_digests_lookup",
+    [
+        (
+            "top-level and all platform digests signed: passes",
+            ["sha256:amd64digest", "sha256:arm64digest"],
+            [MagicMock(), MagicMock(), MagicMock()],
+            "",
+            3,
+            True,
+        ),
+        (
+            "platform digest missing signature: warns only, does not raise",
+            ["sha256:amd64digest"],
+            [MagicMock(), NO_SIGNATURE_ERR],
+            "",
+            2,
+            True,
+        ),
+        (
+            "platform digest has invalid signature: raises",
+            ["sha256:amd64digest"],
+            [MagicMock(), INVALID_SIGNATURE_ERR],
+            "Failed to verify signature for platform image",
+            2,
+            True,
+        ),
+        (
+            "top-level signature missing: raises without checking platform digests",
+            [],
+            NO_SIGNATURE_ERR,
+            "Failed to verify signature for image",
+            1,
+            False,
+        ),
+    ],
+)
+@patch("scripts.release.build.image_signing.get_platform_manifest_digests")
+@patch("scripts.release.build.image_signing.run_command_with_retries")
+@patch("scripts.release.build.image_signing.requests")
+def test_verify_signature(
+    mock_requests,
+    mock_run,
+    mock_digests,
+    name,
+    platform_digests,
+    run_side_effect,
+    want_err,
+    want_call_count,
+    want_digests_lookup,
+):
+    mock_requests.get.return_value = MagicMock(status_code=200, text="fake-public-key")
+    mock_digests.return_value = platform_digests
+    mock_run.side_effect = run_side_effect
+
+    if want_err:
+        with pytest.raises(Exception, match=want_err):
+            verify_signature("myrepo/myimage", "1.0.0")
+    else:
+        verify_signature("myrepo/myimage", "1.0.0")
+
+    assert mock_run.call_count == want_call_count
+    assert mock_digests.called == want_digests_lookup

--- a/scripts/release/tests/image_signing_test.py
+++ b/scripts/release/tests/image_signing_test.py
@@ -50,6 +50,8 @@ NO_SIGNATURE_ERR = CalledProcessError(1, ["cosign", "verify"], stderr="Error: no
 INVALID_SIGNATURE_ERR = CalledProcessError(
     1, ["cosign", "verify"], stderr="Error: no matching signatures: invalid signature when validating ASN.1"
 )
+
+
 @pytest.mark.parametrize(
     "name, platform_digests, run_side_effect, want_err",
     [

--- a/scripts/release/tests/image_signing_test.py
+++ b/scripts/release/tests/image_signing_test.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
-from scripts.release.build.image_signing import get_platform_manifest_digests, verify_signature
+from scripts.release.build.image_signing import get_manifest_digests, verify_signature
 
 MULTI_ARCH_MANIFEST = {
     "mediaType": "application/vnd.oci.image.index.v1+json",
@@ -37,10 +37,10 @@ SINGLE_ARCH_MANIFEST = {
     ],
 )
 @patch("scripts.release.build.image_signing.run_command_with_retries")
-def test_get_platform_manifest_digests(mock_run, name, manifest, want_digests):
+def test_get_manifest_digests(mock_run, name, manifest, want_digests):
     mock_run.return_value = MagicMock(stdout=json.dumps(manifest))
 
-    digests = get_platform_manifest_digests("myrepo/myimage:1.0.0")
+    digests = get_manifest_digests("myrepo/myimage:1.0.0")
 
     assert digests == want_digests
 
@@ -90,7 +90,7 @@ INVALID_SIGNATURE_ERR = CalledProcessError(
         ),
     ],
 )
-@patch("scripts.release.build.image_signing.get_platform_manifest_digests")
+@patch("scripts.release.build.image_signing.get_manifest_digests")
 @patch("scripts.release.build.image_signing.run_command_with_retries")
 @patch("scripts.release.build.image_signing.requests")
 def test_verify_signature(


### PR DESCRIPTION
# Summary

Add recursive signature verification after #1467 added recursive signing beyond the multi arch image.

This is a separate PR as cosign does not include a recursive verification option, so we needed to compute the extra manifests to sign one by one.

Recursive signatures means that **cosing** does not sign only the top level manifest of a multi-arch image, but also each of the per-platform images as well. This is a better UX for customers as they can verify any hash signature, not just the top index manifest. But for us it means for good test coverage we also need to verify we properly ssigned not just the top index manifest, but also the dependant images.

## Proof of Work

CI added python unit tests.

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
