### PR TITLE
fix(ci): IP detection on s390x

### DIFF
--- a/scripts/minikube/setup_minikube.sh
+++ b/scripts/minikube/setup_minikube.sh
@@ -76,6 +76,15 @@ start_minikube_cluster() {
   start_args+=("--cpus=4" "--memory=8g")
   start_args+=("--cni=bridge")
 
+  # s390x + rootful podman: kubeadm inside the container can't auto-detect
+  # a non-loopback IP. Pass --listen-address with the host's primary IP,
+  # which tells kubeadm what apiserver-advertise-address to use.
+  local HOST_IP
+  HOST_IP=$(ip -4 addr show scope global | awk '/inet / {print $2; exit}' | cut -d/ -f1)
+  if [[ -n "${HOST_IP}" ]]; then
+    start_args+=("--listen-address=${HOST_IP}")
+  fi
+
   echo "Starting minikube with args: ${start_args[*]}"
   if sudo TMPDIR="${MINIKUBE_TMPDIR}" "${PROJECT_DIR:-.}/bin/minikube" start "${start_args[@]}"; then
     echo "✅ Minikube started successfully"

--- a/scripts/minikube/setup_minikube.sh
+++ b/scripts/minikube/setup_minikube.sh
@@ -74,16 +74,7 @@ start_minikube_cluster() {
   # --force allows running minikube with root privileges
   local start_args=("--driver=podman" "--container-runtime=containerd" "--force")
   start_args+=("--cpus=4" "--memory=8g")
-  start_args+=("--cni=bridge")
-
-  # s390x + rootful podman: kubeadm inside the container can't auto-detect
-  # a non-loopback IP. Pass --listen-address with the host's primary IP,
-  # which tells kubeadm what apiserver-advertise-address to use.
-  local HOST_IP
-  HOST_IP=$(ip -4 addr show scope global | awk '/inet / {print $2; exit}' | cut -d/ -f1)
-  if [[ -n "${HOST_IP}" ]]; then
-    start_args+=("--listen-address=${HOST_IP}")
-  fi
+  # --cni=bridge removed: podman's default CNI handles networking in rootful mode
 
   echo "Starting minikube with args: ${start_args[*]}"
   if sudo TMPDIR="${MINIKUBE_TMPDIR}" "${PROJECT_DIR:-.}/bin/minikube" start "${start_args[@]}"; then


### PR DESCRIPTION
# Summary

Solve IP Detection failure on IBM Z server tests by letting podman default CNI handle networking.

## Proof of Work

🚧 [Patch test](https://spruce.corp.mongodb.com/version/6a871673eaa8ae000702acb6)
```shell
evergreen patch -p mongodb-kubernetes \
  -v e2e_smoke_ibm_z -v e2e_static_smoke_ibm_z -v e2e_smoke_ibm_power -v e2e_static_smoke_ibm_power \
  -t e2e_replica_set -d "fix: remove --cni=bridge to let podman default CNI handle networking" -f -y -u
```

## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
