### PR TITLE
KUBE-338: Fix authMechanism in $external MongoDBUser connection string secrets

### DIFF
--- a/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
+++ b/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
@@ -3,5 +3,5 @@ kind: fix
 date: 2026-08-20
 ---
 
-* **MongoDBUser**: Fixed the generated connection string secret carrying a SCRAM `authMechanism` (for example `SCRAM-SHA-256`) for users with `spec.db: "$external"` on deployments that enable SCRAM alongside external authentication. The secret now omits `authMechanism`; clients supply the appropriate external mechanism at connect time.
-* **MongoDBUser**: The connection string secret no longer contains an empty `password` key for users with `spec.db: "$external"`. Certificate and LDAP based identities have no password; the key is omitted rather than written empty.
+* **MongoDBUser**: Fixed the generated connection string secret carrying a SCRAM `authMechanism` (for example `SCRAM-SHA-256`) for users with `spec.db: "$external"` on deployments that enable SCRAM alongside external authentication. The secret now omits `authMechanism` so clients supply the appropriate external mechanism at connect time.
+* **MongoDBUser**: The connection string secret no longer contains an empty `password` key for users with `spec.db: "$external"`. The key is omitted rather than written empty.

--- a/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
+++ b/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
@@ -3,5 +3,5 @@ kind: fix
 date: 2026-08-20
 ---
 
-* **MongoDBUser**: Fixed the generated connection string secret carrying `authMechanism=SCRAM-SHA-256` for users with `spec.db: "$external"` on resources that enable both SCRAM and X.509.
+* **MongoDBUser**: Fixed the generated connection string secret carrying a SCRAM `authMechanism` (for example `SCRAM-SHA-256`) for users with `spec.db: "$external"` on deployments that enable SCRAM alongside external authentication. The secret now omits `authMechanism` so clients supply the appropriate external mechanism at connect time.
 * **MongoDBUser**: The connection string secret no longer contains an empty `password` key for users with `spec.db: "$external"`, since a certificate or LDAP based identity has no password. The key is omitted rather than written empty.

--- a/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
+++ b/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
@@ -3,5 +3,5 @@ kind: fix
 date: 2026-08-20
 ---
 
-* **MongoDBUser**: Fixed the generated connection string secret carrying a SCRAM `authMechanism` (for example `SCRAM-SHA-256`) for users with `spec.db: "$external"` on deployments that enable SCRAM alongside external authentication. The secret now omits `authMechanism` so clients supply the appropriate external mechanism at connect time.
-* **MongoDBUser**: The connection string secret no longer contains an empty `password` key for users with `spec.db: "$external"`, since a certificate or LDAP based identity has no password. The key is omitted rather than written empty.
+* **MongoDBUser**: Fixed the generated connection string secret carrying a SCRAM `authMechanism` (for example `SCRAM-SHA-256`) for users with `spec.db: "$external"` on deployments that enable SCRAM alongside external authentication. The secret now omits `authMechanism`; clients supply the appropriate external mechanism at connect time.
+* **MongoDBUser**: The connection string secret no longer contains an empty `password` key for users with `spec.db: "$external"`. Certificate and LDAP based identities have no password; the key is omitted rather than written empty.

--- a/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
+++ b/changelog/20260820_fix_external_user_connection_string_auth_mechanism.md
@@ -1,0 +1,7 @@
+---
+kind: fix
+date: 2026-08-20
+---
+
+* **MongoDBUser**: Fixed the generated connection string secret carrying `authMechanism=SCRAM-SHA-256` for users with `spec.db: "$external"` on resources that enable both SCRAM and X.509.
+* **MongoDBUser**: The connection string secret no longer contains an empty `password` key for users with `spec.db: "$external"`, since a certificate or LDAP based identity has no password. The key is omitted rather than written empty.

--- a/controllers/operator/connectionstring/connectionstring.go
+++ b/controllers/operator/connectionstring/connectionstring.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mongodb/mongodb-kubernetes/pkg/dns"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/stringutil"
 )
 
@@ -185,7 +186,11 @@ func (b *builder) Build() string {
 	if authSource != "" {
 		connectionParams["authSource"] = authSource
 	}
-	if authMechanism != "" {
+	// Users authenticating against $external use X.509 or LDAP, so a SCRAM mechanism the resource
+	// also enables must not leak into their connection string. Which of the two applies is a
+	// property of how the individual user was provisioned rather than of the deployment, so the
+	// mechanism is left for the client to supply.
+	if authMechanism != "" && b.connectionParams["authSource"] != constants.ExternalDB {
 		connectionParams["authMechanism"] = authMechanism
 	}
 

--- a/controllers/operator/connectionstring/connectionstring.go
+++ b/controllers/operator/connectionstring/connectionstring.go
@@ -185,10 +185,7 @@ func (b *builder) Build() string {
 	if authSource != "" {
 		connectionParams["authSource"] = authSource
 	}
-	// Users authenticating against $external use X.509 or LDAP, so a SCRAM mechanism the resource
-	// also enables must not leak into their connection string. Which of the two applies is a
-	// property of how the individual user was provisioned rather than of the deployment, so the
-	// mechanism is left for the client to supply.
+	// Omit authMechanism for $external users; the client supplies the mechanism at connect time.
 	if authMechanism != "" && b.connectionParams["authSource"] != constants.ExternalDB {
 		connectionParams["authMechanism"] = authMechanism
 	}

--- a/controllers/operator/mongodbuser_controller.go
+++ b/controllers/operator/mongodbuser_controller.go
@@ -288,14 +288,19 @@ func (r *MongoDBUserReconciler) updateConnectionStringSecret(ctx context.Context
 	mongoAuthUserURI := connectionBuilder.BuildConnectionString(user.Spec.Username, password, user.Spec.ConnectionStringDatabase, connectionstring.SchemeMongoDB, map[string]string{"authSource": user.Spec.Database})
 	mongoAuthUserSRVURI := connectionBuilder.BuildConnectionString(user.Spec.Username, password, user.Spec.ConnectionStringDatabase, connectionstring.SchemeMongoDBSRV, map[string]string{"authSource": user.Spec.Database})
 
-	memberClusterSecret := secret.Builder().
+	secretBuilder := secret.Builder().
 		SetName(secretName).
 		SetNamespace(user.Namespace).
 		SetField("connectionString.standard", mongoAuthUserURI).
 		SetField("connectionString.standardSrv", mongoAuthUserSRVURI).
-		SetField("username", user.Spec.Username).
-		SetField("password", password).
-		Build()
+		SetField("username", user.Spec.Username)
+
+	// External users have no password, so the key is left out rather than written empty.
+	if user.Spec.Database != authentication.ExternalDB {
+		secretBuilder.SetField("password", password)
+	}
+
+	memberClusterSecret := secretBuilder.Build()
 
 	for _, c := range r.memberClusterSecretClientsMap {
 		err = secret.CreateOrUpdate(ctx, c, memberClusterSecret)

--- a/controllers/operator/mongodbuser_controller_test.go
+++ b/controllers/operator/mongodbuser_controller_test.go
@@ -547,9 +547,6 @@ func TestConnectionStringSecret_X509_UsesExternalDb_AsAuthSource(t *testing.T) {
 		string(secret.Data["connectionString.standardSrv"]))
 }
 
-// TestConnectionStringSecret_ExternalUser_OnScramAndX509Resource_HasNoAuthMechanism covers a
-// resource with both SCRAM and X.509 enabled. The SCRAM mechanism must not leak into the
-// connection string of a user authenticating against $external, and no password is written.
 func TestConnectionStringSecret_ExternalUser_OnScramAndX509Resource_HasNoAuthMechanism(t *testing.T) {
 	ctx := context.Background()
 	user := DefaultMongoDBUserBuilder().SetMongoDBResourceName("my-rs").SetDatabase(authentication.ExternalDB).Build()

--- a/controllers/operator/mongodbuser_controller_test.go
+++ b/controllers/operator/mongodbuser_controller_test.go
@@ -547,6 +547,34 @@ func TestConnectionStringSecret_X509_UsesExternalDb_AsAuthSource(t *testing.T) {
 		string(secret.Data["connectionString.standardSrv"]))
 }
 
+// TestConnectionStringSecret_ExternalUser_OnScramAndX509Resource_HasNoAuthMechanism covers a
+// resource with both SCRAM and X.509 enabled. The SCRAM mechanism must not leak into the
+// connection string of a user authenticating against $external, and no password is written.
+func TestConnectionStringSecret_ExternalUser_OnScramAndX509Resource_HasNoAuthMechanism(t *testing.T) {
+	ctx := context.Background()
+	user := DefaultMongoDBUserBuilder().SetMongoDBResourceName("my-rs").SetDatabase(authentication.ExternalDB).Build()
+	reconciler, client, _ := userReconcilerWithAuthMode(ctx, user, util.AutomationConfigX509Option)
+
+	_ = client.Create(ctx, DefaultReplicaSetBuilder().EnableSCRAM().EnableX509().SetName("my-rs").Build())
+	createUserControllerConfigMap(ctx, client)
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kube.ObjectKey(user.Namespace, user.Name)})
+	require.NoError(t, err)
+
+	secret := &corev1.Secret{}
+	err = client.Get(ctx, kube.ObjectKey(user.Namespace, user.GetConnectionStringSecretName()), secret)
+	require.NoError(t, err)
+
+	for _, key := range []string{"connectionString.standard", "connectionString.standardSrv"} {
+		cs := string(secret.Data[key])
+		assert.Contains(t, cs, "authSource=$external", "authSource should be $external (%s)", key)
+		assert.NotContains(t, cs, "authMechanism", "no authMechanism must be set for an external user (%s)", key)
+		assert.NotContains(t, cs, "@", "no credentials must appear in the URI for an external user (%s)", key)
+	}
+
+	assert.NotContains(t, secret.Data, "password", "password key must be omitted for an external user")
+}
+
 func TestConnectionStringSecret_ScramSHA1_UsesSpecDb_AsAuthSource(t *testing.T) {
 	ctx := context.Background()
 	user := DefaultMongoDBUserBuilder().SetMongoDBResourceName("my-rs").SetDatabase("mydb").Build()

--- a/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_scram_sha_and_x509.py
+++ b/docker/mongodb-kubernetes-tests/tests/authentication/replica_set_scram_sha_and_x509.py
@@ -1,13 +1,14 @@
 import tempfile
+from typing import Dict
 
 import pytest
-from kubetester import try_load
+from kubetester import read_secret, try_load
 from kubetester.automation_config_tester import AutomationConfigTester
 from kubetester.certs import ISSUER_CA_NAME, create_mongodb_tls_certs, create_x509_user_cert
 from kubetester.kubetester import KubernetesTester
 from kubetester.kubetester import fixture as load_fixture
 from kubetester.mongodb import MongoDB
-from kubetester.mongotester import ReplicaSetTester
+from kubetester.mongotester import MongoTester, ReplicaSetTester, assert_connection_string_with_mongosh, with_x509
 from kubetester.phase import Phase
 
 MDB_RESOURCE = "replica-set-scram-256-and-x509"
@@ -115,9 +116,13 @@ class TestScramUserCanAuthenticate(KubernetesTester):
 @pytest.mark.e2e_replica_set_scram_sha_and_x509
 class TestAddMongoDBUser(KubernetesTester):
     """
+    description: |
+      Creates the x509 MongoDBUser. connectionStringDatabase is set to admin, the only database
+      this user holds readWrite on, so that a write through the generated URI lands somewhere its
+      roles apply.
     create:
       file: test-x509-user.yaml
-      patch: '[{"op":"replace","path":"/spec/mongodbResourceRef/name","value": "replica-set-scram-256-and-x509" }]'
+      patch: '[{"op":"replace","path":"/spec/mongodbResourceRef/name","value": "replica-set-scram-256-and-x509" },{"op":"add","path":"/spec/connectionStringDatabase","value": "admin" }]'
       wait_until: user_exists
     """
 
@@ -167,3 +172,79 @@ class TestCanStillAuthAsScramUsers(KubernetesTester):
             auth_mechanism="SCRAM-SHA-256",
             tlsCAFile=ca_path,
         )
+
+
+# Secret name: {resource}-{user-object-name}-external  ($external strips the $)
+X509_USER_SECRET_NAME = f"{MDB_RESOURCE}-test-x509-user-external"
+
+
+@pytest.mark.e2e_replica_set_scram_sha_and_x509
+def test_external_user_connection_string_has_no_scram_mechanism(namespace: str):
+    """The resource enables both SCRAM and X509, so the SCRAM mechanism must not leak into
+    the connection string of a user authenticating against $external, and no password is set."""
+    secret: Dict[str, str] = read_secret(namespace, X509_USER_SECRET_NAME)
+
+    for key in ("connectionString.standard", "connectionString.standardSrv"):
+        assert key in secret
+        connection_string = secret[key]
+        assert "authSource=$external" in connection_string
+        assert "authMechanism" not in connection_string
+        # No credentials belong in an external user's URI
+        assert "@" not in connection_string
+        # authSource stays $external while the URI path carries connectionStringDatabase
+        assert "/admin?" in connection_string
+
+    assert "password" not in secret
+
+
+@pytest.mark.e2e_replica_set_scram_sha_and_x509
+def test_external_user_connection_string_can_connect(namespace: str, issuer: str, ca_path: str):
+    secret: Dict[str, str] = read_secret(namespace, X509_USER_SECRET_NAME)
+    cert_file = tempfile.NamedTemporaryFile(delete=False, mode="w")
+    try:
+        create_x509_user_cert(issuer, namespace, path=cert_file.name)
+        x509_opts = with_x509(cert_file.name, ca_path)
+        for key in ("connectionString.standard", "connectionString.standardSrv"):
+            MongoTester(secret[key], use_ssl=True, ca_path=ca_path).assert_connectivity(opts=[x509_opts])
+    finally:
+        cert_file.close()
+
+
+@pytest.mark.e2e_replica_set_scram_sha_and_x509
+def test_external_user_connection_string_with_mongosh(namespace: str, issuer: str, ca_path: str):
+    """mongosh uses the secret URI as-is, like a customer would. X.509 has to be named explicitly
+    because mechanism negotiation only ever selects between the SCRAM mechanisms, so the check is
+    that the generated string accepts the mechanism rather than contradicting it.
+
+    The script asserts on the authenticated identity and then writes, because a command such as
+    ping needs neither authentication nor any privilege and would pass even when auth failed."""
+    secret: Dict[str, str] = read_secret(namespace, X509_USER_SECRET_NAME)
+    cert_file = tempfile.NamedTemporaryFile(delete=False, mode="w")
+    try:
+        create_x509_user_cert(issuer, namespace, path=cert_file.name)
+        tls_args = f"tls=true&tlsCertificateKeyFile={cert_file.name}&tlsCAFile={ca_path}"
+        authenticate_and_write = (
+            "const users = db.runCommand({connectionStatus: 1}).authInfo.authenticatedUsers;"
+            "if (!users.some(u => u.user === 'CN=x509-testing-user' && u.db === '$external'))"
+            "  throw new Error('not authenticated as the $external user: ' + JSON.stringify(users));"
+            "db.mongoshX509Check.insertOne({});"
+        )
+
+        for key in ("connectionString.standard", "connectionString.standardSrv"):
+            connection_string = secret[key]
+
+            assert_connection_string_with_mongosh(
+                f"{connection_string}&authMechanism=MONGODB-X509&{tls_args}",
+                expect_success=True,
+                eval_script=authenticate_and_write,
+            )
+
+            # The mechanism the operator used to write here cannot authenticate an $external user,
+            # so the connection is left unauthenticated and the write is refused.
+            assert_connection_string_with_mongosh(
+                f"{connection_string}&authMechanism=SCRAM-SHA-256&{tls_args}",
+                expect_success=False,
+                eval_script=authenticate_and_write,
+            )
+    finally:
+        cert_file.close()


### PR DESCRIPTION
# Summary

Fix connection string secrets for MongoDBUsers with `spec.db: "$external"` on deployments that enable SCRAM alongside external authentication.

**Why:** `$external` users authenticate outside SCRAM — via X.509, LDAP, or another external mechanism depending on how the user was provisioned. The secret already set `authSource=$external` from `spec.db`, but still derived `authMechanism` from the deployment's auth modes. When the deployment enables both SCRAM and an external mechanism, that produced:

```text
authSource=$external&authMechanism=SCRAM-SHA-256
```

That URI cannot authenticate any `$external` user and had to be edited by hand. The wrong mechanism is a property of the deployment, not of the individual user.

**What changes:**
- Do not set `authMechanism` in the generated connection string when `authSource` is `$external`. Clients supply the correct mechanism at connect time (e.g. `authMechanism=MONGODB-X509` for certificate users, or the appropriate mechanism for LDAP users).
- Omit the `password` secret key for `$external` users instead of writing it empty.

## Proof of Work

**Unit tests** (`controllers/operator/mongodbuser_controller_test.go`):
- `TestConnectionStringSecret_ExternalUser_OnScramAndX509Resource_HasNoAuthMechanism` — uses a SCRAM+X.509 deployment as the regression case (a common mixed-auth setup), and asserts both `connectionString.standard` and `connectionString.standardSrv` have `authSource=$external`, no `authMechanism`, no `@` in the URI, and no `password` key in the secret.

**E2E** (`docker/mongodb-kubernetes-tests/tests/authentication/replica_set_scram_sha_and_x509.py`):
- `test_external_user_connection_string_has_no_scram_mechanism` — secret shape assertions for a `$external` user on a mixed SCRAM+X.509 deployment.
- `test_external_user_connection_string_with_mongosh` — demonstrates the X.509 consumption pattern (one external mechanism) against both connection string variants:

  ```python
  f"{connection_string}&authMechanism=MONGODB-X509&{tls_args}"
  ```

  Asserts authenticated identity as `CN=x509-testing-user` on `$external` and a successful write. Also asserts appending `authMechanism=SCRAM-SHA-256` fails.

- `test_external_user_connection_string_can_connect` — connectivity via driver X.509 options for both string variants.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - `changelog/20260820_fix_external_user_connection_string_auth_mechanism.md`

---

Key wording changes:
- **Opening line:** `$external` users on SCRAM + external-auth deployments (not "SCRAM and X.509")
- **Why:** names X.509 and LDAP as examples, not the sole scope
- **What changes:** mechanism examples cover both X.509 and LDAP
- **Proof of Work:** clarifies X.509 tests are the exercised external mechanism, not the limit of the fix