### PR TITLE
KUBE-329: Reject externalDomain on operator-managed MongoDB + Search (single-cluster)

### DIFF
--- a/changelog/20260821_fix_reject_externaldomain_on_mongodb_deployments_with.md
+++ b/changelog/20260821_fix_reject_externaldomain_on_mongodb_deployments_with.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-08-21
+---
+
+* **MongoDBSearch**: MongoDB resources with `spec.externalAccess.externalDomain` set are now rejected as a Search source; the `MongoDBSearch` resource enters the `Failed` phase with a clear error. This combination never worked — `mongot` connects over the internal service DNS, which does not match the externally advertised member identities.

--- a/changelog/20260821_fix_reject_externaldomain_on_mongodb_deployments_with.md
+++ b/changelog/20260821_fix_reject_externaldomain_on_mongodb_deployments_with.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-08-21
 ---
 
-* **MongoDBSearch**: MongoDB resources with `spec.externalAccess.externalDomain` set are now rejected as a Search source; the `MongoDBSearch` resource enters the `Failed` phase with a clear error. This combination never worked — `mongot` connects over the internal service DNS, which does not match the externally advertised member identities.
+* **MongoDBSearch**: MongoDB resources with `spec.externalAccess.externalDomain` set are now rejected as a Search source; the `MongoDBSearch` resource enters the `Failed` phase with a clear error.

--- a/controllers/searchcontroller/enterprise_search_source.go
+++ b/controllers/searchcontroller/enterprise_search_source.go
@@ -74,6 +74,10 @@ func (r EnterpriseResourceSearchSource) Validate() error {
 		return xerrors.Errorf("MongoDBSearch is only supported for %s resources", mdbv1.ReplicaSet)
 	}
 
+	if err := validateSearchSourceExternalDomain(&r.Spec); err != nil {
+		return err
+	}
+
 	authModes := r.Spec.GetSecurityAuthenticationModes()
 	foundScram := false
 	for _, authMode := range authModes {

--- a/controllers/searchcontroller/enterprise_search_source_test.go
+++ b/controllers/searchcontroller/enterprise_search_source_test.go
@@ -61,6 +61,7 @@ func TestEnterpriseResourceSearchSource_Validate(t *testing.T) {
 		resourceType        mdbv1.ResourceType
 		authModes           []string
 		internalClusterAuth string
+		externalDomain      *string
 		expectError         bool
 		expectedErrMsg      string
 	}{
@@ -160,6 +161,17 @@ func TestEnterpriseResourceSearchSource_Validate(t *testing.T) {
 			resourceType: mdbv1.ReplicaSet,
 			authModes:    []string{},
 			expectError:  false,
+		},
+		// External domain validation tests
+		{
+			name:           "SingleCluster with externalDomain",
+			version:        "8.2.0",
+			topology:       mdbv1.ClusterTopologySingleCluster,
+			resourceType:   mdbv1.ReplicaSet,
+			authModes:      []string{},
+			externalDomain: ptr.To("example.com"),
+			expectError:    true,
+			expectedErrMsg: errExternalDomainNotSupported.Error(),
 		},
 		// Authentication mode tests
 		{
@@ -280,6 +292,9 @@ func TestEnterpriseResourceSearchSource_Validate(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			src := newEnterpriseSearchSource(c.version, c.topology, c.resourceType, c.authModes, c.internalClusterAuth)
+			if c.externalDomain != nil {
+				src.Spec.ExternalAccessConfiguration = &mdbv1.ExternalAccessConfiguration{ExternalDomain: c.externalDomain}
+			}
 			err := src.Validate()
 
 			if c.expectError {
@@ -368,6 +383,51 @@ func TestShardedEnterpriseSearchSource_GetShardNames(t *testing.T) {
 
 			shardNames := src.GetShardNames()
 			assert.Equal(t, tc.expectedShards, shardNames)
+		})
+	}
+}
+
+func TestShardedInternalSearchSource_Validate(t *testing.T) {
+	cases := []struct {
+		name           string
+		topology       string
+		externalDomain *string
+		expectError    bool
+	}{
+		{
+			name:        "SingleCluster without externalDomain",
+			topology:    mdbv1.ClusterTopologySingleCluster,
+			expectError: false,
+		},
+		{
+			name:           "SingleCluster with externalDomain",
+			topology:       mdbv1.ClusterTopologySingleCluster,
+			externalDomain: ptr.To("example.com"),
+			expectError:    true,
+		},
+		{
+			name:           "MultiCluster with externalDomain also rejected",
+			topology:       mdbv1.ClusterTopologyMultiCluster,
+			externalDomain: ptr.To("example.com"),
+			expectError:    true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mdb := newShardedClusterMongoDB("test-sharded", "test-ns", 2, "8.2.0")
+			mdb.Spec.Topology = c.topology
+			if c.externalDomain != nil {
+				mdb.Spec.ExternalAccessConfiguration = &mdbv1.ExternalAccessConfiguration{ExternalDomain: c.externalDomain}
+			}
+			src := NewShardedInternalSearchSource(mdb, nil)
+
+			err := src.Validate()
+			if c.expectError {
+				assert.ErrorIs(t, err, errExternalDomainNotSupported)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/controllers/searchcontroller/enterprise_search_source_test.go
+++ b/controllers/searchcontroller/enterprise_search_source_test.go
@@ -390,24 +390,15 @@ func TestShardedEnterpriseSearchSource_GetShardNames(t *testing.T) {
 func TestShardedInternalSearchSource_Validate(t *testing.T) {
 	cases := []struct {
 		name           string
-		topology       string
 		externalDomain *string
 		expectError    bool
 	}{
 		{
 			name:        "SingleCluster without externalDomain",
-			topology:    mdbv1.ClusterTopologySingleCluster,
 			expectError: false,
 		},
 		{
 			name:           "SingleCluster with externalDomain",
-			topology:       mdbv1.ClusterTopologySingleCluster,
-			externalDomain: ptr.To("example.com"),
-			expectError:    true,
-		},
-		{
-			name:           "MultiCluster with externalDomain also rejected",
-			topology:       mdbv1.ClusterTopologyMultiCluster,
 			externalDomain: ptr.To("example.com"),
 			expectError:    true,
 		},
@@ -416,7 +407,6 @@ func TestShardedInternalSearchSource_Validate(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			mdb := newShardedClusterMongoDB("test-sharded", "test-ns", 2, "8.2.0")
-			mdb.Spec.Topology = c.topology
 			if c.externalDomain != nil {
 				mdb.Spec.ExternalAccessConfiguration = &mdbv1.ExternalAccessConfiguration{ExternalDomain: c.externalDomain}
 			}

--- a/controllers/searchcontroller/search_construction.go
+++ b/controllers/searchcontroller/search_construction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -88,6 +89,17 @@ type SearchSourceShardedDeployment interface {
 	GetShardNames() []string
 	GetUnmanagedLBEndpointForShard(shardName string) string
 	MongosHostsAndPorts() []string
+}
+
+var errExternalDomainNotSupported = xerrors.New("MongoDB Search is not supported on operator-managed MongoDB resources with spec.externalAccess.externalDomain set")
+
+// validateSearchSourceExternalDomain rejects sources with externalDomain set: mongot connects
+// via the internal service DNS, which doesn't match the externally advertised member identities.
+func validateSearchSourceExternalDomain(spec *mdb.MongoDbSpec) error {
+	if spec.GetExternalDomain() != nil {
+		return errExternalDomainNotSupported
+	}
+	return nil
 }
 
 type TLSSourceConfig struct {

--- a/controllers/searchcontroller/sharded_internal_search_source.go
+++ b/controllers/searchcontroller/sharded_internal_search_source.go
@@ -97,6 +97,10 @@ func (r *ShardedInternalSearchSource) Validate() error {
 		return xerrors.New("ShardCount must be greater than 0 for sharded clusters")
 	}
 
+	if err := validateSearchSourceExternalDomain(&r.Spec); err != nil {
+		return err
+	}
+
 	authModes := r.Spec.GetSecurityAuthenticationModes()
 	foundScram := false
 	for _, authMode := range authModes {


### PR DESCRIPTION
# Summary

`spec.externalAccess.externalDomain` makes the operator advertise external hostnames as replica-set member identities, while mongot's internal-source path always dials internal service DNS — so MongoDB Search on an externalDomain-configured, operator-managed MongoDB never worked and failed only at runtime. This PR rejects the combination at reconcile time: a shared `validateSearchSourceExternalDomain` check, called from `EnterpriseResourceSearchSource.Validate()` and `ShardedInternalSearchSource.Validate()`, moves the `MongoDBSearch` to `Failed` with:

> MongoDB Search is not supported on operator-managed MongoDB resources with spec.externalAccess.externalDomain set

**Scope:** the check applies regardless of topology — multi-cluster internal mongod sources are not supported anyway, and multi-cluster search requires an external source. `MongoDBCommunity` has no `externalAccess`/`externalDomain` field, so despite the ticket's "Enterprise or Community" wording there is no community-side check to add.

**Intended side effect:** the same `Validate()` calls gate mongot parameter injection in the replica-set and sharded-cluster controllers, so the rejected combination also stops receiving mongot config (`mongotHost` setParameter) there — consistent, since a rejected Search should not wire mongot. Verified at both call sites that a `Validate()` failure only skips search wiring and never fails the MongoDB reconcile. This side effect is described here only; the changelog entry covers the user-facing rejection.

## Proof of Work

- Unit tests assert against the shared error value: `TestEnterpriseResourceSearchSource_Validate` gains a single-cluster + externalDomain rejection row; new `TestShardedInternalSearchSource_Validate` covers the rejection and the passing baseline.
- `go build ./...`, `go test ./controllers/searchcontroller/... ./api/... ./controllers/operator/...`, and `golangci-lint run ./controllers/searchcontroller/...` clean locally.
- e2e: not applicable — reconcile-time validation only.

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

