### PR TITLE
CLOUDP-400899: Add envtest validation coverage for operator API CRDs

### DIFF
--- a/api/operator/v1/main_test.go
+++ b/api/operator/v1/main_test.go
@@ -1,0 +1,15 @@
+package v1_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/mongodb-kubernetes/test/envtest/env"
+)
+
+// TestMain boots one envtest control plane shared by all tests in this package
+// (see test/envtest/env). Future envtest-based tests in this package should use
+// env.Shared(t) instead of starting their own environment.
+func TestMain(m *testing.M) {
+	os.Exit(env.RunShared(m, env.WithCRDs("operator.mongodb.com_memberclusters.yaml", "operator.mongodb.com_operatorconfigs.yaml")))
+}

--- a/api/operator/v1/membercluster_envtest_test.go
+++ b/api/operator/v1/membercluster_envtest_test.go
@@ -1,0 +1,68 @@
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+	"github.com/mongodb/mongodb-kubernetes/test/envtest/env"
+)
+
+// TestMemberClusterValidation proves that the CEL validation rule defined on the
+// MemberCluster CRD (credentialSecretRef.name must not be empty) is enforced by a
+// real Kubernetes API server (booted locally via envtest).
+func TestMemberClusterValidation(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := env.Shared(t).Client
+
+	newMemberCluster := func(clusterName, secretName string) *operatorv1.MemberCluster {
+		return &operatorv1.MemberCluster{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mc-", Namespace: "default"},
+			Spec: operatorv1.MemberClusterSpec{
+				ClusterName:         clusterName,
+				CredentialSecretRef: corev1.LocalObjectReference{Name: secretName},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		clusterName string
+		secretName  string
+		// errorContains is the expected validation message; empty means the
+		// create must succeed.
+		errorContains string
+	}{
+		{
+			name:        "valid spec is accepted",
+			clusterName: "cluster-a",
+			secretName:  "cluster-a-credentials",
+		},
+		{
+			name:          "credentialSecretRef.name must not be empty",
+			clusterName:   "cluster-a",
+			secretName:    "",
+			errorContains: "credentialSecretRef.name must not be empty",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k8sClient.Create(ctx, newMemberCluster(tc.clusterName, tc.secretName))
+
+			if tc.errorContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got: %v", err)
+			assert.Contains(t, err.Error(), tc.errorContains)
+		})
+	}
+}

--- a/api/operator/v1/operatorconfig_envtest_test.go
+++ b/api/operator/v1/operatorconfig_envtest_test.go
@@ -1,0 +1,104 @@
+package v1_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
+	"github.com/mongodb/mongodb-kubernetes/test/envtest/env"
+)
+
+// TestOperatorConfigValidation proves that the CEL validation rules defined on the
+// OperatorConfig CRD (the telemetry duration minimums) are enforced by a real
+// Kubernetes API server (booted locally via envtest).
+func TestOperatorConfigValidation(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := env.Shared(t).Client
+
+	newOperatorConfig := func(spec operatorv1.OperatorConfigSpec) *operatorv1.OperatorConfig {
+		return &operatorv1.OperatorConfig{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-opconfig-", Namespace: "default"},
+			Spec:       spec,
+		}
+	}
+
+	tests := []struct {
+		name string
+		spec operatorv1.OperatorConfigSpec
+		// errorContains is the expected validation message; empty means the
+		// create must succeed.
+		errorContains string
+	}{
+		{
+			name: "empty spec is accepted",
+			spec: operatorv1.OperatorConfigSpec{},
+		},
+		{
+			name: "valid telemetry durations are accepted",
+			spec: operatorv1.OperatorConfigSpec{
+				Telemetry: &operatorv1.TelemetryConfig{
+					Collection: &operatorv1.TelemetryCollectionConfig{
+						Frequency:   &metav1.Duration{Duration: time.Minute},
+						KubeTimeout: &metav1.Duration{Duration: time.Second},
+					},
+					Send: &operatorv1.TelemetrySendConfig{
+						Frequency: &metav1.Duration{Duration: time.Hour},
+					},
+				},
+			},
+		},
+		{
+			name: "telemetry.collection.frequency must be at least 1m",
+			spec: operatorv1.OperatorConfigSpec{
+				Telemetry: &operatorv1.TelemetryConfig{
+					Collection: &operatorv1.TelemetryCollectionConfig{
+						Frequency: &metav1.Duration{Duration: 30 * time.Second},
+					},
+				},
+			},
+			errorContains: "frequency must be at least 1m",
+		},
+		{
+			name: "telemetry.collection.kubeTimeout must be at least 1s",
+			spec: operatorv1.OperatorConfigSpec{
+				Telemetry: &operatorv1.TelemetryConfig{
+					Collection: &operatorv1.TelemetryCollectionConfig{
+						KubeTimeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+					},
+				},
+			},
+			errorContains: "kubeTimeout must be at least 1s",
+		},
+		{
+			name: "telemetry.send.frequency must be at least 1h",
+			spec: operatorv1.OperatorConfigSpec{
+				Telemetry: &operatorv1.TelemetryConfig{
+					Send: &operatorv1.TelemetrySendConfig{
+						Frequency: &metav1.Duration{Duration: 30 * time.Minute},
+					},
+				},
+			},
+			errorContains: "frequency must be at least 1h",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k8sClient.Create(ctx, newOperatorConfig(tc.spec))
+
+			if tc.errorContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, apierrors.IsInvalid(err), "expected an Invalid error, got: %v", err)
+			assert.Contains(t, err.Error(), tc.errorContains)
+		})
+	}
+}

--- a/docs/dev/envtest.md
+++ b/docs/dev/envtest.md
@@ -24,9 +24,10 @@ in `kubernetes-versions.json`; override with `make envtest-assets ENVTEST_K8S_VE
 ## Writing a new envtest test
 
 Use the shared helper in `test/envtest/env` — it starts the control plane, installs the
-CRDs from `config/crd/bases` and returns a client with the `mongodb.com/v1` scheme
-registered. It works from any package — co-locate CEL tests next to the API types that
-define the rules (see below), or use it from controller tests:
+CRDs from `config/crd/bases` and returns a client with the `mongodb.com/v1` and
+`operator.mongodb.com/v1` schemes registered. It works from any package — co-locate
+CEL tests next to the API types that define the rules (see below), or use it from
+controller tests:
 
 ```go
 func TestMain(m *testing.M) {
@@ -59,3 +60,5 @@ Guidelines:
 
 See `api/mongodb/v1/search/mongodbsearch_cel_envtest_test.go` for a complete example:
 it verifies the CEL rules declared on the `MongoDBSearch` type in the very same package.
+`api/operator/v1` shows the multi-file variant: `main_test.go` boots the shared
+environment and each `*_envtest_test.go` covers one API type's validation rules.

--- a/test/envtest/env/env.go
+++ b/test/envtest/env/env.go
@@ -29,6 +29,7 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1"
+	operatorv1 "github.com/mongodb/mongodb-kubernetes/api/operator/v1"
 )
 
 // TestEnv is a running envtest control plane together with the means to talk to it.
@@ -38,7 +39,8 @@ type TestEnv struct {
 	// Config is the rest.Config for the local API server; use it to build
 	// managers or additional clients (e.g. in controller tests).
 	Config *rest.Config
-	// Client is a controller-runtime client with the mongodb.com/v1 scheme registered.
+	// Client is a controller-runtime client with the mongodb.com/v1 and
+	// operator.mongodb.com/v1 schemes registered.
 	Client client.Client
 }
 
@@ -116,6 +118,9 @@ func start(opts ...Option) (*TestEnv, error) {
 
 	scheme := kruntime.NewScheme()
 	if err := mdbv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := operatorv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Summary

The `MemberCluster` and `OperatorConfig` CRDs ship with hand-written CEL validation rules that had no test coverage: enforcement happens in the Kubernetes API server, so plain Go unit tests cannot exercise them. This PR adds envtest-based tests that boot a local control plane and prove each CEL rule is enforced:

- `api/operator/v1/main_test.go` — boots one shared envtest control plane (via the existing `test/envtest/env` helper) with both CRDs installed.
- `api/operator/v1/membercluster_envtest_test.go` — covers the `credentialSecretRef.name must not be empty` CEL rule.
- `api/operator/v1/operatorconfig_envtest_test.go` — covers the three telemetry duration CEL rules (collection `frequency` ≥ 1m, `kubeTimeout` ≥ 1s, send `frequency` ≥ 1h).

The shared helper's client now also registers the `operator.mongodb.com/v1` scheme, and `docs/dev/envtest.md` documents the multi-file layout (`main_test.go` + one test file per API type).

## Proof of Work

- `go test ./api/operator/v1/...` — 7 subtests pass against the envtest API server; every asserted message matches the CRD manifests verbatim (`config/crd/bases/operator.mongodb.com_{memberclusters,operatorconfigs}.yaml`).
- Regression: `go test ./api/mongodb/v1/search/...` (the existing envtest consumer) stays green.
- `make precommit` clean.
- e2e: N/A (test-only change; no runtime code touched).

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?