### PR TITLE
CLOUDP-400899: Do not gate `memberClusterReconciler` with `mongodbmulticluster` CR watch

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,31 +269,28 @@ func run() error {
 	// startup-built snapshot.
 	memberClustersProvider := multicluster.NewProvider()
 
-	// TODO(m1kola): This shouldn't be wrapped in this condtion anymore, probably.
-	if slices.Contains(watchedResources, mongoDBMultiClusterCRDPlural) {
-		// MemberCluster CRs drive the provider reactively: the reconciler builds and starts
-		// each member cluster's runtime entry (and tears it down on CR deletion) without an
-		// operator restart. The initial informer replay registers the CRs that already exist.
-		memberClusterReconciler := membercluster.NewReconciler(ctx, mgr.GetClient(), currentNamespace, time.Duration(memberClusterClientTimeout)*time.Second, memberClustersProvider,
-			func(restConfig *rest.Config) (runtime_cluster.Cluster, error) {
-				return runtime_cluster.New(restConfig, func(options *runtime_cluster.Options) {
-					// Use the operator scheme so cross-cluster owner references
-					// can resolve our CRD types (default scheme lacks them).
-					options.Scheme = scheme
-					if len(namespacesToWatch) > 1 || namespacesToWatch[0] != "" {
-						defaultNamespaces := make(map[string]cache.Config)
-						for _, namespace := range namespacesToWatch {
-							defaultNamespaces[namespace] = cache.Config{}
-						}
-						options.Cache = cache.Options{
-							DefaultNamespaces: defaultNamespaces,
-						}
+	// MemberCluster CRs drive the provider reactively: the reconciler builds and starts
+	// each member cluster's runtime entry (and tears it down on CR deletion) without an
+	// operator restart. The initial informer replay registers the CRs that already exist.
+	memberClusterReconciler := membercluster.NewReconciler(ctx, mgr.GetClient(), currentNamespace, time.Duration(memberClusterClientTimeout)*time.Second, memberClustersProvider,
+		func(restConfig *rest.Config) (runtime_cluster.Cluster, error) {
+			return runtime_cluster.New(restConfig, func(options *runtime_cluster.Options) {
+				// Use the operator scheme so cross-cluster owner references
+				// can resolve our CRD types (default scheme lacks them).
+				options.Scheme = scheme
+				if len(namespacesToWatch) > 1 || namespacesToWatch[0] != "" {
+					defaultNamespaces := make(map[string]cache.Config)
+					for _, namespace := range namespacesToWatch {
+						defaultNamespaces[namespace] = cache.Config{}
 					}
-				})
+					options.Cache = cache.Options{
+						DefaultNamespaces: defaultNamespaces,
+					}
+				}
 			})
-		if err := memberClusterReconciler.SetupWithManager(mgr); err != nil {
-			return err
-		}
+		})
+	if err := memberClusterReconciler.SetupWithManager(mgr); err != nil {
+		return err
 	}
 
 	// Setup all Controllers


### PR DESCRIPTION
# Summary

The change ensures that the `memberClusterReconciler` is always created and set up, regardless of which resources are being watched.


## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
