### PR TITLE
CLOUDP-429011 - Block AppDB config changes during forward migration

### DIFF
--- a/controllers/operator/appdbreplicaset_controller.go
+++ b/controllers/operator/appdbreplicaset_controller.go
@@ -732,6 +732,18 @@ func (r *ReconcileAppDbReplicaSet) reclaimAppDBSecret(ctx context.Context, opsMa
 }
 
 // ReconcileAppDB deploys the "headless" agent, and wait until it reaches the goal state
+//
+// Warning: this reconciler does not guarantee that AutomationConfig is pushed before
+// other actions (e.g. the StatefulSet spec) take effect. Do not assume publish ordering
+// here unless you've explicitly verified it (see e.g. publishAutomationConfigFirst).
+//
+// If a change you're adding here relies on AutomationConfig being pushed first to be
+// safe, it must also be rejected during AppDB forward migration: during that window
+// the AppDB pods run headless agents that never poll Ops Manager, so this operator
+// cannot ensure AutomationConfig is actually pushed first. Add the corresponding guard
+// to validateAppDBForwardMigration (mongodbreplicaset_controller.go) so the migration
+// window rejects the change too - otherwise it can silently create an unsafe mixed
+// population of pods mid-rollout.
 func (r *ReconcileAppDbReplicaSet) ReconcileAppDB(ctx context.Context, opsManager *omv1.MongoDBOpsManager) (res reconcile.Result, e error) {
 	rs := opsManager.Spec.AppDB
 	log := zap.S().With("ReplicaSet (AppDB)", kube.ObjectKey(opsManager.Namespace, rs.Name()))

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -838,13 +838,28 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 
 const appDBForwardMigrationViolationFmt = "cannot change AppDB configuration during forward migration: %s"
 
-// validateAppDBForwardMigration rejects spec changes that cannot be applied while the AppDB
-// StatefulSet handover (forward migration) is in progress. The window is open until this
-// controller replaces the StatefulSet spec with the enterprise form: until then the pods run
-// headless agents that read the mounted automation config and never poll Ops Manager, so for
-// cluster-visible settings (TLS, CA, members) no publish ordering works - rotated members become
-// incompatible with the unrotated ones. The handover must be config-identical; changes apply
-// once the migration completes.
+// validateAppDBForwardMigration rejects spec changes that are unsafe to apply during
+// AppDB forward migration.
+//
+// There is a window of time during which some spec changes are not safe to reconcile.
+// The window runs from the start of forward migration until AppDBMigrationReadyAnnotation
+// becomes true, at which point this controller replaces the StatefulSet spec with the
+// enterprise form.
+//
+// Changes are unsafe during this window because, for some configurations, they could
+// create a situation where two mutually incompatible populations of pods are running
+// during the rolling update. Transitioning cluster-visible settings (TLS, CA, members)
+// from state A to state Z normally goes through intermediate states (A -> N1 -> N2 ->
+// ... -> Z); a population spanning two neighbouring states (e.g. A and N1) is fine, but
+// a population made up of both A and Z pods is not.
+//
+// In normal operation we handle this in the operator (see e.g. publishAutomationConfigFirst),
+// which has enough visibility to sequence the transition safely. But before
+// AppDBMigrationReadyAnnotation is true, the AppDB pods run headless agents that read
+// the automation config from a locally mounted file and never poll Ops Manager. Since
+// they never poll, the operator has no way to roll a cluster-visible config change out
+// pod-by-pod without creating an incompatible mixed population mid-rollout. The handover
+// must therefore be config-identical; changes apply once the migration completes.
 func (r *ReplicaSetReconcilerHelper) validateAppDBForwardMigration(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) workflow.Status {
 	if sts.Annotations[util.AppDBMigrationReadyAnnotation] != trueString {
 		return workflow.OK()

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
@@ -53,8 +54,10 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/annotations"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/configmap"
+	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
+	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
@@ -798,6 +801,10 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 		return ref.UID == mdb.UID
 	})
 
+	if validationStatus := r.validateAppDBForwardMigration(ctx, mdb, sts); !validationStatus.IsOK() {
+		return validationStatus
+	}
+
 	// Forward Migration, reclaim the AppDB Statefulset
 	if sts.Annotations[util.AppDBMigrationReadyAnnotation] == trueString {
 		if len(sts.OwnerReferences) == 0 {
@@ -829,6 +836,85 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 	}
 
 	return workflow.OK()
+}
+
+// validateAppDBForwardMigration rejects spec changes that cannot be applied while the AppDB
+// StatefulSet handover (forward migration) is in progress. The window is open until this
+// controller replaces the StatefulSet spec with the enterprise form: until then the pods run
+// headless agents that read the mounted automation config and never poll Ops Manager, so for
+// cluster-visible settings (TLS, CA, members) no publish ordering works - rotated members become
+// incompatible with the unrotated ones. The handover must be config-identical; changes apply
+// once the migration completes.
+//
+// All checks read the adopted StatefulSet, plus one existence GET on the TLS cert secret:
+// the AppDB pod template mounts the TLS volumes unconditionally with Optional=true, so volume
+// presence alone cannot tell whether TLS is enabled.
+func (r *ReplicaSetReconcilerHelper) validateAppDBForwardMigration(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) workflow.Status {
+	if !appDBForwardMigrationWindowOpen(sts) {
+		return workflow.OK()
+	}
+
+	var violations []string
+
+	if certSecretName := podTemplateVolumeSecretName(sts, util.SecretVolumeName); certSecretName != "" {
+		tlsEnabled, err := secret.Exists(ctx, r.reconciler.SecretClient, kube.ObjectKey(mdb.Namespace, certSecretName))
+		if err != nil {
+			return workflow.Failed(xerrors.Errorf("failed to check TLS cert secret %s: %w", certSecretName, err))
+		}
+		if tlsEnabled {
+			if !mdb.Spec.Security.IsTLSEnabled() {
+				violations = append(violations, "spec.security.tls.enabled must remain true")
+			} else if caConfigMapName := podTemplateVolumeConfigMapName(sts, tls.ConfigMapVolumeCAName); caConfigMapName != "" && specCAConfigMapName(mdb) != caConfigMapName {
+				violations = append(violations, fmt.Sprintf("spec.security.tls.ca must reference ConfigMap %q", caConfigMapName))
+			}
+		}
+	}
+
+	if sts.Spec.Replicas != nil && mdb.Spec.Members != int(*sts.Spec.Replicas) {
+		violations = append(violations, fmt.Sprintf("spec.members must remain %d", *sts.Spec.Replicas))
+	}
+
+	if len(violations) == 0 {
+		return workflow.OK()
+	}
+
+	return workflow.Invalid("cannot change AppDB configuration during forward migration: [%s]; complete the migration with a matching spec, then apply the changes", strings.Join(violations, "; "))
+}
+
+func appDBForwardMigrationWindowOpen(sts appsv1.StatefulSet) bool {
+	if sts.Annotations[util.AppDBMigrationReadyAnnotation] == trueString {
+		return true
+	}
+
+	return container.GetByName(util.DatabaseContainerName, sts.Spec.Template.Spec.Containers) == nil
+}
+
+func specCAConfigMapName(mdb *mdbv1.MongoDB) string {
+	if mdb.Spec.Security.TLSConfig == nil {
+		return ""
+	}
+
+	return mdb.Spec.Security.TLSConfig.CA
+}
+
+func podTemplateVolumeSecretName(sts appsv1.StatefulSet, volumeName string) string {
+	for _, v := range sts.Spec.Template.Spec.Volumes {
+		if v.Name == volumeName && v.Secret != nil {
+			return v.Secret.SecretName
+		}
+	}
+
+	return ""
+}
+
+func podTemplateVolumeConfigMapName(sts appsv1.StatefulSet, volumeName string) string {
+	for _, v := range sts.Spec.Template.Spec.Volumes {
+		if v.Name == volumeName && v.ConfigMap != nil {
+			return v.ConfigMap.Name
+		}
+	}
+
+	return ""
 }
 
 func (r *ReplicaSetReconcilerHelper) reclaimAppDBStatefulsetOwnership(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) error {

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
@@ -54,7 +53,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/annotations"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/configmap"
-	"github.com/mongodb/mongodb-kubernetes/pkg/kube/container"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
 	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
@@ -838,6 +836,8 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 	return workflow.OK()
 }
 
+const appDBForwardMigrationViolationFmt = "cannot change AppDB configuration during forward migration: %s"
+
 // validateAppDBForwardMigration rejects spec changes that cannot be applied while the AppDB
 // StatefulSet handover (forward migration) is in progress. The window is open until this
 // controller replaces the StatefulSet spec with the enterprise form: until then the pods run
@@ -845,48 +845,25 @@ func (r *ReplicaSetReconcilerHelper) ensureAppDBStatefulSetOwnership(ctx context
 // cluster-visible settings (TLS, CA, members) no publish ordering works - rotated members become
 // incompatible with the unrotated ones. The handover must be config-identical; changes apply
 // once the migration completes.
-//
-// All checks read the adopted StatefulSet, plus one existence GET on the TLS cert secret:
-// the AppDB pod template mounts the TLS volumes unconditionally with Optional=true, so volume
-// presence alone cannot tell whether TLS is enabled.
 func (r *ReplicaSetReconcilerHelper) validateAppDBForwardMigration(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) workflow.Status {
-	if !appDBForwardMigrationWindowOpen(sts) {
+	if sts.Annotations[util.AppDBMigrationReadyAnnotation] != trueString {
 		return workflow.OK()
 	}
 
-	var violations []string
-
-	if certSecretName := podTemplateVolumeSecretName(sts, util.SecretVolumeName); certSecretName != "" {
-		tlsEnabled, err := secret.Exists(ctx, r.reconciler.SecretClient, kube.ObjectKey(mdb.Namespace, certSecretName))
-		if err != nil {
-			return workflow.Failed(xerrors.Errorf("failed to check TLS cert secret %s: %w", certSecretName, err))
+	if wasTLSSecretMounted(ctx, r.reconciler.SecretClient, sts, *mdb, r.log) {
+		if !mdb.Spec.Security.IsTLSEnabled() {
+			return workflow.Invalid(appDBForwardMigrationViolationFmt, "spec.security.tls.enabled must remain true")
 		}
-		if tlsEnabled {
-			if !mdb.Spec.Security.IsTLSEnabled() {
-				violations = append(violations, "spec.security.tls.enabled must remain true")
-			} else if caConfigMapName := podTemplateVolumeConfigMapName(sts, tls.ConfigMapVolumeCAName); caConfigMapName != "" && specCAConfigMapName(mdb) != caConfigMapName {
-				violations = append(violations, fmt.Sprintf("spec.security.tls.ca must reference ConfigMap %q", caConfigMapName))
-			}
+		if caVolume, err := getVolumeFromStatefulSet(sts, tls.ConfigMapVolumeCAName); err == nil && specCAConfigMapName(mdb) != caVolume.ConfigMap.Name {
+			return workflow.Invalid(appDBForwardMigrationViolationFmt, fmt.Sprintf("spec.security.tls.ca must reference ConfigMap %q", caVolume.ConfigMap.Name))
 		}
 	}
 
 	if sts.Spec.Replicas != nil && mdb.Spec.Members != int(*sts.Spec.Replicas) {
-		violations = append(violations, fmt.Sprintf("spec.members must remain %d", *sts.Spec.Replicas))
+		return workflow.Invalid(appDBForwardMigrationViolationFmt, fmt.Sprintf("spec.members must remain %d", *sts.Spec.Replicas))
 	}
 
-	if len(violations) == 0 {
-		return workflow.OK()
-	}
-
-	return workflow.Invalid("cannot change AppDB configuration during forward migration: [%s]; complete the migration with a matching spec, then apply the changes", strings.Join(violations, "; "))
-}
-
-func appDBForwardMigrationWindowOpen(sts appsv1.StatefulSet) bool {
-	if sts.Annotations[util.AppDBMigrationReadyAnnotation] == trueString {
-		return true
-	}
-
-	return container.GetByName(util.DatabaseContainerName, sts.Spec.Template.Spec.Containers) == nil
+	return workflow.OK()
 }
 
 func specCAConfigMapName(mdb *mdbv1.MongoDB) string {
@@ -895,26 +872,6 @@ func specCAConfigMapName(mdb *mdbv1.MongoDB) string {
 	}
 
 	return mdb.Spec.Security.TLSConfig.CA
-}
-
-func podTemplateVolumeSecretName(sts appsv1.StatefulSet, volumeName string) string {
-	for _, v := range sts.Spec.Template.Spec.Volumes {
-		if v.Name == volumeName && v.Secret != nil {
-			return v.Secret.SecretName
-		}
-	}
-
-	return ""
-}
-
-func podTemplateVolumeConfigMapName(sts appsv1.StatefulSet, volumeName string) string {
-	for _, v := range sts.Spec.Template.Spec.Volumes {
-		if v.Name == volumeName && v.ConfigMap != nil {
-			return v.ConfigMap.Name
-		}
-	}
-
-	return ""
 }
 
 func (r *ReplicaSetReconcilerHelper) reclaimAppDBStatefulsetOwnership(ctx context.Context, mdb *mdbv1.MongoDB, sts appsv1.StatefulSet) error {

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube"
 	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
+	"github.com/mongodb/mongodb-kubernetes/pkg/tls"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/architectures"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
@@ -1852,6 +1853,21 @@ func (b *StatefulSetBuilder) SetAnnotations(annotations map[string]string) *Stat
 	return b
 }
 
+func (b *StatefulSetBuilder) SetReplicas(replicas int32) *StatefulSetBuilder {
+	b.sts.Spec.Replicas = ptr.To(replicas)
+	return b
+}
+
+func (b *StatefulSetBuilder) SetContainers(containers []corev1.Container) *StatefulSetBuilder {
+	b.sts.Spec.Template.Spec.Containers = containers
+	return b
+}
+
+func (b *StatefulSetBuilder) SetVolumes(volumes []corev1.Volume) *StatefulSetBuilder {
+	b.sts.Spec.Template.Spec.Volumes = volumes
+	return b
+}
+
 func (b *StatefulSetBuilder) Build() appsv1.StatefulSet {
 	return b.sts
 }
@@ -2097,6 +2113,153 @@ func TestAdoptionGate_ForwardMigrationTakesPrecedence(t *testing.T) {
 
 	ownershipStatus := helper.ensureAppDBStatefulSetOwnership(ctx, mdb)
 	assert.True(t, ownershipStatus.IsOK(), "forward migration takes precedence: reclaim ownership even if reverse is also requested")
+}
+
+func TestValidateAppDBForwardMigration(t *testing.T) {
+	const certSecretName = "my-om-db-cert-pem"
+	const appDBCAConfigMap = "my-om-db-ca"
+
+	tests := []struct {
+		name               string
+		tlsEnabled         bool
+		tlsCA              string
+		members            int
+		stsReplicas        int32
+		enterpriseForm     bool
+		annotated          bool
+		certSecretExists   bool
+		expectedViolations []string // substrings of the Invalid message; empty = expect OK
+	}{
+		{
+			name:               "disabling TLS is blocked",
+			members:            3,
+			stsReplicas:        3,
+			certSecretExists:   true,
+			expectedViolations: []string{"spec.security.tls.enabled must remain true"},
+		},
+		{
+			name:        "TLS-off spec against a non-TLS AppDB passes",
+			members:     3,
+			stsReplicas: 3,
+		},
+		{
+			name:               "changing the CA is blocked",
+			tlsEnabled:         true,
+			tlsCA:              "other-ca",
+			members:            3,
+			stsReplicas:        3,
+			certSecretExists:   true,
+			expectedViolations: []string{`spec.security.tls.ca must reference ConfigMap "my-om-db-ca"`},
+		},
+		{
+			name:               "scaling down is blocked",
+			tlsEnabled:         true,
+			tlsCA:              appDBCAConfigMap,
+			members:            3,
+			stsReplicas:        5,
+			certSecretExists:   true,
+			expectedViolations: []string{"spec.members must remain 5"},
+		},
+		{
+			name:               "scaling up is blocked",
+			tlsEnabled:         true,
+			tlsCA:              appDBCAConfigMap,
+			members:            5,
+			stsReplicas:        3,
+			certSecretExists:   true,
+			expectedViolations: []string{"spec.members must remain 3"},
+		},
+		{
+			name:             "violations are aggregated into a single message",
+			members:          5,
+			stsReplicas:      3,
+			certSecretExists: true,
+			expectedViolations: []string{
+				"spec.security.tls.enabled must remain true",
+				"spec.members must remain 3",
+			},
+		},
+		{
+			name:             "matching spec passes",
+			tlsEnabled:       true,
+			tlsCA:            appDBCAConfigMap,
+			members:          3,
+			stsReplicas:      3,
+			certSecretExists: true,
+		},
+		{
+			name:             "enterprise-form StatefulSet closes the window",
+			members:          5,
+			stsReplicas:      3,
+			enterpriseForm:   true,
+			certSecretExists: true,
+		},
+		{
+			name:               "migration annotation keeps the window open on an enterprise-form StatefulSet",
+			tlsEnabled:         true,
+			tlsCA:              appDBCAConfigMap,
+			members:            5,
+			stsReplicas:        3,
+			enterpriseForm:     true,
+			annotated:          true,
+			certSecretExists:   true,
+			expectedViolations: []string{"spec.members must remain 3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			builder := DefaultReplicaSetBuilder().SetName("my-om-db").SetRole(mdbv1.RoleAppDB).SetMembers(tt.members)
+			if tt.tlsEnabled {
+				builder.EnableTLS()
+			}
+			if tt.tlsCA != "" {
+				builder.SetTLSCA(tt.tlsCA)
+			}
+			mdb := builder.Build()
+
+			// the AppDB pod template mounts the TLS volumes unconditionally (Optional=true),
+			// so the fixture always carries them regardless of whether TLS is enabled
+			containers := []corev1.Container{{Name: util.AgentContainerName}, {Name: util.MongodbContainerName}}
+			if tt.enterpriseForm {
+				containers = []corev1.Container{{Name: util.DatabaseContainerName}}
+			}
+			annotations := map[string]string{}
+			if tt.annotated {
+				annotations[util.AppDBMigrationReadyAnnotation] = "true"
+			}
+			sts := DefaultStatefulSetBuilder().SetName("my-om-db").
+				SetAnnotations(annotations).
+				SetReplicas(tt.stsReplicas).
+				SetContainers(containers).
+				SetVolumes([]corev1.Volume{
+					{Name: util.SecretVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certSecretName}}},
+					{Name: tls.ConfigMapVolumeCAName, VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: appDBCAConfigMap}}}},
+				}).Build()
+
+			reconciler, kubeClient, _ := defaultReplicaSetReconciler(ctx, nil, "", "", mdb, architectures.NonStatic)
+			if tt.certSecretExists {
+				certSecret := secret.Builder().SetName(certSecretName).SetNamespace(mdb.Namespace).SetField("tls.crt", "cert").Build()
+				require.NoError(t, kubeClient.CreateSecret(ctx, certSecret))
+			}
+			helper := &ReplicaSetReconcilerHelper{resource: mdb, reconciler: reconciler, log: zap.S()}
+
+			validationStatus := helper.validateAppDBForwardMigration(ctx, mdb, sts)
+
+			if len(tt.expectedViolations) == 0 {
+				assert.True(t, validationStatus.IsOK())
+				return
+			}
+			require.False(t, validationStatus.IsOK())
+			assert.Equal(t, status.PhaseFailed, validationStatus.Phase())
+			msg := statusMessage(validationStatus)
+			assert.Contains(t, msg, "cannot change AppDB configuration during forward migration")
+			for _, violation := range tt.expectedViolations {
+				assert.Contains(t, msg, violation)
+			}
+		})
+	}
 }
 
 func TestEnsureAppDBRoleSecrets_ClaimedByCR(t *testing.T) {

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -1858,11 +1858,6 @@ func (b *StatefulSetBuilder) SetReplicas(replicas int32) *StatefulSetBuilder {
 	return b
 }
 
-func (b *StatefulSetBuilder) SetContainers(containers []corev1.Container) *StatefulSetBuilder {
-	b.sts.Spec.Template.Spec.Containers = containers
-	return b
-}
-
 func (b *StatefulSetBuilder) SetVolumes(volumes []corev1.Volume) *StatefulSetBuilder {
 	b.sts.Spec.Template.Spec.Volumes = volumes
 	return b
@@ -2120,64 +2115,66 @@ func TestValidateAppDBForwardMigration(t *testing.T) {
 	const appDBCAConfigMap = "my-om-db-ca"
 
 	tests := []struct {
-		name               string
-		tlsEnabled         bool
-		tlsCA              string
-		members            int
-		stsReplicas        int32
-		enterpriseForm     bool
-		annotated          bool
-		certSecretExists   bool
-		expectedViolations []string // substrings of the Invalid message; empty = expect OK
+		name             string
+		tlsEnabled       bool
+		tlsCA            string
+		members          int
+		stsReplicas      int32
+		annotated        bool
+		certSecretExists bool
+		expectedError    string // exact Invalid message; empty = expect OK
 	}{
 		{
-			name:               "disabling TLS is blocked",
-			members:            3,
-			stsReplicas:        3,
-			certSecretExists:   true,
-			expectedViolations: []string{"spec.security.tls.enabled must remain true"},
+			name:             "disabling TLS is blocked",
+			members:          3,
+			stsReplicas:      3,
+			annotated:        true,
+			certSecretExists: true,
+			expectedError:    "cannot change AppDB configuration during forward migration: spec.security.tls.enabled must remain true",
 		},
 		{
 			name:        "TLS-off spec against a non-TLS AppDB passes",
 			members:     3,
 			stsReplicas: 3,
+			annotated:   true,
 		},
 		{
-			name:               "changing the CA is blocked",
-			tlsEnabled:         true,
-			tlsCA:              "other-ca",
-			members:            3,
-			stsReplicas:        3,
-			certSecretExists:   true,
-			expectedViolations: []string{`spec.security.tls.ca must reference ConfigMap "my-om-db-ca"`},
+			name:             "changing the CA is blocked",
+			tlsEnabled:       true,
+			tlsCA:            "other-ca",
+			members:          3,
+			stsReplicas:      3,
+			annotated:        true,
+			certSecretExists: true,
+			expectedError:    `cannot change AppDB configuration during forward migration: spec.security.tls.ca must reference ConfigMap "my-om-db-ca"`,
 		},
 		{
-			name:               "scaling down is blocked",
-			tlsEnabled:         true,
-			tlsCA:              appDBCAConfigMap,
-			members:            3,
-			stsReplicas:        5,
-			certSecretExists:   true,
-			expectedViolations: []string{"spec.members must remain 5"},
+			name:             "scaling down is blocked",
+			tlsEnabled:       true,
+			tlsCA:            appDBCAConfigMap,
+			members:          3,
+			stsReplicas:      5,
+			annotated:        true,
+			certSecretExists: true,
+			expectedError:    "cannot change AppDB configuration during forward migration: spec.members must remain 5",
 		},
 		{
-			name:               "scaling up is blocked",
-			tlsEnabled:         true,
-			tlsCA:              appDBCAConfigMap,
-			members:            5,
-			stsReplicas:        3,
-			certSecretExists:   true,
-			expectedViolations: []string{"spec.members must remain 3"},
-		},
-		{
-			name:             "violations are aggregated into a single message",
+			name:             "scaling up is blocked",
+			tlsEnabled:       true,
+			tlsCA:            appDBCAConfigMap,
 			members:          5,
 			stsReplicas:      3,
+			annotated:        true,
 			certSecretExists: true,
-			expectedViolations: []string{
-				"spec.security.tls.enabled must remain true",
-				"spec.members must remain 3",
-			},
+			expectedError:    "cannot change AppDB configuration during forward migration: spec.members must remain 3",
+		},
+		{
+			name:             "first violation wins when several settings diverge",
+			members:          5,
+			stsReplicas:      3,
+			annotated:        true,
+			certSecretExists: true,
+			expectedError:    "cannot change AppDB configuration during forward migration: spec.security.tls.enabled must remain true",
 		},
 		{
 			name:             "matching spec passes",
@@ -2185,25 +2182,14 @@ func TestValidateAppDBForwardMigration(t *testing.T) {
 			tlsCA:            appDBCAConfigMap,
 			members:          3,
 			stsReplicas:      3,
+			annotated:        true,
 			certSecretExists: true,
 		},
 		{
-			name:             "enterprise-form StatefulSet closes the window",
+			name:             "missing migration annotation closes the window",
 			members:          5,
 			stsReplicas:      3,
-			enterpriseForm:   true,
 			certSecretExists: true,
-		},
-		{
-			name:               "migration annotation keeps the window open on an enterprise-form StatefulSet",
-			tlsEnabled:         true,
-			tlsCA:              appDBCAConfigMap,
-			members:            5,
-			stsReplicas:        3,
-			enterpriseForm:     true,
-			annotated:          true,
-			certSecretExists:   true,
-			expectedViolations: []string{"spec.members must remain 3"},
 		},
 	}
 	for _, tt := range tests {
@@ -2219,20 +2205,15 @@ func TestValidateAppDBForwardMigration(t *testing.T) {
 			}
 			mdb := builder.Build()
 
-			// the AppDB pod template mounts the TLS volumes unconditionally (Optional=true),
-			// so the fixture always carries them regardless of whether TLS is enabled
-			containers := []corev1.Container{{Name: util.AgentContainerName}, {Name: util.MongodbContainerName}}
-			if tt.enterpriseForm {
-				containers = []corev1.Container{{Name: util.DatabaseContainerName}}
-			}
 			annotations := map[string]string{}
 			if tt.annotated {
 				annotations[util.AppDBMigrationReadyAnnotation] = "true"
 			}
+			// the AppDB pod template mounts the TLS volumes unconditionally (Optional=true),
+			// so the fixture always carries them regardless of whether TLS is enabled
 			sts := DefaultStatefulSetBuilder().SetName("my-om-db").
 				SetAnnotations(annotations).
 				SetReplicas(tt.stsReplicas).
-				SetContainers(containers).
 				SetVolumes([]corev1.Volume{
 					{Name: util.SecretVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certSecretName}}},
 					{Name: tls.ConfigMapVolumeCAName, VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: appDBCAConfigMap}}}},
@@ -2247,17 +2228,13 @@ func TestValidateAppDBForwardMigration(t *testing.T) {
 
 			validationStatus := helper.validateAppDBForwardMigration(ctx, mdb, sts)
 
-			if len(tt.expectedViolations) == 0 {
+			if tt.expectedError == "" {
 				assert.True(t, validationStatus.IsOK())
 				return
 			}
 			require.False(t, validationStatus.IsOK())
 			assert.Equal(t, status.PhaseFailed, validationStatus.Phase())
-			msg := statusMessage(validationStatus)
-			assert.Contains(t, msg, "cannot change AppDB configuration during forward migration")
-			for _, violation := range tt.expectedViolations {
-				assert.Contains(t, msg, violation)
-			}
+			assert.Equal(t, tt.expectedError, statusMessage(validationStatus))
 		})
 	}
 }


### PR DESCRIPTION
# Summary

During forward migration the AppDB pods still run headless agents that read the mounted automation config and never poll Ops Manager, so for cluster-visible settings (TLS, CA, members) no publish ordering can apply a change safely — rotated members become incompatible with unrotated ones and the rolling update wedges (see [this discussion](https://github.com/mongodb/mongodb-kubernetes/pull/1440#discussion_r3862882368)). This PR adds runtime validations in the replicaset controller that reject a `role: AppDB` CR spec diverging from the running AppDB while the handover is in progress: TLS must stay enabled, the CA ConfigMap must stay identical, and the member count must match the StatefulSet. The migration window is detected from the adopted StatefulSet itself (pod template still in AppDB form, or the migration-ready annotation present), so it self-closes once the controller replaces the StatefulSet spec. Violations are aggregated into a single validation failure (`Failed` phase, no requeue) telling the user to complete the migration with a matching spec first.

## Proof of Work

- `TestValidateAppDBForwardMigration` — table-driven coverage of every rule (TLS disable, CA change, scale up/down, aggregation, matching spec, closed window)
- Existing `TestAdoptionGate_*` tests pass through the new validation path
- e2e: pending — validation-only change, negative paths covered by unit tests; `e2e_om_external_appdb_*` to be run via Evergreen patch

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details