### PR TITLE
Fix merge skew

### DIFF
--- a/api/mongodb/v1/mdbmulti/mongodb_multi_types_test.go
+++ b/api/mongodb/v1/mdbmulti/mongodb_multi_types_test.go
@@ -59,27 +59,27 @@ func TestMongoDBMultiCluster_ConnectionURL_NotSecure(t *testing.T) {
 	mrs.Spec.ClusterSpecList = defaultTestClusterSpecList()
 
 	var cnx string
-	cnx = mrs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local,temple-0-2-svc.my-namespace.svc.cluster.local/"+
-		"?connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"?connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Connection parameters. The default one is overridden
-	cnx = mrs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"})
+	cnx = mrs.BuildConnectionString("", "", "", connectionstring.SchemeMongoDB, map[string]string{"connectTimeoutMS": "30000", "readPreference": "secondary"})
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local,temple-0-2-svc.my-namespace.svc.cluster.local/"+
-		"?connectTimeoutMS=30000&readPreference=secondary&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"?connectTimeoutMS=30000&readPreference=secondary&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Custom cluster domain
 	mrs = DefaultMultiReplicaSetBuilder().Build()
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.ClusterDomain = "company.domain.net"
-	cnx = mrs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.company.domain.net,"+
 		"temple-0-1-svc.my-namespace.svc.company.domain.net/?connectTimeoutMS=20000&replicaSet=temple"+
-		"&serverSelectionTimeoutMS=20000",
+		"&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 }
 
@@ -92,10 +92,10 @@ func TestMongoDBMultiCluster_ConnectionURL_MultiClusterTopology(t *testing.T) {
 		{ClusterName: "member-cluster-2", Members: 1},
 	}
 
-	cnx := mrs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, nil)
+	cnx := mrs.BuildConnectionString("", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local,temple-1-0-svc.my-namespace.svc.cluster.local/"+
-		"?connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"?connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 }
 
@@ -108,7 +108,7 @@ func TestMongoDBMultiCluster_ConnectionURL_Secure(t *testing.T) {
 	mrs := DefaultMultiReplicaSetBuilder().Build()
 	mrs.Spec.ClusterSpecList = defaultTestClusterSpecList()
 	mrs.Spec.Security.TLSConfig.Enabled = true
-	cnx = mrs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local,temple-0-2-svc.my-namespace.svc.cluster.local/?"+
 		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=true",
@@ -119,7 +119,7 @@ func TestMongoDBMultiCluster_ConnectionURL_Secure(t *testing.T) {
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.Security.TLSConfig.Enabled = true
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.SCRAM}}
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://the_user:the_passwd@temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-256&authSource=admin&"+
 		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=true",
@@ -130,81 +130,81 @@ func TestMongoDBMultiCluster_ConnectionURL_Secure(t *testing.T) {
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.Version = "3.6.1"
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.SCRAM, util.X509}}
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://the_user:the_passwd@temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-1&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Explicit SCRAM-SHA-1 mode -> credentials embedded, authMechanism set by builder, authSource is caller's responsibility
 	mrs = DefaultMultiReplicaSetBuilder().Build()
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.SCRAMSHA1, util.MONGODBCR}}
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://the_user:the_passwd@temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-1&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Explicit SCRAM-SHA-1 mode with SRV scheme
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDBSRV, nil)
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDBSRV, nil)
 	assert.Equal(t, "mongodb+srv://the_user:the_passwd@temple-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-1&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Caller-supplied authSource (as updateConnectionStringSecret always does) is added alongside authMechanism
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, map[string]string{"authSource": "testdb"})
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDB, map[string]string{"authSource": "testdb"})
 	assert.Equal(t, "mongodb://the_user:the_passwd@temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-1&authSource=testdb&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Special symbols in user/password must be encoded
 	mrs = DefaultMultiReplicaSetBuilder().Build()
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.SCRAM}}
-	cnx = mrs.BuildConnectionString("user/@", "pwd#!@", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("user/@", "pwd#!@", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://user%2F%40:pwd%23%21%40@temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-256&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// Caller can override any connection parameters, e.g. "authMechanism"
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-1"})
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDB, map[string]string{"authMechanism": "SCRAM-SHA-1"})
 	assert.Equal(t, "mongodb://the_user:the_passwd@temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-1&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
 	// X509 -> no user/password in the url. It's possible to pass user/password in the params though
 	mrs = DefaultMultiReplicaSetBuilder().Build()
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.X509}}
-	cnx = mrs.BuildConnectionString("the_user", "the_passwd", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("the_user", "the_passwd", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?connectTimeoutMS=20000&replicaSet=temple&"+
-		"serverSelectionTimeoutMS=20000", cnx)
+		"serverSelectionTimeoutMS=20000&ssl=false", cnx)
 
 	// username + password must both be provided if scram is enabled
 	mrs = DefaultMultiReplicaSetBuilder().Build()
 	mrs.Spec.ClusterSpecList = mdb.ClusterSpecList{{ClusterName: "cluster-1", Members: 2}}
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.SCRAM}}
-	cnx = mrs.BuildConnectionString("the_user", "", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("the_user", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-256&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
-	cnx = mrs.BuildConnectionString("", "the_password", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("", "the_password", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-256&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 
-	cnx = mrs.BuildConnectionString("", "", connectionstring.SchemeMongoDB, nil)
+	cnx = mrs.BuildConnectionString("", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0-svc.my-namespace.svc.cluster.local,"+
 		"temple-0-1-svc.my-namespace.svc.cluster.local/?authMechanism=SCRAM-SHA-256&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 }
 
@@ -221,10 +221,10 @@ func TestMongoDBMultiCluster_ConnectionURL_ExternalDomain(t *testing.T) {
 	}
 	mrs.Spec.Security.Authentication = &mdb.Authentication{Modes: []mdb.AuthMode{util.SCRAM}}
 
-	cnx := mrs.BuildConnectionString("the_user", "", connectionstring.SchemeMongoDB, nil)
+	cnx := mrs.BuildConnectionString("the_user", "", "", connectionstring.SchemeMongoDB, nil)
 	assert.Equal(t, "mongodb://temple-0-0.az1.example.com,"+
 		"temple-0-1.az1.example.com,temple-1-0.az2.example.com,temple-1-1.az2.example.com"+
 		"/?authMechanism=SCRAM-SHA-256&authSource=admin&"+
-		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000",
+		"connectTimeoutMS=20000&replicaSet=temple&serverSelectionTimeoutMS=20000&ssl=false",
 		cnx)
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.11.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.11.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -77,16 +77,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -127,12 +127,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_11_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.11.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_11_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.11.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_11_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.11.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_11_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.11.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_11_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.11.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_11_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.11.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.11.0
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.11.1
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.10.0
+  replaces: mongodb-kubernetes.v1.11.0
   version: 0.0.0

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.11.0
+version: 1.11.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.11.0
+  version: 1.11.1
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.11.0
+  version: 1.11.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -146,11 +146,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.11.0
+  version: 1.11.1
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.11.0
+  version: 1.11.1
 
 ## Ops Manager
 opsManager:
@@ -158,7 +158,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.11.0
+  version: 1.11.1
 
 agent:
   name: mongodb-agent

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -344,7 +344,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.11.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.11.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -403,16 +403,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -339,7 +339,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.11.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.11.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -392,16 +392,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -440,12 +440,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_11_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.11.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_11_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.11.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_11_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.11.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_11_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.11.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_11_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.11.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_11_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.11.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -344,7 +344,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.11.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.11.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -400,16 +400,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: DATABASE_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.11.0"
+              value: "1.11.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.17.0.tgz"
   },
-  "mongodbOperator": "1.11.0",
-  "initDatabaseVersion": "1.11.0",
-  "initOpsManagerVersion": "1.11.0",
-  "databaseImageVersion": "1.11.0",
+  "mongodbOperator": "1.11.1",
+  "initDatabaseVersion": "1.11.1",
+  "initOpsManagerVersion": "1.11.1",
+  "databaseImageVersion": "1.11.1",
   "agentVersion": "108.0.12.8846-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -102,7 +102,8 @@
         "1.9.1",
         "1.9.2",
         "1.10.0",
-        "1.11.0"
+        "1.11.0",
+        "1.11.1"
       ],
       "variants": [
         "ubi"
@@ -310,7 +311,8 @@
         "1.9.1",
         "1.9.2",
         "1.10.0",
-        "1.11.0"
+        "1.11.0",
+        "1.11.1"
       ],
       "variants": [
         "ubi"
@@ -336,7 +338,8 @@
         "1.9.1",
         "1.9.2",
         "1.10.0",
-        "1.11.0"
+        "1.11.0",
+        "1.11.1"
       ],
       "variants": [
         "ubi"
@@ -362,7 +365,8 @@
         "1.9.1",
         "1.9.2",
         "1.10.0",
-        "1.11.0"
+        "1.11.0",
+        "1.11.1"
       ],
       "variants": [
         "ubi"


### PR DESCRIPTION
#1520 branched from master before the stack containing #1476 and #1483 was merged, but was merged after without rebasing first. This broke the Go unit tests added by #1520 because the `BuildConnectionString()` signature and behavior was changed in the other PRs. This fixes the merge discrepancy.

EDIT: The version number should also be updated - a rebase before merge in #1520 would have caught this, too.