### PR TITLE
Fix release configuration found during 1.11.0 release

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -1023,7 +1023,7 @@ functions:
           - OPERATOR_VERSION
         env:
           GH_TOKEN: ${GH_TOKEN}
-        binary: scripts/dev/run_python.sh scripts/release/create_chart_release_pr.py --chart_version ${OPERATOR_VERSION|*RELEASE_VERSION}
+        binary: scripts/dev/run_python.sh scripts/release/create_chart_release_pr.py --chart_version ${OPERATOR_VERSION|*triggered_by_git_tag}
 
   add_releaseinfo_to_github_assets:
     - command: github.generate_token
@@ -1037,7 +1037,7 @@ functions:
           - OPERATOR_VERSION
         env:
           GH_TOKEN: ${GH_TOKEN}
-        binary: scripts/dev/run_python.sh scripts/release/release_info.py --version ${OPERATOR_VERSION|*RELEASE_VERSION}
+        binary: scripts/dev/run_python.sh scripts/release/release_info.py --version ${OPERATOR_VERSION|*triggered_by_git_tag}
 
   release_kubectl_mongodb_plugin:
     - command: github.generate_token

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -126,6 +126,8 @@ tasks:
       - func: clone
       - func: python_venv
       - func: install_macos_notarization_service
+      - func: assume_devprod_platforms_ecr_role
+      - func: write_devprod_platforms_ecr_aws_profile
       - func: release_kubectl_mongodb_plugin
 
   - name: add_releaseinfo_to_github_assets


### PR DESCRIPTION
# Summary

This patch fixes the missing AWS config (introduced in https://github.com/mongodb/mongodb-kubernetes/pull/1397)  for signing the release binary when publishing the `kubectl` plugin. It also fixes a broken variable expansion that prevents the automation of creating the Helm chart release PR and addition of release binaries to the draft release.

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
