### PR TITLE
CLOUDP-400899: Add --member-cluster-api-server to generate-member-registration

### DIFF
--- a/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
+++ b/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
@@ -96,7 +96,7 @@ func parseFlags() (memberregistration.Options, error) {
 		if err != nil {
 			return memberregistration.Options{}, xerrors.Errorf("invalid --member-cluster-api-server %q: %v", memberClusterApiServer, err)
 		}
-		if u.Scheme == "" || u.Host == "" {
+		if u.Scheme == "" || u.Hostname() == "" {
 			return memberregistration.Options{}, xerrors.Errorf("invalid --member-cluster-api-server %q: must be an absolute URL with scheme and host", memberClusterApiServer)
 		}
 	}

--- a/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
+++ b/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
@@ -2,6 +2,7 @@ package generatememberregistration
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -19,6 +20,7 @@ var flags struct {
 	memberClusterNamespace   string
 	operatorNamespace        string
 	memberClusterLogicalName string
+	memberClusterApiServer   string
 }
 
 func init() {
@@ -27,6 +29,7 @@ func init() {
 	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterNamespace, "member-cluster-namespace", "", "Namespace on the member cluster holding the operator's credentials. [required]")
 	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.operatorNamespace, "operator-namespace", "", "Namespace on the operator's cluster where the MemberCluster CR and credential Secret will be created. Must match the operator's installation namespace. [required]")
 	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterLogicalName, "member-cluster-logical-name", "", "Name that workloads use to reference this member cluster. Only needed when that name is not RFC 1123 compliant (e.g. it contains underscores). [optional, default: --member-cluster]")
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterApiServer, "member-cluster-api-server", "", "API server address of the member cluster; must be reachable from the operator Pod. [optional, default: the server address from --member-cluster-context]")
 }
 
 // GenerateMemberRegistrationCmd reads a member cluster's ServiceAccount token and emits the
@@ -39,6 +42,7 @@ token that 'generate-member-resources' created on it, and writes a credential Se
 single-context kubeconfig) and a MemberCluster CR as multi-document YAML to stdout.
 
 If the token Secret is not populated yet, the command waits up to a minute for Kubernetes to provision it.
+By default the credential kubeconfig uses the API server address from --member-cluster-context; pass --member-cluster-api-server to override it.
 
 Apply the output to the operator's cluster with kubectl, or commit it to Git for GitOps.
 
@@ -86,11 +90,20 @@ func parseFlags() (memberregistration.Options, error) {
 		memberClusterLogicalName = flags.memberCluster
 	}
 
+	memberClusterApiServer := strings.TrimSpace(flags.memberClusterApiServer)
+	if memberClusterApiServer != "" {
+		u, err := url.Parse(memberClusterApiServer)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return memberregistration.Options{}, xerrors.Errorf("invalid --member-cluster-api-server %q: must be an absolute URL with scheme and host", memberClusterApiServer)
+		}
+	}
+
 	return memberregistration.Options{
 		MemberClusterName:        flags.memberCluster,
 		MemberClusterNamespace:   flags.memberClusterNamespace,
 		OperatorNamespace:        flags.operatorNamespace,
 		MemberClusterLogicalName: memberClusterLogicalName,
+		MemberClusterApiServer:   memberClusterApiServer,
 		TokenWaitTimeout:         memberregistration.DefaultTokenWaitTimeout,
 	}, nil
 }

--- a/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
+++ b/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
@@ -93,7 +93,10 @@ func parseFlags() (memberregistration.Options, error) {
 	memberClusterApiServer := strings.TrimSpace(flags.memberClusterApiServer)
 	if memberClusterApiServer != "" {
 		u, err := url.Parse(memberClusterApiServer)
-		if err != nil || u.Scheme == "" || u.Host == "" {
+		if err != nil {
+			return memberregistration.Options{}, xerrors.Errorf("invalid --member-cluster-api-server %q: %v", memberClusterApiServer, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
 			return memberregistration.Options{}, xerrors.Errorf("invalid --member-cluster-api-server %q: must be an absolute URL with scheme and host", memberClusterApiServer)
 		}
 	}

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration.go
@@ -49,7 +49,8 @@ type Options struct {
 	MemberClusterNamespace string
 	// OperatorNamespace is the namespace on the operator's cluster where the emitted CR and
 	// credential Secret are placed.
-	OperatorNamespace string
+	OperatorNamespace      string
+	MemberClusterApiServer string
 	// TokenWaitTimeout is how long Generate waits for the token Secret to be populated by
 	// Kubernetes's token controller before failing. It must be positive; the CLI passes
 	// DefaultTokenWaitTimeout.
@@ -65,6 +66,10 @@ func Generate(ctx context.Context, memberClusterClient kubernetes.Interface, mem
 	token, ca, err := waitForTokenSecret(ctx, memberClusterClient, tokenSecretName, opts)
 	if err != nil {
 		return "", err
+	}
+
+	if opts.MemberClusterApiServer != "" {
+		memberClusterServerURL = opts.MemberClusterApiServer
 	}
 
 	kubeconfig, err := buildKubeConfig(opts.MemberClusterName, memberClusterServerURL, opts.MemberClusterNamespace, ca, token)

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
@@ -171,6 +171,31 @@ func TestGenerate_KubeconfigContents(t *testing.T) {
 	assert.Equal(t, testToken, authInfo.Token)
 }
 
+func TestGenerate_KubeconfigContents_ApiServerOverride(t *testing.T) {
+	client := fake.NewSimpleClientset(tokenSecret("cluster-east", testNamespace, map[string][]byte{
+		corev1.ServiceAccountTokenKey:  []byte(testToken),
+		corev1.ServiceAccountRootCAKey: []byte(testCA),
+	}))
+
+	const apiServerOverride = "https://member-api.internal:6443"
+	out, err := Generate(context.Background(), client, testServerURL, Options{
+		MemberClusterName:        "cluster-east",
+		MemberClusterNamespace:   testNamespace,
+		OperatorNamespace:        testOperatorNamespace,
+		MemberClusterLogicalName: "cluster-east",
+		MemberClusterApiServer:   apiServerOverride,
+	})
+	require.NoError(t, err)
+
+	secret, _ := parseOutput(t, out)
+	cfg, err := clientcmd.Load([]byte(secret.StringData[credentialSecretKey]))
+	require.NoError(t, err)
+
+	cluster := cfg.Clusters[cfg.Contexts[cfg.CurrentContext].Cluster]
+	require.NotNil(t, cluster)
+	assert.Equal(t, apiServerOverride, cluster.Server)
+}
+
 func TestGenerate_Errors(t *testing.T) {
 	tests := map[string]struct {
 		objects     []*corev1.Secret


### PR DESCRIPTION
# Summary

The legacy `multicluster setup`/`recover` commands supported `--member-clusters-api-servers` to override the API server addresses written into member-cluster kubeconfigs — needed when the address in the caller's kubeconfig is not reachable from the operator Pod (e.g. VPN or `kind`). The new `multicluster generate-member-registration` command always took the address from the `--member-cluster-context` kubeconfig entry. This PR adds the optional `--member-cluster-api-server` flag: when set, its value (validated as an absolute URL before any cluster contact) is written into the emitted credential kubeconfig instead; when unset, behaviour is unchanged.

## Proof of Work

- unit: `go test ./pkg/kubectl-mongodb/... ./cmd/kubectl-mongodb/...` — new `TestGenerate_KubeconfigContents_ApiServerOverride` covers the override; existing `TestGenerate_KubeconfigContents` covers the default path
- `make precommit` clean
- e2e: N/A (no runtime change — kubectl plugin tooling only)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->