### PR TITLE
KUBE-339,CLOUDP-400899: Add --member-cluster-api-server-ca to generate-member-registration

### DIFF
--- a/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
+++ b/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration.go
@@ -1,6 +1,8 @@
 package generatememberregistration
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"os"
@@ -21,6 +23,7 @@ var flags struct {
 	operatorNamespace        string
 	memberClusterLogicalName string
 	memberClusterApiServer   string
+	memberClusterApiServerCA string
 }
 
 func init() {
@@ -30,6 +33,7 @@ func init() {
 	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.operatorNamespace, "operator-namespace", "", "Namespace on the operator's cluster where the MemberCluster CR and credential Secret will be created. Must match the operator's installation namespace. [required]")
 	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterLogicalName, "member-cluster-logical-name", "", "Name that workloads use to reference this member cluster. Only needed when that name is not RFC 1123 compliant (e.g. it contains underscores). [optional, default: --member-cluster]")
 	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterApiServer, "member-cluster-api-server", "", "API server address of the member cluster; must be reachable from the operator Pod. [optional, default: the server address from --member-cluster-context]")
+	GenerateMemberRegistrationCmd.Flags().StringVar(&flags.memberClusterApiServerCA, "member-cluster-api-server-ca", "", "Path to a PEM file with the CA certificate the operator should use to verify the member cluster's API server. [optional, default: the CA from the member cluster's ServiceAccount token Secret]")
 }
 
 // GenerateMemberRegistrationCmd reads a member cluster's ServiceAccount token and emits the
@@ -43,6 +47,7 @@ single-context kubeconfig) and a MemberCluster CR as multi-document YAML to stdo
 
 If the token Secret is not populated yet, the command waits up to a minute for Kubernetes to provision it.
 By default the credential kubeconfig uses the API server address from --member-cluster-context; pass --member-cluster-api-server to override it.
+By default the credential kubeconfig uses the CA from the member cluster's ServiceAccount token Secret; pass --member-cluster-api-server-ca to override it.
 
 Apply the output to the operator's cluster with kubectl, or commit it to Git for GitOps.
 
@@ -101,12 +106,52 @@ func parseFlags() (memberregistration.Options, error) {
 		}
 	}
 
+	memberClusterApiServerCA, err := loadMemberClusterApiServerCA(flags.memberClusterApiServerCA)
+	if err != nil {
+		return memberregistration.Options{}, err
+	}
+
 	return memberregistration.Options{
 		MemberClusterName:        flags.memberCluster,
 		MemberClusterNamespace:   flags.memberClusterNamespace,
 		OperatorNamespace:        flags.operatorNamespace,
 		MemberClusterLogicalName: memberClusterLogicalName,
 		MemberClusterApiServer:   memberClusterApiServer,
+		MemberClusterApiServerCA: memberClusterApiServerCA,
 		TokenWaitTimeout:         memberregistration.DefaultTokenWaitTimeout,
 	}, nil
+}
+
+// loadMemberClusterApiServerCA reads and validates the PEM bundle named by
+// --member-cluster-api-server-ca; a blank flag value means no override.
+func loadMemberClusterApiServerCA(path string) ([]byte, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, nil
+	}
+	caPEM, err := os.ReadFile(path)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid --member-cluster-api-server-ca: failed reading CA file %q: %w", path, err)
+	}
+	if err := validateCAPEM(caPEM); err != nil {
+		return nil, xerrors.Errorf("invalid --member-cluster-api-server-ca: %q: %w", path, err)
+	}
+	return caPEM, nil
+}
+
+// validateCAPEM rejects a bundle the Operator could not use, or should never be handed: it builds
+// its cert pool from this value alone, and the bundle is copied verbatim into a Secret.
+func validateCAPEM(caPEM []byte) error {
+	// a bundle exported from a TLS terminator can carry the server key next to its certificate
+	for block, rest := pem.Decode(caPEM); block != nil; block, rest = pem.Decode(rest) {
+		if strings.HasSuffix(block.Type, "PRIVATE KEY") {
+			return xerrors.Errorf("found a private key (%s block), pass certificates only", block.Type)
+		}
+	}
+
+	if !x509.NewCertPool().AppendCertsFromPEM(caPEM) {
+		return xerrors.Errorf("no PEM encoded certificate found")
+	}
+
+	return nil
 }

--- a/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration_test.go
+++ b/cmd/kubectl-mongodb/multicluster/generatememberregistration/generate_member_registration_test.go
@@ -1,0 +1,142 @@
+package generatememberregistration
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cryptorand "crypto/rand"
+)
+
+func TestLoadMemberClusterApiServerCA(t *testing.T) {
+	caPEM := generateTestCAPEM(t, "member-cluster-ca")
+
+	tests := []struct {
+		name      string
+		flagValue string
+		setup     func(t *testing.T) (path string, want []byte)
+		wantError string
+	}{
+		{
+			name:      "blank value means no override",
+			flagValue: "",
+		},
+		{
+			name: "valid single CA cert file",
+			setup: func(t *testing.T) (string, []byte) {
+				return writeTestFile(t, t.TempDir(), "ca.pem", caPEM), caPEM
+			},
+		},
+		{
+			name: "valid multi-cert bundle",
+			setup: func(t *testing.T) (string, []byte) {
+				bundle := concatPEMs(caPEM, generateTestCAPEM(t, "member-cluster-ca-2"))
+				return writeTestFile(t, t.TempDir(), "ca-bundle.pem", bundle), bundle
+			},
+		},
+		{
+			name: "bundle containing a private key is rejected",
+			setup: func(t *testing.T) (string, []byte) {
+				bundle := concatPEMs(caPEM, generateTestPrivateKeyPEM(t))
+				return writeTestFile(t, t.TempDir(), "tls-bundle.pem", bundle), nil
+			},
+			wantError: "found a private key",
+		},
+		{
+			name: "non-PEM garbage is rejected",
+			setup: func(t *testing.T) (string, []byte) {
+				return writeTestFile(t, t.TempDir(), "garbage.pem", []byte("not a pem bundle")), nil
+			},
+			wantError: "no PEM encoded certificate found",
+		},
+		{
+			name:      "missing file is rejected",
+			flagValue: filepath.Join(t.TempDir(), "does-not-exist.pem"),
+			wantError: "failed reading CA file",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := tc.flagValue
+			var want []byte
+			if tc.setup != nil {
+				path, want = tc.setup(t)
+			}
+
+			got, err := loadMemberClusterApiServerCA(path)
+			if tc.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// generateTestCAPEM returns a self signed, PEM encoded CA certificate. It is generated rather than
+// hardcoded so the fixture is always accepted by x509.CertPool.AppendCertsFromPEM, which is what
+// validateCAPEM relies on.
+func generateTestCAPEM(t *testing.T, commonName string) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// generateTestPrivateKeyPEM returns a PEM encoded EC private key, standing in for the server key a
+// TLS terminator keeps alongside its certificate in a single bundle file.
+func generateTestPrivateKeyPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	require.NoError(t, err)
+
+	der, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+// concatPEMs joins PEM blocks into the single bundle file a user would pass on the command line.
+func concatPEMs(pems ...[]byte) []byte {
+	var bundle []byte
+	for _, p := range pems {
+		bundle = append(bundle, p...)
+	}
+	return bundle
+}
+
+func writeTestFile(t *testing.T, dir, name string, contents []byte) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, contents, 0o600))
+	return path
+}

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration.go
@@ -49,8 +49,9 @@ type Options struct {
 	MemberClusterNamespace string
 	// OperatorNamespace is the namespace on the operator's cluster where the emitted CR and
 	// credential Secret are placed.
-	OperatorNamespace      string
-	MemberClusterApiServer string
+	OperatorNamespace        string
+	MemberClusterApiServer   string
+	MemberClusterApiServerCA []byte
 	// TokenWaitTimeout is how long Generate waits for the token Secret to be populated by
 	// Kubernetes's token controller before failing. It must be positive; the CLI passes
 	// DefaultTokenWaitTimeout.
@@ -70,6 +71,9 @@ func Generate(ctx context.Context, memberClusterClient kubernetes.Interface, mem
 
 	if opts.MemberClusterApiServer != "" {
 		memberClusterServerURL = opts.MemberClusterApiServer
+	}
+	if len(opts.MemberClusterApiServerCA) > 0 {
+		ca = opts.MemberClusterApiServerCA
 	}
 
 	kubeconfig, err := buildKubeConfig(opts.MemberClusterName, memberClusterServerURL, opts.MemberClusterNamespace, ca, token)

--- a/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
+++ b/pkg/kubectl-mongodb/memberregistration/memberregistration_test.go
@@ -2,7 +2,13 @@ package memberregistration
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
 
+	cryptorand "crypto/rand"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -194,6 +201,56 @@ func TestGenerate_KubeconfigContents_ApiServerOverride(t *testing.T) {
 	cluster := cfg.Clusters[cfg.Contexts[cfg.CurrentContext].Cluster]
 	require.NotNil(t, cluster)
 	assert.Equal(t, apiServerOverride, cluster.Server)
+}
+
+func TestGenerate_KubeconfigContents_CertificateAuthorityOverride(t *testing.T) {
+	client := fake.NewSimpleClientset(tokenSecret("cluster-east", testNamespace, map[string][]byte{
+		corev1.ServiceAccountTokenKey:  []byte(testToken),
+		corev1.ServiceAccountRootCAKey: []byte(testCA),
+	}))
+
+	caOverride := generateTestCAPEM(t, "member-cluster-ca-override")
+	out, err := Generate(context.Background(), client, testServerURL, Options{
+		MemberClusterName:        "cluster-east",
+		MemberClusterNamespace:   testNamespace,
+		OperatorNamespace:        testOperatorNamespace,
+		MemberClusterLogicalName: "cluster-east",
+		MemberClusterApiServerCA: caOverride,
+	})
+	require.NoError(t, err)
+
+	secret, _ := parseOutput(t, out)
+	cfg, err := clientcmd.Load([]byte(secret.StringData[credentialSecretKey]))
+	require.NoError(t, err)
+
+	cluster := cfg.Clusters[cfg.Contexts[cfg.CurrentContext].Cluster]
+	require.NotNil(t, cluster)
+	assert.Equal(t, caOverride, cluster.CertificateAuthorityData)
+}
+
+// generateTestCAPEM returns a self signed, PEM encoded CA certificate. It is generated rather than
+// hardcoded so the fixture is always accepted by x509.CertPool.AppendCertsFromPEM, which is what
+// the CLI's --member-cluster-api-server-ca validation relies on.
+func generateTestCAPEM(t *testing.T, commonName string) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
 
 func TestGenerate_Errors(t *testing.T) {


### PR DESCRIPTION
# Summary

MCK 1.x (#1521) added `--member-cluster-ca` to the legacy `multicluster setup`/`recover` commands for cases where the operator must verify a member cluster's API server against a different CA than the caller's environment — e.g. a TLS-terminating proxy in front of the API server. The new `multicluster generate-member-registration` command always embeds the member cluster's ServiceAccount token Secret `ca.crt` into the emitted credential kubeconfig. This PR adds the optional `--member-cluster-api-server-ca` flag (path to a PEM file, validated before any cluster contact): when set, its bundle replaces the token Secret's CA in the emitted kubeconfig; when unset, behaviour is unchanged. The 1.x flag's warn-before-clobber machinery is not ported: the new command is render-only and never touches the operator cluster.

## Proof of Work

- unit: `go test ./pkg/kubectl-mongodb/... ./cmd/kubectl-mongodb/...` — new `TestGenerate_KubeconfigContents_CertificateAuthorityOverride` (override path; existing test covers the default) and new cmd-level `TestLoadMemberClusterApiServerCA` (PEM validation table: valid cert/bundle, private key rejected, non-PEM rejected, missing file)
- `make precommit` clean
- e2e: N/A (no runtime change — kubectl plugin tooling only)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->