### PR TITLE
KUBE-358: Retag simply after publish

### DIFF
--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -183,8 +183,9 @@ buildvariants:
     tasks:
       - name: add_releaseinfo_to_github_assets
 
-  # Depends on release_publish only: the retag should proceed as soon as images
-  # are published to production, regardless of preflight/code-snippet/bundle results.
+  # Not tagged "release-publish": tag selectors in depends_on don't
+  # auto-activate. Using the direct variant name "release_publish" causes
+  # auto-activation and gates the retag only on image publish succeeding.
   - name: retag_new_release
     display_name: retag_new_release
     run_on:

--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -183,8 +183,8 @@ buildvariants:
     tasks:
       - name: add_releaseinfo_to_github_assets
 
-  # Not tagged "release-publish" itself (it depends on every "release-publish"-
-  # tagged variant succeeding, which would otherwise create a self-dependency).
+  # Depends on release_publish only: the retag should proceed as soon as images
+  # are published to production, regardless of preflight/code-snippet/bundle results.
   - name: retag_new_release
     display_name: retag_new_release
     run_on:
@@ -192,8 +192,7 @@ buildvariants:
     allowed_requesters: [ "patch", "github_tag" ]
     depends_on:
       - name: "*"
-        variant: ".release-publish"
-        status: "success"
+        variant: release_publish
     tasks:
       - name: retag_new_release
 

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -488,8 +488,9 @@ buildvariants:
     tasks:
       - name: release_chart_to_oci_registry
 
-  # Depends on release_images only: the retag should proceed as soon as images
-  # are published to production, regardless of test/preflight/code-snippet results.
+  # Not tagged "deprecated-release": tag selectors in depends_on don't
+  # auto-activate. Using the direct variant name "release_images" causes
+  # auto-activation and gates the retag only on image publish succeeding.
   - name: retag_legacy_release
     display_name: retag_legacy_release
     run_on:

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -488,8 +488,8 @@ buildvariants:
     tasks:
       - name: release_chart_to_oci_registry
 
-  # Not tagged "deprecated-release" itself (it depends on every "deprecated-release"-tagged variant
-  # succeeding, which would otherwise create a self-dependency).
+  # Depends on release_images only: the retag should proceed as soon as images
+  # are published to production, regardless of test/preflight/code-snippet results.
   - name: retag_legacy_release
     display_name: retag_legacy_release
     run_on:
@@ -497,7 +497,6 @@ buildvariants:
     allowed_requesters: [ "patch", "github_tag" ]
     depends_on:
       - name: "*"
-        variant: ".deprecated-release"
-        status: "success"
+        variant: release_images
     tasks:
       - name: retag_legacy_release


### PR DESCRIPTION
# Summary

Do not block retagging on anything other than the publishing of the images. Once public the release has happened anyway.

## Proof of Work

TBD

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
