### PR TITLE
KUBE-360: Fix bump agent image version

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -90,7 +90,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.26.9062-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -162,7 +162,7 @@ initOpsManager:
 
 agent:
   name: mongodb-agent
-  version: 108.0.12.8846-1
+  version: 108.0.26.9062-1
 
 # This is only used by the MongoDBCommunity resource reconciler - START
 versionUpgradeHook:

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -416,7 +416,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.26.9062-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -405,7 +405,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.26.9062-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -413,7 +413,7 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
-              value: "quay.io/mongodb/mongodb-agent:108.0.12.8846-1"
+              value: "quay.io/mongodb/mongodb-agent:108.0.26.9062-1"
             - name: MDB_AGENT_IMAGE_REPOSITORY
               value: "quay.io/mongodb/mongodb-agent"
             - name: MONGODB_IMAGE

--- a/release.json
+++ b/release.json
@@ -6,7 +6,7 @@
   "initDatabaseVersion": "1.12.0",
   "initOpsManagerVersion": "1.12.0",
   "databaseImageVersion": "1.12.0",
-  "agentVersion": "108.0.12.8846-1",
+  "agentVersion": "108.0.26.9062-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
   "openshift": {

--- a/scripts/evergreen/release/update_release.py
+++ b/scripts/evergreen/release/update_release.py
@@ -35,6 +35,11 @@ def update_release_json():
     # Adds mapping between latest major version of OM and agent to the release.json
     update_latest_om_agent_mapping(data)
 
+    # Sync top-level agentVersion with the latest agent from OM mapping
+    latest_mapping = data["latestOpsManagerAgentMapping"]
+    latest = max(latest_mapping, key=lambda x: int(list(x.keys())[0]))
+    data["agentVersion"] = list(latest.values())[0]["agentVersion"]
+
     with open(release, "w") as f:
         json.dump(
             data,


### PR DESCRIPTION
# Summary

This properly propagates the agent image version bump to all missing locations.

Related to #1008 

## Proof of Work

After `make precommit` see all sites bumped in the second commit.

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
