### PR TITLE
Only run AppDB backup/restore against OM8 variant

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1301,7 +1301,6 @@ task_groups:
       - e2e_om_appdb_scram
       - e2e_om_external_appdb_forward
       - e2e_om_external_appdb_fresh
-      - e2e_om_external_appdb_backup_and_restore
       - e2e_om_external_connectivity
       - e2e_om_jvm_params
       - e2e_om_migration
@@ -1347,7 +1346,6 @@ task_groups:
       - e2e_om_appdb_scram
       - e2e_om_external_appdb_forward
       - e2e_om_external_appdb_fresh
-      - e2e_om_external_appdb_backup_and_restore
       - e2e_om_external_connectivity
       - e2e_om_jvm_params
       - e2e_om_weak_password
@@ -1427,6 +1425,7 @@ task_groups:
     <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
     tasks:
       - e2e_om_ops_manager_backup_object_lock
+      - e2e_om_external_appdb_backup_and_restore
 
   # Tests features only supported on OM70 and OM80, its only upgrade test as we test upgrading from 6 to 7 or 7 to 8
   - name: e2e_ops_manager_upgrade_only_task_group


### PR DESCRIPTION
# Summary

The OM7 variants include the AppDB backup and restore test which is not compatible with OM7. This patch ensures that we only run this test against the OM8 variant.

## Proof of Work

Task configuration for OM7 variant doesn't include the backup and restore test for AppDB: https://spruce.corp.mongodb.com/patch/6a995ed498c9270007f39856/configure/tasks 

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
