### PR TITLE
KUBE-415: fix: require ns binding on legacy OM API key Secret fallback

### DIFF
--- a/api/mongodb/v1/om/opsmanager_types.go
+++ b/api/mongodb/v1/om/opsmanager_types.go
@@ -42,6 +42,10 @@ const (
 	queryableBackupDefaultPort int32  = 25999
 
 	LabelResourceOwner = "mongodb.com/v1.mongodbOpsManagerResourceOwner"
+
+	// OpsManagerNamespaceLabel is set on the admin API key Secret to record
+	// the namespace of the MongoDBOpsManager CR that owns the key.
+	OpsManagerNamespaceLabel = "mongodb.com/v1.opsManagerNamespace"
 )
 
 // The MongoDBOpsManager resource allows you to deploy Ops Manager within your Kubernetes cluster
@@ -924,23 +928,40 @@ func (om *MongoDBOpsManager) GetStatusPath(options ...status.Option) string {
 }
 
 // APIKeySecretName returns the secret object name to store the API key to communicate to ops-manager.
-// To ensure backward compatibility, it checks if a secret key is present with the old format name({$ops-manager-name}-admin-key),
-// if not it returns the new name format ({$ops-manager-namespace}-${ops-manager-name}-admin-key), to have multiple om deployments
-// with the same name.
+// It first tries the namespace-qualified name ({$namespace}-{$name}-admin-key).
+// If not found, it falls back to the legacy name ({$name}-admin-key) only when the legacy
+// Secret carries a matching OpsManagerNamespaceLabel that equals the CR's namespace.
 func (om *MongoDBOpsManager) APIKeySecretName(ctx context.Context, client secrets.SecretClientInterface, operatorSecretPath string) (string, error) {
-	oldAPISecretName := fmt.Sprintf("%s-admin-key", om.Name)
+	qualifiedName := fmt.Sprintf("%s-%s-admin-key", om.Namespace, om.Name)
 	operatorNamespace := env.ReadOrPanic(util.CurrentNamespace) // nolint:forbidigo
-	oldAPIKeySecretNamespacedName := types.NamespacedName{Name: oldAPISecretName, Namespace: operatorNamespace}
 
-	_, err := client.ReadSecret(ctx, oldAPIKeySecretNamespacedName, fmt.Sprintf("%s/%s/%s", operatorSecretPath, operatorNamespace, oldAPISecretName))
-	if err != nil {
-		if secret.SecretNotExist(err) {
-			return fmt.Sprintf("%s-%s-admin-key", om.Namespace, om.Name), nil
-		}
-
+	// 1. Check namespace-qualified name first.
+	qualifiedNamespacedName := types.NamespacedName{Name: qualifiedName, Namespace: operatorNamespace}
+	_, err := client.ReadSecret(ctx, qualifiedNamespacedName, fmt.Sprintf("%s/%s/%s", operatorSecretPath, operatorNamespace, qualifiedName))
+	if err == nil {
+		return qualifiedName, nil
+	}
+	if !secret.SecretNotExist(err) {
 		return "", err
 	}
-	return oldAPISecretName, nil
+
+	// 2. Fall back to legacy name only if it carries a matching namespace label.
+	oldAPISecretName := fmt.Sprintf("%s-admin-key", om.Name)
+	oldAPIKeySecretNamespacedName := types.NamespacedName{Name: oldAPISecretName, Namespace: operatorNamespace}
+
+	labels, err := client.ReadSecretLabels(ctx, oldAPIKeySecretNamespacedName, fmt.Sprintf("%s/%s/%s", operatorSecretPath, operatorNamespace, oldAPISecretName))
+	if err != nil {
+		if secret.SecretNotExist(err) {
+			return qualifiedName, nil
+		}
+		return "", err
+	}
+
+	if ns, ok := labels[OpsManagerNamespaceLabel]; ok && ns == om.Namespace {
+		return oldAPISecretName, nil
+	}
+
+	return qualifiedName, nil
 }
 
 func (om *MongoDBOpsManager) GetSecurity() MongoDBOpsManagerSecurity {

--- a/changelog/20260904_fix_apikeysecretname_legacy_fallback_namespace_binding.md
+++ b/changelog/20260904_fix_apikeysecretname_legacy_fallback_namespace_binding.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-04
+---
+
+* **MongoDBOpsManager**: Fixed a security issue where the legacy `<name>-admin-key` API key `Secret` fallback in `APIKeySecretName` resolved by CR name only, without binding to the owning namespace. A `MongoDBOpsManager` CR in a different namespace could inherit another CR's admin credentials by sharing the same name. The fallback now requires a `mongodb.com/v1.opsManagerNamespace` label on the `Secret` matching the CR's namespace. **Note:** deployments with a legacy-format admin key `Secret` that lacks this label must either delete the `Secret` (the operator will recreate it) or manually add the label before upgrading.

--- a/controllers/operator/mongodbopsmanager_controller.go
+++ b/controllers/operator/mongodbopsmanager_controller.go
@@ -1392,7 +1392,9 @@ func (r *OpsManagerReconciler) prepareOpsManager(ctx context.Context, opsManager
 				SetNamespace(adminKeySecretName.Namespace).
 				SetName(adminKeySecretName.Name).
 				SetStringMapToData(secretData).
-				SetLabels(map[string]string{}).Build()
+				SetLabels(map[string]string{
+					omv1.OpsManagerNamespaceLabel: opsManager.Namespace,
+				}).Build()
 
 			if err := r.PutSecret(ctx, adminSecret, operatorVaultPath); err != nil {
 				return workflow.Failed(xerrors.Errorf("failed to create a secret for admin public api key. %s. The error : %w",

--- a/controllers/operator/opsmanager_apikeysecretname_test.go
+++ b/controllers/operator/opsmanager_apikeysecretname_test.go
@@ -1,0 +1,48 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omv1 "github.com/mongodb/mongodb-kubernetes/api/mongodb/v1/om"
+	"github.com/mongodb/mongodb-kubernetes/controllers/operator/secrets"
+	kubernetesClient "github.com/mongodb/mongodb-kubernetes/pkg/kube/client"
+)
+
+func TestAPIKeySecretName_RejectsLegacyFallbackForDifferentNamespace(t *testing.T) {
+	t.Setenv("NAMESPACE", "operator-ns")
+
+	fakeClient := fake.NewClientBuilder().WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-om-admin-key",
+				Namespace: "operator-ns",
+			},
+			Data: map[string][]byte{
+				"publicKey":  []byte("victim-legacy-key"),
+				"privateKey": []byte("victim-legacy-key-priv"),
+			},
+		},
+	).Build()
+
+	wrappedClient := kubernetesClient.NewClient(fakeClient)
+	secretClient := secrets.SecretClient{KubeClient: wrappedClient}
+
+	om := omv1.NewOpsManagerBuilderDefault().SetName("shared-om").Build()
+	om.SetNamespace("attacker-ns")
+
+	got, err := om.APIKeySecretName(context.Background(), secretClient, "")
+	require.NoError(t, err)
+
+	// With the current code, this will FAIL — the legacy name takes precedence.
+	assert.Equal(t, "attacker-ns-shared-om-admin-key", got,
+		"APIKeySecretName should return namespace-qualified name, not the unqualified legacy fallback")
+	assert.NotEqual(t, "shared-om-admin-key", got)
+}

--- a/controllers/operator/secrets/secrets.go
+++ b/controllers/operator/secrets/secrets.go
@@ -19,6 +19,8 @@ import (
 
 type SecretClientInterface interface {
 	ReadSecret(ctx context.Context, secretName types.NamespacedName, basePath string) (map[string]string, error)
+	// ReadSecretLabels returns the labels of the Secret. For Vault-backed secrets, it returns an empty map.
+	ReadSecretLabels(ctx context.Context, secretName types.NamespacedName, basePath string) (map[string]string, error)
 }
 
 var _ SecretClientInterface = (*SecretClient)(nil)
@@ -70,6 +72,18 @@ func (r SecretClient) ReadSecret(ctx context.Context, secretName types.Namespace
 		}
 	}
 	return secrets, nil
+}
+
+func (r SecretClient) ReadSecretLabels(ctx context.Context, secretName types.NamespacedName, basePath string) (map[string]string, error) {
+	if vault.IsVaultSecretBackend() {
+		// Vault secrets do not carry Kubernetes labels.
+		return nil, nil
+	}
+	s, err := r.KubeClient.GetSecret(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+	return s.GetLabels(), nil
 }
 
 func (r SecretClient) ReadBinarySecret(ctx context.Context, secretName types.NamespacedName, basePath string) (map[string][]byte, error) {


### PR DESCRIPTION
# Summary

The legacy <name>-admin-key Secret fallback in APIKeySecretName resolved by CR name only, allowing a same-named CR in a different namespace to inherit another CR's admin credentials. The fallback now checks a mongodb.com/v1.opsManagerNamespace label on the Secret and rejects mismatches.

BREAKING: legacy-format Secrets without this label (post-upgrade state) will cause a one-time reconciliation failure. Remediation: delete the legacy Secret (operator recreates it) or add the label manually.

H1: #3975503
SECBUG: SECBUG-5144

## Proof of Work

Includes detection/regression unit test.

## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details
