### PR TITLE
Install kubectl-mongodb plugin only when it is built for the architecture

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -614,13 +614,13 @@ functions:
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         binary: scripts/release/publish_helm_chart.sh
 
-  build_multi_cluster_binary:
+  build_kubectl_plugin:
     - command: subprocess.exec
       params:
         working_dir: src/github.com/mongodb/mongodb-kubernetes
         binary: scripts/release/kubectl_mongodb/build_kubectl_plugin.sh
 
-  download_multi_cluster_binary:
+  download_kubectl_plugin:
     - command: subprocess.exec
       params:
         include_expansions_in_env:

--- a/.evergreen-snippets.yml
+++ b/.evergreen-snippets.yml
@@ -8,7 +8,7 @@ variables:
       - func: download_kube_tools
       - func: switch_context
       - func: python_venv
-      - func: download_multi_cluster_binary
+      - func: download_kubectl_plugin
         vars:
           platform: linux/amd64
     teardown_task:
@@ -55,7 +55,7 @@ variables:
       - func: setup_building_host
       - func: setup_kubernetes_environment
       - func: setup_cloud_qa
-      - func: download_multi_cluster_binary
+      - func: download_kubectl_plugin
         vars:
           platform: linux/amd64
     teardown_task:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -460,13 +460,13 @@ tasks:
     commands:
       - func: clone
       - func: setup_building_host
-      - func: build_multi_cluster_binary
+      - func: build_kubectl_plugin
 
   - name: build_test_image
     commands:
       - func: clone
       - func: setup_building_host
-      - func: download_multi_cluster_binary
+      - func: download_kubectl_plugin
         vars:
           platform: linux/amd64
       - func: quay_staging_login
@@ -478,7 +478,7 @@ tasks:
     commands:
       - func: clone
       - func: setup_building_host
-      - func: download_multi_cluster_binary
+      - func: download_kubectl_plugin
         vars:
           platform: linux/arm64
       - func: quay_staging_login

--- a/docker/mongodb-kubernetes-tests/Dockerfile
+++ b/docker/mongodb-kubernetes-tests/Dockerfile
@@ -99,4 +99,8 @@ COPY release.json /tests/release.json
 # we use the public directory to automatically test resources samples
 COPY public /mongodb-kubernetes/public
 
-ADD "docker/mongodb-kubernetes-tests/kubectl-mongodb_${TARGETARCH}" /usr/local/bin/kubectl-mongodb
+# Only the VM migration tests use the plugin, and it is not built for every
+# architecture, so install it when the binary is present in the build context.
+RUN if [ -f "/tests/kubectl-mongodb_${TARGETARCH}" ]; then \
+    install -m 755 "/tests/kubectl-mongodb_${TARGETARCH}" /usr/local/bin/kubectl-mongodb; \
+    fi


### PR DESCRIPTION
# Summary

The `build_test_image_ibm_z` and `build_test_image_ibm_power` tasks fail during the container build with exit code 125:

```
Error: building at STEP "ADD "docker/mongodb-kubernetes-tests/kubectl-mongodb_${TARGETARCH}" /usr/local/bin/kubectl-mongodb":
copier: stat: "/docker/mongodb-kubernetes-tests/kubectl-mongodb_s390x": no such file or directory
```

The plugin used to be installed conditionally, so a missing binary was tolerated. Commit 9dcfac16f replaced that with an unconditional `ADD`, which turns an absent binary into a hard build failure. The IBM test image tasks never fetch the plugin, so both architectures now break on the final build step.

Only the VM migration tests invoke `kubectl-mongodb`, and the IBM smoke variants run `e2e_replica_set`, which does not. Those images therefore do not need the binary at all, and downloading it for them would add an S3 dependency that nothing on those platforms exercises. This restores the conditional install instead: the plugin is picked up on the architectures where it is downloaded into the build context, and skipped where it is not.

This also renames the two Evergreen functions for this binary. It stopped being multicluster-only once `migrate-to-mck` landed, so `build_multi_cluster_binary` and `download_multi_cluster_binary` are now `build_kubectl_plugin` and `download_kubectl_plugin`, matching the scripts they already invoke.

## Proof of Work

- e2e: N/A (no runtime change — the diff touches Evergreen CI configuration and the tests image Dockerfile)
- Confirmed only `tests/vm_migration` references the plugin, and the IBM smoke variants run `e2e_replica_set`, which has no such reference.
- Confirmed `COPY docker/mongodb-kubernetes-tests /tests` places the binary where the conditional looks for it on architectures that do download it, and that `.dockerignore` does not exclude it, so amd64 keeps installing the plugin as before.
- Parsed all three Evergreen files after the rename and verified every `func:` reference resolves to a defined function, with no remaining references to the old names.

The IBM tasks are `staging`-tagged, so a green commit build is the real confirmation.

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details