### PR TITLE
KUBE-326: Reject LDAP auth mode without an ldap configuration block

### DIFF
--- a/api/mongodb/v1/mdb/mongodb_validation.go
+++ b/api/mongodb/v1/mdb/mongodb_validation.go
@@ -383,6 +383,16 @@ func agentModeIsSetIfMoreThanADeploymentAuthModeIsSet(d DbCommonSpec) v1.Validat
 	return v1.ValidationSuccess()
 }
 
+func ldapConfigIsSetIfLdapAuthModeIsEnabled(d DbCommonSpec) v1.ValidationResult {
+	if d.Security == nil || !d.Security.Authentication.IsLDAPEnabled() {
+		return v1.ValidationSuccess()
+	}
+	if d.Security.Authentication.Ldap == nil {
+		return v1.ValidationError("spec.security.authentication.ldap must be specified if LDAP is present in spec.security.authentication.modes")
+	}
+	return v1.ValidationSuccess()
+}
+
 func ldapGroupDnIsSetIfLdapAuthzIsEnabledAndAgentsAreExternal(d DbCommonSpec) v1.ValidationResult {
 	if d.Security == nil || d.Security.Authentication == nil || d.Security.Authentication.Ldap == nil {
 		return v1.ValidationSuccess()
@@ -686,6 +696,7 @@ func CommonValidators(db DbCommonSpec) []func(d DbCommonSpec) v1.ValidationResul
 		ldapAuthRequiresEnterprise,
 		rolesAttributeIsCorrectlyConfigured,
 		agentModeIsSetIfMoreThanADeploymentAuthModeIsSet,
+		ldapConfigIsSetIfLdapAuthModeIsEnabled,
 		ldapGroupDnIsSetIfLdapAuthzIsEnabledAndAgentsAreExternal,
 		specWithExactlyOneSchema,
 		featureCompatibilityVersionValidation,

--- a/api/mongodb/v1/mdb/mongodb_validation_test.go
+++ b/api/mongodb/v1/mdb/mongodb_validation_test.go
@@ -353,6 +353,44 @@ func TestScramSha1AuthValidation(t *testing.T) {
 	}
 }
 
+func TestLdapConfigIsSetIfLdapAuthModeIsEnabled(t *testing.T) {
+	tests := map[string]struct {
+		spec          DbCommonSpec
+		errorExpected bool
+	}{
+		"LDAP mode without an ldap block is rejected": {
+			spec:          NewReplicaSetBuilder().SetVersion("4.0.2-ent").EnableAuth([]AuthMode{util.LDAP}).Build().Spec.DbCommonSpec,
+			errorExpected: true,
+		},
+		"LDAP mode with an ldap block is accepted": {
+			spec: func() DbCommonSpec {
+				rs := NewReplicaSetBuilder().SetVersion("4.0.2-ent").EnableAuth([]AuthMode{util.LDAP}).Build()
+				rs.Spec.Security.Authentication.Ldap = &Ldap{}
+				return rs.Spec.DbCommonSpec
+			}(),
+			errorExpected: false,
+		},
+		"non-LDAP mode without an ldap block is accepted": {
+			spec:          NewReplicaSetBuilder().EnableAuth([]AuthMode{util.SCRAM}).Build().Spec.DbCommonSpec,
+			errorExpected: false,
+		},
+		"auth disabled with LDAP listed in modes is accepted": {
+			spec: func() DbCommonSpec {
+				rs := NewReplicaSetBuilder().EnableAuth([]AuthMode{util.LDAP}).Build()
+				rs.Spec.Security.Authentication.Enabled = false
+				return rs.Spec.DbCommonSpec
+			}(),
+			errorExpected: false,
+		},
+	}
+	for testName, testConfig := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := ldapConfigIsSetIfLdapAuthModeIsEnabled(testConfig.spec)
+			assert.Equal(t, testConfig.errorExpected, v1.ValidationSuccess() != result, "got %v", result)
+		})
+	}
+}
+
 func TestReplicasetMemberIsSpecified(t *testing.T) {
 	rs := NewDefaultReplicaSetBuilder().Build()
 	err := rs.ProcessValidationsOnReconcile(nil)

--- a/changelog/20260907_fix_reject_ldap_auth_mode_without_ldap_configuration.md
+++ b/changelog/20260907_fix_reject_ldap_auth_mode_without_ldap_configuration.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-07
+---
+
+* **MongoDB**, **MongoDBMultiCluster**: resources that list `LDAP` in `spec.security.authentication.modes` without a `spec.security.authentication.ldap` block are now rejected with a validation error. Previously such a resource caused a nil pointer dereference that terminated the operator process, stopping reconciliation of every other resource.


### PR DESCRIPTION
## Summary

A `MongoDB` or `MongoDBMultiCluster` resource that lists `LDAP` in `spec.security.authentication.modes` without a `spec.security.authentication.ldap` block terminates the whole operator process.

`Authentication.IsLDAPEnabled()` (`api/mongodb/v1/mdb/mongodb_types.go:1270`) returns true on `Enabled && modes contains LDAP` and never nil-checks `a.Ldap`. `updateOmAuthentication` uses that as its only guard (`controllers/operator/common_controller.go:923`) before dereferencing `Authentication.Ldap.BindQuerySecretRef.Name` at `:924`. There is no `recover()` anywhere outside `vendor/` and `_test.go`, so this is not a failed reconcile — the shared process dies and every other resource stops reconciling. An ordinary CR edit is enough to trigger it.

## Fix

Adds `ldapConfigIsSetIfLdapAuthModeIsEnabled` to `CommonValidators`, rejecting the resource with an actionable message.

This closes every path that reaches the dereference:

- `updateOmAuthentication` has exactly four callers — standalone, sharded, replica set, multi-replica-set. No AppDB or Ops Manager path reaches it.
- All four are `MongoDB` or `MongoDBMultiCluster`, and both run `mdbv1.CommonValidators` (`mdbmulti/mongodbmulti_validation.go:58`).
- Each of those reconcilers calls `ProcessValidationsOnReconcile` before any Ops Manager work (e.g. `mongodbreplicaset_controller.go:207`) and returns `workflow.Invalid` on an error-level result. The fix therefore holds even when the validating webhook is disabled via `MDB_WEBHOOK_REGISTER_CONFIGURATION`.

## Considered and rejected

- **A defensive nil guard at the dereference site.** Unreachable once validation gates all four callers, so it would be dead code.
- **Nil-checking inside `IsLDAPEnabled()`.** That would silently skip LDAP setup for a misconfigured resource instead of telling the user why it is wrong.

## Compatibility

No working configuration is newly rejected: any resource this validator rejects was already panicking the operator on reconcile.

## Testing

`TestLdapConfigIsSetIfLdapAuthModeIsEnabled` covers LDAP-without-block (rejected), LDAP-with-block, non-LDAP mode, and auth-disabled. `./api/...` and `./controllers/operator/` pass.

Resolves SECBUG-3959.