### PR TITLE
Redact mongodb+srv and portless MongoDB URIs in operator logs

### DIFF
--- a/changelog/20260907_fix_redact_srv_and_portless_mongodb_uris_in_logs.md
+++ b/changelog/20260907_fix_redact_srv_and_portless_mongodb_uris_in_logs.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-07
+---
+
+* **MongoDBOpsManager**: connection strings that use the `mongodb+srv://` scheme, or that omit a port after the host, are now redacted in operator logs. Previously `RedactMongoURI` matched only `mongodb://` URIs containing a port and returned any other form unchanged, leaving the password in cleartext.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -172,7 +172,7 @@ func RedactMongoURI(uri string) string {
 	if !strings.Contains(uri, "@") {
 		return uri
 	}
-	re := regexp.MustCompile("(mongodb://.*:)(.*)(@.*:.*)")
+	re := regexp.MustCompile(`(mongodb(?:\+srv)?://.*:)(.*)(@.*)`)
 	return re.ReplaceAllString(uri, "$1<redacted>$3")
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -64,6 +64,21 @@ func TestRedactURI(t *testing.T) {
 	uri = "mongo.mongoUri=mongodb://om-scram-db-0.om-scram-db-svc.mongodb.svc.cluster.local:27017"
 	expected = "mongo.mongoUri=mongodb://om-scram-db-0.om-scram-db-svc.mongodb.svc.cluster.local:27017"
 	assert.Equal(t, expected, RedactMongoURI(uri))
+
+	// mongodb+srv:// scheme
+	uri = "mongo.mongoUri=mongodb+srv://mongodb-ops-manager:my-scram-password@om-scram-db-svc.mongodb.svc.cluster.local/?authSource=admin"
+	expected = "mongo.mongoUri=mongodb+srv://mongodb-ops-manager:<redacted>@om-scram-db-svc.mongodb.svc.cluster.local/?authSource=admin"
+	assert.Equal(t, expected, RedactMongoURI(uri))
+
+	// no port after the host
+	uri = "mongo.mongoUri=mongodb://mongodb-ops-manager:my-scram-password@om-scram-db-0.om-scram-db-svc.mongodb.svc.cluster.local/?authSource=admin"
+	expected = "mongo.mongoUri=mongodb://mongodb-ops-manager:<redacted>@om-scram-db-0.om-scram-db-svc.mongodb.svc.cluster.local/?authSource=admin"
+	assert.Equal(t, expected, RedactMongoURI(uri))
+
+	// mongodb+srv:// with no port and an '@' in the password
+	uri = "mongo.mongoUri=mongodb+srv://some-user:12345AllTheCharactersWith@SymbolToo@om-scram-db-svc.mongodb.svc.cluster.local"
+	expected = "mongo.mongoUri=mongodb+srv://some-user:<redacted>@om-scram-db-svc.mongodb.svc.cluster.local"
+	assert.Equal(t, expected, RedactMongoURI(uri))
 }
 
 type someId struct {


### PR DESCRIPTION
## Summary

`RedactMongoURI` (`pkg/util/util.go:171`) returns two common URI shapes completely unredacted, with the password in cleartext:

```go
if !strings.Contains(uri, "@") {
    return uri
}
re := regexp.MustCompile("(mongodb://.*:)(.*)(@.*:.*)")
```

1. **`mongodb+srv://` URIs.** `"mongodb+srv://"` does not contain the substring `"mongodb://"`. The `@` guard passes, the regex then fails to match, and `ReplaceAllString` returns the input verbatim.
2. **URIs with no port after the host.** The trailing group `(@.*:.*)` requires a colon after the `@`, so `...@host/db` never matches.

Live call site: `controllers/operator/mongodbopsmanager_controller.go:1102` via `log.Debugw`.

## Fix

Make the scheme suffix optional and drop the required port from the trailing group:

```go
re := regexp.MustCompile(`(mongodb(?:\+srv)?://.*:)(.*)(@.*)`)
```

The password group stays greedy, so passwords containing `@` are still redacted in full (existing behaviour, covered by a pre-existing test case).

## Caveats for reviewers

- Severity is bounded by the call site being `Debugw` — debug level only.
- I have **not** traced whether a `+srv` or portless URI actually reaches `:1102` in practice. The fix is worth making regardless: a redaction helper should redact whatever it is handed, and the current failure mode is silent.
- This is **not** a scanner finding. It was found while verifying SECBUG-3950, whose own vector (the `DataStoreConfig`/`S3Config` `String()` methods) was genuinely removed by #1140. This leak is separate and was never flagged.

## Testing

Four cases added to `TestRedactURI`: `+srv` with password, `mongodb://` with no port, `+srv` with no port and an `@` in the password, plus the existing cases unchanged. All of the new cases fail before the change and pass after. `./pkg/util/...` and `./controllers/operator/` pass.