### PR TITLE
Gitignore the GCP service-account key written by setup_gcloud_cli.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ __debug_bin*
 scripts/dev/contexts/private-context
 scripts/dev/contexts/private-context-*
 
+# GCP service-account key written to the working directory by scripts/evergreen/setup_gcloud_cli.sh
+gcp_keyfile.json
+
 # On Evergreen we install uv in the project directory, so make sure it's ignored
 /.uv
 


### PR DESCRIPTION
## Summary

`scripts/evergreen/setup_gcloud_cli.sh:13` writes the `GCP_SERVICE_ACCOUNT_JSON_FOR_SNIPPETS_TESTS` credential to `gcp_keyfile.json` in the working directory:

```sh
echo "${GCP_SERVICE_ACCOUNT_JSON_FOR_SNIPPETS_TESTS}" > gcp_keyfile.json
```

Unlike the reference-architecture key material, which is covered by `public/architectures/**/secrets/*` (`.gitignore:51`), that filename was not ignored — so the key was committable from any workspace holding it. `scripts/evergreen/precommit_bump.sh:48` does a `git add .` followed by a commit and push to this public repo, which is the path that makes an unignored credential in the working tree matter.

One line, and correct independently of whether that push path can actually be reached.

## Verification

```
$ git check-ignore -v gcp_keyfile.json
.gitignore:40:gcp_keyfile.json	gcp_keyfile.json
```

## Notes

No changelog entry: this is CI/dev-tooling hygiene with no user-facing behaviour change, so it needs the `skip-changelog` label.

Relates to SECBUG-3930.