### PR TITLE
Fix the trigger evg -> evg by installing evergreen before using it

### DIFF
--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -69,6 +69,18 @@ functions:
       working_dir: src/github.com/mongodb/mongodb-kubernetes
       binary: scripts/evergreen/setup_jq.sh
 
+  setup_evergreen_cli: &setup_evergreen_cli
+    command: subprocess.exec
+    type: setup
+    retry_on_failure: true
+    params:
+      include_expansions_in_env:
+        - workdir
+      add_to_path:
+        - ${workdir}/bin
+      working_dir: src/github.com/mongodb/mongodb-kubernetes
+      binary: scripts/evergreen/setup_evergreen_cli.sh
+
   setup_context: &setup_context # Running the first switch is important to fill the workdir and other important initial env vars
     command: shell.exec
     type: setup

--- a/.evergreen-functions.yml
+++ b/.evergreen-functions.yml
@@ -70,16 +70,15 @@ functions:
       binary: scripts/evergreen/setup_jq.sh
 
   setup_evergreen_cli: &setup_evergreen_cli
-    command: subprocess.exec
+    command: shell.exec
     type: setup
     retry_on_failure: true
     params:
-      include_expansions_in_env:
-        - workdir
-      add_to_path:
-        - ${workdir}/bin
+      shell: bash
       working_dir: src/github.com/mongodb/mongodb-kubernetes
-      binary: scripts/evergreen/setup_evergreen_cli.sh
+      script: |
+        source .generated/context.export.env
+        scripts/evergreen/setup_evergreen_cli.sh
 
   setup_context: &setup_context # Running the first switch is important to fill the workdir and other important initial env vars
     command: shell.exec

--- a/.evergreen-release-publish.yml
+++ b/.evergreen-release-publish.yml
@@ -13,16 +13,21 @@ include:
 
 tasks:
   # Reads the tag annotation to decide which release pipeline to run,
-  # then creates an Evergreen patch via the matching alias and waits for it.
+  # then creates an Evergreen patch via the matching alias.
   - name: decide_release_process
     commands:
       - func: clone
+      - func: setup_evergreen_cli
       - command: subprocess.exec
         type: test
         params:
           working_dir: src/github.com/mongodb/mongodb-kubernetes
+          add_to_path:
+            - ${workdir}/bin
           include_expansions_in_env:
             - triggered_by_git_tag
+            - EVERGREEN_USER
+            - EVERGREEN_API_KEY
           binary: scripts/evergreen/decide_release_process.sh ${triggered_by_git_tag}
 
   - name: mckci_release_publish_images
@@ -53,13 +58,18 @@ tasks:
   - name: publish_doc_snippets
     commands:
       - func: clone
+      - func: setup_evergreen_cli
       - command: subprocess.exec
         type: test
         params:
           working_dir: src/github.com/mongodb/mongodb-kubernetes
+          add_to_path:
+            - ${workdir}/bin
           include_expansions_in_env:
             - revision
             - triggered_by_git_tag
+            - EVERGREEN_USER
+            - EVERGREEN_API_KEY
           binary: scripts/dev/trigger_public_docs_snippets.sh
 
 buildvariants:

--- a/.evergreen-release.yml
+++ b/.evergreen-release.yml
@@ -150,13 +150,18 @@ tasks:
   - name: trigger_public_docs_snippets
     commands:
       - func: clone
+      - func: setup_evergreen_cli
       - command: subprocess.exec
         type: test
         params:
           working_dir: src/github.com/mongodb/mongodb-kubernetes
+          add_to_path:
+            - ${workdir}/bin
           include_expansions_in_env:
             - revision
             - triggered_by_git_tag
+            - EVERGREEN_USER
+            - EVERGREEN_API_KEY
           binary: scripts/dev/trigger_public_docs_snippets.sh
 
   - name: release_chart_to_oci_registry

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -58,7 +58,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -81,16 +81,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -131,12 +131,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.12.0
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.12.1
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.11.0
+  replaces: mongodb-kubernetes.v1.12.0
   version: 0.0.0

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.12.0
+version: 1.12.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.12.0
+  version: 1.12.1
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.12.0
+  version: 1.12.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -146,11 +146,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.12.0
+  version: 1.12.1
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.12.0
+  version: 1.12.1
 
 ## Ops Manager
 opsManager:
@@ -158,7 +158,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.12.0
+  version: 1.12.1
 
 agent:
   name: mongodb-agent

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -396,7 +396,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -417,16 +417,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -349,7 +349,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -383,7 +383,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -406,16 +406,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -454,12 +454,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -393,7 +393,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -414,16 +414,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.17.0.tgz"
   },
-  "mongodbOperator": "1.12.0",
-  "initDatabaseVersion": "1.12.0",
-  "initOpsManagerVersion": "1.12.0",
-  "databaseImageVersion": "1.12.0",
+  "mongodbOperator": "1.12.1",
+  "initDatabaseVersion": "1.12.1",
+  "initOpsManagerVersion": "1.12.1",
+  "databaseImageVersion": "1.12.1",
   "agentVersion": "108.0.26.9062-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -103,7 +103,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"
@@ -312,7 +313,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"
@@ -339,7 +341,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"
@@ -366,7 +369,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"

--- a/scripts/dev/trigger_public_docs_snippets.sh
+++ b/scripts/dev/trigger_public_docs_snippets.sh
@@ -19,6 +19,7 @@ if ! git merge-base --is-ancestor "${revision}" origin/master; then
 fi
 
 echo "trigger_public_docs_snippets: triggering public snippet refresh for released version ${triggered_by_git_tag}"
+source scripts/funcs/evergreen_auth
 evergreen patch \
   -p mongodb-kubernetes \
   -v public_kind_code_snippets \

--- a/scripts/evergreen/decide_release_process.sh
+++ b/scripts/evergreen/decide_release_process.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Reads the git tag annotation to decide which release pipeline to run
-# and creates an Evergreen patch via the matching alias, waiting for it.
+# and creates an Evergreen patch via the matching alias.
 # "[new]" MUST be the first token in the annotation; "[dry-run]" is optional.
 #
 # Usage: decide_release_process.sh <tag_name>
@@ -23,6 +23,8 @@ if [[ "${annotation}" == *"[dry-run]"* ]]; then
   echo "Dry run enabled: setting IS_DRYRUN=true"
 fi
 
+source scripts/funcs/evergreen_auth
+
 echo "Creating Evergreen patch with alias '${alias}' for release ${tag}"
 evergreen patch \
   -p mongodb-kubernetes \
@@ -30,5 +32,5 @@ evergreen patch \
   -d "Release ${tag}" \
   --param "triggered_by_git_tag=${tag}" \
   "${params[@]}" \
-  -f -y -w
+  -f -y
 

--- a/scripts/evergreen/setup_evergreen_cli.sh
+++ b/scripts/evergreen/setup_evergreen_cli.sh
@@ -7,7 +7,7 @@
 
 set -Eeou pipefail
 
-dest="${PROJECT_DIR:-${workdir}}/bin"
+dest="${workdir}/bin"
 mkdir -p "${dest}"
 
 echo "Installing evergreen CLI via go install..."

--- a/scripts/evergreen/setup_evergreen_cli.sh
+++ b/scripts/evergreen/setup_evergreen_cli.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# A script Evergreen will use to setup the evergreen CLI via go install.
+#
+# Go is available on Evg hosts at /opt/golang/go*/bin/go.
+# The binary is installed into ${workdir}/bin so it lands on PATH.
+
+set -Eeou pipefail
+
+dest="${PROJECT_DIR:-${workdir}}/bin"
+mkdir -p "${dest}"
+
+echo "Installing evergreen CLI via go install..."
+GOBIN="${dest}" go install github.com/evergreen-ci/evergreen/cmd/evergreen@latest
+chmod +x "${dest}/evergreen"
+echo "Installed evergreen to ${dest}"

--- a/scripts/funcs/evergreen_auth
+++ b/scripts/funcs/evergreen_auth
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Shared helper: writes ~/.evergreen.yml for the evergreen CLI to authenticate.
+# Sources this script in any script that calls `evergreen patch` or other
+# evergreen CLI commands that require authentication.
+#
+# Requires EVERGREEN_USER and EVERGREEN_API_KEY environment variables.
+
+set -Eeuo pipefail
+
+: "${EVERGREEN_USER:?EVERGREEN_USER must be set}"
+: "${EVERGREEN_API_KEY:?EVERGREEN_API_KEY must be set}"
+
+cat <<EOF > ~/.evergreen.yml
+user: "${EVERGREEN_USER}"
+api_key: "${EVERGREEN_API_KEY}"
+api_server_host: "https://evergreen.mongodb.com/api"
+ui_server_host: "https://spruce.mongodb.com"
+EOF
+


### PR DESCRIPTION
# Summary

We were using `evergreen` binary in **evergreen** without installing it first. This fixed that.

## Proof of Work

Re-run of the trigger docs snippets which exercises these fixes:
```shell
evergreen patch -p mongodb-kubernetes \
-t trigger_public_docs_snippets -v trigger_public_docs_snippets \
--param triggered_by_git_tag=1.12.0 -f -y
```
🚧[Repeat trigger_public_docs_snippets with this fix](https://spruce.corp.mongodb.com/version/6a9ff588438aff0007cb14f3)


## Checklist

- [X] Have you added changelog file?
    - use `skip-changelog` label if not needed
