### PR TITLE
KUBE-334 Add support for specifying ubi9-slim server image variants in Static Containers

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1141,7 +1141,6 @@ task_groups:
       - e2e_tls_sc_additional_certs
       - e2e_tls_x509_configure_all_options_sc
       - e2e_tls_x509_sc
-      - e2e_meko_mck_upgrade
       - e2e_mongodb_custom_roles
       - e2e_sharded_cluster_oidc_m2m_group
       - e2e_sharded_cluster_oidc_m2m_user
@@ -1149,6 +1148,12 @@ task_groups:
       - e2e_multi_cluster_oidc_m2m_user
       - e2e_search_simulated_mc_rs
       - e2e_search_simulated_mc_sharded
+
+  - name: e2e_multi_cluster_kind_meko_upgrade_task_group
+    max_hosts: -1
+    <<: [*setup_group, *setup_and_teardown_task_cloudqa, *teardown_group]
+    tasks:
+      - e2e_meko_mck_upgrade
 
 
   - name: e2e_multi_cluster_2_clusters_task_group
@@ -1262,10 +1267,15 @@ task_groups:
       - e2e_om_ops_manager_backup_kmip
       - e2e_om_ops_manager_scale
       - e2e_om_ops_manager_upgrade
-      - e2e_multi_cluster_appdb_upgrade_downgrade_v1_27_to_mck
       - e2e_om_update_before_reconciliation
       - e2e_om_feature_controls
       - e2e_multi_cluster_sharded_disaster_recovery
+
+  - name: e2e_static_multi_cluster_om_appdb_meko_upgrade_task_group
+    max_hosts: -1
+    <<: [*setup_group_multi_cluster, *setup_and_teardown_task, *teardown_group]
+    tasks:
+      - e2e_multi_cluster_appdb_upgrade_downgrade_v1_27_to_mck
 
   # Multi-cluster MongoDBSearch tests that need a self-hosted Ops Manager:
   # the metrics forwarder requires OM >= 8.0.25, so these cannot run on the
@@ -1367,7 +1377,6 @@ task_groups:
       - e2e_om_feature_controls
       - e2e_vault_setup_om
       - e2e_vault_setup_om_backup
-      - e2e_operator_upgrade_ops_manager
     #   Deactivated tests
     #    - e2e_om_localmode_multiple_pv
     #    - e2e_om_localmode
@@ -1375,6 +1384,12 @@ task_groups:
     #    - e2e_om_ops_manager_https_enabled_internet_mode
     #    - e2e_om_ops_manager_https_enabled
     #    - e2e_om_ops_manager_https_enabled_prefix
+
+  - name: e2e_static_ops_manager_kind_operator_upgrade_task_group
+    max_hosts: -1
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
+    tasks:
+      - e2e_operator_upgrade_ops_manager
 
   - name: e2e_smoke_task_group
     max_hosts: -1
@@ -1456,6 +1471,18 @@ task_groups:
     tasks:
       - e2e_olm_operator_upgrade
       - e2e_olm_operator_upgrade_with_resources
+
+  - name: e2e_kind_olm_meko_upgrade_group
+    max_hosts: -1
+    <<: [*setup_group, *setup_and_teardown_task, *teardown_group]
+    setup_task_can_fail_task: true
+    setup_task:
+      - func: cleanup_exec_environment
+      - func: configure_docker_auth
+      - func: setup_kubernetes_environment
+      - func: setup_prepare_openshift_bundles
+      - func: install_olm
+    tasks:
       - e2e_olm_meko_operator_upgrade_with_resources
 
 buildvariants:
@@ -1521,6 +1548,15 @@ buildvariants:
   - name: e2e_static_mdb_kind_ubi_cloudqa
     display_name: e2e_static_mdb_kind_ubi_cloudqa
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "static" ]
+    <<: [*production_code_paths, *base_no_om_image_dependency]
+    run_on:
+      - ubuntu2404-medium
+    tasks:
+      - name: e2e_mdb_kind_cloudqa_task_group
+
+  - name: e2e_static_mdb_kind_ubi9_slim_cloudqa
+    display_name: e2e_static_mdb_kind_ubi9_slim_cloudqa
+    tags: [ "staging", "e2e_test_suite", "cloudqa", "static" ]
     <<: [*production_code_paths, *base_no_om_image_dependency]
     run_on:
       - ubuntu2404-medium
@@ -1603,6 +1639,21 @@ buildvariants:
     tasks:
       - name: e2e_mdb_openshift_ubi_cloudqa_task_group
 
+  - name: e2e_static_openshift_mdb_ubi9_slim_cloudqa
+    display_name: e2e_static_openshift_mdb_ubi9_slim_cloudqa
+    tags: [ "staging", "e2e_openshift_test_suite", "cloudqa", "static" ]
+    depends_on:
+      - name: build_operator_ubi
+        variant: init_test_run
+      - name: build_test_image
+        variant: init_test_run
+      - name: build_init_database_image_ubi
+        variant: init_test_run
+    run_on:
+      - ubuntu2404-small
+    tasks:
+      - name: e2e_mdb_openshift_ubi_cloudqa_task_group
+
   - name: e2e_mdb_openshift_search_ubi_cloudqa
     display_name: e2e_mdb_openshift_search_ubi_cloudqa
     tags: [ "staging", "e2e_openshift_test_suite", "cloudqa", "cloudqa_non_static" ]
@@ -1659,6 +1710,7 @@ buildvariants:
     <<: *base_om7_dependency
     tasks:
       - name: e2e_static_ops_manager_kind_only_task_group
+      - name: e2e_static_ops_manager_kind_operator_upgrade_task_group
       - name: e2e_static_ops_manager_kind_6_0_only_task_group
       - name: e2e_ops_manager_upgrade_only_task_group
 
@@ -1678,6 +1730,18 @@ buildvariants:
 
   - name: e2e_static_om80_kind_ubi
     display_name: e2e_static_om80_kind_ubi
+    tags: [ "staging", "e2e_test_suite", "static" ]
+    run_on:
+      - ubuntu2404-large
+    <<: *base_om8_dependency
+    tasks:
+      - name: e2e_static_ops_manager_kind_only_task_group
+      - name: e2e_static_ops_manager_kind_operator_upgrade_task_group
+      - name: e2e_static_ops_manager_kind_6_0_only_task_group
+      - name: e2e_ops_manager_upgrade_only_task_group
+
+  - name: e2e_static_om80_kind_ubi9_slim
+    display_name: e2e_static_om80_kind_ubi9_slim
     tags: [ "staging", "e2e_test_suite", "static" ]
     run_on:
       - ubuntu2404-large
@@ -1758,6 +1822,27 @@ buildvariants:
     tasks:
       - name: e2e_smoke_ibm_task_group
 
+  - name: e2e_static_smoke_ibm_power_ubi9_slim
+    display_name: e2e_static_smoke_ibm_power_ubi9_slim
+    tags: [ "staging", "e2e_smoke_test_suite", "static" ]
+    run_on:
+      - rhel9-power-small
+      - rhel9-power-large
+    allowed_requesters: [ "patch", "commit" ]
+    depends_on:
+      - name: build_operator_ubi
+        variant: init_test_run
+      - name: build_init_database_image_ubi
+        variant: init_test_run
+      - name: build_database_image_ubi
+        variant: init_test_run
+      - name: build_test_image_ibm_power
+        variant: init_test_run_ibm_power
+      - name: publish_helm_chart
+        variant: init_test_run
+    tasks:
+      - name: e2e_smoke_ibm_task_group
+
   - name: e2e_smoke_ibm_z
     display_name: e2e_smoke_ibm_z
     tags: [ "staging", "e2e_smoke_test_suite" ]
@@ -1781,6 +1866,25 @@ buildvariants:
 
   - name: e2e_static_smoke_ibm_z
     display_name: e2e_static_smoke_ibm_z
+    tags: [ "staging", "e2e_smoke_test_suite", "static" ]
+    run_on:
+      - rhel9-zseries-small
+      - rhel9-zseries-large
+    allowed_requesters: [ "patch", "commit" ]
+    depends_on:
+      - name: build_operator_ubi
+        variant: init_test_run
+      - name: build_init_database_image_ubi
+        variant: init_test_run
+      - name: build_test_image_ibm_z
+        variant: init_test_run_ibm_z
+      - name: publish_helm_chart
+        variant: init_test_run
+    tasks:
+      - name: e2e_smoke_ibm_task_group
+
+  - name: e2e_static_smoke_ibm_z_ubi9_slim
+    display_name: e2e_static_smoke_ibm_z_ubi9_slim
     tags: [ "staging", "e2e_smoke_test_suite", "static" ]
     run_on:
       - rhel9-zseries-small
@@ -1836,6 +1940,24 @@ buildvariants:
     tasks:
       - name: e2e_smoke_arm_task_group
 
+  - name: e2e_static_smoke_arm_ubi9_slim
+    display_name: e2e_static_smoke_arm_ubi9_slim
+    tags: [ "staging", "e2e_smoke_test_suite", "static" ]
+    run_on:
+      - ubuntu2404-arm64-large
+    allowed_requesters: [ "patch", "commit" ]
+    depends_on:
+      - name: build_operator_ubi
+        variant: init_test_run
+      - name: build_init_database_image_ubi
+        variant: init_test_run
+      - name: build_test_image_arm
+        variant: init_test_run_arm
+      - name: publish_helm_chart
+        variant: init_test_run
+    tasks:
+      - name: e2e_smoke_arm_task_group
+
   - name: e2e_multi_cluster_kind
     display_name: e2e_multi_cluster_kind
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite", "cloudqa", "cloudqa_non_static" ]
@@ -1844,6 +1966,7 @@ buildvariants:
       - ubuntu2404-large
     tasks:
       - name: e2e_multi_cluster_kind_task_group
+      - name: e2e_multi_cluster_kind_meko_upgrade_task_group
 
   - name: e2e_static_multi_cluster_kind
     display_name: e2e_static_multi_cluster_kind
@@ -1851,6 +1974,16 @@ buildvariants:
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
+    tasks:
+      - name: e2e_multi_cluster_kind_task_group
+      - name: e2e_multi_cluster_kind_meko_upgrade_task_group
+
+  - name: e2e_static_multi_cluster_kind_ubi9_slim
+    display_name: e2e_static_multi_cluster_kind_ubi9_slim
+    tags: [ "staging", "e2e_test_suite", "cloudqa", "static" ]
+    run_on:
+      - ubuntu2404-large
+    <<: *base_om8_dependency
     tasks:
       - name: e2e_multi_cluster_kind_task_group
 
@@ -1872,6 +2005,15 @@ buildvariants:
     tasks:
       - name: e2e_multi_cluster_2_clusters_task_group
 
+  - name: e2e_static_multi_cluster_2_clusters_ubi9_slim
+    display_name: e2e_static_multi_cluster_2_clusters_ubi9_slim
+    tags: [ "staging", "e2e_test_suite", "cloudqa", "static" ]
+    run_on:
+      - ubuntu2404-large
+    <<: *base_om8_dependency
+    tasks:
+      - name: e2e_multi_cluster_2_clusters_task_group
+
   - name: e2e_multi_cluster_om_appdb
     display_name: e2e_multi_cluster_om_appdb
     tags: [ "pr_patch_e2e", "staging", "e2e_test_suite" ]
@@ -1887,6 +2029,16 @@ buildvariants:
     run_on:
       - ubuntu2404-large
     <<: *base_om7_dependency
+    tasks:
+      - name: e2e_static_multi_cluster_om_appdb_task_group
+      - name: e2e_static_multi_cluster_om_appdb_meko_upgrade_task_group
+
+  - name: e2e_static_multi_cluster_om_appdb_ubi9_slim
+    display_name: e2e_static_multi_cluster_om_appdb_ubi9_slim
+    tags: [ "staging", "e2e_test_suite", "static" ]
+    run_on:
+      - ubuntu2404-large
+    <<: *base_om8_dependency
     tasks:
       - name: e2e_static_multi_cluster_om_appdb_task_group
 
@@ -1958,9 +2110,30 @@ buildvariants:
         variant: init_tests_with_olm
     tasks:
       - name: e2e_kind_olm_group
+      - name: e2e_kind_olm_meko_upgrade_group
 
   - name: e2e_static_kind_olm_ubi
     display_name: e2e_static_kind_olm_ubi
+    tags: [ "staging", "e2e_test_suite", "static" ]
+    run_on:
+      - ubuntu2404-large
+    depends_on:
+      - name: build_operator_ubi
+        variant: init_test_run
+      - name: build_test_image
+        variant: init_test_run
+      - name: build_init_om_images_ubi
+        variant: init_test_run
+      - name: prepare_and_upload_openshift_bundles_for_e2e
+        variant: init_tests_with_olm
+      - name: build_init_database_image_ubi
+        variant: init_test_run
+    tasks:
+      - name: e2e_kind_olm_group
+      - name: e2e_kind_olm_meko_upgrade_group
+
+  - name: e2e_static_kind_olm_ubi9_slim
+    display_name: e2e_static_kind_olm_ubi9_slim
     tags: [ "staging", "e2e_test_suite", "static" ]
     run_on:
       - ubuntu2404-large

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,7 +134,7 @@ repos:
 
       - id: ty
         name: ty
-        entry: bash -c 'cd docker/mongodb-kubernetes-tests && uvx ty check tests/'
+        entry: bash -c 'cd docker/mongodb-kubernetes-tests && uvx ty check --python ../../venv tests/'
         language: system
         pass_filenames: false
         files: docker/mongodb-kubernetes-tests/tests/.*\.py$

--- a/changelog/20260908_feature_ubi_9_slim_images.md
+++ b/changelog/20260908_feature_ubi_9_slim_images.md
@@ -1,0 +1,7 @@
+---
+title: UBI 9 Slim Server images
+kind: feature
+date: 2026-09-08
+---
+
+* **UBI 9 Slim images**: Added support for deploying `MongoDB`, `MongoDBMultiCluster`, and `MongoDBOpsManager` application database resources with UBI 9 Slim MongoDB server images in static container architecture by specifying a version ending in `-ubi9-slim`.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -58,7 +58,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -81,16 +81,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -131,12 +131,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-kubernetes.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     capabilities: Deep Insights
     categories: Database
     certified: "true"
-    containerImage: quay.io/mongodb/mongodb-kubernetes:1.12.0
+    containerImage: quay.io/mongodb/mongodb-kubernetes:1.12.1
     createdAt: ""
     description: The MongoDB Controllers for Kubernetes enable easy deploys of 
       MongoDB into Kubernetes clusters, using our management, monitoring and 
@@ -478,5 +478,5 @@ spec:
   maturity: stable
   provider:
     name: MongoDB, Inc
-  replaces: mongodb-kubernetes.v1.11.0
+  replaces: mongodb-kubernetes.v1.12.0
   version: 0.0.0

--- a/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
+++ b/docker/mongodb-kubernetes-tests/kubetester/kubetester.py
@@ -1769,6 +1769,17 @@ def ensure_ent_version(mdb_version: str) -> str:
     return mdb_version
 
 
+def get_mongodb_version_for_automation_config(version: str) -> str:
+    if not is_default_architecture_static():
+        return version
+
+    version = version.removesuffix("-ent")
+    for image_type in ("ubi9-slim", "ubi9", "ubi8"):
+        version = version.removesuffix(f"-{image_type}")
+
+    return ensure_ent_version(version)
+
+
 @TRACER.start_as_current_span("wait_processes_ready")
 def wait_processes_ready():
     # Get current automation status

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_down_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_down_cluster.py
@@ -78,21 +78,7 @@ def test_statefulsets_have_been_created_correctly(
     mongodb_multi: MongoDBMulti,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    statefulsets = mongodb_multi.read_statefulsets(member_cluster_clients)
-
-    assert len(statefulsets) == 3
-
-    cluster_one_client = member_cluster_clients[0]
-    cluster_one_sts = statefulsets[cluster_one_client.cluster_name]
-    assert cluster_one_sts.status.ready_replicas == 2
-
-    cluster_two_client = member_cluster_clients[1]
-    cluster_two_sts = statefulsets[cluster_two_client.cluster_name]
-    assert cluster_two_sts.status.ready_replicas == 1
-
-    cluster_three_client = member_cluster_clients[2]
-    cluster_three_sts = statefulsets[cluster_three_client.cluster_name]
-    assert cluster_three_sts.status.ready_replicas == 2
+    mongodb_multi.assert_statefulsets_are_ready(member_cluster_clients)
 
 
 @pytest.mark.e2e_multi_cluster_scale_down_cluster

--- a/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
+++ b/docker/mongodb-kubernetes-tests/tests/multicluster/multi_cluster_scale_up_cluster_new_cluster.py
@@ -90,17 +90,7 @@ def test_statefulsets_have_been_created_correctly(
     mongodb_multi: MongoDBMulti,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    clients = {c.cluster_name: c for c in member_cluster_clients}
-
-    # read all statefulsets except the last one
-    statefulsets = mongodb_multi.read_statefulsets(member_cluster_clients[:-1])
-    cluster_one_client = clients["kind-e2e-cluster-1"]
-    cluster_one_sts = statefulsets[cluster_one_client.cluster_name]
-    assert cluster_one_sts.status.ready_replicas == 2
-
-    cluster_two_client = clients["kind-e2e-cluster-2"]
-    cluster_two_sts = statefulsets[cluster_two_client.cluster_name]
-    assert cluster_two_sts.status.ready_replicas == 1
+    mongodb_multi.assert_statefulsets_are_ready(member_cluster_clients[:-1])
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster_new_cluster
@@ -146,20 +136,7 @@ def test_statefulsets_have_been_created_correctly_after_cluster_addition(
     mongodb_multi: MongoDBMulti,
     member_cluster_clients: List[MultiClusterClient],
 ):
-    clients = {c.cluster_name: c for c in member_cluster_clients}
-    # read all statefulsets except the last one
-    statefulsets = mongodb_multi.read_statefulsets(member_cluster_clients)
-    cluster_one_client = clients["kind-e2e-cluster-1"]
-    cluster_one_sts = statefulsets[cluster_one_client.cluster_name]
-    assert cluster_one_sts.status.ready_replicas == 2
-
-    cluster_two_client = clients["kind-e2e-cluster-2"]
-    cluster_two_sts = statefulsets[cluster_two_client.cluster_name]
-    assert cluster_two_sts.status.ready_replicas == 1
-
-    cluster_three_client = clients["kind-e2e-cluster-3"]
-    cluster_three_sts = statefulsets[cluster_three_client.cluster_name]
-    assert cluster_three_sts.status.ready_replicas == 2
+    mongodb_multi.assert_statefulsets_are_ready(member_cluster_clients)
 
 
 @pytest.mark.e2e_multi_cluster_scale_up_cluster_new_cluster

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set.py
@@ -14,7 +14,12 @@ from kubetester import (
 from kubetester.automation_config_tester import AutomationConfigTester
 from kubetester.kubetester import KubernetesTester, fcv_from_version
 from kubetester.kubetester import fixture as yaml_fixture
-from kubetester.kubetester import is_default_architecture_static, run_periodically, skip_if_local
+from kubetester.kubetester import (
+    get_mongodb_version_for_automation_config,
+    is_default_architecture_static,
+    run_periodically,
+    skip_if_local,
+)
 from kubetester.mongodb import MongoDB
 from kubetester.mongotester import ReplicaSetTester
 from kubetester.phase import Phase
@@ -254,7 +259,7 @@ class TestReplicaSetCreation(KubernetesTester):
             p = processes[idx]
             assert p["name"] == f"k8s/{self.namespace}/{name}"
             assert p["processType"] == "mongod"
-            assert custom_mdb_version in p["version"]
+            assert p["version"] == get_mongodb_version_for_automation_config(custom_mdb_version)
             assert p["authSchemaVersion"] == 5
             assert p["featureCompatibilityVersion"] == fcv_from_version(custom_mdb_version)
             assert p["hostname"] == "{}.my-replica-set-svc.{}.svc.{}".format(name, self.namespace, cluster_domain)
@@ -445,7 +450,7 @@ class TestReplicaSetScaleUp(KubernetesTester):
             p = processes[idx]
             assert p["name"] == f"k8s/{self.namespace}/{name}"
             assert p["processType"] == "mongod"
-            assert custom_mdb_version in p["version"]
+            assert p["version"] == get_mongodb_version_for_automation_config(custom_mdb_version)
             assert p["authSchemaVersion"] == 5
             assert p["featureCompatibilityVersion"] == fcv_from_version(custom_mdb_version)
             assert p["hostname"] == "{}.my-replica-set-svc.{}.svc.{}".format(name, self.namespace, cluster_domain)

--- a/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_pv.py
+++ b/docker/mongodb-kubernetes-tests/tests/replicaset/replica_set_pv.py
@@ -3,7 +3,7 @@ import pytest
 from kubernetes import client
 from kubetester.kubetester import KubernetesTester, fcv_from_version
 from kubetester.kubetester import fixture as load_fixture
-from kubetester.kubetester import run_periodically
+from kubetester.kubetester import get_mongodb_version_for_automation_config, run_periodically
 from kubetester.mongodb import MongoDB
 from kubetester.phase import Phase
 from tests.constants import LEGACY_OPERATOR_NAME, OPERATOR_NAME
@@ -74,7 +74,7 @@ class TestReplicaSetPersistentVolumeCreation(KubernetesTester):
         config = self.get_automation_config()
         processes = config["processes"]
         for idx, p in enumerate(processes):
-            assert custom_mdb_version in p["version"]
+            assert p["version"] == get_mongodb_version_for_automation_config(custom_mdb_version)
             assert p["name"] == f"k8s/{self.namespace}/rs001-pv-{idx}"
             assert p["processType"] == "mongod"
             assert p["authSchemaVersion"] == 5

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   MongoDB Controllers for Kubernetes translate the human knowledge of
   creating a MongoDB instance into a scalable, repeatable, and standardized
   method.
-version: 1.12.0
+version: 1.12.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -34,7 +34,7 @@ operator:
   # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
   # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
   # https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-  version: 1.12.0
+  version: 1.12.1
 relatedImages:
   opsManager:
   - 6.0.26

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -17,7 +17,7 @@ operator:
   operator_image_name: mongodb-kubernetes
 
   # Version of mongodb-kubernetes-operator
-  version: 1.12.0
+  version: 1.12.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -146,11 +146,11 @@ operator:
 ## Database
 database:
   name: mongodb-kubernetes-database
-  version: 1.12.0
+  version: 1.12.1
 
 initDatabase:
   name: mongodb-kubernetes-init-database
-  version: 1.12.0
+  version: 1.12.1
 
 ## Ops Manager
 opsManager:
@@ -158,7 +158,7 @@ opsManager:
 
 initOpsManager:
   name: mongodb-kubernetes-init-ops-manager
-  version: 1.12.0
+  version: 1.12.1
 
 agent:
   name: mongodb-agent

--- a/pkg/images/Imageurls.go
+++ b/pkg/images/Imageurls.go
@@ -138,17 +138,17 @@ func GetOfficialImage(imageUrls ImageUrls, version string, annotations map[strin
 
 	assumeOldFormat := env.ReadBoolOrDefault(util.MdbAppdbAssumeOldFormat, false) // nolint:forbidigo
 	if IsEnterpriseImage(imageURL) && !assumeOldFormat {
-		// 5.0.6-ent -> 5.0.6-ubi8
-		if strings.HasSuffix(version, "-ent") {
-			version = fmt.Sprintf("%s%s", strings.TrimSuffix(version, "ent"), imageType)
-		}
-		// 5.0.6 ->  5.0.6-ubi8
-		r := regexp.MustCompile("-.+$")
-		if !r.MatchString(version) {
-			version = version + "-" + imageType
-		}
-		if found, suffix := architectures.HasSupportedImageTypeSuffix(version); found {
-			version = fmt.Sprintf("%s%s", strings.TrimSuffix(version, suffix), imageType)
+		version = strings.TrimSuffix(version, "-ent")
+		found, suffix := architectures.HasSupportedImageTypeSuffix(version)
+		if !found || suffix != string(architectures.ImageTypeUBI9Slim) {
+			// 5.0.6 ->  5.0.6-ubi8
+			r := regexp.MustCompile("-.+$")
+			if !r.MatchString(version) {
+				version = version + "-" + imageType
+			}
+			if found {
+				version = fmt.Sprintf("%s%s", strings.TrimSuffix(version, suffix), imageType)
+			}
 		}
 		// if neither, let's not change it: 5.0.6-ubi8 -> 5.0.6-ubi8
 	}

--- a/pkg/images/Imageurls_test.go
+++ b/pkg/images/Imageurls_test.go
@@ -172,6 +172,43 @@ func TestGetAppDBImage(t *testing.T) {
 				t.Setenv(util.MongodbImageEnv, util.OfficialEnterpriseServerImageName)
 			},
 		},
+		{
+			name:  "Getting official ubi9 slim image on static architecture",
+			input: "8.0.23-ubi9-slim",
+			annotations: map[string]string{
+				"mongodb.com/v1.architecture": string(architectures.Static),
+			},
+			want: "quay.io/mongodb/mongodb-enterprise-server:8.0.23-ubi9-slim",
+			setupEnvs: func(t *testing.T) {
+				t.Setenv(util.MongodbRepoUrlEnv, "quay.io/mongodb")
+				t.Setenv(util.MongodbImageEnv, util.OfficialEnterpriseServerImageName)
+			},
+		},
+		{
+			name:  "Getting official ubi9 slim image with enterprise suffix on static architecture",
+			input: "8.0.23-ubi9-slim-ent",
+			annotations: map[string]string{
+				"mongodb.com/v1.architecture": string(architectures.Static),
+			},
+			want: "quay.io/mongodb/mongodb-enterprise-server:8.0.23-ubi9-slim",
+			setupEnvs: func(t *testing.T) {
+				t.Setenv(util.MongodbRepoUrlEnv, "quay.io/mongodb")
+				t.Setenv(util.MongodbImageEnv, util.OfficialEnterpriseServerImageName)
+			},
+		},
+		{
+			name:  "Getting related ubi9 slim image with enterprise suffix on static architecture",
+			input: "8.0.23-ubi9-slim-ent",
+			annotations: map[string]string{
+				"mongodb.com/v1.architecture": string(architectures.Static),
+			},
+			want: "registry.example.com/mongodb-enterprise-server@sha256:1234",
+			setupEnvs: func(t *testing.T) {
+				t.Setenv("RELATED_IMAGE_MONGODB_IMAGE_8_0_23_ubi9_slim", "registry.example.com/mongodb-enterprise-server@sha256:1234")
+				t.Setenv(util.MongodbRepoUrlEnv, "quay.io/mongodb")
+				t.Setenv(util.MongodbImageEnv, util.OfficialEnterpriseServerImageName)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/architectures/static.go
+++ b/pkg/util/architectures/static.go
@@ -11,12 +11,16 @@ type DefaultArchitecture string
 type ImageType string
 
 const (
-	ImageTypeUBI8    ImageType = "ubi8"
-	ImageTypeUBI9    ImageType = "ubi9"
-	DefaultImageType ImageType = ImageTypeUBI8
+	ImageTypeUBI8     ImageType = "ubi8"
+	ImageTypeUBI9     ImageType = "ubi9"
+	ImageTypeUBI9Slim ImageType = "ubi9-slim"
+	DefaultImageType  ImageType = ImageTypeUBI8
 )
 
 func HasSupportedImageTypeSuffix(imageVersion string) (suffixFound bool, suffix string) {
+	if strings.HasSuffix(imageVersion, string(ImageTypeUBI9Slim)) {
+		return true, string(ImageTypeUBI9Slim)
+	}
 	if strings.HasSuffix(imageVersion, string(ImageTypeUBI8)) {
 		return true, string(ImageTypeUBI8)
 	}
@@ -69,14 +73,23 @@ func GetArchitecture(annotations map[string]string, defaultArchitecture DefaultA
 // If we are in static containers architecture, we need the -ent suffix in case we are running the ea image.
 // If not, the agent will try to change the version to reflect the non-enterprise image.
 func GetMongoVersionForAutomationConfig(mongoDBImage, version string, forceEnterprise bool, architecture DefaultArchitecture) string {
+	hasEnterpriseSuffix := strings.HasSuffix(version, "-ent")
+	versionWithoutEnterpriseSuffix := strings.TrimSuffix(version, "-ent")
+	if found, suffix := HasSupportedImageTypeSuffix(versionWithoutEnterpriseSuffix); found {
+		version = strings.TrimSuffix(versionWithoutEnterpriseSuffix, "-"+suffix)
+	} else if architecture != Static {
+		return version
+	} else {
+		version = versionWithoutEnterpriseSuffix
+	}
+
 	if architecture != Static {
 		return version
 	}
+
 	// the image repo should be	either mongodb / mongodb-enterprise-server or mongodb / mongodb-community-server
-	if strings.Contains(mongoDBImage, util.OfficialEnterpriseServerImageName) || forceEnterprise {
-		if !strings.HasSuffix(version, "-ent") {
-			version = version + "-ent"
-		}
+	if strings.Contains(mongoDBImage, util.OfficialEnterpriseServerImageName) || forceEnterprise || hasEnterpriseSuffix {
+		version = version + "-ent"
 	}
 
 	return version

--- a/pkg/util/architectures/static_test.go
+++ b/pkg/util/architectures/static_test.go
@@ -62,6 +62,27 @@ func TestIsRunningStaticArchitecture(t *testing.T) {
 	}
 }
 
+func TestHasSupportedImageTypeSuffix(t *testing.T) {
+	tests := []struct {
+		version string
+		found   bool
+		suffix  string
+	}{
+		{version: "8.0.0-ubi8", found: true, suffix: "ubi8"},
+		{version: "8.0.0-ubi9", found: true, suffix: "ubi9"},
+		{version: "8.0.23-ubi9-slim", found: true, suffix: "ubi9-slim"},
+		{version: "8.0.0-ubuntu"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			found, suffix := HasSupportedImageTypeSuffix(tt.version)
+			if found != tt.found || suffix != tt.suffix {
+				t.Errorf("HasSupportedImageTypeSuffix() = (%v, %q), want (%v, %q)", found, suffix, tt.found, tt.suffix)
+			}
+		})
+	}
+}
+
 func TestGetMongoVersion(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -86,6 +107,46 @@ func TestGetMongoVersion(t *testing.T) {
 			forceEnterprise: false,
 			architecture:    Static,
 			want:            "8.0.0-ent",
+		},
+		{
+			name:            "enterprise repo with ubi9 slim image suffix",
+			mongoDBImage:    "quay.io/mongodb/mongodb-enterprise-server",
+			version:         "8.0.23-ubi9-slim",
+			forceEnterprise: false,
+			architecture:    Static,
+			want:            "8.0.23-ent",
+		},
+		{
+			name:            "enterprise repo with ubi9 slim image and enterprise suffixes",
+			mongoDBImage:    "quay.io/mongodb/mongodb-enterprise-server",
+			version:         "8.0.23-ubi9-slim-ent",
+			forceEnterprise: false,
+			architecture:    Static,
+			want:            "8.0.23-ent",
+		},
+		{
+			name:            "enterprise repo with ubi9 image suffix",
+			mongoDBImage:    "quay.io/mongodb/mongodb-enterprise-server",
+			version:         "8.0.23-ubi9",
+			forceEnterprise: false,
+			architecture:    Static,
+			want:            "8.0.23-ent",
+		},
+		{
+			name:            "enterprise repo with ubi9 slim image suffix on non-static architecture",
+			mongoDBImage:    "quay.io/mongodb/mongodb-enterprise-server",
+			version:         "8.0.23-ubi9-slim",
+			forceEnterprise: false,
+			architecture:    NonStatic,
+			want:            "8.0.23",
+		},
+		{
+			name:            "enterprise repo with ubi9 slim image and enterprise suffixes on non-static architecture",
+			mongoDBImage:    "quay.io/mongodb/mongodb-enterprise-server",
+			version:         "8.0.23-ubi9-slim-ent",
+			forceEnterprise: false,
+			architecture:    NonStatic,
+			want:            "8.0.23",
 		},
 		{
 			name:            "community repo",

--- a/public/mongodb-kubernetes-multi-cluster.yaml
+++ b/public/mongodb-kubernetes-multi-cluster.yaml
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator-multi-cluster
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -396,7 +396,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -417,16 +417,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/public/mongodb-kubernetes-openshift.yaml
+++ b/public/mongodb-kubernetes-openshift.yaml
@@ -349,7 +349,7 @@ spec:
       serviceAccountName: mongodb-kubernetes-operator
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -383,7 +383,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -406,16 +406,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE
@@ -454,12 +454,12 @@ spec:
             - name: MDB_COMMUNITY_IMAGE_TYPE
               value: "ubi8"
             # Community Env Vars End
-            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.0"
-            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_0
-              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.0"
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-database:1.12.1"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_12_1
+              value: "quay.io/mongodb/mongodb-kubernetes-init-ops-manager:1.12.1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_12_8669_1
               value: "quay.io/mongodb/mongodb-agent:107.0.12.8669-1"
             - name: RELATED_IMAGE_AGENT_IMAGE_107_0_13_8702_1

--- a/public/mongodb-kubernetes.yaml
+++ b/public/mongodb-kubernetes.yaml
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mongodb-kubernetes-operator
-          image: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+          image: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb
@@ -393,7 +393,7 @@ spec:
             # Migration dry-run job image.
             # Optional: it can be resolved from the API server.
             - name: MDB_OPERATOR_IMAGE
-              value: "quay.io/mongodb/mongodb-kubernetes:1.12.0"
+              value: "quay.io/mongodb/mongodb-kubernetes:1.12.1"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -414,16 +414,16 @@ spec:
             - name: INIT_DATABASE_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-database
             - name: INIT_DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: DATABASE_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             # Ops Manager
             - name: OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
             - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
               value: quay.io/mongodb/mongodb-kubernetes-init-ops-manager
             - name: INIT_OPS_MANAGER_VERSION
-              value: "1.12.0"
+              value: "1.12.1"
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: Always
             - name: AGENT_IMAGE

--- a/release.json
+++ b/release.json
@@ -2,10 +2,10 @@
   "mongodbToolsBundle": {
     "ubi": "mongodb-database-tools-rhel88-x86_64-100.17.0.tgz"
   },
-  "mongodbOperator": "1.12.0",
-  "initDatabaseVersion": "1.12.0",
-  "initOpsManagerVersion": "1.12.0",
-  "databaseImageVersion": "1.12.0",
+  "mongodbOperator": "1.12.1",
+  "initDatabaseVersion": "1.12.1",
+  "initOpsManagerVersion": "1.12.1",
+  "databaseImageVersion": "1.12.1",
   "agentVersion": "108.0.26.9062-1",
   "readinessProbeVersion": "1.0.24",
   "versionUpgradeHookVersion": "1.0.10",
@@ -103,7 +103,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"
@@ -312,7 +313,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"
@@ -339,7 +341,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"
@@ -366,7 +369,8 @@
         "1.9.2",
         "1.10.0",
         "1.11.0",
-        "1.12.0"
+        "1.12.0",
+        "1.12.1"
       ],
       "variants": [
         "ubi"

--- a/scripts/dev/contexts/e2e_static_kind_olm_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_kind_olm_ubi9_slim
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_kind_olm_ubi"
+source "${script_dir}/variables/om80"
+source "${script_dir}/variables/mongodb_slim"
+
+export CUSTOM_APPDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"
+export CUSTOM_MDB_VERSION_AFTER_OPERATOR_UPGRADE="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_mdb_kind_ubi9_slim_cloudqa
+++ b/scripts/dev/contexts/e2e_static_mdb_kind_ubi9_slim_cloudqa
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_mdb_kind_ubi_cloudqa"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_PREV_VERSION=7.0.5
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_2_clusters_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_2_clusters_ubi9_slim
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_multi_cluster_2_clusters"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_PREV_VERSION=7.0.5
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_kind_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_kind_ubi9_slim
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_multi_cluster_kind"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_PREV_VERSION=7.0.5
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_multi_cluster_om_appdb_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_multi_cluster_om_appdb_ubi9_slim
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_multi_cluster_om_appdb"
+source "${script_dir}/variables/om80"
+source "${script_dir}/variables/mongodb_slim"
+
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"
+export CUSTOM_APPDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_om80_kind_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_om80_kind_ubi9_slim
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_om80_kind_ubi"
+source "${script_dir}/variables/mongodb_slim"
+
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"
+export CUSTOM_APPDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_openshift_mdb_ubi9_slim_cloudqa
+++ b/scripts/dev/contexts/e2e_static_openshift_mdb_ubi9_slim_cloudqa
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_openshift_mdb_ubi_cloudqa"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_smoke_arm_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_smoke_arm_ubi9_slim
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_smoke_arm"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_smoke_ibm_power_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_smoke_ibm_power_ubi9_slim
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_smoke_ibm_power"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/e2e_static_smoke_ibm_z_ubi9_slim
+++ b/scripts/dev/contexts/e2e_static_smoke_ibm_z_ubi9_slim
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+script_name=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${script_name}")
+
+source "${script_dir}/e2e_static_smoke_ibm_z"
+source "${script_dir}/variables/mongodb_slim"
+
+CUSTOM_OM_VERSION=$(grep -E "^\s*-\s*&ops_manager_80_latest\s+(\S+)\s+#" <"${PROJECT_DIR}"/.evergreen.yml | awk '{print $3}')
+export CUSTOM_OM_VERSION
+export CUSTOM_MDB_VERSION="${SLIM_MDB_VERSION}-ubi${SLIM_UBI_VERSION}-slim"

--- a/scripts/dev/contexts/variables/mongodb_slim
+++ b/scripts/dev/contexts/variables/mongodb_slim
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -Eeou pipefail
+
+export SLIM_MDB_VERSION=8.0.23
+export SLIM_UBI_VERSION=9

--- a/scripts/python/find_test_variants_test.py
+++ b/scripts/python/find_test_variants_test.py
@@ -13,14 +13,20 @@ def test_find_task_variants():
     project_dir = os.environ.get("PROJECT_DIR", ".")
     evergreen_file = os.path.join(project_dir, ".evergreen.yml")
     result = find_task_variants(evergreen_file, "e2e_feature_controls_authentication")
-    assert sorted(result) == ["e2e_mdb_kind_ubi_cloudqa", "e2e_static_mdb_kind_ubi_cloudqa"]
+    assert sorted(result) == [
+        "e2e_mdb_kind_ubi_cloudqa",
+        "e2e_static_mdb_kind_ubi9_slim_cloudqa",
+        "e2e_static_mdb_kind_ubi_cloudqa",
+    ]
 
     result = find_task_variants(evergreen_file, "e2e_sharded_cluster")
     assert sorted(result) == [
         "e2e_mdb_kind_ubi_cloudqa",
         "e2e_multi_cluster_kind",
+        "e2e_static_mdb_kind_ubi9_slim_cloudqa",
         "e2e_static_mdb_kind_ubi_cloudqa",
         "e2e_static_multi_cluster_kind",
+        "e2e_static_multi_cluster_kind_ubi9_slim",
     ]
 
     result = find_task_variants(evergreen_file, "")
@@ -45,7 +51,11 @@ def test_main_output(monkeypatch):
     monkeypatch.setattr("sys.stdout", captured)
     main()
     output = captured.getvalue().strip().splitlines()
-    assert sorted(output) == ["e2e_mdb_kind_ubi_cloudqa", "e2e_static_mdb_kind_ubi_cloudqa"]
+    assert sorted(output) == [
+        "e2e_mdb_kind_ubi_cloudqa",
+        "e2e_static_mdb_kind_ubi9_slim_cloudqa",
+        "e2e_static_mdb_kind_ubi_cloudqa",
+    ]
 
 
 def test_main_output_no_matches(monkeypatch):


### PR DESCRIPTION
# Summary

Add support for MongoDB `x.y.z-ubi9-slim` versions suffixes when specifying a mongod version in static architecture. This select the ubi9-slim enterprise server image variant while keeping image identifiers separate from the canonical versions sent to Ops Manager. Slim tags are preserved when selecting container images, while Automation Config versions are normalized to `x.y.z-ent`.

The e2e matrix gains ten static-architecture variants covering Kind, OpenShift, OLM, multi-cluster, Ops Manager/AppDB, and supported hardware architectures. These variants run on staging patches, not PRs, as the risk of regression for this change is low.

### Evergreen variants

| Variant | Coverage | Host/platform | Version mapping |
|---|---|---|---|
| `e2e_static_mdb_kind_ubi9_slim_cloudqa` | Standard MongoDB Kind suite | Ubuntu 24.04 | OM `8.0.26`; MongoDB `7.0.5` → `8.0.23-ubi9-slim` |
| `e2e_static_openshift_mdb_ubi9_slim_cloudqa` | OpenShift MongoDB suite | OpenShift on Ubuntu 24.04 | OM `8.0.26`; MongoDB `8.0.23-ubi9-slim` |
| `e2e_static_om80_kind_ubi9_slim` | Ops Manager and upgrade suites | Ubuntu 24.04 | OM 8.0; MongoDB and AppDB `8.0.23-ubi9-slim` |
| `e2e_static_smoke_arm_ubi9_slim` | ARM smoke suite | Ubuntu 24.04 ARM64 | OM `8.0.26`; MongoDB `8.0.23-ubi9-slim` |
| `e2e_static_smoke_ibm_power_ubi9_slim` | IBM Power smoke suite | RHEL 9 Power | OM `8.0.26`; MongoDB `8.0.23-ubi9-slim` |
| `e2e_static_smoke_ibm_z_ubi9_slim` | IBM Z smoke suite | RHEL 9 zSeries | OM `8.0.26`; MongoDB `8.0.23-ubi9-slim` |
| `e2e_static_multi_cluster_kind_ubi9_slim` | Full multi-cluster Kind suite | Ubuntu 24.04 | OM `8.0.26`; MongoDB `7.0.5` → `8.0.23-ubi9-slim` |
| `e2e_static_multi_cluster_2_clusters_ubi9_slim` | Two-member-cluster suite | Ubuntu 24.04 | OM `8.0.26`; MongoDB `7.0.5` → `8.0.23-ubi9-slim` |
| `e2e_static_multi_cluster_om_appdb_ubi9_slim` | Multi-cluster Ops Manager/AppDB suite | Ubuntu 24.04 | OM 8.0; MongoDB and AppDB `8.0.23-ubi9-slim` |
| `e2e_static_kind_olm_ubi9_slim` | OLM installation and operator upgrade suites | Ubuntu 24.04 | OM 8.0; Slim AppDB and post-upgrade MongoDB `8.0.23-ubi9-slim` |

## Proof of Work

- Added unit coverage for Slim suffix detection, official and related image resolution, and Automation Config version normalization.
- `scripts/dev/run_python.sh -m pytest -q scripts/python/find_test_variants_test.py`
- [Evergreen staging run that also includes the new variants](https://spruce.corp.mongodb.com/version/6a9e80fec50b59000792bbe0)

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details