### PR TITLE
Fix operator upgrade test

### DIFF
--- a/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/meko_mck_upgrade.py
@@ -31,6 +31,16 @@ logger = test_logger.get_test_logger(__name__)
 RS_NAME = "my-replica-set"
 CERT_PREFIX = "prefix"
 
+# AC process names recorded while the legacy MEKO operator owns the deployment. MEKO predates
+# the k8s/{namespace}/{pod} process naming introduced in MCK 1.12.0, so the Automation Config
+# holds legacy bare pod names. The upgraded operator must keep them on existing deployments
+# instead of renaming to the new scheme.
+process_names_before_upgrade: set = set()
+
+
+def get_ac_process_names(replica_set: MongoDB) -> set:
+    return {p["name"] for p in replica_set.get_automation_config_tester().get_all_processes()}
+
 
 @fixture(scope="module")
 def rs_certs_secret(namespace: str, issuer: str):
@@ -104,6 +114,13 @@ def test_install_replicaset(replica_set: MongoDB):
 
 
 @mark.e2e_meko_mck_upgrade
+def test_record_process_names_before_upgrade(replica_set: MongoDB):
+    process_names_before_upgrade.update(get_ac_process_names(replica_set))
+    assert process_names_before_upgrade
+    assert not any(name.startswith("k8s/") for name in process_names_before_upgrade)
+
+
+@mark.e2e_meko_mck_upgrade
 def test_downscale_latest_official_operator(namespace: str):
     deployment_name = LEGACY_MULTI_CLUSTER_OPERATOR_NAME if is_multi_cluster() else LEGACY_OPERATOR_NAME
     downscale_operator_deployment(deployment_name, namespace)
@@ -146,6 +163,13 @@ def test_upgrade_operator(
 def test_replicaset_reconciled(replica_set: MongoDB):
     replica_set.assert_abandons_phase(phase=Phase.Running, timeout=300)
     replica_set.assert_reaches_phase(phase=Phase.Running, timeout=800)
+
+
+@mark.e2e_meko_mck_upgrade
+def test_process_names_unchanged_after_upgrade(replica_set: MongoDB):
+    current = get_ac_process_names(replica_set)
+    assert current == process_names_before_upgrade
+    assert not any(name.startswith("k8s/") for name in current)
 
 
 @mark.e2e_meko_mck_upgrade

--- a/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_replica_set.py
+++ b/docker/mongodb-kubernetes-tests/tests/upgrades/operator_upgrade_replica_set.py
@@ -16,8 +16,8 @@ CERT_PREFIX = "prefix"
 
 logger = test_logger.get_test_logger(__name__)
 
-# AC process names recorded while the old operator owns the deployment. The new operator must
-# keep the legacy bare pod names on existing deployments instead of renaming to k8s/{namespace}/{pod}.
+# AC process names recorded while the old operator owns the deployment. The upgraded operator
+# must keep the existing process names unchanged instead of renaming them.
 process_names_before_upgrade: set = set()
 
 
@@ -130,7 +130,6 @@ def test_replicaset_reconciled(replica_set: MongoDB):
 def test_process_names_unchanged_after_upgrade():
     current = get_ac_process_names()
     assert current == process_names_before_upgrade
-    assert not any(name.startswith("k8s/") for name in current)
 
 
 @mark.e2e_operator_upgrade_replica_set


### PR DESCRIPTION
# Summary

The operator upgrade test was testing upgrades from latest released to current version. After releasing 1.12.0, the process naming assertion failed. Moved this assertion to a meko to mck test where it is guaranteed that the process name assertion passes.

This assertion is changed only for replicasets. There is a separate sharded cluster test (1.27 -> latest) which makes a similar assertion

## Proof of Work

green patch: https://spruce.corp.mongodb.com/version/6aa01321e682cd000724e98e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Checklist

- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
