### PR TITLE
fix(community): allow a private mirror to be declared an official MongoDB repo

### DIFF
--- a/changelog/20260909_fix_allow_a_private_mirror_to_be_declared_an_official.md
+++ b/changelog/20260909_fix_allow_a_private_mirror_to_be_declared_an_official.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-09
+---
+
+* **MongoDBCommunity**: A private mirror of the official MongoDB images can now be declared official via the `MDB_ADDITIONAL_OFFICIAL_MONGODB_REPO_URLS` environment variable, a comma-separated list of registry URLs. Previously the image type suffix (`MDB_COMMUNITY_IMAGE_TYPE`, for example `ubi8`) was appended only for `docker.io/mongodb` and `quay.io/mongodb`, so pointing `MDB_COMMUNITY_REPO_URL` at a mirror silently produced a tag without the suffix — for example `mongodb-community-server:8.0.0` instead of `mongodb-community-server:8.0.0-ubi8` — which does not exist in the mirror or upstream, leaving the StatefulSet in `ImagePullBackOff`. The variable is empty by default, so a repository URL that is neither official nor listed keeps the existing behaviour of taking the version as the whole tag.

--- a/mongodb-community-operator/controllers/replica_set_controller.go
+++ b/mongodb-community-operator/controllers/replica_set_controller.go
@@ -841,10 +841,8 @@ func getMongoDBImage(repoUrl, mongodbImage, mongodbImageType, version string) st
 		repoUrl = strings.TrimRight(repoUrl, "/")
 	}
 	mongoImageName := mongodbImage
-	for _, officialUrl := range util.OfficialMongodbRepoUrls {
-		if repoUrl == officialUrl {
-			return fmt.Sprintf("%s/%s:%s-%s", repoUrl, mongoImageName, version, mongodbImageType)
-		}
+	if util.IsOfficialMongodbRepoUrl(repoUrl) {
+		return fmt.Sprintf("%s/%s:%s-%s", repoUrl, mongoImageName, version, mongodbImageType)
 	}
 
 	// This is the old images backwards compatibility code path.

--- a/mongodb-community-operator/controllers/replicaset_controller_test.go
+++ b/mongodb-community-operator/controllers/replicaset_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/resourcerequirements"
 	"github.com/mongodb/mongodb-kubernetes/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes/pkg/statefulset"
+	"github.com/mongodb/mongodb-kubernetes/pkg/util"
 	"github.com/mongodb/mongodb-kubernetes/pkg/util/constants"
 )
 
@@ -1467,11 +1468,12 @@ func marshalRuntimeObjectFromYAMLBytes(bytes []byte, obj runtime.Object) error {
 
 func TestGetMongoDBImage(t *testing.T) {
 	type testConfig struct {
-		mongodbRepoUrl   string
-		mongodbImage     string
-		mongodbImageType string
-		version          string
-		expectedImage    string
+		mongodbRepoUrl             string
+		mongodbImage               string
+		mongodbImageType           string
+		version                    string
+		additionalOfficialRepoUrls string
+		expectedImage              string
 	}
 	tests := map[string]testConfig{
 		"Default UBI8 Community image": {
@@ -1526,10 +1528,44 @@ func TestGetMongoDBImage(t *testing.T) {
 			version:          "5.0.14-ent",
 			expectedImage:    "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.14-ent",
 		},
+		"Private mirror not declared official keeps the backwards compatible tag": {
+			mongodbRepoUrl:   "registry.example.com/mongodb",
+			mongodbImage:     "mongodb-community-server",
+			mongodbImageType: "ubi8",
+			version:          "6.0.5",
+			expectedImage:    "registry.example.com/mongodb/mongodb-community-server:6.0.5",
+		},
+		"Private mirror declared official gets the image type suffix": {
+			mongodbRepoUrl:             "registry.example.com/mongodb",
+			mongodbImage:               "mongodb-community-server",
+			mongodbImageType:           "ubi8",
+			version:                    "6.0.5",
+			additionalOfficialRepoUrls: "registry.example.com/mongodb",
+			expectedImage:              "registry.example.com/mongodb/mongodb-community-server:6.0.5-ubi8",
+		},
+		"Additional official repo urls are a list, and tolerate spacing and trailing slashes": {
+			mongodbRepoUrl:             "registry.example.com/mongodb",
+			mongodbImage:               "mongodb-community-server",
+			mongodbImageType:           "ubi8",
+			version:                    "6.0.5",
+			additionalOfficialRepoUrls: "mirror.example.org/mongodb, registry.example.com/mongodb/ ",
+			expectedImage:              "registry.example.com/mongodb/mongodb-community-server:6.0.5-ubi8",
+		},
+		"An empty additional official repo url list does not make every repo official": {
+			mongodbRepoUrl:             "registry.example.com/mongodb",
+			mongodbImage:               "mongodb-community-server",
+			mongodbImageType:           "ubi8",
+			version:                    "6.0.5",
+			additionalOfficialRepoUrls: " , ",
+			expectedImage:              "registry.example.com/mongodb/mongodb-community-server:6.0.5",
+		},
 	}
 	for testName := range tests {
 		t.Run(testName, func(t *testing.T) {
 			testConfig := tests[testName]
+			if testConfig.additionalOfficialRepoUrls != "" {
+				t.Setenv(util.AdditionalOfficialMongodbRepoUrlsEnv, testConfig.additionalOfficialRepoUrls)
+			}
 			image := getMongoDBImage(testConfig.mongodbRepoUrl, testConfig.mongodbImage, testConfig.mongodbImageType, testConfig.version)
 			assert.Equal(t, testConfig.expectedImage, image)
 		})

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"strings"
 	"time"
 )
@@ -400,6 +401,34 @@ var OperatorVersion string
 var LogAutomationConfigDiff string
 
 var OfficialMongodbRepoUrls = []string{"docker.io/mongodb", "quay.io/mongodb"}
+
+// AdditionalOfficialMongodbRepoUrlsEnv is a comma-separated list of extra registries that
+// serve the official MongoDB images unchanged, typically a private mirror or pull-through
+// cache. Registries listed here are treated exactly like the entries in
+// OfficialMongodbRepoUrls, so the image type suffix is appended to the tag for them too.
+//
+// It is empty by default: a repository URL that is neither official nor listed here keeps
+// the historical behaviour of taking the version as the whole tag.
+const AdditionalOfficialMongodbRepoUrlsEnv = "MDB_ADDITIONAL_OFFICIAL_MONGODB_REPO_URLS"
+
+// IsOfficialMongodbRepoUrl reports whether repoUrl serves the official MongoDB images,
+// either because it is one of the official registries or because the operator was told
+// it mirrors them via AdditionalOfficialMongodbRepoUrlsEnv.
+func IsOfficialMongodbRepoUrl(repoUrl string) bool {
+	repoUrl = strings.TrimRight(repoUrl, "/")
+	for _, officialUrl := range OfficialMongodbRepoUrls {
+		if repoUrl == officialUrl {
+			return true
+		}
+	}
+	for _, additionalUrl := range strings.Split(os.Getenv(AdditionalOfficialMongodbRepoUrlsEnv), ",") {
+		additionalUrl = strings.TrimRight(strings.TrimSpace(additionalUrl), "/")
+		if additionalUrl != "" && repoUrl == additionalUrl {
+			return true
+		}
+	}
+	return false
+}
 
 func ShouldLogAutomationConfigDiff() bool {
 	return strings.EqualFold(LogAutomationConfigDiff, "true")


### PR DESCRIPTION
## Summary

`MDB_COMMUNITY_IMAGE_TYPE` is ignored whenever `MDB_COMMUNITY_REPO_URL` points anywhere other than `docker.io/mongodb` or `quay.io/mongodb`, which makes a private mirror of the official community images unusable. This adds an opt-in way to declare such a mirror official.

## The problem

`getMongoDBImage` only appends the image type suffix on an exact match against `OfficialMongodbRepoUrls`:

```go
for _, officialUrl := range util.OfficialMongodbRepoUrls {
    if repoUrl == officialUrl {
        return fmt.Sprintf("%s/%s:%s-%s", repoUrl, mongoImageName, version, mongodbImageType)
    }
}

// This is the old images backwards compatibility code path.
return fmt.Sprintf("%s/%s:%s", repoUrl, mongoImageName, version)
```

with `var OfficialMongodbRepoUrls = []string{"docker.io/mongodb", "quay.io/mongodb"}`.

Any other registry takes the compatibility path, so `MDB_COMMUNITY_IMAGE_TYPE` is read, defaulted to `ubi8` and then silently discarded. Pointing `MDB_COMMUNITY_REPO_URL` at a mirror produces

```
<mirror>/mongodb-community-server:8.0.0
```

rather than `…:8.0.0-ubi8`. That tag exists in neither the mirror nor upstream — the official repositories only publish the suffixed form — so the MongoDBCommunity StatefulSet goes to `ImagePullBackOff`.

We hit this mirroring the official images into a private Artifact Registry. The operator env was correct (`MDB_COMMUNITY_IMAGE_TYPE=ubi8`) and the mirror did contain `mongodb-community-server:8.0.0-ubi8`; the operator simply asked for a different tag once the repo URL was customised. Two details made it awkward to diagnose: the image inputs are read once at startup and passed to `setupCommunityController`, so the change needs an operator restart to take effect at all, and once a pod is in `ImagePullBackOff` a `podManagementPolicy: OrderedReady` StatefulSet will not roll it, so it cannot self-heal after the config is corrected.

## The change

A new optional environment variable, `MDB_ADDITIONAL_OFFICIAL_MONGODB_REPO_URLS`, taking a comma-separated list of registries that mirror the official images unchanged. Those are then treated exactly like the entries in `OfficialMongodbRepoUrls`.

The matching moves into `util.IsOfficialMongodbRepoUrl`, next to the constant it extends, and `getMongoDBImage` loses its inline loop.

**Backwards compatible by construction.** The variable is empty by default, so a repository that is neither official nor listed keeps the existing behaviour. That path is deliberate — the existing test suite documents customers who encode the suffix in the version themselves:

```go
"Deprecated AppDB images defined the old way": {
    // In this example, we intentionally don't use the suffix from the env. variable and let users
    // define it in the version instead. There are some known customers who do this.
```

so opting in seemed safer than changing the default. Happy to reshape it if you would rather it worked another way — the goal is that a mirror can be made to behave like the official registries, not this particular spelling of it.

## Tests

Four cases added to the existing `TestGetMongoDBImage` table:

- a mirror **not** declared official keeps the backwards compatible tag
- a mirror declared official gets the image type suffix
- the list tolerates spacing and trailing slashes
- an all-whitespace list does not make every repository official

All 11 subtests pass. `go build ./...` and `go test ./pkg/util/...` are clean, and the code is gofmt clean.

## Housekeeping

- Changelog entry added under `changelog/`.
- Commit is signed.
- Contributor Agreement signed.
