### PR TITLE
KUBE-318: Delete stored LDAP block from deployment when Ldap is nil

### DIFF
--- a/changelog/20260910_fix_ldap_disable_purges_bindquerypassword_from_om_config.md
+++ b/changelog/20260910_fix_ldap_disable_purges_bindquerypassword_from_om_config.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-10
+---
+
+* **LDAP**: Fixed a bug where disabling LDAP did not remove the stored `bindQueryPassword` from the Ops Manager automation config. The LDAP block (including the plaintext bind credential) previously persisted indefinitely in OM config, backups, and agent downloads even after the user deleted the Kubernetes secret. Now the block is properly deleted from the deployment on disable.

--- a/controllers/om/automation_config.go
+++ b/controllers/om/automation_config.go
@@ -59,7 +59,9 @@ func applyInto(a AutomationConfig, into *Deployment) error {
 		(*into)["tls"] = mergedTLS
 	}
 
-	if _, ok := a.Deployment["ldap"]; ok {
+	if a.Ldap == nil {
+		delete(*into, "ldap")
+	} else if _, ok := a.Deployment["ldap"]; ok {
 		mergedLdap, err := util.MergeWith(a.Ldap, a.Deployment["ldap"].(map[string]interface{}), &util.AutomationConfigTransformer{})
 		if err != nil {
 			return err

--- a/controllers/om/automation_config_test.go
+++ b/controllers/om/automation_config_test.go
@@ -1073,6 +1073,27 @@ func TestOIDCProviderConfigsAreMerged(t *testing.T) {
 	}
 }
 
+func TestApplyInto_RemovesLDAPBlockWhenLdapIsNil(t *testing.T) {
+	storedDeployment := Deployment{
+		"ldap": map[string]interface{}{
+			"bindQueryUser":     "cn=admin,dc=example,dc=com",
+			"bindQueryPassword": "live-corporate-credential",
+			"servers":           "ldap.example.com",
+			"transportSecurity": "tls",
+		},
+	}
+	config := AutomationConfig{
+		Ldap:       nil,
+		Deployment: storedDeployment,
+	}
+	into := NewDeployment()
+	err := applyInto(config, &into)
+	assert.NoError(t, err)
+
+	_, ldapExists := into["ldap"]
+	assert.False(t, ldapExists, "ldap block should be deleted from deployment when Ldap is nil")
+}
+
 func TestApplyInto(t *testing.T) {
 	config := AutomationConfig{
 		Auth: NewAuth(),


### PR DESCRIPTION
# Summary

When LDAP is disabled, ac.Ldap is set to nil but applyInto merges the  stored deployment["ldap"] block back, including the plaintext  bindQueryPassword, because there was no delete-on-nil guard. This lets the credential persist indefinitely in OM config, backups, and agent downloads even after the user deleted the Kubernetes secret.

Mirror the OIDC pattern: if a.Ldap == nil, delete(*into, "ldap") so the entire stored block (and its bind password) is removed from the deployment on every push.

## Proof of Work

CI Pass

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
