### PR TITLE
KUBE-317: Scope PVC resize selection by ownerReference

### DIFF
--- a/changelog/20260911_fix_pvc_resize_owner_reference_isolation.md
+++ b/changelog/20260911_fix_pvc_resize_owner_reference_isolation.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-11
+---
+
+* **PVC resize security isolation**: Fixed a vulnerability where the PVC resize logic could match foreign PVCs in the same namespace using an ambiguous name-prefix regex. PVC selection now verifies that the PVC is owned by the StatefulSet (via `ownerReference.UID`), preventing cross-workload PVC modification.

--- a/controllers/operator/appdbreplicaset_controller_test.go
+++ b/controllers/operator/appdbreplicaset_controller_test.go
@@ -2029,6 +2029,14 @@ func TestAppDB_PVCStatusClearedAfterSuccessfulResize(t *testing.T) {
 		// Create the PVCs that Kubernetes would generate for the AppDB StatefulSet.
 		// VolumeClaimTemplate name is "data" (AppDBSpec.DataVolumeName()), STS name is "<om-name>-db".
 		stsName := opsManager.Spec.AppDB.Name()
+		var existingSts appsv1.StatefulSet
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: stsName, Namespace: opsManager.Namespace}, &existingSts))
+		stsOwnerRef := metav1.OwnerReference{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+			Name:       existingSts.Name,
+			UID:        existingSts.UID,
+		}
 		initialStorage := resource.MustParse("16G")
 		newStorage := resource.MustParse("50G")
 
@@ -2036,8 +2044,9 @@ func TestAppDB_PVCStatusClearedAfterSuccessfulResize(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			p := corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("data-%s-%d", stsName, i),
-					Namespace: opsManager.Namespace,
+					Name:            fmt.Sprintf("data-%s-%d", stsName, i),
+					Namespace:       opsManager.Namespace,
+					OwnerReferences: []metav1.OwnerReference{stsOwnerRef},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					Resources: corev1.VolumeResourceRequirements{

--- a/controllers/operator/create/create.go
+++ b/controllers/operator/create/create.go
@@ -151,11 +151,11 @@ func HandlePVCResize(ctx context.Context, memberClient kubernetesClient.Client, 
 		}
 
 		log.Infof("Detected PVC size expansion; patching all pvcs and increasing the size for sts: %s", desiredSts.Name)
-		if err := resizePVCsStorage(ctx, memberClient, desiredSts, log); err != nil {
+		if err := resizePVCsStorage(ctx, memberClient, desiredSts, existingStatefulSet.UID, log); err != nil {
 			return workflow.Failed(xerrors.Errorf("can't resize pvc, err: %s", err))
 		}
 
-		finishedResizing, err := hasFinishedResizing(ctx, memberClient, desiredSts)
+		finishedResizing, err := hasFinishedResizing(ctx, memberClient, desiredSts, existingStatefulSet.UID)
 		if err != nil {
 			return workflow.Failed(err)
 		}
@@ -268,7 +268,7 @@ func checkStatefulsetIsDeleted(ctx context.Context, memberClient kubernetesClien
 	return deletedIsStatefulset
 }
 
-func hasFinishedResizing(ctx context.Context, memberClient kubernetesClient.Client, desiredSts *appsv1.StatefulSet) (bool, error) {
+func hasFinishedResizing(ctx context.Context, memberClient kubernetesClient.Client, desiredSts *appsv1.StatefulSet, stsUID types.UID) (bool, error) {
 	pvcList := corev1.PersistentVolumeClaimList{}
 	if err := memberClient.List(ctx, &pvcList, client.InNamespace(desiredSts.Namespace)); err != nil {
 		return false, err
@@ -276,7 +276,7 @@ func hasFinishedResizing(ctx context.Context, memberClient kubernetesClient.Clie
 
 	finishedResizing := true
 	for _, currentPVC := range pvcList.Items {
-		if template, index := getMatchingPVCTemplateFromSTS(desiredSts, &currentPVC); template != nil {
+		if template, index := getMatchingPVCTemplateFromSTS(desiredSts, &currentPVC, stsUID); template != nil {
 			if currentPVC.Status.Capacity.Storage().Cmp(*desiredSts.Spec.VolumeClaimTemplates[index].Spec.Resources.Requests.Storage()) != 0 {
 				finishedResizing = false
 			}
@@ -286,7 +286,7 @@ func hasFinishedResizing(ctx context.Context, memberClient kubernetesClient.Clie
 }
 
 // resizePVCsStorage takes the sts we want to create and update all matching pvc with the new storage
-func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, statefulSetToCreate *appsv1.StatefulSet, log *zap.SugaredLogger) error {
+func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, statefulSetToCreate *appsv1.StatefulSet, stsUID types.UID, log *zap.SugaredLogger) error {
 	// this is to ensure that requests to a potentially not allowed resource is not blocking the operator until the end
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
@@ -297,7 +297,7 @@ func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, 
 	}
 
 	for _, existingPVC := range pvcList.Items {
-		if template, _ := getMatchingPVCTemplateFromSTS(statefulSetToCreate, &existingPVC); template != nil {
+		if template, _ := getMatchingPVCTemplateFromSTS(statefulSetToCreate, &existingPVC, stsUID); template != nil {
 			currentSize := existingPVC.Spec.Resources.Requests[corev1.ResourceStorage]
 			targetSize := *template.Spec.Resources.Requests.Storage()
 			log.Infof("Resizing PVC %s/%s from %s to %s", existingPVC.GetNamespace(), existingPVC.GetName(), currentSize.String(), targetSize.String())
@@ -310,7 +310,10 @@ func resizePVCsStorage(ctx context.Context, kubeClient kubernetesClient.Client, 
 	return nil
 }
 
-func getMatchingPVCTemplateFromSTS(statefulSet *appsv1.StatefulSet, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, int) {
+func getMatchingPVCTemplateFromSTS(statefulSet *appsv1.StatefulSet, pvc *corev1.PersistentVolumeClaim, stsUID types.UID) (*corev1.PersistentVolumeClaim, int) {
+	if !isOwnedByStatefulSet(pvc, stsUID) {
+		return nil, -1
+	}
 	for i, claimTemplate := range statefulSet.Spec.VolumeClaimTemplates {
 		expectedPrefix := fmt.Sprintf("%s-%s", claimTemplate.Name, statefulSet.Name)
 
@@ -321,6 +324,15 @@ func getMatchingPVCTemplateFromSTS(statefulSet *appsv1.StatefulSet, pvc *corev1.
 		}
 	}
 	return nil, -1
+}
+
+func isOwnedByStatefulSet(pvc *corev1.PersistentVolumeClaim, stsUID types.UID) bool {
+	for _, ownerRef := range pvc.OwnerReferences {
+		if ownerRef.Kind == "StatefulSet" && ownerRef.UID == stsUID {
+			return true
+		}
+	}
+	return false
 }
 
 // createExternalServices creates the per-pod external LoadBalancer services for one StatefulSet.

--- a/controllers/operator/create/create_test.go
+++ b/controllers/operator/create/create_test.go
@@ -1052,14 +1052,22 @@ func TestResizePVCsStorage(t *testing.T) {
 	const testStsName = "test"
 	const testStsNamespace = "mongodb-test"
 	initialSts := createStatefulSet(testStsName, testStsNamespace, "20Gi", "20Gi", "20Gi")
+	initialSts.UID = types.UID("initial-sts-uid")
 
 	// Create the StatefulSet that we want to resize the PVC to
 	err := fakeClient.CreateStatefulSet(context.TODO(), *initialSts)
 	assert.NoError(t, err)
 
+	ownerRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+		Name:       initialSts.Name,
+		UID:        initialSts.UID,
+	}
+
 	for _, template := range initialSts.Spec.VolumeClaimTemplates {
 		for i := range *initialSts.Spec.Replicas {
-			pvc := createPVCFromTemplate(template, initialSts.Name, initialSts.Namespace, i)
+			pvc := createPVCFromTemplate(template, initialSts.Name, initialSts.Namespace, i, ownerRef)
 			err = fakeClient.Create(context.TODO(), pvc)
 			assert.NoError(t, err)
 		}
@@ -1069,21 +1077,29 @@ func TestResizePVCsStorage(t *testing.T) {
 	// Previously, we had not taken into account namespace when listing PVCs https://jira.mongodb.org/browse/HELP-85556
 	const otherTestStsNamespace = "mongodb-test-2"
 	otherSts := createStatefulSet(testStsName, otherTestStsNamespace, "25Gi", "20Gi", "15Gi")
+	otherSts.UID = types.UID("other-sts-uid")
 
 	// Create the StatefulSet that we want to resize the PVC to
 	err = fakeClient.CreateStatefulSet(context.TODO(), *otherSts)
 	assert.NoError(t, err)
 
+	otherOwnerRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+		Name:       otherSts.Name,
+		UID:        otherSts.UID,
+	}
+
 	for _, template := range otherSts.Spec.VolumeClaimTemplates {
 		for i := range *otherSts.Spec.Replicas {
-			pvc := createPVCFromTemplate(template, otherSts.Name, otherSts.Namespace, i)
+			pvc := createPVCFromTemplate(template, otherSts.Name, otherSts.Namespace, i, otherOwnerRef)
 			err = fakeClient.Create(context.TODO(), pvc)
 			assert.NoError(t, err)
 		}
 	}
 
 	// We are resizing only initialSts PVCs here and otherSts PVCs should remain unchanged
-	err = resizePVCsStorage(context.TODO(), fakeClient, createStatefulSet(testStsName, testStsNamespace, "30Gi", "30Gi", "20Gi"), zap.S())
+	err = resizePVCsStorage(context.TODO(), fakeClient, createStatefulSet(testStsName, testStsNamespace, "30Gi", "30Gi", "20Gi"), initialSts.UID, zap.S())
 	assert.NoError(t, err)
 
 	pvcList := corev1.PersistentVolumeClaimList{}
@@ -1119,6 +1135,74 @@ func TestResizePVCsStorage(t *testing.T) {
 			assert.Equal(t, pvc.Spec.Resources.Requests.Storage().String(), pvcSizes["logs"])
 		} else {
 			t.Fatal("no pvc was compared while we should have at least detected and compared one")
+		}
+	}
+}
+
+func TestResizePVCsStorage_ForeignPVCNotMatched(t *testing.T) {
+	fakeClient := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().Build())
+
+	const stsName = "my-app"
+	const stsNamespace = "shared-ns"
+	sts := createStatefulSet(stsName, stsNamespace, "10Gi", "10Gi", "10Gi")
+	sts.UID = types.UID("our-sts-uid")
+
+	err := fakeClient.CreateStatefulSet(context.TODO(), *sts)
+	assert.NoError(t, err)
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+		Name:       sts.Name,
+		UID:        sts.UID,
+	}
+
+	// Create our own PVCs with ownerReference
+	for _, template := range sts.Spec.VolumeClaimTemplates {
+		for i := range *sts.Spec.Replicas {
+			pvc := createPVCFromTemplate(template, sts.Name, sts.Namespace, i, ownerRef)
+			err = fakeClient.Create(context.TODO(), pvc)
+			assert.NoError(t, err)
+		}
+	}
+
+	// Create a foreign PVC whose name matches the ambiguous prefix pattern
+	// ^data-my-app-[0-9]+$ (template=data, sts=my-app)
+	// This simulates the attack: an attacker chooses CR name + template name
+	// such that the prefix matches a foreign workload's PVC.
+	// The foreign PVC has a different ownerReference (wrong UID).
+	foreignOwnerRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+		Name:       "foreign-sts",
+		UID:        types.UID("foreign-uid"),
+	}
+	// foreign PVC with a name that matches the pattern ^data-my-app-[0-9]+$
+	// but owned by a different StatefulSet — should NOT be resized
+	foreignPVC := createPVCWithCapacity("data-my-app-5", stsNamespace, "5Gi", foreignOwnerRef)
+	err = fakeClient.Create(context.TODO(), foreignPVC)
+	assert.NoError(t, err)
+
+	// Resize our PVCs from 10Gi to 20Gi
+	desiredSts := createStatefulSet(stsName, stsNamespace, "20Gi", "20Gi", "20Gi")
+	desiredSts.UID = sts.UID
+	err = resizePVCsStorage(context.TODO(), fakeClient, desiredSts, sts.UID, zap.S())
+	assert.NoError(t, err)
+
+	// Verify: our PVCs were resized to 20Gi
+	pvcList := corev1.PersistentVolumeClaimList{}
+	err = fakeClient.List(context.TODO(), &pvcList)
+	assert.NoError(t, err)
+
+	for _, pvc := range pvcList.Items {
+		if pvc.OwnerReferences[0].UID == sts.UID {
+			// Our PVCs should be resized
+			assert.Equal(t, "20Gi", pvc.Spec.Resources.Requests.Storage().String(),
+				"our PVC %s should have been resized to 20Gi", pvc.Name)
+		} else {
+			// Foreign PVC should remain unchanged
+			assert.Equal(t, "5Gi", pvc.Spec.Resources.Requests.Storage().String(),
+				"foreign PVC %s should NOT have been resized", pvc.Name)
 		}
 	}
 }
@@ -1174,12 +1258,13 @@ func createStatefulSet(name, namespace, size1, size2, size3 string) *appsv1.Stat
 	}
 }
 
-func createPVCFromTemplate(pvcTemplate corev1.PersistentVolumeClaim, stsName string, namespace string, ordinal int32) *corev1.PersistentVolumeClaim {
+func createPVCFromTemplate(pvcTemplate corev1.PersistentVolumeClaim, stsName string, namespace string, ordinal int32, ownerRefs ...metav1.OwnerReference) *corev1.PersistentVolumeClaim {
 	pvcName := fmt.Sprintf("%s-%s-%d", pvcTemplate.Name, stsName, ordinal)
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvcName,
-			Namespace: namespace,
+			Name:            pvcName,
+			Namespace:       namespace,
+			OwnerReferences: ownerRefs,
 		},
 		Spec: pvcTemplate.Spec,
 	}
@@ -1292,6 +1377,7 @@ func TestHasFinishedResizing(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "mongodb-test",
+			UID:       types.UID("sts-uid"),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
@@ -1323,16 +1409,27 @@ func TestHasFinishedResizing(t *testing.T) {
 		},
 	}
 
+	stsOwnerRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+		Name:       sts.Name,
+		UID:        sts.UID,
+	}
+
 	ctx := context.TODO()
 	{
-		fakeClient, _ := mock.NewDefaultFakeClient()
+		fakeClient := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().Build())
+		// Create the StatefulSet so hasFinishedResizing can fetch it to get the UID
+		err := fakeClient.CreateStatefulSet(ctx, *sts)
+		assert.NoError(t, err)
+
 		// Scenario 1: All PVCs have finished resizing
-		pvc1 := createPVCWithCapacity("data-"+sts.Name+"-0", sts.Namespace, "20Gi")
-		pvc2 := createPVCWithCapacity("logs-"+sts.Name+"-0", sts.Namespace, "30Gi")
+		pvc1 := createPVCWithCapacity("data-"+sts.Name+"-0", sts.Namespace, "20Gi", stsOwnerRef)
+		pvc2 := createPVCWithCapacity("logs-"+sts.Name+"-0", sts.Namespace, "30Gi", stsOwnerRef)
 		// PVCs in different namespace, but same name, should be ignored and not taken into account when checking resizing status
-		pvc1InDifferentNamespace := createPVCWithCapacity("data-"+sts.Name+"-0", "mongodb-test-2", "15Gi")
-		pvc2InDifferentNamespace := createPVCWithCapacity("logs-"+sts.Name+"-0", "mongodb-test-2", "10Gi")
-		err := fakeClient.Create(ctx, pvc1)
+		pvc1InDifferentNamespace := createPVCWithCapacity("data-"+sts.Name+"-0", "mongodb-test-2", "15Gi", stsOwnerRef)
+		pvc2InDifferentNamespace := createPVCWithCapacity("logs-"+sts.Name+"-0", "mongodb-test-2", "10Gi", stsOwnerRef)
+		err = fakeClient.Create(ctx, pvc1)
 		assert.NoError(t, err)
 		err = fakeClient.Create(ctx, pvc2)
 		assert.NoError(t, err)
@@ -1341,30 +1438,34 @@ func TestHasFinishedResizing(t *testing.T) {
 		err = fakeClient.Create(ctx, pvc2InDifferentNamespace)
 		assert.NoError(t, err)
 
-		finished, err := hasFinishedResizing(ctx, fakeClient, sts)
+		finished, err := hasFinishedResizing(ctx, fakeClient, sts, sts.UID)
 		assert.NoError(t, err)
 		assert.True(t, finished, "PVCs should be finished resizing")
 	}
 
 	{
 		// Scenario 2: Some PVCs are still resizing
-		fakeClient, _ := mock.NewDefaultFakeClient()
-		pvc2Incomplete := createPVCWithCapacity("logs-"+sts.Name+"-0", sts.Namespace, "10Gi")
-		err := fakeClient.Create(ctx, pvc2Incomplete)
+		fakeClient := kubernetesClient.NewClient(mock.NewEmptyFakeClientBuilder().Build())
+		err := fakeClient.CreateStatefulSet(ctx, *sts)
 		assert.NoError(t, err)
 
-		finished, err := hasFinishedResizing(ctx, fakeClient, sts)
+		pvc2Incomplete := createPVCWithCapacity("logs-"+sts.Name+"-0", sts.Namespace, "10Gi", stsOwnerRef)
+		err = fakeClient.Create(ctx, pvc2Incomplete)
+		assert.NoError(t, err)
+
+		finished, err := hasFinishedResizing(ctx, fakeClient, sts, sts.UID)
 		assert.NoError(t, err)
 		assert.False(t, finished, "PVCs should not be finished resizing")
 	}
 }
 
 // Helper function to create a PVC with a specific capacity and status
-func createPVCWithCapacity(name string, namespace string, capacity string) *corev1.PersistentVolumeClaim {
+func createPVCWithCapacity(name string, namespace string, capacity string, ownerRefs ...metav1.OwnerReference) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: ownerRefs,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			Resources: corev1.VolumeResourceRequirements{
@@ -1382,9 +1483,11 @@ func createPVCWithCapacity(name string, namespace string, capacity string) *core
 }
 
 func TestGetMatchingPVCTemplateFromSTS(t *testing.T) {
+	const stsUID types.UID = "example-sts-uid"
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "example-sts",
+			UID:  stsUID,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
@@ -1407,12 +1510,35 @@ func TestGetMatchingPVCTemplateFromSTS(t *testing.T) {
 	tests := []struct {
 		name             string
 		pvcName          string
+		ownerRefs        []metav1.OwnerReference
 		expectedTemplate *corev1.PersistentVolumeClaim
 		expectedIndex    int
 	}{
 		{
 			name:    "Matching data-pvc with ordinal 0",
 			pvcName: "data-pvc-example-sts-0",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "other-sts",
+					UID:        types.UID("other-uid"),
+				},
+			},
+			expectedTemplate: nil,
+			expectedIndex:    -1,
+		},
+		{
+			name:    "Matching data-pvc with ordinal 0 and correct owner",
+			pvcName: "data-pvc-example-sts-0",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "example-sts",
+					UID:        stsUID,
+				},
+			},
 			expectedTemplate: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "data-pvc",
@@ -1421,8 +1547,16 @@ func TestGetMatchingPVCTemplateFromSTS(t *testing.T) {
 			expectedIndex: 0,
 		},
 		{
-			name:    "Matching logs-pvc with ordinal 1",
+			name:    "Matching logs-pvc with ordinal 1 and correct owner",
 			pvcName: "logs-pvc-example-sts-1",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "example-sts",
+					UID:        stsUID,
+				},
+			},
 			expectedTemplate: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "logs-pvc",
@@ -1431,14 +1565,22 @@ func TestGetMatchingPVCTemplateFromSTS(t *testing.T) {
 			expectedIndex: 1,
 		},
 		{
-			name:             "Non-matching PVC name",
+			name:             "Non-matching PVC name and no owner",
 			pvcName:          "cache-pvc-example-sts-0",
 			expectedTemplate: nil,
 			expectedIndex:    -1,
 		},
 		{
-			name:    "Matching data-pvc with high ordinal",
+			name:    "Matching data-pvc with high ordinal and correct owner",
 			pvcName: "data-pvc-example-sts-1000",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "example-sts",
+					UID:        stsUID,
+				},
+			},
 			expectedTemplate: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "data-pvc",
@@ -1470,17 +1612,32 @@ func TestGetMatchingPVCTemplateFromSTS(t *testing.T) {
 			expectedTemplate: nil,
 			expectedIndex:    -1,
 		},
+		{
+			name:    "Foreign PVC matching name pattern but owned by different STS is rejected",
+			pvcName: "data-pvc-example-sts-0",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "attacker-sts",
+					UID:        types.UID("attacker-uid"),
+				},
+			},
+			expectedTemplate: nil,
+			expectedIndex:    -1,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: tt.pvcName,
+					Name:            tt.pvcName,
+					OwnerReferences: tt.ownerRefs,
 				},
 			}
 
-			template, index := getMatchingPVCTemplateFromSTS(statefulSet, p)
+			template, index := getMatchingPVCTemplateFromSTS(statefulSet, p, stsUID)
 
 			if tt.expectedTemplate == nil {
 				assert.Nil(t, template, "Expected no matching PVC template")

--- a/controllers/operator/mongodbreplicaset_controller_test.go
+++ b/controllers/operator/mongodbreplicaset_controller_test.go
@@ -883,6 +883,7 @@ func TestHandlePVCResize(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example-sts",
 				Namespace: "default",
+				UID:       types.UID("example-sts-uid"),
 			},
 			Spec: appsv1.StatefulSetSpec{
 				Replicas: ptr.To(int32(3)),
@@ -907,6 +908,14 @@ func TestHandlePVCResize(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "data-pvc-example-sts-0",
 				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       "example-sts",
+						UID:        types.UID("example-sts-uid"),
+					},
+				},
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: resource.MustParse("1Gi")}}},
 			Status: corev1.PersistentVolumeClaimStatus{

--- a/controllers/operator/mongodbshardedcluster_controller_test.go
+++ b/controllers/operator/mongodbshardedcluster_controller_test.go
@@ -490,6 +490,14 @@ func createPVCs(t *testing.T, sts appsv1.StatefulSet, c client.Writer) []corev1.
 				Name:      pvcName,
 				Namespace: sts.Namespace,
 				Labels:    sts.Spec.Template.Labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       sts.Name,
+						UID:        sts.UID,
+					},
+				},
 			},
 			Spec: sts.Spec.VolumeClaimTemplates[0].Spec,
 		}


### PR DESCRIPTION
# Summary

The PVC resize logic selected PVCs by a namespace-wide list + ambiguous name prefix regex (^<template>-<sts>-[0-9]+$), which could match foreign PVCs in the same namespace when the attacker controls the CR name and volumeClaimTemplate name via the STS spec merge.

Fix: verify PVC ownership via ownerReference (Kind=StatefulSet, UID match) before applying the name regex. PVCs not owned by the StatefulSet are rejected regardless of name match.

## Proof of Work

CI Pass

## Checklist

- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you added changelog file?
    - use `skip-changelog` label if not needed
    - refer to [Changelog files and Release Notes](https://github.com/mongodb/mongodb-kubernetes/blob/master/CONTRIBUTING.md#changelog-files-and-release-notes) section in CONTRIBUTING.md for more details

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->
