### PR TITLE
KUBE-315: bound Ops Manager pagination and request timeouts, validate baseUrl

### DIFF
--- a/changelog/20260910_fix_bound_ops_manager_pagination_and_http_timeouts.md
+++ b/changelog/20260910_fix_bound_ops_manager_pagination_and_http_timeouts.md
@@ -3,4 +3,4 @@ kind: fix
 date: 2026-09-10
 ---
 
-* Bounded the Ops Manager API pagination loop with a maximum page count and an overall deadline, added a request timeout to the Ops Manager HTTP client, and validated that the `baseUrl` read from the project `ConfigMap` is a well-formed `http(s)` URL. A misbehaving or malicious Ops Manager endpoint can no longer stall a reconcile worker indefinitely; the affected resource now reaches `Failed` with a descriptive message.
+* Bounded the Ops Manager API pagination loop with a maximum page count and an overall deadline, added a request timeout to the Ops Manager HTTP client, and validated that the `baseUrl` read from the project `ConfigMap` is a well-formed `http(s)` URL. A misbehaving or malicious Ops Manager endpoint can no longer stall a reconcile worker indefinitely; the request now fails with a descriptive error instead of blocking, and reconciliation retries or continues.

--- a/changelog/20260910_fix_bound_ops_manager_pagination_and_http_timeouts.md
+++ b/changelog/20260910_fix_bound_ops_manager_pagination_and_http_timeouts.md
@@ -1,0 +1,6 @@
+---
+kind: fix
+date: 2026-09-10
+---
+
+* Bounded the Ops Manager API pagination loop with a maximum page count and an overall deadline, added a request timeout to the Ops Manager HTTP client, and validated that the `baseUrl` read from the project `ConfigMap` is a well-formed `http(s)` URL. A misbehaving or malicious Ops Manager endpoint can no longer stall a reconcile worker indefinitely; the affected resource now reaches `Failed` with a descriptive message.

--- a/controllers/om/api/http.go
+++ b/controllers/om/api/http.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -51,6 +52,9 @@ const (
 	defaultRetryWaitMin = 1 * time.Second
 	defaultRetryWaitMax = 10 * time.Second
 	defaultRetryMax     = 3
+
+	// defaultRequestTimeout bounds a single HTTP attempt (connection, response headers and body) against Ops Manager.
+	defaultRequestTimeout = 2 * time.Minute
 )
 
 type Client struct {
@@ -66,9 +70,9 @@ type Client struct {
 
 // NewHTTPClient is a functional options constructor, based on this blog post:
 // https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
-// The default clients specifies some important timeouts (some of them are synced with AA one):
-// 10 seconds for connection (TLS/non TLS)
-// 10 minutes for requests (time to get the first response headers)
+// The default client uses http.DefaultTransport and bounds every attempt with defaultRequestTimeout. Failed
+// requests are retried up to defaultRetryMax times, so an overall deadline can only be enforced by the context
+// passed to RequestWithContext.
 func NewHTTPClient(options ...func(*Client) error) (*Client, error) {
 	client := &Client{
 		Client: newDefaultHTTPClient(),
@@ -79,7 +83,7 @@ func NewHTTPClient(options ...func(*Client) error) (*Client, error) {
 
 func newDefaultHTTPClient() *retryablehttp.Client {
 	return &retryablehttp.Client{
-		HTTPClient:   &http.Client{Transport: http.DefaultTransport},
+		HTTPClient:   &http.Client{Transport: http.DefaultTransport, Timeout: defaultRequestTimeout},
 		RetryWaitMin: defaultRetryWaitMin,
 		RetryWaitMax: defaultRetryWaitMax,
 		RetryMax:     defaultRetryMax,
@@ -160,17 +164,23 @@ func OptionCAValidate(ca string) func(client *Client) error {
 
 // Request executes an HTTP request, given a series of parameters, over this *Client object.
 // It handles Digest when needed and json marshaling of the `v` struct.
+// Use RequestWithContext to enforce an overall deadline.
 func (client *Client) Request(method, hostname, path string, v interface{}) ([]byte, http.Header, error) {
+	return client.RequestWithContext(context.Background(), method, hostname, path, v)
+}
+
+// RequestWithContext is like Request, but aborts the whole exchange (including retries and backoff waits) as soon as ctx is done.
+func (client *Client) RequestWithContext(ctx context.Context, method, hostname, path string, v interface{}) ([]byte, http.Header, error) {
 	url := hostname + path
 
-	req, err := createHTTPRequest(method, url, v)
+	req, err := createHTTPRequest(ctx, method, url, v)
 	if err != nil {
 		return nil, nil, apierror.New(err)
 	}
 
 	if client.username != "" && client.password != "" {
 		// Only add Digest auth when needed.
-		err = client.authorizeRequest(method, hostname, path, req)
+		err = client.authorizeRequest(ctx, method, hostname, path, req)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -187,7 +197,7 @@ func (client *Client) Request(method, hostname, path string, v interface{}) ([]b
 func (client *Client) RequestWithAgentAuth(method, hostname, path string, agentAuth string, v interface{}) ([]byte, http.Header, error) {
 	url := hostname + path
 
-	req, err := createHTTPRequest(method, url, v)
+	req, err := createHTTPRequest(context.Background(), method, url, v)
 	if err != nil {
 		return nil, nil, apierror.New(err)
 	}
@@ -200,10 +210,10 @@ func (client *Client) RequestWithAgentAuth(method, hostname, path string, agentA
 // authorizeRequest executes one request that's meant to be challenged by the
 // server in order to build the next one. The `request` parameter is aggregated
 // with the required `Authorization` header.
-func (client *Client) authorizeRequest(method, hostname, path string, request *retryablehttp.Request) error {
+func (client *Client) authorizeRequest(ctx context.Context, method, hostname, path string, request *retryablehttp.Request) error {
 	url := hostname + path
 
-	digestRequest, err := retryablehttp.NewRequest(method, url, nil)
+	digestRequest, err := retryablehttp.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return err
 	}
@@ -239,14 +249,14 @@ func (client *Client) authorizeRequest(method, hostname, path string, request *r
 	return nil
 }
 
-// createHTTPRequest
-func createHTTPRequest(method string, url string, v interface{}) (*retryablehttp.Request, error) {
+// createHTTPRequest builds a retryable request bound to ctx, with 'v' serialized to JSON as the body.
+func createHTTPRequest(ctx context.Context, method string, url string, v interface{}) (*retryablehttp.Request, error) {
 	buffer, err := serializeToBuffer(v)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := retryablehttp.NewRequest(method, url, buffer)
+	req, err := retryablehttp.NewRequestWithContext(ctx, method, url, buffer)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/om/api/http_test.go
+++ b/controllers/om/api/http_test.go
@@ -1,14 +1,20 @@
 package api
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateHttpRequest(t *testing.T) {
-	httpRequest, e := createHTTPRequest("POST", "http://some.com", nil)
+	httpRequest, e := createHTTPRequest(context.Background(), "POST", "http://some.com", nil)
 	u, _ := url.Parse("http://some.com")
 
 	assert.NoError(t, e)
@@ -17,4 +23,67 @@ func TestCreateHttpRequest(t *testing.T) {
 	assert.Equal(t, "POST", httpRequest.Method)
 	assert.Equal(t, u, httpRequest.URL)
 	assert.Nil(t, httpRequest.Body)
+}
+
+func TestCreateHttpRequest_IsBoundToContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	httpRequest, err := createHTTPRequest(ctx, "GET", "http://some.com", nil)
+	require.NoError(t, err)
+
+	cancel()
+	assert.ErrorIs(t, httpRequest.Context().Err(), context.Canceled)
+}
+
+func TestNewHTTPClient_SetsRequestTimeout(t *testing.T) {
+	client, err := NewHTTPClient()
+	require.NoError(t, err)
+
+	assert.Equal(t, defaultRequestTimeout, client.HTTPClient.Timeout)
+}
+
+// hangingServer never answers; the handler returns only once the client has gone away so that srv.Close() completes.
+func hangingServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &requests
+}
+
+func TestRequestWithContext_DeadlineAbortsHangingServer(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []func(*Client) error
+		// only one request may reach the server: the aborted request itself, or the digest challenge
+		requestsMsg string
+	}{
+		{
+			name:        "without digest auth",
+			requestsMsg: "a request aborted by its context must not be retried",
+		},
+		{
+			name:        "with digest auth",
+			options:     []func(*Client) error{OptionDigestAuth("user", "password")},
+			requestsMsg: "the digest challenge is the only request that may reach the server",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, requests := hangingServer(t)
+
+			client, err := NewHTTPClient(tt.options...)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			_, _, err = client.RequestWithContext(ctx, "GET", srv.URL, "/api/public/v1.0/groups", nil)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
+			assert.Equal(t, int32(1), requests.Load(), tt.requestsMsg)
+		})
+	}
 }

--- a/controllers/om/mockedomclient.go
+++ b/controllers/om/mockedomclient.go
@@ -1,6 +1,7 @@
 package om
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -488,7 +489,7 @@ func (oc *MockedOmConnection) ReadAutomationStatus() (*AutomationStatus, error) 
 	return oc.buildAutomationStatusFromDeployment(oc.deployment, false), nil
 }
 
-func (oc *MockedOmConnection) ReadAutomationAgents(pageNum int) (Paginated, error) {
+func (oc *MockedOmConnection) ReadAutomationAgents(_ context.Context, pageNum int) (Paginated, error) {
 	oc.addToHistory(reflect.ValueOf(oc.ReadAutomationAgents))
 	if oc.ReadAutomationAgentsFunc != nil {
 		return oc.ReadAutomationAgentsFunc(pageNum)
@@ -537,7 +538,7 @@ func (oc *MockedOmConnection) ReadOrganizationsByName(name string) ([]*Organizat
 	return allOrgs, nil
 }
 
-func (oc *MockedOmConnection) ReadOrganizations(page int) (Paginated, error) {
+func (oc *MockedOmConnection) ReadOrganizations(_ context.Context, page int) (Paginated, error) {
 	oc.addToHistory(reflect.ValueOf(oc.ReadOrganizations))
 	// We don't set Next field - so there should be no pagination
 	allOrgs := make([]*Organization, 0)
@@ -568,7 +569,7 @@ func (oc *MockedOmConnection) ReadProjectsInOrganizationByName(orgID string, nam
 	return projects, nil
 }
 
-func (oc *MockedOmConnection) ReadProjectsInOrganization(orgID string, page int) (Paginated, error) {
+func (oc *MockedOmConnection) ReadProjectsInOrganization(_ context.Context, orgID string, page int) (Paginated, error) {
 	oc.addToHistory(reflect.ValueOf(oc.ReadProjectsInOrganization))
 	org, err := oc.findOrganization(orgID)
 	if err != nil {

--- a/controllers/om/omclient.go
+++ b/controllers/om/omclient.go
@@ -1,6 +1,7 @@
 package om
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -47,17 +48,18 @@ type Connection interface {
 	ReadProcessLogRotation() (*automationconfig.AcLogRotate, error)
 	ReadAuditLogRotation() (*automationconfig.AcLogRotate, error)
 	ReadAutomationStatus() (*AutomationStatus, error)
-	ReadAutomationAgents(page int) (Paginated, error)
+	// ReadAutomationAgents returns the automation agents registered in the project at the specified page
+	ReadAutomationAgents(ctx context.Context, page int) (Paginated, error)
 	MarkProjectAsBackingDatabase(databaseType BackingDatabaseType) error
 
 	ReadOrganizationsByName(name string) ([]*Organization, error)
 	// ReadOrganizations returns all organizations at specified page
-	ReadOrganizations(page int) (Paginated, error)
+	ReadOrganizations(ctx context.Context, page int) (Paginated, error)
 	ReadOrganization(orgID string) (*Organization, error)
 
 	ReadProjectsInOrganizationByName(orgID string, name string) ([]*Project, error)
 	// ReadProjectsInOrganization returns all projects in the organization at the specified page
-	ReadProjectsInOrganization(orgID string, page int) (Paginated, error)
+	ReadProjectsInOrganization(ctx context.Context, orgID string, page int) (Paginated, error)
 	CreateProject(project *Project) (*Project, error)
 	UpdateProject(project *Project) (*Project, error)
 
@@ -549,10 +551,10 @@ func (oc *HTTPOmConnection) GenerateAgentKey() (string, error) {
 }
 
 // ReadAutomationAgents returns the state of the automation agents registered in Ops Manager
-func (oc *HTTPOmConnection) ReadAutomationAgents(pageNum int) (Paginated, error) {
+func (oc *HTTPOmConnection) ReadAutomationAgents(ctx context.Context, pageNum int) (Paginated, error) {
 	// TODO: Add proper testing to this pagination. In order to test it I just used `itemsPerPage=1`, which will make
 	// the endpoint to be called 3 times in a 3 member replica set. The default itemsPerPage is 100
-	ans, err := oc.get(fmt.Sprintf("/api/public/v1.0/groups/%s/agents/AUTOMATION?pageNum=%d", oc.GroupID(), pageNum))
+	ans, err := oc.getWithContext(ctx, fmt.Sprintf("/api/public/v1.0/groups/%s/agents/AUTOMATION?pageNum=%d", oc.GroupID(), pageNum))
 	if err != nil {
 		return nil, err
 	}
@@ -626,9 +628,9 @@ func (oc *HTTPOmConnection) ReadOrganizationsByName(name string) ([]*Organizatio
 }
 
 // ReadOrganizations returns all organizations at the specified page.
-func (oc *HTTPOmConnection) ReadOrganizations(page int) (Paginated, error) {
+func (oc *HTTPOmConnection) ReadOrganizations(ctx context.Context, page int) (Paginated, error) {
 	mPath := fmt.Sprintf("/api/public/v1.0/orgs?itemsPerPage=500&pageNum=%d", page)
-	res, err := oc.get(mPath)
+	res, err := oc.getWithContext(ctx, mPath)
 	if err != nil {
 		return nil, err
 	}
@@ -684,9 +686,9 @@ func (oc *HTTPOmConnection) ReadProjectsInOrganizationByName(orgID string, name 
 }
 
 // ReadProjectsInOrganization returns all projects inside organization
-func (oc *HTTPOmConnection) ReadProjectsInOrganization(orgID string, page int) (Paginated, error) {
+func (oc *HTTPOmConnection) ReadProjectsInOrganization(ctx context.Context, orgID string, page int) (Paginated, error) {
 	mPath := fmt.Sprintf("/api/public/v1.0/orgs/%s/groups?itemsPerPage=500&pageNum=%d", url.PathEscape(orgID), page)
-	res, err := oc.get(mPath)
+	res, err := oc.getWithContext(ctx, mPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1034,34 +1036,42 @@ func GetReplicaSetMemberIds(conn Connection) (map[string]map[string]int, error) 
 
 //********************************** Private methods *******************************************************************
 
+// The verb helpers without a context are bounded only by the HTTP client's per-attempt timeout (see api.NewHTTPClient).
+// Calls that need an overall deadline, e.g. the paginated traversals, use getWithContext.
+
 func (oc *HTTPOmConnection) get(path string) ([]byte, error) {
-	return oc.httpVerb("GET", path, nil)
+	return oc.getWithContext(context.Background(), path)
+}
+
+// getWithContext performs a GET request that is aborted as soon as ctx is done.
+func (oc *HTTPOmConnection) getWithContext(ctx context.Context, path string) ([]byte, error) {
+	return oc.httpVerb(ctx, "GET", path, nil)
 }
 
 func (oc *HTTPOmConnection) post(path string, v interface{}) ([]byte, error) {
-	return oc.httpVerb("POST", path, v)
+	return oc.httpVerb(context.Background(), "POST", path, v)
 }
 
 func (oc *HTTPOmConnection) put(path string, v interface{}) ([]byte, error) {
-	return oc.httpVerb("PUT", path, v)
+	return oc.httpVerb(context.Background(), "PUT", path, v)
 }
 
 func (oc *HTTPOmConnection) patch(path string, v interface{}) ([]byte, error) {
-	return oc.httpVerb("PATCH", path, v)
+	return oc.httpVerb(context.Background(), "PATCH", path, v)
 }
 
 func (oc *HTTPOmConnection) delete(path string) error {
-	_, err := oc.httpVerb("DELETE", path, nil)
+	_, err := oc.httpVerb(context.Background(), "DELETE", path, nil)
 	return err
 }
 
-func (oc *HTTPOmConnection) httpVerb(method, path string, v interface{}) ([]byte, error) {
+func (oc *HTTPOmConnection) httpVerb(ctx context.Context, method, path string, v interface{}) ([]byte, error) {
 	client, err := oc.getHTTPClient()
 	if err != nil {
 		return nil, err
 	}
 
-	response, header, err := client.Request(method, oc.BaseURL(), path, v)
+	response, header, err := client.RequestWithContext(ctx, method, oc.BaseURL(), path, v)
 	oc.setVersionFromHeader(header)
 
 	return response, err

--- a/controllers/om/omclient_pagination_test.go
+++ b/controllers/om/omclient_pagination_test.go
@@ -1,0 +1,70 @@
+package om
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// endlessAgentsPage is an automation agents page that always reports a next page.
+const endlessAgentsPage = `{"totalCount": 9223372036854775807, "links": [{"rel": "next"}], "results": [{"hostname": "host-%d", "typeName": "AUTOMATION", "lastConf": "2024-01-01T00:00:00Z"}]}`
+
+// automationAgents registers the automation agents endpoint of group "1", counting every request it receives.
+func automationAgents(requests *atomic.Int32, respond func(w http.ResponseWriter, r *http.Request)) handleFunc {
+	return func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/public/v1.0/groups/1/agents/AUTOMATION", func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			respond(w, r)
+		})
+	}
+}
+
+func TestReadAutomationAgents_StopsAtMaxPagesWhenServerAlwaysReportsNext(t *testing.T) {
+	var requests atomic.Int32
+	srv := serverMock(automationAgents(&requests, func(w http.ResponseWriter, r *http.Request) {
+		pageNum, _ := strconv.Atoi(r.URL.Query().Get("pageNum"))
+		_, _ = fmt.Fprintf(w, endlessAgentsPage, pageNum)
+	}))
+	defer srv.Close()
+
+	conn := NewOpsManagerConnectionWithOptions(&OMContext{BaseURL: srv.URL, GroupID: "1"}, OptionRetryConfig(0, 0, 0))
+
+	itemsSeen := 0
+	found, err := TraversePages(context.Background(), conn.ReadAutomationAgents, func(interface{}) bool {
+		itemsSeen++
+		return false
+	})
+
+	require.Error(t, err)
+	assert.False(t, found)
+	assert.ErrorIs(t, err, ErrPageLimitExceeded)
+	assert.Equal(t, int32(maxPages), requests.Load(), "traversal must stop after exactly maxPages requests")
+	assert.Equal(t, maxPages, itemsSeen)
+}
+
+func TestReadAutomationAgents_ContextDeadlineAbortsHangingOpsManager(t *testing.T) {
+	var requests atomic.Int32
+	srv := serverMock(automationAgents(&requests, func(_ http.ResponseWriter, r *http.Request) {
+		// Hang until the client gives up; returning on r.Context().Done() lets srv.Close() finish.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	conn := NewOpsManagerConnection(&OMContext{BaseURL: srv.URL, GroupID: "1"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := TraversePages(ctx, conn.ReadAutomationAgents, func(interface{}) bool { return false })
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(1), requests.Load(), "the timed-out request must not be retried")
+}

--- a/controllers/om/omclient_test.go
+++ b/controllers/om/omclient_test.go
@@ -1,6 +1,7 @@
 package om
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -356,7 +357,7 @@ func TestReadProjectsInOrganization_OrgIDIsPathEscaped(t *testing.T) {
 
 		conn := NewOpsManagerConnectionWithOptions(&OMContext{BaseURL: srv.URL}, OptionRetryConfig(0, 0, 1))
 
-		_, err := conn.ReadProjectsInOrganization(orgID, 0)
+		_, err := conn.ReadProjectsInOrganization(context.Background(), orgID, 0)
 		require.NoError(t, err)
 
 		got := rec.get()

--- a/controllers/om/ompaginator.go
+++ b/controllers/om/ompaginator.go
@@ -1,10 +1,28 @@
 package om
 
+import (
+	"context"
+	"errors"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	// maxPages is the hard upper bound on the number of pages TraversePages reads.
+	maxPages = 100
+
+	// traversePagesTimeout is the overall deadline for a single TraversePages call.
+	traversePagesTimeout = time.Minute
+)
+
+// ErrPageLimitExceeded is returned by TraversePages when Ops Manager keeps reporting a next page after maxPages pages.
+var ErrPageLimitExceeded = errors.New("pagination exceeded the maximum number of pages")
+
 // Paginated is the general interface for a single page returned by Ops Manager api.
 type Paginated interface {
 	HasNext() bool
 	Results() []interface{}
-	ItemsCount() int
 }
 
 type OMPaginated struct {
@@ -26,55 +44,72 @@ func (o OMPaginated) HasNext() bool {
 	return false
 }
 
-func (o OMPaginated) ItemsCount() int {
-	return o.TotalCount
-}
-
-// PageReader is the function that reads a single page by its number
-type PageReader func(pageNum int) (Paginated, error)
+// PageReader is the function that reads a single page by its number. The context carries the deadline of the whole
+// traversal and must be propagated to the underlying HTTP request.
+type PageReader func(ctx context.Context, pageNum int) (Paginated, error)
 
 // PageItemPredicate is the function that processes single item on the page and returns true if no further processing
 // needs to be done (usually it's the search logic)
 type PageItemPredicate func(interface{}) bool
 
-// TraversePages reads page after page using 'apiFunc' and applies the 'predicate' for each item on the page.
-// Stops traversal when the 'predicate' returns true
-// Note, that in OM 4.0 the max number of pages is 100, but in OM 4.1 and CM - 500.
-// So we'll traverse 100000 (200 pages 500 items on each) records in Cloud Manager and 20000 records in OM 4.0 - I believe it's ok
-// This won't be necessary if MMS-5638 is implemented or if we make 'orgId' configuration mandatory
-func TraversePages(reader PageReader, predicate PageItemPredicate) (found bool, err error) {
-	// First we check the first page and get the number of items to calculate the max number of pages to traverse
-	paginated, e := reader(1)
-	if e != nil {
-		return false, e
+// TraversePages reads page after page using 'reader' and applies the 'predicate' for each item on the page.
+// Stops traversal when the 'predicate' returns true or when the page has no 'next' link.
+// The traversal is bounded both by a maximum number of pages and by an overall timeout: an error is returned when
+// either bound is hit.
+func TraversePages(ctx context.Context, reader PageReader, predicate PageItemPredicate) (found bool, err error) {
+	ctx, cancel := context.WithTimeout(ctx, traversePagesTimeout)
+	defer cancel()
+
+	paginated, err := readPage(ctx, reader, 1)
+	if err != nil {
+		return false, err
 	}
-	for _, entity := range paginated.Results() {
-		if predicate(entity) {
+	if applyPredicate(paginated, predicate) {
+		return true, nil
+	}
+
+	// Note that we start from 2nd page as we've checked the 1st one above
+	for pageNum := 2; paginated.HasNext(); pageNum++ {
+		if pageNum > maxPages {
+			return false, xerrors.Errorf("%w: stopped after %d pages", ErrPageLimitExceeded, maxPages)
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, xerrors.Errorf("timed out traversing Ops Manager pages after %d pages: %w", pageNum-1, ctxErr)
+		}
+
+		paginated, err = readPage(ctx, reader, pageNum)
+		if err != nil {
+			return false, err
+		}
+		if applyPredicate(paginated, predicate) {
 			return true, nil
 		}
 	}
-	if !paginated.HasNext() {
-		return false, nil
-	}
-
-	// We take 100 as the denuminator here assuming it's the OM 4.0. If it's OM 4.1 or CM - then we'll stop earlier
-	// thanks to '!paginated.HasNext()' as they support pages of size 500
-	pagesNum := (paginated.ItemsCount() / 100) + 1
-
-	// Note that we start from 2nd page as we've checked the 1st one above
-	for i := 2; i <= pagesNum; i++ {
-		paginated, e := reader(i)
-		if e != nil {
-			return false, e
-		}
-		for _, entity := range paginated.Results() {
-			if predicate(entity) {
-				return true, nil
-			}
-		}
-		if !paginated.HasNext() {
-			return false, nil
-		}
-	}
 	return false, nil
+}
+
+// readPage reads a single page.
+func readPage(ctx context.Context, reader PageReader, pageNum int) (Paginated, error) {
+	paginated, err := reader(ctx, pageNum)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			// the OM client wraps requests in apierror.Error which drops the error chain,
+			// so the context error is wrapped here to keep the deadline detectable
+			return nil, xerrors.Errorf("failed reading Ops Manager page %d: %w", pageNum, ctxErr)
+		}
+		return nil, err
+	}
+	if paginated == nil {
+		return nil, xerrors.Errorf("reader returned no data for Ops Manager page %d", pageNum)
+	}
+	return paginated, nil
+}
+
+func applyPredicate(paginated Paginated, predicate PageItemPredicate) bool {
+	for _, entity := range paginated.Results() {
+		if predicate(entity) {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/om/ompaginator.go
+++ b/controllers/om/ompaginator.go
@@ -3,13 +3,15 @@ package om
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"golang.org/x/xerrors"
 )
 
 const (
-	// maxPages is the hard upper bound on the number of pages TraversePages reads.
+	// maxPages is the hard upper bound on the number of pages TraversePages reads: 10,000 automation agents at Ops
+	// Manager's default of 100 per page, or 50,000 organizations at the itemsPerPage=500 the callers request.
 	maxPages = 100
 
 	// traversePagesTimeout is the overall deadline for a single TraversePages call.
@@ -95,7 +97,7 @@ func readPage(ctx context.Context, reader PageReader, pageNum int) (Paginated, e
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			// the OM client wraps requests in apierror.Error which drops the error chain,
 			// so the context error is wrapped here to keep the deadline detectable
-			return nil, xerrors.Errorf("failed reading Ops Manager page %d: %w", pageNum, ctxErr)
+			return nil, fmt.Errorf("failed reading Ops Manager page %d: %w; %w", pageNum, err, ctxErr)
 		}
 		return nil, err
 	}

--- a/controllers/om/ompaginator_test.go
+++ b/controllers/om/ompaginator_test.go
@@ -1,41 +1,136 @@
 package om
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPagination_SinglePage(t *testing.T) {
-	found, err := TraversePages(singleOrganizationsPage, func(obj interface{}) bool { return obj.(*Organization).Name == "test" })
+	ctx := context.Background()
+	found, err := TraversePages(ctx, singleOrganizationsPage, func(obj interface{}) bool { return obj.(*Organization).Name == "test" })
 	assert.True(t, found)
 	assert.NoError(t, err)
 
-	found, err = TraversePages(singleOrganizationsPage, func(obj interface{}) bool { return obj.(*Organization).Name == "fake" })
+	found, err = TraversePages(ctx, singleOrganizationsPage, func(obj interface{}) bool { return obj.(*Organization).Name == "fake" })
 	assert.False(t, found)
 	assert.NoError(t, err)
 }
 
 func TestPagination_MultiplePages(t *testing.T) {
-	found, err := TraversePages(multipleOrganizationsPage, func(obj interface{}) bool { return obj.(*Organization).Name == "test1220" })
+	ctx := context.Background()
+
+	pagesRead := 0
+	reader := func(ctx context.Context, pageNum int) (Paginated, error) {
+		pagesRead++
+		return multipleOrganizationsPage(ctx, pageNum)
+	}
+
+	found, err := TraversePages(ctx, reader, func(obj interface{}) bool { return obj.(*Organization).Name == "test1220" })
 	assert.True(t, found)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, numberOfPagesTraversed)
+	assert.Equal(t, 3, pagesRead)
 
-	found, err = TraversePages(multipleOrganizationsPage, func(obj interface{}) bool { return obj.(*Organization).Name == "test1400" })
+	pagesRead = 0
+	found, err = TraversePages(ctx, reader, func(obj interface{}) bool { return obj.(*Organization).Name == "test1400" })
 	assert.False(t, found)
 	assert.NoError(t, err)
+	assert.Equal(t, 3, pagesRead)
 }
 
 func TestPagination_Error(t *testing.T) {
-	_, err := TraversePages(func(pageNum int) (Paginated, error) { return nil, errors.New("Error!") },
+	_, err := TraversePages(context.Background(), func(_ context.Context, _ int) (Paginated, error) { return nil, errors.New("Error!") },
 		func(obj interface{}) bool { return obj.(*Organization).Name == "test1220" })
-	assert.Errorf(t, err, "Error!")
+	assert.EqualError(t, err, "Error!")
 }
 
-var singleOrganizationsPage = func(pageNum int) (Paginated, error) {
+func TestPagination_StopsAtMaxPagesWhenServerAlwaysReportsNext(t *testing.T) {
+	pagesRead := 0
+	reader := func(_ context.Context, pageNum int) (Paginated, error) {
+		pagesRead++
+		return AutomationAgentStatusResponse{
+			OMPaginated:      OMPaginated{TotalCount: math.MaxInt64, Links: []*Link{{Rel: "next"}}},
+			AutomationAgents: []AgentStatus{{Hostname: fmt.Sprintf("host-%d", pageNum), TypeName: "AUTOMATION"}},
+		}, nil
+	}
+
+	itemsSeen := 0
+	found, err := TraversePages(context.Background(), reader, func(interface{}) bool {
+		itemsSeen++
+		return false
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPageLimitExceeded)
+	assert.False(t, found)
+	assert.Equal(t, maxPages, pagesRead, "the reader must be called exactly maxPages times")
+	assert.Equal(t, maxPages, itemsSeen)
+}
+
+func TestPagination_ContextDeadlineAbortsTraversal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	pagesRead := 0
+	reader := func(ctx context.Context, pageNum int) (Paginated, error) {
+		pagesRead++
+		if pageNum == 1 {
+			return endlessOrganizationsPage(), nil
+		}
+		// Emulate an Ops Manager that never answers.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	_, err := TraversePages(ctx, reader, func(interface{}) bool { return false })
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.LessOrEqual(t, pagesRead, 2, "no page may be requested once the deadline has passed")
+}
+
+func TestPagination_ReaderReceivesContextWithDeadline(t *testing.T) {
+	start := time.Now()
+	var deadline time.Time
+	var hasDeadline bool
+	reader := func(ctx context.Context, pageNum int) (Paginated, error) {
+		deadline, hasDeadline = ctx.Deadline()
+		return singleOrganizationsPage(ctx, pageNum)
+	}
+
+	_, err := TraversePages(context.Background(), reader, func(interface{}) bool { return false })
+
+	require.NoError(t, err)
+	assert.True(t, hasDeadline, "the reader must receive a context bounded by traversePagesTimeout")
+	assert.WithinDuration(t, start.Add(traversePagesTimeout), deadline, 5*time.Second)
+}
+
+func TestPagination_CancelledParentContextStopsBeforeNextPage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pagesRead := 0
+	reader := func(_ context.Context, _ int) (Paginated, error) {
+		pagesRead++
+		// Cancel while processing the first page: the traversal must not request page 2.
+		cancel()
+		return endlessOrganizationsPage(), nil
+	}
+
+	_, err := TraversePages(ctx, reader, func(interface{}) bool { return false })
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, pagesRead)
+}
+
+func singleOrganizationsPage(_ context.Context, pageNum int) (Paginated, error) {
 	if pageNum == 1 {
 		// Note, that we don't specify 'next' attribute, so no extra pages will be requested
 		return &OrganizationsResponse{
@@ -46,11 +141,16 @@ var singleOrganizationsPage = func(pageNum int) (Paginated, error) {
 	return nil, errors.New("Not found!")
 }
 
-var numberOfPagesTraversed = 0
+// endlessOrganizationsPage is a page that always claims there is a next one.
+func endlessOrganizationsPage() Paginated {
+	return &OrganizationsResponse{
+		OMPaginated:   OMPaginated{TotalCount: math.MaxInt64, Links: []*Link{{Rel: "next"}}},
+		Organizations: generateOrganizations(0, 1),
+	}
+}
 
-var multipleOrganizationsPage = func(pageNum int) (Paginated, error) {
-	numberOfPagesTraversed++
-	// page 1
+// multipleOrganizationsPage serves 1300 organizations over 3 pages.
+func multipleOrganizationsPage(_ context.Context, pageNum int) (Paginated, error) {
 	switch pageNum {
 	case 1:
 		return &OrganizationsResponse{

--- a/controllers/om/ompaginator_test.go
+++ b/controllers/om/ompaginator_test.go
@@ -95,6 +95,22 @@ func TestPagination_ContextDeadlineAbortsTraversal(t *testing.T) {
 	assert.LessOrEqual(t, pagesRead, 2, "no page may be requested once the deadline has passed")
 }
 
+func TestPagination_DeadlineKeepsReaderError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	reader := func(ctx context.Context, _ int) (Paginated, error) {
+		<-ctx.Done()
+		return nil, errors.New("401 Unauthorized")
+	}
+
+	_, err := TraversePages(ctx, reader, func(interface{}) bool { return false })
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "401 Unauthorized")
+}
+
 func TestPagination_ReaderReceivesContextWithDeadline(t *testing.T) {
 	start := time.Now()
 	var deadline time.Time

--- a/controllers/operator/agents/agents.go
+++ b/controllers/operator/agents/agents.go
@@ -84,12 +84,12 @@ func ApiKeySecretName(project string) string {
 }
 
 // WaitForRsAgentsToRegister waits until all the agents associated with the given StatefulSet have registered with Ops Manager.
-func WaitForRsAgentsToRegister(set appsv1.StatefulSet, members int, clusterName string, omConnection om.Connection, log *zap.SugaredLogger, rs *mdbv1.MongoDB) error {
+func WaitForRsAgentsToRegister(ctx context.Context, set appsv1.StatefulSet, members int, clusterName string, omConnection om.Connection, log *zap.SugaredLogger, rs *mdbv1.MongoDB) error {
 	hostnames, _ := dns.GetDnsForStatefulSetReplicasSpecified(set, clusterName, members, rs.Spec.DbCommonSpec.GetExternalDomain())
 
 	log = log.With("statefulset", set.Name)
 
-	ok, msg := waitUntilRegistered(omConnection, log, retryParams{retrials: 5, waitSeconds: 3}, hostnames...)
+	ok, msg := waitUntilRegistered(ctx, omConnection, log, retryParams{retrials: 5, waitSeconds: 3}, hostnames...)
 	if !ok {
 		return getAgentRegisterError(msg)
 	}
@@ -97,12 +97,12 @@ func WaitForRsAgentsToRegister(set appsv1.StatefulSet, members int, clusterName 
 }
 
 // WaitForRsAgentsToRegisterByResource waits for RS agents to register using MongoDB resource directly without StatefulSet
-func WaitForRsAgentsToRegisterByResource(rs *mdbv1.MongoDB, members int, omConnection om.Connection, log *zap.SugaredLogger) error {
+func WaitForRsAgentsToRegisterByResource(ctx context.Context, rs *mdbv1.MongoDB, members int, omConnection om.Connection, log *zap.SugaredLogger) error {
 	hostnames, _ := dns.GetDNSNames(rs.Name, rs.ServiceName(), rs.Namespace, rs.Spec.GetClusterDomain(), members, rs.Spec.DbCommonSpec.GetExternalDomain())
 
 	log = log.With("mongodb", rs.Name)
 
-	ok, msg := waitUntilRegistered(omConnection, log, retryParams{retrials: 5, waitSeconds: 3}, hostnames...)
+	ok, msg := waitUntilRegistered(ctx, omConnection, log, retryParams{retrials: 5, waitSeconds: 3}, hostnames...)
 	if !ok {
 		return getAgentRegisterError(msg)
 	}
@@ -110,8 +110,8 @@ func WaitForRsAgentsToRegisterByResource(rs *mdbv1.MongoDB, members int, omConne
 }
 
 // WaitForRsAgentsToRegisterSpecifiedHostnames waits for the specified agents to registry with Ops Manager.
-func WaitForRsAgentsToRegisterSpecifiedHostnames(omConnection om.Connection, hostnames []string, log *zap.SugaredLogger) error {
-	ok, msg := waitUntilRegistered(omConnection, log, retryParams{retrials: 10, waitSeconds: 9}, hostnames...)
+func WaitForRsAgentsToRegisterSpecifiedHostnames(ctx context.Context, omConnection om.Connection, hostnames []string, log *zap.SugaredLogger) error {
+	ok, msg := waitUntilRegistered(ctx, omConnection, log, retryParams{retrials: 10, waitSeconds: 9}, hostnames...)
 	if !ok {
 		return getAgentRegisterError(msg)
 	}
@@ -167,9 +167,10 @@ type MongoDBClusterStateInOM struct {
 
 // GetMongoDBClusterState executes requests to OM from the given omConnection to gather the current deployment state.
 // It combines the data from the automation status and the list of automation agents.
-func GetMongoDBClusterState(omConnection om.Connection) (MongoDBClusterStateInOM, error) {
+func GetMongoDBClusterState(ctx context.Context, omConnection om.Connection) (MongoDBClusterStateInOM, error) {
 	var agentStatuses []om.AgentStatus
 	_, err := om.TraversePages(
+		ctx,
 		omConnection.ReadAutomationAgents,
 		func(aa interface{}) bool {
 			agentStatuses = append(agentStatuses, aa.(om.AgentStatus))
@@ -256,7 +257,7 @@ func calculateProcessStateMap(processStatuses []om.ProcessStatus, agentStatuses 
 	return processStates, nil
 }
 
-func agentCheck(omConnection om.Connection, agentHostnames []string, log *zap.SugaredLogger) (string, bool) {
+func agentCheck(ctx context.Context, omConnection om.Connection, agentHostnames []string, log *zap.SugaredLogger) (string, bool) {
 	registeredHostnamesSet := map[string]struct{}{}
 	predicateFunc := func(aa interface{}) bool {
 		automationAgent := aa.(om.Status)
@@ -272,6 +273,7 @@ func agentCheck(omConnection om.Connection, agentHostnames []string, log *zap.Su
 	}
 
 	_, err := om.TraversePages(
+		ctx,
 		omConnection.ReadAutomationAgents,
 		predicateFunc,
 	)
@@ -304,7 +306,7 @@ func agentCheck(omConnection om.Connection, agentHostnames []string, log *zap.Su
 
 // waitUntilRegistered waits until all agents with 'agentHostnames' are registered in OM. Note, that wait
 // happens after retrial - this allows to skip waiting in case agents are already registered
-func waitUntilRegistered(omConnection om.Connection, log *zap.SugaredLogger, r retryParams, agentHostnames ...string) (bool, string) {
+func waitUntilRegistered(ctx context.Context, omConnection om.Connection, log *zap.SugaredLogger, r retryParams, agentHostnames ...string) (bool, string) {
 	if len(agentHostnames) == 0 {
 		log.Debugf("Not waiting for agents as the agentHostnames list is empty")
 		return true, "Not waiting for agents as the agentHostnames list is empty"
@@ -315,8 +317,8 @@ func waitUntilRegistered(omConnection om.Connection, log *zap.SugaredLogger, r r
 	retrials := env.ReadIntOrDefault(util.PodWaitRetriesEnv, r.retrials)       // nolint:forbidigo
 
 	agentsCheckFunc := func() (string, bool) {
-		return agentCheck(omConnection, agentHostnames, log)
+		return agentCheck(ctx, omConnection, agentHostnames, log)
 	}
 
-	return util.DoAndRetry(agentsCheckFunc, log, retrials, waitSeconds)
+	return util.DoAndRetryWithContext(ctx, agentsCheckFunc, log, retrials, waitSeconds)
 }

--- a/controllers/operator/agents/agents.go
+++ b/controllers/operator/agents/agents.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -125,6 +126,9 @@ func getAgentRegisterError(errorMsg string) error {
 }
 
 const StaleProcessDuration = time.Minute * 2
+
+// agentRegistrationTimeout bounds one wait for agents to register, including all retries. Overridden in tests.
+var agentRegistrationTimeout = 3 * time.Minute
 
 // ProcessState represents the state of the mongodb process.
 // Most importantly it contains the information whether the node is down (precisely whether the agent running next to mongod is actively reporting pings to OM),
@@ -316,9 +320,16 @@ func waitUntilRegistered(ctx context.Context, omConnection om.Connection, log *z
 	waitSeconds := env.ReadIntOrDefault(util.PodWaitSecondsEnv, r.waitSeconds) // nolint:forbidigo
 	retrials := env.ReadIntOrDefault(util.PodWaitRetriesEnv, r.retrials)       // nolint:forbidigo
 
+	ctx, cancel := context.WithTimeout(ctx, agentRegistrationTimeout)
+	defer cancel()
+
 	agentsCheckFunc := func() (string, bool) {
 		return agentCheck(ctx, omConnection, agentHostnames, log)
 	}
 
-	return util.DoAndRetryWithContext(ctx, agentsCheckFunc, log, retrials, waitSeconds)
+	ok, msg := util.DoAndRetryWithContext(ctx, agentsCheckFunc, log, retrials, waitSeconds)
+	if !ok && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		msg = fmt.Sprintf("%s (timed out after %s waiting for agents to register)", msg, agentRegistrationTimeout)
+	}
+	return ok, msg
 }

--- a/controllers/operator/agents/agents_test.go
+++ b/controllers/operator/agents/agents_test.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -450,7 +451,7 @@ func TestGetClusterState(t *testing.T) {
 				return tc.mockAgentStatusResponse, tc.mockAgentStatusErr
 			}
 
-			clusterState, err := GetMongoDBClusterState(mockConn)
+			clusterState, err := GetMongoDBClusterState(context.Background(), mockConn)
 			if tc.expectErr {
 				require.Error(t, err, "Expected an error but got none")
 				return

--- a/controllers/operator/agents/agents_test.go
+++ b/controllers/operator/agents/agents_test.go
@@ -6,10 +6,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/mongodb/mongodb-kubernetes/controllers/om"
 )
+
+func TestWaitUntilRegistered_BoundedByOverallTimeout(t *testing.T) {
+	original := agentRegistrationTimeout
+	agentRegistrationTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { agentRegistrationTimeout = original })
+
+	conn := om.NewMockedOmConnection(om.NewDeployment())
+	conn.ReadAutomationAgentsFunc = func(_ int) (om.Paginated, error) {
+		return om.AutomationAgentStatusResponse{}, nil
+	}
+
+	// a retry budget the deadline cannot outlast, so the deadline is what ends the wait
+	ok, msg := waitUntilRegistered(context.Background(), conn, zap.NewNop().Sugar(),
+		retryParams{retrials: 100, waitSeconds: 1}, "host-that-never-registers")
+
+	assert.False(t, ok)
+	assert.Contains(t, msg, "timed out after")
+}
 
 func TestCalculateProcessStateMap(t *testing.T) {
 	sampleTimeStamp := "2023-06-03T10:00:00Z"

--- a/controllers/operator/mongodbmultireplicaset_controller.go
+++ b/controllers/operator/mongodbmultireplicaset_controller.go
@@ -733,7 +733,7 @@ func (r *ReconcileMongoDbMultiReplicaSet) updateOmDeploymentRs(ctx context.Conte
 		reachableHostnames = append(reachableHostnames, hostnamesToAdd...)
 	}
 
-	err = agents.WaitForRsAgentsToRegisterSpecifiedHostnames(conn, reachableHostnames, log)
+	err = agents.WaitForRsAgentsToRegisterSpecifiedHostnames(ctx, conn, reachableHostnames, log)
 	if err != nil && !isRecovering {
 		return err
 	}

--- a/controllers/operator/mongodbreplicaset_controller.go
+++ b/controllers/operator/mongodbreplicaset_controller.go
@@ -755,7 +755,7 @@ func (r *ReplicaSetReconcilerHelper) updateOmDeploymentRs(ctx context.Context, c
 	// - if scaling down, let's observe only members that will remain after scale-down operation
 	// - if scaling up, observe only current members, because new ones might not exist yet
 	replicasTarget := scale.ReplicasThisReconciliation(rs)
-	err := agents.WaitForRsAgentsToRegisterByResource(rs, util_int.Min(membersNumberBefore, replicasTarget), conn, log)
+	err := agents.WaitForRsAgentsToRegisterByResource(ctx, rs, util_int.Min(membersNumberBefore, replicasTarget), conn, log)
 	if err != nil && !isRecovering {
 		return workflow.Failed(err)
 	}

--- a/controllers/operator/mongodbshardedcluster_controller.go
+++ b/controllers/operator/mongodbshardedcluster_controller.go
@@ -1814,7 +1814,7 @@ func (r *ShardedClusterReconcileHelper) cleanOpsManagerState(ctx context.Context
 	if preCleanupReadErr != nil {
 		errs = multierror.Append(errs, xerrors.Errorf("failed to read deployment before cleanup. Skipping the wait for ready state and continuing with cleanup: %w", preCleanupReadErr))
 	} else {
-		healthyProcessNames := r.getHealthyProcessNamesToWaitForReadyState(preCleanupDeployment, conn, log)
+		healthyProcessNames := r.getHealthyProcessNamesToWaitForReadyState(ctx, preCleanupDeployment, conn, log)
 		logDiffOfProcessNames(processNames, healthyProcessNames, log.With("ctx", "cleanOpsManagerState"))
 		if err := om.WaitForReadyState(conn, healthyProcessNames, false, log); err != nil {
 			errs = multierror.Append(errs, xerrors.Errorf("failed to wait for ready state. Continuing with cleanup: %w", err))
@@ -2010,7 +2010,7 @@ type deploymentOptions struct {
 // The logic is designed to be idempotent: if the reconciliation is retried the controller will never skip the phase 1
 // until the agents have performed draining
 func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(ctx context.Context, conn om.Connection, sc *mdbv1.MongoDB, opts deploymentOptions, isRecovering bool, log *zap.SugaredLogger) workflow.Status {
-	err := r.waitForAgentsToRegister(sc, conn, log)
+	err := r.waitForAgentsToRegister(ctx, sc, conn, log)
 	if err != nil {
 		if !isRecovering {
 			return workflow.Failed(err)
@@ -2043,7 +2043,7 @@ func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(ctx con
 		logWarnIgnoredDueToRecovery(log, workflowStatus)
 	}
 
-	healthyProcessesToWaitForReadyState := r.getHealthyProcessNamesToWaitForReadyState(dep, conn, log)
+	healthyProcessesToWaitForReadyState := r.getHealthyProcessNamesToWaitForReadyState(ctx, dep, conn, log)
 	logDiffOfProcessNames(processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "updateOmDeploymentShardedCluster"))
 	if err = om.WaitForReadyState(conn, healthyProcessesToWaitForReadyState, isRecovering, log); err != nil {
 		if !isRecovering {
@@ -2067,7 +2067,7 @@ func (r *ShardedClusterReconcileHelper) updateOmDeploymentShardedCluster(ctx con
 			logWarnIgnoredDueToRecovery(log, workflowStatus)
 		}
 
-		healthyProcessesToWaitForReadyState := r.getHealthyProcessNamesToWaitForReadyState(dep, conn, log)
+		healthyProcessesToWaitForReadyState := r.getHealthyProcessNamesToWaitForReadyState(ctx, dep, conn, log)
 		logDiffOfProcessNames(processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "shardsRemoving"))
 		if err = om.WaitForReadyState(conn, healthyProcessesToWaitForReadyState, isRecovering, log); err != nil {
 			if !isRecovering {
@@ -2154,7 +2154,7 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 		return nil, false, workflow.Failed(err)
 	}
 
-	healthyProcessesToWaitForReadyState := r.getHealthyProcessNamesToWaitForReadyState(existingDeployment, conn, log)
+	healthyProcessesToWaitForReadyState := r.getHealthyProcessNamesToWaitForReadyState(ctx, existingDeployment, conn, log)
 
 	logDiffOfProcessNames(opts.processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "updateOmAuthentication"))
 
@@ -2244,7 +2244,7 @@ func (r *ShardedClusterReconcileHelper) publishDeployment(ctx context.Context, c
 		return nil, shardsRemoving, reconcileResult
 	}
 
-	healthyProcessesToWaitForReadyState = r.getHealthyProcessNamesToWaitForReadyState(existingDeployment, conn, log)
+	healthyProcessesToWaitForReadyState = r.getHealthyProcessNamesToWaitForReadyState(ctx, existingDeployment, conn, log)
 	logDiffOfProcessNames(opts.processNames, healthyProcessesToWaitForReadyState, log.With("ctx", "publishDeployment"))
 	if err := om.WaitForReadyState(conn, healthyProcessesToWaitForReadyState, isRecovering, log); err != nil {
 		return nil, shardsRemoving, workflow.Failed(err)
@@ -2293,14 +2293,14 @@ func getAllProcesses(shards []om.ReplicaSetWithProcesses, configRs om.ReplicaSet
 	return allProcesses
 }
 
-func (r *ShardedClusterReconcileHelper) waitForAgentsToRegister(sc *mdbv1.MongoDB, conn om.Connection, log *zap.SugaredLogger) error {
+func (r *ShardedClusterReconcileHelper) waitForAgentsToRegister(ctx context.Context, sc *mdbv1.MongoDB, conn om.Connection, log *zap.SugaredLogger) error {
 	var mongosHostnames []string
 	for _, memberCluster := range getHealthyMemberClusters(r.mongosMemberClusters) {
 		hostnames, _ := r.getMongosHostnames(memberCluster, scale.ReplicasThisReconciliation(r.GetMongosScaler(memberCluster)))
 		mongosHostnames = append(mongosHostnames, hostnames...)
 	}
 
-	if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(conn, mongosHostnames, log.With("hostnamesOf", "mongos")); err != nil {
+	if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(ctx, conn, mongosHostnames, log.With("hostnamesOf", "mongos")); err != nil {
 		return xerrors.Errorf("Mongos agents didn't register with Ops Manager: %w", err)
 	}
 
@@ -2309,7 +2309,7 @@ func (r *ShardedClusterReconcileHelper) waitForAgentsToRegister(sc *mdbv1.MongoD
 		hostnames, _ := r.getConfigSrvHostnames(memberCluster, scale.ReplicasThisReconciliation(r.GetConfigSrvScaler(memberCluster)))
 		configSrvHostnames = append(configSrvHostnames, hostnames...)
 	}
-	if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(conn, configSrvHostnames, log.With("hostnamesOf", "configServer")); err != nil {
+	if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(ctx, conn, configSrvHostnames, log.With("hostnamesOf", "configServer")); err != nil {
 		return xerrors.Errorf("Config server agents didn't register with Ops Manager: %w", err)
 	}
 
@@ -2319,7 +2319,7 @@ func (r *ShardedClusterReconcileHelper) waitForAgentsToRegister(sc *mdbv1.MongoD
 			hostnames, _ := r.getShardHostnames(shardIdx, memberCluster, scale.ReplicasThisReconciliation(r.GetShardScaler(shardIdx, memberCluster)))
 			shardHostnames = append(shardHostnames, hostnames...)
 		}
-		if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(conn, shardHostnames, log.With("hostnamesOf", "shard", "shardIdx", shardIdx)); err != nil {
+		if err := agents.WaitForRsAgentsToRegisterSpecifiedHostnames(ctx, conn, shardHostnames, log.With("hostnamesOf", "shard", "shardIdx", shardIdx)); err != nil {
 			return xerrors.Errorf("Shards agents didn't register with Ops Manager: %w", err)
 		}
 	}
@@ -3301,10 +3301,10 @@ func (r *ShardedClusterReconcileHelper) getHealthyProcessNames(existingDeploymen
 	return processNames
 }
 
-func (r *ShardedClusterReconcileHelper) getHealthyProcessNamesToWaitForReadyState(existingDeployment om.Deployment, conn om.Connection, log *zap.SugaredLogger) []string {
+func (r *ShardedClusterReconcileHelper) getHealthyProcessNamesToWaitForReadyState(ctx context.Context, existingDeployment om.Deployment, conn om.Connection, log *zap.SugaredLogger) []string {
 	processList := r.getHealthyProcessNames(existingDeployment)
 
-	clusterState, err := agents.GetMongoDBClusterState(conn)
+	clusterState, err := agents.GetMongoDBClusterState(ctx, conn)
 	if err != nil {
 		log.Warnf("Skipping check for mongos deadlock for all the nodes being healthy (deadlock) due to error: %v", err)
 		return processList

--- a/controllers/operator/mongodbstandalone_controller.go
+++ b/controllers/operator/mongodbstandalone_controller.go
@@ -360,7 +360,7 @@ func (r *ReconcileMongoDbStandalone) Reconcile(ctx context.Context, request reco
 }
 
 func (r *ReconcileMongoDbStandalone) updateOmDeployment(ctx context.Context, conn om.Connection, s *mdbv1.MongoDB, set appsv1.StatefulSet, isRecovering bool, agentCertPath string, log *zap.SugaredLogger) workflow.Status {
-	if err := agents.WaitForRsAgentsToRegister(set, 0, s.Spec.GetClusterDomain(), conn, log, s); err != nil {
+	if err := agents.WaitForRsAgentsToRegister(ctx, set, 0, s.Spec.GetClusterDomain(), conn, log, s); err != nil {
 		return workflow.Failed(err)
 	}
 

--- a/controllers/operator/project/projectconfig.go
+++ b/controllers/operator/project/projectconfig.go
@@ -26,7 +26,24 @@ func validateProjectConfig(ctx context.Context, cmGetter configmap.Getter, proje
 			return nil, xerrors.Errorf(`property "%s" is not specified in ConfigMap %s`, requiredField, projectConfigMap)
 		}
 	}
+
+	if err := validateBaseURL(data[util.OmBaseUrl]); err != nil {
+		return nil, xerrors.Errorf(`property "%s" in ConfigMap %s is not a valid Ops Manager base URL: %w`, util.OmBaseUrl, projectConfigMap, err)
+	}
 	return data, nil
+}
+
+// validateBaseURL makes sure the Ops Manager base URL is a plain http(s) URL with a host, rejecting query
+// strings and fragments.
+func validateBaseURL(baseURL string) error {
+	u, err := util.ParseURL(baseURL)
+	if err != nil {
+		return err
+	}
+	if u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return xerrors.Errorf("query string or fragment is not allowed: %s", baseURL)
+	}
+	return nil
 }
 
 // ReadProjectConfig returns a "Project" config build from a ConfigMap with a series of attributes

--- a/controllers/operator/project/projectconfig_test.go
+++ b/controllers/operator/project/projectconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -105,6 +106,49 @@ func TestMissingRequiredFieldsFromCM(t *testing.T) {
 		_, err = ReadProjectConfig(ctx, client, kube.ObjectKey(mock.TestNamespace, "cm1"), "")
 		assert.Error(t, err)
 	})
+}
+
+func TestReadProjectConfig_ValidatesBaseURL(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		baseURL string
+		wantErr bool
+	}{
+		{baseURL: "http://mycompany.example.com:8080"},
+		{baseURL: "https://om.example.com:8443/"},
+		{baseURL: "http://[::1]:8080"},
+		{baseURL: "https://cloud.mongodb.com"},
+		{baseURL: "", wantErr: true},
+		{baseURL: "   ", wantErr: true},
+		{baseURL: "mycompany.example.com:8080", wantErr: true},
+		{baseURL: "ftp://mycompany.example.com", wantErr: true},
+		{baseURL: "file:///etc/passwd", wantErr: true},
+		{baseURL: "http://", wantErr: true},
+		{baseURL: "http:///path-only", wantErr: true},
+		{baseURL: "http://mycompany.example.com:8080?x=1", wantErr: true},
+		{baseURL: "http://mycompany.example.com:8080?", wantErr: true},
+		{baseURL: "http://mycompany.example.com:8080#frag", wantErr: true},
+		{baseURL: "::not-a-url", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.baseURL, func(t *testing.T) {
+			// a fresh client per case, so a single ConfigMap name is enough
+			client, _ := mock.NewDefaultFakeClient()
+			cm := defaultConfigMap("cm")
+			cm.Data[util.OmBaseUrl] = tt.baseURL
+			require.NoError(t, client.Create(ctx, &cm))
+
+			projectConfig, err := ReadProjectConfig(ctx, client, kube.ObjectKey(mock.TestNamespace, "cm"), "")
+			if tt.wantErr {
+				require.Error(t, err, "baseUrl %q must be rejected", tt.baseURL)
+				assert.Contains(t, err.Error(), "is not a valid Ops Manager base URL")
+				return
+			}
+			require.NoError(t, err, "baseUrl %q must be accepted", tt.baseURL)
+			assert.Equal(t, tt.baseURL, projectConfig.BaseURL)
+		})
+	}
 }
 
 func defaultConfigMap(name string) corev1.ConfigMap {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5" //nolint //Part of the algorithm
 	"encoding/gob"
 	"encoding/hex"
@@ -81,6 +82,11 @@ func StripEnt(version string) string {
 // DoAndRetry performs the task 'f' until it returns true or 'count' retrials are executed. Sleeps for 'interval' seconds
 // between retries. String return parameter contains the fail message that is printed in case of failure.
 func DoAndRetry(f func() (string, bool), log *zap.SugaredLogger, count, interval int) (bool, string) {
+	return DoAndRetryWithContext(context.Background(), f, log, count, interval)
+}
+
+// DoAndRetryWithContext is like DoAndRetry but gives up as soon as ctx is done, without waiting out the interval.
+func DoAndRetryWithContext(ctx context.Context, f func() (string, bool), log *zap.SugaredLogger, count, interval int) (bool, string) {
 	var ok bool
 	var msg string
 	for i := 0; i < count; i++ {
@@ -92,7 +98,13 @@ func DoAndRetry(f func() (string, bool), log *zap.SugaredLogger, count, interval
 			msg += "."
 		}
 		log.Debugf("%s Retrying %d/%d (waiting for %d more seconds)", msg, i+1, count, interval)
-		time.Sleep(time.Duration(interval) * time.Second)
+		timer := time.NewTimer(time.Duration(interval) * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false, msg
+		case <-timer.C:
+		}
 	}
 	return false, msg
 }

--- a/pkg/util/util_retry_test.go
+++ b/pkg/util/util_retry_test.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestDoAndRetryWithContext_StopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	calls := 0
+	f := func() (string, bool) {
+		calls++
+		cancel()
+		return "not yet", false
+	}
+
+	start := time.Now()
+	ok, msg := DoAndRetryWithContext(ctx, f, zap.NewNop().Sugar(), 10, 5)
+
+	assert.False(t, ok)
+	assert.Equal(t, "not yet.", msg)
+	assert.Equal(t, 1, calls, "no further attempts once the context is cancelled")
+	assert.Less(t, time.Since(start), 5*time.Second, "must not wait out the interval once the context is cancelled")
+}
+
+func TestDoAndRetryWithContext_RetriesUntilSuccess(t *testing.T) {
+	calls := 0
+	f := func() (string, bool) {
+		calls++
+		return "done", calls == 2
+	}
+
+	ok, msg := DoAndRetryWithContext(context.Background(), f, zap.NewNop().Sugar(), 5, 0)
+
+	assert.True(t, ok)
+	assert.Equal(t, "done", msg)
+	assert.Equal(t, 2, calls)
+}
+
+func TestDoAndRetryWithContext_GivesUpAfterCount(t *testing.T) {
+	calls := 0
+	f := func() (string, bool) {
+		calls++
+		return "nope", false
+	}
+
+	ok, msg := DoAndRetryWithContext(context.Background(), f, zap.NewNop().Sugar(), 3, 0)
+
+	assert.False(t, ok)
+	assert.Equal(t, "nope.", msg)
+	assert.Equal(t, 3, calls)
+}


### PR DESCRIPTION
# Summary

When the operator needs a list from Ops Manager (agents, organizations, projects), it fetches it page by page and trusts Ops Manager to say when the list ends. The Ops Manager URL comes from the project ConfigMap, which users can edit. A misconfigured or unresponsive Ops Manager can claim the list is huge and always offer one more page, so the operator keeps fetching forever. The operator handles changes with a small pool of workers, and each endless fetch ties up one of them. Once every worker is stuck, the operator stops responding to any change in every namespace it watches. Nothing crashes, so the crash protection never kicks in. It just waits.

The PR changes:
  - A list fetch now stops after 100 pages or 1 minute, whichever comes first, and reports an error. 100 pages covers 10,000 agents at the default page size.
  - Every Ops Manager request now has a 2-minute timeout, so a server that never responds can't hold the operator indefinitely.
  - If a reconcile is cancelled while a fetch is in progress, the fetch stops right away instead of finishing the current page first.
  - The Ops Manager URL from the project ConfigMap is now checked for a valid scheme and host before it is used.
  - After deploying a cluster, the operator waits for the MongoDB agents to appear in Ops Manager. That wait used to retry up to ten times per component with no time limit on each attempt, so a sharded cluster could wait close to an hour. Each wait now stops after 3 minutes and reports an error.

Tests: the page cap and time limit, the request timeout against a server that never responds, accepted and rejected URL values, and the registration wait deadline.


## Proof of Work

[EVG Patch Link](https://spruce.corp.mongodb.com/version/6aa2eff27d6aa1000763f9b1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

- `gofmt -l` clean, `go build ./...` clean, `go vet` clean.
- `go test ./controllers/om/... ./controllers/operator/agents/... ./pkg/util/`
  all pass.



## Checklist

- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you added changelog file?

---

<!-- start git-machete generated -->
<!-- end git-machete generated -->